### PR TITLE
Bind widgets to query params - Part 3

### DIFF
--- a/e2e_playwright/st_checkbox.py
+++ b/e2e_playwright/st_checkbox.py
@@ -105,3 +105,21 @@ else:
         kwargs={"param": "initial kwarg param"},
     )
     st.write("Initial checkbox state:", state)
+
+# Query param binding checkbox (default False)
+st.markdown("Query param binding:")
+bound_checkbox = st.checkbox(
+    "Bound checkbox (default False)",
+    key="bound_checkbox",
+    bind="query-params",
+)
+st.write("bound checkbox value:", bound_checkbox)
+
+# Query param binding checkbox with default True
+bound_checkbox_true = st.checkbox(
+    "Bound checkbox (default True)",
+    value=True,
+    key="bound_true",
+    bind="query-params",
+)
+st.write("bound checkbox true value:", bound_checkbox_true)

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -15,7 +15,11 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_checkbox,
@@ -28,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-CHECKBOX_ELEMENTS = 17
+CHECKBOX_ELEMENTS = 19
 
 
 def test_checkbox_widget_display(
@@ -206,3 +210,69 @@ def test_dynamic_checkbox_props(app: Page, assert_snapshot: ImageCompareFunction
     # Click the checkbox
     click_checkbox(app, "Updated dynamic checkbox")
     expect_prefixed_markdown(app, "Updated checkbox state:", "False")
+
+
+def test_checkbox_query_param_seeding(page: Page, app_port: int):
+    """Test that checkbox value can be seeded from URL query params."""
+    # Load app with query param set to true
+    page.goto(f"http://localhost:{app_port}/?bound_checkbox=true")
+    wait_for_app_loaded(page)
+
+    # Checkbox should be checked
+    checkbox = get_checkbox(page, "Bound checkbox (default False)")
+    expect(checkbox.locator("input")).to_be_checked()
+    expect_prefixed_markdown(page, "bound checkbox value:", "True")
+
+
+def test_checkbox_query_param_updates_url(app: Page):
+    """Test that clicking a bound checkbox updates the URL."""
+    # Initially unchecked (default is False), no query param in URL
+    expect_prefixed_markdown(app, "bound checkbox value:", "False")
+    expect(app).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+
+    # Click the checkbox
+    click_checkbox(app, "Bound checkbox (default False)")
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_checkbox=true"))
+    expect_prefixed_markdown(app, "bound checkbox value:", "True")
+
+    # Click again to uncheck (back to default)
+    click_checkbox(app, "Bound checkbox (default False)")
+
+    # Query param should be removed since value is back to default
+    expect(app).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+    expect_prefixed_markdown(app, "bound checkbox value:", "False")
+
+
+def test_checkbox_query_param_default_true(page: Page, app_port: int):
+    """Test checkbox with default=True: seeding with false and param removal."""
+    # Load app with query param set to false (overriding true default)
+    page.goto(f"http://localhost:{app_port}/?bound_true=false")
+    wait_for_app_loaded(page)
+
+    # Checkbox should be unchecked (false overrides true default)
+    checkbox = get_checkbox(page, "Bound checkbox (default True)")
+    expect(checkbox.locator("input")).not_to_be_checked()
+    expect_prefixed_markdown(page, "bound checkbox true value:", "False")
+
+    # Click to check (back to default True)
+    click_checkbox(page, "Bound checkbox (default True)")
+
+    # Query param should be removed since value is back to default (True)
+    expect(page).to_have_url(re.compile(r"^((?!bound_true).)*$"))
+    expect_prefixed_markdown(page, "bound checkbox true value:", "True")
+
+
+def test_checkbox_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    # Load app with invalid query param value
+    page.goto(f"http://localhost:{app_port}/?bound_checkbox=invalid")
+    wait_for_app_loaded(page)
+
+    # Checkbox should use default (False), and invalid param should be cleared
+    checkbox = get_checkbox(page, "Bound checkbox (default False)")
+    expect(checkbox.locator("input")).not_to_be_checked()
+    expect_prefixed_markdown(page, "bound checkbox value:", "False")
+    # Invalid param should be removed from URL
+    expect(page).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))

--- a/e2e_playwright/st_color_picker.py
+++ b/e2e_playwright/st_color_picker.py
@@ -124,3 +124,21 @@ if "runs" not in st.session_state:
     st.session_state.runs = 0
 st.session_state.runs += 1
 st.write("Runs:", st.session_state.runs)
+
+# Query param binding color picker (no provided default = black)
+st.markdown("Query param binding:")
+bound_color = st.color_picker(
+    "Bound color (no provided default)",
+    key="bound_color",
+    bind="query-params",
+)
+st.write("bound color value:", bound_color)
+
+# Query param binding color picker with custom default
+bound_color_custom = st.color_picker(
+    "Bound color (default red)",
+    value="#ff0000",
+    key="bound_red",
+    bind="query-params",
+)
+st.write("bound color red value:", bound_color_custom)

--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
@@ -26,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
 )
 
