### PR TITLE
[fix] Display wildcard addresses as localhost in URLs

### DIFF
--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -246,13 +246,13 @@ def _print_url(is_running_hello: bool) -> None:
         ]
 
     elif (
-        config.is_manually_set("server.address") and not server_address_is_unix_socket()
+        config.is_manually_set("server.address")
+        and not server_address_is_unix_socket()
+        and config.get_option("server.address") not in {"0.0.0.0", "::"}  # noqa: S104
     ):
-        display_address = server_util.get_display_address(
-            config.get_option("server.address")
-        )
+        # Non-wildcard specific address - show single URL
         named_urls = [
-            ("URL", server_util.get_url(display_address)),
+            ("URL", server_util.get_url(config.get_option("server.address"))),
         ]
 
     elif server_address_is_unix_socket():

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -139,7 +139,7 @@ def _on_server_start(server: Server) -> None:
             if server_address_is_unix_socket():
                 # Don't open browser when server address is an unix socket
                 return
-            addr = config.get_option("server.address")
+            addr = server_util.get_display_address(config.get_option("server.address"))
         else:
             addr = "localhost"
 
@@ -248,8 +248,11 @@ def _print_url(is_running_hello: bool) -> None:
     elif (
         config.is_manually_set("server.address") and not server_address_is_unix_socket()
     ):
+        display_address = server_util.get_display_address(
+            config.get_option("server.address")
+        )
         named_urls = [
-            ("URL", server_util.get_url(config.get_option("server.address"))),
+            ("URL", server_util.get_url(display_address)),
         ]
 
     elif server_address_is_unix_socket():

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -137,6 +137,28 @@ def _get_server_address_if_manually_set() -> str | None:
     return None
 
 
+def get_display_address(address: str) -> str:
+    """Get a display-friendly address for URLs shown to users.
+
+    Wildcard addresses like "0.0.0.0" (all IPv4) or "::" (all interfaces)
+    are not valid browser addresses on all platforms. This translates
+    them to "localhost" for display purposes.
+
+    Parameters
+    ----------
+    address
+        The server address (IP or hostname).
+
+    Returns
+    -------
+    str
+        Address suitable for display. Wildcards become "localhost".
+    """
+    if address in {"0.0.0.0", "::"}:  # noqa: S104
+        return "localhost"
+    return address
+
+
 def make_url_path_regex(
     *path: str,
     trailing_slash: Literal["optional", "required", "prohibited"] = "optional",

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -293,8 +293,10 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         out = sys.stdout.getvalue()
         assert "Unix Socket: unix://mysocket.sock" in out
 
-    def test_print_urls_with_wildcard_address(self):
-        """Verify 0.0.0.0 is displayed as localhost in the URL."""
+    @patch("streamlit.net_util.get_internal_ip")
+    def test_print_urls_with_wildcard_address(self, mock_get_internal_ip):
+        """Verify 0.0.0.0 shows both Local URL and Network URL like default."""
+        mock_get_internal_ip.return_value = "internal-ip"
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(
             {"browser.serverAddress": False, "server.address": True}
         )
@@ -303,6 +305,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
                 "server.address": "0.0.0.0",
                 "server.port": 8501,
                 "global.developmentMode": False,
+                "server.headless": False,
             }
         )
 
@@ -313,12 +316,20 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        assert "URL: http://localhost:8501" in out
+        assert "Local URL: http://localhost:8501" in out
+        assert "Network URL: http://internal-ip:8501" in out
         # The raw 0.0.0.0 address should not appear in the URL
         assert "0.0.0.0" not in out
+        # Should not show generic "URL:" label (that's for specific addresses)
+        # Using regex to match "URL:" that is NOT preceded by "Local " or "Network "
+        import re
 
-    def test_print_urls_with_ipv6_wildcard(self):
-        """Verify :: (IPv6 wildcard) is displayed as localhost in the URL."""
+        assert not re.search(r"(?<!Local )(?<!Network )URL:", out)
+
+    @patch("streamlit.net_util.get_internal_ip")
+    def test_print_urls_with_ipv6_wildcard(self, mock_get_internal_ip):
+        """Verify :: (IPv6 wildcard) shows both Local URL and Network URL like default."""
+        mock_get_internal_ip.return_value = "internal-ip"
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(
             {"browser.serverAddress": False, "server.address": True}
         )
@@ -327,6 +338,7 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
                 "server.address": "::",
                 "server.port": 8501,
                 "global.developmentMode": False,
+                "server.headless": False,
             }
         )
 
@@ -337,9 +349,15 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
             bootstrap._print_url(False)
 
         out = sys.stdout.getvalue()
