### PR TITLE
[feat] Add snapshot autofix workflow for E2E test snapshots

### DIFF
--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -56,6 +56,39 @@ jobs:
             echo "script_status=failed" >> $GITHUB_OUTPUT
           fi
 
+      - name: Comment on PR when snapshot update fails
+        if: steps.update-snapshots.outputs.script_status == 'failed'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              "⚠️ **Snapshot Autofix Failed**",
+              "",
+              "The snapshot autofix workflow could not update snapshots. This can happen if:",
+              "- The Playwright E2E tests passed (no snapshot mismatches to fix)",
+              "- No Playwright workflow run was found for the current commit",
+              "- The snapshot artifacts could not be downloaded",
+              "",
+              `Please check the [workflow run logs](${runUrl}) for details.`,
+              "",
+              "If you need to update snapshots manually, you can:",
+              "1. Download the snapshot artifacts from the failed Playwright workflow run",
+              "2. Extract them to `e2e_playwright/__snapshots__/`",
+              "3. Commit and push the changes",
+              "",
+              "You can re-run this workflow by removing and re-adding the `snapshots` label."
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
       - name: Count updated snapshots
         if: steps.update-snapshots.outputs.script_status == 'success'
         id: count-snapshots

--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -1,5 +1,5 @@
 # Snapshot autofix workflow - updates E2E test snapshots when Playwright tests fail
-# Triggered by adding the 'snapshots' label to a PR
+# Triggered by adding the 'update-snapshots' label to a PR
 name: Snapshot Autofix
 
 on:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   snapshot-autofix:
-    if: contains(github.event.pull_request.labels.*.name, 'snapshots')
+    if: contains(github.event.pull_request.labels.*.name, 'update-snapshots')
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -79,7 +79,7 @@ jobs:
               "2. Extract them to `e2e_playwright/__snapshots__/`",
               "3. Commit and push the changes",
               "",