-NUM_COLOR_PICKERS = 13
+NUM_COLOR_PICKERS = 15
 
 
 def test_color_picker_widget_display_themed(
@@ -300,3 +306,78 @@ def test_dynamic_color_picker_props(app: Page, assert_snapshot: ImageCompareFunc
     wait_for_app_run(app)
 
     expect_prefixed_markdown(app, "Updated color picker value:", "#ffffff")
+
+
+def test_color_picker_query_param_seeding(page: Page, app_port: int):
+    """Test that color picker value can be seeded from URL query params."""
+    # Load app with query param set (URL-encoded # is %23)
+    page.goto(f"http://localhost:{app_port}/?bound_color=%23FF5733")
+    wait_for_app_loaded(page)
+
+    # Color picker should show the seeded color (displayed uppercase)
+    expect_prefixed_markdown(page, "bound color value:", "#FF5733")
+
+
+def test_color_picker_query_param_updates_url(app: Page):
+    """Test that changing a bound color picker updates the URL."""
+    # Initially default black, no query param in URL
+    expect_prefixed_markdown(app, "bound color value:", "#000000")
+    expect(app).to_have_url(re.compile(r"^((?!bound_color=).)*$"))
+
+    # Change the color
+    color_picker = get_color_picker(app, "Bound color (no provided default)")
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+    text_input = app.get_by_test_id("stColorPickerPopover").locator("input")
+    text_input.fill("#00ff00")
+    # Click outside to close popover
+    app.get_by_text("Bound color (no provided default)").click()
+    wait_for_app_run(app)
+
+    # URL should now contain the query param (URL-encoded)
+    expect(app).to_have_url(re.compile(r"bound_color=%2300ff00"))
+    expect_prefixed_markdown(app, "bound color value:", "#00ff00")
+
+    # Reset to default (black)
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+    text_input = app.get_by_test_id("stColorPickerPopover").locator("input")
+    text_input.fill("#000000")
+    app.get_by_text("Bound color (no provided default)").click()
+    wait_for_app_run(app)
+
+    # Query param should be removed since value is back to default
+    expect(app).to_have_url(re.compile(r"^((?!bound_color=).)*$"))
+    expect_prefixed_markdown(app, "bound color value:", "#000000")
+
+
+def test_color_picker_query_param_default_custom(page: Page, app_port: int):
+    """Test color picker with custom default: seeding and param removal."""
+    # Load app with query param overriding the red default
+    page.goto(f"http://localhost:{app_port}/?bound_red=%2300FF00")
+    wait_for_app_loaded(page)
+
+    # Color picker should show green (overriding red default, case preserved from URL)
+    expect_prefixed_markdown(page, "bound color red value:", "#00FF00")
+
+    # Change back to default (red) - use lowercase since react-color outputs lowercase
+    color_picker = get_color_picker(page, "Bound color (default red)")
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+    text_input = page.get_by_test_id("stColorPickerPopover").locator("input")
+    text_input.fill("#ff0000")
+    page.get_by_text("Bound color (default red)").click()
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default (red)
+    expect(page).to_have_url(re.compile(r"^((?!bound_red).)*$"))
+    expect_prefixed_markdown(page, "bound color red value:", "#ff0000")
+
+
+def test_color_picker_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    # Load app with invalid query param value (not a valid hex color)
+    page.goto(f"http://localhost:{app_port}/?bound_color=notacolor")
+    wait_for_app_loaded(page)
+
+    # Color picker should use default (black), and invalid param should be cleared
+    expect_prefixed_markdown(page, "bound color value:", "#000000")
+    # Invalid param should be removed from URL
+    expect(page).to_have_url(re.compile(r"^((?!bound_color).)*$"))

--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -381,3 +381,16 @@ def test_color_picker_query_param_invalid_value(page: Page, app_port: int):
     expect_prefixed_markdown(page, "bound color value:", "#000000")
     # Invalid param should be removed from URL
     expect(page).to_have_url(re.compile(r"^((?!bound_color).)*$"))
+
+
+def test_color_picker_query_param_3char_hex(page: Page, app_port: int):
+    """Test that 3-char hex shorthand colors (e.g., #F00) work in URL params."""
+    # Load app with 3-char hex color (URL-encoded # is %23)
+    # #F00 is shorthand for #FF0000 (red)
+    page.goto(f"http://localhost:{app_port}/?bound_color=%23F00")
+    wait_for_app_loaded(page)
+
+    # Color picker should accept the 3-char hex and display it
+    # Note: The color picker may expand to 6-char or keep 3-char depending on implementation
+    # We just verify it's treated as valid (red color)
+    expect_prefixed_markdown(page, "bound color value:", "#F00")

--- a/e2e_playwright/st_toggle.py
+++ b/e2e_playwright/st_toggle.py
@@ -95,3 +95,21 @@ else:
         kwargs={"param": "initial kwarg param"},
     )
     st.write("Initial toggle state:", state)
+
+# Query param binding toggle (default False)
+st.markdown("Query param binding:")
+bound_toggle = st.toggle(
+    "Bound toggle (default False)",
+    key="bound_toggle",
+    bind="query-params",
+)
+st.write("bound toggle value:", bound_toggle)
+
+# Query param binding toggle with default True
+bound_toggle_true = st.toggle(
+    "Bound toggle (default True)",
+    value=True,
+    key="bound_true",
+    bind="query-params",
+)
+st.write("bound toggle true value:", bound_toggle_true)

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -16,7 +16,11 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -28,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_toggle,
 )
 
