### PR TITLE
[fix] Support boolean values for client.showErrorLinks config option

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -1009,13 +1009,21 @@ def _get_toolbar_mode() -> Config.ToolbarMode.ValueType:
 
 def _get_show_error_links() -> Config.ShowErrorLinks.ValueType:
     config_key = "client.showErrorLinks"
+    config_value = config.get_option(config_key)
+
+    # Handle boolean values (from st.set_option or programmatic setting)
+    if config_value is True:
+        return Config.ShowErrorLinks.SHOW_ERROR_LINKS_TRUE
+    if config_value is False:
+        return Config.ShowErrorLinks.SHOW_ERROR_LINKS_FALSE
+
+    # Handle string values (from config.toml or command-line)
     allowed_values = ["auto", "true", "false"]
     value_to_enum = {
         "auto": Config.ShowErrorLinks.SHOW_ERROR_LINKS_AUTO,
         "true": Config.ShowErrorLinks.SHOW_ERROR_LINKS_TRUE,
         "false": Config.ShowErrorLinks.SHOW_ERROR_LINKS_FALSE,
     }
-    config_value = config.get_option(config_key)
     if config_value not in allowed_values:
         raise ValueError(
             f"Config {config_key!r} expects to have one of "

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -2439,6 +2439,20 @@ class GetShowErrorLinksTest(unittest.TestCase):
 
         assert _get_show_error_links() == Config.ShowErrorLinks.SHOW_ERROR_LINKS_FALSE
 
+    @patch_config_options({"client.showErrorLinks": True})
+    def test_bool_true(self):
+        """Test that boolean True is handled correctly."""
+        from streamlit.runtime.app_session import _get_show_error_links
+
+        assert _get_show_error_links() == Config.ShowErrorLinks.SHOW_ERROR_LINKS_TRUE
+
+    @patch_config_options({"client.showErrorLinks": False})
+    def test_bool_false(self):
+        """Test that boolean False is handled correctly."""
+        from streamlit.runtime.app_session import _get_show_error_links
+
+        assert _get_show_error_links() == Config.ShowErrorLinks.SHOW_ERROR_LINKS_FALSE
+
     @patch_config_options({"client.showErrorLinks": "invalid"})
     def test_invalid_raises(self):
         from streamlit.runtime.app_session import _get_show_error_links


### PR DESCRIPTION
## Summary

Fixes the `client.showErrorLinks` config option to accept boolean values (`True`/`False`) in addition to string values (`"auto"`, `"true"`, `"false"`).

Previously, setting the config option with a boolean like `client.showErrorLinks = false` in config.toml would not work because the code only checked for string values. This change aligns `showErrorLinks` with the behavior of other config options that accept both boolean and string values.

## Test plan

- Added unit tests for boolean `True` and `False` values
- All existing tests pass
- Verified manually that `client.showErrorLinks = false` in config.toml now works correctly