### PR TITLE
Fix right padding for code blocks when scrolling horizontally

### DIFF
--- a/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
+++ b/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
@@ -100,7 +100,12 @@ export const StyledPre = styled.pre<StyledCodeProps>(
     // Add padding around the code
     padding: theme.spacing.lg,
 
-    code: { ...codeBlockStyle(theme, wrapLines) },
+    code: {
+      ...codeBlockStyle(theme, wrapLines),
+      // Ensure code block takes full width and has right padding for scroll end
+      display: "block",
+      paddingRight: theme.iconSizes.threeXL,
+    },
 
     // The token can consist of many lines, e.g. a triple-quote string, so
     // we need to make sure that the color is not overwritten.


### PR DESCRIPTION
## Summary                                                                                                                                                          
  - Move `paddingRight` from the `pre` element to the inner `code` element                                                                                            
  - Add `display: "block"` to ensure proper padding behavior at scroll end                                                                                            
                                                                                                                                                                      
  ## After Fix                                                                                                                                                        
                   
![WS000089](https://github.com/user-attachments/assets/c883114c-6de9-4f65-bba2-4695c23a6cc3)
      
![WS000090](https://github.com/user-attachments/assets/da1e8128-a758-4a8d-8b94-319e080d52ba)
                          
![WS000091](https://github.com/user-attachments/assets/3431bf78-2ad2-47b2-85ca-fe247781e2a6)
                                                  
                                                                                                                                                                      
  The "before" state can be seen in the original issue: #8206                                                                                                         
                                                                                                                                                                      
  ## Test Plan                                                                                                                                                        
  - [x] Verified with `st.code()` long lines                                                                                                                          
  - [x] Verified with `st.exception()` stack traces                                                                                                                   
                                                                                                                                                                      
  Fixes #8206                              