### PR TITLE
[feat] Utilize pytest.mark.external_test in 2 tests

### DIFF
--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -40,6 +40,7 @@ Import from `conftest.py`:
 ## External Test Mode
 
 - When writing `@pytest.mark.external_test` tests, prefer `app_target` over a bare `Page`/`FrameLocator`. It abstracts whether the app DOM is at the top-level (`Page`) or inside a host page (`FrameLocator`).
+- The `external_test` marker supports a small set of keyword arguments. See `e2e_playwright/conftest.py` (and `pytest --markers`) for the canonical list and behavior.
 - External modes are configured via CLI/env and may affect what fixtures mean:
   - `--external-app-url` / `STREAMLIT_E2E_EXTERNAL_APP_URL`: run against an externally hosted Streamlit app (no local server).
   - `--external-host-url` / `STREAMLIT_E2E_EXTERNAL_HOST_URL`: run against a host page that embeds the app in an iframe (no local server).

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -38,6 +38,7 @@ Import from `conftest.py`:
 ## External Test Mode
 
 - When writing `@pytest.mark.external_test` tests, prefer `app_target` over a bare `Page`/`FrameLocator`. It abstracts whether the app DOM is at the top-level (`Page`) or inside a host page (`FrameLocator`).
+- The `external_test` marker supports a small set of keyword arguments. See `e2e_playwright/conftest.py` (and `pytest --markers`) for the canonical list and behavior.
 - External modes are configured via CLI/env and may affect what fixtures mean:
   - `--external-app-url` / `STREAMLIT_E2E_EXTERNAL_APP_URL`: run against an externally hosted Streamlit app (no local server).
   - `--external-host-url` / `STREAMLIT_E2E_EXTERNAL_HOST_URL`: run against a host page that embeds the app in an iframe (no local server).

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -34,6 +34,7 @@ Import from `conftest.py`:
 ## External Test Mode
 
 - When writing `@pytest.mark.external_test` tests, prefer `app_target` over a bare `Page`/`FrameLocator`. It abstracts whether the app DOM is at the top-level (`Page`) or inside a host page (`FrameLocator`).
+- The `external_test` marker supports a small set of keyword arguments. See `e2e_playwright/conftest.py` (and `pytest --markers`) for the canonical list and behavior.
 - External modes are configured via CLI/env and may affect what fixtures mean:
   - `--external-app-url` / `STREAMLIT_E2E_EXTERNAL_APP_URL`: run against an externally hosted Streamlit app (no local server).
   - `--external-host-url` / `STREAMLIT_E2E_EXTERNAL_HOST_URL`: run against a host page that embeds the app in an iframe (no local server).

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -129,7 +129,11 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
-        "external_test: mark test as compatible with external app execution mode",
+        "external_test(upload_test_assets=False): "
+        "mark test as compatible with external app execution mode. "
+        "Set upload_test_assets=True when the hosted app needs "
+        "`e2e_playwright/test_assets/` to be available. "
+        "Only the documented keyword arguments are supported (unknown kwargs error).",
     )
 
 
@@ -163,6 +167,35 @@ def pytest_collection_modifyitems(
     all tests will be skipped (see ``skip_non_external_tests_in_external_mode``)
     which is usually not what the user intended.
     """
+    for item in items:
+        marker = item.get_closest_marker("external_test")
+        if marker is None:
+            continue
+
+        if marker.args:
+            raise pytest.UsageError(
+                "external_test marker does not accept positional arguments. "
+                "Use keyword arguments only, e.g. "
+                "@pytest.mark.external_test(upload_test_assets=True)."
+            )
+
+        allowed_kwargs = {"upload_test_assets"}
+        unknown_kwargs = sorted(set(marker.kwargs) - allowed_kwargs)
+        if unknown_kwargs:
+            raise pytest.UsageError(
+                "external_test marker received unknown keyword arguments: "
+                f"{', '.join(unknown_kwargs)}. "
+                "Allowed keyword arguments: upload_test_assets."
+            )
+
+        if "upload_test_assets" in marker.kwargs and not isinstance(
+            marker.kwargs["upload_test_assets"], bool
+        ):
+            raise pytest.UsageError(
+                "external_test marker keyword argument upload_test_assets "
+                "must be a boolean."
+            )
+
     external_app = _get_config_option_or_env(
         config, "--external-app-url", "STREAMLIT_E2E_EXTERNAL_APP_URL"
     )

--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -21,10 +21,12 @@ import pytest
 from playwright.sync_api import expect
 
 from e2e_playwright.conftest import IframedPage, rerun_app, wait_for_app_run
-from e2e_playwright.shared.app_utils import expect_no_skeletons, goto_app
+from e2e_playwright.shared.app_utils import expect_no_skeletons
 
 if TYPE_CHECKING:
     from playwright.sync_api import ConsoleMessage, FrameLocator, Page
+
+    from e2e_playwright.shared.app_target import AppTarget
 
 
 def is_expected_error(
@@ -62,7 +64,11 @@ def is_expected_error(
     )
 
 
-def test_no_console_errors(page: Page, app_port: int, browser_name: str):
+@pytest.mark.external_test(upload_test_assets=True)
+def test_no_console_errors(
+    app_target: AppTarget,
+    browser_name: str,
+):
     """Test that the app does not log any console errors."""
 
     console_errors = []
@@ -82,19 +88,16 @@ def test_no_console_errors(page: Page, app_port: int, browser_name: str):
                 }
             )
 
-    page.on("console", on_console_message)
-    goto_app(page, f"http://localhost:{app_port}")
-
-    page.wait_for_load_state()
+    app_target.page.on("console", on_console_message)
 
     # Make sure that all elements are rendered and no skeletons are shown:
-    expect_no_skeletons(page, timeout=25000)
+    expect_no_skeletons(app_target.locator_context, timeout=25000)
 
     # There should be only one exception in the app:
-    expect(page.get_by_test_id("stException")).to_have_count(1)
+    expect(app_target.get_by_test_id("stException")).to_have_count(1)
 
     # Check that title is visible:
-    expect(page.get_by_text("🎈 Mega tester app")).to_be_visible()
+    expect(app_target.get_by_text("🎈 Mega tester app")).to_be_visible()
 
     # There should be no unexpected console errors:
     assert not console_errors, "Console errors were logged " + str(console_errors)

--- a/e2e_playwright/st_text_test.py
+++ b/e2e_playwright/st_text_test.py
@@ -16,6 +16,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.app_target import AppTarget
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     expect_help_tooltip,
@@ -42,10 +43,11 @@ def test_st_text_doesnt_apply_formatting(
     )
 
 
-def test_help_tooltip_works(app: Page):
+@pytest.mark.external_test
+def test_help_tooltip_works(app_target: AppTarget):
     """Test that the help tooltip is displayed on hover."""
-    text_with_help = app.get_by_test_id("stText").nth(2)
-    expect_help_tooltip(app, text_with_help, "This is a help tooltip!")
+    text_with_help = app_target.get_by_test_id("stText").nth(2)
+    expect_help_tooltip(app_target, text_with_help, "This is a help tooltip!")
 
 
 def test_multiline_text(app: Page):


### PR DESCRIPTION
## Describe your changes

Added the `@pytest.mark.external_test` decorator to tests that should run in external test environments. Updated the `mega_tester_app_test.py` and `st_text_test.py` to use the `AppTarget` fixture instead of directly using the `Page` object.

## Testing Plan

- Will be run in CI and in SiS vNext tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.