### PR TITLE
Bind widgets to query params - Part 4

### DIFF
--- a/e2e_playwright/st_number_input.py
+++ b/e2e_playwright/st_number_input.py
@@ -175,3 +175,32 @@ v19 = st.number_input(
     key="number_input_19",
 )
 st.write(f"number input 19 (small step decrement) - value: {v19:.7f}")
+
+# Query param bound number inputs
+st.markdown("Query param bound number inputs:")
+
+bound_int = st.number_input(
+    "Bound number input (int, no default)",
+    value=None,
+    key="bound_int",
+    bind="query-params",
+)
+st.write("bound int value:", bound_int)
+
+bound_float = st.number_input(
+    "Bound number input (float, default 3.14)",
+    value=3.14,
+    key="bound_float",
+    bind="query-params",
+)
+st.write("bound float value:", bound_float)
+
+bound_with_min_max = st.number_input(
+    "Bound number input (min=0, max=100)",
+    value=50,
+    min_value=0,
+    max_value=100,
+    key="bound_minmax",
+    bind="query-params",
+)
+st.write("bound minmax value:", bound_with_min_max)

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -18,7 +18,11 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -30,7 +34,7 @@ from e2e_playwright.shared.app_utils import (
     reset_hovering,
 )
 
-NUMBER_INPUT_COUNT = 20
+NUMBER_INPUT_COUNT = 23
 
 
 def test_number_input_widget_display(
@@ -485,3 +489,77 @@ def test_number_input_scientific_notation_step_decrement(app: Page):
     expect_prefixed_markdown(
         app, "number input 19 (small step decrement) - value:", "0.0000000"
     )
+
+
+def test_number_input_query_param_seeding_int(page: Page, app_port: int):
+    """Test that number input (int) value can be seeded from URL query params."""
+    # Load app with query param set
+    page.goto(f"http://localhost:{app_port}/?bound_int=42")
+    wait_for_app_loaded(page)
+
+    # Number input should show the seeded value
+    expect_prefixed_markdown(page, "bound int value:", "42")
+
+
+def test_number_input_query_param_seeding_float(page: Page, app_port: int):
+    """Test that number input (float) value can be seeded from URL query params."""
+    # Load app with query param overriding the "3.14" default
+    page.goto(f"http://localhost:{app_port}/?bound_float=2.718")
+    wait_for_app_loaded(page)
+
+    # Number input should show "2.718" (overriding "3.14" default)
+    expect_prefixed_markdown(page, "bound float value:", "2.718")
+
+
+def test_number_input_query_param_updates_url(app: Page):
+    """Test that changing a bound number input updates the URL."""
+    # Use the float widget which has a default value (easier to test)
+    number_input = get_element_by_key(app, "bound_float")
+    input_field = number_input.get_by_test_id("stNumberInputField")
+
+    # Change from default (3.14) to a new value
+    input_field.fill("2.718")
+    input_field.press("Enter")
+    wait_for_app_run(app)
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_float=2\.718"))
+    expect_prefixed_markdown(app, "bound float value:", "2.718")
+
+
+def test_number_input_query_param_with_default(page: Page, app_port: int):
+    """Test number input with custom default: seeding and param removal."""
+    # Load app with query param overriding the "3.14" default
+    page.goto(f"http://localhost:{app_port}/?bound_float=9.99")
+    wait_for_app_loaded(page)
+
+    # Number input should show "9.99"
+    expect_prefixed_markdown(page, "bound float value:", "9.99")
+
+    # Change back to default ("3.14")
+    number_input = get_element_by_key(page, "bound_float")
+    input_field = number_input.get_by_test_id("stNumberInputField")
+    input_field.fill("3.14")
+    input_field.press("Enter")
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default
+    expect(page).to_have_url(re.compile(r"^((?!bound_float).)*$"))
+    expect_prefixed_markdown(page, "bound float value:", "3.14")
+
+
+def test_number_input_query_param_clamped_to_min_max(page: Page, app_port: int):
+    """Test that URL values exceeding min/max are clamped."""
+    # Load app with value exceeding max=100
+    page.goto(f"http://localhost:{app_port}/?bound_minmax=999")
+    wait_for_app_loaded(page)
+
+    # Number input should clamp to max value (100)
+    expect_prefixed_markdown(page, "bound minmax value:", "100")
+
+    # Now test below min
+    page.goto(f"http://localhost:{app_port}/?bound_minmax=-50")
+    wait_for_app_loaded(page)
+
+    # Number input should clamp to min value (0)
+    expect_prefixed_markdown(page, "bound minmax value:", "0")

--- a/e2e_playwright/st_text_area.py
+++ b/e2e_playwright/st_text_area.py
@@ -185,3 +185,27 @@ else:
         max_chars=100,
     )
     st.write("Initial text area value:", ta_value)