-              "You can re-run this workflow by removing and re-adding the `snapshots` label."
+              "You can re-run this workflow by removing and re-adding the `update-snapshots` label."
             ].join("\n");
 
             await github.rest.issues.createComment({
@@ -130,7 +130,7 @@ jobs:
 
             Automated snapshot updates for #${{ github.event.pull_request.number }} created via the snapshot autofix CI workflow.
 
-            This workflow was triggered by adding the `snapshots` label to a PR after Playwright E2E tests failed with snapshot mismatches.
+            This workflow was triggered by adding the `update-snapshots` label to a PR after Playwright E2E tests failed with snapshot mismatches.
 
             **Updated snapshots:** ${{ steps.count-snapshots.outputs.snapshot_count }} file(s)
 
@@ -144,12 +144,12 @@ jobs:
             --title "[snapshots] Update E2E snapshots for #${{ github.event.pull_request.number }}" \
             --body "$PR_BODY"
 
-      - name: Remove 'snapshots' label from source PR
+      - name: Remove 'update-snapshots' label from source PR
         if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "snapshots"
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "update-snapshots"
 
       - name: Show notices for fork PRs
         if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -35,6 +35,13 @@ jobs:
           submodules: "recursive"
           fetch-depth: 2
 
+      - name: Remove 'update-snapshots' label to prevent re-triggers
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "update-snapshots"
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -143,13 +150,6 @@ jobs:
             --base "${{ github.head_ref }}" \
             --title "[snapshots] Update E2E snapshots for #${{ github.event.pull_request.number }}" \
             --body "$PR_BODY"
-
-      - name: Remove 'update-snapshots' label from source PR
-        if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "update-snapshots"
 
       - name: Show notices for fork PRs
         if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true'
         id: git-check
         run: |
-          git add -A
+          git add e2e_playwright/__snapshots__
           git status --porcelain
           echo "changes=$(if git diff --staged --quiet; then echo false; else echo true; fi)" >> $GITHUB_OUTPUT
 
@@ -84,7 +84,7 @@ jobs:
           git config user.name "Streamlit Bot"
           fix_branch="snapshots/${{ github.event.pull_request.number }}-${{ github.run_id }}"
           git checkout -b "$fix_branch"
-          git add -A
+          git add e2e_playwright/__snapshots__
           git commit -m "Update E2E test snapshots"
           git push --set-upstream origin "$fix_branch"
 

--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -27,99 +27,7 @@ jobs:
         shell: bash
 
     steps:
-      - name: Get short SHA
-        id: short_sha
-        run: |
-          echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
-
-      - name: Wait for Playwright tests to complete
-        id: wait-playwright
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const headSha = '${{ github.event.pull_request.head.sha }}';
-            const maxWaitMs = 35 * 60 * 1000; // 35 minutes
-            const pollIntervalMs = 60 * 1000; // 1 minute
-            const startTime = Date.now();
-
-            // We primarily care about playwright.yml (full E2E tests)
-            // playwright-changed-files.yml only runs a subset and may pass even when full tests fail
-            const primaryWorkflow = 'playwright.yml';
-
-            while (Date.now() - startTime < maxWaitMs) {
-              try {
-                const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: primaryWorkflow,
-                  head_sha: headSha,
-                  per_page: 1
-                });
-
-                if (runs.workflow_runs.length > 0) {
-                  const run = runs.workflow_runs[0];
-                  console.log(`${primaryWorkflow}: status=${run.status}, conclusion=${run.conclusion}`);
-
-                  if (run.status === 'completed') {
-                    if (run.conclusion === 'failure') {
-                      // Found a failed Playwright run - this is what we want
-                      console.log(`Found failed Playwright run: ${primaryWorkflow}, run_id=${run.id}`);
-                      core.setOutput('status', 'failed');
-                      core.setOutput('run_id', run.id.toString());
-                      core.setOutput('workflow', primaryWorkflow);
-                      return;
-                    } else if (run.conclusion === 'success') {
-                      // Playwright passed - no snapshots to update
-                      core.notice('Playwright tests passed - no snapshot updates needed');
-                      core.setOutput('status', 'passed');
-                      core.setOutput('run_id', '');
-                      return;
-                    } else {
-                      // Other conclusions (cancelled, skipped)
-                      core.notice(`Playwright workflow completed with conclusion: ${run.conclusion}`);
-                      core.setOutput('status', run.conclusion);
-                      core.setOutput('run_id', '');
-                      return;
-                    }
-                  }
-                  // Still running - continue polling
-                  console.log('Playwright tests still running, waiting...');
-                } else {
-                  // No workflow run found yet
-                  const elapsed = Math.round((Date.now() - startTime) / 1000);
-                  if (elapsed > 120) {
-                    // After 2 minutes, if no workflow found, give up
-                    core.notice('No Playwright workflow runs found for this commit');
-                    core.setOutput('status', 'not_found');
-                    core.setOutput('run_id', '');
-                    return;
-                  }
-                  console.log('Playwright workflow not started yet, waiting...');
-                }
-              } catch (error) {
-                console.log(`Could not fetch runs for ${primaryWorkflow}: ${error.message}`);
-              }
-
-              // Wait before next poll
-              await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
-            }
-
-            // Timeout reached
-            core.setFailed('Timeout waiting for Playwright tests to complete');
-
-      - name: Check if we should continue
-        id: check-continue
-        run: |
-          status="${{ steps.wait-playwright.outputs.status }}"
-          if [[ "$status" != "failed" ]]; then
-            echo "Playwright status is '$status', skipping snapshot update"
-            echo "should_continue=false" >> $GITHUB_OUTPUT
-          else
-            echo "should_continue=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout Streamlit code
-        if: steps.check-continue.outputs.should_continue == 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
@@ -127,56 +35,42 @@ jobs:
           submodules: "recursive"
           fetch-depth: 2
 
-      - name: Download Playwright test artifacts
-        if: steps.check-continue.outputs.should_continue == 'true'
-        uses: actions/download-artifact@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.wait-playwright.outputs.run_id }}
-          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
-          path: /tmp/playwright_artifacts
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          python-version: "3.12"
 
-      - name: Check for snapshot updates
-        if: steps.check-continue.outputs.should_continue == 'true'
-        id: check-snapshots
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run update_e2e_snapshots.py
+        id: update-snapshots
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ -d "/tmp/playwright_artifacts/snapshot-updates" ]]; then
-            # Check if there are actual snapshot files
-            snapshot_count=$(find /tmp/playwright_artifacts/snapshot-updates -type f \( -name "*.png" -o -name "*.jpg" \) | wc -l)
-            if [[ "$snapshot_count" -gt 0 ]]; then
-              echo "Found $snapshot_count snapshot updates"
-              echo "has_updates=true" >> $GITHUB_OUTPUT
-              echo "snapshot_count=$snapshot_count" >> $GITHUB_OUTPUT
-            else
-              echo "No snapshot files found in snapshot-updates directory"
-              echo "has_updates=false" >> $GITHUB_OUTPUT
-            fi
+          # Run the existing script with the token
+          # The script will wait for Playwright to complete, download artifacts, and merge snapshots
+          if python scripts/update_e2e_snapshots.py --token "$GITHUB_TOKEN"; then
+            echo "script_status=success" >> $GITHUB_OUTPUT
           else
