### PR TITLE
Fix material icon font download script

### DIFF
--- a/scripts/update_material_icon_font_and_names.py
+++ b/scripts/update_material_icon_font_and_names.py
@@ -45,9 +45,7 @@ PLAYWRIGHT_TEST_REGEX = re.compile(
     re.DOTALL,
 )
 
-FONT_FILE_URL_REGEX = (
-    r"url\((https://fonts\.gstatic\.com/s/materialsymbolsrounded/[^\)]+)\)"
-)
+FONT_FILE_URL_REGEX = r"url\((https://fonts\.gstatic\.com/[^\)]+)\)"
 
 NAMES_MODULE_PATH = os.path.join(BASE_DIR, "lib", "streamlit", "material_icon_names.py")
 FONT_FILE_PATH = os.path.join(
@@ -106,8 +104,8 @@ with open(NAMES_MODULE_PATH, "w", encoding="utf-8") as file:
 response = requests.get(
     MATERIAL_ICONS_FONT_URL,
     headers={
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_1) AppleWebKit/605.1.15 "
-        "(KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     },
 )
 

--- a/scripts/update_material_icon_font_and_names.py
+++ b/scripts/update_material_icon_font_and_names.py
@@ -45,7 +45,7 @@ PLAYWRIGHT_TEST_REGEX = re.compile(
     re.DOTALL,
 )
 
-FONT_FILE_URL_REGEX = r"url\((https://fonts\.gstatic\.com/[^\)]+)\)"
+FONT_FILE_URL_REGEX = r"url\((https://fonts\.gstatic\.com/[^)]+\.woff2)\)"
 
 NAMES_MODULE_PATH = os.path.join(BASE_DIR, "lib", "streamlit", "material_icon_names.py")
 FONT_FILE_PATH = os.path.join(


### PR DESCRIPTION
## Describe your changes

Fixed the material icon font download script that was failing to extract the font URL. Google Fonts changed the URL structure from `/s/materialsymbolsrounded/` to `/l/font?kit=` format. Also updated the User-Agent from Safari to Chrome to ensure `.woff2` format is returned instead of `.woff`.

## GitHub Issue Link (if applicable)

Related to the issue where `update_material_icon_font_and_names.py` was failing with "URL not found".

## Testing Plan

- Script has been tested to successfully extract the font URL and download the `.woff2` file.
- No additional tests required as this is a maintenance script that's run manually.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.