### PR TITLE
[feat] Add AppTarget class for test abstraction

### DIFF
--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -28,11 +28,27 @@ Import from `conftest.py`:
 
 - `app: Page` - Light mode app fixture
 - `themed_app: Page` - Light & dark mode app fixture
+- `app_target: AppTarget` - App interaction wrapper (supports iframe-hosted external apps)
+- `app_base_url: str` - Base URL for app navigation (external or localhost)
+- `build_app_url(...)` - URL builder to compose paths/query/fragment from `app_base_url`
 - `assert_snapshot` - Screenshot testing fixture. Ensure element is stable before calling.
 - `wait_for_app_run(app)` - Wait for app run to finish
 - `wait_for_app_loaded(app)` - Wait for initial app load
 - `rerun_app(app)` - Trigger app rerun and wait
 - `wait_until(app, fn)` - Run test function until True or timeout
+
+## External Test Mode
+
+- When writing `@pytest.mark.external_test` tests, prefer `app_target` over a bare `Page`/`FrameLocator`. It abstracts whether the app DOM is at the top-level (`Page`) or inside a host page (`FrameLocator`).
+- External modes are configured via CLI/env and may affect what fixtures mean:
+  - `--external-app-url` / `STREAMLIT_E2E_EXTERNAL_APP_URL`: run against an externally hosted Streamlit app (no local server).
+  - `--external-host-url` / `STREAMLIT_E2E_EXTERNAL_HOST_URL`: run against a host page that embeds the app in an iframe (no local server).
+  - `--external-iframe-selector` / `STREAMLIT_E2E_EXTERNAL_IFRAME_SELECTOR`: iframe selector inside the host page (defaults to `iframe`).
+- Deciding whether a test should be marked `external_test` is **manual for now**. Only add the marker when the test is explicitly intended to run against an externally hosted app/host page.
+- As a rule of thumb, a test is a good candidate for `external_test` if it:
+  - can run without starting the local app server (it should not depend on the test module's `*.py` script being launched by the harness),
+  - uses stable selectors and the `app_target`/`app_base_url` abstractions (so it works both for top-level and iframe-hosted apps),
+  - avoids relying on local-only infrastructure like request routing/interception (`iframed_app`) or filesystem-coupled assumptions.
 
 ## Best Practices
 

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -26,11 +26,27 @@ Import from `conftest.py`:
 
 - `app: Page` - Light mode app fixture
 - `themed_app: Page` - Light & dark mode app fixture
+- `app_target: AppTarget` - App interaction wrapper (supports iframe-hosted external apps)
+- `app_base_url: str` - Base URL for app navigation (external or localhost)
+- `build_app_url(...)` - URL builder to compose paths/query/fragment from `app_base_url`
 - `assert_snapshot` - Screenshot testing fixture. Ensure element is stable before calling.
 - `wait_for_app_run(app)` - Wait for app run to finish
 - `wait_for_app_loaded(app)` - Wait for initial app load
 - `rerun_app(app)` - Trigger app rerun and wait
 - `wait_until(app, fn)` - Run test function until True or timeout
+
+## External Test Mode
+
+- When writing `@pytest.mark.external_test` tests, prefer `app_target` over a bare `Page`/`FrameLocator`. It abstracts whether the app DOM is at the top-level (`Page`) or inside a host page (`FrameLocator`).
+- External modes are configured via CLI/env and may affect what fixtures mean:
+  - `--external-app-url` / `STREAMLIT_E2E_EXTERNAL_APP_URL`: run against an externally hosted Streamlit app (no local server).
+  - `--external-host-url` / `STREAMLIT_E2E_EXTERNAL_HOST_URL`: run against a host page that embeds the app in an iframe (no local server).
+  - `--external-iframe-selector` / `STREAMLIT_E2E_EXTERNAL_IFRAME_SELECTOR`: iframe selector inside the host page (defaults to `iframe`).
+- Deciding whether a test should be marked `external_test` is **manual for now**. Only add the marker when the test is explicitly intended to run against an externally hosted app/host page.
+- As a rule of thumb, a test is a good candidate for `external_test` if it:
+  - can run without starting the local app server (it should not depend on the test module's `*.py` script being launched by the harness),
+  - uses stable selectors and the `app_target`/`app_base_url` abstractions (so it works both for top-level and iframe-hosted apps),
+  - avoids relying on local-only infrastructure like request routing/interception (`iframed_app`) or filesystem-coupled assumptions.
 
 ## Best Practices
 

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -22,11 +22,27 @@ Import from `conftest.py`:
 
 - `app: Page` - Light mode app fixture
 - `themed_app: Page` - Light & dark mode app fixture
+- `app_target: AppTarget` - App interaction wrapper (supports iframe-hosted external apps)
+- `app_base_url: str` - Base URL for app navigation (external or localhost)
+- `build_app_url(...)` - URL builder to compose paths/query/fragment from `app_base_url`
 - `assert_snapshot` - Screenshot testing fixture. Ensure element is stable before calling.
 - `wait_for_app_run(app)` - Wait for app run to finish
 - `wait_for_app_loaded(app)` - Wait for initial app load
 - `rerun_app(app)` - Trigger app rerun and wait
 - `wait_until(app, fn)` - Run test function until True or timeout
+
+## External Test Mode
+
+- When writing `@pytest.mark.external_test` tests, prefer `app_target` over a bare `Page`/`FrameLocator`. It abstracts whether the app DOM is at the top-level (`Page`) or inside a host page (`FrameLocator`).
+- External modes are configured via CLI/env and may affect what fixtures mean:
+  - `--external-app-url` / `STREAMLIT_E2E_EXTERNAL_APP_URL`: run against an externally hosted Streamlit app (no local server).
+  - `--external-host-url` / `STREAMLIT_E2E_EXTERNAL_HOST_URL`: run against a host page that embeds the app in an iframe (no local server).
+  - `--external-iframe-selector` / `STREAMLIT_E2E_EXTERNAL_IFRAME_SELECTOR`: iframe selector inside the host page (defaults to `iframe`).
+- Deciding whether a test should be marked `external_test` is **manual for now**. Only add the marker when the test is explicitly intended to run against an externally hosted app/host page.
+- As a rule of thumb, a test is a good candidate for `external_test` if it:
+  - can run without starting the local app server (it should not depend on the test module's `*.py` script being launched by the harness),
+  - uses stable selectors and the `app_target`/`app_base_url` abstractions (so it works both for top-level and iframe-hosted apps),
+  - avoids relying on local-only infrastructure like request routing/interception (`iframed_app`) or filesystem-coupled assumptions.
 
 ## Best Practices
 

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -53,6 +53,10 @@ from playwright.sync_api import (
 )
 from typing_extensions import Self
 
+from e2e_playwright.shared.app_target import (
+    AppTarget,
+    wait_for_app_target_loaded,
+)
 from e2e_playwright.shared.git_utils import get_git_root
 from e2e_playwright.shared.performance import (
     is_supported_browser,
@@ -569,45 +573,108 @@ def skip_non_external_tests_in_external_mode(
         pytest.skip("External app mode only supports tests marked 'external_test'.")
 
 
-@pytest.fixture
-def app(page: Page, app_base_url: str, request: pytest.FixtureRequest) -> Page:
-    """Fixture that opens the app."""
+def _get_app_hash_fragment(request: pytest.FixtureRequest) -> str:
+    """Return the fragment from `@pytest.mark.app_hash(...)`, or "" if unset."""
     marker = request.node.get_closest_marker("app_hash")
-    fragment: str | None = None
-    if marker:
-        if not marker.args:
-            raise pytest.UsageError(
-                "app_hash marker requires a single string argument, e.g. "
-                "@pytest.mark.app_hash('my-fragment')"
-            )
-        marker_arg = marker.args[0]
-        if not isinstance(marker_arg, str):
-            raise pytest.UsageError(
-                f"app_hash marker argument must be a string, got {type(marker_arg).__name__}."
-            )
-        fragment = marker_arg
+    if marker is None:
+        return ""
 
-    response: Response | None = None
-    try:
-        response = page.goto(_build_app_url(app_base_url, fragment=fragment))
-    except Exception as e:
-        print(e, flush=True)
+    if len(marker.args) != 1:
+        raise pytest.UsageError(
+            "app_hash marker requires a single string argument, e.g. "
+            "@pytest.mark.app_hash('my-fragment')"
+        )
 
+    marker_arg = marker.args[0]
+    if not isinstance(marker_arg, str):
+        raise pytest.UsageError(
+            f"app_hash marker argument must be a string, got {type(marker_arg).__name__}."
+        )
+
+    return marker_arg
+
+
+def _open_app(page: Page, app_base_url: str, *, hash_fragment: str) -> None:
+    url = build_app_url(app_base_url, fragment=hash_fragment)
+    response = page.goto(url)
     if response is None:
-        raise RuntimeError("Unable to load page")
-    if response.status != 200:
-        print(f"Unsuccessful in loading page. Status: {response.status}", flush=True)
-        if response.status == 404:
-            print(
-                "404 error: try building the frontend with make frontend-fast",
-                flush=True,
-            )
-        raise RuntimeError("Unable to load page")
-    print("Successfully loaded page", flush=True)
+        raise RuntimeError(f"Unable to load {url!r}")
+    if response.status == 404:
+        raise RuntimeError(
+            "App returned 404. Try building the frontend with `make frontend-fast`."
+        )
+    if not response.ok:
+        raise RuntimeError(f"Unable to load {url!r}. Status: {response.status}")
 
+
+@pytest.fixture
+def app(
+    page: Page,
+    app_base_url: str,
+    request: pytest.FixtureRequest,
+) -> Page:
+    """Fixture that opens the app."""
+    hash_fragment = _get_app_hash_fragment(request)
+
+    _open_app(page, app_base_url, hash_fragment=hash_fragment)
     start_capture_traces(page)
     wait_for_app_loaded(page)
     return page
+
+
+@pytest.fixture
+def app_target(
+    page: Page,
+    app_base_url: str,
+    request: pytest.FixtureRequest,
+    external_app_url: str | None,
+    external_host_url: str | None,
+    external_iframe_selector: str,
+) -> AppTarget:
+    """Return an AppTarget that abstracts where the app is hosted.
+
+    Tests should use this fixture (instead of receiving a bare FrameLocator) for
+    external-compatible scenarios. This keeps iframe-vs-top-level an internal
+    implementation detail of our test infrastructure.
+    """
+    hash_fragment = _get_app_hash_fragment(request)
+
+    if external_host_url:
+        page.goto(external_host_url)
+        start_capture_traces(page)
+        page.wait_for_load_state()
+
+        # External host mode embeds the app in an iframe. If a test requests a
+        # specific fragment via `@pytest.mark.app_hash(...)`, propagate it to
+        # the iframe's URL before we start interacting with the DOM.
+        if hash_fragment:
+            iframe = page.locator(external_iframe_selector).first
+            iframe_src = iframe.get_attribute("src")
+            iframe_base_url = iframe_src or external_app_url or app_base_url
+            iframe_url = build_app_url(iframe_base_url, fragment=hash_fragment)
+            if iframe_src != iframe_url:
+                iframe.evaluate("(el, src) => { el.src = src; }", iframe_url)
+
+        frame_locator = page.frame_locator(external_iframe_selector)
+        target = AppTarget(
+            page=page,
+            dom=frame_locator,
+            base_url=app_base_url,
+            mode="external_host",
+        )
+        wait_for_app_target_loaded(target)
+        return target
+
+    _open_app(page, app_base_url, hash_fragment=hash_fragment)
+    start_capture_traces(page)
+    target = AppTarget(
+        page=page,
+        dom=page,
+        base_url=app_base_url,
+        mode="external_direct" if external_app_url else "local",
+    )
+    wait_for_app_target_loaded(target)
+    return target
 
 
 @pytest.fixture(scope="module")
@@ -620,20 +687,107 @@ def app_base_url(app_port: int, external_app_url: str | None) -> str:
     return external_app_url or f"http://localhost:{app_port}"
 
 
+def build_app_url(
+    base_url: str,
+    *,
+    path: str = "",
+    query: dict[str, Any] | str | None = None,
+    fragment: str = "",
+) -> str:
+    """Build a URL relative to the provided base URL.
+
+    Notes
+    -----
+    Passing ``path=""`` (the default) is treated the same as not providing a
+    path at all.
+    """
+    split_url = parse.urlsplit(base_url)
+    base_path = split_url.path or ""
+    if path:
+        # Always preserve any existing base path, even when `path` starts with "/".
+        #
+        # Examples:
+        # - base_url="https://host/prefix", path="/_stcore/health"
+        #   -> "/prefix/_stcore/health"
+        # - base_url="https://host/prefix", path="//some-path"
+        #   -> "/prefix//some-path"
+        # - base_url="https://host", path="/_stcore/health"
+        #   -> "/_stcore/health"
+        if path.startswith("/"):
+            full_path = f"{base_path.rstrip('/')}{path}" if base_path else path
+        elif base_path:
+            full_path = f"{base_path.rstrip('/')}/{path}"
+        else:
+            full_path = f"/{path}"
+    # Preserve the base URL as-is when no additional parts are provided:
+    #
+    # - base_url="http://localhost:8501" -> "http://localhost:8501"
+    #
+    # But when adding a query string or fragment to a host-only base URL,
+    # add a "/" so parameters attach to the root path:
+    #
+    # - base_url="http://localhost:8501", query="a=1" -> "http://localhost:8501/?a=1"
+    # - base_url="http://localhost:8501", fragment="foo" -> "http://localhost:8501/#foo"
+    elif base_path:
+        full_path = base_path
+    else:
+        full_path = "/" if (query is not None or fragment) else ""
+
+    base_query = parse.parse_qsl(split_url.query, keep_blank_values=True)
+    if query is None:
+        combined_query = base_query
+    else:
+        if isinstance(query, str):
+            # Allow callers to pass either "a=1&b=2" or "?a=1&b=2".
+            query_items = parse.parse_qsl(query.lstrip("?"), keep_blank_values=True)
+        else:
+            query_items = parse.parse_qsl(
+                parse.urlencode(query, doseq=True), keep_blank_values=True
+            )
+        combined_query = base_query + query_items
+
+    query_string = parse.urlencode(combined_query, doseq=True)
+    # Allow callers to pass either "foo" or "#foo".
+    final_fragment = fragment.lstrip("#") if fragment else split_url.fragment
+
+    return parse.urlunsplit(
+        (split_url.scheme, split_url.netloc, full_path, query_string, final_fragment)
+    )
+
+
+def _ensure_nonempty_path(url: str) -> str:
+    """Ensure the URL has a non-empty path (at least '/')."""
+    split_url = parse.urlsplit(url)
+    if split_url.path:
+        return url
+    return parse.urlunsplit(
+        (split_url.scheme, split_url.netloc, "/", split_url.query, split_url.fragment)
+    )
+
+
+def _normalize_url_for_compare(url: str) -> str:
+    """Normalize a URL for reliable comparison across browsers."""
+    split_url = parse.urlsplit(url)
+    normalized_path = split_url.path.rstrip("/") or "/"
+    return parse.urlunsplit(
+        (split_url.scheme, split_url.netloc, normalized_path, split_url.query, "")
+    )
+
+
 @pytest.fixture
 def static_app(
     page: Page,
-    app_port: int,
+    app_base_url: str,
     request: pytest.FixtureRequest,
 ) -> Page:
     """Fixture that opens the app."""
     query_param = request.node.get_closest_marker("query_param")
     query_string = query_param.args[0] if query_param else ""
 
-    # Indicate this is a StaticPage
+    # Indicate this is a static app page.
     page.__class__ = StaticPage
 
-    page.goto(f"http://localhost:{app_port}/{query_string}")
+    page.goto(build_app_url(app_base_url, path=query_string))
     start_capture_traces(page)
     wait_for_app_loaded(page)
     return page
@@ -641,15 +795,14 @@ def static_app(
 
 @pytest.fixture
 def app_with_query_params(
-    page: Page, app_port: int, request: pytest.FixtureRequest
+    page: Page, app_base_url: str, request: pytest.FixtureRequest
 ) -> tuple[Page, dict[str, Any]]:
     """Fixture that opens the app with additional query parameters.
     The query parameters are passed as a dictionary in the 'param' key of the request.
     """
     query_params = request.param
     query_string = parse.urlencode(query_params, doseq=True)
-    url = f"http://localhost:{app_port}/?{query_string}"
-    page.goto(url)
+    page.goto(build_app_url(app_base_url, query=query_string))
     wait_for_app_loaded(page)
 
     return page, query_params
@@ -678,7 +831,7 @@ class IframedPage:
 
 
 @pytest.fixture
-def iframed_app(page: Page, app_port: int) -> IframedPage:
+def iframed_app(page: Page, app_base_url: str) -> IframedPage:
     """Fixture that returns an IframedPage.
 
     The page object can be used to configure additional routes, for example to override
@@ -688,8 +841,27 @@ def iframed_app(page: Page, app_port: int) -> IframedPage:
     # chosen and does not even exist
     fake_iframe_server_origin = "http://localhost:1345"
     fake_iframe_server_route = f"{fake_iframe_server_origin}/iframed_app.html"
-    # the url where the Streamlit server is reachable
-    app_url = f"http://localhost:{app_port}"
+    # The URL where the Streamlit server is reachable (used to build CSP endpoints).
+    # This must not include query params or fragments, since we later append paths.
+    split_base_url = parse.urlsplit(app_base_url)
+
+    normalized_path = (split_base_url.path or "").rstrip("/")
+    app_url_for_endpoints = parse.urlunsplit(
+        (split_base_url.scheme, split_base_url.netloc, normalized_path, "", "")
+    )
+    app_url_for_iframe = _ensure_nonempty_path(app_url_for_endpoints)
+
+    # Compute the websocket stream URL from the configured app base URL.
+    # This is required because the iframe page applies a strict CSP that must allow the
+    # app's websocket endpoint, otherwise the app will never reach CONNECTED.
+    split_app_url = parse.urlsplit(app_url_for_endpoints)
+    ws_scheme = "wss" if split_app_url.scheme == "https" else "ws"
+    base_path = (split_app_url.path or "").rstrip("/")
+    ws_stream_path = f"{base_path}/_stcore/stream" if base_path else "/_stcore/stream"
+    ws_stream_url = parse.urlunsplit(
+        (ws_scheme, split_app_url.netloc, ws_stream_path, "", "")
+    )
+
     # the CSP header returned for the Streamlit index.html loaded in the iframe. This is
     # similar to a common CSP we have seen in the wild.
     app_csp_header = f"""
@@ -697,18 +869,18 @@ default-src 'none';
 worker-src blob:;
 form-action 'none';
 frame-ancestors {fake_iframe_server_origin};
-frame-src data: {app_url}/_stcore/component/ {app_url}/component/;
+frame-src data: {app_url_for_endpoints}/_stcore/component/ {app_url_for_endpoints}/component/;
 img-src 'self' https: data: blob:;
 media-src 'self' https: data: blob:;
-connect-src ws://localhost:{app_port}/_stcore/stream
-    {app_url}/_stcore/component/
-    {app_url}/_stcore/bidi-components/
-    {app_url}/component/
-    {app_url}/_stcore/upload_file/
-    {app_url}/_stcore/host-config
-    {app_url}/_stcore/health
-    {app_url}/_stcore/message
-    {app_url}/media/
+connect-src {ws_stream_url}
+    {app_url_for_endpoints}/_stcore/component/
+    {app_url_for_endpoints}/_stcore/bidi-components/
+    {app_url_for_endpoints}/component/
+    {app_url_for_endpoints}/_stcore/upload_file/
+    {app_url_for_endpoints}/_stcore/host-config
+    {app_url_for_endpoints}/_stcore/health
+    {app_url_for_endpoints}/_stcore/message
+    {app_url_for_endpoints}/media/
     https://some-prefix.com/somethingelse/_stcore/upload_file/
     https://events.mapbox.com/
     https://api.mapbox.com/v4/
@@ -728,12 +900,12 @@ connect-src ws://localhost:{app_port}/_stcore/stream
     data: blob:;
 style-src 'unsafe-inline'
     https://api.mapbox.com/mapbox-gl-js/
-    {app_url}/static/css/
+    {app_url_for_endpoints}/static/css/
     blob:;
 script-src 'unsafe-inline' 'wasm-unsafe-eval' blob:
     https://api.mapbox.com/mapbox-gl-js/
-    {app_url}/static/js/;
-font-src {app_url}/static/fonts/ {app_url}/static/media/ https: data: blob:;
+    {app_url_for_endpoints}/static/js/;
+font-src {app_url_for_endpoints}/static/fonts/ {app_url_for_endpoints}/static/media/ https: data: blob:;
 """.replace("\n", " ").strip()
 
     def _open_app(iframe_element_attrs: IframedPageAttrs | None = None) -> FrameLocator:
@@ -741,11 +913,11 @@ font-src {app_url}/static/fonts/ {app_url}/static/media/ https: data: blob:;
         if _iframe_element_attrs is None:
             _iframe_element_attrs = IframedPageAttrs()
 
-        query_params = ""
-        if _iframe_element_attrs.src_query_params:
-            query_params = "?" + parse.urlencode(_iframe_element_attrs.src_query_params)
-
-        src = f"{app_url}/{query_params}"
+        src = build_app_url(
+            app_url_for_iframe, query=_iframe_element_attrs.src_query_params
+        )
+        if not parse.urlsplit(src).path:
+            raise RuntimeError(f"Iframe src must include a path: {src!r}")
         additional_html_head = _iframe_element_attrs.additional_html_head or ""
         _iframed_body = (
             f"""
@@ -770,7 +942,9 @@ font-src {app_url}/static/fonts/ {app_url}/static/media/ https: data: blob:;
             </html>
             """
             if _iframe_element_attrs.html_content is None
-            else _iframe_element_attrs.html_content.replace("$APP_URL", app_url)
+            else _iframe_element_attrs.html_content.replace(
+                "$APP_URL", app_url_for_iframe
+            )
         )
 
         def fulfill_iframe_request(route: Route) -> None:
@@ -790,7 +964,7 @@ font-src {app_url}/static/fonts/ {app_url}/static/media/ https: data: blob:;
                 body=_iframed_body,
                 headers={
                     "Content-Type": "text/html",
-                    "Content-Security-Policy": f"frame-src {frame_src_blob} {app_url};",
+                    "Content-Security-Policy": f"frame-src {frame_src_blob} {app_url_for_iframe};",
                 },
             )
 
@@ -817,7 +991,8 @@ font-src {app_url}/static/fonts/ {app_url}/static/media/ https: data: blob:;
             """
 
             return (
-                response.url == src
+                _normalize_url_for_compare(response.url)
+                == _normalize_url_for_compare(src)
                 and response.headers["content-security-policy"] == app_csp_header
             )
 
@@ -1022,14 +1197,14 @@ def app_theme(request: pytest.FixtureRequest) -> str:
 @pytest.fixture
 def themed_app(page: Page, app_base_url: str, app_theme: str) -> Page:
     """Fixture that opens the app with the given theme."""
-    page.goto(_with_query_params(app_base_url, {"embed_options": app_theme}))
+    page.goto(build_app_url(app_base_url, query={"embed_options": app_theme}))
     start_capture_traces(page)
     wait_for_app_loaded(page)
     return page
 
 
 @pytest.fixture
-def app_with_microphone_permission_denied(page: Page, app_port: int) -> Page:
+def app_with_microphone_permission_denied(page: Page, app_base_url: str) -> Page:
     """Fixture that opens the app with getUserMedia mocked to deny microphone permissions.
 
     This fixture is used for testing microphone permission denied error handling in audio
@@ -1054,7 +1229,7 @@ def app_with_microphone_permission_denied(page: Page, app_port: int) -> Page:
     """)
 
     # Now navigate to the app
-    page.goto(f"http://localhost:{app_port}/")
+    page.goto(build_app_url(app_base_url, path="/"))
     wait_for_app_loaded(page)
     return page
 

--- a/e2e_playwright/shared/app_target.py
+++ b/e2e_playwright/shared/app_target.py
@@ -1,0 +1,101 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for interacting with the Streamlit app under test.
+
+This module defines `AppTarget`, a core e2e abstraction that wraps Playwright's
+`Page` and `FrameLocator` APIs into a single, stable interface. The goal is to
+centralize (and hide) the "where does the app DOM live?" details so tests and
+shared helpers don't need to branch on local vs external/iframe-hosted modes,
+which keeps cyclomatic complexity low across the suite.
+
+In e2e tests, prefer using the `app_target` fixture (from
+`e2e_playwright/conftest.py`) and call `locator()`, `get_by_test_id()`, etc., on
+the returned `AppTarget` instead of accessing `Page`/`FrameLocator` directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+if TYPE_CHECKING:
+    from playwright.sync_api import FrameLocator, Locator, Page
+
+
+@dataclass(frozen=True)
+class AppTarget:
+    """A stable abstraction for interacting with the app under test.
+
+    - `page` is the top-level Playwright Page we control (for routing, events,
+      reload, timeouts, tracing, etc).
+    - `dom` is where app selectors should run (Page in local mode; FrameLocator
+      in external host mode).
+    - `base_url` is the canonical base URL of the app (not the host page).
+    """
+
+    page: Page
+    dom: Page | FrameLocator
+    base_url: str
+    mode: Literal["local", "external_direct", "external_host"]
+
+    def locator(self, selector: str) -> Locator:
+        return self.dom.locator(selector)
+
+    def get_by_test_id(self, test_id: str) -> Locator:
+        return self.dom.get_by_test_id(test_id)
+
+    def get_by_role(self, role: str, **kwargs: Any) -> Locator:
+        # Playwright's `get_by_role` is typed with a Literal union of valid ARIA
+        # roles. We accept `str` here for convenience and cast at the call site.
+        return self.dom.get_by_role(cast("Any", role), **kwargs)
+
+    def get_by_text(self, text: str, **kwargs: Any) -> Locator:
+        return self.dom.get_by_text(text, **kwargs)
+
+    def wait_for_run(self, *, wait_delay: int = 100, initial_wait: int = 210) -> None:
+        wait_for_app_target_run(self, wait_delay=wait_delay, initial_wait=initial_wait)
+
+    def wait_for_loaded(self) -> None:
+        wait_for_app_target_loaded(self)
+
+    @property
+    def locator_context(self) -> Page | FrameLocator:
+        return self.dom
+
+
+def wait_for_app_target_run(
+    app: AppTarget,
+    *,
+    wait_delay: int = 100,
+    initial_wait: int = 210,
+) -> None:
+    """Wait for the given app target to finish running.
+
+    This intentionally reuses the existing `wait_for_app_run` implementation so
+    we have a single place to maintain the core "app is connected and idle"
+    detection logic.
+    """
+    # Import lazily to avoid introducing import-time circular dependencies.
+    from e2e_playwright.conftest import wait_for_app_run
+
+    wait_for_app_run(app.dom, wait_delay=wait_delay, initial_wait=initial_wait)
+
+
+def wait_for_app_target_loaded(app: AppTarget) -> None:
+    """Wait for initial app load (works when hosted in an iframe)."""
+    app.dom.locator("[data-testid='stAppViewContainer']").wait_for(
+        timeout=30000, state="attached"
+    )
+    wait_for_app_target_run(app)

--- a/e2e_playwright/shared/app_utils.py
+++ b/e2e_playwright/shared/app_utils.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import platform
 import re
-from typing import Literal, cast
+from typing import Literal, Protocol, cast
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Frame, FrameLocator, Locator, Page, expect
@@ -25,6 +25,36 @@ from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
 
 # Meta = Apple's Command Key; for complete list see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#special_values
 COMMAND_KEY = "Meta" if platform.system() == "Darwin" else "Control"  # ty: ignore[unresolved-attribute]
+
+
+class LocatorContext(Protocol):
+    """A minimal DOM-query context for Playwright tests.
+
+    This is intentionally structural (duck-typed) so helpers can accept:
+    - `Page` (local mode)
+    - `FrameLocator` (external host mode; DOM is inside an iframe)
+    - `AppTarget` (our stable abstraction that forwards to `dom`)
+    - `Locator` (occasionally useful for scoped queries)
+    """
+
+    def get_by_test_id(self, test_id: str) -> Locator: ...
+
+
+def _resolve_app_root_context(locator: LocatorContext) -> LocatorContext:
+    """Resolve a context suitable for querying the app root.
+
+    If callers pass a `Locator`, we want to reset hover/focus relative to the
+    owning page rather than within the locator subtree.
+
+    Notes
+    -----
+    For iframe-hosted apps, prefer passing a `FrameLocator` (or `AppTarget`)
+    instead of a `Locator`, since a locator only provides access to the top-level
+    `Page` and cannot reliably target the iframe DOM.
+    """
+    if isinstance(locator, Locator):
+        return locator.page
+    return locator
 
 
 def get_chat_input(locator: Locator | Page, label: str | re.Pattern[str]) -> Locator:
@@ -944,7 +974,7 @@ def click_form_button(
 
 
 def expect_help_tooltip(
-    app: Locator | Page,
+    app: LocatorContext,
     element_with_help_tooltip: Locator,
     tooltip_text: str | re.Pattern[str],
 ) -> None:
@@ -957,8 +987,9 @@ def expect_help_tooltip(
 
     Parameters
     ----------
-    app : Page
-        The page to search for the tooltip.
+    app : LocatorContext
+        The Playwright context to search for the tooltip (page, frame, or
+        `AppTarget`).
 
     element_with_help_tooltip : Locator
         The locator of the element with the help tooltip.
@@ -985,23 +1016,22 @@ def expect_help_tooltip(
     expect(tooltip_content).not_to_be_attached()
 
 
-def reset_hovering(locator: Locator | Page) -> None:
+def reset_hovering(locator: LocatorContext) -> None:
     """Reset the hovering of the app.
 
     This can be used to ensure that there aren't unexpected UI elements visible
     based on the current mouse position.
     """
-    page = locator.page if isinstance(locator, Locator) else locator
-
-    page.get_by_test_id("stApp").hover(
+    app_root = _resolve_app_root_context(locator)
+    app_root.get_by_test_id("stApp").hover(
         position={"x": 0, "y": 0}, no_wait_after=True, force=True
     )
 
 
-def reset_focus(locator: Locator | Page) -> None:
+def reset_focus(locator: LocatorContext) -> None:
     """Reset the focus of the app."""
-    page = locator.page if isinstance(locator, Locator) else locator
-    page.get_by_test_id("stApp").click(position={"x": 0, "y": 0}, force=True)
+    app_root = _resolve_app_root_context(locator)
+    app_root.get_by_test_id("stApp").click(position={"x": 0, "y": 0}, force=True)
 
 
 def tab_until_focused(page: Page, locator: Locator, max_tabs: int = 50) -> None:


### PR DESCRIPTION
## Describe your changes

Introduce an `AppTarget` abstraction so Playwright E2E tests can interact with the Streamlit app consistently whether it’s loaded at the top-level (local / external-direct) or embedded in an iframe (external-host mode).

- Add `AppTarget` (and `app_target` fixture) to centralize "where does the app DOM live?" (page vs iframe) so tests/helpers don’t need to branch on external hosting mode.
- Add `app_base_url` + `build_app_url(...)` and standardize navigation/URL building to work for both localhost and externally hosted apps (including hash-fragment `app_hash` routing).
- Update shared helpers (`LocatorContext` Protocol) so utilities can accept page/frame contexts (and `AppTarget`) without leaking iframe details into tests.
- Document external test mode + new fixtures in E2E guidance (`.cursor/rules`, `AGENTS.md`, GitHub instructions).

## Testing Plan

- No additional tests needed as this is a testing utility class that will be used by other E2E tests
- The functionality will be validated through usage in future Playwright E2E tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.