### PR TITLE
Consolidate/refactor theme color mapping

### DIFF
--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
@@ -266,7 +266,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect((spec.spec as Record<string, unknown>).encoding).toMatchObject({
         color: { value: mockTheme.colors.greenColor },
@@ -290,7 +290,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect((spec.spec as Record<string, unknown>).encoding).toMatchObject({
         color: { value: mockTheme.colors.blueColor },
@@ -321,7 +321,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       const innerSpec = spec.spec as Record<string, unknown>
       const layers = innerSpec.layer as Array<Record<string, unknown>>
@@ -363,7 +363,7 @@ describe("colorUtils", () => {
         ],
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       const outerLayers = spec.layer as Array<Record<string, unknown>>
       const innerLayers = outerLayers[0].layer as Array<
@@ -402,7 +402,7 @@ describe("colorUtils", () => {
         ],
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       const vconcat = spec.vconcat as Array<Record<string, unknown>>
       const hconcat = vconcat[0].hconcat as Array<Record<string, unknown>>

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { EmotionTheme, lightTheme } from "~lib/theme"
-import { isNamedColor, resolveNamedColor } from "~lib/theme/getColors"
+import { resolveNamedColor } from "~lib/theme/getColors"
+import { isNamedColor } from "~lib/theme/namedColors"
 
 import { resolveNamedColorsInSpec } from "./colorUtils"
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
@@ -15,12 +15,9 @@
  */
 
 import { EmotionTheme, lightTheme } from "~lib/theme"
+import { isBuiltinColorName, resolveBuiltinColor } from "~lib/theme/getColors"
 
-import {
-  isBuiltinColorName,
-  resolveBuiltinColor,
-  resolveBuiltinColorsInSpec,
-} from "./colorUtils"
+import { resolveBuiltinColorsInSpec } from "./colorUtils"
 
 // Use the actual light theme for realistic color values
 const mockTheme: EmotionTheme = lightTheme.emotion

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.test.ts
@@ -15,15 +15,15 @@
  */
 
 import { EmotionTheme, lightTheme } from "~lib/theme"
-import { isBuiltinColorName, resolveBuiltinColor } from "~lib/theme/getColors"
+import { isNamedColor, resolveNamedColor } from "~lib/theme/getColors"
 
-import { resolveBuiltinColorsInSpec } from "./colorUtils"
+import { resolveNamedColorsInSpec } from "./colorUtils"
 
 // Use the actual light theme for realistic color values
 const mockTheme: EmotionTheme = lightTheme.emotion
 
 describe("colorUtils", () => {
-  describe("isBuiltinColorName", () => {
+  describe("isNamedColor", () => {
     it.each([
       "red",
       "orange",
@@ -35,13 +35,13 @@ describe("colorUtils", () => {
       "grey",
       "primary",
     ])('returns true for builtin color name "%s"', name => {
-      expect(isBuiltinColorName(name)).toBe(true)
+      expect(isNamedColor(name)).toBe(true)
     })
 
     it.each(["Red", "RED", "Blue", "GRAY", "Grey", "PRIMARY"])(
       'returns true for case-insensitive builtin color name "%s"',
       name => {
-        expect(isBuiltinColorName(name)).toBe(true)
+        expect(isNamedColor(name)).toBe(true)
       }
     )
 
@@ -53,58 +53,58 @@ describe("colorUtils", () => {
       "pink",
       "cyan",
     ])('returns false for non-builtin color "%s"', value => {
-      expect(isBuiltinColorName(value)).toBe(false)
+      expect(isNamedColor(value)).toBe(false)
     })
 
     it.each([null, undefined, 123, [], {}])(
       "returns false for non-string value %p",
       value => {
-        expect(isBuiltinColorName(value)).toBe(false)
+        expect(isNamedColor(value)).toBe(false)
       }
     )
   })
 
-  describe("resolveBuiltinColor", () => {
+  describe("resolveNamedColor", () => {
     it("resolves builtin color names to theme colors", () => {
-      expect(resolveBuiltinColor("red", mockTheme)).toBe(
+      expect(resolveNamedColor("red", mockTheme)).toBe(
         mockTheme.colors.redColor
       )
-      expect(resolveBuiltinColor("blue", mockTheme)).toBe(
+      expect(resolveNamedColor("blue", mockTheme)).toBe(
         mockTheme.colors.blueColor
       )
-      expect(resolveBuiltinColor("primary", mockTheme)).toBe(
+      expect(resolveNamedColor("primary", mockTheme)).toBe(
         mockTheme.colors.primary
       )
     })
 
     it("handles grey/gray alias", () => {
-      expect(resolveBuiltinColor("gray", mockTheme)).toBe(
+      expect(resolveNamedColor("gray", mockTheme)).toBe(
         mockTheme.colors.grayColor
       )
-      expect(resolveBuiltinColor("grey", mockTheme)).toBe(
+      expect(resolveNamedColor("grey", mockTheme)).toBe(
         mockTheme.colors.grayColor
       )
     })
 
     it("is case-insensitive", () => {
-      expect(resolveBuiltinColor("RED", mockTheme)).toBe(
+      expect(resolveNamedColor("RED", mockTheme)).toBe(
         mockTheme.colors.redColor
       )
-      expect(resolveBuiltinColor("Blue", mockTheme)).toBe(
+      expect(resolveNamedColor("Blue", mockTheme)).toBe(
         mockTheme.colors.blueColor
       )
     })
 
     it("returns non-builtin colors unchanged", () => {
-      expect(resolveBuiltinColor("#ff0000", mockTheme)).toBe("#ff0000")
-      expect(resolveBuiltinColor("rgb(255, 0, 0)", mockTheme)).toBe(
+      expect(resolveNamedColor("#ff0000", mockTheme)).toBe("#ff0000")
+      expect(resolveNamedColor("rgb(255, 0, 0)", mockTheme)).toBe(
         "rgb(255, 0, 0)"
       )
-      expect(resolveBuiltinColor("notacolor", mockTheme)).toBe("notacolor")
+      expect(resolveNamedColor("notacolor", mockTheme)).toBe("notacolor")
     })
   })
 
-  describe("resolveBuiltinColorsInSpec", () => {
+  describe("resolveNamedColorsInSpec", () => {
     it("resolves single color value in encoding", () => {
       const spec = {
         encoding: {
@@ -112,7 +112,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(spec.encoding.color.value).toBe(mockTheme.colors.redColor)
     })
@@ -128,7 +128,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(spec.encoding.color.scale.range).toEqual([
         mockTheme.colors.redColor,
@@ -148,7 +148,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(spec.encoding.color.scale.range).toEqual([
         mockTheme.colors.redColor,
@@ -175,7 +175,7 @@ describe("colorUtils", () => {
         ],
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(
         (spec.layer[0] as Record<string, unknown>).encoding
@@ -205,7 +205,7 @@ describe("colorUtils", () => {
         ],
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(
         (spec.vconcat[0] as Record<string, unknown>).encoding
@@ -235,7 +235,7 @@ describe("colorUtils", () => {
         ],
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(
         (spec.hconcat[0] as Record<string, unknown>).encoding
@@ -420,7 +420,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(spec.encoding.color.value).toBe("#ff0000")
     })
@@ -434,7 +434,7 @@ describe("colorUtils", () => {
       }
 
       // Should not throw
-      expect(() => resolveBuiltinColorsInSpec(spec, mockTheme)).not.toThrow()
+      expect(() => resolveNamedColorsInSpec(spec, mockTheme)).not.toThrow()
     })
 
     it("handles spec without encoding", () => {
@@ -443,7 +443,7 @@ describe("colorUtils", () => {
       }
 
       // Should not throw
-      expect(() => resolveBuiltinColorsInSpec(spec, mockTheme)).not.toThrow()
+      expect(() => resolveNamedColorsInSpec(spec, mockTheme)).not.toThrow()
     })
 
     it("resolves primary color", () => {
@@ -453,7 +453,7 @@ describe("colorUtils", () => {
         },
       }
 
-      resolveBuiltinColorsInSpec(spec, mockTheme)
+      resolveNamedColorsInSpec(spec, mockTheme)
 
       expect(spec.encoding.color.value).toBe(mockTheme.colors.primary)
     })

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
@@ -15,67 +15,7 @@
  */
 
 import { EmotionTheme } from "~lib/theme"
-
-/**
- * Built-in color names that map to Streamlit theme colors.
- * These are passed from the backend as strings and resolved here
- * to actual theme color values.
- *
- * TODO: Consolidate with similar getColorMapping functions in
- * ProgressColumn.ts, ChartColumn.ts, and MultiselectColumn.ts
- * into a shared theme utility.
- */
-const BUILTIN_COLOR_NAMES = new Set([
-  "red",
-  "orange",
-  "yellow",
-  "green",
-  "blue",
-  "violet",
-  "gray",
-  "grey", // alias for gray
-  "primary",
-])
-
-/**
- * Maps built-in color names to their corresponding theme color keys.
- */
-const COLOR_NAME_TO_THEME_KEY: Record<string, keyof EmotionTheme["colors"]> = {
-  red: "redColor",
-  orange: "orangeColor",
-  yellow: "yellowColor",
-  green: "greenColor",
-  blue: "blueColor",
-  violet: "violetColor",
-  gray: "grayColor",
-  grey: "grayColor", // alias
-  primary: "primary",
-}
-
-/**
- * Check if a value is a built-in color name.
- */
-export function isBuiltinColorName(value: unknown): value is string {
-  return (
-    typeof value === "string" && BUILTIN_COLOR_NAMES.has(value.toLowerCase())
-  )
-}
-
-/**
- * Resolve a built-in color name to its theme color value.
- * If the color is not a built-in name, returns it unchanged.
- */
-export function resolveBuiltinColor(
-  color: string,
-  theme: EmotionTheme
-): string {
-  const lowerColor = color.toLowerCase()
-  const themeKey = COLOR_NAME_TO_THEME_KEY[lowerColor]
-  if (themeKey) {
-    return theme.colors[themeKey] as string
-  }
-  return color
-}
+import { isBuiltinColorName, resolveBuiltinColor } from "~lib/theme/getColors"
 
 /**
  * Resolve built-in color names in a Vega-Lite spec to their theme color values.

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
@@ -15,10 +15,10 @@
  */
 
 import { EmotionTheme } from "~lib/theme"
-import { isBuiltinColorName, resolveBuiltinColor } from "~lib/theme/getColors"
+import { isNamedColor, resolveNamedColor } from "~lib/theme/getColors"
 
 /**
- * Resolve built-in color names in a Vega-Lite spec to their theme color values.
+ * Resolve named colors in a Vega-Lite spec to their theme color values.
  * This mutates the spec in place.
  *
  * Handles all Vega-Lite composition types via recursive traversal:
@@ -36,7 +36,7 @@ import { isBuiltinColorName, resolveBuiltinColor } from "~lib/theme/getColors"
  * @param spec The Vega-Lite specification object
  * @param theme The Streamlit EmotionTheme containing color values
  */
-export function resolveBuiltinColorsInSpec(
+export function resolveNamedColorsInSpec(
   spec: Record<string, unknown>,
   theme: EmotionTheme
 ): void {
@@ -59,7 +59,7 @@ export function resolveBuiltinColorsInSpec(
     if (Array.isArray(spec[key])) {
       for (const subSpec of spec[key] as unknown[]) {
         if (subSpec && typeof subSpec === "object") {
-          resolveBuiltinColorsInSpec(subSpec as Record<string, unknown>, theme)
+          resolveNamedColorsInSpec(subSpec as Record<string, unknown>, theme)
         }
       }
     }
@@ -91,8 +91,8 @@ function resolveEncodingColors(
 
   // Case 1: ColorValue - { value: "red" }
   // Used when: st.line_chart(df, color="red")
-  if ("value" in colorEncoding && isBuiltinColorName(colorEncoding.value)) {
-    colorEncoding.value = resolveBuiltinColor(colorEncoding.value, theme)
+  if ("value" in colorEncoding && isNamedColor(colorEncoding.value)) {
+    colorEncoding.value = resolveNamedColor(colorEncoding.value, theme)
   }
 
   // Case 2: Color with scale - { scale: { range: ["red", "blue"] } }
@@ -100,7 +100,7 @@ function resolveEncodingColors(
   const scale = colorEncoding.scale as Record<string, unknown> | undefined
   if (scale && Array.isArray(scale.range)) {
     scale.range = (scale.range as unknown[]).map(color =>
-      isBuiltinColorName(color) ? resolveBuiltinColor(color, theme) : color
+      isNamedColor(color) ? resolveNamedColor(color, theme) : color
     )
   }
 }

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
@@ -49,7 +49,7 @@ export function resolveNamedColorsInSpec(
   if (Array.isArray(spec.layer)) {
     for (const layerSpec of spec.layer) {
       if (layerSpec && typeof layerSpec === "object") {
-        resolveBuiltinColorsInSpec(layerSpec as Record<string, unknown>, theme)
+        resolveNamedColorsInSpec(layerSpec as Record<string, unknown>, theme)
       }
     }
   }
@@ -71,7 +71,7 @@ export function resolveNamedColorsInSpec(
     spec.spec &&
     typeof spec.spec === "object"
   ) {
-    resolveBuiltinColorsInSpec(spec.spec as Record<string, unknown>, theme)
+    resolveNamedColorsInSpec(spec.spec as Record<string, unknown>, theme)
   }
 }
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/colorUtils.ts
@@ -15,7 +15,8 @@
  */
 
 import { EmotionTheme } from "~lib/theme"
-import { isNamedColor, resolveNamedColor } from "~lib/theme/getColors"
+import { resolveNamedColor } from "~lib/theme/getColors"
+import { isNamedColor } from "~lib/theme/namedColors"
 
 /**
  * Resolve named colors in a Vega-Lite spec to their theme color values.

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
@@ -21,7 +21,7 @@ import { EmotionTheme } from "~lib/theme"
 import { isNullOrUndefined } from "~lib/util/utils"
 
 import { VegaLiteChartElement } from "./arrowUtils"
-import { resolveBuiltinColorsInSpec } from "./colorUtils"
+import { resolveNamedColorsInSpec } from "./colorUtils"
 import { applyStreamlitTheme, applyThemeDefaults } from "./CustomTheme"
 
 /**
@@ -188,7 +188,7 @@ const generateSpec = (
   }
 
   // Resolve built-in color names (red, blue, etc.) to theme color values
-  resolveBuiltinColorsInSpec(spec, theme)
+  resolveNamedColorsInSpec(spec, theme)
 
   return spec
 }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -24,7 +24,7 @@ import IsDialogContext from "~lib/components/core/IsDialogContext"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { mockTheme } from "~lib/mocks/mockTheme"
 import { render, renderWithContexts } from "~lib/test_util"
-import { getMarkdownBgColors } from "~lib/theme/getColors"
+import { getThemeBackgroundColors } from "~lib/theme/getColors"
 import { colors } from "~lib/theme/primitives/colors"
 
 import StreamlitMarkdown, {
@@ -347,12 +347,12 @@ describe("linkReference", () => {
 })
 
 describe("StreamlitMarkdown", () => {
-  let bgColors: ReturnType<typeof getMarkdownBgColors>
+  let bgColors: ReturnType<typeof getThemeBackgroundColors>
   let backgroundColorMapping: Map<string, string>
 
   beforeAll(() => {
     // Use the actual implementation to get background colors
-    bgColors = getMarkdownBgColors(mockTheme.emotion)
+    bgColors = getThemeBackgroundColors(mockTheme.emotion)
 
     backgroundColorMapping = new Map([
       ["red", bgColors.redbg],

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -62,8 +62,8 @@ import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import {
   convertRemToPx,
   EmotionTheme,
-  getMarkdownBgColors,
   getMarkdownTextColors,
+  getThemeBackgroundColors,
 } from "~lib/theme"
 
 import {
@@ -579,7 +579,7 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
     purplebg,
     graybg,
     primarybg,
-  }: Record<string, string> = getMarkdownBgColors(theme)
+  }: Record<string, string> = getThemeBackgroundColors(theme)
 
   return new Map(
     Object.entries({

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -21,7 +21,8 @@ import {
 } from "@glideapps/glide-data-grid"
 import { SparklineCellType } from "@glideapps/glide-data-grid-cells"
 
-import { EmotionTheme } from "~lib/theme"
+import { ChartColor, EmotionTheme } from "~lib/theme"
+import { resolveBuiltinColor } from "~lib/theme/getColors"
 import { formatNumber } from "~lib/util/formatNumber"
 import { isNullOrUndefined } from "~lib/util/utils"
 
@@ -39,46 +40,6 @@ import {
 export const LINE_CHART_TYPE = "line_chart"
 export const AREA_CHART_TYPE = "area_chart"
 export const BAR_CHART_TYPE = "bar_chart"
-
-/**
- * Get the color mapping to map a user-defined color to the our
- * theme colors.
- *
- * @param theme The theme to use.
- * @returns The color mapping.
- */
-const getColorMapping = (theme: EmotionTheme): Map<string, string> => {
-  return new Map(
-    Object.entries({
-      red: theme.colors.redColor,
-      blue: theme.colors.blueColor,
-      green: theme.colors.greenColor,
-      yellow: theme.colors.yellowColor,
-      violet: theme.colors.violetColor,
-      orange: theme.colors.orangeColor,
-      gray: theme.colors.grayColor,
-      grey: theme.colors.grayColor,
-      primary: theme.colors.primary,
-    })
-  )
-}
-
-type ChartAutoColor = "auto" | "auto-inverse"
-type ChartNamedSwatch =
-  | "red"
-  | "blue"
-  | "green"
-  | "yellow"
-  | "violet"
-  | "orange"
-  | "gray"
-  | "grey"
-  | "primary"
-
-declare const __cssColorBrand: unique symbol
-type CSSColorString = string & { readonly [__cssColorBrand]?: never }
-
-type ChartColor = ChartAutoColor | ChartNamedSwatch | CSSColorString
 
 export interface ChartColumnParams {
   /**
@@ -119,14 +80,12 @@ function BaseChartColumn(
     props.columnTypeOptions
   ) as ChartColumnParams
 
-  const colorMapping = getColorMapping(theme)
-
   let defaultColor: string | undefined
   if (parameters.color === "auto" || parameters.color === "auto-inverse") {
     defaultColor = theme.colors.greenColor
   } else {
     defaultColor = parameters.color
-      ? (colorMapping.get(parameters.color) ?? parameters.color)
+      ? resolveBuiltinColor(parameters.color, theme)
       : undefined
   }
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -22,7 +22,7 @@ import {
 import { SparklineCellType } from "@glideapps/glide-data-grid-cells"
 
 import { ChartColor, EmotionTheme } from "~lib/theme"
-import { resolveBuiltinColor } from "~lib/theme/getColors"
+import { resolveNamedColor } from "~lib/theme/getColors"
 import { formatNumber } from "~lib/util/formatNumber"
 import { isNullOrUndefined } from "~lib/util/utils"
 
@@ -85,7 +85,7 @@ function BaseChartColumn(
     defaultColor = theme.colors.greenColor
   } else {
     defaultColor = parameters.color
-      ? resolveBuiltinColor(parameters.color, theme)
+      ? resolveNamedColor(parameters.color, theme)
       : undefined
   }
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.test.ts
@@ -20,7 +20,7 @@ import { transparentize } from "color2k"
 
 import { DataFrameCellType } from "~lib/dataframes/arrowTypeUtils"
 import { mockTheme } from "~lib/mocks/mockTheme"
-import { blend, getMarkdownBgColors } from "~lib/theme"
+import { blend, getThemeBackgroundColors } from "~lib/theme"
 
 import MultiselectColumn, {
   type MultiselectColumnParams,
@@ -214,7 +214,7 @@ describe("prepareOptions", () => {
       { value: "prio", label: "Priority", color: "red" },
     ]
     const opts = prepareOptions(namedColorOption, mockTheme.emotion)
-    const mdColors = getMarkdownBgColors(mockTheme.emotion)
+    const mdColors = getThemeBackgroundColors(mockTheme.emotion)
     const expected = blend(mdColors.redbg, mockTheme.emotion.colors.bgColor)
     expect(opts[0].color).toEqual(expected)
   })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.ts
@@ -21,8 +21,8 @@ import { transparentize } from "color2k"
 import {
   blend,
   EmotionTheme,
-  getMarkdownBgColors,
   hasLightBackgroundColor,
+  resolveBuiltinBackgroundColor,
 } from "~lib/theme"
 import { isNullOrUndefined } from "~lib/util/utils"
 
@@ -38,32 +38,6 @@ import {
 } from "./utils"
 
 type SelectOption = { value: string; label?: string; color?: string }
-
-/**
- * Get the color mapping to map a user-defined color to the our
- * theme color (text background.)
- *
- * @param theme The theme to use.
- * @returns The color mapping.
- */
-const getColorMapping = (theme: EmotionTheme): Map<string, string> => {
-  const textBackgroundColors = getMarkdownBgColors(theme)
-
-  return new Map(
-    Object.entries({
-      red: textBackgroundColors.redbg,
-      blue: textBackgroundColors.bluebg,
-      green: textBackgroundColors.greenbg,
-      yellow: textBackgroundColors.yellowbg,
-      violet: textBackgroundColors.violetbg,
-      purple: textBackgroundColors.purplebg,
-      orange: textBackgroundColors.orangebg,
-      gray: textBackgroundColors.graybg,
-      grey: textBackgroundColors.graybg,
-      primary: textBackgroundColors.primarybg,
-    })
-  )
-}
 /**
  * Unifies the options into the format required by the multi-select cell.
  *
@@ -78,7 +52,6 @@ export const prepareOptions = (
     return []
   }
 
-  const colorMapping = getColorMapping(theme)
   // Categorical chart colors are used for the "auto" color option:
   const categoricalColors = theme.colors.chartCategoricalColors
   const isLightTheme = hasLightBackgroundColor(theme)
@@ -108,8 +81,9 @@ export const prepareOptions = (
 
         autoColorIndex += 1
       } else if (option.color) {
-        // Try to map the color to a theme color, otherwise use the color value directly.
-        resolvedColor = colorMapping.get(option.color) ?? option.color
+        // Resolve built-in color names to theme background colors,
+        // otherwise use the color value directly.
+        resolvedColor = resolveBuiltinBackgroundColor(option.color, theme)
       }
       // The upstream implementation has some issues with the alpha channel.
       // Therefore, we are blending the color with the background to remove the alpha channel.

--- a/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.ts
@@ -22,7 +22,7 @@ import {
   blend,
   EmotionTheme,
   hasLightBackgroundColor,
-  resolveBuiltinBackgroundColor,
+  resolveNamedBackgroundColor,
 } from "~lib/theme"
 import { isNullOrUndefined } from "~lib/util/utils"
 
@@ -83,7 +83,7 @@ export const prepareOptions = (
       } else if (option.color) {
         // Resolve built-in color names to theme background colors,
         // otherwise use the color value directly.
-        resolvedColor = resolveBuiltinBackgroundColor(option.color, theme)
+        resolvedColor = resolveNamedBackgroundColor(option.color, theme)
       }
       // The upstream implementation has some issues with the alpha channel.
       // Therefore, we are blending the color with the background to remove the alpha channel.

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -22,7 +22,8 @@ import {
 import { RangeCellType } from "@glideapps/glide-data-grid-cells"
 
 import { isIntegerType } from "~lib/dataframes/arrowTypeUtils"
-import { EmotionTheme } from "~lib/theme"
+import { ChartColor, EmotionTheme } from "~lib/theme"
+import { resolveBuiltinColor } from "~lib/theme/getColors"
 import { formatNumber } from "~lib/util/formatNumber"
 import { isNullOrUndefined, notNullOrUndefined } from "~lib/util/utils"
 
@@ -36,46 +37,6 @@ import {
   toSafeNumber,
   toSafeString,
 } from "./utils"
-
-type ChartAutoColor = "auto" | "auto-inverse"
-type ChartNamedSwatch =
-  | "red"
-  | "blue"
-  | "green"
-  | "yellow"
-  | "violet"
-  | "orange"
-  | "gray"
-  | "grey"
-  | "primary"
-
-declare const __cssColorBrand: unique symbol
-type CSSColorString = string & { readonly [__cssColorBrand]?: never }
-
-type ChartColor = ChartAutoColor | ChartNamedSwatch | CSSColorString
-
-/**
- * Get the color mapping to map a user-defined color to the our
- * theme colors.
- *
- * @param theme The theme to use.
- * @returns The color mapping.
- */
-const getColorMapping = (theme: EmotionTheme): Map<string, string> => {
-  return new Map(
-    Object.entries({
-      red: theme.colors.redColor,
-      blue: theme.colors.blueColor,
-      green: theme.colors.greenColor,
-      yellow: theme.colors.yellowColor,
-      violet: theme.colors.violetColor,
-      orange: theme.colors.orangeColor,
-      gray: theme.colors.grayColor,
-      grey: theme.colors.grayColor,
-      primary: theme.colors.primary,
-    })
-  )
-}
 export interface ProgressColumnParams {
   /**
    * The minimum permitted value. Defaults to 0.
@@ -128,8 +89,6 @@ function ProgressColumn(
     // User parameters:
     props.columnTypeOptions
   ) as ProgressColumnParams
-
-  const colorMapping = getColorMapping(theme)
 
   const fixedDecimals =
     isNullOrUndefined(parameters.step) || Number.isNaN(parameters.step)
@@ -261,8 +220,7 @@ function ProgressColumn(
             : theme?.colors.greenColor
         }
       } else if (parameters.color) {
-        progressColor =
-          colorMapping.get(parameters.color) ?? (parameters.color as string)
+        progressColor = resolveBuiltinColor(parameters.color, theme)
       }
 
       return {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -23,7 +23,7 @@ import { RangeCellType } from "@glideapps/glide-data-grid-cells"
 
 import { isIntegerType } from "~lib/dataframes/arrowTypeUtils"
 import { ChartColor, EmotionTheme } from "~lib/theme"
-import { resolveBuiltinColor } from "~lib/theme/getColors"
+import { resolveNamedColor } from "~lib/theme/getColors"
 import { formatNumber } from "~lib/util/formatNumber"
 import { isNullOrUndefined, notNullOrUndefined } from "~lib/util/utils"
 
@@ -220,7 +220,7 @@ function ProgressColumn(
             : theme?.colors.greenColor
         }
       } else if (parameters.color) {
-        progressColor = resolveBuiltinColor(parameters.color, theme)
+        progressColor = resolveNamedColor(parameters.color, theme)
       }
 
       return {

--- a/frontend/lib/src/theme/getColors.test.ts
+++ b/frontend/lib/src/theme/getColors.test.ts
@@ -17,16 +17,17 @@
 import { transparentize } from "color2k"
 
 import { darkTheme, lightTheme } from "~lib/theme/index"
+import { NamedColor } from "~lib/theme/types"
 
 import {
-  BUILTIN_COLOR_NAMES,
   getDividerColors,
   getMarkdownTextColors,
   getThemeBackgroundColors,
   hasLightBackgroundColor,
-  isBuiltinColorName,
-  resolveBuiltinBackgroundColor,
-  resolveBuiltinColor,
+  isNamedColor,
+  NAMED_COLORS,
+  resolveNamedBackgroundColor,
+  resolveNamedColor,
 } from "./getColors"
 
 describe("getDividerColors", () => {
@@ -245,7 +246,7 @@ describe("getMarkdownTextColors", () => {
   })
 })
 
-describe("BUILTIN_COLOR_NAMES", () => {
+describe("NAMED_COLORS", () => {
   it("contains all expected color names", () => {
     const expectedColors = [
       "red",
@@ -259,70 +260,94 @@ describe("BUILTIN_COLOR_NAMES", () => {
       "primary",
     ]
     expectedColors.forEach(color => {
-      expect(BUILTIN_COLOR_NAMES.has(color)).toBe(true)
+      expect(NAMED_COLORS.has(color)).toBe(true)
     })
-    expect(BUILTIN_COLOR_NAMES.size).toBe(expectedColors.length)
+    expect(NAMED_COLORS.size).toBe(expectedColors.length)
+  })
+
+  it("is derived from NAMED_COLOR_CONFIG (config is the source of truth)", () => {
+    // This test ensures that if someone adds a color to the config,
+    // it automatically becomes available in NAMED_COLORS.
+    // NamedColor is now derived from NAMED_COLOR_CONFIG,
+    // so this compile-time check verifies the type covers all expected values.
+    const allBuiltinColors: NamedColor[] = [
+      "red",
+      "orange",
+      "yellow",
+      "green",
+      "blue",
+      "violet",
+      "gray",
+      "grey",
+      "primary",
+    ]
+
+    // Runtime check that all NamedColor values are in the set
+    allBuiltinColors.forEach(color => {
+      expect(NAMED_COLORS.has(color)).toBe(true)
+    })
+
+    // Verify the set size matches (no extra colors in set)
+    expect(NAMED_COLORS.size).toBe(allBuiltinColors.length)
   })
 })
 
-describe("isBuiltinColorName", () => {
+describe("isNamedColor", () => {
   it("returns true for valid builtin color names", () => {
-    expect(isBuiltinColorName("red")).toBe(true)
-    expect(isBuiltinColorName("blue")).toBe(true)
-    expect(isBuiltinColorName("primary")).toBe(true)
-    expect(isBuiltinColorName("gray")).toBe(true)
-    expect(isBuiltinColorName("grey")).toBe(true)
+    expect(isNamedColor("red")).toBe(true)
+    expect(isNamedColor("blue")).toBe(true)
+    expect(isNamedColor("primary")).toBe(true)
+    expect(isNamedColor("gray")).toBe(true)
+    expect(isNamedColor("grey")).toBe(true)
   })
 
   it("returns true for uppercase color names (case insensitive)", () => {
-    expect(isBuiltinColorName("RED")).toBe(true)
-    expect(isBuiltinColorName("Blue")).toBe(true)
-    expect(isBuiltinColorName("PRIMARY")).toBe(true)
+    expect(isNamedColor("RED")).toBe(true)
+    expect(isNamedColor("Blue")).toBe(true)
+    expect(isNamedColor("PRIMARY")).toBe(true)
   })
 
   it("returns false for non-builtin colors", () => {
-    expect(isBuiltinColorName("#ff0000")).toBe(false)
-    expect(isBuiltinColorName("pink")).toBe(false)
-    expect(isBuiltinColorName("rgb(255, 0, 0)")).toBe(false)
+    expect(isNamedColor("#ff0000")).toBe(false)
+    expect(isNamedColor("pink")).toBe(false)
+    expect(isNamedColor("rgb(255, 0, 0)")).toBe(false)
   })
 
   it("returns false for non-string values", () => {
-    expect(isBuiltinColorName(null)).toBe(false)
-    expect(isBuiltinColorName(undefined)).toBe(false)
-    expect(isBuiltinColorName(123)).toBe(false)
-    expect(isBuiltinColorName({})).toBe(false)
+    expect(isNamedColor(null)).toBe(false)
+    expect(isNamedColor(undefined)).toBe(false)
+    expect(isNamedColor(123)).toBe(false)
+    expect(isNamedColor({})).toBe(false)
   })
 })
 
-describe("resolveBuiltinColor", () => {
+describe("resolveNamedColor", () => {
   it("resolves builtin color names to theme colors for light theme", () => {
     const colors = lightTheme.emotion.colors
 
-    expect(resolveBuiltinColor("red", lightTheme.emotion)).toBe(
-      colors.redColor
-    )
-    expect(resolveBuiltinColor("orange", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("red", lightTheme.emotion)).toBe(colors.redColor)
+    expect(resolveNamedColor("orange", lightTheme.emotion)).toBe(
       colors.orangeColor
     )
-    expect(resolveBuiltinColor("yellow", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("yellow", lightTheme.emotion)).toBe(
       colors.yellowColor
     )
-    expect(resolveBuiltinColor("green", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("green", lightTheme.emotion)).toBe(
       colors.greenColor
     )
-    expect(resolveBuiltinColor("blue", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("blue", lightTheme.emotion)).toBe(
       colors.blueColor
     )
-    expect(resolveBuiltinColor("violet", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("violet", lightTheme.emotion)).toBe(
       colors.violetColor
     )
-    expect(resolveBuiltinColor("gray", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("gray", lightTheme.emotion)).toBe(
       colors.grayColor
     )
-    expect(resolveBuiltinColor("grey", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("grey", lightTheme.emotion)).toBe(
       colors.grayColor
     )
-    expect(resolveBuiltinColor("primary", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("primary", lightTheme.emotion)).toBe(
       colors.primary
     )
   })
@@ -330,11 +355,9 @@ describe("resolveBuiltinColor", () => {
   it("resolves builtin color names to theme colors for dark theme", () => {
     const colors = darkTheme.emotion.colors
 
-    expect(resolveBuiltinColor("red", darkTheme.emotion)).toBe(colors.redColor)
-    expect(resolveBuiltinColor("blue", darkTheme.emotion)).toBe(
-      colors.blueColor
-    )
-    expect(resolveBuiltinColor("primary", darkTheme.emotion)).toBe(
+    expect(resolveNamedColor("red", darkTheme.emotion)).toBe(colors.redColor)
+    expect(resolveNamedColor("blue", darkTheme.emotion)).toBe(colors.blueColor)
+    expect(resolveNamedColor("primary", darkTheme.emotion)).toBe(
       colors.primary
     )
   })
@@ -342,69 +365,79 @@ describe("resolveBuiltinColor", () => {
   it("handles case-insensitive color names", () => {
     const colors = lightTheme.emotion.colors
 
-    expect(resolveBuiltinColor("RED", lightTheme.emotion)).toBe(
-      colors.redColor
-    )
-    expect(resolveBuiltinColor("Blue", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("RED", lightTheme.emotion)).toBe(colors.redColor)
+    expect(resolveNamedColor("Blue", lightTheme.emotion)).toBe(
       colors.blueColor
     )
-    expect(resolveBuiltinColor("PRIMARY", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("PRIMARY", lightTheme.emotion)).toBe(
       colors.primary
     )
   })
 
   it("returns non-builtin colors unchanged", () => {
-    expect(resolveBuiltinColor("#ff0000", lightTheme.emotion)).toBe("#ff0000")
-    expect(resolveBuiltinColor("pink", lightTheme.emotion)).toBe("pink")
-    expect(resolveBuiltinColor("rgb(255, 0, 0)", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("#ff0000", lightTheme.emotion)).toBe("#ff0000")
+    expect(resolveNamedColor("pink", lightTheme.emotion)).toBe("pink")
+    expect(resolveNamedColor("rgb(255, 0, 0)", lightTheme.emotion)).toBe(
       "rgb(255, 0, 0)"
     )
   })
 
   it("does not resolve purple (no purpleColor exists, use violet instead)", () => {
     // "purple" is not a built-in color name - it passes through unchanged
-    // This differs from resolveBuiltinBackgroundColor which DOES support "purple"
-    expect(resolveBuiltinColor("purple", lightTheme.emotion)).toBe("purple")
+    // This differs from resolveNamedBackgroundColor which DOES support "purple"
+    expect(resolveNamedColor("purple", lightTheme.emotion)).toBe("purple")
 
     // Use "violet" for the main color
-    expect(resolveBuiltinColor("violet", lightTheme.emotion)).toBe(
+    expect(resolveNamedColor("violet", lightTheme.emotion)).toBe(
       lightTheme.emotion.colors.violetColor
     )
   })
+
+  it("returns consistent results on repeated calls (memoization)", () => {
+    // First call
+    const result1 = resolveNamedColor("red", lightTheme.emotion)
+    // Second call should return the same value
+    const result2 = resolveNamedColor("red", lightTheme.emotion)
+    expect(result1).toBe(result2)
+
+    // Different color, same theme
+    const result3 = resolveNamedColor("blue", lightTheme.emotion)
+    expect(result3).toBe(lightTheme.emotion.colors.blueColor)
+  })
 })
 
-describe("resolveBuiltinBackgroundColor", () => {
+describe("resolveNamedBackgroundColor", () => {
   it("resolves builtin color names to background colors for light theme", () => {
     const bgColors = getThemeBackgroundColors(lightTheme.emotion)
 
-    expect(resolveBuiltinBackgroundColor("red", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("red", lightTheme.emotion)).toBe(
       bgColors.redbg
     )
-    expect(resolveBuiltinBackgroundColor("orange", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("orange", lightTheme.emotion)).toBe(
       bgColors.orangebg
     )
-    expect(resolveBuiltinBackgroundColor("yellow", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("yellow", lightTheme.emotion)).toBe(
       bgColors.yellowbg
     )
-    expect(resolveBuiltinBackgroundColor("green", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("green", lightTheme.emotion)).toBe(
       bgColors.greenbg
     )
-    expect(resolveBuiltinBackgroundColor("blue", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("blue", lightTheme.emotion)).toBe(
       bgColors.bluebg
     )
-    expect(resolveBuiltinBackgroundColor("violet", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("violet", lightTheme.emotion)).toBe(
       bgColors.violetbg
     )
-    expect(resolveBuiltinBackgroundColor("purple", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("purple", lightTheme.emotion)).toBe(
       bgColors.purplebg
     )
-    expect(resolveBuiltinBackgroundColor("gray", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("gray", lightTheme.emotion)).toBe(
       bgColors.graybg
     )
-    expect(resolveBuiltinBackgroundColor("grey", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("grey", lightTheme.emotion)).toBe(
       bgColors.graybg
     )
-    expect(resolveBuiltinBackgroundColor("primary", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("primary", lightTheme.emotion)).toBe(
       bgColors.primarybg
     )
   })
@@ -412,13 +445,13 @@ describe("resolveBuiltinBackgroundColor", () => {
   it("resolves builtin color names to background colors for dark theme", () => {
     const bgColors = getThemeBackgroundColors(darkTheme.emotion)
 
-    expect(resolveBuiltinBackgroundColor("red", darkTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("red", darkTheme.emotion)).toBe(
       bgColors.redbg
     )
-    expect(resolveBuiltinBackgroundColor("blue", darkTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("blue", darkTheme.emotion)).toBe(
       bgColors.bluebg
     )
-    expect(resolveBuiltinBackgroundColor("primary", darkTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("primary", darkTheme.emotion)).toBe(
       bgColors.primarybg
     )
   })
@@ -426,36 +459,36 @@ describe("resolveBuiltinBackgroundColor", () => {
   it("handles case-insensitive color names", () => {
     const bgColors = getThemeBackgroundColors(lightTheme.emotion)
 
-    expect(resolveBuiltinBackgroundColor("RED", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("RED", lightTheme.emotion)).toBe(
       bgColors.redbg
     )
-    expect(resolveBuiltinBackgroundColor("Blue", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("Blue", lightTheme.emotion)).toBe(
       bgColors.bluebg
     )
-    expect(resolveBuiltinBackgroundColor("PRIMARY", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("PRIMARY", lightTheme.emotion)).toBe(
       bgColors.primarybg
     )
   })
 
   it("returns non-builtin colors unchanged", () => {
-    expect(resolveBuiltinBackgroundColor("#ff0000", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("#ff0000", lightTheme.emotion)).toBe(
       "#ff0000"
     )
-    expect(resolveBuiltinBackgroundColor("pink", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("pink", lightTheme.emotion)).toBe(
       "pink"
     )
     expect(
-      resolveBuiltinBackgroundColor("rgb(255, 0, 0)", lightTheme.emotion)
+      resolveNamedBackgroundColor("rgb(255, 0, 0)", lightTheme.emotion)
     ).toBe("rgb(255, 0, 0)")
   })
 
   it("has distinct purple and violet background colors", () => {
     const bgColors = getThemeBackgroundColors(lightTheme.emotion)
 
-    expect(resolveBuiltinBackgroundColor("purple", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("purple", lightTheme.emotion)).toBe(
       bgColors.purplebg
     )
-    expect(resolveBuiltinBackgroundColor("violet", lightTheme.emotion)).toBe(
+    expect(resolveNamedBackgroundColor("violet", lightTheme.emotion)).toBe(
       bgColors.violetbg
     )
     // Unlike main colors, purple and violet have distinct background colors

--- a/frontend/lib/src/theme/getColors.test.ts
+++ b/frontend/lib/src/theme/getColors.test.ts
@@ -17,15 +17,12 @@
 import { transparentize } from "color2k"
 
 import { darkTheme, lightTheme } from "~lib/theme/index"
-import { NamedColor } from "~lib/theme/types"
 
 import {
   getDividerColors,
   getMarkdownTextColors,
   getThemeBackgroundColors,
   hasLightBackgroundColor,
-  isNamedColor,
-  NAMED_COLORS,
   resolveNamedBackgroundColor,
   resolveNamedColor,
 } from "./getColors"
@@ -246,80 +243,8 @@ describe("getMarkdownTextColors", () => {
   })
 })
 
-describe("NAMED_COLORS", () => {
-  it("contains all expected color names", () => {
-    const expectedColors = [
-      "red",
-      "orange",
-      "yellow",
-      "green",
-      "blue",
-      "violet",
-      "gray",
-      "grey",
-      "primary",
-    ]
-    expectedColors.forEach(color => {
-      expect(NAMED_COLORS.has(color)).toBe(true)
-    })
-    expect(NAMED_COLORS.size).toBe(expectedColors.length)
-  })
-
-  it("is derived from NAMED_COLOR_CONFIG (config is the source of truth)", () => {
-    // This test ensures that if someone adds a color to the config,
-    // it automatically becomes available in NAMED_COLORS.
-    // NamedColor is now derived from NAMED_COLOR_CONFIG,
-    // so this compile-time check verifies the type covers all expected values.
-    const allBuiltinColors: NamedColor[] = [
-      "red",
-      "orange",
-      "yellow",
-      "green",
-      "blue",
-      "violet",
-      "gray",
-      "grey",
-      "primary",
-    ]
-
-    // Runtime check that all NamedColor values are in the set
-    allBuiltinColors.forEach(color => {
-      expect(NAMED_COLORS.has(color)).toBe(true)
-    })
-
-    // Verify the set size matches (no extra colors in set)
-    expect(NAMED_COLORS.size).toBe(allBuiltinColors.length)
-  })
-})
-
-describe("isNamedColor", () => {
-  it("returns true for valid builtin color names", () => {
-    expect(isNamedColor("red")).toBe(true)
-    expect(isNamedColor("blue")).toBe(true)
-    expect(isNamedColor("primary")).toBe(true)
-    expect(isNamedColor("gray")).toBe(true)
-    expect(isNamedColor("grey")).toBe(true)
-  })
-
-  it("returns true for uppercase color names (case insensitive)", () => {
-    expect(isNamedColor("RED")).toBe(true)
-    expect(isNamedColor("Blue")).toBe(true)
-    expect(isNamedColor("PRIMARY")).toBe(true)
-  })
-
-  it("returns false for non-builtin colors", () => {
-    expect(isNamedColor("#ff0000")).toBe(false)
-    expect(isNamedColor("pink")).toBe(false)
-    expect(isNamedColor("rgb(255, 0, 0)")).toBe(false)
-  })
-
-  it("returns false for non-string values", () => {
-    expect(isNamedColor(null)).toBe(false)
-    expect(isNamedColor(undefined)).toBe(false)
-    expect(isNamedColor(123)).toBe(false)
-    expect(isNamedColor({})).toBe(false)
-  })
-})
+// Note: Tests for NAMED_COLORS and isNamedColor are in namedColors.test.ts
+// This file only tests functions defined in getColors.ts
 
 describe("resolveNamedColor", () => {
   it("resolves builtin color names to theme colors for light theme", () => {

--- a/frontend/lib/src/theme/getColors.test.ts
+++ b/frontend/lib/src/theme/getColors.test.ts
@@ -19,10 +19,14 @@ import { transparentize } from "color2k"
 import { darkTheme, lightTheme } from "~lib/theme/index"
 
 import {
+  BUILTIN_COLOR_NAMES,
   getDividerColors,
-  getMarkdownBgColors,
   getMarkdownTextColors,
+  getThemeBackgroundColors,
   hasLightBackgroundColor,
+  isBuiltinColorName,
+  resolveBuiltinBackgroundColor,
+  resolveBuiltinColor,
 } from "./getColors"
 
 describe("getDividerColors", () => {
@@ -177,9 +181,9 @@ describe("getDividerColors", () => {
   })
 })
 
-describe("getMarkdownBgColors", () => {
+describe("getThemeBackgroundColors", () => {
   it("returns correct background colors for light theme", () => {
-    const result = getMarkdownBgColors(lightTheme.emotion)
+    const result = getThemeBackgroundColors(lightTheme.emotion)
     const colors = lightTheme.emotion.colors
 
     expect(result.redbg).toBe(colors.redBackgroundColor)
@@ -194,7 +198,7 @@ describe("getMarkdownBgColors", () => {
   })
 
   it("returns correct background colors for dark theme", () => {
-    const result = getMarkdownBgColors(darkTheme.emotion)
+    const result = getThemeBackgroundColors(darkTheme.emotion)
     const colors = darkTheme.emotion.colors
 
     expect(result.redbg).toBe(colors.redBackgroundColor)
@@ -238,5 +242,223 @@ describe("getMarkdownTextColors", () => {
     expect(result.purple).toBe(colors.purple80)
     expect(result.gray).toBe(colors.grayTextColor)
     expect(result.primary).toBe(colors.primary)
+  })
+})
+
+describe("BUILTIN_COLOR_NAMES", () => {
+  it("contains all expected color names", () => {
+    const expectedColors = [
+      "red",
+      "orange",
+      "yellow",
+      "green",
+      "blue",
+      "violet",
+      "gray",
+      "grey",
+      "primary",
+    ]
+    expectedColors.forEach(color => {
+      expect(BUILTIN_COLOR_NAMES.has(color)).toBe(true)
+    })
+    expect(BUILTIN_COLOR_NAMES.size).toBe(expectedColors.length)
+  })
+})
+
+describe("isBuiltinColorName", () => {
+  it("returns true for valid builtin color names", () => {
+    expect(isBuiltinColorName("red")).toBe(true)
+    expect(isBuiltinColorName("blue")).toBe(true)
+    expect(isBuiltinColorName("primary")).toBe(true)
+    expect(isBuiltinColorName("gray")).toBe(true)
+    expect(isBuiltinColorName("grey")).toBe(true)
+  })
+
+  it("returns true for uppercase color names (case insensitive)", () => {
+    expect(isBuiltinColorName("RED")).toBe(true)
+    expect(isBuiltinColorName("Blue")).toBe(true)
+    expect(isBuiltinColorName("PRIMARY")).toBe(true)
+  })
+
+  it("returns false for non-builtin colors", () => {
+    expect(isBuiltinColorName("#ff0000")).toBe(false)
+    expect(isBuiltinColorName("pink")).toBe(false)
+    expect(isBuiltinColorName("rgb(255, 0, 0)")).toBe(false)
+  })
+
+  it("returns false for non-string values", () => {
+    expect(isBuiltinColorName(null)).toBe(false)
+    expect(isBuiltinColorName(undefined)).toBe(false)
+    expect(isBuiltinColorName(123)).toBe(false)
+    expect(isBuiltinColorName({})).toBe(false)
+  })
+})
+
+describe("resolveBuiltinColor", () => {
+  it("resolves builtin color names to theme colors for light theme", () => {
+    const colors = lightTheme.emotion.colors
+
+    expect(resolveBuiltinColor("red", lightTheme.emotion)).toBe(
+      colors.redColor
+    )
+    expect(resolveBuiltinColor("orange", lightTheme.emotion)).toBe(
+      colors.orangeColor
+    )
+    expect(resolveBuiltinColor("yellow", lightTheme.emotion)).toBe(
+      colors.yellowColor
+    )
+    expect(resolveBuiltinColor("green", lightTheme.emotion)).toBe(
+      colors.greenColor
+    )
+    expect(resolveBuiltinColor("blue", lightTheme.emotion)).toBe(
+      colors.blueColor
+    )
+    expect(resolveBuiltinColor("violet", lightTheme.emotion)).toBe(
+      colors.violetColor
+    )
+    expect(resolveBuiltinColor("gray", lightTheme.emotion)).toBe(
+      colors.grayColor
+    )
+    expect(resolveBuiltinColor("grey", lightTheme.emotion)).toBe(
+      colors.grayColor
+    )
+    expect(resolveBuiltinColor("primary", lightTheme.emotion)).toBe(
+      colors.primary
+    )
+  })
+
+  it("resolves builtin color names to theme colors for dark theme", () => {
+    const colors = darkTheme.emotion.colors
+
+    expect(resolveBuiltinColor("red", darkTheme.emotion)).toBe(colors.redColor)
+    expect(resolveBuiltinColor("blue", darkTheme.emotion)).toBe(
+      colors.blueColor
+    )
+    expect(resolveBuiltinColor("primary", darkTheme.emotion)).toBe(
+      colors.primary
+    )
+  })
+
+  it("handles case-insensitive color names", () => {
+    const colors = lightTheme.emotion.colors
+
+    expect(resolveBuiltinColor("RED", lightTheme.emotion)).toBe(
+      colors.redColor
+    )
+    expect(resolveBuiltinColor("Blue", lightTheme.emotion)).toBe(
+      colors.blueColor
+    )
+    expect(resolveBuiltinColor("PRIMARY", lightTheme.emotion)).toBe(
+      colors.primary
+    )
+  })
+
+  it("returns non-builtin colors unchanged", () => {
+    expect(resolveBuiltinColor("#ff0000", lightTheme.emotion)).toBe("#ff0000")
+    expect(resolveBuiltinColor("pink", lightTheme.emotion)).toBe("pink")
+    expect(resolveBuiltinColor("rgb(255, 0, 0)", lightTheme.emotion)).toBe(
+      "rgb(255, 0, 0)"
+    )
+  })
+
+  it("does not resolve purple (no purpleColor exists, use violet instead)", () => {
+    // "purple" is not a built-in color name - it passes through unchanged
+    // This differs from resolveBuiltinBackgroundColor which DOES support "purple"
+    expect(resolveBuiltinColor("purple", lightTheme.emotion)).toBe("purple")
+
+    // Use "violet" for the main color
+    expect(resolveBuiltinColor("violet", lightTheme.emotion)).toBe(
+      lightTheme.emotion.colors.violetColor
+    )
+  })
+})
+
+describe("resolveBuiltinBackgroundColor", () => {
+  it("resolves builtin color names to background colors for light theme", () => {
+    const bgColors = getThemeBackgroundColors(lightTheme.emotion)
+
+    expect(resolveBuiltinBackgroundColor("red", lightTheme.emotion)).toBe(
+      bgColors.redbg
+    )
+    expect(resolveBuiltinBackgroundColor("orange", lightTheme.emotion)).toBe(
+      bgColors.orangebg
+    )
+    expect(resolveBuiltinBackgroundColor("yellow", lightTheme.emotion)).toBe(
+      bgColors.yellowbg
+    )
+    expect(resolveBuiltinBackgroundColor("green", lightTheme.emotion)).toBe(
+      bgColors.greenbg
+    )
+    expect(resolveBuiltinBackgroundColor("blue", lightTheme.emotion)).toBe(
+      bgColors.bluebg
+    )
+    expect(resolveBuiltinBackgroundColor("violet", lightTheme.emotion)).toBe(
+      bgColors.violetbg
+    )
+    expect(resolveBuiltinBackgroundColor("purple", lightTheme.emotion)).toBe(
+      bgColors.purplebg
+    )
+    expect(resolveBuiltinBackgroundColor("gray", lightTheme.emotion)).toBe(
+      bgColors.graybg
+    )
+    expect(resolveBuiltinBackgroundColor("grey", lightTheme.emotion)).toBe(
+      bgColors.graybg
+    )
+    expect(resolveBuiltinBackgroundColor("primary", lightTheme.emotion)).toBe(
+      bgColors.primarybg
+    )
+  })
+
+  it("resolves builtin color names to background colors for dark theme", () => {
+    const bgColors = getThemeBackgroundColors(darkTheme.emotion)
+
+    expect(resolveBuiltinBackgroundColor("red", darkTheme.emotion)).toBe(
+      bgColors.redbg
+    )
+    expect(resolveBuiltinBackgroundColor("blue", darkTheme.emotion)).toBe(
+      bgColors.bluebg
+    )
+    expect(resolveBuiltinBackgroundColor("primary", darkTheme.emotion)).toBe(
+      bgColors.primarybg
+    )
+  })
+
+  it("handles case-insensitive color names", () => {
+    const bgColors = getThemeBackgroundColors(lightTheme.emotion)
+
+    expect(resolveBuiltinBackgroundColor("RED", lightTheme.emotion)).toBe(
+      bgColors.redbg
+    )
+    expect(resolveBuiltinBackgroundColor("Blue", lightTheme.emotion)).toBe(
+      bgColors.bluebg
+    )
+    expect(resolveBuiltinBackgroundColor("PRIMARY", lightTheme.emotion)).toBe(
+      bgColors.primarybg
+    )
+  })
+
+  it("returns non-builtin colors unchanged", () => {
+    expect(resolveBuiltinBackgroundColor("#ff0000", lightTheme.emotion)).toBe(
+      "#ff0000"
+    )
+    expect(resolveBuiltinBackgroundColor("pink", lightTheme.emotion)).toBe(
+      "pink"
+    )
+    expect(
+      resolveBuiltinBackgroundColor("rgb(255, 0, 0)", lightTheme.emotion)
+    ).toBe("rgb(255, 0, 0)")
+  })
+
+  it("has distinct purple and violet background colors", () => {
+    const bgColors = getThemeBackgroundColors(lightTheme.emotion)
+
+    expect(resolveBuiltinBackgroundColor("purple", lightTheme.emotion)).toBe(
+      bgColors.purplebg
+    )
+    expect(resolveBuiltinBackgroundColor("violet", lightTheme.emotion)).toBe(
+      bgColors.violetbg
+    )
+    // Unlike main colors, purple and violet have distinct background colors
+    expect(bgColors.purplebg).not.toBe(bgColors.violetbg)
   })
 })

--- a/frontend/lib/src/theme/getColors.ts
+++ b/frontend/lib/src/theme/getColors.ts
@@ -24,10 +24,6 @@ import {
   GenericColors,
 } from "./types"
 
-// Re-export from namedColors for convenience
-export { isNamedColor, NAMED_COLORS } from "./namedColors"
-export type { NamedColor } from "./namedColors"
-
 export const computeDerivedColors = (
   genericColors: GenericColors
 ): DerivedColors => {

--- a/frontend/lib/src/theme/getColors.ts
+++ b/frontend/lib/src/theme/getColors.ts
@@ -16,13 +16,17 @@
 
 import { darken, getLuminance, lighten, mix, transparentize } from "color2k"
 
+import { BACKGROUND_ONLY_COLORS, NAMED_COLOR_CONFIG } from "./namedColors"
 import {
-  BuiltinColorName,
   DerivedColors,
   EmotionTheme,
   EmotionThemeColors,
   GenericColors,
 } from "./types"
+
+// Re-export from namedColors for convenience
+export { isNamedColor, NAMED_COLORS } from "./namedColors"
+export type { NamedColor } from "./namedColors"
 
 export const computeDerivedColors = (
   genericColors: GenericColors
@@ -328,116 +332,96 @@ export function getIncreasingGreen(theme: EmotionTheme): string {
     : theme.colors.green40
 }
 
-/**
- * Set of built-in color names for quick lookup.
- */
-export const BUILTIN_COLOR_NAMES: ReadonlySet<string> = new Set([
-  "red",
-  "orange",
-  "yellow",
-  "green",
-  "blue",
-  "violet",
-  "gray",
-  "grey",
-  "primary",
-])
-
-/**
- * Type guard to check if a value is a built-in color name.
- */
-export function isBuiltinColorName(value: unknown): value is BuiltinColorName {
-  return (
-    typeof value === "string" && BUILTIN_COLOR_NAMES.has(value.toLowerCase())
-  )
-}
-
-// Cache color mappings per theme to avoid recreating objects on every call.
 // WeakMap allows garbage collection when themes are no longer referenced.
-const builtinColorCache = new WeakMap<EmotionTheme, Record<string, string>>()
-const builtinBgColorCache = new WeakMap<EmotionTheme, Record<string, string>>()
+const namedColorCache = new WeakMap<EmotionTheme, Map<string, string>>()
+const namedBgColorCache = new WeakMap<EmotionTheme, Map<string, string>>()
 
 /**
- * Get or create the builtin color mapping for a theme.
+ * Get or create the named color mapping for a theme.
+ * Built from NAMED_COLOR_CONFIG to ensure consistency.
  */
-function getBuiltinColorMap(theme: EmotionTheme): Record<string, string> {
-  let colorMap = builtinColorCache.get(theme)
+function getNamedColorMap(theme: EmotionTheme): Map<string, string> {
+  let colorMap = namedColorCache.get(theme)
   if (!colorMap) {
-    colorMap = {
-      red: theme.colors.redColor,
-      orange: theme.colors.orangeColor,
-      yellow: theme.colors.yellowColor,
-      green: theme.colors.greenColor,
-      blue: theme.colors.blueColor,
-      violet: theme.colors.violetColor,
-      gray: theme.colors.grayColor,
-      grey: theme.colors.grayColor,
-      primary: theme.colors.primary,
+    colorMap = new Map()
+    for (const [name, config] of Object.entries(NAMED_COLOR_CONFIG)) {
+      const themeColor = theme.colors[config.colorKey]
+      if (typeof themeColor === "string") {
+        colorMap.set(name, themeColor)
+      }
     }
-    builtinColorCache.set(theme, colorMap)
+    namedColorCache.set(theme, colorMap)
   }
   return colorMap
 }
 
 /**
- * Get or create the builtin background color mapping for a theme.
+ * Get or create the named background color mapping for a theme.
+ * Built from NAMED_COLOR_CONFIG and BACKGROUND_ONLY_COLORS.
  */
-function getBuiltinBgColorMap(theme: EmotionTheme): Record<string, string> {
-  let colorMap = builtinBgColorCache.get(theme)
+function getNamedBgColorMap(theme: EmotionTheme): Map<string, string> {
+  let colorMap = namedBgColorCache.get(theme)
   if (!colorMap) {
     const bgColors = getThemeBackgroundColors(theme)
-    colorMap = {
-      red: bgColors.redbg,
-      orange: bgColors.orangebg,
-      yellow: bgColors.yellowbg,
-      green: bgColors.greenbg,
-      blue: bgColors.bluebg,
-      violet: bgColors.violetbg,
-      // "purple" has its own distinct background color (different from violet)
-      purple: bgColors.purplebg,
-      gray: bgColors.graybg,
-      grey: bgColors.graybg,
-      primary: bgColors.primarybg,
+    colorMap = new Map()
+
+    // Add colors from main config that have background colors
+    for (const [name, config] of Object.entries(NAMED_COLOR_CONFIG)) {
+      if (config.bgColorKey) {
+        const bgColor = theme.colors[config.bgColorKey]
+        if (typeof bgColor === "string") {
+          colorMap.set(name, bgColor)
+        }
+      }
     }
-    builtinBgColorCache.set(theme, colorMap)
+
+    // Add primary background (computed, not from theme.colors directly)
+    colorMap.set("primary", bgColors.primarybg)
+
+    // Add background-only colors (like purple)
+    for (const [name, config] of Object.entries(BACKGROUND_ONLY_COLORS)) {
+      const bgColor = bgColors[config.bgColorKey as keyof typeof bgColors]
+      if (typeof bgColor === "string") {
+        colorMap.set(name, bgColor)
+      }
+    }
+
+    namedBgColorCache.set(theme, colorMap)
   }
   return colorMap
 }
 
 /**
- * Resolve a built-in color name to its theme color value.
- * If the color is not a built-in name, returns it unchanged.
+ * Resolve a named color to its theme color value.
+ * If the color is not a named color, returns it unchanged.
  *
  * Note: "purple" is not supported here (no purpleColor exists in the theme).
  * Use "violet" instead. For background colors, both "purple" and "violet"
- * are supported via resolveBuiltinBackgroundColor().
+ * are supported via resolveNamedBackgroundColor().
  *
  * @param color - The color string to resolve
  * @param theme - The EmotionTheme containing color values
- * @returns The resolved theme color or the original color if not a built-in name
+ * @returns The resolved theme color or the original color if not a named color
  */
-export function resolveBuiltinColor(
-  color: string,
-  theme: EmotionTheme
-): string {
-  const colorMap = getBuiltinColorMap(theme)
-  return colorMap[color.toLowerCase()] ?? color
+export function resolveNamedColor(color: string, theme: EmotionTheme): string {
+  const colorMap = getNamedColorMap(theme)
+  return colorMap.get(color.toLowerCase()) ?? color
 }
 
 /**
- * Resolve a built-in color name to its theme background color value.
- * If the color is not a built-in name, returns it unchanged.
+ * Resolve a named color to its theme background color value.
+ * If the color is not a named color, returns it unchanged.
  *
  * Note: "purple" and "violet" have distinct background colors.
  *
  * @param color - The color string to resolve
  * @param theme - The EmotionTheme containing color values
- * @returns The resolved theme background color or the original color if not a built-in name
+ * @returns The resolved theme background color or the original color if not a named color
  */
-export function resolveBuiltinBackgroundColor(
+export function resolveNamedBackgroundColor(
   color: string,
   theme: EmotionTheme
 ): string {
-  const colorMap = getBuiltinBgColorMap(theme)
-  return colorMap[color.toLowerCase()] ?? color
+  const colorMap = getNamedBgColorMap(theme)
+  return colorMap.get(color.toLowerCase()) ?? color
 }

--- a/frontend/lib/src/theme/getColors.ts
+++ b/frontend/lib/src/theme/getColors.ts
@@ -17,6 +17,7 @@
 import { darken, getLuminance, lighten, mix, transparentize } from "color2k"
 
 import {
+  BuiltinColorName,
   DerivedColors,
   EmotionTheme,
   EmotionThemeColors,
@@ -137,7 +138,7 @@ export function getDividerColors(theme: EmotionTheme): DividerColors {
   }
 }
 
-type MarkdownBgColors = {
+type ThemeBackgroundColors = {
   redbg: string
   orangebg: string
   yellowbg: string
@@ -149,7 +150,9 @@ type MarkdownBgColors = {
   primarybg: string
 }
 
-export function getMarkdownBgColors(theme: EmotionTheme): MarkdownBgColors {
+export function getThemeBackgroundColors(
+  theme: EmotionTheme
+): ThemeBackgroundColors {
   const lightTheme = hasLightBackgroundColor(theme)
   const colors = theme.colors
 
@@ -323,4 +326,118 @@ export function getIncreasingGreen(theme: EmotionTheme): string {
   return hasLightBackgroundColor(theme)
     ? theme.colors.blueGreen80
     : theme.colors.green40
+}
+
+/**
+ * Set of built-in color names for quick lookup.
+ */
+export const BUILTIN_COLOR_NAMES: ReadonlySet<string> = new Set([
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "violet",
+  "gray",
+  "grey",
+  "primary",
+])
+
+/**
+ * Type guard to check if a value is a built-in color name.
+ */
+export function isBuiltinColorName(value: unknown): value is BuiltinColorName {
+  return (
+    typeof value === "string" && BUILTIN_COLOR_NAMES.has(value.toLowerCase())
+  )
+}
+
+// Cache color mappings per theme to avoid recreating objects on every call.
+// WeakMap allows garbage collection when themes are no longer referenced.
+const builtinColorCache = new WeakMap<EmotionTheme, Record<string, string>>()
+const builtinBgColorCache = new WeakMap<EmotionTheme, Record<string, string>>()
+
+/**
+ * Get or create the builtin color mapping for a theme.
+ */
+function getBuiltinColorMap(theme: EmotionTheme): Record<string, string> {
+  let colorMap = builtinColorCache.get(theme)
+  if (!colorMap) {
+    colorMap = {
+      red: theme.colors.redColor,
+      orange: theme.colors.orangeColor,
+      yellow: theme.colors.yellowColor,
+      green: theme.colors.greenColor,
+      blue: theme.colors.blueColor,
+      violet: theme.colors.violetColor,
+      gray: theme.colors.grayColor,
+      grey: theme.colors.grayColor,
+      primary: theme.colors.primary,
+    }
+    builtinColorCache.set(theme, colorMap)
+  }
+  return colorMap
+}
+
+/**
+ * Get or create the builtin background color mapping for a theme.
+ */
+function getBuiltinBgColorMap(theme: EmotionTheme): Record<string, string> {
+  let colorMap = builtinBgColorCache.get(theme)
+  if (!colorMap) {
+    const bgColors = getThemeBackgroundColors(theme)
+    colorMap = {
+      red: bgColors.redbg,
+      orange: bgColors.orangebg,
+      yellow: bgColors.yellowbg,
+      green: bgColors.greenbg,
+      blue: bgColors.bluebg,
+      violet: bgColors.violetbg,
+      // "purple" has its own distinct background color (different from violet)
+      purple: bgColors.purplebg,
+      gray: bgColors.graybg,
+      grey: bgColors.graybg,
+      primary: bgColors.primarybg,
+    }
+    builtinBgColorCache.set(theme, colorMap)
+  }
+  return colorMap
+}
+
+/**
+ * Resolve a built-in color name to its theme color value.
+ * If the color is not a built-in name, returns it unchanged.
+ *
+ * Note: "purple" is not supported here (no purpleColor exists in the theme).
+ * Use "violet" instead. For background colors, both "purple" and "violet"
+ * are supported via resolveBuiltinBackgroundColor().
+ *
+ * @param color - The color string to resolve
+ * @param theme - The EmotionTheme containing color values
+ * @returns The resolved theme color or the original color if not a built-in name
+ */
+export function resolveBuiltinColor(
+  color: string,
+  theme: EmotionTheme
+): string {
+  const colorMap = getBuiltinColorMap(theme)
+  return colorMap[color.toLowerCase()] ?? color
+}
+
+/**
+ * Resolve a built-in color name to its theme background color value.
+ * If the color is not a built-in name, returns it unchanged.
+ *
+ * Note: "purple" and "violet" have distinct background colors.
+ *
+ * @param color - The color string to resolve
+ * @param theme - The EmotionTheme containing color values
+ * @returns The resolved theme background color or the original color if not a built-in name
+ */
+export function resolveBuiltinBackgroundColor(
+  color: string,
+  theme: EmotionTheme
+): string {
+  const colorMap = getBuiltinBgColorMap(theme)
+  return colorMap[color.toLowerCase()] ?? color
 }

--- a/frontend/lib/src/theme/index.ts
+++ b/frontend/lib/src/theme/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from "./baseui"
+export * from "./namedColors"
 export * from "./consts"
 export * from "./getColors"
 export * from "./globalStyles"

--- a/frontend/lib/src/theme/namedColors.test.ts
+++ b/frontend/lib/src/theme/namedColors.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BACKGROUND_ONLY_COLORS,
+  isNamedColor,
+  NAMED_COLOR_CONFIG,
+  NAMED_COLORS,
+  NamedColor,
+} from "./namedColors"
+
+describe("namedColors", () => {
+  describe("NAMED_COLOR_CONFIG", () => {
+    it("contains all standard color names", () => {
+      const expectedColors = [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "violet",
+        "gray",
+        "grey",
+        "primary",
+      ]
+      expectedColors.forEach(color => {
+        expect(NAMED_COLOR_CONFIG).toHaveProperty(color)
+      })
+    })
+
+    it("each entry has colorKey property", () => {
+      Object.entries(NAMED_COLOR_CONFIG).forEach(([_name, config]) => {
+        expect(config).toHaveProperty("colorKey")
+        expect(typeof config.colorKey).toBe("string")
+      })
+    })
+
+    it("each entry has bgColorKey property (string or null)", () => {
+      Object.entries(NAMED_COLOR_CONFIG).forEach(([_name, config]) => {
+        expect(config).toHaveProperty("bgColorKey")
+        expect(
+          config.bgColorKey === null || typeof config.bgColorKey === "string"
+        ).toBe(true)
+      })
+    })
+
+    it("grey is an alias for gray", () => {
+      expect(NAMED_COLOR_CONFIG.grey.colorKey).toBe(
+        NAMED_COLOR_CONFIG.gray.colorKey
+      )
+      expect(NAMED_COLOR_CONFIG.grey.bgColorKey).toBe(
+        NAMED_COLOR_CONFIG.gray.bgColorKey
+      )
+    })
+
+    it("primary has null bgColorKey (computed separately)", () => {
+      expect(NAMED_COLOR_CONFIG.primary.bgColorKey).toBeNull()
+    })
+  })
+
+  describe("BACKGROUND_ONLY_COLORS", () => {
+    it("contains purple (distinct from violet)", () => {
+      expect(BACKGROUND_ONLY_COLORS).toHaveProperty("purple")
+      expect(BACKGROUND_ONLY_COLORS.purple.bgColorKey).toBe("purplebg")
+    })
+  })
+
+  describe("NAMED_COLORS", () => {
+    it("is derived from NAMED_COLOR_CONFIG keys", () => {
+      const configKeys = Object.keys(NAMED_COLOR_CONFIG)
+      expect(NAMED_COLORS.size).toBe(configKeys.length)
+      configKeys.forEach(key => {
+        expect(NAMED_COLORS.has(key)).toBe(true)
+      })
+    })
+
+    it("does not include background-only colors", () => {
+      Object.keys(BACKGROUND_ONLY_COLORS).forEach(key => {
+        expect(NAMED_COLORS.has(key)).toBe(false)
+      })
+    })
+  })
+
+  describe("NamedColor type", () => {
+    it("accepts all config keys at compile time", () => {
+      // This is a compile-time check - if it compiles, the type is correct
+      const validColors: NamedColor[] = [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "violet",
+        "gray",
+        "grey",
+        "primary",
+      ]
+      expect(validColors).toHaveLength(Object.keys(NAMED_COLOR_CONFIG).length)
+    })
+  })
+
+  describe("isNamedColor", () => {
+    it.each([
+      "red",
+      "orange",
+      "yellow",
+      "green",
+      "blue",
+      "violet",
+      "gray",
+      "grey",
+      "primary",
+    ])('returns true for "%s"', color => {
+      expect(isNamedColor(color)).toBe(true)
+    })
+
+    it.each(["RED", "Red", "BLUE", "Blue", "PRIMARY", "Primary"])(
+      'returns true for case-insensitive "%s"',
+      color => {
+        expect(isNamedColor(color)).toBe(true)
+      }
+    )
+
+    it.each(["#ff0000", "rgb(255,0,0)", "pink", "cyan", "purple", "magenta"])(
+      'returns false for non-builtin "%s"',
+      color => {
+        expect(isNamedColor(color)).toBe(false)
+      }
+    )
+
+    it.each([null, undefined, 123, [], {}, true])(
+      "returns false for non-string %p",
+      value => {
+        expect(isNamedColor(value)).toBe(false)
+      }
+    )
+  })
+})

--- a/frontend/lib/src/theme/namedColors.ts
+++ b/frontend/lib/src/theme/namedColors.ts
@@ -15,10 +15,19 @@
  */
 
 /**
+ * Named Colors - Single Source of Truth
+ *
  * This file defines all named colors (e.g., "red", "blue", "primary") and
- * their mappings to theme color properties.
+ * their mappings to theme color properties. Named colors can be used across
+ * charts, DataFrame columns, and other Streamlit components.
+ *
  * To add a new color: add it to NAMED_COLOR_CONFIG below.
  * The type and set are automatically derived from the config.
+ *
+ * NOTE: "purple" and "violet" are handled differently:
+ * - For main colors, "purple" is not supported (passes through unchanged).
+ * - For background colors, "purple" is computed as purplebg (DISTINCT from violet)
+ *   in order to support the rainbow gradient.
  */
 
 /**

--- a/frontend/lib/src/theme/namedColors.ts
+++ b/frontend/lib/src/theme/namedColors.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file defines all named colors (e.g., "red", "blue", "primary") and
+ * their mappings to theme color properties.
+ * To add a new color: add it to NAMED_COLOR_CONFIG below.
+ * The type and set are automatically derived from the config.
+ */
+
+/**
+ * Configuration for mapping named colors to theme color keys.
+ * Each entry maps a user-facing color name to the corresponding theme property.
+ *
+ * colorKey: The theme.colors property for the main color (e.g., "redColor")
+ * bgColorKey: The theme.colors property for background color, or null if computed
+ */
+export const NAMED_COLOR_CONFIG = {
+  red: { colorKey: "redColor", bgColorKey: "redBackgroundColor" },
+  orange: { colorKey: "orangeColor", bgColorKey: "orangeBackgroundColor" },
+  yellow: { colorKey: "yellowColor", bgColorKey: "yellowBackgroundColor" },
+  green: { colorKey: "greenColor", bgColorKey: "greenBackgroundColor" },
+  blue: { colorKey: "blueColor", bgColorKey: "blueBackgroundColor" },
+  violet: { colorKey: "violetColor", bgColorKey: "violetBackgroundColor" },
+  gray: { colorKey: "grayColor", bgColorKey: "grayBackgroundColor" },
+  grey: { colorKey: "grayColor", bgColorKey: "grayBackgroundColor" }, // alias
+  primary: { colorKey: "primary", bgColorKey: null }, // primary bg is computed
+} as const
+
+/**
+ * Additional background colors that don't have a corresponding main color.
+ * These are only available via resolveNamedBackgroundColor().
+ */
+export const BACKGROUND_ONLY_COLORS = {
+  purple: { bgColorKey: "purplebg" }, // distinct from violet
+} as const
+
+/**
+ * Named colors that map to Streamlit theme colors.
+ * Derived from NAMED_COLOR_CONFIG - this is the single source of truth.
+ */
+export type NamedColor = keyof typeof NAMED_COLOR_CONFIG
+
+/**
+ * Set of named colors for quick runtime lookup.
+ * Derived from NAMED_COLOR_CONFIG to ensure consistency.
+ */
+export const NAMED_COLORS: ReadonlySet<string> = new Set(
+  Object.keys(NAMED_COLOR_CONFIG)
+)
+
+/**
+ * Type guard to check if a value is a named color.
+ */
+export function isNamedColor(value: unknown): value is NamedColor {
+  return typeof value === "string" && NAMED_COLORS.has(value.toLowerCase())
+}

--- a/frontend/lib/src/theme/types.ts
+++ b/frontend/lib/src/theme/types.ts
@@ -131,3 +131,37 @@ export type IconSize = keyof IconSizes
 export type ThemeSizing = keyof ThemeSizings
 export type ThemeSpacing = keyof ThemeSpacings
 export type PresetThemeName = "Light" | "Dark"
+
+/**
+ * Built-in color names that map to Streamlit theme colors.
+ * Used across charts, DataFrame columns, and other components.
+ */
+export type BuiltinColorName =
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "violet"
+  | "gray"
+  | "grey"
+  | "primary"
+
+/**
+ * Auto color modes for charts and progress bars.
+ * - "auto": Green when positive/increasing, red when negative/decreasing
+ * - "auto-inverse": Red when positive/increasing, green when negative/decreasing
+ */
+export type ChartAutoColor = "auto" | "auto-inverse"
+
+/**
+ * Branded type for CSS color strings (hex, rgb, etc.)
+ * Allows any string while providing type safety for color values.
+ */
+declare const __cssColorBrand: unique symbol
+export type CSSColorString = string & { readonly [__cssColorBrand]?: never }
+
+/**
+ * Union of all valid color parameter values for charts and progress bars.
+ */
+export type ChartColor = ChartAutoColor | BuiltinColorName | CSSColorString

--- a/frontend/lib/src/theme/types.ts
+++ b/frontend/lib/src/theme/types.ts
@@ -25,7 +25,10 @@ import {
   RequiredThemeColors,
 } from "./emotionBaseTheme/themeColors"
 import { ThemeShadows } from "./getShadows"
+import type { NamedColor } from "./namedColors"
 import { PrimitiveColors } from "./primitives"
+// Re-export NamedColor from the single source of truth
+export type { NamedColor } from "./namedColors"
 
 /**
  * Comprehensive type for emotion theme colors.
@@ -133,21 +136,6 @@ export type ThemeSpacing = keyof ThemeSpacings
 export type PresetThemeName = "Light" | "Dark"
 
 /**
- * Built-in color names that map to Streamlit theme colors.
- * Used across charts, DataFrame columns, and other components.
- */
-export type BuiltinColorName =
-  | "red"
-  | "orange"
-  | "yellow"
-  | "green"
-  | "blue"
-  | "violet"
-  | "gray"
-  | "grey"
-  | "primary"
-
-/**
  * Auto color modes for charts and progress bars.
  * - "auto": Green when positive/increasing, red when negative/decreasing
  * - "auto-inverse": Red when positive/increasing, green when negative/decreasing
@@ -164,4 +152,4 @@ export type CSSColorString = string & { readonly [__cssColorBrand]?: never }
 /**
  * Union of all valid color parameter values for charts and progress bars.
  */
-export type ChartColor = ChartAutoColor | BuiltinColorName | CSSColorString
+export type ChartColor = ChartAutoColor | NamedColor | CSSColorString

--- a/frontend/lib/src/theme/types.ts
+++ b/frontend/lib/src/theme/types.ts
@@ -27,8 +27,6 @@ import {
 import { ThemeShadows } from "./getShadows"
 import type { NamedColor } from "./namedColors"
 import { PrimitiveColors } from "./primitives"
-// Re-export NamedColor from the single source of truth
-export type { NamedColor } from "./namedColors"
 
 /**
  * Comprehensive type for emotion theme colors.


### PR DESCRIPTION
## Describe your changes
Consolidates duplicated named color mapping logic into a single source of truth (`namedColors.ts`), improving maintainability and type safety.
Removed duplication across `ArrowVegaLiteChart/colorUtils.ts`, `ChartColumn.ts`, `ProgressColumn.ts`, and `MultiselectColumn.ts`

| Name          | Main Color    | Background Color       |
|---------------|---------------|------------------------|
| `red`         | `redColor`    | `redBackgroundColor`   |
| `orange`      | `orangeColor` | `orangeBackgroundColor`|
| `yellow`      | `yellowColor` | `yellowBackgroundColor`|
| `green`       | `greenColor`  | `greenBackgroundColor` |
| `blue`        | `blueColor`   | `blueBackgroundColor`  |
| `violet`      | `violetColor` | `violetBackgroundColor`|
| `gray`/`grey` | `grayColor`   | `grayBackgroundColor`  |
| `primary`     | `primary`     | computed               |
| `purple`      | ❌ not supported | `purplebg` (for rainbow gradient) |

## Testing Plan
- JS Unit Tests: ✅ Added & Updated