-        assert "URL: http://localhost:8501" in out
+        assert "Local URL: http://localhost:8501" in out
+        assert "Network URL: http://internal-ip:8501" in out
         # The raw :: address should not appear in the URL
         assert "http://::" not in out
+        # Should not show generic "URL:" label (that's for specific addresses)
+        # Using regex to match "URL:" that is NOT preceded by "Local " or "Network "
+        import re
+
+        assert not re.search(r"(?<!Local )(?<!Network )URL:", out)
 
     @patch("streamlit.web.bootstrap.asyncio.get_running_loop", Mock())
     @patch("streamlit.web.bootstrap.secrets.load_if_toml_exists", Mock())

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -293,6 +293,54 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         out = sys.stdout.getvalue()
         assert "Unix Socket: unix://mysocket.sock" in out
 
+    def test_print_urls_with_wildcard_address(self):
+        """Verify 0.0.0.0 is displayed as localhost in the URL."""
+        mock_is_manually_set = testutil.build_mock_config_is_manually_set(
+            {"browser.serverAddress": False, "server.address": True}
+        )
+        mock_get_option = testutil.build_mock_config_get_option(
+            {
+                "server.address": "0.0.0.0",
+                "server.port": 8501,
+                "global.developmentMode": False,
+            }
+        )
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
+        ):
+            bootstrap._print_url(False)
+
+        out = sys.stdout.getvalue()
+        assert "URL: http://localhost:8501" in out
+        # The raw 0.0.0.0 address should not appear in the URL
+        assert "0.0.0.0" not in out
+
+    def test_print_urls_with_ipv6_wildcard(self):
+        """Verify :: (IPv6 wildcard) is displayed as localhost in the URL."""
+        mock_is_manually_set = testutil.build_mock_config_is_manually_set(
+            {"browser.serverAddress": False, "server.address": True}
+        )
+        mock_get_option = testutil.build_mock_config_get_option(
+            {
+                "server.address": "::",
+                "server.port": 8501,
+                "global.developmentMode": False,
+            }
+        )
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.object(config, "is_manually_set", new=mock_is_manually_set),
+        ):
+            bootstrap._print_url(False)
+
+        out = sys.stdout.getvalue()
+        assert "URL: http://localhost:8501" in out
+        # The raw :: address should not appear in the URL
+        assert "http://::" not in out
+
     @patch("streamlit.web.bootstrap.asyncio.get_running_loop", Mock())
     @patch("streamlit.web.bootstrap.secrets.load_if_toml_exists", Mock())
     @patch("streamlit.web.bootstrap._maybe_print_static_folder_warning")

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -146,3 +146,22 @@ class ServerUtilTest(unittest.TestCase):
             server_util.make_url_path_regex("foo", trailing_slash="prohibited")
             == r"^/foo$"
         )
+
+    @parameterized.expand(
+        [
+            ("0.0.0.0", "localhost"),
+            ("::", "localhost"),
+            ("127.0.0.1", "127.0.0.1"),
+            ("localhost", "localhost"),
+            ("192.168.1.100", "192.168.1.100"),
+            ("myhost.local", "myhost.local"),
+        ]
+    )
+    def test_get_display_address(self, address: str, expected: str):
+        """Test that wildcard addresses are translated to localhost for display."""
+        assert server_util.get_display_address(address) == expected
+
+    def test_get_display_address_does_not_modify_non_wildcards(self):
+        """Verify non-wildcard addresses are returned unchanged."""
+        for addr in ["127.0.0.1", "localhost", "10.0.0.1", "example.com"]:
+            assert server_util.get_display_address(addr) == addr

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -163,5 +163,5 @@ class ServerUtilTest(unittest.TestCase):
 
     def test_get_display_address_does_not_modify_non_wildcards(self):
         """Verify non-wildcard addresses are returned unchanged."""
-        for addr in ["127.0.0.1", "localhost", "10.0.0.1", "example.com"]:
+        for addr in ["10.0.0.1", "example.com", "my-other-host.local", "203.0.113.5"]:
             assert server_util.get_display_address(addr) == addr


### PR DESCRIPTION
## Describe your changes

Improved URL display for wildcard IP addresses. When using wildcard addresses like "0.0.0.0" or "::" for the server, these are now displayed as "localhost" in the browser URL and console output. This makes the URLs more user-friendly and avoids confusion, as wildcard addresses aren't directly accessible in browsers on all platforms.

This closes #13712

## Testing Plan

- Unit Tests (Python): Added comprehensive tests to verify wildcard addresses are properly translated to "localhost" for display purposes
    - Added tests for both IPv4 (0.0.0.0) and IPv6 (::) wildcard addresses
    - Added tests to verify non-wildcard addresses remain unchanged
    - Added tests to verify the URLs displayed in the console use the translated addresses

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.