### PR TITLE
[fix] Fix number_input submitting stale values when pressing Enter in forms

### DIFF
--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -210,6 +210,27 @@ def test_enter_to_submit_false(app: Page):
     expect(form_8.get_by_test_id("stMarkdown").last).not_to_have_text("Form submitted")
 
 
+def test_number_input_enter_submits_current_value(app: Page):
+    """Tests that pressing Enter on number_input submits the current value (not stale).
+
+    This is a regression test for issue #13751 where the form would submit
+    with the old value instead of the newly typed value when pressing Enter
+    without first blurring the field.
+    """
+    # Use form_1 which has number_input and displays the submitted value
+    form_1 = app.get_by_test_id("stForm").nth(0)
+    number_input = form_1.get_by_test_id("stNumberInput").locator("input")
+
+    # Type a new value and press Enter WITHOUT blurring the field
+    number_input.fill("42")
+    number_input.press("Enter")
+    wait_for_app_run(app)
+
+    # Verify the submitted value is the new value, not the old one (0.0)
+    markdown_elements = app.get_by_test_id("stMarkdown")
+    expect(markdown_elements.nth(3)).to_have_text("Number Input: 42.0")
+
+
 def test_form_submits_on_click(app: Page):
     """Tests that submit via enabled form submit button works."""
     form_6 = app.get_by_test_id("stForm").nth(5)

--- a/e2e_playwright/st_form_test.py
+++ b/e2e_playwright/st_form_test.py
@@ -228,6 +228,7 @@ def test_number_input_enter_submits_current_value(app: Page):
 
     # Verify the submitted value is the new value, not the old one (0.0)
     markdown_elements = app.get_by_test_id("stMarkdown")
+    expect(markdown_elements.nth(3)).not_to_have_text("Number Input: 0.0")
     expect(markdown_elements.nth(3)).to_have_text("Number Input: 42.0")
 
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -311,6 +311,13 @@ describe("NumberInput widget", () => {
       ]
     const submitFormCallIndex = submitFormSpy.mock.invocationCallOrder[0]
     expect(setValueCallIndex).toBeLessThan(submitFormCallIndex)
+
+    // Verify setIntValue was called exactly once with 42 (no duplicate update).
+    // This ensures we don't trigger both the synchronous direct call AND the async effect.
+    const callsWith42 = setIntValueSpy.mock.calls.filter(
+      call => call[1] === 42 && call[2]?.fromUi === true
+    )
+    expect(callsWith42).toHaveLength(1)
   })
 
   it("shows Input Instructions on dirty state when not in form (by default)", async () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -273,6 +273,46 @@ describe("NumberInput widget", () => {
     )
   })
 