+
+# Query param bound text areas
+bound_value = st.text_area(
+    "Bound text area (no default)",
+    key="bound_text_area",
+    bind="query-params",
+)
+st.write("bound text area value:", bound_value)
+
+bound_with_default = st.text_area(
+    "Bound text area (default 'hello')",
+    value="hello",
+    key="bound_text_area_default",
+    bind="query-params",
+)
+st.write("bound text area default value:", bound_with_default)
+
+bound_with_max_chars = st.text_area(
+    "Bound text area (max_chars=5)",
+    key="bound_text_area_max",
+    bind="query-params",
+    max_chars=5,
+)
+st.write("bound max chars value:", bound_with_max_chars)

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -26,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_text_area,
 )
 
-NUM_TEXT_AREAS = 25
+NUM_TEXT_AREAS = 28
 
 
 def test_text_area_widget_rendering(
@@ -366,3 +372,87 @@ def test_text_area_content_height_expansion(
     # Test reducing content and verify it shrinks back
     content_height_form.locator("textarea").first.fill("Line 1\nLine 2")
     assert_snapshot(content_height_form, name="st_text_area-content_height_reduced")
+
+
+# ============================================
+# Query Param Binding Tests
+# ============================================
+
+
+def test_text_area_query_param_seeding(page: Page, app_port: int):
+    """Test that text area value can be seeded from URL query params."""
+    # Load app with query param set
+    page.goto(f"http://localhost:{app_port}/?bound_text_area=seeded_value")
+    wait_for_app_loaded(page)
+
+    # Text area should show the seeded value
+    expect_prefixed_markdown(page, "bound text area value:", "seeded_value")
+
+
+def test_text_area_query_param_updates_url(app: Page):
+    """Test that changing a bound text area updates the URL."""
+    # Initially empty, no query param in URL
+    expect_prefixed_markdown(app, "bound text area value:", "")
+    expect(app).to_have_url(re.compile(r"^((?!bound_text_area=).)*$"))
+
+    # Type a value and submit
+    text_area = get_text_area(app, "Bound text area (no default)")
+    textarea_field = text_area.locator("textarea").first
+    textarea_field.fill("test_value")
+    textarea_field.press("Control+Enter")
+    wait_for_app_run(app)
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_text_area=test_value"))
+    expect_prefixed_markdown(app, "bound text area value:", "test_value")
+
+    # Clear the text area (back to empty default)
+    textarea_field.clear()
+    textarea_field.press("Control+Enter")
+    wait_for_app_run(app)
+
+    # Query param should be removed since value is back to default (empty)
+    expect(app).to_have_url(re.compile(r"^((?!bound_text_area=).)*$"))
+    expect_prefixed_markdown(app, "bound text area value:", "")
+
+
+def test_text_area_query_param_with_default(page: Page, app_port: int):
+    """Test text area with custom default: seeding and param removal."""
+    # Load app with query param overriding the "hello" default
+    page.goto(f"http://localhost:{app_port}/?bound_text_area_default=world")
+    wait_for_app_loaded(page)
+
+    # Text area should show "world" (overriding "hello" default)
+    expect_prefixed_markdown(page, "bound text area default value:", "world")
+
+    # Change back to default ("hello")
+    text_area = get_text_area(page, "Bound text area (default 'hello')")
+    textarea_field = text_area.locator("textarea").first
+    textarea_field.fill("hello")
+    textarea_field.press("Control+Enter")
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default
+    expect(page).to_have_url(re.compile(r"^((?!bound_text_area_default).)*$"))
+    expect_prefixed_markdown(page, "bound text area default value:", "hello")
+
+
+def test_text_area_query_param_special_characters(page: Page, app_port: int):
+    """Test that special characters in URL params are handled correctly."""
+    # Load app with URL-encoded special characters
+    # "hello world!" URL-encoded is "hello%20world%21"
+    page.goto(f"http://localhost:{app_port}/?bound_text_area=hello%20world%21")
+    wait_for_app_loaded(page)
+
+    # Text area should correctly decode and show "hello world!"
+    expect_prefixed_markdown(page, "bound text area value:", "hello world!")
+
+
+def test_text_area_query_param_max_chars_truncation(page: Page, app_port: int):
+    """Test that URL values exceeding max_chars are truncated."""
+    # Load app with value longer than max_chars=5
+    page.goto(f"http://localhost:{app_port}/?bound_text_area_max=verylongtext")
+    wait_for_app_loaded(page)
+
+    # Text area should truncate to 5 characters
+    expect_prefixed_markdown(page, "bound max chars value:", "veryl")

--- a/e2e_playwright/st_text_input.py
+++ b/e2e_playwright/st_text_input.py
@@ -141,3 +141,29 @@ else:
         max_chars=100,
     )
     st.write("Initial text input value:", txt_value)
+
+# Query param bound text inputs
+st.markdown("Query param bound text inputs:")
+
+bound_value = st.text_input(
+    "Bound text input (no default)",
+    key="bound_text",
+    bind="query-params",
+)
+st.write("bound text value:", bound_value)
+
+bound_with_default = st.text_input(
+    "Bound text input (default 'hello')",
+    value="hello",
+    key="bound_text_default",
+    bind="query-params",
+)
+st.write("bound text default value:", bound_with_default)
+
+bound_with_max_chars = st.text_input(
+    "Bound text input (max_chars=5)",
+    key="bound_max",
+    bind="query-params",
+    max_chars=5,
+)
+st.write("bound max chars value:", bound_with_max_chars)

--- a/e2e_playwright/st_text_input_test.py
+++ b/e2e_playwright/st_text_input_test.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 
+import re
+
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -30,7 +36,7 @@ from e2e_playwright.shared.input_utils import (
     type_common_characters_into_input,
 )
 
-TEXT_INPUT_ELEMENTS = 19
+TEXT_INPUT_ELEMENTS = 22
 
 
 def test_text_input_widget_rendering(
@@ -369,3 +375,82 @@ def test_dynamic_text_input_props(app: Page, assert_snapshot: ImageCompareFuncti
     wait_for_app_run(app)
 
     expect_prefixed_markdown(app, "Updated text input value:", "bar")
+
+
+def test_text_input_query_param_seeding(page: Page, app_port: int):
+    """Test that text input value can be seeded from URL query params."""
+    # Load app with query param set
+    page.goto(f"http://localhost:{app_port}/?bound_text=seeded_value")
+    wait_for_app_loaded(page)
+
+    # Text input should show the seeded value
+    expect_prefixed_markdown(page, "bound text value:", "seeded_value")
+
+
+def test_text_input_query_param_updates_url(app: Page):
+    """Test that changing a bound text input updates the URL."""
+    # Initially empty, no query param in URL
+    expect_prefixed_markdown(app, "bound text value:", "")
+    expect(app).to_have_url(re.compile(r"^((?!bound_text=).)*$"))
+
+    # Type a value and submit
+    text_input = get_text_input(app, "Bound text input (no default)")
+    input_field = text_input.locator("input").first
+    input_field.fill("test_value")
+    input_field.press("Enter")
+    wait_for_app_run(app)
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_text=test_value"))
+    expect_prefixed_markdown(app, "bound text value:", "test_value")
+
+    # Clear the text input (back to empty default)
+    input_field.clear()
+    input_field.press("Enter")
+    wait_for_app_run(app)
+
+    # Query param should be removed since value is back to default (empty)
+    expect(app).to_have_url(re.compile(r"^((?!bound_text=).)*$"))
+    expect_prefixed_markdown(app, "bound text value:", "")
+
+
+def test_text_input_query_param_with_default(page: Page, app_port: int):
+    """Test text input with custom default: seeding and param removal."""
+    # Load app with query param overriding the "hello" default
+    page.goto(f"http://localhost:{app_port}/?bound_text_default=world")
+    wait_for_app_loaded(page)
+
+    # Text input should show "world" (overriding "hello" default)
+    expect_prefixed_markdown(page, "bound text default value:", "world")
+
+    # Change back to default ("hello")
+    text_input = get_text_input(page, "Bound text input (default 'hello')")
+    input_field = text_input.locator("input").first
+    input_field.fill("hello")
+    input_field.press("Enter")
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default
+    expect(page).to_have_url(re.compile(r"^((?!bound_text_default).)*$"))
+    expect_prefixed_markdown(page, "bound text default value:", "hello")
+
+
+def test_text_input_query_param_special_characters(page: Page, app_port: int):
+    """Test that special characters in URL params are handled correctly."""
+    # Load app with URL-encoded special characters
+    # "hello world!" URL-encoded is "hello%20world%21"
+    page.goto(f"http://localhost:{app_port}/?bound_text=hello%20world%21")
+    wait_for_app_loaded(page)
+
+    # Text input should correctly decode and show "hello world!"
+    expect_prefixed_markdown(page, "bound text value:", "hello world!")
+
+
+def test_text_input_query_param_max_chars_truncation(page: Page, app_port: int):
+    """Test that URL values exceeding max_chars are truncated."""
+    # Load app with value longer than max_chars=5
+    page.goto(f"http://localhost:{app_port}/?bound_max=verylongtext")
+    wait_for_app_loaded(page)
+
+    # Text input should truncate to 5 characters
+    expect_prefixed_markdown(page, "bound max chars value:", "veryl")

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -1451,3 +1451,68 @@ describe("NumberInput widget", () => {
     })
   })
 })
