### PR TITLE
Add `make check` command for validating changes

### DIFF
--- a/.cursor/rules/make_commands.mdc
+++ b/.cursor/rules/make_commands.mdc
@@ -45,6 +45,7 @@ trace-e2e-test            Run e2e test with tracing and view it. Use via `make t
 lighthouse-tests          Run Lighthouse performance tests.
 bare-execution-tests      Run all e2e tests in bare mode.
 cli-smoke-tests           Run CLI smoke tests.
+check                     Run format, lint, and test checks on changed (uncommitted) files only. Auto-fixes where possible.
 autofix                   Autofix linting and formatting errors.
 package                   Create Python wheel files in `dist/`.
 conda-package             Create conda distribution files.

--- a/.cursor/rules/make_commands.mdc
+++ b/.cursor/rules/make_commands.mdc
@@ -45,7 +45,7 @@ trace-e2e-test            Run e2e test with tracing and view it. Use via `make t
 lighthouse-tests          Run Lighthouse performance tests.
 bare-execution-tests      Run all e2e tests in bare mode.
 cli-smoke-tests           Run CLI smoke tests.
-check                     Run format, lint, and test checks on changed (uncommitted) files only. Auto-fixes where possible.
+check                     Run all checks (format, lint, types, unit tests) on changed files only. Useful to verify the current state of the codebase before committing.
 autofix                   Autofix linting and formatting errors.
 package                   Create Python wheel files in `dist/`.
 conda-package             Create conda distribution files.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -46,7 +46,7 @@ alwaysApply: true
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands.
-- `check`: Run all checks (format, lint, types, tests) on changed files only.
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Useful to verify the current state of the codebase before committing.
 - `protobuf`: Recompile Protobufs for Python and the frontend.
 - `autofix`: Autofix linting and formatting errors.
 
