### PR TITLE
Fix content-width DataFrames not being resizable

### DIFF
--- a/e2e_playwright/st_dataframe_content_width_resize.py
+++ b/e2e_playwright/st_dataframe_content_width_resize.py
@@ -1,0 +1,44 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+import streamlit as st
+
+df = pd.DataFrame(
+    {
+        "Name": ["Alice", "Bob", "Charlie"],
+        "Value": [10, 20, 30],
+    }
+)
+
+st.subheader("Normal layout")
+st.dataframe(df, width="content", key="normal_content_width")
+
+st.subheader("Horizontal layout")
+col1, col2 = st.columns(2)
+with col1:
+    st.dataframe(df, width="content", key="horizontal_content_width")
+
+st.subheader("Centered container")
+with st.container(horizontal_alignment="center", key="centered_container", border=True):
+    st.dataframe(df, width="content", key="centered_content_width")
+
+st.subheader("Sidebar")
+st.sidebar.dataframe(df, width="content", key="sidebar_content_width")
+
+st.subheader("Tabs")
+tab1, tab2 = st.tabs(["Data", "Info"])
+with tab1:
+    st.dataframe(df, width="content", key="tab_content_width")

--- a/e2e_playwright/st_dataframe_content_width_resize_test.py
+++ b/e2e_playwright/st_dataframe_content_width_resize_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.shared.app_utils import get_element_by_key
 
 
-def _get_dataframe_container(app: Page, key: str):
+def _get_dataframe_container(app: Page, key: str) -> Locator:
     """Get the stDataFrame element within a keyed widget container."""
     key_container = get_element_by_key(app, key)
     return key_container.get_by_test_id("stDataFrame")

--- a/e2e_playwright/st_dataframe_content_width_resize_test.py
+++ b/e2e_playwright/st_dataframe_content_width_resize_test.py
@@ -1,0 +1,69 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.shared.app_utils import get_element_by_key
+
+
+def _get_dataframe_container(app: Page, key: str):
+    """Get the stDataFrame element within a keyed widget container."""
+    key_container = get_element_by_key(app, key)
+    return key_container.get_by_test_id("stDataFrame")
+
+
+def test_content_width_dataframe_is_resizable_in_normal_layout(app: Page):
+    """Test that content-width DataFrames are resizable in normal layouts.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/12683
+    """
+    dataframe = _get_dataframe_container(app, "normal_content_width")
+    expect(dataframe).to_be_visible()
+    # inline-block means resize is enabled
+    expect(dataframe).to_have_css("display", "inline-block")
+
+
+def test_content_width_dataframe_is_not_resizable_in_horizontal_layout(app: Page):
+    """Test that content-width DataFrames are not resizable in horizontal layouts.
+
+    This preserves the fix from PR #12682 for horizontal_alignment.
+    """
+    dataframe = _get_dataframe_container(app, "horizontal_content_width")
+    expect(dataframe).to_be_visible()
+    # flex means resize is disabled
+    expect(dataframe).to_have_css("display", "flex")
+
+
+def test_content_width_dataframe_is_resizable_in_centered_container(app: Page):
+    """Test that content-width DataFrames are resizable in centered containers.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/12683
+    """
+    dataframe = _get_dataframe_container(app, "centered_content_width")
+    expect(dataframe).to_be_visible()
+    expect(dataframe).to_have_css("display", "inline-block")
+
+
+def test_content_width_dataframe_is_resizable_in_sidebar(app: Page):
+    """Test that content-width DataFrames are resizable in the sidebar."""
+    dataframe = _get_dataframe_container(app, "sidebar_content_width")
+    expect(dataframe).to_be_visible()
+    expect(dataframe).to_have_css("display", "inline-block")
+
+
+def test_content_width_dataframe_is_resizable_in_tabs(app: Page):
+    """Test that content-width DataFrames are resizable inside tabs."""
+    dataframe = _get_dataframe_container(app, "tab_content_width")
+    expect(dataframe).to_be_visible()
+    expect(dataframe).to_have_css("display", "inline-block")

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -19,6 +19,8 @@ import { screen } from "@testing-library/react"
 
 import { Arrow as ArrowProto } from "@streamlit/protobuf"
 
+import { FlexContext } from "~lib/components/core/Layout/FlexContext"
+import { Direction } from "~lib/components/core/Layout/utils"
 import { Quiver } from "~lib/dataframes/Quiver"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { TEN_BY_TEN } from "~lib/mocks/arrow"
@@ -212,5 +214,85 @@ describe("DataFrame widget", () => {
       }),
       {}
     )
