### PR TITLE
Require screenshots in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,17 @@
 ## Describe your changes
 
-## Screenshot or video (only for visual changes)
+## Screenshot or video
 
-## GitHub Issue Link (if applicable)
+<!--
+External contributors: screenshots or a short video are REQUIRED for any UI changes.
+PRs without them won't be reviewed.
+-->
 
-## Testing Plan
+- [ ] I added a screenshot or video, or this PR does not affect the UI at all.
+
+## GitHub issue link (if applicable)
+
+## Testing plan
 
 - Explanation of why no additional tests are needed
 - Unit Tests (JS and/or Python)
@@ -13,6 +20,7 @@
 
 ---
 
-**Contribution License Agreement**
+**Contribution license agreement**
 
-By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
+By submitting this pull request you agree that all contributions to this project are
+made under the Apache 2.0 license.


### PR DESCRIPTION
## Describe your changes

Many PRs from external contributors do not contain videos/screenshots of the new feature, which makes it hard to review. This makes it a bit more explicit in the PR template that adding screenshots/videos is required for UI changes. 

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