+
+describe("NumberInput query param binding", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: { current: null },
+      values: [250],
+    })
+  })
+
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getIntProps({ queryParamKey: "my_number" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_number",
+      "double_value",
+      props.element.default,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getIntProps({ queryParamKey: "my_number" })
+    vi.spyOn(props.widgetMgr, "unregisterQueryParamBinding")
+
+    const { unmount } = render(<NumberInput {...props} />)
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getIntProps({ queryParamKey: "" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding with float default value", () => {
+    const props = getFloatProps({
+      queryParamKey: "my_float",
+      default: 3.14,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_float",
+      "double_value",
+      3.14,
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -39,7 +39,6 @@ import {
 import { useBasicWidgetState } from "~lib/hooks/useBasicWidgetState"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import { convertRemToPx } from "~lib/theme"
 import {
   isInForm,
@@ -145,16 +144,13 @@ const NumberInput: React.FC<Props> = ({
       setDirty(false)
       setFormattedValue(formatCurrentValue(newValue))
     }, [elementDefault, formatCurrentValue]),
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "double_value",
+        }
+      : undefined,
   })
-
-  // Query param binding registration
-  useQueryParamBinding(
-    widgetMgr,
-    element.id,
-    element.queryParamKey,
-    "double_value",
-    element.default
-  )
 
   // Additional local state for UI interactions
   const [isFocused, setIsFocused] = useState(false)

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -39,6 +39,7 @@ import {
 import { useBasicWidgetState } from "~lib/hooks/useBasicWidgetState"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import { convertRemToPx } from "~lib/theme"
 import {
   isInForm,
@@ -145,6 +146,15 @@ const NumberInput: React.FC<Props> = ({
       setFormattedValue(formatCurrentValue(newValue))
     }, [elementDefault, formatCurrentValue]),
   })
+
+  // Query param binding registration
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    element.queryParamKey,
+    "double_value",
+    element.default
+  )
 
   // Additional local state for UI interactions
   const [isFocused, setIsFocused] = useState(false)

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -418,3 +418,61 @@ describe("TextArea widget", () => {
     expect(forId2).toBe(forId1)
   })
 })
+
+describe("TextArea query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_text_area" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<TextArea {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_text_area",
+      "string_value",
+      "",
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_text_area" })
+    vi.spyOn(props.widgetMgr, "unregisterQueryParamBinding")
+
+    const { unmount } = render(<TextArea {...props} />)
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps({ queryParamKey: "" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<TextArea {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding with custom default value", () => {
+    const props = getProps({
+      queryParamKey: "my_text_area",
+      default: "default text",
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<TextArea {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_text_area",
+      "string_value",
+      "default text",
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -34,6 +34,7 @@ import {
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
+import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import { useTextInputAutoExpand } from "~lib/hooks/useTextInputAutoExpand"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
@@ -59,7 +60,7 @@ const getStateFromWidgetMgr = (
   widgetMgr: WidgetStateManager,
   element: TextAreaProto
 ): TextAreaValue | undefined => {
-  return widgetMgr.getStringValue(element) ?? element.default ?? null
+  return widgetMgr.getStringValue(element) ?? undefined
 }
 
 const getDefaultStateFromProto = (element: TextAreaProto): TextAreaValue => {
@@ -143,6 +144,15 @@ const TextArea: FC<Props> = ({
     fragmentId,
     onFormCleared,
   })
+
+  // Query param binding registration
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    element.queryParamKey,
+    "string_value",
+    element.default
+  )
 
   useUpdateUiValue(value, uiValue, setUiValue, dirty)
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -34,7 +34,6 @@ import {
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
-import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import { useTextInputAutoExpand } from "~lib/hooks/useTextInputAutoExpand"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
@@ -143,16 +142,13 @@ const TextArea: FC<Props> = ({
     widgetMgr,
     fragmentId,
     onFormCleared,
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "string_value",
+        }
+      : undefined,
   })
-
-  // Query param binding registration
-  useQueryParamBinding(
-    widgetMgr,
-    element.id,
-    element.queryParamKey,
-    "string_value",
-    element.default
-  )
 
   useUpdateUiValue(value, uiValue, setUiValue, dirty)
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -560,7 +560,7 @@ describe("TextInput query param binding", () => {
   })
 
   it("does not register query param binding when queryParamKey is not set", () => {
-    const props = getProps()
+    const props = getProps({ queryParamKey: "" })
     vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
 
     render(<TextInput {...props} />)

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -529,3 +529,61 @@ describe("TextInput widget", () => {
     expect(materialIcon).toHaveTextContent("search")
   })
 })
+
+describe("TextInput query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_text" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<TextInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_text",
+      "string_value",
+      props.element.default,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_text" })
+    vi.spyOn(props.widgetMgr, "unregisterQueryParamBinding")
+
+    const { unmount } = render(<TextInput {...props} />)
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<TextInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding with custom default value", () => {
+    const props = getProps({
+      queryParamKey: "search_query",
+      default: "initial search",
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<TextInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "search_query",
+      "string_value",
+      "initial search",
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -35,6 +35,7 @@ import {
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
+import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
 import { convertRemToPx } from "~lib/theme"
@@ -89,6 +90,15 @@ function TextInput({
     fragmentId,
     onFormCleared,
   })
+
+  // Query param binding registration
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    element.queryParamKey,
+    "string_value",
+    element.default
+  )
 
   useUpdateUiValue(value, uiValue, setUiValue, dirty)
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -35,7 +35,6 @@ import {
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
-import { useQueryParamBinding } from "~lib/hooks/useQueryParamBinding"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
 import { convertRemToPx } from "~lib/theme"
@@ -89,16 +88,13 @@ function TextInput({
     widgetMgr,
     fragmentId,
     onFormCleared,
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "string_value",
+        }
+      : undefined,
   })
-
-  // Query param binding registration
-  useQueryParamBinding(
-    widgetMgr,
-    element.id,
-    element.queryParamKey,
-    "string_value",
-    element.default
-  )
 
   useUpdateUiValue(value, uiValue, setUiValue, dirty)
 

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -643,9 +643,14 @@ class NumberInputMixin:
         if bind == "query-params" and key is not None:
             number_input_proto.query_param_key = str(key)
 
-        # min_value and max_value are guaranteed to be set by JSNumber defaults above
+        # min_value and max_value are guaranteed to be Number (not None) after
+        # the JSNumber defaults above. The casts are needed for ty (which doesn't
+        # narrow the type), but mypy sees them as redundant.
         serde = NumberInputSerde(
-            value, data_type, cast("Number", min_value), cast("Number", max_value)
+            value,
+            data_type,
+            cast("Number", min_value),  # type: ignore[redundant-cast]
+            cast("Number", max_value),  # type: ignore[redundant-cast]
         )
         widget_state = register_widget(
             number_input_proto.id,

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -48,6 +48,7 @@ from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -69,6 +70,8 @@ FloatOrNone = TypeVar("FloatOrNone", float, None)
 class NumberInputSerde:
     value: Number | None
     data_type: int
+    min_value: Number
+    max_value: Number
 
     def serialize(self, v: Number | None) -> Number | None:
         return v
@@ -76,8 +79,11 @@ class NumberInputSerde:
     def deserialize(self, ui_value: Number | None) -> Number | None:
         val: Number | None = ui_value if ui_value is not None else self.value
 
-        if val is not None and self.data_type == NumberInputProto.INT:
-            val = int(val)
+        if val is not None:
+            if self.data_type == NumberInputProto.INT:
+                val = int(val)
+            # Clamp to min/max range (e.g., for values seeded from URL)
+            val = max(self.min_value, min(self.max_value, val))
 
         return val
 
@@ -107,6 +113,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int | IntOrNone: ...
 
     # If "max_value: int" is given and all other numerical inputs are
@@ -133,6 +140,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int | IntOrNone: ...
 
     # If "value=int" is given and all other numerical inputs are "int"s
@@ -157,6 +165,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int: ...
 
     # If "step=int" is given and all other numerical inputs are "int"s
@@ -183,6 +192,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int | IntOrNone: ...
 
     # If all numerical inputs are floats (with value optionally being "min")
@@ -209,6 +219,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> float | FloatOrNone: ...
 
     @gather_metrics("number_input")
@@ -231,6 +242,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> Number | None:
         r"""Display a numeric input widget.
 
@@ -366,6 +378,15 @@ class NumberInputMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Values from URL are automatically clamped
+            to ``min_value`` and ``max_value`` if set. Requires a ``key`` to
+            be set, which will be used as the query parameter name. The
+            default is ``None``.
+
         Returns
         -------
         int or float or None
@@ -415,6 +436,7 @@ class NumberInputMixin:
             label_visibility=label_visibility,
             icon=icon,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -437,6 +459,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> Number | None:
         key = to_key(key)
@@ -616,7 +639,14 @@ class NumberInputMixin:
         if icon is not None:
             number_input_proto.icon = validate_icon_or_emoji(icon)
 
-        serde = NumberInputSerde(value, data_type)
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            number_input_proto.query_param_key = str(key)
+
+        # min_value and max_value are guaranteed to be set by JSNumber defaults above
+        serde = NumberInputSerde(
+            value, data_type, cast("Number", min_value), cast("Number", max_value)
+        )
         widget_state = register_widget(
             number_input_proto.id,
             on_change_handler=on_change,
@@ -626,6 +656,7 @@ class NumberInputMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="double_value",
+            bind=bind,
         )
 
         # Validate the current value against the new min/max bounds.

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -77,9 +77,14 @@ class TextInputSerde:
 @dataclass
 class TextAreaSerde:
     value: str | None
+    max_chars: int | None = None
 
     def deserialize(self, ui_value: str | None) -> str | None:
-        return ui_value if ui_value is not None else self.value
+        result = ui_value if ui_value is not None else self.value
+        # Truncate if max_chars is set (handles URL-seeded values exceeding limit)
+        if result is not None and self.max_chars is not None:
+            result = result[: self.max_chars]
+        return result
 
     def serialize(self, v: str | None) -> str | None:
         return v
@@ -451,6 +456,7 @@ class TextWidgetsMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> str:
         pass
 
@@ -471,6 +477,7 @@ class TextWidgetsMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> str | None:
         pass
 
@@ -491,6 +498,7 @@ class TextWidgetsMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> str | None:
         r"""Display a multi-line text input widget.
 
@@ -593,6 +601,13 @@ class TextWidgetsMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         str or None
@@ -634,6 +649,7 @@ class TextWidgetsMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -653,6 +669,7 @@ class TextWidgetsMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str | None:
         key = to_key(key)
@@ -707,7 +724,11 @@ class TextWidgetsMixin:
         if placeholder is not None:
             text_area_proto.placeholder = str(placeholder)
 
-        serde = TextAreaSerde(value)
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            text_area_proto.query_param_key = str(key)
+
+        serde = TextAreaSerde(value, max_chars)
         widget_state = register_widget(
             text_area_proto.id,
             on_change_handler=on_change,
@@ -717,6 +738,7 @@ class TextWidgetsMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_value",
+            bind=bind,
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -43,6 +43,7 @@ from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -60,9 +61,14 @@ if TYPE_CHECKING:
 @dataclass
 class TextInputSerde:
     value: str | None
+    max_chars: int | None = None
 
     def deserialize(self, ui_value: str | None) -> str | None:
-        return ui_value if ui_value is not None else self.value
+        result = ui_value if ui_value is not None else self.value
+        # Truncate if max_chars is set (handles URL-seeded values exceeding limit)
+        if result is not None and self.max_chars is not None:
+            result = result[: self.max_chars]
+        return result
 
     def serialize(self, v: str | None) -> str | None:
         return v
@@ -99,6 +105,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> str:
         pass
 
@@ -121,6 +128,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> str | None:
         pass
 
@@ -143,6 +151,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> str | None:
         r"""Display a single-line text input widget.
 
@@ -256,6 +265,13 @@ class TextWidgetsMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         str or None
@@ -291,6 +307,7 @@ class TextWidgetsMixin:
             label_visibility=label_visibility,
             icon=icon,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -312,6 +329,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str | None:
         key = to_key(key)
@@ -387,7 +405,11 @@ class TextWidgetsMixin:
             autocomplete = "new-password" if type == "password" else ""
         text_input_proto.autocomplete = autocomplete
 
-        serde = TextInputSerde(value)
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            text_input_proto.query_param_key = str(key)
+
+        serde = TextInputSerde(value, max_chars)
 
         widget_state = register_widget(
             text_input_proto.id,
@@ -398,6 +420,7 @@ class TextWidgetsMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_value",
+            bind=bind,
         )
 
         if widget_state.value_changed:

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -751,11 +751,19 @@ class NumberInputBindQueryParamsTest(DeltaGeneratorTestCase):
         assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
-        """Test that without bind parameter, query_param_key is not set."""
-        st.number_input("the label", key="my_key")
+        """Test that without bind parameter, query_param_key is not set.
+
+        When query_param_key is empty, the frontend will not register any
+        URL query parameter binding, so the widget operates normally without
+        URL synchronization.
+        """
+        st.number_input("the label", key="my_key", value=0)
 
         c = self.get_delta_from_queue().new_element.number_input
         assert c.query_param_key == ""
+        # Verify widget still has normal properties (not affected by missing bind)
+        assert c.label == "the label"
+        assert c.default == 0
 
     def test_invalid_bind_value_raises_exception(self):
         """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
@@ -806,6 +814,7 @@ class NumberInputBindQueryParamsTest(DeltaGeneratorTestCase):
         (150, 100),  # Above max -> clamped to max
         (-50, 0),  # Below min -> clamped to min
         (50, 50),  # In range -> unchanged
+        (None, 50),  # None -> returns default value
     ],
 )
 def test_serde_clamps_to_min_max(ui_value, expected):

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -748,7 +748,7 @@ class NumberInputBindQueryParamsTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             st.number_input("the label", bind="query-params")
 
-        assert "must have a 'key' parameter" in str(exc.value)
+        assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
         """Test that without bind parameter, query_param_key is not set."""

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -21,8 +21,10 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.js_number import JSNumber
+from streamlit.elements.widgets.number_input import NumberInputSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidBindValueError,
     StreamlitInvalidWidthError,
     StreamlitValueAboveMaxError,
 )
@@ -729,3 +731,86 @@ def test_dynamic_bounds_with_float_values():
     at = at.run()
     # Now min_value=5.0, so 2.5 is invalid and should reset to default (7.5)
     assert at.number_input[0].value == 7.5
+
+
+class NumberInputBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for number_input bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.number_input("the label", key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.number_input("the label", bind="query-params")
+
+        assert "must have a 'key' parameter" in str(exc.value)
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.number_input("the label", key="my_key")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            st.number_input("the label", key="my_key", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)
+
+    def test_bind_query_params_with_int_value(self):
+        """Test that bind works with integer values."""
+        st.number_input("the label", value=42, key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+        assert c.data_type == NumberInput.INT
+
+    def test_bind_query_params_with_float_value(self):
+        """Test that bind works with float values."""
+        st.number_input("the label", value=3.14, key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+        assert c.data_type == NumberInput.FLOAT
+
+    def test_bind_query_params_with_min_max(self):
+        """Test that bind works with min/max constraints."""
+        st.number_input(
+            "the label",
+            min_value=0,
+            max_value=100,
+            value=50,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+        assert c.has_min
+        assert c.min == 0
+        assert c.has_max
+        assert c.max == 100
+
+
+@pytest.mark.parametrize(
+    ("ui_value", "expected"),
+    [
+        (150, 100),  # Above max -> clamped to max
+        (-50, 0),  # Below min -> clamped to min
+        (50, 50),  # In range -> unchanged
+    ],
+)
+def test_serde_clamps_to_min_max(ui_value, expected):
+    """Test that NumberInputSerde.deserialize clamps values outside min/max range."""
+    serde = NumberInputSerde(
+        value=50, data_type=NumberInput.INT, min_value=0, max_value=100
+    )
+    assert serde.deserialize(ui_value) == expected

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -411,7 +411,7 @@ class TextAreaBindQueryParamsTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             st.text_area("the label", bind="query-params")
 
-        assert "must have a 'key' parameter" in str(exc.value)
+        assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
         """Test that without bind parameter, query_param_key is not set."""

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidBindValueError,
     StreamlitInvalidHeightError,
     StreamlitInvalidWidthError,
 )
@@ -393,3 +394,54 @@ def test_None_session_state_value_retained():
     at = AppTest.from_function(script).run()
     at = at.button[0].click().run()
     assert at.text_area[0].value is None
+
+
+class TextAreaBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for text_area bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.text_area("the label", key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.text_area("the label", bind="query-params")
+
+        assert "must have a 'key' parameter" in str(exc.value)
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.text_area("the label", key="my_key")
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            st.text_area("the label", key="my_key", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)
+
+    def test_bind_query_params_with_default_value(self):
+        """Test that bind works with a default value."""
+        st.text_area(
+            "the label", value="default text", key="my_key", bind="query-params"
+        )
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.query_param_key == "my_key"
+        assert c.default == "default text"
+
+    def test_bind_query_params_with_max_chars(self):
+        """Test that bind works with max_chars - values should be truncated."""
+        st.text_area("the label", key="my_key", bind="query-params", max_chars=10)
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.query_param_key == "my_key"
+        assert c.max_chars == 10

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -414,11 +414,19 @@ class TextAreaBindQueryParamsTest(DeltaGeneratorTestCase):
         assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
-        """Test that without bind parameter, query_param_key is not set."""
+        """Test that without bind parameter, query_param_key is not set.
+
+        When query_param_key is empty, the frontend will not register any
+        URL query parameter binding, so the widget operates normally without
+        URL synchronization.
+        """
         st.text_area("the label", key="my_key")
 
         c = self.get_delta_from_queue().new_element.text_area
         assert c.query_param_key == ""
+        # Verify widget still has normal properties (not affected by missing bind)
+        assert c.label == "the label"
+        assert c.default == ""
 
     def test_invalid_bind_value_raises_exception(self):
         """Test that an invalid bind value raises StreamlitInvalidBindValueError."""

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -396,11 +396,19 @@ class TextInputBindQueryParamsTest(DeltaGeneratorTestCase):
         assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
-        """Test that without bind parameter, query_param_key is not set."""
+        """Test that without bind parameter, query_param_key is not set.
+
+        When query_param_key is empty, the frontend will not register any
+        URL query parameter binding, so the widget operates normally without
+        URL synchronization.
+        """
         st.text_input("the label", key="my_key")
 
         c = self.get_delta_from_queue().new_element.text_input
         assert c.query_param_key == ""
+        # Verify widget still has normal properties (not affected by missing bind)
+        assert c.label == "the label"
+        assert c.default == ""
 
     def test_invalid_bind_value_raises_exception(self):
         """Test that an invalid bind value raises StreamlitInvalidBindValueError."""

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -21,7 +21,11 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidWidthError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidBindValueError,
+    StreamlitInvalidWidthError,
+)
 from streamlit.proto.LabelVisibilityMessage_pb2 import LabelVisibilityMessage
 from streamlit.proto.TextInput_pb2 import TextInput
 from streamlit.testing.v1.app_test import AppTest
@@ -372,3 +376,62 @@ def test_None_session_state_value_retained():
     at = AppTest.from_function(script).run()
     at = at.button[0].click().run()
     assert at.text_input[0].value is None
+
+
+class TextInputBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for text_input bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.text_input("the label", key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.text_input("the label", bind="query-params")
+
+        assert "must have a 'key' parameter" in str(exc.value)
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.text_input("the label", key="my_key")
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            st.text_input("the label", key="my_key", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)
+
+    def test_bind_query_params_with_default_value(self):
+        """Test that bind works with a default value."""
+        st.text_input(
+            "the label", value="default text", key="my_key", bind="query-params"
+        )
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.query_param_key == "my_key"
+        assert c.default == "default text"
+
+    def test_bind_query_params_with_password_type(self):
+        """Test that bind works with password type (though not recommended)."""
+        st.text_input("password", type="password", key="pw", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.query_param_key == "pw"
+        assert c.type == TextInput.PASSWORD
+
+    def test_bind_query_params_with_max_chars(self):
+        """Test that bind works with max_chars - values should be truncated."""
+        st.text_input("the label", key="my_key", bind="query-params", max_chars=5)
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.query_param_key == "my_key"
+        assert c.max_chars == 5

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -393,7 +393,7 @@ class TextInputBindQueryParamsTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException) as exc:
             st.text_input("the label", bind="query-params")
 
-        assert "must have a 'key' parameter" in str(exc.value)
+        assert "must have a unique 'key' parameter" in str(exc.value)
 
     def test_no_bind_does_not_set_query_param_key(self):
         """Test that without bind parameter, query_param_key is not set."""

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -49,6 +49,8 @@ message NumberInput {
   LabelVisibilityMessage label_visibility = 22;
   string placeholder = 23;
   string icon = 24;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 25;
 
   reserved 4, 5, 6, 7, 9, 10;
 }

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -37,4 +37,6 @@ message TextArea {
   string placeholder = 10;
   bool disabled = 11;
   LabelVisibilityMessage label_visibility = 12;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 13;
 }

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -44,4 +44,6 @@ message TextInput {
   bool disabled = 12;
   LabelVisibilityMessage label_visibility = 13;
   string icon = 14;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 15;
 }


### PR DESCRIPTION
## Describe your changes
**Bind Widgets to Query Params - Part 4**
This PR adds the `bind` parameter to `st.text_input`, `st.text_area`, and `st.number_input` to enable two-way sync between widget values and URL query parameters.

- **URL seeding** - Widgets initialize from URL on page load
- **URL sync** - User input updates URL in real-time (on blur/enter)
- **Default cleanup** - URL param removed when widget returns to default value
- **Constraint handling** - `max_chars` truncates seeded values; `min`/`max` clamps number inputs
- **Error handling** - `StreamlitInvalidBindValueError` for invalid bind values

## Testing Plan
- Python/JS Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 