+  it("commits value synchronously to widgetMgr before submitForm when pressing Enter", async () => {
+    const user = userEvent.setup()
+    const props = getIntProps({ formId: "form", default: 0 })
+    const setIntValueSpy = vi.spyOn(props.widgetMgr, "setIntValue")
+    vi.spyOn(props.widgetMgr, "allowFormEnterToSubmit").mockReturnValue(true)
+    const submitFormSpy = vi.spyOn(props.widgetMgr, "submitForm")
+
+    render(<NumberInput {...props} />)
+    const numberInput = screen.getByTestId("stNumberInputField")
+
+    // Clear spies before the action we want to test
+    setIntValueSpy.mockClear()
+    submitFormSpy.mockClear()
+
+    await user.clear(numberInput)
+    await user.type(numberInput, "42")
+    await user.keyboard("{enter}")
+
+    // Verify setIntValue was called with 42 BEFORE submitForm.
+    // This is critical: the form must have the current value when it submits.
+    // Find the call that set value to 42 with fromUi: true
+    const setValueCall = setIntValueSpy.mock.calls.find(
+      call => call[1] === 42 && call[2]?.fromUi === true
+    )
+    expect(setValueCall).toBeDefined()
+
+    // Verify submitForm was called
+    expect(submitFormSpy).toHaveBeenCalledWith("form", undefined)
+
+    // Verify the order: setIntValue with 42 should have been called before submitForm
+    const setValueCallIndex =
+      setIntValueSpy.mock.invocationCallOrder[
+        setIntValueSpy.mock.calls.findIndex(
+          call => call[1] === 42 && call[2]?.fromUi === true
+        )
+      ]
+    const submitFormCallIndex = submitFormSpy.mock.invocationCallOrder[0]
+    expect(setValueCallIndex).toBeLessThan(submitFormCallIndex)
+  })
+
   it("shows Input Instructions on dirty state when not in form (by default)", async () => {
     const user = userEvent.setup()
     const props = getIntProps()

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -175,13 +175,16 @@ const NumberInput: React.FC<Props> = ({
   }, [value, dirty, formatCurrentValue])
 
   // Commit a value: validate, update widget manager, and sync to URL
+  // When synchronous=true, also update widget manager immediately (needed for form submit on Enter)
   const commitValue = useCallback(
     ({
       value: valueArg,
       fromUi,
+      synchronous = false,
     }: {
       value: number | null
       fromUi: boolean
+      synchronous?: boolean
     }) => {
       // Validate range and show browser validation message if out of range
       if (notNullOrUndefined(valueArg) && (min > valueArg || valueArg > max)) {
@@ -193,10 +196,33 @@ const NumberInput: React.FC<Props> = ({
 
       setValueWithSource({ value: newValue, fromUi })
 
+      // When synchronous=true, also update widget manager immediately.
+      // This is needed for form submit on Enter: the setValueWithSource above
+      // triggers an async useEffect for widget mgr, but submitForm runs
+      // immediately after, reading stale state. By calling updateWidgetMgrState
+      // directly, we bypass the async path and ensure the form has the current value.
+      if (synchronous) {
+        updateWidgetMgrState(
+          element,
+          widgetMgr,
+          { value: newValue, fromUi },
+          fragmentId
+        )
+      }
+
       setDirty(false)
       setFormattedValue(formatCurrentValue(newValue))
     },
-    [min, max, elementDefault, formatCurrentValue, setValueWithSource]
+    [
+      min,
+      max,
+      elementDefault,
+      formatCurrentValue,
+      setValueWithSource,
+      element,
+      widgetMgr,
+      fragmentId,
+    ]
   )
 
   const handleFocus = useCallback((): void => {
@@ -313,37 +339,13 @@ const NumberInput: React.FC<Props> = ({
     (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
       if (e.key === "Enter") {
         if (dirty) {
-          // Validate range first - if invalid, report and don't submit
-          if (
-            notNullOrUndefined(currentNumericValue) &&
-            (min > currentNumericValue || currentNumericValue > max)
-          ) {
-            inputRef.current?.reportValidity()
-            return
-          }
-
-          const newValue = currentNumericValue ?? elementDefault ?? null
-
-          // Update local state
-          setDirty(false)
-          setFormattedValue(formatCurrentValue(newValue))
-
-          // Update the internal React state so value stays in sync.
-          // This is needed because the useEffect at lines 170-175 will reset
-          // formattedValue based on 'value' when props change (and dirty=false).
-          setValueWithSource({ value: newValue, fromUi: true })
-
-          // CRITICAL: Also update widget manager SYNCHRONOUSLY before form submit.
-          // This ensures the form has the current value when it submits.
-          // The setValueWithSource above triggers an async useEffect for widget mgr,
-          // but submitForm runs immediately after, reading stale state.
-          // By calling updateWidgetMgrState directly, we bypass the async path.
-          updateWidgetMgrState(
-            element,
-            widgetMgr,
-            { value: newValue, fromUi: true },
-            fragmentId
-          )
+          // Commit with synchronous=true to ensure widget manager is updated
+          // before form submission (see commitValue for details)
+          commitValue({
+            value: currentNumericValue,
+            fromUi: true,
+            synchronous: true,
+          })
         }
         if (widgetMgr.allowFormEnterToSubmit(elementFormId)) {
           widgetMgr.submitForm(elementFormId, fragmentId)
@@ -353,15 +355,10 @@ const NumberInput: React.FC<Props> = ({
     [
       dirty,
       currentNumericValue,
-      min,
-      max,
-      elementDefault,
-      formatCurrentValue,
-      setValueWithSource,
-      element,
+      commitValue,
       widgetMgr,
-      fragmentId,
       elementFormId,
+      fragmentId,
     ]
   )
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -175,7 +175,8 @@ const NumberInput: React.FC<Props> = ({
   }, [value, dirty, formatCurrentValue])
 
   // Commit a value: validate, update widget manager, and sync to URL
-  // When synchronous=true, also update widget manager immediately (needed for form submit on Enter)
+  // When synchronous=true, update widget manager directly without triggering
+  // the async effect (needed for form submit on Enter)
   const commitValue = useCallback(
     ({
       value: valueArg,
@@ -194,13 +195,11 @@ const NumberInput: React.FC<Props> = ({
 
       const newValue = valueArg ?? elementDefault ?? null
 
-      setValueWithSource({ value: newValue, fromUi })
-
-      // When synchronous=true, also update widget manager immediately.
-      // This is needed for form submit on Enter: the setValueWithSource above
-      // triggers an async useEffect for widget mgr, but submitForm runs
-      // immediately after, reading stale state. By calling updateWidgetMgrState
-      // directly, we bypass the async path and ensure the form has the current value.
+      // When synchronous=true, update widget manager directly in this event handler.
+      // This follows the "events, not effects" principle from React docs.
+      // We skip setValueWithSource to avoid triggering the async useEffect in
+      // useBasicWidgetState, which would cause a duplicate widget manager update.
+      // The widget manager needs the current value immediately for form submission.
       if (synchronous) {
         updateWidgetMgrState(
           element,
@@ -208,6 +207,9 @@ const NumberInput: React.FC<Props> = ({
           { value: newValue, fromUi },
           fragmentId
         )
+      } else {
+        // Normal async path via useBasicWidgetState effect
+        setValueWithSource({ value: newValue, fromUi })
       }
 
       setDirty(false)
@@ -338,16 +340,19 @@ const NumberInput: React.FC<Props> = ({
   const handleKeyPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
       if (e.key === "Enter") {
+        const willSubmitForm = widgetMgr.allowFormEnterToSubmit(elementFormId)
+
         if (dirty) {
-          // Commit with synchronous=true to ensure widget manager is updated
-          // before form submission (see commitValue for details)
+          // Use synchronous=true only when form submission will follow immediately.
+          // This ensures the widget manager has the current value before submitForm reads it.
+          // For non-form cases, use the normal async path.
           commitValue({
             value: currentNumericValue,
             fromUi: true,
-            synchronous: true,
+            synchronous: willSubmitForm,
           })
         }
-        if (widgetMgr.allowFormEnterToSubmit(elementFormId)) {
+        if (willSubmitForm) {
           widgetMgr.submitForm(elementFormId, fragmentId)
         }
       }

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -313,9 +313,32 @@ const NumberInput: React.FC<Props> = ({
     (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
       if (e.key === "Enter") {
         if (dirty) {
-          // When committing, if currentNumericValue is null (empty input),
-          // commitValue will fall back to elementDefault
-          commitValue({ value: currentNumericValue, fromUi: true })
+          // Validate range first - if invalid, report and don't submit
+          if (
+            notNullOrUndefined(currentNumericValue) &&
+            (min > currentNumericValue || currentNumericValue > max)
+          ) {
+            inputRef.current?.reportValidity()
+            return
+          }
+
+          const newValue = currentNumericValue ?? elementDefault ?? null
+
+          // Update local state
+          setDirty(false)
+          setFormattedValue(formatCurrentValue(newValue))
+
+          // CRITICAL FIX: Update widget manager SYNCHRONOUSLY before form submit.
+          // This ensures the form has the current value when it submits.
+          // The setValueWithSource in commitValue triggers an async useEffect,
+          // but submitForm runs immediately after, reading stale state.
+          // By calling updateWidgetMgrState directly, we bypass the async path.
+          updateWidgetMgrState(
+            element,
+            widgetMgr,
+            { value: newValue, fromUi: true },
+            fragmentId
+          )
         }
         if (widgetMgr.allowFormEnterToSubmit(elementFormId)) {
           widgetMgr.submitForm(elementFormId, fragmentId)
@@ -325,10 +348,14 @@ const NumberInput: React.FC<Props> = ({
     [
       dirty,
       currentNumericValue,
-      commitValue,
+      min,
+      max,
+      elementDefault,
+      formatCurrentValue,
+      element,
       widgetMgr,
-      elementFormId,
       fragmentId,
+      elementFormId,
     ]
   )
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -328,9 +328,14 @@ const NumberInput: React.FC<Props> = ({
           setDirty(false)
           setFormattedValue(formatCurrentValue(newValue))
 
-          // CRITICAL FIX: Update widget manager SYNCHRONOUSLY before form submit.
+          // Update the internal React state so value stays in sync.
+          // This is needed because the useEffect at lines 170-175 will reset
+          // formattedValue based on 'value' when props change (and dirty=false).
+          setValueWithSource({ value: newValue, fromUi: true })
+
+          // CRITICAL: Also update widget manager SYNCHRONOUSLY before form submit.
           // This ensures the form has the current value when it submits.
-          // The setValueWithSource in commitValue triggers an async useEffect,
+          // The setValueWithSource above triggers an async useEffect for widget mgr,
           // but submitForm runs immediately after, reading stale state.
           // By calling updateWidgetMgrState directly, we bypass the async path.
           updateWidgetMgrState(
@@ -352,6 +357,7 @@ const NumberInput: React.FC<Props> = ({
       max,
       elementDefault,
       formatCurrentValue,
+      setValueWithSource,
       element,
       widgetMgr,
       fragmentId,


### PR DESCRIPTION
## Describe your changes

Fixed a bug where pressing Enter in a number_input within a form would submit the old value instead of the newly typed value. The issue occurred when users pressed Enter without first blurring the field. The fix ensures that the current value is properly committed to the widget manager synchronously before form submission.

## GitHub Issue Link (if applicable)

Fixes #13751

## Testing Plan

- E2E Tests: Added a new Playwright test `test_number_input_enter_submits_current_value` that verifies the fix by:
  1. Typing a new value (42) into a number input
  2. Pressing Enter without blurring the field
  3. Verifying the submitted value is 42.0 (the new value) and not 0.0 (the old value)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.