-            echo "No snapshot-updates directory found in artifacts"
+            echo "script_status=failed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Count updated snapshots
+        if: steps.update-snapshots.outputs.script_status == 'success'
+        id: count-snapshots
+        run: |
+          # Count files that were modified
+          snapshot_count=$(git status --porcelain e2e_playwright/__snapshots__ | wc -l)
+          echo "snapshot_count=$snapshot_count" >> $GITHUB_OUTPUT
+          if [[ "$snapshot_count" -gt 0 ]]; then
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+          else
             echo "has_updates=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Show notice when no snapshots to update
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates != 'true'
-        run: |
-          notice_title="No snapshot updates found"
-          notice_body="The Playwright tests failed, but no snapshot updates were generated. This may indicate a non-snapshot related test failure."
-          echo "::notice title=${notice_title}::${notice_body}"
-
-      - name: Copy snapshot updates to repository
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true'
-        run: |
-          echo "Copying snapshot updates to e2e_playwright/__snapshots__/"
-          # Copy all snapshot updates, preserving directory structure
-          # The structure is: snapshot-updates/{platform}/{module_name}/{snapshot_file}
-          cp -rv /tmp/playwright_artifacts/snapshot-updates/* e2e_playwright/__snapshots__/
-
-          echo "Updated snapshots:"
-          find e2e_playwright/__snapshots__ -type f -newer /tmp/playwright_artifacts -name "*.png" -o -name "*.jpg" | head -50
-
       - name: Check for changes
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true'
+        if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true'
         id: git-check
         run: |
           git add -A
@@ -184,7 +78,7 @@ jobs:
           echo "changes=$(if git diff --staged --quiet; then echo false; else echo true; fi)" >> $GITHUB_OUTPUT
 
       - name: Commit changes to new branch
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.email "core+streamlitbot-github@streamlit.io"
           git config user.name "Streamlit Bot"
@@ -195,7 +89,7 @@ jobs:
           git push --set-upstream origin "$fix_branch"
 
       - name: Create PR with snapshot updates
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: |
@@ -205,7 +99,7 @@ jobs:
 
             This workflow was triggered by adding the `snapshots` label to a PR after Playwright E2E tests failed with snapshot mismatches.
 
-            **Updated snapshots:** ${{ steps.check-snapshots.outputs.snapshot_count }} file(s)
+            **Updated snapshots:** ${{ steps.count-snapshots.outputs.snapshot_count }} file(s)
 
             ⚠️ **Please review the snapshot changes carefully** - they could mask visual bugs if accepted blindly.
 
@@ -218,14 +112,14 @@ jobs:
             --body "$PR_BODY"
 
       - name: Remove 'snapshots' label from source PR
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "snapshots"
 
       - name: Show notices for fork PRs
-        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        if: steps.update-snapshots.outputs.script_status == 'success' && steps.count-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           notice_title="Snapshot autofix skipped for fork PR"
           notice_body="This PR originates from a fork. GitHub Actions tokens are read-only for forked PRs, so snapshot autofix cannot push changes automatically. Please download the snapshot artifacts from the Playwright workflow run and update them manually."

--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -1,0 +1,239 @@
+# Snapshot autofix workflow - updates E2E test snapshots when Playwright tests fail
+# Triggered by adding the 'snapshots' label to a PR
+name: Snapshot Autofix
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  snapshot-autofix:
+    if: contains(github.event.pull_request.labels.*.name, 'snapshots')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-snapshot-autofix
+      cancel-in-progress: true
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Get short SHA
+        id: short_sha
+        run: |
+          echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
+
+      - name: Wait for Playwright tests to complete
+        id: wait-playwright
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = '${{ github.event.pull_request.head.sha }}';
+            const maxWaitMs = 35 * 60 * 1000; // 35 minutes
+            const pollIntervalMs = 60 * 1000; // 1 minute
+            const startTime = Date.now();
+
+            // List of Playwright workflow files to check
+            const playwrightWorkflows = ['playwright.yml', 'playwright-changed-files.yml'];
+
+            while (Date.now() - startTime < maxWaitMs) {
+              let foundCompletedRun = null;
+              let foundRunningWorkflow = false;
+
+              for (const workflowFile of playwrightWorkflows) {
+                try {
+                  const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflowFile,
+                    head_sha: headSha,
+                    per_page: 1
+                  });
+
+                  if (runs.workflow_runs.length > 0) {
+                    const run = runs.workflow_runs[0];
+                    console.log(`${workflowFile}: status=${run.status}, conclusion=${run.conclusion}`);
+
+                    if (run.status === 'completed') {
+                      if (run.conclusion === 'failure') {
+                        // Found a failed Playwright run - this is what we want
+                        foundCompletedRun = { workflow: workflowFile, run };
+                        break;
+                      } else if (run.conclusion === 'success') {
+                        // Playwright passed - no snapshots to update
+                        core.notice('Playwright tests passed - no snapshot updates needed');
+                        core.setOutput('status', 'passed');
+                        core.setOutput('run_id', '');
+                        return;
+                      }
+                      // Other conclusions (cancelled, skipped) - continue checking other workflows
+                    } else {
+                      // Still running
+                      foundRunningWorkflow = true;
+                    }
+                  }
+                } catch (error) {
+                  console.log(`Could not fetch runs for ${workflowFile}: ${error.message}`);
+                }
+              }
+
+              if (foundCompletedRun) {
+                console.log(`Found failed Playwright run: ${foundCompletedRun.workflow}, run_id=${foundCompletedRun.run.id}`);
+                core.setOutput('status', 'failed');
+                core.setOutput('run_id', foundCompletedRun.run.id.toString());
+                core.setOutput('workflow', foundCompletedRun.workflow);
+                return;
+              }
+
+              if (!foundRunningWorkflow) {
+                // No Playwright workflows found or all were skipped/cancelled
+                const elapsed = Math.round((Date.now() - startTime) / 1000);
+                if (elapsed > 120) {
+                  // After 2 minutes, if no workflow found, give up
+                  core.notice('No Playwright workflow runs found for this commit');
+                  core.setOutput('status', 'not_found');
+                  core.setOutput('run_id', '');
+                  return;
+                }
+              }
+
+              // Wait before next poll
+              console.log('Playwright tests still running or not started, waiting...');
+              await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+            }
+
+            // Timeout reached
+            core.setFailed('Timeout waiting for Playwright tests to complete');
+
+      - name: Check if we should continue
+        id: check-continue
+        run: |
+          status="${{ steps.wait-playwright.outputs.status }}"
+          if [[ "$status" != "failed" ]]; then
+            echo "Playwright status is '$status', skipping snapshot update"
+            echo "should_continue=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_continue=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout Streamlit code
+        if: steps.check-continue.outputs.should_continue == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
+          submodules: "recursive"
+          fetch-depth: 2
+
+      - name: Download Playwright test artifacts
+        if: steps.check-continue.outputs.should_continue == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.wait-playwright.outputs.run_id }}
+          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
+          path: /tmp/playwright_artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for snapshot updates
+        if: steps.check-continue.outputs.should_continue == 'true'
+        id: check-snapshots
+        run: |
+          if [[ -d "/tmp/playwright_artifacts/snapshot-updates" ]]; then
+            # Check if there are actual snapshot files
+            snapshot_count=$(find /tmp/playwright_artifacts/snapshot-updates -type f \( -name "*.png" -o -name "*.jpg" \) | wc -l)
+            if [[ "$snapshot_count" -gt 0 ]]; then
+              echo "Found $snapshot_count snapshot updates"
+              echo "has_updates=true" >> $GITHUB_OUTPUT
+              echo "snapshot_count=$snapshot_count" >> $GITHUB_OUTPUT
+            else
+              echo "No snapshot files found in snapshot-updates directory"
+              echo "has_updates=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "No snapshot-updates directory found in artifacts"
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Show notice when no snapshots to update
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates != 'true'
+        run: |
+          notice_title="No snapshot updates found"
+          notice_body="The Playwright tests failed, but no snapshot updates were generated. This may indicate a non-snapshot related test failure."
+          echo "::notice title=${notice_title}::${notice_body}"
+
+      - name: Copy snapshot updates to repository
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true'
+        run: |
+          echo "Copying snapshot updates to e2e_playwright/__snapshots__/"
+          # Copy all snapshot updates, preserving directory structure
+          # The structure is: snapshot-updates/{platform}/{module_name}/{snapshot_file}
+          cp -rv /tmp/playwright_artifacts/snapshot-updates/* e2e_playwright/__snapshots__/
+
+          echo "Updated snapshots:"
+          find e2e_playwright/__snapshots__ -type f -newer /tmp/playwright_artifacts -name "*.png" -o -name "*.jpg" | head -50
+
+      - name: Check for changes
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true'
+        id: git-check
+        run: |
+          git add -A
+          git status --porcelain
+          echo "changes=$(if git diff --staged --quiet; then echo false; else echo true; fi)" >> $GITHUB_OUTPUT
+
+      - name: Commit changes to new branch
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.email "core+streamlitbot-github@streamlit.io"
+          git config user.name "Streamlit Bot"
+          fix_branch="snapshots/${{ github.event.pull_request.number }}-${{ github.run_id }}"
+          git checkout -b "$fix_branch"
+          git add -A
+          git commit -m "Update E2E test snapshots"
+          git push --set-upstream origin "$fix_branch"
+
+      - name: Create PR with snapshot updates
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: |
+            ## Describe your changes
+
+            Automated snapshot updates for #${{ github.event.pull_request.number }} created via the snapshot autofix CI workflow.
+
+            This workflow was triggered by adding the `snapshots` label to a PR after Playwright E2E tests failed with snapshot mismatches.
+
+            **Updated snapshots:** ${{ steps.check-snapshots.outputs.snapshot_count }} file(s)
+
+            ⚠️ **Please review the snapshot changes carefully** - they could mask visual bugs if accepted blindly.
+
+            This PR targets a feature branch and can be merged without review approval.
+        run: |
+          gh pr create \
+            --head "snapshots/${{ github.event.pull_request.number }}-${{ github.run_id }}" \
+            --base "${{ github.head_ref }}" \
+            --title "[snapshots] Update E2E snapshots for #${{ github.event.pull_request.number }}" \
+            --body "$PR_BODY"
+
+      - name: Remove 'snapshots' label from source PR
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "snapshots"
+
+      - name: Show notices for fork PRs
+        if: steps.check-continue.outputs.should_continue == 'true' && steps.check-snapshots.outputs.has_updates == 'true' && steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          notice_title="Snapshot autofix skipped for fork PR"
+          notice_body="This PR originates from a fork. GitHub Actions tokens are read-only for forked PRs, so snapshot autofix cannot push changes automatically. Please download the snapshot artifacts from the Playwright workflow run and update them manually."
+          echo "::notice title=${notice_title}::${notice_body}"

--- a/.github/workflows/snapshot-autofix.yml
+++ b/.github/workflows/snapshot-autofix.yml
@@ -42,72 +42,65 @@ jobs:
             const pollIntervalMs = 60 * 1000; // 1 minute
             const startTime = Date.now();
 
-            // List of Playwright workflow files to check
-            const playwrightWorkflows = ['playwright.yml', 'playwright-changed-files.yml'];
+            // We primarily care about playwright.yml (full E2E tests)
+            // playwright-changed-files.yml only runs a subset and may pass even when full tests fail
+            const primaryWorkflow = 'playwright.yml';
 
             while (Date.now() - startTime < maxWaitMs) {
-              let foundCompletedRun = null;
-              let foundRunningWorkflow = false;
+              try {
+                const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: primaryWorkflow,
+                  head_sha: headSha,
+                  per_page: 1
+                });
 
-              for (const workflowFile of playwrightWorkflows) {
-                try {
-                  const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: workflowFile,
-                    head_sha: headSha,
-                    per_page: 1
-                  });
+                if (runs.workflow_runs.length > 0) {
+                  const run = runs.workflow_runs[0];
+                  console.log(`${primaryWorkflow}: status=${run.status}, conclusion=${run.conclusion}`);
 
-                  if (runs.workflow_runs.length > 0) {
-                    const run = runs.workflow_runs[0];
-                    console.log(`${workflowFile}: status=${run.status}, conclusion=${run.conclusion}`);
-
-                    if (run.status === 'completed') {
-                      if (run.conclusion === 'failure') {
-                        // Found a failed Playwright run - this is what we want
-                        foundCompletedRun = { workflow: workflowFile, run };
-                        break;
-                      } else if (run.conclusion === 'success') {
-                        // Playwright passed - no snapshots to update
-                        core.notice('Playwright tests passed - no snapshot updates needed');
-                        core.setOutput('status', 'passed');
-                        core.setOutput('run_id', '');
-                        return;
-                      }
-                      // Other conclusions (cancelled, skipped) - continue checking other workflows
+                  if (run.status === 'completed') {
+                    if (run.conclusion === 'failure') {
+                      // Found a failed Playwright run - this is what we want
+                      console.log(`Found failed Playwright run: ${primaryWorkflow}, run_id=${run.id}`);
+                      core.setOutput('status', 'failed');
+                      core.setOutput('run_id', run.id.toString());
+                      core.setOutput('workflow', primaryWorkflow);
+                      return;
+                    } else if (run.conclusion === 'success') {
+                      // Playwright passed - no snapshots to update
+                      core.notice('Playwright tests passed - no snapshot updates needed');
+                      core.setOutput('status', 'passed');
+                      core.setOutput('run_id', '');
+                      return;
                     } else {
-                      // Still running
-                      foundRunningWorkflow = true;
+                      // Other conclusions (cancelled, skipped)
+                      core.notice(`Playwright workflow completed with conclusion: ${run.conclusion}`);
+                      core.setOutput('status', run.conclusion);
+                      core.setOutput('run_id', '');
+                      return;
                     }
                   }
-                } catch (error) {
-                  console.log(`Could not fetch runs for ${workflowFile}: ${error.message}`);
+                  // Still running - continue polling
+                  console.log('Playwright tests still running, waiting...');
+                } else {
+                  // No workflow run found yet
+                  const elapsed = Math.round((Date.now() - startTime) / 1000);
+                  if (elapsed > 120) {
+                    // After 2 minutes, if no workflow found, give up
+                    core.notice('No Playwright workflow runs found for this commit');
+                    core.setOutput('status', 'not_found');
+                    core.setOutput('run_id', '');
+                    return;
+                  }
+                  console.log('Playwright workflow not started yet, waiting...');
                 }
-              }
-
-              if (foundCompletedRun) {
-                console.log(`Found failed Playwright run: ${foundCompletedRun.workflow}, run_id=${foundCompletedRun.run.id}`);
-                core.setOutput('status', 'failed');
-                core.setOutput('run_id', foundCompletedRun.run.id.toString());
-                core.setOutput('workflow', foundCompletedRun.workflow);
-                return;
-              }
-
-              if (!foundRunningWorkflow) {
-                // No Playwright workflows found or all were skipped/cancelled
-                const elapsed = Math.round((Date.now() - startTime) / 1000);
-                if (elapsed > 120) {
-                  // After 2 minutes, if no workflow found, give up
-                  core.notice('No Playwright workflow runs found for this commit');
-                  core.setOutput('status', 'not_found');
-                  core.setOutput('run_id', '');
-                  return;
-                }
+              } catch (error) {
+                console.log(`Could not fetch runs for ${primaryWorkflow}: ${error.message}`);
               }
 
               // Wait before next poll
-              console.log('Playwright tests still running or not started, waiting...');
               await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
             }
 


### PR DESCRIPTION
## Describe your changes

Added a new GitHub Actions workflow for automatically updating E2E test snapshots when Playwright tests fail. This workflow is triggered when the 'snapshots' label is added to a PR and:

1. Runs the `update_e2e_snapshots.py` script to download and merge snapshot artifacts
2. Creates a new branch with the updated snapshots
3. Opens a PR targeting the original feature branch with the snapshot updates
4. Removes the 'snapshots' label from the source PR once complete

The workflow includes special handling for fork PRs, displaying a notice that manual updates are required since GitHub Actions tokens are read-only for forked PRs.

## Testing Plan

- No additional tests needed as this is a CI workflow improvement
- The workflow will be tested in real-world usage when PRs with failing snapshots are labeled with 'snapshots'
- Success criteria: workflow should automatically create PRs with updated snapshots when triggered


# Examples
https://github.com/streamlit/streamlit/pull/13750
https://github.com/streamlit/streamlit/pull/13699

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.