-TOGGLE_ELEMENTS = 17
+TOGGLE_ELEMENTS = 19
 
 
 def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -180,3 +184,69 @@ def test_dynamic_toggle_props(app: Page, assert_snapshot: ImageCompareFunction):
     # Click the toggle
     click_toggle(app, "Updated dynamic toggle")
     expect_prefixed_markdown(app, "Updated toggle state:", "False")
+
+
+def test_toggle_query_param_seeding(page: Page, app_port: int):
+    """Test that toggle value can be seeded from URL query params."""
+    # Load app with query param set to true
+    page.goto(f"http://localhost:{app_port}/?bound_toggle=true")
+    wait_for_app_loaded(page)
+
+    # Toggle should be checked
+    toggle = get_toggle(page, "Bound toggle (default False)")
+    expect(toggle.locator("input")).to_be_checked()
+    expect_prefixed_markdown(page, "bound toggle value:", "True")
+
+
+def test_toggle_query_param_updates_url(app: Page):
+    """Test that clicking a bound toggle updates the URL."""
+    # Initially unchecked (default is False), no query param in URL
+    expect_prefixed_markdown(app, "bound toggle value:", "False")
+    expect(app).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+
+    # Click the toggle
+    click_toggle(app, "Bound toggle (default False)")
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_toggle=true"))
+    expect_prefixed_markdown(app, "bound toggle value:", "True")
+
+    # Click again to turn off (back to default)
+    click_toggle(app, "Bound toggle (default False)")
+
+    # Query param should be removed since value is back to default
+    expect(app).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+    expect_prefixed_markdown(app, "bound toggle value:", "False")
+
+
+def test_toggle_query_param_default_true(page: Page, app_port: int):
+    """Test toggle with default=True: seeding with false and param removal."""
+    # Load app with query param set to false (overriding true default)
+    page.goto(f"http://localhost:{app_port}/?bound_true=false")
+    wait_for_app_loaded(page)
+
+    # Toggle should be off (false overrides true default)
+    toggle = get_toggle(page, "Bound toggle (default True)")
+    expect(toggle.locator("input")).not_to_be_checked()
+    expect_prefixed_markdown(page, "bound toggle true value:", "False")
+
+    # Click to turn on (back to default True)
+    click_toggle(page, "Bound toggle (default True)")
+
+    # Query param should be removed since value is back to default (True)
+    expect(page).to_have_url(re.compile(r"^((?!bound_true).)*$"))
+    expect_prefixed_markdown(page, "bound toggle true value:", "True")
+
+
+def test_toggle_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    # Load app with invalid query param value
+    page.goto(f"http://localhost:{app_port}/?bound_toggle=invalid")
+    wait_for_app_loaded(page)
+
+    # Toggle should use default (False), and invalid param should be cleared
+    toggle = get_toggle(page, "Bound toggle (default False)")
+    expect(toggle.locator("input")).not_to_be_checked()
+    expect_prefixed_markdown(page, "bound toggle value:", "False")
+    # Invalid param should be removed from URL
+    expect(page).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -206,7 +206,9 @@ describe("Checkbox query param binding", () => {
       props.element.id,
       "my_checkbox",
       "bool_value",
-      props.element.default
+      props.element.default,
+      undefined,
+      undefined
     )
   })
 
@@ -245,7 +247,9 @@ describe("Checkbox query param binding", () => {
       props.element.id,
       "my_toggle",
       "bool_value",
-      true
+      true,
+      undefined,
+      undefined
     )
   })
 })

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -194,3 +194,58 @@ describe("Checkbox widget", () => {
     )
   })
 })
+
+describe("Checkbox query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_checkbox" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Checkbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_checkbox",
+      "bool_value",
+      props.element.default
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_checkbox" })
+    vi.spyOn(props.widgetMgr, "unregisterQueryParamBinding")
+
+    const { unmount } = render(<Checkbox {...props} />)
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Checkbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding for toggle widget", () => {
+    const props = getProps({
+      queryParamKey: "my_toggle",
+      type: CheckboxProto.StyleType.TOGGLE,
+      default: true,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Checkbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_toggle",
+      "bool_value",
+      true
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -32,7 +32,6 @@ import {
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import { hasLightBackgroundColor } from "~lib/theme"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -63,16 +62,13 @@ function Checkbox({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "bool_value",
+        }
+      : undefined,
   })
-
-  // Query param binding registration
-  useQueryParamBinding(
-    widgetMgr,
-    element.id,
-    element.queryParamKey,
-    "bool_value",
-    element.default
-  )
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>): void => {

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useCallback } from "react"
+import { memo, ReactElement, useCallback, useEffect } from "react"
 
 import {
   LABEL_PLACEMENT,
@@ -63,6 +63,24 @@ function Checkbox({
     widgetMgr,
     fragmentId,
   })
+
+  // Query param binding registration
+  const queryParamKey = element.queryParamKey
+  const widgetId = element.id
+  const defaultValue = element.default
+  useEffect(() => {
+    if (queryParamKey) {
+      widgetMgr.registerQueryParamBinding(
+        widgetId,
+        queryParamKey,
+        "bool_value",
+        defaultValue
+      )
+      return () => {
+        widgetMgr.unregisterQueryParamBinding(widgetId)
+      }
+    }
+  }, [widgetMgr, widgetId, queryParamKey, defaultValue])
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>): void => {

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useCallback, useEffect } from "react"
+import { memo, ReactElement, useCallback } from "react"
 
 import {
   LABEL_PLACEMENT,
@@ -32,6 +32,7 @@ import {
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import { hasLightBackgroundColor } from "~lib/theme"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -65,22 +66,13 @@ function Checkbox({
   })
 
   // Query param binding registration
-  const queryParamKey = element.queryParamKey
-  const widgetId = element.id
-  const defaultValue = element.default
-  useEffect(() => {
-    if (queryParamKey) {
-      widgetMgr.registerQueryParamBinding(
-        widgetId,
-        queryParamKey,
-        "bool_value",
-        defaultValue
-      )
-      return () => {
-        widgetMgr.unregisterQueryParamBinding(widgetId)
-      }
-    }
-  }, [widgetMgr, widgetId, queryParamKey, defaultValue])
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    element.queryParamKey,
+    "bool_value",
+    element.default
+  )
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>): void => {

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -187,7 +187,9 @@ describe("ColorPicker query param binding", () => {
       props.element.id,
       "my_color",
       "string_value",
-      props.element.default
+      props.element.default,
+      undefined,
+      undefined
     )
   })
 
@@ -225,7 +227,9 @@ describe("ColorPicker query param binding", () => {
       props.element.id,
       "theme_color",
       "string_value",
-      "#750dc5"
+      "#750dc5",
+      undefined,
+      undefined
     )
 
     // Verify the widget displays the custom default color

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -175,3 +175,61 @@ describe("ColorPicker widget", () => {
     )
   })
 })
