### PR TITLE
Ignore unused type warnings when running `ty`

### DIFF
--- a/ty.toml
+++ b/ty.toml
@@ -26,3 +26,4 @@ exclude = [
 [rules]
 unresolved-import = "ignore"
 possibly-unresolved-reference = "error"
+unused-ignore-comment = "ignore"


### PR DESCRIPTION
## Describe your changes

The output from `ty` got quite noisy recently since all the unused type ignores are showing up as warnings. But these are required for mypy. Ignoring these warnings in the config. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
