### PR TITLE
Bind widgets to query params - Part 2

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -2095,19 +2095,20 @@ describe("App", () => {
           .pageScriptHash
       ).toBe("subpage_hash")
 
-      // With query param binding, we preserve query params from state
-      // (which may include bound widget params) instead of clearing them
+      // When navigating to a different page, non-embed and non-bound params
+      // (like foo=bar) are cleared. Only embed params and bound widget params
+      // are preserved.
       expect(
         // @ts-expect-error
         connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
-      ).toBe("foo=bar")
+      ).toBe("")
 
-      // No SET_QUERY_PARAM message sent during page navigation
-      // (The old behavior would clear params and send SET_QUERY_PARAM with "")
+      // SET_QUERY_PARAM message is sent to update the URL (clearing foo=bar)
       const setQueryParamCalls = (
         hostCommunicationMgr.sendMessageToHost as Mock
       ).mock.calls.filter(call => call[0]?.type === "SET_QUERY_PARAM")
-      expect(setQueryParamCalls).toHaveLength(0)
+      expect(setQueryParamCalls).toHaveLength(1)
+      expect(setQueryParamCalls[0][0].queryParams).toBe("")
     })
   })
 
@@ -5354,12 +5355,13 @@ describe("App", () => {
         connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
       ).toBe(embedParams)
 
-      // With query param binding, we preserve query params from state
-      // instead of sending a SET_QUERY_PARAM message on every page change
+      // SET_QUERY_PARAM is sent to confirm the query params state to the host.
+      // For embed params, they are preserved so the message contains them.
       const setQueryParamCalls = (
         hostCommunicationMgr.sendMessageToHost as Mock
       ).mock.calls.filter(call => call[0]?.type === "SET_QUERY_PARAM")
-      expect(setQueryParamCalls).toHaveLength(0)
+      expect(setQueryParamCalls).toHaveLength(1)
+      expect(setQueryParamCalls[0][0].queryParams).toBe(embedParams)
     })
 
     it("works with baseUrlPaths", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -5361,7 +5361,7 @@ describe("App", () => {
         hostCommunicationMgr.sendMessageToHost as Mock
       ).mock.calls.filter(call => call[0]?.type === "SET_QUERY_PARAM")
       expect(setQueryParamCalls).toHaveLength(1)
-      expect(setQueryParamCalls[0][0].queryParams).toBe(embedParams)
+      expect(setQueryParamCalls[0][0].queryParams).toBe(`?${embedParams}`)
     })
 
     it("works with baseUrlPaths", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -25,6 +25,7 @@ import {
   waitFor,
 } from "@testing-library/react"
 import { cloneDeep } from "lodash-es"
+import { type Mock } from "vitest"
 
 import {
   getMenuStructure,
@@ -2039,7 +2040,7 @@ describe("App", () => {
       ).toBe("baz")
     })
 
-    it("sets queryString to an empty string if the page hash is different", () => {
+    it("preserves query params from state when navigating to different page", () => {
       renderApp(getProps())
 
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
@@ -2079,11 +2080,14 @@ describe("App", () => {
       const navLinks = screen.queryAllByTestId("stSidebarNavLink")
       expect(navLinks).toHaveLength(2)
 
+      const connectionManager = getMockConnectionManager()
+
+      // Clear only the hostCommunicationMgr mock before navigation
+      ;(hostCommunicationMgr.sendMessageToHost as Mock).mockClear()
+
       // TODO: Utilize user-event instead of fireEvent
       // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.click(navLinks[1])
-
-      const connectionManager = getMockConnectionManager()
 
       expect(
         // @ts-expect-error
@@ -2091,15 +2095,19 @@ describe("App", () => {
           .pageScriptHash
       ).toBe("subpage_hash")
 
+      // With query param binding, we preserve query params from state
+      // (which may include bound widget params) instead of clearing them
       expect(
         // @ts-expect-error
         connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
-      ).toBe("")
+      ).toBe("foo=bar")
 
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_QUERY_PARAM",
-        queryParams: "",
-      })
+      // No SET_QUERY_PARAM message sent during page navigation
+      // (The old behavior would clear params and send SET_QUERY_PARAM with "")
+      const setQueryParamCalls = (
+        hostCommunicationMgr.sendMessageToHost as Mock
+      ).mock.calls.filter(call => call[0]?.type === "SET_QUERY_PARAM")
+      expect(setQueryParamCalls).toHaveLength(0)
     })
   })
 
@@ -5332,21 +5340,26 @@ describe("App", () => {
       const navLinks = screen.queryAllByTestId("stSidebarNavLink")
       expect(navLinks).toHaveLength(2)
 
+      const connectionManager = getMockConnectionManager()
+
+      // Clear only the hostCommunicationMgr mock before navigation
+      ;(hostCommunicationMgr.sendMessageToHost as Mock).mockClear()
+
       // TODO: Utilize user-event instead of fireEvent
       // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.click(navLinks[1])
-
-      const connectionManager = getMockConnectionManager()
 
       expect(
         // @ts-expect-error
         connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
       ).toBe(embedParams)
 
-      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
-        type: "SET_QUERY_PARAM",
-        queryParams: embedParams,
-      })
+      // With query param binding, we preserve query params from state
+      // instead of sending a SET_QUERY_PARAM message on every page change
+      const setQueryParamCalls = (
+        hostCommunicationMgr.sendMessageToHost as Mock
+      ).mock.calls.filter(call => call[0]?.type === "SET_QUERY_PARAM")
+      expect(setQueryParamCalls).toHaveLength(0)
     })
 
     it("works with baseUrlPaths", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -347,7 +347,8 @@ export class App extends PureComponent<Props, State> {
       hostHideSidebarNav: false,
       sidebarChevronDownshift: 0,
       pageLinkBaseUrl: "",
-      queryParams: "",
+      // Initialize with actual URL query params so the first rerun includes them
+      queryParams: window.location?.search?.replace(/^\?/, "") ?? "",
       deployedAppMetadata: {},
       libConfig: {},
       appConfig: {},
@@ -363,6 +364,13 @@ export class App extends PureComponent<Props, State> {
       sendRerunBackMsg: this.sendRerunBackMsg,
       formsDataChanged: formsData => this.setState({ formsData }),
     })
+
+    // Wire up query param change handler for widget-to-URL sync.
+    // This keeps App's queryParams state in sync with the URL so that
+    // page navigation preserves query params from bound widgets.
+    this.widgetMgr.setQueryParamsChangeHandler(
+      this.handleQueryParamsFromWidget
+    )
 
     this.hostCommunicationMgr = new HostCommunicationManager({
       streamlitExecutionStartedAt: props.streamlitExecutionStartedAt,
@@ -1085,6 +1093,21 @@ export class App extends PureComponent<Props, State> {
         }
       })
     }
+  }
+
+  /**
+   * Handle query parameter changes originating from widget value changes.
+   * This is called by WidgetStateManager when a widget bound to a query param
+   * updates its value. This keeps App's queryParams state in sync with the URL
+   * so that page navigation preserves bound widget query params.
+   */
+  handleQueryParamsFromWidget = (queryString: string): void => {
+    this.setState({ queryParams: queryString })
+
+    this.hostCommunicationMgr.sendMessageToHost({
+      type: "SET_QUERY_PARAM",
+      queryParams: queryString ? `?${queryString}` : "",
+    })
   }
 
   handlePageInfoChanged = (pageInfo: PageInfo): void => {
@@ -1883,19 +1906,31 @@ export class App extends PureComponent<Props, State> {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
       if (pageScriptHash !== currentPageScriptHash && !preserveQueryParams) {
-        // Clear non-embed query parameters within a page change while we wait
-        // for the server to send updated query params (if any).
-        // Skip clearing if preserveQueryParams is true (e.g., browser back/forward
-        // navigation where query params from the URL should be preserved).
-        const preservedQueryParams = preserveEmbedQueryParams()
-
-        queryString = getQueryString(queryStringOverride, preservedQueryParams)
-
-        this.setState({ queryParams: queryString })
-        this.hostCommunicationMgr.sendMessageToHost({
-          type: "SET_QUERY_PARAM",
-          queryParams: queryString,
-        })
+        // For page navigation, preserve query params from bound widgets.
+        // Previously we cleared all non-embed params, but with query param binding,
+        // we want to preserve params that were set by widgets (especially from
+        // the entry file in MPA v2 apps).
+        //
+        // If queryStringOverride is provided, use it. Otherwise, preserve
+        // the current state.queryParams (which includes bound widget params).
+        // Only fall back to embed params if neither is available.
+        const currentParams = this.state.queryParams
+        if (!queryStringOverride && currentParams) {
+          // Preserve bound widget params from state
+          queryString = currentParams
+        } else {
+          // Fall back to embed params only
+          const preservedQueryParams = preserveEmbedQueryParams()
+          queryString = getQueryString(
+            queryStringOverride,
+            preservedQueryParams
+          )
+          this.setState({ queryParams: queryString })
+          this.hostCommunicationMgr.sendMessageToHost({
+            type: "SET_QUERY_PARAM",
+            queryParams: queryString,
+          })
+        }
       }
     } else if (currentPageScriptHash) {
       // The user didn't specify which page to run, which happens when they

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -347,7 +347,7 @@ export class App extends PureComponent<Props, State> {
       hostHideSidebarNav: false,
       sidebarChevronDownshift: 0,
       pageLinkBaseUrl: "",
-      // Initialize with actual URL query params so the first rerun includes them
+      // Capture initial URL params for page navigation preservation
       queryParams: window.location?.search?.replace(/^\?/, "") ?? "",
       deployedAppMetadata: {},
       libConfig: {},
@@ -365,9 +365,7 @@ export class App extends PureComponent<Props, State> {
       formsDataChanged: formsData => this.setState({ formsData }),
     })
 
-    // Wire up query param change handler for widget-to-URL sync.
-    // This keeps App's queryParams state in sync with the URL so that
-    // page navigation preserves query params from bound widgets.
+    // Sync widget URL changes to App state for page navigation preservation.
     this.widgetMgr.setQueryParamsChangeHandler(
       this.handleQueryParamsFromWidget
     )
@@ -1095,12 +1093,7 @@ export class App extends PureComponent<Props, State> {
     }
   }
 
-  /**
-   * Handle query parameter changes originating from widget value changes.
-   * This is called by WidgetStateManager when a widget bound to a query param
-   * updates its value. This keeps App's queryParams state in sync with the URL
-   * so that page navigation preserves bound widget query params.
-   */
+  /** Callback for WidgetStateManager when bound widgets update URL params. */
   handleQueryParamsFromWidget = (queryString: string): void => {
     this.setState({ queryParams: queryString })
 
@@ -1906,20 +1899,12 @@ export class App extends PureComponent<Props, State> {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
       if (pageScriptHash !== currentPageScriptHash && !preserveQueryParams) {
-        // For page navigation, preserve query params from bound widgets.
-        // Previously we cleared all non-embed params, but with query param binding,
-        // we want to preserve params that were set by widgets (especially from
-        // the entry file in MPA v2 apps).
-        //
-        // If queryStringOverride is provided, use it. Otherwise, preserve
-        // the current state.queryParams (which includes bound widget params).
-        // Only fall back to embed params if neither is available.
+        // Preserve query params (including bound widget params) on page navigation.
         const currentParams = this.state.queryParams
         if (!queryStringOverride && currentParams) {
-          // Preserve bound widget params from state
           queryString = currentParams
         } else {
-          // Fall back to embed params only
+          // Fall back to embed params only.
           const preservedQueryParams = preserveEmbedQueryParams()
           queryString = getQueryString(
             queryStringOverride,

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1900,26 +1900,17 @@ export class App extends PureComponent<Props, State> {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
       if (pageScriptHash !== currentPageScriptHash && !preserveQueryParams) {
-        const currentParams = this.state.queryParams
-        // Use existing params from state (which includes bound widget params)
-        // unless there's an explicit override or no params exist yet.
-        const shouldPreserveCurrentParams =
-          !queryStringOverride && currentParams
-        if (shouldPreserveCurrentParams) {
-          queryString = currentParams
-        } else {
-          // Fall back to embed params only.
-          const preservedQueryParams = preserveEmbedQueryParams()
-          queryString = getQueryString(
-            queryStringOverride,
-            preservedQueryParams
-          )
-          this.setState({ queryParams: queryString })
-          this.hostCommunicationMgr.sendMessageToHost({
-            type: "SET_QUERY_PARAM",
-            queryParams: queryString,
-          })
-        }
+        // When switching pages, preserve only embed params and widget-bound params.
+        // All other params (like ?foo=bar) should be cleared.
+        const filteredParams = this.widgetMgr.filterParamsForPageChange(
+          preserveEmbedQueryParams()
+        )
+        queryString = getQueryString(queryStringOverride, filteredParams)
+        this.setState({ queryParams: queryString })
+        this.hostCommunicationMgr.sendMessageToHost({
+          type: "SET_QUERY_PARAM",
+          queryParams: queryString,
+        })
       }
     } else if (currentPageScriptHash) {
       // The user didn't specify which page to run, which happens when they

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -347,7 +347,8 @@ export class App extends PureComponent<Props, State> {
       hostHideSidebarNav: false,
       sidebarChevronDownshift: 0,
       pageLinkBaseUrl: "",
-      // Capture initial URL params for page navigation preservation
+      // Initialize from URL so bound widget params from shared links are
+      // preserved on first page navigation (before handlePageInfoChanged fires).
       queryParams: window.location?.search?.replace(/^\?/, "") ?? "",
       deployedAppMetadata: {},
       libConfig: {},
@@ -1899,9 +1900,12 @@ export class App extends PureComponent<Props, State> {
       // The user specified exactly which page to run. We can simply use this
       // value in the BackMsg we send to the server.
       if (pageScriptHash !== currentPageScriptHash && !preserveQueryParams) {
-        // Preserve query params (including bound widget params) on page navigation.
         const currentParams = this.state.queryParams
-        if (!queryStringOverride && currentParams) {
+        // Use existing params from state (which includes bound widget params)
+        // unless there's an explicit override or no params exist yet.
+        const shouldPreserveCurrentParams =
+          !queryStringOverride && currentParams
+        if (shouldPreserveCurrentParams) {
           queryString = currentParams
         } else {
           // Fall back to embed params only.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1909,7 +1909,7 @@ export class App extends PureComponent<Props, State> {
         this.setState({ queryParams: queryString })
         this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_QUERY_PARAM",
-          queryParams: queryString,
+          queryParams: queryString ? `?${queryString}` : "",
         })
       }
     } else if (currentPageScriptHash) {

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1436,4 +1436,346 @@ describe("Trigger JSON payloads (aggregated)", () => {
       undefined
     )
   })
+
+  describe("Query Param Binding", () => {
+    let mockOnQueryParamsChange: Mock
+
+    beforeEach(() => {
+      mockOnQueryParamsChange = vi.fn()
+      widgetMgr.setQueryParamsChangeHandler(mockOnQueryParamsChange)
+      // Mock window.history.replaceState to capture URL changes
+      let currentUrl = "http://localhost:3000/"
+      window.history.replaceState = vi.fn((_, __, url) => {
+        if (url) currentUrl = url as string
+      })
+      // Mock window.location with proper URL structure
+      Object.defineProperty(window, "location", {
+        get() {
+          return new URL(currentUrl)
+        },
+        configurable: true,
+      })
+    })
+
+    describe("registerQueryParamBinding", () => {
+      it("registers a binding", () => {
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default"
+        )
+
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
+      })
+
+      it("registers binding with options for index-based widgets", () => {
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "color",
+          "int_value",
+          0,
+          undefined,
+          ["Red", "Green", "Blue"]
+        )
+
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
+      })
+
+      it("registers binding with urlFormat", () => {
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "tags",
+          "string_array_value",
+          [],
+          "comma"
+        )
+
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
+      })
+    })
+
+    describe("unregisterQueryParamBinding", () => {
+      it("unregisters a binding", () => {
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default"
+        )
+        widgetMgr.unregisterQueryParamBinding("widget1")
+
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(false)
+      })
+
+      it("is a no-op for non-existent widget", () => {
+        expect(() => {
+          widgetMgr.unregisterQueryParamBinding("nonexistent")
+        }).not.toThrow()
+      })
+    })
+
+    describe("URL sync for scalar values", () => {
+      it("syncs bool value to URL", () => {
+        const widget = { id: "checkbox1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "checkbox1",
+          "enabled",
+          "bool_value",
+          false
+        )
+
+        widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("enabled=true")
+      })
+
+      it("syncs int value to URL", () => {
+        const widget = { id: "number1", formId: "" }
+        widgetMgr.registerQueryParamBinding("number1", "count", "int_value", 0)
+
+        widgetMgr.setIntValue(widget, 42, { fromUi: true }, undefined)
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("count=42")
+      })
+
+      it("syncs double value to URL", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "value",
+          "double_value",
+          0
+        )
+
+        widgetMgr.setDoubleValue(widget, 3.14, { fromUi: true }, undefined)
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("value=3.14")
+      })
+
+      it("syncs string value to URL", () => {
+        const widget = { id: "text1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "text1",
+          "name",
+          "string_value",
+          ""
+        )
+
+        widgetMgr.setStringValue(widget, "Alice", { fromUi: true }, undefined)
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("name=Alice")
+      })
+
+      it("does not sync when value is from backend", () => {
+        const widget = { id: "checkbox1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "checkbox1",
+          "enabled",
+          "bool_value",
+          false
+        )
+
+        widgetMgr.setBoolValue(widget, true, { fromUi: false }, undefined)
+
+        expect(window.history.replaceState).not.toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+      })
+
+      it("clears URL param when value equals default", () => {
+        const widget = { id: "checkbox1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "checkbox1",
+          "enabled",
+          "bool_value",
+          false
+        )
+
+        // Set to non-default
+        widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+        vi.clearAllMocks()
+
+        // Set back to default
+        widgetMgr.setBoolValue(widget, false, { fromUi: true }, undefined)
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+    })
+
+    describe("URL sync with options (index-based widgets)", () => {
+      it("converts index to option string for int_value", () => {
+        const widget = { id: "radio1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "radio1",
+          "color",
+          "int_value",
+          0,
+          undefined,
+          ["Red", "Green", "Blue"]
+        )
+
+        widgetMgr.setIntValue(widget, 1, { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("color=Green")
+      })
+
+      it("falls back to index if option not found", () => {
+        const widget = { id: "radio1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "radio1",
+          "color",
+          "int_value",
+          0,
+          undefined,
+          ["Red", "Green", "Blue"]
+        )
+
+        widgetMgr.setIntValue(widget, 99, { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("color=99")
+      })
+
+      it("converts indices to option strings for int_array_value", () => {
+        const widget = { id: "pills1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "pills1",
+          "tags",
+          "int_array_value",
+          [],
+          undefined,
+          ["Apple", "Banana", "Cherry"]
+        )
+
+        widgetMgr.setIntArrayValue(widget, [0, 2], { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "tags=Apple&tags=Cherry"
+        )
+      })
+    })
+
+    describe("URL sync for array values", () => {
+      it("syncs string array with repeated params", () => {
+        const widget = { id: "multiselect1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          []
+        )
+
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["foo", "bar"],
+          { fromUi: true },
+          undefined
+        )
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "tags=foo&tags=bar"
+        )
+      })
+
+      it("syncs string array with comma format", () => {
+        const widget = { id: "multiselect1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          [],
+          "comma"
+        )
+
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["foo", "bar"],
+          { fromUi: true },
+          undefined
+        )
+
+        // Comma is URL-encoded by URLSearchParams.toString()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("tags=foo%2Cbar")
+      })
+
+      it("syncs double array with repeated params", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100]
+        )
+
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [10, 90],
+          { fromUi: true },
+          undefined
+        )
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "range=10&range=90"
+        )
+      })
+
+      it("filters out invalid double array values", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100]
+        )
+
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [10, NaN, 90],
+          { fromUi: true },
+          undefined
+        )
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "range=10&range=90"
+        )
+      })
+
+      it("clears URL param when array is empty", () => {
+        const widget = { id: "multiselect1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          []
+        )
+
+        widgetMgr.setStringArrayValue(widget, [], { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+    })
+
+    describe("setQueryParamsChangeHandler", () => {
+      it("calls handler when URL changes", () => {
+        const handler = vi.fn()
+        widgetMgr.setQueryParamsChangeHandler(handler)
+
+        const widget = { id: "checkbox1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "checkbox1",
+          "enabled",
+          "bool_value",
+          false
+        )
+
+        widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+
+        expect(handler).toHaveBeenCalledWith("enabled=true")
+      })
+    })
+  })
 })

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1651,6 +1651,21 @@ describe("Trigger JSON payloads (aggregated)", () => {
         expect(window.history.replaceState).toHaveBeenCalled()
         expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
       })