+
+describe("ColorPicker query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_color" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_color",
+      "string_value",
+      props.element.default
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_color" })
+    vi.spyOn(props.widgetMgr, "unregisterQueryParamBinding")
+
+    const { unmount } = render(<ColorPicker {...props} />)
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding with custom default color", () => {
+    const props = getProps({
+      queryParamKey: "theme_color",
+      default: "#750dc5",
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "theme_color",
+      "string_value",
+      "#750dc5"
+    )
+
+    // Verify the widget displays the custom default color
+    const colorBlock = screen.getByTestId("stColorPickerBlock")
+    expect(colorBlock).toHaveStyle("background-color: #750dc5")
+  })
+})

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, memo, useCallback, useEffect } from "react"
+import { FC, memo, useCallback } from "react"
 
 import { ColorPicker as ColorPickerProto } from "@streamlit/protobuf"
 
@@ -23,6 +23,7 @@ import {
   useBasicWidgetState,
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
+import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -96,22 +97,13 @@ const ColorPicker: FC<Props> = ({
   })
 
   // Query param binding registration
-  const queryParamKey = element.queryParamKey
-  const widgetId = element.id
-  const defaultValue = element.default
-  useEffect(() => {
-    if (queryParamKey) {
-      widgetMgr.registerQueryParamBinding(
-        widgetId,
-        queryParamKey,
-        "string_value",
-        defaultValue
-      )
-      return () => {
-        widgetMgr.unregisterQueryParamBinding(widgetId)
-      }
-    }
-  }, [widgetMgr, widgetId, queryParamKey, defaultValue])
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    element.queryParamKey,
+    "string_value",
+    element.default
+  )
 
   const handleColorClose = useCallback(
     (color: string): void => {

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, memo, useCallback } from "react"
+import { FC, memo, useCallback, useEffect } from "react"
 
 import { ColorPicker as ColorPickerProto } from "@streamlit/protobuf"
 
@@ -49,13 +49,15 @@ const getStateFromWidgetMgr = (
 const getDefaultStateFromProto = (
   element: ColorPickerProto
 ): ColorPickerValue => {
-  return element.default ?? null
+  // Default to a sensible color if proto default is not set
+  return element.default || "#000000"
 }
 
 const getCurrStateFromProto = (
   element: ColorPickerProto
 ): ColorPickerValue => {
-  return element.value ?? null
+  // Return the current value, falling back to default if not set
+  return element.value || element.default || "#000000"
 }
 
 const updateWidgetMgrState = (
@@ -90,6 +92,24 @@ const ColorPicker: FC<Props> = ({
     widgetMgr,
     fragmentId,
   })
+
+  // Query param binding registration
+  const queryParamKey = element.queryParamKey
+  const widgetId = element.id
+  const defaultValue = element.default
+  useEffect(() => {
+    if (queryParamKey) {
+      widgetMgr.registerQueryParamBinding(
+        widgetId,
+        queryParamKey,
+        "string_value",
+        defaultValue
+      )
+      return () => {
+        widgetMgr.unregisterQueryParamBinding(widgetId)
+      }
+    }
+  }, [widgetMgr, widgetId, queryParamKey, defaultValue])
 
   const handleColorClose = useCallback(
     (color: string): void => {

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -50,14 +50,16 @@ const getDefaultStateFromProto = (
   element: ColorPickerProto
 ): ColorPickerValue => {
   // Default to a sensible color if proto default is not set
-  return element.default || "#000000"
+  // Use ?? to only fallback on null/undefined, not empty string
+  return element.default ?? "#000000"
 }
 
 const getCurrStateFromProto = (
   element: ColorPickerProto
 ): ColorPickerValue => {
   // Return the current value, falling back to default if not set
-  return element.value || element.default || "#000000"
+  // Use ?? to only fallback on null/undefined, not empty string
+  return element.value ?? element.default ?? "#000000"
 }
 
 const updateWidgetMgrState = (

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -23,7 +23,6 @@ import {
   useBasicWidgetState,
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
-import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -94,16 +93,13 @@ const ColorPicker: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "string_value",
+        }
+      : undefined,
   })
-
-  // Query param binding registration
-  useQueryParamBinding(
-    widgetMgr,
-    element.id,
-    element.queryParamKey,
-    "string_value",
-    element.default
-  )
 
   const handleColorClose = useCallback(
     (color: string): void => {

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -19,6 +19,7 @@ import { renderHook } from "@testing-library/react"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
+  type QueryParamBindingConfig,
   useBasicWidgetState,
   type ValueWithSource,
 } from "./useBasicWidgetState"
@@ -27,6 +28,7 @@ import {
 interface MockProto {
   formId: string
   setValue: boolean
+  id: string
   value: string | number | string[] | number[]
   default: string | number | string[] | number[]
 }
@@ -66,6 +68,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-1",
         value: "url-seeded-value",
         default: "default-value",
       }
@@ -89,6 +92,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-2",
         value: "some-value",
         default: "default-value",
       }
@@ -115,6 +119,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-3",
         value: "different-value",
         default: "default-value",
       }
@@ -144,6 +149,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-4",
         value: "proto-value",
         default: "default-value",
       }
@@ -172,6 +178,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-5",
         value: "new-backend-value",
         default: "default-value",
       }
@@ -197,6 +204,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-6",
         value: [3, 4, 5],
         default: [1, 2],
       }
