### PR TITLE
Increase ai-pr-review timeout

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -26,7 +26,7 @@ jobs:
   ai-pr-review:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ai-review'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Describe your changes

I have seen it a couple of times that the PR review runs over 15 minutes for more complicated PRs. I think it's fine to increase this to 20 minutes.


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
