### PR TITLE
Define selection constants (select all 1)

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -29,6 +29,10 @@ import { convertRemToPx } from "~lib/theme/utils"
 
 import { ThemedStyledDropdownListItem } from "./styled-components"
 
+// Constants for special dropdown option IDs used by Multiselect
+export const SELECT_ALL_ID = "__SELECT_ALL__"
+export const SELECT_MATCHES_ID = "__SELECT_MATCHES__"
+
 /*
  * A component that renders a large dropdown to render only a fixed amount of
  * options at a time. Overall, the dropdown improves performance for

--- a/frontend/lib/src/components/shared/Dropdown/index.ts
+++ b/frontend/lib/src/components/shared/Dropdown/index.ts
@@ -15,4 +15,8 @@
  */
 
 export { default } from "./Selectbox"
-export { default as VirtualDropdown } from "./VirtualDropdown"
+export {
+  default as VirtualDropdown,
+  SELECT_ALL_ID,
+  SELECT_MATCHES_ID,
+} from "./VirtualDropdown"

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -39,7 +39,11 @@ import { MultiSelect as MultiSelectProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { getBorderColor } from "~lib/components/shared/Base/styled-components"
-import { VirtualDropdown } from "~lib/components/shared/Dropdown"
+import {
+  SELECT_ALL_ID,
+  SELECT_MATCHES_ID,
+  VirtualDropdown,
+} from "~lib/components/shared/Dropdown"
 import {
   WidgetLabel,
   WidgetLabelHelpIcon,
@@ -113,6 +117,8 @@ const Multiselect: FC<Props> = props => {
       }
     : undefined
 
+  // Ref to store filtered matches for "Select X matches" option
+  const selectMatchesRef = useRef<string[]>([])
   const [value, setValueWithSource] = useBasicWidgetState<
     MultiselectValue,
     MultiSelectProto
@@ -150,6 +156,34 @@ const Multiselect: FC<Props> = props => {
           return []
         }
         case "select": {
+          // Handle "Select all" option (no search) - compute from element.options
+          if (data.option?.value === SELECT_ALL_ID) {
+            const unselectedValues = element.options.filter(
+              opt => !value.includes(opt)
+            )
+
+            // Respect maxSelections limit
+            if (element.maxSelections > 0) {
+              const remainingSlots = element.maxSelections - value.length
+              return [...value, ...unselectedValues.slice(0, remainingSlots)]
+            }
+
+            return [...value, ...unselectedValues]
+          }
+
+          // Handle "Select x matches" option (with search) - values stored in ref
+          if (data.option?.value === SELECT_MATCHES_ID) {
+            const filteredValues = selectMatchesRef.current
+
+            // Respect maxSelections limit
+            if (element.maxSelections > 0) {
+              const remainingSlots = element.maxSelections - value.length
+              return [...value, ...filteredValues.slice(0, remainingSlots)]
+            }
+
+            return [...value, ...filteredValues]
+          }
+
           return value.concat([data.option?.value])
         }
         default: {
@@ -158,7 +192,7 @@ const Multiselect: FC<Props> = props => {
         }
       }
     },
-    [value]
+    [value, element.maxSelections, element.options]
   )
 
   /**


### PR DESCRIPTION
## Describe your changes
This introduces two constants that will be used to create a select-all feature for `st.multiselect`. This is not functionally connected and not available to the frontend. This will be implemented in the next PR in the stack.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