@@ -219,6 +227,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-7",
         value: [3, 4, 5],
         default: [1, 2],
       }
@@ -243,6 +252,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-8",
         value: 42,
         default: 0,
       }
@@ -265,6 +275,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-9",
         value: 42,
         default: 0,
       }
@@ -281,6 +292,147 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       )
 
       expect(result.current[0]).toBe(0)
+    })
+  })
+
+  describe("query param binding integration", () => {
+    it("registers binding when queryParamBinding config is provided", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-with-binding",
+        value: "test",
+        default: "default",
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "my_param",
+        valueType: "string_value",
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          queryParamBinding,
+        })
+      )
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        "widget-with-binding",
+        "my_param",
+        "string_value",
+        "default",
+        undefined,
+        undefined
+      )
+    })
+
+    it("does not register binding when queryParamBinding is undefined", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-no-binding",
+        value: "test",
+        default: "default",
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          // No queryParamBinding
+        })
+      )
+
+      expect(registerSpy).not.toHaveBeenCalled()
+    })
+
+    it("unregisters binding on unmount", () => {
+      const unregisterSpy = vi.spyOn(widgetMgr, "unregisterQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-unmount-test",
+        value: "test",
+        default: "default",
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "unmount_param",
+        valueType: "bool_value",
+      }
+
+      const { unmount } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          queryParamBinding,
+        })
+      )
+
+      expect(unregisterSpy).not.toHaveBeenCalled()
+
+      unmount()
+
+      expect(unregisterSpy).toHaveBeenCalledWith("widget-unmount-test")
+    })
+
+    it("passes urlFormat and optionStrings correctly", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-with-options",
+        value: 0,
+        default: 0,
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "color",
+        valueType: "int_value",
+        urlFormat: "comma",
+        optionStrings: ["Red", "Green", "Blue"],
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          queryParamBinding,
+        })
+      )
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        "widget-with-options",
+        "color",
+        "int_value",
+        0,
+        "comma",
+        ["Red", "Green", "Blue"]
+      )
     })
   })
 })

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -24,7 +24,13 @@ import {
 
 import { useFormClearHelper } from "~lib/components/widgets/Form"
 import { isNullOrUndefined } from "~lib/util/utils"
-import { Source, WidgetStateManager } from "~lib/WidgetStateManager"
+import {
+  Source,
+  WidgetStateManager,
+  WidgetValueType,
+} from "~lib/WidgetStateManager"
+
+import { useQueryParamBinding } from "./useQueryParamBinding"
 
 export type ValueWithSource<T> = {
   value: T
@@ -144,9 +150,30 @@ export function useBasicWidgetClientState<
   return [currentValue, setNextValueWithSource]
 }
 
-// Interface for a proto that has a setValue, and .formId
+// Interface for a proto that has a setValue, id, and .formId
 interface ValueElementProtoInterfaceWithSetValue extends ValueElementProtoInterface {
   setValue: boolean
+  id: string
+}
+
+/**
+ * Configuration for query parameter binding integration.
+ * When provided to useBasicWidgetState, the hook will automatically
+ * register/unregister the widget's URL query parameter binding.
+ */
+export interface QueryParamBindingConfig {
+  /** The URL query parameter key */
+  paramKey: string
+  /** The widget value type for URL conversion */
+  valueType: WidgetValueType
+  /** How to serialize arrays in the URL ("comma" or "repeated") */
+  urlFormat?: "comma" | "repeated"
+  /**
+   * For index-based widgets, the formatted option strings to use in URLs.
+   * TODO(query-params): Remove after wire format changes from index-based
+   * to string-based values for applicable widgets (selectbox, pills, etc.)
+   */
+  optionStrings?: string[]
 }
 
 export interface UseBasicWidgetStateArgs<
@@ -157,6 +184,12 @@ export interface UseBasicWidgetStateArgs<
   // either declare them at the module level or wrap in useCallback.
   getDefaultStateFromProto: (el: P) => T
   getCurrStateFromProto: (el: P) => T
+  /**
+   * Optional query parameter binding configuration.
+   * When provided, the hook will automatically register the widget
+   * for URL query parameter synchronization.
+   */
+  queryParamBinding?: QueryParamBindingConfig
 }
 
 /**
@@ -181,6 +214,7 @@ export function useBasicWidgetState<
   widgetMgr,
   fragmentId,
   onFormCleared,
+  queryParamBinding,
 }: UseBasicWidgetStateArgs<T, P>): [
   T,
   Dispatch<SetStateAction<ValueWithSource<T> | null>>,
@@ -209,6 +243,21 @@ export function useBasicWidgetState<
     fragmentId,
     onFormCleared,
   })
+
+  // Query param binding registration (optional, integrated for convenience)
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    queryParamBinding?.paramKey ?? null,
+    queryParamBinding?.valueType ?? "string_value",
+    getDefaultStateFromProto(element),
+    queryParamBinding
+      ? {
+          urlFormat: queryParamBinding.urlFormat,
+          optionStrings: queryParamBinding.optionStrings,
+        }
+      : undefined
+  )
 
   // Respond to value changes via session_state. This is also set via an
   // "event", this time using the .setValue property of the proto.

--- a/frontend/lib/src/hooks/useQueryParamBinding.test.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest"
+
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import { useQueryParamBinding } from "./useQueryParamBinding"
+
+describe("useQueryParamBinding", () => {
+  let mockWidgetMgr: {
+    registerQueryParamBinding: Mock
+    unregisterQueryParamBinding: Mock
+  }
+
+  beforeEach(() => {
+    mockWidgetMgr = {
+      registerQueryParamBinding: vi.fn(),
+      unregisterQueryParamBinding: vi.fn(),
+    }
+  })
+
+  it("registers binding when queryParamKey is provided", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "my_key",
+        "string_value",
+        "default"
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123",
+      "my_key",
+      "string_value",
+      "default",
+      undefined,
+      undefined
+    )
+  })
+
+  it("does not register when queryParamKey is undefined", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        undefined,
+        "string_value",
+        "default"
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("unregisters binding on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "my_key",
+        "bool_value",
+        false
+      )
+    )
+
+    expect(mockWidgetMgr.unregisterQueryParamBinding).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(mockWidgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123"
+    )
+  })
+
+  it("does not unregister on unmount when queryParamKey is undefined", () => {
+    const { unmount } = renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        undefined,
+        "bool_value",
+        false
+      )
+    )
+
+    unmount()
+
+    expect(mockWidgetMgr.unregisterQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("passes urlFormat option correctly", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "tags",
+        "string_array_value",
+        [],
+        { urlFormat: "comma" }
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123",
+      "tags",
+      "string_array_value",
+      [],
+      "comma",
+      undefined
+    )
+  })
+
+  it("passes optionStrings option correctly", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "color",
+        "int_value",
+        0,
+        { optionStrings: ["Red", "Green", "Blue"] }
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123",
+      "color",
+      "int_value",
+      0,
+      undefined,
+      ["Red", "Green", "Blue"]
+    )
+  })
+
+  it("re-registers when queryParamKey changes", () => {
+    const { rerender } = renderHook(
+      ({ queryParamKey }) =>
+        useQueryParamBinding(
+          mockWidgetMgr as unknown as WidgetStateManager,
+          "widget-123",
+          queryParamKey,
+          "string_value",
+          "default"
+        ),
+      { initialProps: { queryParamKey: "key1" } }
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledTimes(1)
+
+    rerender({ queryParamKey: "key2" })
+
+    // Should unregister old and register new
+    expect(mockWidgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123"
+    )
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/lib/src/hooks/useQueryParamBinding.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from "react"
+
+import { WidgetStateManager, WidgetValueType } from "~lib/WidgetStateManager"
+
+export interface QueryParamBindingOptions {
+  /** How to serialize arrays in the URL ("comma" for comma-separated, "repeated" for ?key=a&key=b) */
+  urlFormat?: "comma" | "repeated"
+  /** For index-based widgets, the formatted option strings to use in URLs */
+  optionStrings?: string[]
+}
+
+/**
+ * Custom hook to register a widget's binding to a URL query parameter.
+ *
+ * This hook handles:
+ * - Registering the binding on mount (if queryParamKey is provided)
+ * - Unregistering the binding on unmount
+ * - Re-registering if dependencies change
+ *
+ * @param widgetMgr - The WidgetStateManager instance
+ * @param widgetId - The unique widget ID
+ * @param queryParamKey - The query parameter key (null/undefined if not bound)
+ * @param valueType - The widget value type (e.g., "bool_value", "string_value")
+ * @param defaultValue - The widget's default value (for clearing URL when value equals default)
+ * @param options - Optional configuration for URL format and option strings
+ */
+export function useQueryParamBinding(
+  widgetMgr: WidgetStateManager,
+  widgetId: string,
+  queryParamKey: string | null | undefined,
+  valueType: WidgetValueType,
+  defaultValue: unknown,
+  options?: QueryParamBindingOptions
+): void {
+  useEffect(() => {
+    // Treat null and undefined the same - no binding
+    if (!queryParamKey) {
+      return
+    }
+
+    widgetMgr.registerQueryParamBinding(
+      widgetId,
+      queryParamKey,
+      valueType,
+      defaultValue,
+      options?.urlFormat,
+      options?.optionStrings
+    )
+
+    return () => {
+      widgetMgr.unregisterQueryParamBinding(widgetId)
+    }
+  }, [
+    widgetMgr,
+    widgetId,
+    queryParamKey,
+    valueType,
+    defaultValue,
+    options?.urlFormat,
+    options?.optionStrings,
+  ])
+}

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -154,6 +154,13 @@ class CheckboxMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         bool
@@ -281,6 +288,13 @@ class CheckboxMixin:
               fixed width. If the specified width is greater than the width of
               the parent container, the width of the widget matches the width
               of the parent container.
