### PR TITLE
Remove `java_package` and `java_outer_classname` from proto files

### DIFF
--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "AlertProto";
 
 import "streamlit/proto/WidthConfig.proto";
 

--- a/proto/streamlit/proto/AppPage.proto
+++ b/proto/streamlit/proto/AppPage.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "AppPageProto";
 
 // A page in the app. Includes both the name of the page as well as the full
 // path to the corresponding script file.

--- a/proto/streamlit/proto/Arrow.proto
+++ b/proto/streamlit/proto/Arrow.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ArrowProto";
 
 message Arrow {
   // The serialized arrow dataframe

--- a/proto/streamlit/proto/ArrowData.proto
+++ b/proto/streamlit/proto/ArrowData.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ArrowDataProto";
 
 // Data-only Arrow buffer. This intentionally excludes any UI- or element-
 // specific configuration that exists in Arrow.proto. Use this message when

--- a/proto/streamlit/proto/ArrowNamedDataSet.proto
+++ b/proto/streamlit/proto/ArrowNamedDataSet.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ArrowNamedDataSetProto";
 
 import "streamlit/proto/Arrow.proto";
 

--- a/proto/streamlit/proto/ArrowVegaLiteChart.proto
+++ b/proto/streamlit/proto/ArrowVegaLiteChart.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ArrowVegaLiteChartProto";
 
 import "streamlit/proto/Arrow.proto";
 import "streamlit/proto/ArrowNamedDataSet.proto";

--- a/proto/streamlit/proto/Audio.proto
+++ b/proto/streamlit/proto/Audio.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "AudioProto";
 
 import "streamlit/proto/WidthConfig.proto";
 

--- a/proto/streamlit/proto/AudioInput.proto
+++ b/proto/streamlit/proto/AudioInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "AudioInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/AuthRedirect.proto
+++ b/proto/streamlit/proto/AuthRedirect.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "AuthRedirectProto";
 
 message AuthRedirect {
   string url = 1; // URL TO REDIRECT TO

--- a/proto/streamlit/proto/AutoRerun.proto
+++ b/proto/streamlit/proto/AutoRerun.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "AutoRerunProto";
 
 message AutoRerun {
   // The interval of reruns in seconds

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "BackMsgProto";
 
 import "streamlit/proto/ClientState.proto";
 import "streamlit/proto/Common.proto";

--- a/proto/streamlit/proto/Balloons.proto
+++ b/proto/streamlit/proto/Balloons.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "BalloonsProto";
 
 // A python empty.
 message Balloons {

--- a/proto/streamlit/proto/BidiComponent.proto
+++ b/proto/streamlit/proto/BidiComponent.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "BidiComponentProto";
 
 import "streamlit/proto/ArrowData.proto";
 

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "BlockProto";
 
 import "streamlit/proto/WidthConfig.proto";
 import "streamlit/proto/HeightConfig.proto";

--- a/proto/streamlit/proto/BokehChart.proto
+++ b/proto/streamlit/proto/BokehChart.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "BokehChartProto";
 
 message BokehChart {
   // A JSON-formatted string from the Bokeh chart figure.

--- a/proto/streamlit/proto/Button.proto
+++ b/proto/streamlit/proto/Button.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ButtonProto";
 
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 

--- a/proto/streamlit/proto/ButtonGroup.proto
+++ b/proto/streamlit/proto/ButtonGroup.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ButtonGroupProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/ButtonLikeIconPosition.proto
+++ b/proto/streamlit/proto/ButtonLikeIconPosition.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ButtonLikeIconPositionProto";
 
 package streamlit;
 

--- a/proto/streamlit/proto/CameraInput.proto
+++ b/proto/streamlit/proto/CameraInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "CameraInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ChatInputProto";
 
 message ChatInput {
   string id = 1;

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "CheckboxProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ClientStateProto";
 
 import "streamlit/proto/WidgetStates.proto";
 

--- a/proto/streamlit/proto/Code.proto
+++ b/proto/streamlit/proto/Code.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "CodeProto";
 
 // st.code
 message Code {

--- a/proto/streamlit/proto/ColorPicker.proto
+++ b/proto/streamlit/proto/ColorPicker.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ColorPickerProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "CommonProto";
 
 // Message types that are common to multiple protobufs.
 

--- a/proto/streamlit/proto/Components.proto
+++ b/proto/streamlit/proto/Components.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ComponentsProto";
 
 message ComponentInstance {
   // The instance's "widget ID", used to uniquely identify it.

--- a/proto/streamlit/proto/DataFrame.proto
+++ b/proto/streamlit/proto/DataFrame.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DataFrameProto";
 
 import "streamlit/proto/Common.proto";
 

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DateInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/DateTimeInput.proto
+++ b/proto/streamlit/proto/DateTimeInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DateTimeInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/DeckGlJsonChart.proto
+++ b/proto/streamlit/proto/DeckGlJsonChart.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DeckGlJsonChartProto";
 
 message DeckGlJsonChart {
   // The json of the pydeck object (https://deckgl.readthedocs.io/en/latest/deck.html)

--- a/proto/streamlit/proto/Delta.proto
+++ b/proto/streamlit/proto/Delta.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DeltaProto";
 
 import "streamlit/proto/Block.proto";
 import "streamlit/proto/Element.proto";

--- a/proto/streamlit/proto/DocString.proto
+++ b/proto/streamlit/proto/DocString.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DocStringProto";
 
 // Formatted text
 message DocString {

--- a/proto/streamlit/proto/DownloadButton.proto
+++ b/proto/streamlit/proto/DownloadButton.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "DownloadButtonProto";
 
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ElementProto";
 
 import "streamlit/proto/Alert.proto";
 import "streamlit/proto/Arrow.proto";

--- a/proto/streamlit/proto/Empty.proto
+++ b/proto/streamlit/proto/Empty.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "EmptyProto";
 
 // A python empty.
 message Empty {

--- a/proto/streamlit/proto/Exception.proto
+++ b/proto/streamlit/proto/Exception.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ExceptionProto";
 
 import "streamlit/proto/WidthConfig.proto";
 

--- a/proto/streamlit/proto/Favicon.proto
+++ b/proto/streamlit/proto/Favicon.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "FaviconProto";
 
 message Favicon {
   string url = 1;

--- a/proto/streamlit/proto/FileUploader.proto
+++ b/proto/streamlit/proto/FileUploader.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "FileUploaderProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ForwardMsgProto";
 
 import "streamlit/proto/AutoRerun.proto";
 import "streamlit/proto/Common.proto";

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "GapSizeProto";
 
 package streamlit;
 

--- a/proto/streamlit/proto/GitInfo.proto
+++ b/proto/streamlit/proto/GitInfo.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "GitInfoProto";
 
 // Message used to update page metadata.
 message GitInfo {

--- a/proto/streamlit/proto/GraphVizChart.proto
+++ b/proto/streamlit/proto/GraphVizChart.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "GraphVizChartProto";
 
 message GraphVizChart {
   // A specification of the GraphViz graph in the "Dot" language.

--- a/proto/streamlit/proto/Heading.proto
+++ b/proto/streamlit/proto/Heading.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "HeadingProto";
 
 message Heading {
     // h1, h2, h3, div, etc

--- a/proto/streamlit/proto/HeightConfig.proto
+++ b/proto/streamlit/proto/HeightConfig.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "HeightConfigProto";
 
 package streamlit;
 

--- a/proto/streamlit/proto/Html.proto
+++ b/proto/streamlit/proto/Html.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "HtmlProto";
 
 // st.html
 message Html {

--- a/proto/streamlit/proto/IFrame.proto
+++ b/proto/streamlit/proto/IFrame.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "IFrameProto";
 
 message IFrame {
   oneof type {

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ImageProto";
 
 // An image which can be displayed on the screen.
 message Image {

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "JsonProto";
 
 message Json {
   // Content to display.

--- a/proto/streamlit/proto/LabelVisibilityMessage.proto
+++ b/proto/streamlit/proto/LabelVisibilityMessage.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "LabelVisibilityMessageProto";
 
 message LabelVisibilityMessage {
   // We use separate LabelVisibilityMessage instead of just defining Enum and

--- a/proto/streamlit/proto/LinkButton.proto
+++ b/proto/streamlit/proto/LinkButton.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "LinkButtonProto";
 
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 

--- a/proto/streamlit/proto/Logo.proto
+++ b/proto/streamlit/proto/Logo.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "LogoProto";
 
 // Handle the logo for an app
 message Logo {

--- a/proto/streamlit/proto/Markdown.proto
+++ b/proto/streamlit/proto/Markdown.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "MarkdownProto";
 
 // Formatted text
 message Markdown {

--- a/proto/streamlit/proto/Metric.proto
+++ b/proto/streamlit/proto/Metric.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "MetricProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "MetricsEventProto";
 
 import "streamlit/proto/PageProfile.proto";
 

--- a/proto/streamlit/proto/MultiSelect.proto
+++ b/proto/streamlit/proto/MultiSelect.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "MultiSelectProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/NamedDataSet.proto
+++ b/proto/streamlit/proto/NamedDataSet.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "NamedDataSetProto";
 
 import "streamlit/proto/DataFrame.proto";
 

--- a/proto/streamlit/proto/Navigation.proto
+++ b/proto/streamlit/proto/Navigation.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
 
 
 import "streamlit/proto/AppPage.proto";

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "NewSessionProto";
 
 import "streamlit/proto/AppPage.proto";
 import "streamlit/proto/SessionStatus.proto";

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "NumberInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PageConfigProto";
 
 // Properties of the page that the app creator may configure.
 message PageConfig {

--- a/proto/streamlit/proto/PageInfo.proto
+++ b/proto/streamlit/proto/PageInfo.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PageInfoProto";
 
 // Message used to update page metadata.
 message PageInfo {

--- a/proto/streamlit/proto/PageLink.proto
+++ b/proto/streamlit/proto/PageLink.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PageLinkProto";
 
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 

--- a/proto/streamlit/proto/PageNotFound.proto
+++ b/proto/streamlit/proto/PageNotFound.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PageNotFoundProto";
 
 // Message used to tell the client that the requested page does not exist.
 message PageNotFound {

--- a/proto/streamlit/proto/PageProfile.proto
+++ b/proto/streamlit/proto/PageProfile.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PageProfileProto";
 
 
 message PageProfile {

--- a/proto/streamlit/proto/PagesChanged.proto
+++ b/proto/streamlit/proto/PagesChanged.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PagesChangedProto";
 
 import "streamlit/proto/AppPage.proto";
 

--- a/proto/streamlit/proto/ParentMessage.proto
+++ b/proto/streamlit/proto/ParentMessage.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ParentMessageProto";
 
 // NOTE: This proto type is used by some external services so needs to remain
 // relatively stable. While it isn't entirely set in stone, changing it

--- a/proto/streamlit/proto/PlotlyChart.proto
+++ b/proto/streamlit/proto/PlotlyChart.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "PlotlyChartProto";
 
 message PlotlyChart {
   // DEPRECATED: If True, will overwrite the chart width spec to fit to container.

--- a/proto/streamlit/proto/Progress.proto
+++ b/proto/streamlit/proto/Progress.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ProgressProto";
 
 message Progress {
   uint32 value = 1;

--- a/proto/streamlit/proto/Radio.proto
+++ b/proto/streamlit/proto/Radio.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "RadioProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/RootContainer.proto
+++ b/proto/streamlit/proto/RootContainer.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "RootContainerProto";
 
 // Constants for our "RootContainers" - the top-level containers
 // that `st.foo` and `st.sidebar.foo` write to. Each value corresponds

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SelectboxProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/SessionEvent.proto
+++ b/proto/streamlit/proto/SessionEvent.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SessionEventProto";
 
 import "streamlit/proto/Exception.proto";
 

--- a/proto/streamlit/proto/SessionStatus.proto
+++ b/proto/streamlit/proto/SessionStatus.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SessionStatusProto";
 
 // Status for a session. Sent as part of the Initialize message, and also
 // on AppSession status change events.

--- a/proto/streamlit/proto/Skeleton.proto
+++ b/proto/streamlit/proto/Skeleton.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SkeletonProto";
 
 // An empty-like element that displays an app skeleton.
 message Skeleton {

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SliderProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/Snow.proto
+++ b/proto/streamlit/proto/Snow.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SnowProto";
 
 // A python empty.
 message Snow {

--- a/proto/streamlit/proto/Space.proto
+++ b/proto/streamlit/proto/Space.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SpaceProto";
 
 // A space element for adding vertical or horizontal spacing.
 // The size and direction are controlled via Element.width_config and

--- a/proto/streamlit/proto/Spinner.proto
+++ b/proto/streamlit/proto/Spinner.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "SpinnerProto";
 
 message Spinner {
   // A message to display while executing that block.

--- a/proto/streamlit/proto/Text.proto
+++ b/proto/streamlit/proto/Text.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "TextProto";
 
 // Preformatted text
 message Text {

--- a/proto/streamlit/proto/TextAlignmentConfig.proto
+++ b/proto/streamlit/proto/TextAlignmentConfig.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "TextAlignmentConfigProto";
 
 package streamlit;
 

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "TextAreaProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "TextInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/TimeInput.proto
+++ b/proto/streamlit/proto/TimeInput.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "TimeInputProto";
 
 import "streamlit/proto/LabelVisibilityMessage.proto";
 

--- a/proto/streamlit/proto/Toast.proto
+++ b/proto/streamlit/proto/Toast.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "ToastProto";
 
 message Toast {
     // Display message

--- a/proto/streamlit/proto/Transient.proto
+++ b/proto/streamlit/proto/Transient.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "TransientProto";
 
 import "streamlit/proto/Element.proto";
 

--- a/proto/streamlit/proto/VegaLiteChart.proto
+++ b/proto/streamlit/proto/VegaLiteChart.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "VegaLiteChartProto";
 
 import "streamlit/proto/DataFrame.proto";
 import "streamlit/proto/NamedDataSet.proto";

--- a/proto/streamlit/proto/Video.proto
+++ b/proto/streamlit/proto/Video.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "VideoProto";
 
 import "streamlit/proto/WidthConfig.proto";
 

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "WidgetStatesProto";
 
 import "streamlit/proto/Common.proto";
 import "streamlit/proto/Components.proto";

--- a/proto/streamlit/proto/WidthConfig.proto
+++ b/proto/streamlit/proto/WidthConfig.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "WidthConfigProto";
 
 package streamlit;
 

--- a/proto/streamlit/proto/openmetrics_data_model.proto
+++ b/proto/streamlit/proto/openmetrics_data_model.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-option java_package = "com.snowflake.apps.streamlit";
-option java_outer_classname = "OpenmetricsDataModelProto";
 
 // The OpenMetrics protobuf schema which defines the protobuf wire format. 
 // Ensure to interpret "required" as semantically required for a valid message.


### PR DESCRIPTION
## Describe your changes

Removes Java-specific protobuf options (`java_package` and `java_outer_classname`) from all proto files as part of proto cleanup efforts. These options are no longer used in the Snowflake codebase.

## Testing Plan

- No additional testing needed as this is a cleanup of unused protobuf options that don't affect runtime behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.