### PR TITLE
[Prototype] Add environment variable substitution support in secrets

### DIFF
--- a/env-in-secrets-plan.md
+++ b/env-in-secrets-plan.md
@@ -49,8 +49,10 @@ $${{VAR_NAME}}          # Escaped - produces literal ${{VAR_NAME}}
 
 Regex pattern:
 ```python
-r'\$\{\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}\}'
+r'\$\{\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}]|\}(?!\}))*)?)?)\}\}'
 ```
+
+Note: This pattern uses a negative lookahead `\}(?!\})` to correctly handle default values containing single closing braces like `${{VAR:-{key: value}}}`.
 
 ## Implementation Details
 

--- a/env-in-secrets-plan.md
+++ b/env-in-secrets-plan.md
@@ -1,0 +1,136 @@
+# Environment Variable Placeholders in secrets.toml
+
+## Overview
+
+This document describes the implementation plan for supporting environment variable placeholders in Streamlit's `secrets.toml` files.
+
+## Feature Description
+
+Allow users to reference environment variables in their secrets.toml files:
+
+```toml
+# secrets.toml
+db_username = "${{DB_USER}}"
+db_password = "${{DB_PASS}}"
+
+# Combined values
+connection_string = "postgres://${{DB_USER}}:${{DB_PASS}}@${{DB_HOST}}/mydb"
+
+# With default values
+api_key = "${{API_KEY:-development-key}}"
+```
+
+## Syntax Choice: `${{VAR}}`
+
+### Why This Syntax?
+
+| Syntax | Clash Risk | Notes |
+|--------|------------|-------|
+| `${{VAR}}` | **Very low** | Double braces are rare in practice |
+| `${env:VAR}` | Very low | Explicit namespace, but longer |
+| `${VAR}` | Medium | Industry standard but may conflict with shell |
+| `{{VAR}}` | Medium | Conflicts with Jinja2 templates |
+
+**Chosen: `${{VAR}}`** because:
+
+1. **Unlikely to clash** - Double braces are extremely rare in actual config values
+2. **Recognizable** - Uses `$` prefix (variable sigil) familiar to developers
+3. **Supports concatenation** - Works naturally: `"${{USER}}:${{PASS}}"`
+4. **Easy escaping** - `$${{VAR}}` for literal `${{VAR}}`
+5. **Familiar** - Similar to GitHub Actions syntax (`${{ secrets.TOKEN }}`)
+
+### Pattern Specification
+
+```
+${{VAR_NAME}}           # Basic substitution
+${{VAR_NAME:-default}}  # With default value if env var not set
+$${{VAR_NAME}}          # Escaped - produces literal ${{VAR_NAME}}
+```
+
+Regex pattern:
+```python
+r'\$\{\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}\}'
+```
+
+## Implementation Details
+
+### Location
+
+All changes are in `lib/streamlit/runtime/secrets.py`
+
+### Core Function
+
+```python
+def _substitute_env_vars(value: Any) -> Any:
+    """Recursively substitute environment variable placeholders in string values.
+
+    Supports:
+    - ${{VAR}} - basic substitution
+    - ${{VAR:-default}} - substitution with default value
+    - $${{VAR}} - escaped (literal ${{VAR}})
+    """
+```
+
+### Integration Points
+
+1. **`_parse_toml_file`** (line ~265): After `toml.loads()`, apply substitution
+2. **`_parse_directory`** (line ~311): After reading file content, apply substitution
+
+### Behavior
+
+1. **Missing env var without default**: Raises `StreamlitSecretNotFoundError`
+2. **Missing env var with default**: Uses the default value
+3. **Escaped placeholder**: `$${{VAR}}` becomes literal `${{VAR}}`
+4. **Non-string values**: Passed through unchanged (int, float, bool, etc.)
+5. **Nested structures**: Recursively processed
+
+### Error Messages
+
+Add to `SecretErrorMessages`:
+```python
+self.env_var_not_found: Callable[[str, str], str] = lambda var_name, path: (
+    f'Environment variable "{var_name}" referenced in secrets file "{path}" is not set. '
+    "Set the environment variable or provide a default value using ${{VAR:-default}} syntax."
+)
+```
+
+## Scope
+
+- **Included:**
+  - TOML file secrets (`secrets.toml`)
+  - Directory-based secrets (Kubernetes style)
+  - Nested sections
+  - String values only
+
+- **Not included:**
+  - Cross-secret references (`${{secrets.OTHER_KEY}}`) - only env vars
+  - Dynamic reload on env var changes (only file changes trigger reload)
+
+## Testing Strategy
+
+1. **Unit tests** in `lib/tests/streamlit/runtime/secrets_test.py`:
+   - Basic substitution
+   - Default values
+   - Escaping
+   - Missing env var error
+   - Nested sections
+   - Combined/concatenated values
+   - Directory-based secrets with substitution
+
+2. **No E2E tests needed** - functionality is internal to secrets loading
+
+## Effort Estimate
+
+| Component | Lines of Code |
+|-----------|---------------|
+| Core substitution function | ~50 |
+| Integration points | ~15 |
+| Error handling/messages | ~15 |
+| Unit tests | ~120 |
+| **Total** | **~200** |
+
+## Risks & Mitigations
+
+1. **Circular references**: Only env vars supported, not secret-to-secret references
+2. **Performance**: Regex substitution is fast; minimal impact on startup
+3. **Backwards compatibility**: Existing secrets without placeholders work unchanged

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import re
 import threading
 from collections.abc import Callable, ItemsView, Iterator, KeysView, Mapping, ValuesView
 from copy import deepcopy