@@ -86,19 +86,3 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright.
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
-
-## Completing Work Sessions
-
-Before finishing any work session, **always run `make check`** to validate your changes:
-
-```bash
-make check
-```
-
-This command runs all relevant checks (formatting, linting, type checking, and unit tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. E2E tests are not included - use `make run-e2e-test` for those. If any issues are found:
-
-1. Fix the reported issues.
-2. Re-run `make check`.
-3. Repeat until all checks pass.
-
-Only consider your work complete when `make check` succeeds with no errors.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -95,7 +95,7 @@ Before finishing any work session, **always run `make check`** to validate your 
 make check
 ```
 
-This command runs all relevant checks (formatting, linting, type checking, and tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. If any issues are found:
+This command runs all relevant checks (formatting, linting, type checking, and unit tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. E2E tests are not included - use `make run-e2e-test` for those. If any issues are found:
 
 1. Fix the reported issues.
 2. Re-run `make check`.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -46,6 +46,7 @@ alwaysApply: true
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands.
+- `check`: Run all checks (format, lint, types, tests) on changed files only.
 - `protobuf`: Recompile Protobufs for Python and the frontend.
 - `autofix`: Autofix linting and formatting errors.
 
@@ -85,3 +86,19 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright.
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Completing Work Sessions
+
+Before finishing any work session, **always run `make check`** to validate your changes:
+
+```bash
+make check
+```
+
+This command runs all relevant checks (formatting, linting, type checking, and tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. If any issues are found:
+
+1. Fix the reported issues.
+2. Re-run `make check`.
+3. Repeat until all checks pass.
+
+Only consider your work complete when `make check` succeeds with no errors.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands.
-- `check`: Run all checks (format, lint, types, tests) on changed files only.
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Useful to verify the current state of the codebase before committing.
 - `protobuf`: Recompile Protobufs for Python and the frontend.
 - `autofix`: Autofix linting and formatting errors.
 
@@ -80,19 +80,3 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright.
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
-
-## Completing Work Sessions
-
-Before finishing any work session, **always run `make check`** to validate your changes:
-
-```bash
-make check
-```
-
-This command runs all relevant checks (formatting, linting, type checking, and unit tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. E2E tests are not included - use `make run-e2e-test` for those. If any issues are found:
-
-1. Fix the reported issues.
-2. Re-run `make check`.
-3. Repeat until all checks pass.
-
-Only consider your work complete when `make check` succeeds with no errors.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,7 @@ Before finishing any work session, **always run `make check`** to validate your 
 make check
 ```
 
-This command runs all relevant checks (formatting, linting, type checking, and tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. If any issues are found:
+This command runs all relevant checks (formatting, linting, type checking, and unit tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. E2E tests are not included - use `make run-e2e-test` for those. If any issues are found:
 
 1. Fix the reported issues.
 2. Re-run `make check`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,7 @@
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands.
+- `check`: Run all checks (format, lint, types, tests) on changed files only.
 - `protobuf`: Recompile Protobufs for Python and the frontend.
 - `autofix`: Autofix linting and formatting errors.
 
@@ -79,3 +80,19 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright.
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Completing Work Sessions
+
+Before finishing any work session, **always run `make check`** to validate your changes:
+
+```bash
+make check
+```
+
+This command runs all relevant checks (formatting, linting, type checking, and tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. If any issues are found:
+
+1. Fix the reported issues.
+2. Re-run `make check`.
+3. Repeat until all checks pass.
+
+Only consider your work complete when `make check` succeeds with no errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands.
-- `check`: Run all checks (format, lint, types, tests) on changed files only.
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Useful to verify the current state of the codebase before committing.
 - `protobuf`: Recompile Protobufs for Python and the frontend.
 - `autofix`: Autofix linting and formatting errors.
 
@@ -80,19 +80,3 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright.
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
-
-## Completing Work Sessions
-
-Before finishing any work session, **always run `make check`** to validate your changes:
-
-```bash
-make check
-```
-
-This command runs all relevant checks (formatting, linting, type checking, and unit tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. E2E tests are not included - use `make run-e2e-test` for those. If any issues are found:
-
-1. Fix the reported issues.
-2. Re-run `make check`.
-3. Repeat until all checks pass.
-
-Only consider your work complete when `make check` succeeds with no errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Before finishing any work session, **always run `make check`** to validate your 
 make check
 ```
 
-This command runs all relevant checks (formatting, linting, type checking, and tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. If any issues are found:
+This command runs all relevant checks (formatting, linting, type checking, and unit tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. E2E tests are not included - use `make run-e2e-test` for those. If any issues are found:
 
 1. Fix the reported issues.
 2. Re-run `make check`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands.
+- `check`: Run all checks (format, lint, types, tests) on changed files only.
 - `protobuf`: Recompile Protobufs for Python and the frontend.
 - `autofix`: Autofix linting and formatting errors.
 
@@ -79,3 +80,19 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright.
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Completing Work Sessions
+
+Before finishing any work session, **always run `make check`** to validate your changes:
+
+```bash
+make check
+```
+
+This command runs all relevant checks (formatting, linting, type checking, and tests) on uncommitted changes only (staged, unstaged, and untracked files). Already committed files are not checked. If any issues are found:
+
+1. Fix the reported issues.
+2. Re-run `make check`.
+3. Repeat until all checks pass.
+
+Only consider your work complete when `make check` succeeds with no errors.

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,13 @@ check:
 		cd lib && PYTHONPATH=. pytest -v $$PY_TESTS || exit 1; \
 		echo ""; \
 	fi
+	@# Pre-commit hooks on all changed files (handles formatting and linting)
+	@CHANGED=$$(python3 scripts/get_changed_files.py --all); \
+	if [ -n "$$CHANGED" ]; then \
+		echo "=== Pre-commit hooks ==="; \
+		pre-commit run --files $$CHANGED || exit 1; \
+		echo ""; \
+	fi
 	@# Frontend lint (with auto-fix)
 	@FE_FILES=$$(python3 scripts/get_changed_files.py --frontend --frontend-tests --strip-prefix frontend/); \
 	if [ -n "$$FE_FILES" ]; then \
@@ -458,13 +465,6 @@ check:
 		echo "=== Frontend: tests (vitest) ==="; \
 		echo "Running: $$FE_TESTS"; \
 		cd frontend && yarn vitest run $$FE_TESTS || exit 1; \
-		echo ""; \
-	fi
-	@# Pre-commit hooks on all changed files (handles formatting and linting)
-	@CHANGED=$$(python3 scripts/get_changed_files.py --all); \
-	if [ -n "$$CHANGED" ]; then \
-		echo "=== Pre-commit hooks ==="; \
-		pre-commit run --files $$CHANGED || exit 1; \
 		echo ""; \
 	fi
 	@echo "=== All checks passed! ==="

--- a/Makefile
+++ b/Makefile
@@ -458,6 +458,9 @@ check:
 		echo "=== Frontend: lint (eslint) ==="; \
 		cd frontend && ./node_modules/.bin/eslint --fix $$FE_FILES || exit 1; \
 		echo ""; \
+	else \
+		echo "No frontend files changed."; \
+		echo ""; \
 	fi
 	@# Frontend tests
 	@FE_TESTS=$$(python3 scripts/get_changed_files.py --frontend-tests --strip-prefix frontend/); \

--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ cli-smoke-tests:
 	python3 scripts/cli_smoke_tests.py
 
 .PHONY: check
-# Run format, lint, and test checks on changed (uncommitted) files only. Auto-fixes where possible.
+# Run all checks (format, lint, types, unit tests) on changed files only. Useful to verify the current state of the codebase before committing.
 check:
 	@echo "=== Checking changed files ==="
 	@CHANGED=$$(python3 scripts/get_changed_files.py --all); \

--- a/Makefile
+++ b/Makefile
@@ -445,14 +445,14 @@ check:
 		cd lib && PYTHONPATH=. pytest -v $$PY_TESTS || exit 1; \
 		echo ""; \
 	fi
-	@# Pre-commit hooks on all changed files (handles formatting and linting)
+	@# Pre-commit hooks on all changed files (handles frontend formatting via prettier)
 	@CHANGED=$$(python3 scripts/get_changed_files.py --all); \
 	if [ -n "$$CHANGED" ]; then \
 		echo "=== Pre-commit hooks ==="; \
 		pre-commit run --files $$CHANGED || exit 1; \
 		echo ""; \
 	fi
-	@# Frontend lint (with auto-fix)
+	@# Frontend lint only (formatting is handled by pre-commit above)
 	@FE_FILES=$$(python3 scripts/get_changed_files.py --frontend --frontend-tests --strip-prefix frontend/); \
 	if [ -n "$$FE_FILES" ]; then \
 		echo "=== Frontend: lint (eslint) ==="; \

--- a/Makefile
+++ b/Makefile
@@ -406,6 +406,69 @@ bare-execution-tests:
 cli-smoke-tests:
 	python3 scripts/cli_smoke_tests.py
 
+.PHONY: check
+# Run format, lint, and test checks on changed (uncommitted) files only. Auto-fixes where possible.
+check:
+	@echo "=== Checking changed files ==="
+	@CHANGED=$$(python3 scripts/get_changed_files.py --all); \
+	if [ -z "$$CHANGED" ]; then \
+		echo "No changed files found."; \
+		exit 0; \
+	fi; \
+	echo "Changed files:"; \
+	echo "$$CHANGED" | tr ' ' '\n' | sed 's/^/  /'; \
+	echo ""
+	@# Python format and lint checks (with auto-fix)
+	@PY_FILES=$$(python3 scripts/get_changed_files.py --python --python-tests); \
+	if [ -n "$$PY_FILES" ]; then \
+		echo "=== Python: format (ruff) ==="; \
+		ruff format $$PY_FILES || exit 1; \
+		echo ""; \
+		echo "=== Python: lint (ruff) ==="; \
+		ruff check --fix $$PY_FILES || exit 1; \
+		echo ""; \
+		echo "=== Python: type check (ty) ==="; \
+		ty check $$PY_FILES || exit 1; \
+		echo ""; \
+		echo "=== Python: type check (mypy) ==="; \
+		mypy --config-file=mypy.ini $$PY_FILES || exit 1; \
+		echo ""; \
+	else \
+		echo "No Python files changed."; \
+		echo ""; \
+	fi
+	@# Python tests
+	@PY_TESTS=$$(python3 scripts/get_changed_files.py --python-tests --strip-prefix lib/); \
+	if [ -n "$$PY_TESTS" ]; then \
+		echo "=== Python: tests (pytest) ==="; \
+		echo "Running: $$PY_TESTS"; \
+		cd lib && PYTHONPATH=. pytest -v $$PY_TESTS || exit 1; \
+		echo ""; \
+	fi
+	@# Frontend lint (with auto-fix)
+	@FE_FILES=$$(python3 scripts/get_changed_files.py --frontend --frontend-tests --strip-prefix frontend/); \
+	if [ -n "$$FE_FILES" ]; then \
+		echo "=== Frontend: lint (eslint) ==="; \
+		cd frontend && ./node_modules/.bin/eslint --fix $$FE_FILES || exit 1; \
+		echo ""; \
+	fi
+	@# Frontend tests
+	@FE_TESTS=$$(python3 scripts/get_changed_files.py --frontend-tests --strip-prefix frontend/); \
+	if [ -n "$$FE_TESTS" ]; then \
+		echo "=== Frontend: tests (vitest) ==="; \
+		echo "Running: $$FE_TESTS"; \
+		cd frontend && yarn vitest run $$FE_TESTS || exit 1; \
+		echo ""; \
+	fi
+	@# Pre-commit hooks on all changed files (handles formatting and linting)
+	@CHANGED=$$(python3 scripts/get_changed_files.py --all); \
+	if [ -n "$$CHANGED" ]; then \
+		echo "=== Pre-commit hooks ==="; \
+		pre-commit run --files $$CHANGED || exit 1; \
+		echo ""; \
+	fi
+	@echo "=== All checks passed! ==="
+
 .PHONY: autofix
 # Autofix linting and formatting errors.
 autofix:

--- a/scripts/get_changed_files.py
+++ b/scripts/get_changed_files.py
@@ -27,6 +27,9 @@ Usage:
     python scripts/get_changed_files.py --all --base-branch main
 
 Output is space-separated file paths, suitable for passing to commands.
+
+Note: Files with spaces in their paths are not supported and will be ignored.
+This is a limitation of the space-separated output format used for shell consumption.
 """
 
 from __future__ import annotations
@@ -70,7 +73,14 @@ FRONTEND_TEST_PATTERN = r"\.test\.(ts|tsx)$"
 
 
 def _is_excluded(path: str) -> bool:
-    """Check if path should be excluded from checks."""
+    """Check if path should be excluded from checks.
+
+    Excludes:
+    - Paths in EXCLUDED_PATHS (vendor, proto)
+    - Paths containing spaces (not supported due to space-separated output format)
+    """
+    if " " in path:
+        return True
     return any(excluded in path for excluded in EXCLUDED_PATHS)
 
 
@@ -80,6 +90,10 @@ def get_changed_files(base_branch: str | None = None) -> list[str]:
     Args:
         base_branch: If provided, also include files changed between this branch
                      and HEAD (useful for getting all changes in a PR).
+
+    Note:
+        Files with spaces in their paths are excluded (not supported due to
+        space-separated output format).
     """
     files: set[str] = set()
 
@@ -129,7 +143,8 @@ def get_changed_files(base_branch: str | None = None) -> list[str]:
                     f.strip() for f in result.stdout.strip().split("\n") if f.strip()
                 )
 
-    return sorted(files)
+    # Filter out files with spaces (not supported due to space-separated output)
+    return sorted(f for f in files if " " not in f)
 
 
 def get_python_files(files: list[str]) -> list[str]:

--- a/scripts/get_changed_files.py
+++ b/scripts/get_changed_files.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Get changed files by category for use in Makefile targets.
+
+Usage:
+    python scripts/get_changed_files.py --python
+    python scripts/get_changed_files.py --python-tests
+    python scripts/get_changed_files.py --frontend
+    python scripts/get_changed_files.py --frontend-tests
+    python scripts/get_changed_files.py --e2e
+
+    # Include committed changes compared to base branch (for PR-like comparison):
+    python scripts/get_changed_files.py --all --base-branch
+    python scripts/get_changed_files.py --all --base-branch main
+
+Output is space-separated file paths, suitable for passing to commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+
+# Default base branch for comparison
+DEFAULT_BASE_BRANCH = "develop"
+
+# Directory prefixes
+LIB_SOURCE_PREFIX = "lib/streamlit/"
+LIB_TESTS_PREFIX = "lib/tests/streamlit/"
+FRONTEND_PREFIX = "frontend/"
+E2E_PREFIX = "e2e_playwright/"
+
+# Paths to exclude from checks
+EXCLUDED_PATHS = ("/vendor/", "lib/streamlit/proto/")
+
+# File extension patterns
+PYTHON_EXTENSIONS = r"\.(py|pyi)$"
+FRONTEND_EXTENSIONS = r"\.(ts|tsx|js|jsx)$"
+
+# Test file patterns
+PYTHON_TEST_SUFFIX = "_test.py"
+FRONTEND_TEST_PATTERN = r"\.test\.(ts|tsx)$"
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _is_excluded(path: str) -> bool:
+    """Check if path should be excluded from checks."""
+    return any(excluded in path for excluded in EXCLUDED_PATHS)
+
+
+def get_changed_files(base_branch: str | None = None) -> list[str]:
+    """Get all changed files (staged, unstaged, and untracked, excluding deleted).
+
+    Args:
+        base_branch: If provided, also include files changed between this branch
+                     and HEAD (useful for getting all changes in a PR).
+    """
+    files: set[str] = set()
+
+    # Get modified files (staged + unstaged) compared to HEAD
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD", "--diff-filter=d"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if result.returncode == 0:
+        files.update(f.strip() for f in result.stdout.strip().split("\n") if f.strip())
+
+    # Get untracked files (new files not yet added to git)
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if result.returncode == 0:
+        files.update(f.strip() for f in result.stdout.strip().split("\n") if f.strip())
+
+    # If base_branch is provided, also get committed changes since diverging from base
+    if base_branch:
+        # Use merge-base to find common ancestor, then diff from there to HEAD
+        result = subprocess.run(
+            ["git", "merge-base", base_branch, "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        if result.returncode == 0:
+            merge_base = result.stdout.strip()
+            result = subprocess.run(
+                ["git", "diff", "--name-only", merge_base, "HEAD", "--diff-filter=d"],
+                capture_output=True,
+                text=True,
+                cwd=REPO_ROOT,
+                check=False,
+            )
+            if result.returncode == 0:
+                files.update(
+                    f.strip() for f in result.stdout.strip().split("\n") if f.strip()
+                )
+
+    return sorted(files)
+
+
+def get_python_files(files: list[str]) -> list[str]:
+    """Get Python source files (excluding tests, vendor, proto)."""
+    result = []
+    for f in files:
+        if _is_excluded(f):
+            continue
+        if re.search(PYTHON_EXTENSIONS, f) and not f.endswith(PYTHON_TEST_SUFFIX):
+            result.append(f)
+    return result
+
+
+def get_python_test_files(files: list[str]) -> list[str]:
+    """Get Python test files, including mapped tests from changed source files."""
+    test_files = set()
+
+    for f in files:
+        if _is_excluded(f):
+            continue
+
+        if not f.endswith(".py"):
+            continue
+
+        # Direct test file
+        if f.endswith(PYTHON_TEST_SUFFIX):
+            test_files.add(f)
+            continue
+
+        # Map source file to test file: lib/streamlit/foo.py -> lib/tests/streamlit/foo_test.py
+        if f.startswith(LIB_SOURCE_PREFIX):
+            test_file = f.replace(LIB_SOURCE_PREFIX, LIB_TESTS_PREFIX)
+            test_file = re.sub(r"\.py$", PYTHON_TEST_SUFFIX, test_file)
+            if (REPO_ROOT / test_file).exists():
+                test_files.add(test_file)
+
+    return sorted(test_files)
+
+
+def get_frontend_files(files: list[str]) -> list[str]:
+    """Get frontend source files (excluding tests, vendor)."""
+    result = []
+    for f in files:
+        if _is_excluded(f):
+            continue
+        if (
+            f.startswith(FRONTEND_PREFIX)
+            and re.search(FRONTEND_EXTENSIONS, f)
+            and not re.search(FRONTEND_TEST_PATTERN, f)
+        ):
+            result.append(f)
+    return result
+
+
+def get_frontend_test_files(files: list[str]) -> list[str]:
+    """Get frontend test files."""
+    result = []
+    for f in files:
+        if _is_excluded(f):
+            continue
+        if f.startswith(FRONTEND_PREFIX) and re.search(FRONTEND_TEST_PATTERN, f):
+            result.append(f)
+    return result
+
+
+def get_e2e_files(files: list[str]) -> list[str]:
+    """Get e2e test files."""
+    result = []
+    for f in files:
+        if f.startswith(E2E_PREFIX) and f.endswith(PYTHON_TEST_SUFFIX):
+            result.append(f)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Get changed files by category",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--python",
+        action="store_true",
+        help="Python source files (excludes tests)",
+    )
+    parser.add_argument(
+        "--python-tests",
+        action="store_true",
+        help="Python test files (includes mapped tests from source)",
+    )
+    parser.add_argument(
+        "--frontend",
+        action="store_true",
+        help="Frontend source files (excludes tests)",
+    )
+    parser.add_argument(
+        "--frontend-tests",
+        action="store_true",
+        help="Frontend test files",
+    )
+    parser.add_argument(
+        "--e2e",
+        action="store_true",
+        help="E2E test files",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="All changed files (for display)",
+    )
+    parser.add_argument(
+        "--strip-prefix",
+        type=str,
+        metavar="PREFIX",
+        help="Strip prefix from output paths (e.g., 'frontend/' or 'lib/')",
+    )
+    parser.add_argument(
+        "--base-branch",
+        type=str,
+        metavar="BRANCH",
+        nargs="?",
+        const=DEFAULT_BASE_BRANCH,
+        help=(
+            f"Compare against base branch to include committed changes "
+            f"(default: {DEFAULT_BASE_BRANCH} if flag is used without value)"
+        ),
+    )
+
+    args = parser.parse_args()
+
+    # Require at least one category
+    if not any(
+        [
+            args.python,
+            args.python_tests,
+            args.frontend,
+            args.frontend_tests,
+            args.e2e,
+            args.all,
+        ]
+    ):
+        parser.error("At least one category flag is required")
+
+    changed_files = get_changed_files(base_branch=args.base_branch)
+    if not changed_files:
+        return 0
+
+    result_files: list[str] = []
+
+    if args.all:
+        result_files = changed_files
+    else:
+        if args.python:
+            result_files.extend(get_python_files(changed_files))
+        if args.python_tests:
+            result_files.extend(get_python_test_files(changed_files))
+        if args.frontend:
+            result_files.extend(get_frontend_files(changed_files))
+        if args.frontend_tests:
+            result_files.extend(get_frontend_test_files(changed_files))
+        if args.e2e:
+            result_files.extend(get_e2e_files(changed_files))
+
+    # Remove duplicates and sort
+    result_files = sorted(set(result_files))
+
+    # Strip prefix if requested
+    if args.strip_prefix:
+        result_files = [f.removeprefix(args.strip_prefix) for f in result_files]
+
+    # Output space-separated for shell consumption
+    if result_files:
+        print(" ".join(result_files))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/get_changed_files.py
+++ b/scripts/get_changed_files.py
@@ -159,7 +159,10 @@ def get_python_files(files: list[str]) -> list[str]:
 
 
 def get_python_test_files(files: list[str]) -> list[str]:
-    """Get Python test files, including mapped tests from changed source files."""
+    """Get Python unit test files from lib/tests/, including mapped tests from changed source files.
+
+    Note: E2E tests (e2e_playwright/) are excluded - use --e2e for those.
+    """
     test_files = set()
 
     for f in files:
@@ -169,8 +172,12 @@ def get_python_test_files(files: list[str]) -> list[str]:
         if not f.endswith(".py"):
             continue
 
-        # Direct test file
-        if f.endswith(PYTHON_TEST_SUFFIX):
+        # Skip e2e tests - they're handled separately by --e2e
+        if f.startswith(E2E_PREFIX):
+            continue
+
+        # Direct test file (must be in lib/ directory)
+        if f.endswith(PYTHON_TEST_SUFFIX) and f.startswith("lib/"):
             test_files.add(f)
             continue
 

--- a/scripts/get_changed_files.py
+++ b/scripts/get_changed_files.py
@@ -200,14 +200,40 @@ def get_frontend_files(files: list[str]) -> list[str]:
 
 
 def get_frontend_test_files(files: list[str]) -> list[str]:
-    """Get frontend test files."""
-    result = []
+    """Get frontend test files, including mapped tests from changed source files.
+
+    Maps source files to test files in the same directory:
+    - Component.tsx -> Component.test.tsx
+    - utils.ts -> utils.test.ts
+    """
+    test_files: set[str] = set()
+
     for f in files:
         if _is_excluded(f):
             continue
-        if f.startswith(FRONTEND_PREFIX) and re.search(FRONTEND_TEST_PATTERN, f):
-            result.append(f)
-    return result
+
+        if not f.startswith(FRONTEND_PREFIX):
+            continue
+
+        if not re.search(FRONTEND_EXTENSIONS, f):
+            continue
+
+        # Direct test file
+        if re.search(FRONTEND_TEST_PATTERN, f):
+            test_files.add(f)
+            continue
+
+        # Map source file to test file: Component.tsx -> Component.test.tsx
+        # Extract base name and extension
+        match = re.search(r"^(.+)\.(tsx?|jsx?)$", f)
+        if match:
+            base = match.group(1)
+            ext = match.group(2)
+            test_file = f"{base}.test.{ext}"
+            if (REPO_ROOT / test_file).exists():
+                test_files.add(test_file)
+
+    return sorted(test_files)
 
 
 def get_e2e_files(files: list[str]) -> list[str]:


### PR DESCRIPTION
## Describe your changes

Adds a new `make check` command that runs format, lint, type checking, and tests on uncommitted changes only. This helps agents validate their work before completing a session.

Updates documentation in AGENTS.md, copilot instructions, and cursor rules to clarify the purpose and usage of this command.

## Testing Plan

- No additional tests needed as this is a tooling/documentation change
- The `make check` command itself was tested manually during development

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.