### PR TITLE
Fix flaky lighthouse tests by waiting for port release

### DIFF
--- a/frontend/app/performance/lighthouse/LighthouseOrchestrator.mjs
+++ b/frontend/app/performance/lighthouse/LighthouseOrchestrator.mjs
@@ -26,9 +26,49 @@ import { default as treeKill } from "tree-kill"
 
 import fs from "fs"
 import path from "path"
+import net from "net"
 import { exec, execSync } from "child_process"
 
 import { MODES } from "./constants.mjs"
+
+const STREAMLIT_PORT = 3001
+
+/**
+ * Check if a port is available.
+ * @param {number} port - The port to check.
+ * @returns {Promise<boolean>} - Resolves to true if the port is available.
+ */
+const isPortAvailable = port => {
+  return new Promise(resolve => {
+    const server = net.createServer()
+    server.once("error", () => {
+      resolve(false)
+    })
+    server.once("listening", () => {
+      server.close()
+      resolve(true)
+    })
+    server.listen(port)
+  })
+}
+
+/**
+ * Wait for a port to become available.
+ * @param {number} port - The port to wait for.
+ * @param {number} timeout - Maximum time to wait in milliseconds.
+ * @param {number} interval - Polling interval in milliseconds.
+ * @returns {Promise<boolean>} - Resolves to true if port becomes available.
+ */
+const waitForPortAvailable = async (port, timeout = 10000, interval = 200) => {
+  const startTime = Date.now()
+  while (Date.now() - startTime < timeout) {
+    if (await isPortAvailable(port)) {
+      return true
+    }
+    await new Promise(resolve => setTimeout(resolve, interval))
+  }
+  return false
+}
 
 const PATHNAME = new URL(".", import.meta.url).pathname
 const REPORTS_DIRECTORY = path.resolve(
@@ -142,7 +182,7 @@ export class LighthouseOrchestrator {
             --server.headless true \
             --global.developmentMode false \
             --global.e2eTest true \
-            --server.port 3001 \
+            --server.port ${STREAMLIT_PORT} \
             --browser.gatherUsageStats false \
             --server.fileWatcherType none \
             --server.enableStaticServing true`
@@ -181,21 +221,30 @@ export class LighthouseOrchestrator {
   async stopStreamlit() {
     console.log("Stopping Streamlit...")
 
-    return new Promise((resolve, reject) => {
-      if (!this.streamlit || !this.streamlit.pid) {
-        throw new Error("Streamlit is not running")
-      }
+    if (!this.streamlit || !this.streamlit.pid) {
+      throw new Error("Streamlit is not running")
+    }
 
+    await new Promise((resolve, reject) => {
       treeKill(this.streamlit.pid, err => {
         if (err) {
           return reject(err)
         }
-
         this.streamlit = null
-        console.log("Stopped Streamlit")
         resolve(true)
       })
     })
+
+    // Wait for the port to be released before returning
+    const portReleased = await waitForPortAvailable(STREAMLIT_PORT)
+    if (!portReleased) {
+      console.warn(
+        `Warning: Port ${STREAMLIT_PORT} may not have been released in time`
+      )
+    }
+
+    console.log("Stopped Streamlit")
+    return true
   }
 
   /**
@@ -225,7 +274,7 @@ export class LighthouseOrchestrator {
 
     try {
       const runnerResult = await lighthouse(
-        "http://localhost:3001/",
+        `http://localhost:${STREAMLIT_PORT}/`,
         {
           logLevel: "info",
           output: "html",

--- a/frontend/app/performance/lighthouse/LighthouseOrchestrator.mjs
+++ b/frontend/app/performance/lighthouse/LighthouseOrchestrator.mjs
@@ -39,14 +39,24 @@ const STREAMLIT_PORT = 3001
  * @returns {Promise<boolean>} - Resolves to true if the port is available.
  */
 const isPortAvailable = port => {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     const server = net.createServer()
-    server.once("error", () => {
-      resolve(false)
+    server.once("error", err => {
+      // Only treat EADDRINUSE as "port not available". Surface other errors.
+      if (err && err.code === "EADDRINUSE") {
+        resolve(false)
+      } else {
+        reject(err)
+      }
     })
     server.once("listening", () => {
-      server.close()
-      resolve(true)
+      server.close(err => {
+        if (err) {
+          resolve(false)
+          return
+        }
+        resolve(true)
+      })
     })
     server.listen(port)
   })
@@ -238,8 +248,8 @@ export class LighthouseOrchestrator {
     // Wait for the port to be released before returning
     const portReleased = await waitForPortAvailable(STREAMLIT_PORT)
     if (!portReleased) {
-      console.warn(
-        `Warning: Port ${STREAMLIT_PORT} may not have been released in time`
+      throw new Error(
+        `Port ${STREAMLIT_PORT} was not released within timeout after stopping Streamlit`
       )
     }
 


### PR DESCRIPTION
## Describe your changes

The `stopStreamlit()` method was returning immediately after sending the kill signal to the process, without waiting for the port to actually be released. This caused race conditions when starting the next Streamlit instance, leading to "Port 3001 is not available" errors during lighthouse tests.

This fix adds port availability checks that poll and wait up to 10 seconds for the port to be released before returning from `stopStreamlit()`. It also consolidates the hardcoded port number into a `STREAMLIT_PORT` constant for better maintainability.

## Testing Plan

- The fix resolves the flaky "Port 3001 is not available" error that appeared when running consecutive lighthouse tests
- The waiting mechanism has a 10-second timeout to prevent indefinite hangs
- No additional tests are needed as this is a race condition fix in test infrastructure

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.