@@ -32,6 +33,15 @@ from streamlit.errors import StreamlitMaxRetriesError, StreamlitSecretNotFoundEr
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
+
+# Pattern for environment variable substitution in secrets
+# Matches: ${{VAR_NAME}} or ${{VAR_NAME:-default_value}}
+# Group 1: variable name, Group 2: optional default value
+_ENV_VAR_PATTERN: Final = re.compile(
+    r"\$\{\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}]|\}(?!\}))*)?)?\}\}"
+)
+# Pattern for escaped placeholders: $${{VAR}} -> ${{VAR}}
+_ESCAPED_PATTERN: Final = re.compile(r"\$\$\{\{")
 
 
 class SecretErrorMessages:
@@ -71,6 +81,10 @@ class SecretErrorMessages:
         self.invalid_secret_path: Callable[[str], str] = lambda path: (
             f"Invalid secrets path: {path}: path is not a .toml file or a directory"
         )
+        self.env_var_not_found: Callable[[str, str], str] = lambda var_name, path: (
+            f'Environment variable "{var_name}" referenced in secrets at "{path}" is not set. '
+            "Set the environment variable or provide a default value using ${{VAR:-default}} syntax."
+        )
 
     def set_missing_attr_message(self, message: Callable[[str], str]) -> None:
         """Set the missing attribute error message."""
@@ -100,6 +114,10 @@ class SecretErrorMessages:
         """Set the invalid secret path error message."""
         self.invalid_secret_path = message
 
+    def set_env_var_not_found_message(self, message: Callable[[str, str], str]) -> None:
+        """Set the environment variable not found error message."""
+        self.env_var_not_found = message
+
     def get_missing_attr_message(self, attr_name: str) -> str:
         """Get the missing attribute error message."""
         return self.missing_attr_message(attr_name)
@@ -124,8 +142,71 @@ class SecretErrorMessages:
         """Get the invalid secret path error message."""
         return self.invalid_secret_path(path)
 
+    def get_env_var_not_found_message(self, var_name: str, path: str) -> str:
+        """Get the environment variable not found error message."""
+        return self.env_var_not_found(var_name, path)
+
 
 secret_error_messages_singleton: Final = SecretErrorMessages()
+
+
+def _substitute_env_vars(value: Any, path: str) -> Any:
+    """Recursively substitute environment variable placeholders in string values.
+
+    Supports the following syntax in string values:
+    - ${{VAR}} - substitutes with the value of environment variable VAR
+    - ${{VAR:-default}} - substitutes with VAR if set, otherwise uses default
+    - $${{VAR}} - escaped, becomes literal ${{VAR}}
+
+    Parameters
+    ----------
+    value : Any
+        The value to process. Strings are checked for placeholders,
+        dicts and lists are recursively processed, other types pass through.
+    path : str
+        The path to the secrets file, used for error messages.
+
+    Returns
+    -------
+    Any
+        The value with environment variables substituted.
+
+    Raises
+    ------
+    StreamlitSecretNotFoundError
+        If an environment variable is referenced but not set and no default provided.
+    """
+    if isinstance(value, str):
+        # Use a placeholder that's unlikely to appear in actual content
+        escape_marker = "\x00ESCAPED_ENV_VAR\x00"
+
+        # First, temporarily replace escaped patterns $${{ with a marker
+        result = _ESCAPED_PATTERN.sub(escape_marker, value)
+
+        def replace_env_var(match: re.Match[str]) -> str:
+            var_name = match.group(1)
+            default = match.group(2)
+            env_value = os.environ.get(var_name)
+            if env_value is not None:
+                return env_value
+            if default is not None:
+                return default
+            msg = secret_error_messages_singleton.get_env_var_not_found_message(
+                var_name, path
+            )
+            raise StreamlitSecretNotFoundError(msg)
+
+        # Substitute env vars
+        result = _ENV_VAR_PATTERN.sub(replace_env_var, result)
+
+        # Restore escaped placeholders
+        result = result.replace(escape_marker, "${{")
+        return result
+    if isinstance(value, dict):
+        return {k: _substitute_env_vars(v, path) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_substitute_env_vars(item, path) for item in value]
+    return value
 
 
 def _convert_to_dict(obj: Mapping[str, Any] | AttrDict) -> dict[str, Any]:
@@ -271,6 +352,9 @@ class Secrets(Mapping[str, Any]):
             )
             raise StreamlitSecretNotFoundError(msg) from ex
 
+        # Substitute environment variable placeholders
+        secrets = _substitute_env_vars(secrets, path)
+
         return secrets, found_secrets_file
 
     def _parse_directory(self, path: str) -> tuple[Mapping[str, Any], bool]:
@@ -316,6 +400,9 @@ class Secrets(Mapping[str, Any]):
                 secrets[dirname] = sub_secrets[next(iter(sub_secrets.keys()))]
             else:
                 secrets[dirname] = sub_secrets
+
+        # Substitute environment variable placeholders
+        secrets = _substitute_env_vars(secrets, path)
 
         return secrets, found_secrets_file
 

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -158,6 +158,12 @@ def _substitute_env_vars(value: Any, path: str) -> Any:
     - ${{VAR:-default}} - substitutes with VAR if set, otherwise uses default
     - $${{VAR}} - escaped, becomes literal ${{VAR}}
 
+    Note on empty string behavior:
+        This implementation uses the env var value if it's set, even if empty.
+        This differs from POSIX shell's ${VAR:-default} which treats empty strings
+        as unset. Our choice is intentional: if a user explicitly sets VAR="",
+        they likely want that empty value, not the default.
+
     Parameters
     ----------
     value : Any

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -612,3 +612,164 @@ class SecretsFallbackTest(DeltaGeneratorTestCase):
                     markdown_text = element.markdown.body
                     assert "Error" not in markdown_text
                     assert "error" not in markdown_text