+  })
+})
+
+describe("DataFrame resize behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      elementRef: { current: null },
+      values: [250],
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const contentWidthProps = {
+    ...getProps(new Quiver({ data: TEN_BY_TEN })),
+    widthConfig: { useContent: true },
+  }
+
+  it("should enable resize for content-width dataframe in normal layout", () => {
+    // Issue #12683: content-width DataFrames should be resizable
+    // outside of horizontal layouts
+    render(
+      <FlexContext.Provider
+        value={{
+          direction: Direction.VERTICAL,
+          isInHorizontalLayout: false,
+          isInRoot: false,
+          isInContentWidthContainer: false,
+        }}
+      >
+        <DataFrame {...contentWidthProps} />
+      </FlexContext.Provider>
+    )
+
+    const container = screen.getByTestId("stDataFrame")
+    // When resize is enabled, display should be inline-block
+    expect(container).toHaveStyle({ display: "inline-block" })
+  })
+
+  it("should disable resize for dataframe in horizontal layout", () => {
+    render(
+      <FlexContext.Provider
+        value={{
+          direction: Direction.HORIZONTAL,
+          isInHorizontalLayout: true,
+          isInRoot: false,
+          isInContentWidthContainer: false,
+        }}
+      >
+        <DataFrame {...contentWidthProps} />
+      </FlexContext.Provider>
+    )
+
+    const container = screen.getByTestId("stDataFrame")
+    // When resize is disabled, display should be flex
+    expect(container).toHaveStyle({ display: "flex" })
+  })
+
+  it("should enable resize for content-width dataframe in a non-root container", () => {
+    // This is the core regression test for Issue #12683:
+    // Previously, content-width DataFrames in non-root containers had
+    // resize disabled due to the (widthConfig?.useContent && !isInRoot) condition
+    render(
+      <FlexContext.Provider
+        value={{
+          direction: Direction.VERTICAL,
+          isInHorizontalLayout: false,
+          isInRoot: false,
+          isInContentWidthContainer: false,
+        }}
+      >
+        <DataFrame {...contentWidthProps} />
+      </FlexContext.Provider>
+    )
+
+    const container = screen.getByTestId("stDataFrame")
+    expect(container).toHaveStyle({ display: "inline-block" })
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -563,14 +563,10 @@ function DataFrame({
     }
   }, [allColumns.length, columns.length])
 
-  // Disable resize if the dataframe is in a horizontal layout or if it is a content-width dataframe
-  // and not in the root container. This is because the feature requires measurements from the parent container
-  // which cannot be determined when the parent container has a fit-content width or when there are multiple siblings
-  // in a nested container.
-  const disableResize =
-    isInHorizontalLayout || (widthConfig?.useContent && !isInRoot)
-      ? true
-      : false
+  // Disable resize in horizontal layouts to prevent horizontal_alignment issues
+  // (see PR #12682). Content-width DataFrames in other layouts should remain
+  // resizable (see Issue #12683).
+  const disableResize = isInHorizontalLayout
 
   return (
     <StyledResizableContainer


### PR DESCRIPTION
Simplify the disableResize condition in DataFrame.tsx to only disable resize in horizontal layouts, restoring resize functionality for content-width DataFrames in normal, centered, sidebar, and tab layouts.                                                                                                                         
                                                                                                                                                                      
  The previous condition introduced in PR #12682 was overly broad, disabling resize for all content-width DataFrames outside the root container. Only horizontal layouts need resize disabled to prevent horizontal_alignment issues.                                                                                                
                                                                                                                                                                      
  Fixes #12683                                                                                                                                                        
                                                                                                                                                                      
  ## Describe your changes                                                                                                                                            
                                                                                                                                                                      
  - Simplified the `disableResize` condition from `isInHorizontalLayout || (widthConfig?.useContent && !isInRoot)` to just `isInHorizontalLayout`                     
  - This restores resize functionality for content-width DataFrames in normal, centered, sidebar, and tab layouts while keeping resize disabled in horizontal layouts 
  to preserve the horizontal_alignment fix from PR #12682                                                                                                             
                                                                                                                                                                      
  ## Screenshot or video (only for visual changes)                                                                                                                    
                                                                                                                                                                      
  N/A - The visual change is that the resize handle (bottom-right corner drag) reappears on content-width DataFrames outside of horizontal layouts, restoring pre-v1.51.0 behavior.                                                                                                                                               
                                                                                                                                                                      
  ## GitHub Issue Link (if applicable)                                                                                                                                
                                                                                                                                                                      
  Fixes https://github.com/streamlit/streamlit/issues/12683                                                                                                           
                                                                                                                                                                      
  ## Testing Plan                                                                                                                                                     
                                                                                                                                                                      
  - Unit Tests (JS): Added 3 test cases in `DataFrame.test.tsx` verifying `disableResize` behavior across layout contexts (normal, horizontal, non-root container)    
  - E2E Tests: Added `st_dataframe_content_width_resize_test.py` with 5 test cases covering normal layout, horizontal layout, centered container, sidebar, and tabs   
  - Regression: All 11 existing DataFrame unit tests pass 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