+
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -39,6 +39,7 @@ from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -75,6 +76,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> bool:
         r"""Display a checkbox widget.
 
@@ -183,6 +185,7 @@ class CheckboxMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             type=CheckboxProto.StyleType.DEFAULT,
+            bind=bind,
             ctx=ctx,
             width=width,
         )
@@ -201,6 +204,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> bool:
         r"""Display a toggle widget.
 
@@ -309,6 +313,7 @@ class CheckboxMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             type=CheckboxProto.StyleType.TOGGLE,
+            bind=bind,
             ctx=ctx,
             width=width,
         )
@@ -326,6 +331,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         type: CheckboxProto.StyleType.ValueType = CheckboxProto.StyleType.DEFAULT,
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
     ) -> bool:
@@ -364,6 +370,10 @@ class CheckboxMixin:
         if help is not None:
             checkbox_proto.help = dedent(help)
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            checkbox_proto.query_param_key = str(key)
+
         validate_width(width, allow_content=True)
         layout_config = LayoutConfig(width=width)
 
@@ -378,6 +388,7 @@ class CheckboxMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="bool_value",
+            bind=bind,
         )
 
         if checkbox_state.value_changed:

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -41,6 +41,7 @@ from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -49,6 +50,16 @@ from streamlit.runtime.state import (
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+
+# Compiled regex for validating hex colors (#RGB or #RRGGBB format)
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
+
+
+def _normalize_hex_color(color: str) -> str:
+    """Normalize a hex color to include the # prefix."""
+    if not color.startswith("#"):
+        return f"#{color}"
+    return color
 
 
 @dataclass
@@ -59,7 +70,14 @@ class ColorPickerSerde:
         return str(v)
 
     def deserialize(self, ui_value: str | None) -> str:
-        return str(ui_value if ui_value is not None else self.value)
+        # None or empty string means use default
+        if ui_value is None or ui_value == "":
+            return self.value
+        # Normalize first (add # prefix if missing), then validate
+        normalized = _normalize_hex_color(ui_value)
+        if not _HEX_COLOR_RE.match(normalized):
+            raise ValueError(f"Invalid hex color: {ui_value}")
+        return normalized
 
 
 class ColorPickerMixin:
@@ -77,6 +95,7 @@ class ColorPickerMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> str:
         r"""Display a color picker widget.
 
@@ -156,6 +175,13 @@ class ColorPickerMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         str
@@ -185,6 +211,7 @@ class ColorPickerMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -201,6 +228,7 @@ class ColorPickerMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str:
         key = to_key(key)
@@ -246,9 +274,7 @@ like '#00FFAA' or '#000'.
 """)
 
         # validate the value and expects a hex string