+
+
+class EnvVarSubstitutionTest(unittest.TestCase):
+    """Tests for environment variable substitution in secrets."""
+
+    def setUp(self) -> None:
+        # Save and restore os.environ
+        self._prev_environ = dict(os.environ)
+        self.secrets = Secrets()
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._prev_environ)
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_basic_env_var_substitution(self, *mocks):
+        """Test basic ${{VAR}} substitution."""
+        os.environ["TEST_USER"] = "alice"
+        os.environ["TEST_PASS"] = "secret123"
+
+        mock_toml = """
+db_username = "${{TEST_USER}}"
+db_password = "${{TEST_PASS}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["db_username"] == "alice"
+            assert self.secrets["db_password"] == "secret123"
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_env_var_with_default_value(self, *mocks):
+        """Test ${{VAR:-default}} substitution."""
+        # TEST_MISSING is not set
+        os.environ["TEST_SET"] = "set_value"
+
+        mock_toml = """
+with_default = "${{TEST_MISSING:-fallback}}"
+set_var = "${{TEST_SET:-ignored}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["with_default"] == "fallback"
+            assert self.secrets["set_var"] == "set_value"
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_env_var_with_empty_default(self, *mocks):
+        """Test ${{VAR:-}} with empty default."""
+        mock_toml = """
+empty_default = "${{NONEXISTENT:-}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["empty_default"] == ""
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_combined_env_vars(self, *mocks):
+        """Test multiple env vars in a single value."""
+        os.environ["USER"] = "admin"
+        os.environ["PASS"] = "pw123"
+        os.environ["HOST"] = "localhost"
+
+        mock_toml = """
+connection = "postgres://${{USER}}:${{PASS}}@${{HOST}}/db"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["connection"] == "postgres://admin:pw123@localhost/db"
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_nested_section_substitution(self, *mocks):
+        """Test env var substitution in nested sections."""
+        os.environ["DB_USER"] = "jane"
+        os.environ["DB_PASS"] = "password"
+
+        mock_toml = """
+[database]
+user = "${{DB_USER}}"
+password = "${{DB_PASS}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["database"]["user"] == "jane"
+            assert self.secrets.database.password == "password"
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_escaped_placeholder(self, *mocks):
+        """Test $${{VAR}} produces literal ${{VAR}}."""
+        os.environ["REAL_VAR"] = "substituted"
+
+        mock_toml = """
+escaped = "$${{NOT_SUBSTITUTED}}"
+mixed = "${{REAL_VAR}} and $${{LITERAL}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["escaped"] == "${{NOT_SUBSTITUTED}}"
+            assert self.secrets["mixed"] == "substituted and ${{LITERAL}}"
+
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_missing_env_var_raises_error(self, *mocks):
+        """Test that missing env var without default raises error."""
+        mock_toml = """
+missing = "${{NONEXISTENT_VAR}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            with pytest.raises(StreamlitSecretNotFoundError) as exc_info:
+                _ = self.secrets["missing"]
+            assert "NONEXISTENT_VAR" in str(exc_info.value)
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_non_string_values_unchanged(self, *mocks):
+        """Test that non-string values are not affected."""
+        mock_toml = """
+number = 42
+float_val = 3.14
+bool_val = true
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["number"] == 42
+            assert self.secrets["float_val"] == 3.14
+            assert self.secrets["bool_val"] is True
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_list_values_with_substitution(self, *mocks):
+        """Test env var substitution in list values."""
+        os.environ["ITEM1"] = "first"
+        os.environ["ITEM2"] = "second"
+
+        mock_toml = """
+items = ["${{ITEM1}}", "${{ITEM2}}", "literal"]
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["items"] == ["first", "second", "literal"]
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_no_substitution_without_placeholder(self, *mocks):
+        """Test that values without placeholders are unchanged."""
+        mock_toml = """
+plain = "just a regular string"
+with_dollar = "$not_a_placeholder"
+with_braces = "{{not_a_placeholder}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["plain"] == "just a regular string"
+            assert self.secrets["with_dollar"] == "$not_a_placeholder"
+            assert self.secrets["with_braces"] == "{{not_a_placeholder}}"
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_default_with_special_chars(self, *mocks):
+        """Test default values containing special characters."""
+        mock_toml = """
+url = "${{MISSING_URL:-https://example.com/path?q=1}}"
+json_like = "${{MISSING:-{key: value}}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            assert self.secrets["url"] == "https://example.com/path?q=1"
+            assert self.secrets["json_like"] == "{key: value}"

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -481,6 +481,38 @@ class SecretsDirectoryTest(unittest.TestCase):
             assert self.secrets["example_login"]["password"] == "example_password2"
             assert self.secrets["example_token"] == "token123"
 
+    @patch("streamlit.watcher.path_watcher.watch_dir", MagicMock())
+    def test_env_var_substitution_in_directory_secrets(self):
+        """Test that env var substitution works in directory-based (Kubernetes-style) secrets."""
+        # Save and restore os.environ
+        prev_environ = dict(os.environ)
+
+        try:
+            os.environ["SECRET_USER"] = "k8s_user"
+            os.environ["SECRET_PASS"] = "k8s_pass"
+
+            # Create a secret with an env var placeholder
+            os.makedirs(os.path.join(self.temp_dir_path, "k8s_secret"))
+            with open(
+                os.path.join(self.temp_dir_path, "k8s_secret", "connection"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write("user=${{SECRET_USER}},pass=${{SECRET_PASS}}")
+
+            mock_get_option = testutil.build_mock_config_get_option(
+                {"secrets.files": [self.temp_dir_path]}
+            )
+
+            # Create a fresh Secrets instance to avoid cached values
+            secrets = Secrets()
+
+            with patch("streamlit.config.get_option", new=mock_get_option):
+                assert secrets["k8s_secret"] == "user=k8s_user,pass=k8s_pass"
+        finally:
+            os.environ.clear()
+            os.environ.update(prev_environ)
+
 
 class AttrDictTest(unittest.TestCase):
     def test_attr_dict_is_mapping_but_not_built_in_dict(self):
@@ -665,6 +697,27 @@ empty_default = "${{NONEXISTENT:-}}"
 """
         with patch("builtins.open", mock_open(read_data=mock_toml)):
             assert self.secrets["empty_default"] == ""
+
+    @patch("streamlit.watcher.path_watcher.watch_file")
+    @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
+    def test_env_var_set_to_empty_string(self, *mocks):
+        """Test that env vars set to empty string are used (not treated as unset).
+
+        This differs from POSIX shell ${VAR:-default} which treats empty strings
+        as unset. Our implementation uses the empty string value, which is more
+        explicit and avoids unexpected behavior.
+        """
+        os.environ["EMPTY_VAR"] = ""
+
+        mock_toml = """
+basic_empty = "${{EMPTY_VAR}}"
+with_default = "${{EMPTY_VAR:-default}}"
+"""
+        with patch("builtins.open", mock_open(read_data=mock_toml)):
+            # Empty string is used, not treated as unset
+            assert self.secrets["basic_empty"] == ""
+            # Default is NOT used because var is set (even though empty)
+            assert self.secrets["with_default"] == ""
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])

