### PR TITLE
Fix nightly build package name mismatch with uv

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
           ./scripts/update_version.py $TAG
           ./scripts/update_name.py streamlit-nightly
 
-          git add lib/pyproject.toml frontend/package.json lib/streamlit/__init__.py lib/streamlit/version.py
+          git add pyproject.toml lib/pyproject.toml frontend/package.json lib/streamlit/__init__.py lib/streamlit/version.py
 
           git commit -m "Update version and project name in files"
 

--- a/scripts/update_name.py
+++ b/scripts/update_name.py
@@ -52,21 +52,31 @@ def update_root_pyproject_toml(project_name: str) -> None:
         content = f.read()
 
     # Update [tool.uv.sources] section - change the key from 'streamlit' to new name
-    content = re.sub(
-        r'^streamlit = \{ path = "lib", editable = true \}$',
+    uv_sources_pattern = r'^streamlit = \{ path = "lib", editable = true \}$'
+    content, uv_sources_count = re.subn(
+        uv_sources_pattern,
         rf'{project_name} = {{ path = "lib", editable = true }}',
         content,
         flags=re.MULTILINE,
     )
+    if uv_sources_count == 0:
+        raise Exception(
+            f'In file "{file_path}", did not find regex "{uv_sources_pattern}"'
+        )
 
     # Update dependency references in dependency-groups from "streamlit" to new name
     # These appear as standalone "streamlit", entries in the arrays
-    content = re.sub(
-        r'^  "streamlit",$',
+    dep_groups_pattern = r'^  "streamlit",$'
+    content, dep_groups_count = re.subn(
+        dep_groups_pattern,
         rf'  "{project_name}",',
         content,
         flags=re.MULTILINE,
     )
+    if dep_groups_count == 0:
+        raise Exception(
+            f'In file "{file_path}", did not find regex "{dep_groups_pattern}"'
+        )
 
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(content)

--- a/scripts/update_name.py
+++ b/scripts/update_name.py
@@ -40,6 +40,38 @@ FILES_AND_REGEXES = {
 }
 
 
+def update_root_pyproject_toml(project_name: str) -> None:
+    """Update the root pyproject.toml to use the new package name.
+
+    This is required for uv to correctly resolve the local package
+    when its name changes (e.g., from 'streamlit' to 'streamlit-nightly').
+    """
+    file_path = os.path.join(BASE_DIR, "pyproject.toml")
+
+    with open(file_path, encoding="utf-8") as f:
+        content = f.read()
+
+    # Update [tool.uv.sources] section - change the key from 'streamlit' to new name
+    content = re.sub(
+        r'^streamlit = \{ path = "lib", editable = true \}$',
+        rf'{project_name} = {{ path = "lib", editable = true }}',
+        content,
+        flags=re.MULTILINE,
+    )
+
+    # Update dependency references in dependency-groups from "streamlit" to new name
+    # These appear as standalone "streamlit", entries in the arrays
+    content = re.sub(
+        r'^  "streamlit",$',
+        rf'  "{project_name}",',
+        content,
+        flags=re.MULTILINE,
+    )
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
 def update_files(project_name: str, files: dict[str, str]) -> None:
     """Update files with new project name."""
     for filename, regex in files.items():
@@ -63,6 +95,7 @@ def main() -> None:
         raise Exception(f'Specify project name, e.g: "{sys.argv[0]} streamlit-nightly"')
     project_name = sys.argv[1]
     update_files(project_name, FILES_AND_REGEXES)
+    update_root_pyproject_toml(project_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes

After the uv migration (PR #13622), the nightly build fails when it attempts to rename the package to `streamlit-nightly`. The error occurs because uv validates that the package name in the source matches the reference name. This change fixes that by updating the root `pyproject.toml` alongside the package name change.

The fix updates `update_name.py` to modify `[tool.uv.sources]` and dependency-groups in the root `pyproject.toml` when the package name changes. The nightly workflow is also updated to include the root `pyproject.toml` in the git commit.

## Testing Plan

- This fixes the nightly build process
- No new tests needed; the fix is tested by the existing nightly CI workflow
- The script passes ruff lint and mypy type checks

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.