+
+      it("clears URL param when nullable value is set to null", () => {
+        const widget = { id: "number1", formId: "" }
+        widgetMgr.registerQueryParamBinding("number1", "count", "int_value", 0)
+
+        // Set a value first
+        widgetMgr.setIntValue(widget, 5, { fromUi: true }, undefined)
+        vi.clearAllMocks()
+
+        // Set to null (widget cleared)
+        widgetMgr.setIntValue(widget, null, { fromUi: true }, undefined)
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
     })
 
     describe("URL sync with options (index-based widgets)", () => {
@@ -1703,203 +1718,245 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "tags=Apple&tags=Cherry"
         )
       })
-    })
 
-    describe("URL sync for array values", () => {
-      it("syncs string array with repeated params", () => {
-        const widget = { id: "multiselect1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "multiselect1",
-          "tags",
-          "string_array_value",
-          []
-        )
+      describe("URL sync for array values", () => {
+        it("syncs string array with repeated params", () => {
+          const widget = { id: "multiselect1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "multiselect1",
+            "tags",
+            "string_array_value",
+            []
+          )
 
-        widgetMgr.setStringArrayValue(
-          widget,
-          ["foo", "bar"],
-          { fromUi: true },
-          undefined
-        )
+          widgetMgr.setStringArrayValue(
+            widget,
+            ["foo", "bar"],
+            { fromUi: true },
+            undefined
+          )
 
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-          "tags=foo&tags=bar"
-        )
-      })
-
-      it("syncs string array with comma format", () => {
-        const widget = { id: "multiselect1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "multiselect1",
-          "tags",
-          "string_array_value",
-          [],
-          "comma"
-        )
-
-        widgetMgr.setStringArrayValue(
-          widget,
-          ["foo", "bar"],
-          { fromUi: true },
-          undefined
-        )
-
-        // Comma is URL-encoded by URLSearchParams.toString()
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("tags=foo%2Cbar")
-      })
-
-      it("syncs double array with repeated params", () => {
-        const widget = { id: "slider1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "slider1",
-          "range",
-          "double_array_value",
-          [0, 100]
-        )
-
-        widgetMgr.setDoubleArrayValue(
-          widget,
-          [10, 90],
-          { fromUi: true },
-          undefined
-        )
-
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-          "range=10&range=90"
-        )
-      })
-
-      it("filters out invalid double array values", () => {
-        const widget = { id: "slider1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "slider1",
-          "range",
-          "double_array_value",
-          [0, 100]
-        )
-
-        widgetMgr.setDoubleArrayValue(
-          widget,
-          [10, NaN, 90],
-          { fromUi: true },
-          undefined
-        )
-
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-          "range=10&range=90"
-        )
-      })
-
-      it("clears URL param when array is empty", () => {
-        const widget = { id: "multiselect1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "multiselect1",
-          "tags",
-          "string_array_value",
-          []
-        )
-
-        widgetMgr.setStringArrayValue(widget, [], { fromUi: true }, undefined)
-
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-      })
-    })
-
-    describe("handler edge cases", () => {
-      it("gracefully handles no handler set", () => {
-        // Create a new widgetMgr without setting a handler
-        const mgr = new WidgetStateManager({
-          sendRerunBackMsg: vi.fn(),
-          formsDataChanged: vi.fn(),
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "tags=foo&tags=bar"
+          )
         })
 
-        const widget = { id: "checkbox1", formId: "" }
-        mgr.registerQueryParamBinding(
-          "checkbox1",
-          "enabled",
-          "bool_value",
-          false
-        )
+        it("syncs string array with comma format", () => {
+          const widget = { id: "multiselect1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "multiselect1",
+            "tags",
+            "string_array_value",
+            [],
+            "comma"
+          )
 
-        // Should not throw when no handler is set
-        expect(() => {
-          mgr.setBoolValue(widget, true, { fromUi: true }, undefined)
-        }).not.toThrow()
+          widgetMgr.setStringArrayValue(
+            widget,
+            ["foo", "bar"],
+            { fromUi: true },
+            undefined
+          )
+
+          // Comma is URL-encoded by URLSearchParams.toString()
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "tags=foo%2Cbar"
+          )
+        })
+
+        it("syncs double array with options (select_slider)", () => {
+          const widget = { id: "select_slider1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "select_slider1",
+            "range",
+            "double_array_value",
+            [0, 2],
+            undefined,
+            ["Small", "Medium", "Large"]
+          )
+
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [1, 2],
+            { fromUi: true },
+            undefined
+          )
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "range=Medium&range=Large"
+          )
+        })
+
+        it("syncs double array with repeated params", () => {
+          const widget = { id: "slider1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "slider1",
+            "range",
+            "double_array_value",
+            [0, 100]
+          )
+
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [10, 90],
+            { fromUi: true },
+            undefined
+          )
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "range=10&range=90"
+          )
+        })
+
+        it("filters out invalid double array values", () => {
+          const widget = { id: "slider1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "slider1",
+            "range",
+            "double_array_value",
+            [0, 100]
+          )
+
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [10, NaN, 90],
+            { fromUi: true },
+            undefined
+          )
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "range=10&range=90"
+          )
+        })
+
+        it("clears URL param when array is empty", () => {
+          const widget = { id: "multiselect1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "multiselect1",
+            "tags",
+            "string_array_value",
+            []
+          )
+
+          widgetMgr.setStringArrayValue(
+            widget,
+            [],
+            { fromUi: true },
+            undefined
+          )
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+        })
       })
-    })
 