-        match = re.match(r"^#(?:[0-9a-fA-F]{3}){1,2}$", value)
-
-        if not match:
+        if not _HEX_COLOR_RE.match(value):
             raise StreamlitAPIException(f"""
 '{value}' is not a valid hex code for colors. Valid ones are like
 '#00FFAA' or '#000'.
@@ -267,6 +293,10 @@ like '#00FFAA' or '#000'.
         if help is not None:
             color_picker_proto.help = dedent(help)
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            color_picker_proto.query_param_key = str(key)
+
         serde = ColorPickerSerde(value)
 
         widget_state = register_widget(
@@ -278,6 +308,7 @@ like '#00FFAA' or '#000'.
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_value",
+            bind=bind,
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -286,6 +286,17 @@ class StreamlitInvalidTextAlignmentError(LocalizableStreamlitException):
         )
 
 
+class StreamlitInvalidBindValueError(LocalizableStreamlitException):
+    """Exception raised when an invalid value is specified for the bind parameter."""
+
+    def __init__(self, bind_value: Any) -> None:
+        super().__init__(
+            'Invalid `bind` value: "{bind_value}". '
+            'Supported values are: `"query-params"` or `None`.',
+            bind_value=bind_value,
+        )
+
+
 # st.multiselect
 class StreamlitSelectionCountExceedsMaxError(LocalizableStreamlitException):
     """Exception raised when there are more default selections specified than the max allowable selections."""

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.runtime.state.common import (
     BindOption,
     RegisterWidgetResult,
@@ -124,6 +124,10 @@ def register_widget(
         raise StreamlitAPIException(
             "Cannot provide both `on_change` and `callbacks` to a widget."
         )
+
+    # Validate bind parameter value
+    if bind is not None and bind != "query-params":
+        raise StreamlitInvalidBindValueError(bind)
 
     # Validate that widget with bind="query-params" has a provided key
     if bind == "query-params":

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -361,3 +361,48 @@ hello
             == WidthConfigFields.USE_CONTENT.value
         )
         assert el.width_config.use_content is True
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_bind_query_params_sets_query_param_key(
+        self, name: str, widget_func: callable
+    ):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        widget_func("the label", key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.query_param_key == "my_key"
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_bind_query_params_without_key_raises_exception(
+        self, name: str, widget_func: callable
+    ):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            widget_func("the label", bind="query-params")
+
+        assert "must have a 'key' parameter" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_no_bind_does_not_set_query_param_key(
+        self, name: str, widget_func: callable
+    ):
+        """Test that without bind parameter, query_param_key is not set."""
+        widget_func("the label", key="my_key")
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.query_param_key == ""

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -394,7 +394,7 @@ hello
         with pytest.raises(StreamlitAPIException) as exc:
             widget_func("the label", bind="query-params")
 
-        assert "must have a 'key' parameter" in str(exc.value)
+        assert "must have a unique 'key' parameter" in str(exc.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.policies import _LOGGER
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -406,3 +406,19 @@ hello
 
         c = self.get_delta_from_queue().new_element.checkbox
         assert c.query_param_key == ""
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_invalid_bind_value_raises_exception(
+        self, name: str, widget_func: callable
+    ):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            widget_func("the label", key="my_key", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +27,9 @@ from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class SomeObj:
@@ -369,7 +373,7 @@ hello
         ]
     )
     def test_bind_query_params_sets_query_param_key(
-        self, name: str, widget_func: callable
+        self, name: str, widget_func: Callable
     ):
         """Test that bind='query-params' with a key sets query_param_key in proto."""
         widget_func("the label", key="my_key", bind="query-params")
@@ -384,7 +388,7 @@ hello
         ]
     )
     def test_bind_query_params_without_key_raises_exception(
-        self, name: str, widget_func: callable
+        self, name: str, widget_func: Callable
     ):
         """Test that bind='query-params' without a key raises an exception."""
         with pytest.raises(StreamlitAPIException) as exc:
@@ -399,7 +403,7 @@ hello
         ]
     )
     def test_no_bind_does_not_set_query_param_key(
-        self, name: str, widget_func: callable
+        self, name: str, widget_func: Callable
     ):
         """Test that without bind parameter, query_param_key is not set."""
         widget_func("the label", key="my_key")
@@ -414,7 +418,7 @@ hello
         ]
     )
     def test_invalid_bind_value_raises_exception(
-        self, name: str, widget_func: callable
+        self, name: str, widget_func: Callable
     ):
         """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
         with pytest.raises(StreamlitInvalidBindValueError) as exc:

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -245,7 +245,7 @@ class ColorPickerTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             st.color_picker("the label", bind="query-params")
 
-        assert "must have a 'key' parameter" in str(exc.value)
+        assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
         """Test that without bind parameter, query_param_key is not set."""

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -20,7 +20,7 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
@@ -232,3 +232,32 @@ class ColorPickerTest(DeltaGeneratorTestCase):
             c2 = self.get_delta_from_queue().new_element.color_picker
             id2 = c2.id
             assert id1 == id2
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.color_picker("the label", key="my_color", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.color_picker
+        assert c.query_param_key == "my_color"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.color_picker("the label", bind="query-params")
+
+        assert "must have a 'key' parameter" in str(exc.value)
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.color_picker("the label", key="my_color")
+
+        c = self.get_delta_from_queue().new_element.color_picker
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            st.color_picker("the label", key="my_color", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -344,6 +344,8 @@ EXCLUDED_KWARGS_FOR_ELEMENT_ID_COMPUTATION = {
     "on_submit",
     # Key should be provided via `user_key` instead.
     "key",
+    # bind controls URL syncing, not widget identity
+    "bind",
 }
 
 

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -37,4 +37,6 @@ message Checkbox {
   bool disabled = 8;
   LabelVisibilityMessage label_visibility = 9;
   StyleType type = 10;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 11;
 }

--- a/proto/streamlit/proto/ColorPicker.proto
+++ b/proto/streamlit/proto/ColorPicker.proto
@@ -31,4 +31,6 @@ message ColorPicker {
   bool set_value = 7;
   bool disabled = 8;
   LabelVisibilityMessage label_visibility = 9;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 10;
 }


### PR DESCRIPTION
## Describe your changes
**Bind Widgets to Query Params - Part 3**
This PR adds the `bind` parameter to `st.checkbox`, `st.toggle`, and `st.color_picker` to enable two-way sync between widget values and URL query parameters.

- **URL seeding** - Widget initializes from URL on page load
- **URL sync** - Clicking widget updates URL in real-time
- **Default cleanup** - URL param removed when widget returns to default value
- **Hex validation** - Color picker validates/normalizes hex colors from URL (supports both 3-char and 6-char formats, with or without # prefix)
- **Error handling** - `StreamlitInvalidBindValueError` for invalid bind values
- **`useQueryParamBinding` hook** - Extracted reusable hook for registering/unregistering query param bindings

## Testing Plan
- Python/JS Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 