--- a/specs/0005-env-var-secrets/product-spec.md
+++ b/specs/0005-env-var-secrets/product-spec.md
@@ -1,0 +1,444 @@
+---
+author: lukasmasuch
+created: 2025-01-27
+status: Draft
+---
+
+# Environment Variables in Secrets
+
+## Summary
+
+Enable secrets configuration via environment variables to allow users to leverage existing secrets management infrastructure instead of relying solely on `secrets.toml` files. This spec evaluates three approaches and recommends one for implementation.
+
+## Problem
+
+Streamlit's current secrets management requires credentials to be stored in `secrets.toml` files. While the [secrets documentation](https://docs.streamlit.io/develop/api-reference/connections/secrets.toml) states that "existing secrets management tools will work fine in Streamlit," the [authentication documentation](https://docs.streamlit.io/develop/concepts/connections/authentication) specifies that `st.login()` exclusively uses `secrets.toml` for configuration.
+
+This creates friction for users deploying on platforms where secrets are injected as environment variables (Heroku, Azure App Service, AWS ECS, Kubernetes, Docker, etc.). Users must resort to workarounds like:
+
+- Generating `secrets.toml` from environment variables at container startup
+- Directly manipulating `secrets_singleton._secrets` at runtime
+- Using `envsubst` with template files in Docker entrypoints
+
+### Related Issues
+
+| Issue | Upvotes | Description |
+|-------|---------|-------------|
+| [#10543](https://github.com/streamlit/streamlit/issues/10543) | 88+ | Set `[auth]` secrets config from environment variables |
+| [#9016](https://github.com/streamlit/streamlit/issues/9016) | — | Cannot use kwargs only in Snowflake connection |
+
+### Goals
+
+| Goal | Outcome |
+|------|---------|
+| Support environment variable injection | Users can configure secrets via env vars without file manipulation |
+| Enable existing secrets management tools | Works with Vault, AWS Secrets Manager, Azure Key Vault, etc. |
+| Support `st.login()` via env vars | Authentication credentials can be injected at runtime |
+| Maintain backward compatibility | Existing `secrets.toml` files continue to work unchanged |
+| Provide secure defaults | No new security risks introduced |
+
+### Non-Goals
+
+| Out of Scope | Rationale |
+|--------------|-----------|
+| Automatic env var watching/reload | Secrets are loaded at startup; env var changes require restart |
+| Cross-secret references | Only environment variables, not `${{secrets.other_key}}` |
+| Encryption/decryption | Users should use external secrets managers for that |
+
+## Proposal
+
+This section evaluates three approaches for enabling environment variable support in secrets. Each option is described with its syntax, behavior, pros, and cons.
+
+---
+
+### Option A: Placeholder Substitution in `secrets.toml`
+
+Reference environment variables directly in `secrets.toml` using `${{VAR}}` syntax.
+
+#### Example
+
+```toml
+# .streamlit/secrets.toml
+[auth]
+client_id = "${{OAUTH_CLIENT_ID}}"
+client_secret = "${{OAUTH_CLIENT_SECRET}}"
+redirect_uri = "${{OAUTH_REDIRECT_URI:-http://localhost:8501}}"
+
+[database]
+connection_string = "postgres://${{DB_USER}}:${{DB_PASS}}@${{DB_HOST}}/mydb"
+```
+
+#### Syntax
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `${{VAR}}` | Substitute with env var value | `${{API_KEY}}` → `"sk-xxx"` |
+| `${{VAR:-default}}` | Use default if env var not set | `${{PORT:-8501}}` → `"8501"` |
+| `$${{VAR}}` | Escaped, produces literal | `$${{VAR}}` → `"${{VAR}}"` |
+
+#### Behavior
+
+- **Missing env var without default**: Raises `StreamlitSecretNotFoundError` with clear message
+- **Substitution timing**: Happens at parse time (when secrets are first accessed)
+- **Scope**: Only string values are processed; numbers, booleans, arrays are unaffected
+- **Nesting**: Works in nested sections and arrays of strings
+
+#### Syntax Options
+
+Several placeholder syntaxes were considered:
+
+| Syntax | Clash Risk | Default Value Support | Notes |
+|--------|------------|----------------------|-------|
+| `${{VAR}}` | **Very low** | `${{VAR:-default}}` | Double braces; similar to GitHub Actions |
+| `${env:VAR}` | **Very low** | `${env:VAR:-default}` | Explicit namespace; used in Azure DevOps, some CI systems |
+| `${VAR}` | Medium | `${VAR:-default}` | Shell-style; may conflict with shell expansion |
+| `{{VAR}}` | Medium | `{{VAR\|default}}` | Jinja2-style; conflicts with templating |
+| `$(VAR)` | Medium | N/A | Conflicts with shell command substitution |
+
+**Recommendation: `${{VAR}}`** because:
+- Double braces are extremely rare in actual configuration values
+- Familiar to GitHub Actions users (`${{ secrets.TOKEN }}`)
+- Clear `$` prefix indicates variable substitution
+- Shorter than `${env:VAR}` for common use
+
+**Alternative: `${env:VAR}`** is also a good choice because:
+- Explicit about source being environment (vs. potential future `${secrets:OTHER_KEY}`)
+- Used in Azure DevOps, Spring Boot, and other enterprise tools
+- Namespace allows future extension
+- Slightly more verbose but clearer intent
+
+#### Default Value Syntax Options
+
+The `:-` separator for default values comes from POSIX shell parameter expansion. Alternatives:
+
+| Syntax | Origin | Example |
+|--------|--------|---------|
+| `${{VAR:-default}}` | POSIX shell | Standard, widely recognized |
+| `${{VAR:default}}` | Simplified | Shorter, but `:` alone is ambiguous |
+| `${{VAR\|default}}` | Jinja2/Django | Common in templating |
+| `${{VAR??default}}` | C# null-coalescing | Less common |
+
+**Recommendation: `:-`** because:
+- POSIX standard, recognized by developers
+- Used in Docker Compose, shell scripts, GitHub Actions
+- Unambiguous (`:` alone could be part of the value)
+
+#### Pros
+
+- **Explicit**: Clear which values come from env vars
+- **Flexible**: Supports string concatenation (`postgres://${{USER}}:${{PASS}}@host`)
+- **Typed values**: Can combine with static TOML values (numbers, booleans, arrays)
+- **Default values**: Built-in fallback mechanism
+- **Familiar**: Similar to GitHub Actions, Docker Compose, shell syntax
+
+#### Cons
+
+- **Requires file**: Still need to maintain a `secrets.toml` file
+- **Two-step process**: Must define structure in file, then set env vars
+- **Not fully "file-free"**: Doesn't solve the "no secrets file" use case
+
+---
+
+### Option B: Prefixed Environment Variables
+
+Automatically populate `st.secrets` from environment variables with the `STREAMLIT_SECRETS_` prefix. No `secrets.toml` file needed.
+
+#### Example
+
+```bash
+# Environment variables
+export STREAMLIT_SECRETS_AUTH__CLIENT_ID="your-client-id"
+export STREAMLIT_SECRETS_AUTH__CLIENT_SECRET="your-secret"
+export STREAMLIT_SECRETS_AUTH__REDIRECT_URI="https://myapp.example.com/callback"
+export STREAMLIT_SECRETS_AUTH__COOKIE_SECRET="super-secret-cookie-key"
+export STREAMLIT_SECRETS_DATABASE__HOST="localhost"
+export STREAMLIT_SECRETS_API_KEY="sk-xxx"
+```
+
+```python
+# Equivalent to secrets.toml:
+# [auth]
+# client_id = "your-client-id"
+# client_secret = "your-secret"
+# redirect_uri = "https://myapp.example.com/callback"
+# cookie_secret = "super-secret-cookie-key"
+#
+# [database]
+# host = "localhost"
+#
+# api_key = "sk-xxx"
+
+st.secrets["auth"]["client_id"]      # "your-client-id"
+st.secrets["auth"]["redirect_uri"]   # "https://myapp.example.com/callback"
+st.secrets["api_key"]                # "sk-xxx"
+```
+
+#### Naming Convention
+
+| Environment Variable | secrets.toml Equivalent |
+|---------------------|------------------------|
+| `STREAMLIT_SECRETS_API_KEY` | `api_key = "value"` |
+| `STREAMLIT_SECRETS_AUTH__CLIENT_ID` | `[auth]`<br>`client_id = "value"` |
+| `STREAMLIT_SECRETS_AUTH__REDIRECT_URI` | `[auth]`<br>`redirect_uri = "value"` |
+| `STREAMLIT_SECRETS_CONNECTIONS__MYDB__URL` | `[connections.mydb]`<br>`url = "value"` |
+
+**Conversion rules:**
+
+1. **Prefix**: `STREAMLIT_SECRETS_`
+2. **Section separator**: Double underscore (`__`) separates TOML sections
+3. **Key names**: Single underscore (`_`) is preserved in key names
+4. **Case**: Environment variable is UPPER_SNAKE_CASE; key names are **lowercased**
+
+#### Multi-word Key Examples
+
+Secret keys often use snake_case (e.g., `redirect_uri`, `cookie_secret`). The single underscore is preserved:
+
+| Secret Key | Environment Variable |
+|------------|---------------------|
+| `api_key` | `STREAMLIT_SECRETS_API_KEY` |
+| `client_id` | `STREAMLIT_SECRETS_AUTH__CLIENT_ID` |
+| `client_secret` | `STREAMLIT_SECRETS_AUTH__CLIENT_SECRET` |
+| `redirect_uri` | `STREAMLIT_SECRETS_AUTH__REDIRECT_URI` |
+| `cookie_secret` | `STREAMLIT_SECRETS_AUTH__COOKIE_SECRET` |
+| `database_url` | `STREAMLIT_SECRETS_DATABASE_URL` |
+
+#### Difference from Streamlit Config Environment Variables
+
+Streamlit [configuration options](https://docs.streamlit.io/develop/concepts/configuration/options) use a similar pattern:
+
+```bash
+# Config: [server] port = 8501
+STREAMLIT_SERVER_PORT=8501
+
+# Config: [client] showErrorDetails = true
+STREAMLIT_CLIENT_SHOW_ERROR_DETAILS=true
+```
+
+However, config keys use **camelCase** (e.g., `showErrorDetails`), so there's no ambiguity when converting to `UPPER_SNAKE_CASE`.
+
+Secret keys typically use **snake_case** (e.g., `client_id`, `redirect_uri`), which creates ambiguity with a single underscore separator:
+- Is `STREAMLIT_SECRETS_AUTH_CLIENT_ID` → `auth.client_id` or `auth_client.id`?
+
+**Solution**: Use **double underscore** (`__`) for section separators in secrets:
+- `STREAMLIT_SECRETS_AUTH__CLIENT_ID` → unambiguously `auth.client_id`
+
+#### Pros
+
+- **No file needed**: Works on platforms that don't support file mounting
+- **Native integration**: Matches how Heroku, Azure App Service, AWS ECS inject secrets
+- **12-factor compliance**: Follows [12-factor methodology](https://12factor.net/config)
+- **No code changes**: Existing `st.secrets["auth"]["client_id"]` works unchanged
+- **Simple setup**: Just set env vars, no file to manage
+
+#### Cons
+
+- **Strings only**: All values are strings; no numbers, booleans, or arrays
+- **Verbose for deep nesting**: `STREAMLIT_SECRETS_A__B__C__D` becomes awkward
+- **Case handling**: Key names are lowercased from UPPER_SNAKE_CASE
+- **No defaults**: Must set all required env vars
+
+---
+
+### Option C: JSON Bulk Injection
+
+Set all secrets at once via a single JSON environment variable.
+
+#### Example
+
+```bash
+export STREAMLIT_SECRETS_JSON='{
+  "auth": {
+    "client_id": "your-client-id",
+    "client_secret": "your-secret"
+  },
+  "database": {
+    "host": "localhost",
+    "port": 5432
+  }
+}'
+```
+
+#### Behavior
+
+- Parses JSON and merges into secrets
+- Supports all TOML-compatible types (strings, numbers, booleans, arrays, nested objects)
+- Invalid JSON raises `StreamlitSecretNotFoundError` with parse error details
+
+#### Pros
+
+- **Typed values**: Supports numbers, booleans, arrays, nested objects
+- **Single variable**: Easy to inject from secrets managers that output JSON
+- **No file needed**: Works without `secrets.toml`
+- **Complex structures**: Handles deeply nested configs elegantly
+
+#### Cons
+
+- **Hard to read**: JSON in env vars is error-prone and hard to debug
+- **Escaping issues**: Quotes and special characters require careful escaping
+- **Single point of failure**: One typo breaks all secrets
+- **Not human-friendly**: Difficult to set/update individual values
+
+---
+
+## Comparison
+
+| Criteria | Option A: Placeholders | Option B: Prefixed Vars | Option C: JSON |
+|----------|------------------------|------------------------|----------------|
+| No file needed | ❌ | ✅ | ✅ |
+| Typed values | ✅ (partial) | ❌ | ✅ |
+| Default values | ✅ | ❌ | ❌ |
+| Human readable | ✅ | ✅ | ❌ |
+| String concatenation | ✅ | ❌ | ❌ |
+| 12-factor compliant | ✅ | ✅ | ✅ |
+| Easy debugging | ✅ | ✅ | ❌ |
+| Platform compatibility | High | Very High | High |
+| Implementation complexity | Low | Medium | Low |
+
+---
+
+## Recommendation
+
+**Implement Option A (Placeholder Substitution)** as the primary solution.
+
+### Rationale
+
+1. **Covers most use cases**: The majority of issue #10543 requests are about injecting credentials into `st.login()`, which Option A handles elegantly.
+
+2. **Familiar pattern**: Placeholder syntax is widely used (GitHub Actions, Docker Compose, Kubernetes, Helm) and immediately understandable.
+
+3. **Flexible**: Supports string concatenation for connection strings, default values for optional settings, and mixing with static TOML values.
+
+4. **Low risk**: Minimal implementation complexity and no changes to secrets API.
+
+5. **Already implemented**: A working implementation exists (see `lib/streamlit/runtime/secrets.py`).
+
+### What Option A Solves
+
+```toml
+# .streamlit/secrets.toml
+[auth]
+redirect_uri = "https://myapp.example.com/oauth2callback"
+client_id = "${{GOOGLE_CLIENT_ID}}"
+client_secret = "${{GOOGLE_CLIENT_SECRET}}"
+```
+
+```python
+import streamlit as st
+
+st.login()  # Works! Credentials injected from env vars.
+```
+
+### What Option A Doesn't Solve
+
+Users who want **zero files** (pure env-var configuration) would need Option B. This is a valid use case but less common than the "inject secrets into existing config" pattern.
+
+---
+
+## Combining Options
+
+The options are not mutually exclusive. If broader support is desired, multiple options could be implemented with the following precedence (later overrides earlier):
+
+```
+1. secrets.toml files (existing behavior)
+2. Placeholder substitution (${{VAR}}) — applied during file parsing
+3. Prefixed env vars (STREAMLIT_SECRETS_*) — merged after file parsing
+4. JSON env var (STREAMLIT_SECRETS_JSON) — merged last
+```
+
+This would allow users to:
+- Use placeholders for most cases (Option A)
+- Override individual values via prefixed env vars (Option B)
+- Bulk-inject from secrets managers via JSON (Option C)
+
+**Note**: Implementing multiple options increases complexity and testing surface. Starting with Option A alone may be preferable, with other options added based on user feedback.
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Missing env var (no default) | `StreamlitSecretNotFoundError` with variable name and file path |
+| Invalid JSON in `STREAMLIT_SECRETS_JSON` | `StreamlitSecretNotFoundError` with JSON parse error |
+| Invalid prefixed env var name | Silently ignored |
+
+Error message example:
+```
+Environment variable "OAUTH_CLIENT_SECRET" referenced in secrets at
+"/app/.streamlit/secrets.toml" is not set. Set the environment variable
+or provide a default value using ${{VAR:-default}} syntax.
+```
+
+---
+
+## Security Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Env vars visible in process listings | Same risk as any env var; users should use secrets managers |
+| Logging env var values | Streamlit never logs secret values |
+| Secrets in error messages | Only variable names shown, never values |
+| Accidental exposure in `st.write(st.secrets)` | Existing behavior; users are responsible |
+
+The security model is unchanged: users are responsible for protecting their secrets. This feature simply provides more flexibility in *how* secrets are provided to Streamlit.
+
+---
+
+## Examples
+
+### Example 1: `st.login()` with Environment Variables (Option A)
+
+```toml
+# .streamlit/secrets.toml
+[auth]
+redirect_uri = "https://myapp.example.com/oauth2callback"
+client_id = "${{GOOGLE_CLIENT_ID}}"
+client_secret = "${{GOOGLE_CLIENT_SECRET}}"
+```
+
+```python
+import streamlit as st
+
+st.login()  # Works with env vars!
+
+if st.user:
+    st.write(f"Welcome, {st.user.name}!")
+```
+
+### Example 2: Database Connection with Concatenation (Option A)
+
+```toml
+# .streamlit/secrets.toml
+[connections.mydb]
+url = "postgresql://${{DB_USER}}:${{DB_PASS}}@${{DB_HOST:-localhost}}/${{DB_NAME}}"
+```
+
+```python
+import streamlit as st
+
+conn = st.connection("mydb")
+df = conn.query("SELECT * FROM users")
+```
+
+### Example 3: Heroku Deployment (Option B, if implemented)
+
+```bash
+# Heroku config vars
+heroku config:set STREAMLIT_SECRETS_AUTH__CLIENT_ID="xxx"
+heroku config:set STREAMLIT_SECRETS_AUTH__CLIENT_SECRET="yyy"
+```
+
+No `secrets.toml` file needed in the repository.
+
+---
+
+## Checklist
+
+| Item | ✅ or comment |
+|------|---------------|
+| Works on SiS, Cloud, etc? | ✅ Works everywhere; SiS/Cloud may have own env var injection |
+| No breaking API changes | ✅ All mechanisms are additive; existing behavior unchanged |
+| No new dependencies | ✅ Uses only stdlib (`re`, `os`, `json`) |
+| Metrics collected | Consider tracking: placeholder usage count, env var secrets count |
+| Any security/legal impact? | No new security risks; env vars are standard practice |
+| Any docs changes needed? | Yes: Update secrets.toml docs, authentication guide, deployment guides |


### PR DESCRIPTION
## Describe your changes

Adds support for environment variable substitution in secrets files using `${{VAR}}` syntax, with optional defaults via `${{VAR:-default}}`. This allows users to reference environment variables in their `.streamlit/secrets.toml` files, with escaped placeholders `$${{VAR}}` producing literal `${{VAR}}` text.

## Testing Plan

- Comprehensive unit tests for basic substitution, default values, nested structures, escaped placeholders, missing variables, and error handling
- Tests cover lists, dictionaries, nested sections, and various special character scenarios

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.