### PR TITLE
Improve `streamlit config show` output for theme sourcing

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2705,7 +2705,8 @@ def get_config_options(
 
         # Values set in files later in the CONFIG_FILENAMES list overwrite those
         # set earlier.
-        for filename in get_config_files("config.toml"):
+        config_files = get_config_files("config.toml")
+        for filename in config_files:
             if not os.path.exists(filename):
                 continue
 
@@ -2723,7 +2724,7 @@ def get_config_options(
         # This happens AFTER all config sources (files, env vars, flags) are processed
         # so theme.base can be set via any of those
         config_util.process_theme_inheritance(
-            _config_options, _config_options_template, _set_option
+            _config_options, _config_options_template, _set_option, config_files
         )
 
         if old_options and config_util.server_option_changed(

--- a/lib/streamlit/config_util.py
+++ b/lib/streamlit/config_util.py
@@ -19,10 +19,10 @@ import os
 import re
 import urllib.error
 import urllib.request
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
 from streamlit import cli_util, url_util
 from streamlit.config_option import ConfigOption
@@ -36,6 +36,31 @@ from streamlit.errors import (
 # Maximum size for theme files (1MB). Theme files should be small configuration
 # files containing only theme options, not large data files.
 _MAX_THEME_FILE_SIZE_BYTES = 1024 * 1024  # 1MB
+_CONFIG_FILE_SCOPES = ("global", "project", "script")
+
+
+class _ThemeOverride(TypedDict):
+    value: Any
+    where_defined: str
+
+
+def _format_config_file_label(
+    where_defined: str | None, config_file_paths: Sequence[str] | None
+) -> str | None:
+    """Return a scope-labeled config.toml path if where_defined matches a config file."""
+    if not where_defined or not config_file_paths:
+        return None
+
+    for index, path in enumerate(config_file_paths):
+        if where_defined == path:
+            scope = (
+                _CONFIG_FILE_SCOPES[index] if index < len(_CONFIG_FILE_SCOPES) else None
+            )
+            if scope:
+                return f"config.toml ({scope}): {path}"
+            return f"config.toml: {path}"
+
+    return None
 
 
 def _get_logger() -> Any:
@@ -720,6 +745,7 @@ def process_theme_inheritance(
     config_options: dict[str, ConfigOption] | None,
     config_options_template: dict[str, ConfigOption],
     set_option_func: Any,
+    config_file_paths: Sequence[str] | None = None,
 ) -> None:
     """
     Process theme inheritance if theme.base points to a theme file.
@@ -729,6 +755,18 @@ def process_theme_inheritance(
     current config.toml values override the theme.base file values.
 
     Sets the merged theme options to the config.
+
+    Parameters
+    ----------
+    config_options : dict[str, ConfigOption] | None
+        Current configuration options.
+    config_options_template : dict[str, ConfigOption]
+        Template of all valid config options.
+    set_option_func : Any
+        Function to set config option values.
+    config_file_paths : Sequence[str] | None, optional
+        Ordered list of config.toml file paths (global, project, script).
+        Used to label where_defined with scope for clearer provenance.
     """
     # Get the current theme.base value
     if config_options is None:
@@ -770,7 +808,8 @@ def process_theme_inheritance(
         )
 
         # Preserve theme options set by env vars and command line flags (higher precedence)
-        high_precedence_theme_options = {}
+        high_precedence_theme_options: dict[str, _ThemeOverride] = {}
+        config_theme_overrides: dict[str, _ThemeOverride] = {}
         if config_options is not None:
             for opt_name, opt_config in config_options.items():
                 if (
@@ -786,6 +825,18 @@ def process_theme_inheritance(
                         "value": opt_config.value,
                         "where_defined": opt_config.where_defined,
                     }
+                config_label = _format_config_file_label(
+                    opt_config.where_defined, config_file_paths
+                )
+                if (
+                    opt_name.startswith("theme.")
+                    and opt_name != "theme.base"
+                    and config_label is not None
+                ):
+                    config_theme_overrides[opt_name] = {
+                        "value": opt_config.value,
+                        "where_defined": config_label,
+                    }
 
             # Clear existing theme options (except base) to prepare for inheritance
             theme_options_to_remove = [
@@ -799,18 +850,22 @@ def process_theme_inheritance(
         # Handle theme.base - always set it to a valid value ("light" or "dark", not a path/URL)
         theme_file_base = theme_file_content.get("theme", {}).get("base")
         if theme_file_base:
-            set_option_func("theme.base", theme_file_base, f"theme file: {base_value}")
+            set_option_func(
+                "theme.base", theme_file_base, f"base theme file: {base_value}"
+            )
         else:
             # Theme file doesn't specify a base, default to "light"
-            set_option_func(
-                "theme.base", "light", f"theme file: {base_value} (default)"
-            )
+            set_option_func("theme.base", "light", "default light theme")
 
         # Set the merged theme options using recursive helper
         theme_section = merged_theme.get("theme", {})
         _set_theme_options_recursive(
-            theme_section, "theme", set_option_func, f"theme file: {base_value}"
+            theme_section, "theme", set_option_func, f"base theme file: {base_value}"
         )
+
+        # Restore theme options set in config.toml (override base theme file)
+        for opt_name, opt_data in config_theme_overrides.items():
+            set_option_func(opt_name, opt_data["value"], opt_data["where_defined"])
 
         # Finally, restore theme options set by env vars and command line flags (highest precedence)
         for opt_name, opt_data in high_precedence_theme_options.items():

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -1683,6 +1683,9 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 assert config.get_option("theme.primaryColor") == "#00ff41"
                 assert config.get_option("theme.backgroundColor") == "#0a0a0a"
                 assert config.get_option("theme.textColor") == "#ffffff"
+                assert "base theme file:" in config.get_where_defined(
+                    "theme.primaryColor"
+                )
 
     @patch("streamlit.config_util.url_util.is_url")
     @patch("streamlit.config_util.urllib.request.urlopen")
@@ -1910,7 +1913,9 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 # The original theme.base option should show CLI flag as source
                 # But after inheritance, theme.base gets the value from the theme file
                 # Let's verify a non-base option shows the CLI flag was the trigger
-                assert "theme file:" in config.get_where_defined("theme.primaryColor")
+                assert "base theme file:" in config.get_where_defined(
+                    "theme.primaryColor"
+                )
 
     def test_theme_inheritance_with_base_via_env_var(self):
         """Test theme inheritance when theme.base is set via direct environment variable."""
@@ -1966,7 +1971,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                             )  # From theme file content
 
                             # Verify it shows as coming from theme file (since inheritance processed it)
-                            assert "theme file:" in config.get_where_defined(
+                            assert "base theme file:" in config.get_where_defined(
                                 "theme.primaryColor"
                             )
 
@@ -2017,7 +2022,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                         assert (
                             config.get_option("theme.primaryColor") == "#ffffff"
                         )  # From CLI theme file
-                        assert "theme file:" in config.get_where_defined(
+                        assert "base theme file:" in config.get_where_defined(
                             "theme.primaryColor"
                         )
 
@@ -2049,7 +2054,9 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 assert config.get_option("theme.primaryColor") == "#ff0000"
                 assert config.get_option("theme.backgroundColor") == "#ffffff"
                 assert config.get_option("theme.font") == "serif"
-                assert "theme file:" in config.get_where_defined("theme.primaryColor")
+                assert "base theme file:" in config.get_where_defined(
+                    "theme.primaryColor"
+                )
 
     def test_theme_inheritance_complex_precedence(self):
         """Test complex precedence scenario for theme.base and config.toml overrides."""
@@ -2138,10 +2145,13 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
                 )  # From base theme (no override)
 
                 # Verify where_defined is correct
-                assert "theme file:" in config.get_where_defined(
+                assert "base theme file:" in config.get_where_defined(
                     "theme.backgroundColor"
                 )
-                assert "theme file:" in config.get_where_defined("theme.textColor")
+                assert (
+                    config.get_where_defined("theme.textColor")
+                    == f"config.toml (project): {os.path.join(os.getcwd(), '.streamlit/config.toml')}"
+                )
 
     def test_theme_inheritance_preserves_env_var_and_flag_precedence(self):
         """Test that theme inheritance preserves environment variables and command line flags."""
@@ -2302,12 +2312,12 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
 
                 # Verify where_defined is correct
                 assert (
-                    "theme file"
+                    "base theme file"
                     in config.get_where_defined("theme.light.backgroundColor").lower()
                 )
                 assert (
-                    "theme file"
-                    in config.get_where_defined("theme.sidebar.textColor").lower()
+                    config.get_where_defined("theme.sidebar.textColor")
+                    == f"config.toml (project): {os.path.join(os.getcwd(), '.streamlit/config.toml')}"
                 )
                 assert (
                     "command-line"
@@ -2353,9 +2363,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
 
                 # Verify where_defined shows the default behavior
                 where_defined = config.get_where_defined("theme.base")
-                assert "theme file:" in where_defined
-                assert "(default)" in where_defined
-                assert theme_file in where_defined
+                assert where_defined == "default light theme"
 
                 # Verify theme inheritance worked correctly for other options
                 assert (
@@ -2423,8 +2431,7 @@ class ThemeInheritanceIntegrationTest(unittest.TestCase):
 
                 # Verify where_defined for base shows it's from theme file with default
                 where_defined_base = config.get_where_defined("theme.base")
-                assert "theme file:" in where_defined_base
-                assert "(default)" in where_defined_base
+                assert where_defined_base == "default light theme"
 
                 # Simulate what app_session.py would check (this was the warning source)
                 base_map = {"light": "LIGHT", "dark": "DARK"}

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -82,6 +82,41 @@ class ConfigUtilTest(unittest.TestCase):
         result = config_util._clean_paragraphs("")
         assert result == [""]
 
+    def test_format_config_file_label_scopes(self) -> None:
+        assert (
+            config_util._format_config_file_label(
+                "/global.toml", ["/global.toml", "/project.toml", "/script.toml"]
+            )
+            == "config.toml (global): /global.toml"
+        )
+        assert (
+            config_util._format_config_file_label(
+                "/project.toml", ["/global.toml", "/project.toml", "/script.toml"]
+            )
+            == "config.toml (project): /project.toml"
+        )
+        assert (
+            config_util._format_config_file_label(
+                "/script.toml", ["/global.toml", "/project.toml", "/script.toml"]
+            )
+            == "config.toml (script): /script.toml"
+        )
+
+    def test_format_config_file_label_out_of_range(self) -> None:
+        assert (
+            config_util._format_config_file_label(
+                "/extra.toml",
+                ["/global.toml", "/project.toml", "/script.toml", "/extra.toml"],
+            )
+            == "config.toml: /extra.toml"
+        )
+        assert (
+            config_util._format_config_file_label(
+                "/missing.toml", ["/global.toml", "/project.toml"]
+            )
+            is None
+        )
+
     @patch("click.secho")
     def test_default_config_options_commented_out(self, patched_echo):
         config_options = create_config_options(
@@ -1171,7 +1206,7 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         primary_option = ConfigOption(
             "theme.primaryColor", description="", default_val=None
         )
-        primary_option.set_value("#override", "config.toml")
+        primary_option.set_value("#override", "/project.toml")
 
         config_options = {
             "theme.base": base_option,
@@ -1193,20 +1228,43 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             set_option_calls.append((key, value, source))
 
         config_util.process_theme_inheritance(
-            config_options, self.config_template, mock_set_option
+            config_options,
+            self.config_template,
+            mock_set_option,
+            ["/global.toml", "/project.toml"],
         )
 
         # Verify that theme options were set correctly
         set_calls_dict = {call[0]: call[1] for call in set_option_calls}
+        set_calls_source = {call[0]: call[2] for call in set_option_calls}
 
         # Base should be set from theme file
         assert set_calls_dict.get("theme.base") == "dark"
+        assert (
+            set_calls_source.get("theme.base") == "base theme file: custom_theme.toml"
+        )
 
         # Background should come from theme file
         assert set_calls_dict.get("theme.backgroundColor") == "#from_theme_file"
+        assert (
+            set_calls_source.get("theme.backgroundColor")
+            == "base theme file: custom_theme.toml"
+        )
+        assert (
+            set_calls_source.get("theme.backgroundColor")
+            != "config.toml (project): /project.toml"
+        )
 
         # Primary color should be the merged result (config override wins)
         assert set_calls_dict.get("theme.primaryColor") == "#override"
+        assert (
+            set_calls_source.get("theme.primaryColor")
+            == "config.toml (project): /project.toml"
+        )
+        assert (
+            set_calls_source.get("theme.primaryColor")
+            != "base theme file: custom_theme.toml"
+        )
 
     @patch("streamlit.config_util._load_theme_file")
     def test_process_theme_inheritance_successful_complex_merge(self, mock_load_theme):
@@ -1217,21 +1275,21 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
         primary_option = ConfigOption(
             "theme.primaryColor", description="", default_val=None
         )
-        primary_option.set_value("#override", "config.toml")
+        primary_option.set_value("#override", "/project.toml")
 
         light_option = ConfigOption(
             "theme.light.linkColor", description="", default_val=None
         )
-        light_option.set_value("#light_link_override", "config.toml")
+        light_option.set_value("#light_link_override", "/project.toml")
 
         sidebar_option = ConfigOption(
             "theme.sidebar.primaryColor", description="", default_val=None
         )
-        sidebar_option.set_value("#sidebar_override", "config.toml")
+        sidebar_option.set_value("#sidebar_override", "/project.toml")
         sidebar_light_option = ConfigOption(
             "theme.light.sidebar.borderColor", description="", default_val=None
         )
-        sidebar_light_option.set_value("#sidebar_light_override", "config.toml")
+        sidebar_light_option.set_value("#sidebar_light_override", "/project.toml")
 
         config_options = {
             "theme.base": base_option,
@@ -1273,21 +1331,40 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             set_option_calls.append((key, value, source))
 
         config_util.process_theme_inheritance(
-            config_options, self.config_template, mock_set_option
+            config_options,
+            self.config_template,
+            mock_set_option,
+            ["/global.toml", "/project.toml"],
         )
 
         # Verify that theme options were set correctly
         set_calls_dict = {call[0]: call[1] for call in set_option_calls}
+        set_calls_source = {call[0]: call[2] for call in set_option_calls}
 
         # Base should be set from theme file
         assert set_calls_dict.get("theme.base") == "dark"
+        assert (
+            set_calls_source.get("theme.base") == "base theme file: custom_theme.toml"
+        )
 
         # Theme and sidebar primary colors should be the merged result (config override wins)
         assert set_calls_dict.get("theme.primaryColor") == "#override"
         assert set_calls_dict.get("theme.sidebar.primaryColor") == "#sidebar_override"
+        assert (
+            set_calls_source.get("theme.primaryColor")
+            == "config.toml (project): /project.toml"
+        )
+        assert (
+            set_calls_source.get("theme.sidebar.primaryColor")
+            == "config.toml (project): /project.toml"
+        )
 
         # Background color should come from base theme file
         assert set_calls_dict.get("theme.backgroundColor") == "#from_theme_file"
+        assert (
+            set_calls_source.get("theme.backgroundColor")
+            == "base theme file: custom_theme.toml"
+        )
 
         # Config options should include the new section/subsections
         assert set_calls_dict.get("theme.light.primaryColor") == "#light_primary_color"
@@ -1298,6 +1375,10 @@ class ThemeInheritanceUtilTest(unittest.TestCase):
             # override from config.toml should apply in subsubsection
             set_calls_dict.get("theme.light.sidebar.borderColor")
             == "#sidebar_light_override"
+        )
+        assert (
+            set_calls_source.get("theme.light.sidebar.borderColor")
+            == "config.toml (project): /project.toml"
         )
         assert (
             set_calls_dict.get("theme.dark.sidebar.borderColor")


### PR DESCRIPTION
## Describe your changes
This improves the theme `where_defined` labels that surface when running `streamlit config show`, so users can distinguish between values coming from a base theme file, config.toml overrides (with scope), and CLI/env overrides.

**Note**: config.toml (script) only appears when a main script path is set (e.g., via streamlit run); streamlit config show typically includes only global + project config scopes.

**Before Examples:**
- Base theme file value: `theme file: /path/to/theme.toml`
- Config.toml override (global): `theme file: /path/to/theme.toml`
- Config.toml override (project): `theme file: /path/to/theme.toml`
- CLI/env override: `command-line argument or environment variable` (this was already accurate)

**After**
- Base theme file value: `base theme file: /path/to/theme.toml`
- Config.toml override (global): `config.toml (global): /path/to/global/config.toml`
- Config.toml override (project): `config.toml (project): /path/to/project/config.toml`
- CLI/env override: `command-line argument or environment variable`
- Defaulted base (no base in theme file): `default light theme`

## Testing Plan
- Python Unit Tests: ✅ 
- Manual Testing: ✅ 