-    describe("filterParamsForPageChange", () => {
-      it("returns only embed params when no widgets are bound", () => {
-        const result = widgetMgr.filterParamsForPageChange("embed=true")
-        expect(result).toBe("embed=true")
+      describe("handler edge cases", () => {
+        it("gracefully handles no handler set", () => {
+          // Create a new widgetMgr without setting a handler
+          const mgr = new WidgetStateManager({
+            sendRerunBackMsg: vi.fn(),
+            formsDataChanged: vi.fn(),
+          })
+
+          const widget = { id: "checkbox1", formId: "" }
+          mgr.registerQueryParamBinding(
+            "checkbox1",
+            "enabled",
+            "bool_value",
+            false
+          )
+
+          // Should not throw when no handler is set
+          expect(() => {
+            mgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+          }).not.toThrow()
+        })
       })
 
-      it("returns empty string when no embed params and no bound widgets", () => {
-        const result = widgetMgr.filterParamsForPageChange("")
-        expect(result).toBe("")
-      })
+      describe("filterParamsForPageChange", () => {
+        it("returns only embed params when no widgets are bound", () => {
+          const result = widgetMgr.filterParamsForPageChange("embed=true")
+          expect(result).toBe("embed=true")
+        })
 
-      it("preserves bound widget params from current URL", () => {
-        // Register a binding
-        widgetMgr.registerQueryParamBinding(
-          "widget1",
-          "my_key",
-          "string_value",
-          "default"
-        )
+        it("returns empty string when no embed params and no bound widgets", () => {
+          const result = widgetMgr.filterParamsForPageChange("")
+          expect(result).toBe("")
+        })
 
-        // Set the widget value to update URL
-        const widget = { id: "widget1", formId: "" }
-        widgetMgr.setStringValue(
-          widget,
-          "my_value",
-          { fromUi: true },
-          undefined
-        )
+        it("preserves bound widget params from current URL", () => {
+          // Register a binding
+          widgetMgr.registerQueryParamBinding(
+            "widget1",
+            "my_key",
+            "string_value",
+            "default"
+          )
 
-        // Now filter - should preserve the bound param
-        const result = widgetMgr.filterParamsForPageChange("")
-        expect(result).toBe("my_key=my_value")
-      })
+          // Set the widget value to update URL
+          const widget = { id: "widget1", formId: "" }
+          widgetMgr.setStringValue(
+            widget,
+            "my_value",
+            { fromUi: true },
+            undefined
+          )
 
-      it("combines embed params with bound widget params", () => {
-        // Register a binding
-        widgetMgr.registerQueryParamBinding(
-          "widget1",
-          "color",
-          "string_value",
-          "red"
-        )
+          // Now filter - should preserve the bound param
+          const result = widgetMgr.filterParamsForPageChange("")
+          expect(result).toBe("my_key=my_value")
+        })
 
-        // Set the widget value
-        const widget = { id: "widget1", formId: "" }
-        widgetMgr.setStringValue(widget, "blue", { fromUi: true }, undefined)
+        it("combines embed params with bound widget params", () => {
+          // Register a binding
+          widgetMgr.registerQueryParamBinding(
+            "widget1",
+            "color",
+            "string_value",
+            "red"
+          )
 
-        // Filter with embed params
-        const result = widgetMgr.filterParamsForPageChange("embed=true")
-        expect(result).toBe("embed=true&color=blue")
-      })
+          // Set the widget value
+          const widget = { id: "widget1", formId: "" }
+          widgetMgr.setStringValue(widget, "blue", { fromUi: true }, undefined)
 
-      it("preserves multiple bound widget params", () => {
-        // Register multiple bindings
-        widgetMgr.registerQueryParamBinding(
-          "widget1",
-          "name",
-          "string_value",
-          ""
-        )
-        widgetMgr.registerQueryParamBinding("widget2", "count", "int_value", 0)
+          // Filter with embed params
+          const result = widgetMgr.filterParamsForPageChange("embed=true")
+          expect(result).toBe("embed=true&color=blue")
+        })
 
-        // Set widget values
-        const widget1 = { id: "widget1", formId: "" }
-        const widget2 = { id: "widget2", formId: "" }
-        widgetMgr.setStringValue(widget1, "test", { fromUi: true }, undefined)
-        widgetMgr.setIntValue(widget2, 42, { fromUi: true }, undefined)
+        it("preserves multiple bound widget params", () => {
+          // Register multiple bindings
 
-        // Filter - should preserve both bound params
-        const result = widgetMgr.filterParamsForPageChange("")
-        expect(result).toContain("name=test")
-        expect(result).toContain("count=42")
+          widgetMgr.registerQueryParamBinding(
+            "widget1",
+            "name",
+            "string_value",
+            ""
+          )
+          widgetMgr.registerQueryParamBinding(
+            "widget2",
+            "count",
+            "int_value",
+            0
+          )
+
+          // Set widget values
+          const widget1 = { id: "widget1", formId: "" }
+
+          const widget2 = { id: "widget2", formId: "" }
+          widgetMgr.setStringValue(
+            widget1,
+            "test",
+            { fromUi: true },
+            undefined
+          )
+          widgetMgr.setIntValue(widget2, 42, { fromUi: true }, undefined)
+
+          // Filter - should preserve both bound params
+          const result = widgetMgr.filterParamsForPageChange("")
+          expect(result).toContain("name=test")
+          expect(result).toContain("count=42")
+        })
       })
     })
   })

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1439,8 +1439,14 @@ describe("Trigger JSON payloads (aggregated)", () => {
 
   describe("Query Param Binding", () => {
     let mockOnQueryParamsChange: Mock
+    let originalLocation: Location
+    let originalReplaceState: typeof window.history.replaceState
 
     beforeEach(() => {
+      // Store originals for cleanup
+      originalLocation = window.location
+      originalReplaceState = window.history.replaceState
+
       mockOnQueryParamsChange = vi.fn()
       widgetMgr.setQueryParamsChangeHandler(mockOnQueryParamsChange)
       // Mock window.history.replaceState to capture URL changes
@@ -1455,6 +1461,16 @@ describe("Trigger JSON payloads (aggregated)", () => {
         },
         configurable: true,
       })
+    })
+
+    afterEach(() => {
+      // Restore original window.location and history.replaceState
+      Object.defineProperty(window, "location", {
+        value: originalLocation,
+        configurable: true,
+        writable: true,
+      })
+      window.history.replaceState = originalReplaceState
     })
 
     describe("registerQueryParamBinding", () => {
@@ -1520,7 +1536,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
         {
           type: "bool",
           paramKey: "enabled",
-          valueType: "bool_value",
+          valueType: "bool_value" as const,
           defaultVal: false,
           testVal: true,
           expected: "enabled=true",
@@ -1528,7 +1544,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
         {
           type: "int",
           paramKey: "count",
-          valueType: "int_value",
+          valueType: "int_value" as const,
           defaultVal: 0,
           testVal: 42,
           expected: "count=42",
@@ -1536,7 +1552,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
         {
           type: "double",
           paramKey: "value",
-          valueType: "double_value",
+          valueType: "double_value" as const,
           defaultVal: 0,
           testVal: 3.14,
           expected: "value=3.14",
@@ -1544,7 +1560,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
         {
           type: "string",
           paramKey: "name",
-          valueType: "string_value",
+          valueType: "string_value" as const,
           defaultVal: "",
           testVal: "Alice",
           expected: "name=Alice",
@@ -1564,28 +1580,23 @@ describe("Trigger JSON payloads (aggregated)", () => {
           if (valueType === "bool_value") {
             widgetMgr.setBoolValue(
               widget,
-              testVal as boolean,
+              testVal,
               { fromUi: true },
               undefined
             )
           } else if (valueType === "int_value") {
-            widgetMgr.setIntValue(
-              widget,
-              testVal as number,
-              { fromUi: true },
-              undefined
-            )
+            widgetMgr.setIntValue(widget, testVal, { fromUi: true }, undefined)
           } else if (valueType === "double_value") {
             widgetMgr.setDoubleValue(
               widget,
-              testVal as number,
+              testVal,
               { fromUi: true },
               undefined
             )
           } else {
             widgetMgr.setStringValue(
               widget,
-              testVal as string,
+              testVal,
               { fromUi: true },
               undefined
             )
@@ -1814,6 +1825,81 @@ describe("Trigger JSON payloads (aggregated)", () => {
         expect(() => {
           mgr.setBoolValue(widget, true, { fromUi: true }, undefined)
         }).not.toThrow()
+      })
+    })
+
+    describe("filterParamsForPageChange", () => {
+      it("returns only embed params when no widgets are bound", () => {
+        const result = widgetMgr.filterParamsForPageChange("embed=true")
+        expect(result).toBe("embed=true")
+      })
+
+      it("returns empty string when no embed params and no bound widgets", () => {
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toBe("")
+      })
+
+      it("preserves bound widget params from current URL", () => {
+        // Register a binding
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default"
+        )
+
+        // Set the widget value to update URL
+        const widget = { id: "widget1", formId: "" }
+        widgetMgr.setStringValue(
+          widget,
+          "my_value",
+          { fromUi: true },
+          undefined
+        )
+
+        // Now filter - should preserve the bound param
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toBe("my_key=my_value")
+      })
+
+      it("combines embed params with bound widget params", () => {
+        // Register a binding
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "color",
+          "string_value",
+          "red"
+        )
+
+        // Set the widget value
+        const widget = { id: "widget1", formId: "" }
+        widgetMgr.setStringValue(widget, "blue", { fromUi: true }, undefined)
+
+        // Filter with embed params
+        const result = widgetMgr.filterParamsForPageChange("embed=true")
+        expect(result).toBe("embed=true&color=blue")
+      })
+
+      it("preserves multiple bound widget params", () => {
+        // Register multiple bindings
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "name",
+          "string_value",
+          ""
+        )
+        widgetMgr.registerQueryParamBinding("widget2", "count", "int_value", 0)
+
+        // Set widget values
+        const widget1 = { id: "widget1", formId: "" }
+        const widget2 = { id: "widget2", formId: "" }
+        widgetMgr.setStringValue(widget1, "test", { fromUi: true }, undefined)
+        widgetMgr.setIntValue(widget2, 42, { fromUi: true }, undefined)
+
+        // Filter - should preserve both bound params
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toContain("name=test")
+        expect(result).toContain("count=42")
       })
     })
   })

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1516,62 +1516,87 @@ describe("Trigger JSON payloads (aggregated)", () => {
     })
 
     describe("URL sync for scalar values", () => {
-      it("syncs bool value to URL", () => {
-        const widget = { id: "checkbox1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "checkbox1",
-          "enabled",
-          "bool_value",
-          false
-        )
+      it.each([
+        {
+          type: "bool",
+          paramKey: "enabled",
+          valueType: "bool_value",
+          defaultVal: false,
+          testVal: true,
+          expected: "enabled=true",
+        },
+        {
+          type: "int",
+          paramKey: "count",
+          valueType: "int_value",
+          defaultVal: 0,
+          testVal: 42,
+          expected: "count=42",
+        },
+        {
+          type: "double",
+          paramKey: "value",
+          valueType: "double_value",
+          defaultVal: 0,
+          testVal: 3.14,
+          expected: "value=3.14",
+        },
+        {
+          type: "string",
+          paramKey: "name",
+          valueType: "string_value",
+          defaultVal: "",
+          testVal: "Alice",
+          expected: "name=Alice",
+        },
+      ])(
+        "syncs $type value to URL",
+        ({ paramKey, valueType, defaultVal, testVal, expected }) => {
+          const widget = { id: "widget1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "widget1",
+            paramKey,
+            valueType,
+            defaultVal
+          )
 
-        widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+          // Call the appropriate setter based on value type
+          if (valueType === "bool_value") {
+            widgetMgr.setBoolValue(
+              widget,
+              testVal as boolean,
+              { fromUi: true },
+              undefined
+            )
+          } else if (valueType === "int_value") {
+            widgetMgr.setIntValue(
+              widget,
+              testVal as number,
+              { fromUi: true },
+              undefined
+            )
+          } else if (valueType === "double_value") {
+            widgetMgr.setDoubleValue(
+              widget,
+              testVal as number,
+              { fromUi: true },
+              undefined
+            )
+          } else {
+            widgetMgr.setStringValue(
+              widget,
+              testVal as string,
+              { fromUi: true },
+              undefined
+            )
+          }
 
-        expect(window.history.replaceState).toHaveBeenCalled()
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("enabled=true")
-      })
+          expect(window.history.replaceState).toHaveBeenCalled()
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(expected)
+        }
+      )
 
-      it("syncs int value to URL", () => {
-        const widget = { id: "number1", formId: "" }
-        widgetMgr.registerQueryParamBinding("number1", "count", "int_value", 0)
-
-        widgetMgr.setIntValue(widget, 42, { fromUi: true }, undefined)
-
-        expect(window.history.replaceState).toHaveBeenCalled()
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("count=42")
-      })
-
-      it("syncs double value to URL", () => {
-        const widget = { id: "slider1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "slider1",
-          "value",
-          "double_value",
-          0
-        )
-
-        widgetMgr.setDoubleValue(widget, 3.14, { fromUi: true }, undefined)
-
-        expect(window.history.replaceState).toHaveBeenCalled()
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("value=3.14")
-      })
-
-      it("syncs string value to URL", () => {
-        const widget = { id: "text1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "text1",
-          "name",
-          "string_value",
-          ""
-        )
-
-        widgetMgr.setStringValue(widget, "Alice", { fromUi: true }, undefined)
-
-        expect(window.history.replaceState).toHaveBeenCalled()
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("name=Alice")
-      })
-
-      it("does not sync when value is from backend", () => {
+      it("does not sync when value is from backend (fromUi: false)", () => {
         const widget = { id: "checkbox1", formId: "" }
         widgetMgr.registerQueryParamBinding(
           "checkbox1",
@@ -1581,6 +1606,16 @@ describe("Trigger JSON payloads (aggregated)", () => {
         )
 
         widgetMgr.setBoolValue(widget, true, { fromUi: false }, undefined)
+
+        expect(window.history.replaceState).not.toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+      })
+
+      it("does not sync unbound widget", () => {
+        const widget = { id: "unbound_widget", formId: "" }
+        // Don't register any binding for this widget
+
+        widgetMgr.setStringValue(widget, "test", { fromUi: true }, undefined)
 
         expect(window.history.replaceState).not.toHaveBeenCalled()
         expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
@@ -1759,22 +1794,26 @@ describe("Trigger JSON payloads (aggregated)", () => {
       })
     })
 
-    describe("setQueryParamsChangeHandler", () => {
-      it("calls handler when URL changes", () => {
-        const handler = vi.fn()
-        widgetMgr.setQueryParamsChangeHandler(handler)
+    describe("handler edge cases", () => {
+      it("gracefully handles no handler set", () => {
+        // Create a new widgetMgr without setting a handler
+        const mgr = new WidgetStateManager({
+          sendRerunBackMsg: vi.fn(),
+          formsDataChanged: vi.fn(),
+        })
 
         const widget = { id: "checkbox1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
+        mgr.registerQueryParamBinding(
           "checkbox1",
           "enabled",
           "bool_value",
           false
         )
 
-        widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
-
-        expect(handler).toHaveBeenCalledWith("enabled=true")
+        // Should not throw when no handler is set
+        expect(() => {
+          mgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+        }).not.toThrow()
       })
     })
   })

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1509,6 +1509,49 @@ describe("Trigger JSON payloads (aggregated)", () => {
 
         expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
       })
+
+      it("cleans up old binding when different widget binds to same paramKey", () => {
+        // First widget binds to "my_key"
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default1"
+        )
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
+
+        // Second widget binds to the same "my_key" - should clean up widget1
+        widgetMgr.registerQueryParamBinding(
+          "widget2",
+          "my_key",
+          "string_value",
+          "default2"
+        )
+
+        // widget2 should be bound, widget1 should be cleaned up
+        expect(widgetMgr.hasQueryParamBinding("widget2")).toBe(true)
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(false)
+      })
+
+      it("allows same widget to re-register with same paramKey", () => {
+        // Widget registers
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default1"
+        )
+
+        // Same widget re-registers (e.g., on re-render) - should not break
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default2"
+        )
+
+        expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
+      })
     })
 
     describe("unregisterQueryParamBinding", () => {
@@ -1829,6 +1872,87 @@ describe("Trigger JSON payloads (aggregated)", () => {
           )
         })
 
+        it("clears URL param when all double array values are invalid (fromUi: true)", () => {
+          const widget = { id: "slider1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "slider1",
+            "range",
+            "double_array_value",
+            [0, 100]
+          )
+
+          // First set a valid value to put something in the URL
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [10, 90],
+            { fromUi: true },
+            undefined
+          )
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "range=10&range=90"
+          )
+
+          // Now set all invalid values - should clear the URL
+          mockOnQueryParamsChange.mockClear()
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [NaN, NaN],
+            { fromUi: true },
+            undefined
+          )
+
+          // URL should be cleared (empty string means param removed)
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+          // State should NOT be updated when all values are invalid (previous value remains)
+          expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([10, 90])
+        })
+
+        it("does not update URL when all double array values are invalid (fromUi: false)", () => {
+          const widget = { id: "slider1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "slider1",
+            "range",
+            "double_array_value",
+            [0, 100]
+          )
+
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [NaN, NaN],
+            { fromUi: false },
+            undefined
+          )
+
+          // URL should NOT be modified for backend changes
+          expect(window.history.replaceState).not.toHaveBeenCalled()
+          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+          // State should NOT be updated when all values are invalid
+          expect(widgetMgr.getDoubleArrayValue(widget)).toBeUndefined()
+        })
+
+        it("updates state but not URL for valid double array values (fromUi: false)", () => {
+          const widget = { id: "slider1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "slider1",
+            "range",
+            "double_array_value",
+            [0, 100]
+          )
+
+          widgetMgr.setDoubleArrayValue(
+            widget,
+            [25, 75],
+            { fromUi: false },
+            undefined
+          )
+
+          // URL should NOT be modified for backend changes
+          expect(window.history.replaceState).not.toHaveBeenCalled()
+          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+          // State SHOULD be updated
+          expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([25, 75])
+        })
+
         it("clears URL param when array is empty", () => {
           const widget = { id: "multiselect1", formId: "" }
           widgetMgr.registerQueryParamBinding(
@@ -1838,6 +1962,19 @@ describe("Trigger JSON payloads (aggregated)", () => {
             []
           )
 
+          // First set a value to put something in the URL
+          widgetMgr.setStringArrayValue(
+            widget,
+            ["tag1", "tag2"],
+            { fromUi: true },
+            undefined
+          )
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+            "tags=tag1&tags=tag2"
+          )
+
+          // Now clear the array - should clear the URL param
+          mockOnQueryParamsChange.mockClear()
           widgetMgr.setStringArrayValue(
             widget,
             [],

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -657,13 +657,9 @@ export class WidgetStateManager {
     fragmentId: string | undefined
   ): void {
     // Filter out invalid values (NaN, undefined, null) before storing.
-    // If all values are invalid, skip the update entirely.
     const validValue = value.filter(
       v => v !== undefined && v !== null && !Number.isNaN(v)
     )
-    if (validValue.length === 0) {
-      return
-    }
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({
       data: validValue,
     })
@@ -1162,14 +1158,17 @@ export class WidgetStateManager {
     // instead of "Red" === "0").
     let normalizedDefault = defaultValue
     if (options && options.length > 0) {
-      if (typeof defaultValue === "number" && options[defaultValue]) {
+      if (
+        typeof defaultValue === "number" &&
+        options[defaultValue] !== undefined
+      ) {
         // Scalar index -> option string
         normalizedDefault = options[defaultValue]
       } else if (Array.isArray(defaultValue)) {
         // Array of indices -> array of option strings
         normalizedDefault = defaultValue
           .map(idx =>
-            typeof idx === "number" && options[idx]
+            typeof idx === "number" && options[idx] !== undefined
               ? options[idx]
               : String(idx)
           )

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -608,8 +608,13 @@ export class WidgetStateManager {
     const validValue = value.filter(
       v => v !== undefined && v !== null && !Number.isNaN(v)
     )
-    // If all values are invalid, clear URL params but skip state update.
+    // If all values are invalid, preserve previous state and warn.
+    // This can happen if user code passes NaN values (e.g., from empty DataFrame operations).
     if (validValue.length === 0) {
+      LOG.warn(
+        `setDoubleArrayValue: All values were invalid (NaN/null/undefined) ` +
+          `for widget "${widget.id}". Preserving previous state.`
+      )
       this.maybeSyncValueToUrl(widget.id, source, [])
       return
     }
@@ -1063,6 +1068,12 @@ export class WidgetStateManager {
 
   /**
    * Register a widget's binding to a URL query parameter.
+   *
+   * If another widget was previously bound to this paramKey, its binding is
+   * replaced and the old widget's entry in boundWidgets is cleaned up. This
+   * mirrors the backend behavior in QueryParams.bind_widget() which also
+   * handles duplicate paramKey cleanup.
+   *
    * @param options - For index-based widgets, the formatted option strings.
    *   TODO(query-params): Remove options param after wire format changes.
    */
@@ -1074,6 +1085,13 @@ export class WidgetStateManager {
     urlFormat?: "comma" | "repeated",
     options?: string[]
   ): void {
+    // Clean up old binding if a different widget was bound to this paramKey.
+    // This keeps boundWidgets and paramKeyToWidgetId consistent.
+    const existingWidgetId = this.paramKeyToWidgetId.get(paramKey)
+    if (existingWidgetId && existingWidgetId !== widgetId) {
+      this.boundWidgets.delete(existingWidgetId)
+    }
+
     // TODO(query-params): Remove options normalization after wire format changes
     // from index-based to string-based values for applicable widgets.
     // Normalize defaultValue to URL-compatible format for index-based widgets.
@@ -1296,6 +1314,12 @@ export class WidgetStateManager {
       skipNull: true,
       skipEmptyString: false,
     })
+
+    // Skip replaceState if the URL wouldn't actually change
+    const currentSearch = window.location.search.replace(/^\?/, "")
+    if (newSearch === currentSearch) {
+      return
+    }
 
     const newUrl = new URL(window.location.href)
     newUrl.search = newSearch

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -48,11 +48,24 @@ export interface WidgetInfo {
 }
 
 /**
+ * Valid widget value types for query param bindings.
+ * These correspond to the WidgetState proto value field names.
+ */
+export type WidgetValueType =
+  | "bool_value"
+  | "int_value"
+  | "double_value"
+  | "string_value"
+  | "string_array_value"
+  | "int_array_value"
+  | "double_array_value"
+
+/**
  * Binding information for a widget that syncs to URL query parameters.
  */
 export interface QueryParamBinding {
   paramKey: string
-  valueType: string // e.g., "bool_value", "string_value", etc.
+  valueType: WidgetValueType
   defaultValue: unknown
   urlFormat?: "comma" | "repeated" // How to serialize arrays
   options?: string[] // For index-based widgets, the formatted option strings
@@ -1116,7 +1129,7 @@ export class WidgetStateManager {
   public registerQueryParamBinding(
     widgetId: string,
     paramKey: string,
-    valueType: string,
+    valueType: WidgetValueType,
     defaultValue: unknown,
     urlFormat?: "comma" | "repeated",
     options?: string[]
@@ -1270,7 +1283,11 @@ export class WidgetStateManager {
     this.notifyQueryParamsChange()
   }
 
-  /** Convert a primitive value to string safely. */
+  /**
+   * Convert a primitive value to string safely.
+   * @returns The string representation, or undefined if value is not a primitive
+   *          (e.g., null, undefined, object, array).
+   */
   private toStringPrimitive(value: unknown): string | undefined {
     if (
       typeof value === "string" ||
@@ -1296,14 +1313,22 @@ export class WidgetStateManager {
     return valueStr === defaultStr
   }
 
-  /** Check if array equals the widget's default array (with type coercion). */
+  /**
+   * Check if array equals the widget's default array (with type coercion).
+   *
+   * Handles edge cases where the widget's default may be a scalar but the
+   * current value is an array (e.g., slider with value=[5] and defaultValue=5),
+   * or where an empty array should match a non-array default (cleared state).
+   */
   private isDefaultArrayValue(
     values: string[],
     binding: QueryParamBinding
   ): boolean {
     const defaultValue = binding.defaultValue
     if (!Array.isArray(defaultValue)) {
+      // Empty array matches non-array default (widget cleared to empty state)
       if (values.length === 0) return true
+      // Single-element array matches scalar default (e.g., slider: [5] == 5)
       if (values.length === 1 && defaultValue !== null) {
         const defaultStr = this.toStringPrimitive(defaultValue)
         return defaultStr !== undefined && values[0] === defaultStr

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -633,14 +633,14 @@ export class WidgetStateManager {
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
 
-    // Sync to URL if bound and from UI (repeated params for consistency)
+    // Sync to URL if bound and from UI
     if (source.fromUi) {
       const binding = this.boundWidgets.get(widget.id)
-      // For select_slider: convert indices to option strings for human-readable URLs
       if (binding?.options && binding.options.length > 0) {
-        const optionStrings = validValue.map(
-          idx => binding.options?.[idx] ?? String(idx)
-        )
+        // For select_slider: convert indices to option strings, filtering invalid
+        const optionStrings = validValue
+          .map(idx => binding.options?.[idx])
+          .filter((s): s is string => s !== undefined)
         this.syncRepeatedArrayToUrlIfBound(widget.id, optionStrings)
       } else {
         // Regular slider: use numeric values
@@ -677,241 +677,22 @@ export class WidgetStateManager {
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
 
-    // Sync to URL if bound and from UI (repeated params for consistency)
+    // Sync to URL if bound and from UI
     if (source.fromUi) {
       const binding = this.boundWidgets.get(widget.id)
-      // If binding has options, convert indices to option strings for human-readable URLs
       if (binding?.options) {
+        // Convert indices to option strings, filtering out invalid indices
         const optionStrings = value
           .map(idx => binding.options?.[idx])
           .filter((s): s is string => s !== undefined)
         this.syncRepeatedArrayToUrlIfBound(widget.id, optionStrings)
       } else {
-        // Fallback to index values
         this.syncRepeatedArrayToUrlIfBound(
           widget.id,
           value.map(v => String(v))
         )
       }
     }
-  }
-
-  // Query Param Binding Methods
-
-  /**
-   * Register a widget's binding to a URL query parameter.
-   * Called by widget components on mount when they have a queryParamKey.
-   * @param options - For index-based widgets (radio, pills, etc.), the formatted option strings
-   */
-  public registerQueryParamBinding(
-    widgetId: string,
-    paramKey: string,
-    valueType: string,
-    defaultValue: unknown,
-    urlFormat?: "comma" | "repeated",
-    options?: string[]
-  ): void {
-    this.boundWidgets.set(widgetId, {
-      paramKey,
-      valueType,
-      defaultValue,
-      urlFormat,
-      options,
-    })
-    this.paramKeyToWidgetId.set(paramKey, widgetId)
-  }
-
-  /**
-   * Unregister a widget's binding.
-   * Called by widget components on unmount.
-   * Note: We do NOT clear the URL parameter here because:
-   * 1. In React strict mode, components mount/unmount multiple times
-   * 2. During Streamlit re-runs, widgets are recreated
-   * 3. The URL should persist for deep-linking purposes
-   * URL params are only cleared when the value changes to the default.
-   */
-  public unregisterQueryParamBinding(widgetId: string): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (binding) {
-      this.paramKeyToWidgetId.delete(binding.paramKey)
-      this.boundWidgets.delete(widgetId)
-    }
-  }
-
-  /**
-   * Check if a widget has a query param binding.
-   */
-  public hasQueryParamBinding(widgetId: string): boolean {
-    return this.boundWidgets.has(widgetId)
-  }
-
-  /**
-   * Set a callback to be notified when query params change.
-   * This is called by App.tsx to keep its queryParams state in sync.
-   */
-  public setQueryParamsChangeHandler(
-    handler: (queryString: string) => void
-  ): void {
-    this.onQueryParamsChange = handler
-  }
-
-  /**
-   * Notify App.tsx of query param changes so it can update its state.
-   * This is necessary for page navigation to preserve query params.
-   */
-  private notifyQueryParamsChange(): void {
-    if (this.onQueryParamsChange) {
-      const url = new URL(window.location.href)
-      this.onQueryParamsChange(url.searchParams.toString())
-    }
-  }
-
-  /**
-   * Sync a scalar value to URL if the widget is bound.
-   */
-  private syncToUrlIfBound(widgetId: string, value: string): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (!binding) return
-
-    // Don't sync default values to URL (keep URLs clean)
-    if (this.isDefaultValue(value, binding)) {
-      this.clearUrlParam(binding.paramKey)
-      return
-    }
-
-    const url = new URL(window.location.href)
-    url.searchParams.set(binding.paramKey, value)
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
-
-  /**
-   * Sync a comma-separated array value to URL if the widget is bound.
-   * Only used when urlFormat is explicitly set to "comma".
-   */
-  private syncCommaArrayToUrlIfBound(
-    widgetId: string,
-    values: string[]
-  ): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (!binding) return
-
-    // Filter out invalid values like "undefined", "NaN", empty strings
-    const validValues = values.filter(
-      v => v !== "" && v !== "undefined" && v !== "NaN" && v !== "null"
-    )
-    if (validValues.length === 0) {
-      this.clearUrlParam(binding.paramKey)
-      return
-    }
-
-    // Don't sync default values to URL
-    if (this.isDefaultArrayValue(validValues, binding)) {
-      this.clearUrlParam(binding.paramKey)
-      return
-    }
-
-    const url = new URL(window.location.href)
-    url.searchParams.set(binding.paramKey, validValues.join(","))
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
-
-  /**
-   * Sync an array value to URL using repeated params if the widget is bound.
-   * Used for multiselect and pills multi-select.
-   */
-  private syncRepeatedArrayToUrlIfBound(
-    widgetId: string,
-    values: string[]
-  ): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (!binding) return
-
-    const url = new URL(window.location.href)
-    url.searchParams.delete(binding.paramKey)
-
-    // Don't sync empty or default values
-    if (values.length === 0 || this.isDefaultArrayValue(values, binding)) {
-      window.history.replaceState({}, "", url.toString())
-      this.notifyQueryParamsChange()
-      return
-    }
-
-    // Repeated params: ?tags=a&tags=b
-    values.forEach(v => url.searchParams.append(binding.paramKey, v))
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
-
-  /**
-   * Clear a URL parameter.
-   */
-  private clearUrlParam(paramKey: string): void {
-    const url = new URL(window.location.href)
-    url.searchParams.delete(paramKey)
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
-
-  /**
-   * Check if a value equals the widget's default value.
-   * Handles type coercion since URL values are always strings.
-   */
-  /**
-   * Convert a value to string safely, handling primitives.
-   * Returns undefined for non-primitive types to avoid [object Object].
-   */
-  private toStringPrimitive(value: unknown): string | undefined {
-    if (
-      typeof value === "string" ||
-      typeof value === "number" ||
-      typeof value === "boolean"
-    ) {
-      return String(value)
-    }
-    return undefined
-  }
-
-  private isDefaultValue(value: unknown, binding: QueryParamBinding): boolean {
-    const defaultValue = binding.defaultValue
-    // Handle null/undefined
-    if (defaultValue === null || defaultValue === undefined) {
-      return value === null || value === undefined || value === ""
-    }
-    // Convert both to string for comparison (handles bool/number/string)
-    const valueStr = this.toStringPrimitive(value)
-    const defaultStr = this.toStringPrimitive(defaultValue)
-    if (valueStr === undefined || defaultStr === undefined) {
-      return false // Non-primitive types don't match by string comparison
-    }
-    return valueStr === defaultStr
-  }
-
-  /**
-   * Check if an array value equals the widget's default array value.
-   * Handles type coercion since URL values are always strings.
-   */
-  private isDefaultArrayValue(
-    values: string[],
-    binding: QueryParamBinding
-  ): boolean {
-    const defaultValue = binding.defaultValue
-    if (!Array.isArray(defaultValue)) {
-      // Default is not an array - check if values are empty or match single default
-      if (values.length === 0) return true
-      if (values.length === 1 && defaultValue !== null) {
-        const defaultStr = this.toStringPrimitive(defaultValue)
-        return defaultStr !== undefined && values[0] === defaultStr
-      }
-      return false
-    }
-    // Both are arrays - compare element by element as strings
-    if (values.length !== defaultValue.length) return false
-    return values.every((v, i) => {
-      const defaultStr = this.toStringPrimitive(defaultValue[i])
-      return defaultStr !== undefined && v === defaultStr
-    })
   }
 
   public getJsonValue(widget: WidgetInfo): string | undefined {
@@ -1324,6 +1105,180 @@ export class WidgetStateManager {
       this.scheduledFragmentId = undefined
       this.hasFragmentIdConflict = false
     }, 0)
+  }
+
+  // Query Param Binding Methods
+
+  /**
+   * Register a widget's binding to a URL query parameter.
+   * @param options - For index-based widgets, the formatted option strings
+   */
+  public registerQueryParamBinding(
+    widgetId: string,
+    paramKey: string,
+    valueType: string,
+    defaultValue: unknown,
+    urlFormat?: "comma" | "repeated",
+    options?: string[]
+  ): void {
+    this.boundWidgets.set(widgetId, {
+      paramKey,
+      valueType,
+      defaultValue,
+      urlFormat,
+      options,
+    })
+    this.paramKeyToWidgetId.set(paramKey, widgetId)
+  }
+
+  /**
+   * Unregister a widget's query param binding (called on unmount).
+   * Note: Does NOT clear the URL param to support React strict mode remounts.
+   */
+  public unregisterQueryParamBinding(widgetId: string): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (binding) {
+      this.paramKeyToWidgetId.delete(binding.paramKey)
+      this.boundWidgets.delete(widgetId)
+    }
+  }
+
+  /** Check if a widget has a query param binding. */
+  public hasQueryParamBinding(widgetId: string): boolean {
+    return this.boundWidgets.has(widgetId)
+  }
+
+  /** Set callback for query param changes (used by App.tsx). */
+  public setQueryParamsChangeHandler(
+    handler: (queryString: string) => void
+  ): void {
+    this.onQueryParamsChange = handler
+  }
+
+  /** Notify listener of URL query param changes. */
+  private notifyQueryParamsChange(): void {
+    if (this.onQueryParamsChange) {
+      const url = new URL(window.location.href)
+      this.onQueryParamsChange(url.searchParams.toString())
+    }
+  }
+
+  /** Sync a scalar value to URL if the widget is bound. */
+  private syncToUrlIfBound(widgetId: string, value: string): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    if (this.isDefaultValue(value, binding)) {
+      this.clearUrlParam(binding.paramKey)
+      return
+    }
+
+    const url = new URL(window.location.href)
+    url.searchParams.set(binding.paramKey, value)
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /** Sync a comma-separated array to URL (when urlFormat is "comma"). */
+  private syncCommaArrayToUrlIfBound(
+    widgetId: string,
+    values: string[]
+  ): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    const validValues = values.filter(
+      v => v !== "" && v !== "undefined" && v !== "NaN" && v !== "null"
+    )
+    if (
+      validValues.length === 0 ||
+      this.isDefaultArrayValue(validValues, binding)
+    ) {
+      this.clearUrlParam(binding.paramKey)
+      return
+    }
+
+    const url = new URL(window.location.href)
+    url.searchParams.set(binding.paramKey, validValues.join(","))
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /** Sync an array to URL using repeated params (?key=a&key=b). */
+  private syncRepeatedArrayToUrlIfBound(
+    widgetId: string,
+    values: string[]
+  ): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    const url = new URL(window.location.href)
+    url.searchParams.delete(binding.paramKey)
+
+    if (values.length === 0 || this.isDefaultArrayValue(values, binding)) {
+      window.history.replaceState({}, "", url.toString())
+      this.notifyQueryParamsChange()
+      return
+    }
+
+    values.forEach(v => url.searchParams.append(binding.paramKey, v))
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /** Clear a URL parameter. */
+  private clearUrlParam(paramKey: string): void {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(paramKey)
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /** Convert a primitive value to string safely. */
+  private toStringPrimitive(value: unknown): string | undefined {
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      return String(value)
+    }
+    return undefined
+  }
+
+  /** Check if value equals the widget's default (with type coercion). */
+  private isDefaultValue(value: unknown, binding: QueryParamBinding): boolean {
+    const defaultValue = binding.defaultValue
+    if (isNullOrUndefined(defaultValue)) {
+      return isNullOrUndefined(value) || value === ""
+    }
+    const valueStr = this.toStringPrimitive(value)
+    const defaultStr = this.toStringPrimitive(defaultValue)
+    if (valueStr === undefined || defaultStr === undefined) {
+      return false
+    }
+    return valueStr === defaultStr
+  }
+
+  /** Check if array equals the widget's default array (with type coercion). */
+  private isDefaultArrayValue(
+    values: string[],
+    binding: QueryParamBinding
+  ): boolean {
+    const defaultValue = binding.defaultValue
+    if (!Array.isArray(defaultValue)) {
+      if (values.length === 0) return true
+      if (values.length === 1 && defaultValue !== null) {
+        const defaultStr = this.toStringPrimitive(defaultValue)
+        return defaultStr !== undefined && values[0] === defaultStr
+      }
+      return false
+    }
+    if (values.length !== defaultValue.length) return false
+    return values.every((v, i) => {
+      const defaultStr = this.toStringPrimitive(defaultValue[i])
+      return defaultStr !== undefined && v === defaultStr
+    })
   }
 }
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -516,14 +516,21 @@ export class WidgetStateManager {
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
 
     // Sync to URL if bound and from UI
-    if (source.fromUi && value !== null) {
+    if (source.fromUi) {
       const binding = this.boundWidgets.get(widget.id)
-      // If binding has options, convert index to option string for human-readable URLs
-      const optionValue = binding?.options?.[value]
-      if (optionValue !== undefined) {
-        this.syncToUrlIfBound(widget.id, optionValue)
-      } else {
-        this.syncToUrlIfBound(widget.id, String(value))
+      if (binding) {
+        if (value === null) {
+          // Clear URL param when widget is cleared
+          this.clearUrlParam(binding.paramKey)
+        } else {
+          // If binding has options, convert index to option string for human-readable URLs
+          const optionValue = binding.options?.[value]
+          if (optionValue !== undefined) {
+            this.syncToUrlIfBound(widget.id, optionValue)
+          } else {
+            this.syncToUrlIfBound(widget.id, String(value))
+          }
+        }
       }
     }
   }
@@ -547,8 +554,16 @@ export class WidgetStateManager {
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
 
     // Sync to URL if bound and from UI
-    if (source.fromUi && value !== null) {
-      this.syncToUrlIfBound(widget.id, String(value))
+    if (source.fromUi) {
+      const binding = this.boundWidgets.get(widget.id)
+      if (binding) {
+        if (value === null) {
+          // Clear URL param when widget is cleared
+          this.clearUrlParam(binding.paramKey)
+        } else {
+          this.syncToUrlIfBound(widget.id, String(value))
+        }
+      }
     }
   }
 
@@ -571,8 +586,16 @@ export class WidgetStateManager {
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
 
     // Sync to URL if bound and from UI
-    if (source.fromUi && value !== null) {
-      this.syncToUrlIfBound(widget.id, value)
+    if (source.fromUi) {
+      const binding = this.boundWidgets.get(widget.id)
+      if (binding) {
+        if (value === null) {
+          // Clear URL param when widget is cleared
+          this.clearUrlParam(binding.paramKey)
+        } else {
+          this.syncToUrlIfBound(widget.id, value)
+        }
+      }
     }
   }
 
@@ -1134,10 +1157,30 @@ export class WidgetStateManager {
     urlFormat?: "comma" | "repeated",
     options?: string[]
   ): void {
+    // Normalize defaultValue to URL-compatible format for index-based widgets.
+    // This ensures default comparison works correctly (e.g., "Red" === "Red"
+    // instead of "Red" === "0").
+    let normalizedDefault = defaultValue
+    if (options && options.length > 0) {
+      if (typeof defaultValue === "number" && options[defaultValue]) {
+        // Scalar index -> option string
+        normalizedDefault = options[defaultValue]
+      } else if (Array.isArray(defaultValue)) {
+        // Array of indices -> array of option strings
+        normalizedDefault = defaultValue
+          .map(idx =>
+            typeof idx === "number" && options[idx]
+              ? options[idx]
+              : String(idx)
+          )
+          .filter((s): s is string => s !== undefined)
+      }
+    }
+
     this.boundWidgets.set(widgetId, {
       paramKey,
       valueType,
-      defaultValue,
+      defaultValue: normalizedDefault,
       urlFormat,
       options,
     })
@@ -1236,9 +1279,8 @@ export class WidgetStateManager {
     const binding = this.boundWidgets.get(widgetId)
     if (!binding) return
 
-    const validValues = values.filter(
-      v => v !== "" && v !== "undefined" && v !== "NaN" && v !== "null"
-    )
+    // Only filter empty strings - user-provided values like "null" are legitimate
+    const validValues = values.filter(v => v !== "")
     if (
       validValues.length === 0 ||
       this.isDefaultArrayValue(validValues, binding)

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -69,6 +69,8 @@ export interface QueryParamBinding {
   valueType: WidgetValueType
   defaultValue: unknown
   urlFormat?: "comma" | "repeated" // How to serialize arrays
+  // TODO(query-params): Remove options field after wire format changes from
+  // index-based to string-based values for applicable widgets (selectbox, pills, etc.)
   options?: string[] // For index-based widgets, the formatted option strings
 }
 
@@ -1059,7 +1061,8 @@ export class WidgetStateManager {
 
   /**
    * Register a widget's binding to a URL query parameter.
-   * @param options - For index-based widgets, the formatted option strings
+   * @param options - For index-based widgets, the formatted option strings.
+   *   TODO(query-params): Remove options param after wire format changes.
    */
   public registerQueryParamBinding(
     widgetId: string,
@@ -1069,6 +1072,8 @@ export class WidgetStateManager {
     urlFormat?: "comma" | "repeated",
     options?: string[]
   ): void {
+    // TODO(query-params): Remove options normalization after wire format changes
+    // from index-based to string-based values for applicable widgets.
     // Normalize defaultValue to URL-compatible format for index-based widgets.
     // This ensures default comparison works correctly (e.g., "Red" === "Red"
     // instead of "Red" === "0").
@@ -1190,6 +1195,7 @@ export class WidgetStateManager {
       case "double_value":
         return String(value as number)
 
+      // TODO(query-params): Remove options lookup after wire format changes.
       case "int_value": {
         const num = value as number
         return binding.options?.[num] ?? String(num)
@@ -1203,6 +1209,7 @@ export class WidgetStateManager {
         return arr
       }
 
+      // TODO(query-params): Remove options lookup after wire format changes.
       case "int_array_value": {
         const arr = value as number[]
         return binding.options
@@ -1212,6 +1219,7 @@ export class WidgetStateManager {
           : arr.map(n => String(n))
       }
 
+      // TODO(query-params): Remove options lookup after wire format changes.
       case "double_array_value": {
         const arr = value as number[]
         return binding.options && binding.options.length > 0

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -620,11 +620,11 @@ export class WidgetStateManager {
     source: Source,
     fragmentId: string | undefined
   ): void {
-    // Filter out invalid values (NaN, undefined, null) before storing
+    // Filter out invalid values (NaN, undefined, null) before storing.
+    // If all values are invalid, skip the update entirely.
     const validValue = value.filter(
       v => v !== undefined && v !== null && !Number.isNaN(v)
     )
-    // Only update if we have valid values
     if (validValue.length === 0) {
       return
     }

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -17,6 +17,7 @@
 import { Draft, produce } from "immer"
 import { getLogger } from "loglevel"
 import { Long, util } from "protobufjs"
+import queryString from "query-string"
 import { Signal, SignalConnection } from "typed-signals"
 
 import {
@@ -1169,89 +1170,127 @@ export class WidgetStateManager {
     }
   }
 
-  /** Sync a scalar value to URL if the widget is bound. */
-  private syncToUrlIfBound(widgetId: string, value: string): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (!binding) return
-
-    if (this.isDefaultValue(value, binding)) {
-      this.clearUrlParam(binding.paramKey)
-      return
+  /**
+   * Convert widget value to URL-safe format based on binding type.
+   * Returns null to indicate the param should be removed from URL.
+   */
+  private convertToUrlValue(
+    value: unknown,
+    binding: QueryParamBinding
+  ): string | string[] | null {
+    // Null values should clear the param
+    if (value === null) {
+      return null
     }
 
-    const url = new URL(window.location.href)
-    url.searchParams.set(binding.paramKey, value)
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
+    switch (binding.valueType) {
+      case "bool_value":
+        return String(value as boolean)
 
-  /** Sync a comma-separated array to URL (when urlFormat is "comma"). */
-  private syncCommaArrayToUrlIfBound(
-    widgetId: string,
-    values: string[]
-  ): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (!binding) return
+      case "double_value":
+        return String(value as number)
 
-    // Only filter empty strings - user-provided values like "null" are legitimate
-    const validValues = values.filter(v => v !== "")
-    if (
-      validValues.length === 0 ||
-      this.isDefaultArrayValue(validValues, binding)
-    ) {
-      this.clearUrlParam(binding.paramKey)
-      return
+      case "int_value": {
+        const num = value as number
+        return binding.options?.[num] ?? String(num)
+      }
+
+      case "string_value":
+        return value as string
+
+      case "string_array_value": {
+        const arr = (value as string[]).filter(v => v !== "")
+        return arr
+      }
+
+      case "int_array_value": {
+        const arr = value as number[]
+        return binding.options
+          ? arr
+              .map(idx => binding.options?.[idx])
+              .filter((s): s is string => s !== undefined)
+          : arr.map(n => String(n))
+      }
+
+      case "double_array_value": {
+        const arr = value as number[]
+        return binding.options && binding.options.length > 0
+          ? arr
+              .map(idx => binding.options?.[idx])
+              .filter((s): s is string => s !== undefined)
+          : arr.map(n => String(n))
+      }
+
+      default:
+        return null
     }
-
-    const url = new URL(window.location.href)
-    url.searchParams.set(binding.paramKey, validValues.join(","))
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
-
-  /** Sync an array to URL using repeated params (?key=a&key=b). */
-  private syncRepeatedArrayToUrlIfBound(
-    widgetId: string,
-    values: string[]
-  ): void {
-    const binding = this.boundWidgets.get(widgetId)
-    if (!binding) return
-
-    const url = new URL(window.location.href)
-    url.searchParams.delete(binding.paramKey)
-
-    if (values.length === 0 || this.isDefaultArrayValue(values, binding)) {
-      window.history.replaceState({}, "", url.toString())
-      this.notifyQueryParamsChange()
-      return
-    }
-
-    values.forEach(v => url.searchParams.append(binding.paramKey, v))
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
-  }
-
-  /** Clear a URL parameter. */
-  private clearUrlParam(paramKey: string): void {
-    const url = new URL(window.location.href)
-    url.searchParams.delete(paramKey)
-    window.history.replaceState({}, "", url.toString())
-    this.notifyQueryParamsChange()
   }
 
   /**
-   * Sync widget value to URL if the widget is bound and value is from UI.
-   * This is the unified entry point for URL syncing, reducing duplication
-   * across the various set*Value methods.
-   *
-   * @param widgetId - The widget's unique identifier
-   * @param source - The source of the value change (must have fromUi: true to sync)
-   * @param config - Configuration for how to convert and sync the value
-   * @param value - The widget value to sync
+   * Check if value should clear the URL param (is default or empty).
    */
+  private shouldClearUrlParam(
+    urlValue: string | string[] | null,
+    binding: QueryParamBinding
+  ): boolean {
+    if (urlValue === null) return true
+
+    if (Array.isArray(urlValue)) {
+      return (
+        urlValue.length === 0 || this.isDefaultArrayValue(urlValue, binding)
+      )
+    }
+
+    return this.isDefaultValue(urlValue, binding)
+  }
+
+  /**
+   * Update a single URL parameter using query-string library.
+   * Handles both scalar and array values, respecting urlFormat setting.
+   */
+  private updateUrlParam(
+    paramKey: string,
+    value: string | string[] | null,
+    urlFormat: "comma" | "repeated" | undefined
+  ): void {
+    // Parse current URL params - use "none" to correctly parse repeated params (?a=1&a=2)
+    const currentParams = queryString.parse(window.location.search, {
+      arrayFormat: "none",
+    })
+
+    if (value === null) {
+      // Remove the param
+      delete currentParams[paramKey]
+    } else if (Array.isArray(value)) {
+      if (urlFormat === "comma") {
+        // Comma-separated: store as single joined string
+        currentParams[paramKey] = value.join(",")
+      } else {
+        // Repeated params: store as array
+        currentParams[paramKey] = value
+      }
+    } else {
+      // Scalar value
+      currentParams[paramKey] = value
+    }
+
+    // Build new URL using query-string
+    // arrayFormat: "none" produces ?key=a&key=b for arrays
+    const newSearch = queryString.stringify(currentParams, {
+      arrayFormat: "none",
+      skipNull: true,
+      skipEmptyString: false,
+    })
+
+    const newUrl = new URL(window.location.href)
+    newUrl.search = newSearch
+    window.history.replaceState({}, "", newUrl.toString())
+    this.notifyQueryParamsChange()
+  }
+
   /**
    * Sync widget value to URL if bound and change is from UI.
-   * Converts the value to URL format based on the binding's valueType.
+   * Orchestrates pure conversion and side-effect URL update.
    */
   private maybeSyncValueToUrl(
     widgetId: string,
@@ -1263,66 +1302,18 @@ export class WidgetStateManager {
     const binding = this.boundWidgets.get(widgetId)
     if (!binding) return
 
-    // Handle null - clear the param
-    if (value === null) {
-      this.clearUrlParam(binding.paramKey)
-      return
-    }
+    // Pure: Convert value to URL format
+    const urlValue = this.convertToUrlValue(value, binding)
 
-    // Convert and sync based on binding's valueType
-    switch (binding.valueType) {
-      case "bool_value":
-        this.syncToUrlIfBound(widgetId, String(value as boolean))
-        break
+    // Pure: Check if we should clear the param
+    const shouldClear = this.shouldClearUrlParam(urlValue, binding)
 
-      case "double_value":
-        this.syncToUrlIfBound(widgetId, String(value as number))
-        break
-
-      case "int_value": {
-        const num = value as number
-        const urlValue = binding.options?.[num] ?? String(num)
-        this.syncToUrlIfBound(widgetId, urlValue)
-        break
-      }
-
-      case "string_value":
-        this.syncToUrlIfBound(widgetId, value as string)
-        break
-
-      case "string_array_value": {
-        const arr = value as string[]
-        if (binding.urlFormat === "comma") {
-          this.syncCommaArrayToUrlIfBound(widgetId, arr)
-        } else {
-          this.syncRepeatedArrayToUrlIfBound(widgetId, arr)
-        }
-        break
-      }
-
-      case "int_array_value": {
-        const arr = value as number[]
-        const urlValues = binding.options
-          ? arr
-              .map(idx => binding.options?.[idx])
-              .filter((s): s is string => s !== undefined)
-          : arr.map(n => String(n))
-        this.syncRepeatedArrayToUrlIfBound(widgetId, urlValues)
-        break
-      }
-
-      case "double_array_value": {
-        const arr = value as number[]
-        const urlValues =
-          binding.options && binding.options.length > 0
-            ? arr
-                .map(idx => binding.options?.[idx])
-                .filter((s): s is string => s !== undefined)
-            : arr.map(n => String(n))
-        this.syncRepeatedArrayToUrlIfBound(widgetId, urlValues)
-        break
-      }
-    }
+    // Side effect: Update URL
+    this.updateUrlParam(
+      binding.paramKey,
+      shouldClear ? null : urlValue,
+      binding.urlFormat
+    )
   }
 
   /**

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -608,8 +608,9 @@ export class WidgetStateManager {
     const validValue = value.filter(
       v => v !== undefined && v !== null && !Number.isNaN(v)
     )
-    // If all values are invalid, skip the update entirely.
+    // If all values are invalid, clear URL params but skip state update.
     if (validValue.length === 0) {
+      this.maybeSyncValueToUrl(widget.id, source, [])
       return
     }
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -33,6 +33,7 @@ import {
   WidgetStates,
 } from "@streamlit/protobuf"
 
+import { assertNever } from "~lib/util/assertNever"
 import {
   isNullOrUndefined,
   isValidFormId,
@@ -1109,7 +1110,9 @@ export class WidgetStateManager {
 
   /**
    * Unregister a widget's query param binding (called on unmount).
-   * Note: Does NOT clear the URL param to support React strict mode remounts.
+   *
+   * Note: This does NOT clear the URL param - that cleanup is handled by the
+   * backend via remove_stale_bindings().
    */
   public unregisterQueryParamBinding(widgetId: string): void {
     const binding = this.boundWidgets.get(widgetId)
@@ -1139,25 +1142,28 @@ export class WidgetStateManager {
 
     // Get current URL params for bound widgets
     const currentUrl = new URL(window.location.href)
-    const boundParams: string[] = []
+    const boundParamsObj: Record<string, string | string[]> = {}
 
     this.paramKeyToWidgetId.forEach((_, paramKey) => {
       const values = currentUrl.searchParams.getAll(paramKey)
-      values.forEach(value => {
-        boundParams.push(
-          `${encodeURIComponent(paramKey)}=${encodeURIComponent(value)}`
-        )
-      })
+      if (values.length === 1) {
+        boundParamsObj[paramKey] = values[0]
+      } else if (values.length > 1) {
+        boundParamsObj[paramKey] = values
+      }
+    })
+
+    // Build query string using query-string library
+    const boundParamsStr = queryString.stringify(boundParamsObj, {
+      arrayFormat: "none",
     })
 
     // Combine embed params with bound widget params
-    if (boundParams.length === 0) {
+    if (!boundParamsStr) {
       return embedParams
     }
 
-    return embedParams
-      ? `${embedParams}&${boundParams.join("&")}`
-      : boundParams.join("&")
+    return embedParams ? `${embedParams}&${boundParamsStr}` : boundParamsStr
   }
 
   /** Set callback for query param changes (used by App.tsx). */
@@ -1230,7 +1236,7 @@ export class WidgetStateManager {
       }
 
       default:
-        return null
+        return assertNever(binding.valueType)
     }
   }
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -490,11 +490,7 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).boolValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      this.syncToUrlIfBound(widget.id, String(value))
-    }
+    this.maybeSyncValueToUrl(widget.id, source, value)
   }
 
   public getIntValue(widget: WidgetInfo): number | undefined {
@@ -514,25 +510,7 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).intValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      const binding = this.boundWidgets.get(widget.id)
-      if (binding) {
-        if (value === null) {
-          // Clear URL param when widget is cleared
-          this.clearUrlParam(binding.paramKey)
-        } else {
-          // If binding has options, convert index to option string for human-readable URLs
-          const optionValue = binding.options?.[value]
-          if (optionValue !== undefined) {
-            this.syncToUrlIfBound(widget.id, optionValue)
-          } else {
-            this.syncToUrlIfBound(widget.id, String(value))
-          }
-        }
-      }
-    }
+    this.maybeSyncValueToUrl(widget.id, source, value)
   }
 
   public getDoubleValue(widget: WidgetInfo): number | undefined {
@@ -552,19 +530,7 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).doubleValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      const binding = this.boundWidgets.get(widget.id)
-      if (binding) {
-        if (value === null) {
-          // Clear URL param when widget is cleared
-          this.clearUrlParam(binding.paramKey)
-        } else {
-          this.syncToUrlIfBound(widget.id, String(value))
-        }
-      }
-    }
+    this.maybeSyncValueToUrl(widget.id, source, value)
   }
 
   public getStringValue(widget: WidgetInfo): string | undefined {
@@ -584,19 +550,7 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).stringValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      const binding = this.boundWidgets.get(widget.id)
-      if (binding) {
-        if (value === null) {
-          // Clear URL param when widget is cleared
-          this.clearUrlParam(binding.paramKey)
-        } else {
-          this.syncToUrlIfBound(widget.id, value)
-        }
-      }
-    }
+    this.maybeSyncValueToUrl(widget.id, source, value)
   }
 
   public setStringArrayValue(
@@ -609,17 +563,7 @@ export class WidgetStateManager {
       data: value,
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      const binding = this.boundWidgets.get(widget.id)
-      if (binding?.urlFormat === "comma") {
-        this.syncCommaArrayToUrlIfBound(widget.id, value)
-      } else {
-        // Default to repeated params for string arrays
-        this.syncRepeatedArrayToUrlIfBound(widget.id, value)
-      }
-    }
+    this.maybeSyncValueToUrl(widget.id, source, value)
   }
 
   public getStringArrayValue(widget: WidgetInfo): string[] | undefined {
@@ -660,28 +604,15 @@ export class WidgetStateManager {
     const validValue = value.filter(
       v => v !== undefined && v !== null && !Number.isNaN(v)
     )
+    // If all values are invalid, skip the update entirely.
+    if (validValue.length === 0) {
+      return
+    }
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({
       data: validValue,
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      const binding = this.boundWidgets.get(widget.id)
-      if (binding?.options && binding.options.length > 0) {
-        // For select_slider: convert indices to option strings, filtering invalid
-        const optionStrings = validValue
-          .map(idx => binding.options?.[idx])
-          .filter((s): s is string => s !== undefined)
-        this.syncRepeatedArrayToUrlIfBound(widget.id, optionStrings)
-      } else {
-        // Regular slider: use numeric values
-        this.syncRepeatedArrayToUrlIfBound(
-          widget.id,
-          validValue.map(v => String(v))
-        )
-      }
-    }
+    this.maybeSyncValueToUrl(widget.id, source, validValue)
   }
 
   public getIntArrayValue(widget: WidgetInfo): number[] | undefined {
@@ -708,23 +639,7 @@ export class WidgetStateManager {
       data: value,
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
-
-    // Sync to URL if bound and from UI
-    if (source.fromUi) {
-      const binding = this.boundWidgets.get(widget.id)
-      if (binding?.options) {
-        // Convert indices to option strings, filtering out invalid indices
-        const optionStrings = value
-          .map(idx => binding.options?.[idx])
-          .filter((s): s is string => s !== undefined)
-        this.syncRepeatedArrayToUrlIfBound(widget.id, optionStrings)
-      } else {
-        this.syncRepeatedArrayToUrlIfBound(
-          widget.id,
-          value.map(v => String(v))
-        )
-      }
-    }
+    this.maybeSyncValueToUrl(widget.id, source, value)
   }
 
   public getJsonValue(widget: WidgetInfo): string | undefined {
@@ -1322,6 +1237,92 @@ export class WidgetStateManager {
     url.searchParams.delete(paramKey)
     window.history.replaceState({}, "", url.toString())
     this.notifyQueryParamsChange()
+  }
+
+  /**
+   * Sync widget value to URL if the widget is bound and value is from UI.
+   * This is the unified entry point for URL syncing, reducing duplication
+   * across the various set*Value methods.
+   *
+   * @param widgetId - The widget's unique identifier
+   * @param source - The source of the value change (must have fromUi: true to sync)
+   * @param config - Configuration for how to convert and sync the value
+   * @param value - The widget value to sync
+   */
+  /**
+   * Sync widget value to URL if bound and change is from UI.
+   * Converts the value to URL format based on the binding's valueType.
+   */
+  private maybeSyncValueToUrl(
+    widgetId: string,
+    source: Source,
+    value: unknown
+  ): void {
+    if (!source.fromUi) return
+
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    // Handle null - clear the param
+    if (value === null) {
+      this.clearUrlParam(binding.paramKey)
+      return
+    }
+
+    // Convert and sync based on binding's valueType
+    switch (binding.valueType) {
+      case "bool_value":
+        this.syncToUrlIfBound(widgetId, String(value as boolean))
+        break
+
+      case "double_value":
+        this.syncToUrlIfBound(widgetId, String(value as number))
+        break
+
+      case "int_value": {
+        const num = value as number
+        const urlValue = binding.options?.[num] ?? String(num)
+        this.syncToUrlIfBound(widgetId, urlValue)
+        break
+      }
+
+      case "string_value":
+        this.syncToUrlIfBound(widgetId, value as string)
+        break
+
+      case "string_array_value": {
+        const arr = value as string[]
+        if (binding.urlFormat === "comma") {
+          this.syncCommaArrayToUrlIfBound(widgetId, arr)
+        } else {
+          this.syncRepeatedArrayToUrlIfBound(widgetId, arr)
+        }
+        break
+      }
+
+      case "int_array_value": {
+        const arr = value as number[]
+        const urlValues = binding.options
+          ? arr
+              .map(idx => binding.options?.[idx])
+              .filter((s): s is string => s !== undefined)
+          : arr.map(n => String(n))
+        this.syncRepeatedArrayToUrlIfBound(widgetId, urlValues)
+        break
+      }
+
+      case "double_array_value": {
+        const arr = value as number[]
+        const urlValues =
+          binding.options && binding.options.length > 0
+            ? arr
+                .map(idx => binding.options?.[idx])
+                .filter((s): s is string => s !== undefined)
+            : arr.map(n => String(n))
+        this.syncRepeatedArrayToUrlIfBound(widgetId, urlValues)
+        break
+      }
+    }
   }
 
   /**

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -1148,6 +1148,42 @@ export class WidgetStateManager {
     return this.boundWidgets.has(widgetId)
   }
 
+  /**
+   * Filter query params for page navigation.
+   * Preserves embed params and params bound to widgets, clears all others.
+   *
+   * @param embedParams - The embed query params string (from preserveEmbedQueryParams)
+   * @returns Filtered query string with embed + bound widget params
+   */
+  public filterParamsForPageChange(embedParams: string): string {
+    // If no widgets are bound, just return embed params
+    if (this.paramKeyToWidgetId.size === 0) {
+      return embedParams
+    }
+
+    // Get current URL params for bound widgets
+    const currentUrl = new URL(window.location.href)
+    const boundParams: string[] = []
+
+    this.paramKeyToWidgetId.forEach((_, paramKey) => {
+      const values = currentUrl.searchParams.getAll(paramKey)
+      values.forEach(value => {
+        boundParams.push(
+          `${encodeURIComponent(paramKey)}=${encodeURIComponent(value)}`
+        )
+      })
+    })
+
+    // Combine embed params with bound widget params
+    if (boundParams.length === 0) {
+      return embedParams
+    }
+
+    return embedParams
+      ? `${embedParams}&${boundParams.join("&")}`
+      : boundParams.join("&")
+  }
+
   /** Set callback for query param changes (used by App.tsx). */
   public setQueryParamsChangeHandler(
     handler: (queryString: string) => void

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -48,6 +48,17 @@ export interface WidgetInfo {
 }
 
 /**
+ * Binding information for a widget that syncs to URL query parameters.
+ */
+export interface QueryParamBinding {
+  paramKey: string
+  valueType: string // e.g., "bool_value", "string_value", etc.
+  defaultValue: unknown
+  urlFormat?: "comma" | "repeated" // How to serialize arrays
+  options?: string[] // For index-based widgets, the formatted option strings
+}
+
+/**
  * Immutable structure that exposes public data about all the forms in the app.
  * WidgetStateManager produces new instances of this type when forms data
  * changes.
@@ -230,6 +241,23 @@ export class WidgetStateManager {
    * conflicting calls happen in the same macrotask.
    */
   private hasFragmentIdConflict = false
+
+  /**
+   * Registry of widgets bound to URL query parameters.
+   * Maps widgetId -> QueryParamBinding
+   */
+  private readonly boundWidgets = new Map<string, QueryParamBinding>()
+
+  /**
+   * Reverse lookup: paramKey -> widgetId
+   */
+  private readonly paramKeyToWidgetId = new Map<string, string>()
+
+  /**
+   * Callback to notify App.tsx when query params change.
+   * This keeps App's queryParams state in sync with the URL.
+   */
+  private onQueryParamsChange?: (queryString: string) => void
 
   constructor(props: Props) {
     this.props = props
@@ -449,6 +477,11 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).boolValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI
+    if (source.fromUi) {
+      this.syncToUrlIfBound(widget.id, String(value))
+    }
   }
 
   public getIntValue(widget: WidgetInfo): number | undefined {
@@ -468,6 +501,18 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).intValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI
+    if (source.fromUi && value !== null) {
+      const binding = this.boundWidgets.get(widget.id)
+      // If binding has options, convert index to option string for human-readable URLs
+      const optionValue = binding?.options?.[value]
+      if (optionValue !== undefined) {
+        this.syncToUrlIfBound(widget.id, optionValue)
+      } else {
+        this.syncToUrlIfBound(widget.id, String(value))
+      }
+    }
   }
 
   public getDoubleValue(widget: WidgetInfo): number | undefined {
@@ -487,6 +532,11 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).doubleValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI
+    if (source.fromUi && value !== null) {
+      this.syncToUrlIfBound(widget.id, String(value))
+    }
   }
 
   public getStringValue(widget: WidgetInfo): string | undefined {
@@ -506,6 +556,11 @@ export class WidgetStateManager {
   ): void {
     this.createWidgetState(widget, source).stringValue = value
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI
+    if (source.fromUi && value !== null) {
+      this.syncToUrlIfBound(widget.id, value)
+    }
   }
 
   public setStringArrayValue(
@@ -518,6 +573,17 @@ export class WidgetStateManager {
       data: value,
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI
+    if (source.fromUi) {
+      const binding = this.boundWidgets.get(widget.id)
+      if (binding?.urlFormat === "comma") {
+        this.syncCommaArrayToUrlIfBound(widget.id, value)
+      } else {
+        // Default to repeated params for string arrays
+        this.syncRepeatedArrayToUrlIfBound(widget.id, value)
+      }
+    }
   }
 
   public getStringArrayValue(widget: WidgetInfo): string[] | undefined {
@@ -554,10 +620,36 @@ export class WidgetStateManager {
     source: Source,
     fragmentId: string | undefined
   ): void {
+    // Filter out invalid values (NaN, undefined, null) before storing
+    const validValue = value.filter(
+      v => v !== undefined && v !== null && !Number.isNaN(v)
+    )
+    // Only update if we have valid values
+    if (validValue.length === 0) {
+      return
+    }
     this.createWidgetState(widget, source).doubleArrayValue = new DoubleArray({
-      data: value,
+      data: validValue,
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI (repeated params for consistency)
+    if (source.fromUi) {
+      const binding = this.boundWidgets.get(widget.id)
+      // For select_slider: convert indices to option strings for human-readable URLs
+      if (binding?.options && binding.options.length > 0) {
+        const optionStrings = validValue.map(
+          idx => binding.options?.[idx] ?? String(idx)
+        )
+        this.syncRepeatedArrayToUrlIfBound(widget.id, optionStrings)
+      } else {
+        // Regular slider: use numeric values
+        this.syncRepeatedArrayToUrlIfBound(
+          widget.id,
+          validValue.map(v => String(v))
+        )
+      }
+    }
   }
 
   public getIntArrayValue(widget: WidgetInfo): number[] | undefined {
@@ -584,6 +676,242 @@ export class WidgetStateManager {
       data: value,
     })
     this.onWidgetValueChanged(widget.formId, source, fragmentId)
+
+    // Sync to URL if bound and from UI (repeated params for consistency)
+    if (source.fromUi) {
+      const binding = this.boundWidgets.get(widget.id)
+      // If binding has options, convert indices to option strings for human-readable URLs
+      if (binding?.options) {
+        const optionStrings = value
+          .map(idx => binding.options?.[idx])
+          .filter((s): s is string => s !== undefined)
+        this.syncRepeatedArrayToUrlIfBound(widget.id, optionStrings)
+      } else {
+        // Fallback to index values
+        this.syncRepeatedArrayToUrlIfBound(
+          widget.id,
+          value.map(v => String(v))
+        )
+      }
+    }
+  }
+
+  // Query Param Binding Methods
+
+  /**
+   * Register a widget's binding to a URL query parameter.
+   * Called by widget components on mount when they have a queryParamKey.
+   * @param options - For index-based widgets (radio, pills, etc.), the formatted option strings
+   */
+  public registerQueryParamBinding(
+    widgetId: string,
+    paramKey: string,
+    valueType: string,
+    defaultValue: unknown,
+    urlFormat?: "comma" | "repeated",
+    options?: string[]
+  ): void {
+    this.boundWidgets.set(widgetId, {
+      paramKey,
+      valueType,
+      defaultValue,
+      urlFormat,
+      options,
+    })
+    this.paramKeyToWidgetId.set(paramKey, widgetId)
+  }
+
+  /**
+   * Unregister a widget's binding.
+   * Called by widget components on unmount.
+   * Note: We do NOT clear the URL parameter here because:
+   * 1. In React strict mode, components mount/unmount multiple times
+   * 2. During Streamlit re-runs, widgets are recreated
+   * 3. The URL should persist for deep-linking purposes
+   * URL params are only cleared when the value changes to the default.
+   */
+  public unregisterQueryParamBinding(widgetId: string): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (binding) {
+      this.paramKeyToWidgetId.delete(binding.paramKey)
+      this.boundWidgets.delete(widgetId)
+    }
+  }
+
+  /**
+   * Check if a widget has a query param binding.
+   */
+  public hasQueryParamBinding(widgetId: string): boolean {
+    return this.boundWidgets.has(widgetId)
+  }
+
+  /**
+   * Set a callback to be notified when query params change.
+   * This is called by App.tsx to keep its queryParams state in sync.
+   */
+  public setQueryParamsChangeHandler(
+    handler: (queryString: string) => void
+  ): void {
+    this.onQueryParamsChange = handler
+  }
+
+  /**
+   * Notify App.tsx of query param changes so it can update its state.
+   * This is necessary for page navigation to preserve query params.
+   */
+  private notifyQueryParamsChange(): void {
+    if (this.onQueryParamsChange) {
+      const url = new URL(window.location.href)
+      this.onQueryParamsChange(url.searchParams.toString())
+    }
+  }
+
+  /**
+   * Sync a scalar value to URL if the widget is bound.
+   */
+  private syncToUrlIfBound(widgetId: string, value: string): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    // Don't sync default values to URL (keep URLs clean)
+    if (this.isDefaultValue(value, binding)) {
+      this.clearUrlParam(binding.paramKey)
+      return
+    }
+
+    const url = new URL(window.location.href)
+    url.searchParams.set(binding.paramKey, value)
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /**
+   * Sync a comma-separated array value to URL if the widget is bound.
+   * Only used when urlFormat is explicitly set to "comma".
+   */
+  private syncCommaArrayToUrlIfBound(
+    widgetId: string,
+    values: string[]
+  ): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    // Filter out invalid values like "undefined", "NaN", empty strings
+    const validValues = values.filter(
+      v => v !== "" && v !== "undefined" && v !== "NaN" && v !== "null"
+    )
+    if (validValues.length === 0) {
+      this.clearUrlParam(binding.paramKey)
+      return
+    }
+
+    // Don't sync default values to URL
+    if (this.isDefaultArrayValue(validValues, binding)) {
+      this.clearUrlParam(binding.paramKey)
+      return
+    }
+
+    const url = new URL(window.location.href)
+    url.searchParams.set(binding.paramKey, validValues.join(","))
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /**
+   * Sync an array value to URL using repeated params if the widget is bound.
+   * Used for multiselect and pills multi-select.
+   */
+  private syncRepeatedArrayToUrlIfBound(
+    widgetId: string,
+    values: string[]
+  ): void {
+    const binding = this.boundWidgets.get(widgetId)
+    if (!binding) return
+
+    const url = new URL(window.location.href)
+    url.searchParams.delete(binding.paramKey)
+
+    // Don't sync empty or default values
+    if (values.length === 0 || this.isDefaultArrayValue(values, binding)) {
+      window.history.replaceState({}, "", url.toString())
+      this.notifyQueryParamsChange()
+      return
+    }
+
+    // Repeated params: ?tags=a&tags=b
+    values.forEach(v => url.searchParams.append(binding.paramKey, v))
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /**
+   * Clear a URL parameter.
+   */
+  private clearUrlParam(paramKey: string): void {
+    const url = new URL(window.location.href)
+    url.searchParams.delete(paramKey)
+    window.history.replaceState({}, "", url.toString())
+    this.notifyQueryParamsChange()
+  }
+
+  /**
+   * Check if a value equals the widget's default value.
+   * Handles type coercion since URL values are always strings.
+   */
+  /**
+   * Convert a value to string safely, handling primitives.
+   * Returns undefined for non-primitive types to avoid [object Object].
+   */
+  private toStringPrimitive(value: unknown): string | undefined {
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      return String(value)
+    }
+    return undefined
+  }
+
+  private isDefaultValue(value: unknown, binding: QueryParamBinding): boolean {
+    const defaultValue = binding.defaultValue
+    // Handle null/undefined
+    if (defaultValue === null || defaultValue === undefined) {
+      return value === null || value === undefined || value === ""
+    }
+    // Convert both to string for comparison (handles bool/number/string)
+    const valueStr = this.toStringPrimitive(value)
+    const defaultStr = this.toStringPrimitive(defaultValue)
+    if (valueStr === undefined || defaultStr === undefined) {
+      return false // Non-primitive types don't match by string comparison
+    }
+    return valueStr === defaultStr
+  }
+
+  /**
+   * Check if an array value equals the widget's default array value.
+   * Handles type coercion since URL values are always strings.
+   */
+  private isDefaultArrayValue(
+    values: string[],
+    binding: QueryParamBinding
+  ): boolean {
+    const defaultValue = binding.defaultValue
+    if (!Array.isArray(defaultValue)) {
+      // Default is not an array - check if values are empty or match single default
+      if (values.length === 0) return true
+      if (values.length === 1 && defaultValue !== null) {
+        const defaultStr = this.toStringPrimitive(defaultValue)
+        return defaultStr !== undefined && values[0] === defaultStr
+      }
+      return false
+    }
+    // Both are arrays - compare element by element as strings
+    if (values.length !== defaultValue.length) return false
+    return values.every((v, i) => {
+      const defaultStr = this.toStringPrimitive(defaultValue[i])
+      return defaultStr !== undefined && v === defaultStr
+    })
   }
 
   public getJsonValue(widget: WidgetInfo): string | undefined {

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -322,9 +322,10 @@ describe("ButtonGroup widget", () => {
       expectHighlightStyle(buttons[3])
       expectHighlightStyle(buttons[defaultSelectedIndex], false)
 
+      // When setValue is true, widget initializes directly with the setValue value
       expect(props.widgetMgr.setIntArrayValue).toHaveBeenCalledWith(
         props.element,
-        props.element.default,
+        props.element.value,
         {
           fromUi: false,
         },

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -207,12 +207,43 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
   })
 
   describe("array comparison logic", () => {
-    it("uses defaultValue for empty currValue array", () => {
+    it.each([
+      {
+        desc: "uses defaultValue for empty currValue array",
+        currValue: [],
+        defaultValue: [1, 2, 3],
+        expected: [1, 2, 3],
+      },
+      {
+        desc: "uses currValue when array differs from default",
+        currValue: [3, 4],
+        defaultValue: [1, 2],
+        expected: [3, 4],
+      },
+      {
+        desc: "uses currValue when array length differs",
+        currValue: [1, 2, 3],
+        defaultValue: [1, 2],
+        expected: [1, 2, 3],
+      },
+      {
+        desc: "uses defaultValue when arrays are equal",
+        currValue: [1, 2, 3],
+        defaultValue: [1, 2, 3],
+        expected: [1, 2, 3],
+      },
+      {
+        desc: "handles string arrays - uses currValue when differs",
+        currValue: ["option-a", "option-c"],
+        defaultValue: ["option-a", "option-b"],
+        expected: ["option-a", "option-c"],
+      },
+    ])("$desc", ({ currValue, defaultValue, expected }) => {
       const element: MockProto = {
         formId: "",
         setValue: false,
-        value: [], // Empty array
-        default: [1, 2, 3], // Non-empty default
+        value: currValue,
+        default: defaultValue,
       }
 
       const { result } = renderHook(() =>
@@ -226,105 +257,30 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         })
       )
 
-      expect(result.current[0]).toEqual([1, 2, 3])
-    })
-
-    it("uses currValue when array differs from default", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: [3, 4], // URL-seeded selection
-        default: [1, 2], // Widget default
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      expect(result.current[0]).toEqual([3, 4])
-    })
-
-    it("uses currValue when array length differs", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: [1, 2, 3],
-        default: [1, 2],
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      expect(result.current[0]).toEqual([1, 2, 3])
-    })
-
-    it("uses defaultValue when arrays are equal", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: [1, 2, 3],
-        default: [1, 2, 3],
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      expect(result.current[0]).toEqual([1, 2, 3])
-    })
-
-    it("handles string arrays correctly", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: ["option-a", "option-c"], // URL selections
-        default: ["option-a", "option-b"], // Default selections
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      expect(result.current[0]).toEqual(["option-a", "option-c"])
+      expect(result.current[0]).toEqual(expected)
     })
   })
 
   describe("numeric values", () => {
-    it("uses currValue when numeric value differs from default", () => {
+    it.each([
+      {
+        desc: "uses currValue when numeric value differs from default",
+        currValue: 42,
+        defaultValue: 0,
+        expected: 42,
+      },
+      {
+        desc: "uses defaultValue when numeric values are equal",
+        currValue: 0,
+        defaultValue: 0,
+        expected: 0,
+      },
+    ])("$desc", ({ currValue, defaultValue, expected }) => {
       const element: MockProto = {
         formId: "",
         setValue: false,
-        value: 42, // URL-seeded number
-        default: 0, // Widget default
+        value: currValue,
+        default: defaultValue,
       }
 
       const { result } = renderHook(() =>
@@ -338,29 +294,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         })
       )
 
-      expect(result.current[0]).toBe(42)
-    })
-
-    it("uses defaultValue when numeric values are equal", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: 0,
-        default: 0,
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      expect(result.current[0]).toBe(0)
+      expect(result.current[0]).toBe(expected)
     })
   })
 })

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -32,8 +32,9 @@ interface MockProto {
 }
 
 // Helper functions for the hook
+type MockValue = string | number | string[] | number[]
 const getStateFromWidgetMgr = vi.fn(
-  (_wm: WidgetStateManager, _el: MockProto) => undefined
+  (_wm: WidgetStateManager, _el: MockProto): MockValue | undefined => undefined
 )
 
 const getCurrStateFromProto = vi.fn((el: MockProto) => el.value)
@@ -60,7 +61,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
     })
   })
 
-  describe("setValue behavior (URL-seeded values)", () => {
+  describe("setValue behavior", () => {
     it("uses currValue when setValue is true", () => {
       const element: MockProto = {
         formId: "",
@@ -84,12 +85,12 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       expect(result.current[0]).toBe("url-seeded-value")
     })
 
-    it("uses defaultValue when setValue is false and values are equal", () => {
+    it("uses defaultValue when setValue is false", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
-        value: "same-value",
-        default: "same-value",
+        value: "some-value",
+        default: "default-value",
       }
 
       const { result } = renderHook(() =>
@@ -103,91 +104,18 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         })
       )
 
-      expect(result.current[0]).toBe("same-value")
+      // When setValue is false, always use defaultValue
+      expect(result.current[0]).toBe("default-value")
     })
-  })
 
-  describe("React Strict Mode recovery (setValue false but value differs)", () => {
-    it("uses currValue when it differs from defaultValue", () => {
-      // This simulates React Strict Mode: setValue was cleared by first mount,
-      // but element.value still contains the seeded value
+    it("uses defaultValue when setValue is false even if values differ", () => {
+      // This is the key behavior change: we no longer infer seeding from
+      // value != default. Instead, we rely on WidgetStateManager to persist
+      // values across React Strict Mode remounts.
       const element: MockProto = {
         formId: "",
         setValue: false,
-        value: "seeded-value-from-url",
-        default: "widget-default",
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      // Should use currValue since it differs from default
-      expect(result.current[0]).toBe("seeded-value-from-url")
-    })
-  })
-
-  describe("empty string handling (protobuf default)", () => {
-    it("treats empty string as 'no value set' and uses defaultValue", () => {
-      // Protobuf sets string fields to "" by default when not explicitly set
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: "", // Empty string from protobuf
-        default: "#000000", // Actual widget default (e.g., ColorPicker)
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      // Empty string should be treated as "no value", so use default
-      expect(result.current[0]).toBe("#000000")
-    })
-
-    it("uses non-empty currValue when it differs from default", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: "user-entered-text",
-        default: "",
-      }
-
-      const { result } = renderHook(() =>
-        useBasicWidgetState({
-          getStateFromWidgetMgr,
-          getCurrStateFromProto,
-          getDefaultStateFromProto,
-          updateWidgetMgrState,
-          element,
-          widgetMgr,
-        })
-      )
-
-      expect(result.current[0]).toBe("user-entered-text")
-    })
-  })
-
-  describe("null/undefined handling", () => {
-    it("treats null currValue as 'no value set'", () => {
-      const element: MockProto = {
-        formId: "",
-        setValue: false,
-        value: null as unknown as string, // Simulating null
+        value: "different-value",
         default: "default-value",
       }
 
@@ -206,44 +134,18 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
     })
   })
 
-  describe("array comparison logic", () => {
-    it.each([
-      {
-        desc: "uses defaultValue for empty currValue array",
-        currValue: [],
-        defaultValue: [1, 2, 3],
-        expected: [1, 2, 3],
-      },
-      {
-        desc: "uses currValue when array differs from default",
-        currValue: [3, 4],
-        defaultValue: [1, 2],
-        expected: [3, 4],
-      },
-      {
-        desc: "uses currValue when array length differs",
-        currValue: [1, 2, 3],
-        defaultValue: [1, 2],
-        expected: [1, 2, 3],
-      },
-      {
-        desc: "uses defaultValue when arrays are equal",
-        currValue: [1, 2, 3],
-        defaultValue: [1, 2, 3],
-        expected: [1, 2, 3],
-      },
-      {
-        desc: "handles string arrays - uses currValue when differs",
-        currValue: ["option-a", "option-c"],
-        defaultValue: ["option-a", "option-b"],
-        expected: ["option-a", "option-c"],
-      },
-    ])("$desc", ({ currValue, defaultValue, expected }) => {
+  describe("WidgetStateManager takes precedence over getDefaultState", () => {
+    it("uses WidgetStateManager value when setValue is false", () => {
+      // When WidgetStateManager has a value and setValue is false,
+      // WidgetStateManager value takes precedence over getDefaultStateFromProto
+      const storedValue = "stored-in-widget-mgr"
+      getStateFromWidgetMgr.mockReturnValueOnce(storedValue)
+
       const element: MockProto = {
         formId: "",
         setValue: false,
-        value: currValue,
-        default: defaultValue,
+        value: "proto-value",
+        default: "default-value",
       }
 
       const { result } = renderHook(() =>
@@ -257,30 +159,92 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         })
       )
 
-      expect(result.current[0]).toEqual(expected)
+      // WidgetStateManager value wins when setValue is false
+      expect(result.current[0]).toBe(storedValue)
+    })
+
+    it("setValue=true updates state even if WidgetStateManager has a value", () => {
+      // When setValue is true, the backend is explicitly setting a new value
+      // (e.g., from session_state update), so it should override cached value
+      const storedValue = "stored-in-widget-mgr"
+      getStateFromWidgetMgr.mockReturnValueOnce(storedValue)
+
+      const element: MockProto = {
+        formId: "",
+        setValue: true,
+        value: "new-backend-value",
+        default: "default-value",
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      // setValue=true means backend is setting a new value, which should win
+      expect(result.current[0]).toBe("new-backend-value")
+    })
+  })
+
+  describe("array values", () => {
+    it("uses currValue array when setValue is true", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: true,
+        value: [3, 4, 5],
+        default: [1, 2],
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual([3, 4, 5])
+    })
+
+    it("uses defaultValue array when setValue is false", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: [3, 4, 5],
+        default: [1, 2],
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual([1, 2])
     })
   })
 
   describe("numeric values", () => {
-    it.each([
-      {
-        desc: "uses currValue when numeric value differs from default",
-        currValue: 42,
-        defaultValue: 0,
-        expected: 42,
-      },
-      {
-        desc: "uses defaultValue when numeric values are equal",
-        currValue: 0,
-        defaultValue: 0,
-        expected: 0,
-      },
-    ])("$desc", ({ currValue, defaultValue, expected }) => {
+    it("uses currValue when setValue is true", () => {
       const element: MockProto = {
         formId: "",
-        setValue: false,
-        value: currValue,
-        default: defaultValue,
+        setValue: true,
+        value: 42,
+        default: 0,
       }
 
       const { result } = renderHook(() =>
@@ -294,7 +258,29 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         })
       )
 
-      expect(result.current[0]).toBe(expected)
+      expect(result.current[0]).toBe(42)
+    })
+
+    it("uses defaultValue when setValue is false", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: 42,
+        default: 0,
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toBe(0)
     })
   })
 })

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react"
+
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import {
+  useBasicWidgetState,
+  type ValueWithSource,
+} from "./useBasicWidgetState"
+
+// Mock proto interface for testing
+interface MockProto {
+  formId: string
+  setValue: boolean
+  value: string | number | string[] | number[]
+  default: string | number | string[] | number[]
+}
+
+// Helper functions for the hook
+const getStateFromWidgetMgr = vi.fn(
+  (_wm: WidgetStateManager, _el: MockProto) => undefined
+)
+
+const getCurrStateFromProto = vi.fn((el: MockProto) => el.value)
+
+const getDefaultStateFromProto = vi.fn((el: MockProto) => el.default)
+
+const updateWidgetMgrState = vi.fn(
+  (
+    _el: MockProto,
+    _wm: WidgetStateManager,
+    _vws: ValueWithSource<string | number | string[] | number[]>,
+    _fragmentId?: string
+  ) => {}
+)
+
+describe("useBasicWidgetState - getDefaultState logic", () => {
+  let widgetMgr: WidgetStateManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    widgetMgr = new WidgetStateManager({
+      formsDataChanged: vi.fn(),
+      sendRerunBackMsg: vi.fn(),
+    })
+  })
+
+  describe("setValue behavior (URL-seeded values)", () => {
+    it("uses currValue when setValue is true", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: true,
+        value: "url-seeded-value",
+        default: "default-value",
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      // When setValue is true, the hook should use getCurrStateFromProto
+      expect(result.current[0]).toBe("url-seeded-value")
+    })
+
+    it("uses defaultValue when setValue is false and values are equal", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: "same-value",
+        default: "same-value",
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toBe("same-value")
+    })
+  })
+
+  describe("React Strict Mode recovery (setValue false but value differs)", () => {
+    it("uses currValue when it differs from defaultValue", () => {
+      // This simulates React Strict Mode: setValue was cleared by first mount,
+      // but element.value still contains the seeded value
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: "seeded-value-from-url",
+        default: "widget-default",
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      // Should use currValue since it differs from default
+      expect(result.current[0]).toBe("seeded-value-from-url")
+    })
+  })
+
+  describe("empty string handling (protobuf default)", () => {
+    it("treats empty string as 'no value set' and uses defaultValue", () => {
+      // Protobuf sets string fields to "" by default when not explicitly set
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: "", // Empty string from protobuf
+        default: "#000000", // Actual widget default (e.g., ColorPicker)
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      // Empty string should be treated as "no value", so use default
+      expect(result.current[0]).toBe("#000000")
+    })
+
+    it("uses non-empty currValue when it differs from default", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: "user-entered-text",
+        default: "",
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toBe("user-entered-text")
+    })
+  })
+
+  describe("null/undefined handling", () => {
+    it("treats null currValue as 'no value set'", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: null as unknown as string, // Simulating null
+        default: "default-value",
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toBe("default-value")
+    })
+  })
+
+  describe("array comparison logic", () => {
+    it("uses defaultValue for empty currValue array", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: [], // Empty array
+        default: [1, 2, 3], // Non-empty default
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual([1, 2, 3])
+    })
+
+    it("uses currValue when array differs from default", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: [3, 4], // URL-seeded selection
+        default: [1, 2], // Widget default
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual([3, 4])
+    })
+
+    it("uses currValue when array length differs", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: [1, 2, 3],
+        default: [1, 2],
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual([1, 2, 3])
+    })
+
+    it("uses defaultValue when arrays are equal", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: [1, 2, 3],
+        default: [1, 2, 3],
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual([1, 2, 3])
+    })
+
+    it("handles string arrays correctly", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: ["option-a", "option-c"], // URL selections
+        default: ["option-a", "option-b"], // Default selections
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toEqual(["option-a", "option-c"])
+    })
+  })
+
+  describe("numeric values", () => {
+    it("uses currValue when numeric value differs from default", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: 42, // URL-seeded number
+        default: 0, // Widget default
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toBe(42)
+    })
+
+    it("uses defaultValue when numeric values are equal", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        value: 0,
+        default: 0,
+      }
+
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+        })
+      )
+
+      expect(result.current[0]).toBe(0)
+    })
+  })
+})

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -160,24 +160,6 @@ export interface UseBasicWidgetStateArgs<
 }
 
 /**
- * Check if currValue represents a seeded value that differs from default.
- * Used for React Strict Mode recovery where setValue was cleared but value persists.
- */
-function hasSeededValue<T>(currValue: T, defaultValue: T): boolean {
-  // Arrays: compare by value, treat empty as uninitialized
-  if (Array.isArray(currValue) && Array.isArray(defaultValue)) {
-    if (currValue.length === 0) return false
-    if (currValue.length !== defaultValue.length) return true
-    return currValue.some((v, i) => v !== defaultValue[i])
-  }
-
-  // Scalars: null/undefined/empty-string means "not set" (protobuf defaults)
-  if (isNullOrUndefined(currValue) || currValue === "") return false
-
-  return currValue !== defaultValue
-}
-
-/**
  * A React hook that makes the simplest kinds of widgets very easy to implement.
  *
  * This hook handles the standard widget state management pattern, including:
@@ -205,21 +187,15 @@ export function useBasicWidgetState<
 ] {
   const getDefaultState = useCallback<(wm: WidgetStateManager, el: P) => T>(
     (_wm, el) => {
-      // Backend explicitly set a value (e.g., from URL params or session_state)
+      // Backend explicitly set a value (e.g., from URL params or session_state).
+      // This handles both initial URL seeding and session_state updates.
+      // On React Strict Mode remount, WidgetStateManager will have the value
+      // (stored by the first mount's effect), so this path won't be reached.
       if (el.setValue) {
         return getCurrStateFromProto(el)
       }
 
-      // React Strict Mode recovery: setValue was cleared by first mount,
-      // but the seeded value persists in element.value. Use it if it differs.
-      const currValue = getCurrStateFromProto(el)
-      const defaultValue = getDefaultStateFromProto(el)
-
-      if (hasSeededValue(currValue, defaultValue)) {
-        return currValue
-      }
-
-      return defaultValue
+      return getDefaultStateFromProto(el)
     },
     [getDefaultStateFromProto, getCurrStateFromProto]
   )

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -160,6 +160,24 @@ export interface UseBasicWidgetStateArgs<
 }
 
 /**
+ * Check if currValue represents a seeded value that differs from default.
+ * Used for React Strict Mode recovery where setValue was cleared but value persists.
+ */
+function hasSeededValue<T>(currValue: T, defaultValue: T): boolean {
+  // Arrays: compare by value, treat empty as uninitialized
+  if (Array.isArray(currValue) && Array.isArray(defaultValue)) {
+    if (currValue.length === 0) return false
+    if (currValue.length !== defaultValue.length) return true
+    return currValue.some((v, i) => v !== defaultValue[i])
+  }
+
+  // Scalars: null/undefined/empty-string means "not set" (protobuf defaults)
+  if (isNullOrUndefined(currValue) || currValue === "") return false
+
+  return currValue !== defaultValue
+}
+
+/**
  * A React hook that makes the simplest kinds of widgets very easy to implement.
  *
  * This hook handles the standard widget state management pattern, including:
@@ -187,43 +205,17 @@ export function useBasicWidgetState<
 ] {
   const getDefaultState = useCallback<(wm: WidgetStateManager, el: P) => T>(
     (_wm, el) => {
-      // If setValue is true, use the current value from the proto instead of default.
-      // This handles the case where the backend has seeded a value (e.g., from URL params)
-      // and we need to initialize with that value, not the default.
+      // Backend explicitly set a value (e.g., from URL params or session_state)
       if (el.setValue) {
         return getCurrStateFromProto(el)
       }
 
-      // Also check if the proto has a non-default value even if setValue is false.
-      // This handles React Strict Mode where setValue was cleared by the first mount
-      // but the seeded value is still in element.value.
+      // React Strict Mode recovery: setValue was cleared by first mount,
+      // but the seeded value persists in element.value. Use it if it differs.
       const currValue = getCurrStateFromProto(el)
       const defaultValue = getDefaultStateFromProto(el)
 
-      // For arrays, compare by value not reference. Also check for non-empty arrays.
-      // Empty arrays should use defaultValue since they indicate uninitialized state.
-      if (Array.isArray(currValue) && Array.isArray(defaultValue)) {
-        // If currValue is empty, use defaultValue
-        if (currValue.length === 0) {
-          return defaultValue
-        }
-        // If currValue has different values than defaultValue, use currValue
-        if (
-          currValue.length !== defaultValue.length ||
-          currValue.some((v, i) => v !== defaultValue[i])
-        ) {
-          return currValue
-        }
-        // Arrays are equal, return defaultValue
-        return defaultValue
-      }
-
-      // For non-array values, use simple comparison
-      if (
-        currValue !== defaultValue &&
-        currValue !== null &&
-        currValue !== undefined
-      ) {
+      if (hasSeededValue(currValue, defaultValue)) {
         return currValue
       }
 

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -187,9 +187,49 @@ export function useBasicWidgetState<
 ] {
   const getDefaultState = useCallback<(wm: WidgetStateManager, el: P) => T>(
     (_wm, el) => {
-      return getDefaultStateFromProto(el)
+      // If setValue is true, use the current value from the proto instead of default.
+      // This handles the case where the backend has seeded a value (e.g., from URL params)
+      // and we need to initialize with that value, not the default.
+      if (el.setValue) {
+        return getCurrStateFromProto(el)
+      }
+
+      // Also check if the proto has a non-default value even if setValue is false.
+      // This handles React Strict Mode where setValue was cleared by the first mount
+      // but the seeded value is still in element.value.
+      const currValue = getCurrStateFromProto(el)
+      const defaultValue = getDefaultStateFromProto(el)
+
+      // For arrays, compare by value not reference. Also check for non-empty arrays.
+      // Empty arrays should use defaultValue since they indicate uninitialized state.
+      if (Array.isArray(currValue) && Array.isArray(defaultValue)) {
+        // If currValue is empty, use defaultValue
+        if (currValue.length === 0) {
+          return defaultValue
+        }
+        // If currValue has different values than defaultValue, use currValue
+        if (
+          currValue.length !== defaultValue.length ||
+          currValue.some((v, i) => v !== defaultValue[i])
+        ) {
+          return currValue
+        }
+        // Arrays are equal, return defaultValue
+        return defaultValue
+      }
+
+      // For non-array values, use simple comparison
+      if (
+        currValue !== defaultValue &&
+        currValue !== null &&
+        currValue !== undefined
+      ) {
+        return currValue
+      }
+
+      return defaultValue
     },
-    [getDefaultStateFromProto]
+    [getDefaultStateFromProto, getCurrStateFromProto]
   )
 
   const [currentValue, setNextValueWithSource] = useBasicWidgetClientState({


### PR DESCRIPTION
## Describe your changes
**Bind Widgets to Query Params - Part 2**
This PR adds the frontend infrastructure for binding widgets to query parameters - enabling two-way sync between widget interactions and the browser's URL.

- **Binding registration** - `registerQueryParamBinding()` / `unregisterQueryParamBinding()` to track widget-to-param relationships on the frontend
- **URL sync methods** - `syncToUrlIfBound()`, `syncCommaArrayToUrlIfBound()`, `syncRepeatedArrayToUrlIfBound()` update the URL when widgets change
- **Default value detection** - Clears URL param when widget returns to default (keeps URLs clean)
- **Index-to-string mapping** - Converts selection widget indices to human-readable option strings in URLs
- **App integration** - `handleQueryParamsFromWidget()` keeps App state in sync with URL changes
- **MPA page navigation** - `filterParamsForPageChange()` preserves embed params and bound widget params while clearing other query params (like ?foo=bar) when navigating between pages - page-specific ones are cleared by the backend
- **setValue handling in `useBasicWidgetState`** - Uses `setValue` flag to correctly initialize widget state from backend (URL-seeded or `session_state` values), with `WidgetStateManager` persisting values across React Strict Mode remounts

## Testing Plan
- Javascript Unit Tests: ✅ Added
- Manual Testing: Via widgets in downstream PRs & with prototype