### PR TITLE
Bind widgets to query params - support empty values for clearable widgets

### DIFF
--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1953,13 +1953,16 @@ describe("Trigger JSON payloads (aggregated)", () => {
           expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([25, 75])
         })
 
-        it("clears URL param when array is empty", () => {
+        it("clears URL when empty array equals default (hide at default)", () => {
           const widget = { id: "multiselect1", formId: "" }
           widgetMgr.registerQueryParamBinding(
             "multiselect1",
             "tags",
             "string_array_value",
-            []
+            [], // default is empty array
+            undefined,
+            undefined,
+            true // clearable
           )
 
           // First set a value to put something in the URL
@@ -1973,7 +1976,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "tags=tag1&tags=tag2"
           )
 
-          // Now clear the array - should clear the URL param
+          // Now clear the array - empty matches default, so clear param
           mockOnQueryParamsChange.mockClear()
           widgetMgr.setStringArrayValue(
             widget,
@@ -1982,6 +1985,204 @@ describe("Trigger JSON payloads (aggregated)", () => {
             undefined
           )
 
+          // Empty matches default [], so param is cleared (not ?tags=)
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+        })
+
+        it("preserves empty array in URL when empty differs from default", () => {
+          const widget = { id: "multiselect2", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "multiselect2",
+            "langs",
+            "string_array_value",
+            ["Python"], // default is non-empty
+            undefined,
+            undefined,
+            true // clearable
+          )
+
+          // Clear to empty - differs from default, so preserve ?langs=
+          widgetMgr.setStringArrayValue(
+            widget,
+            [],
+            { fromUi: true },
+            undefined
+          )
+
+          // Empty differs from default ["Python"], so we write ?langs=
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("langs=")
+        })
+      })
+
+      describe("empty value handling with clearable parameter", () => {
+        it("preserves empty value in URL when clearable=true (multiselect)", () => {
+          const widget = { id: "multiselect1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "multiselect1",
+            "tags",
+            "string_array_value",
+            ["default"],
+            undefined,
+            undefined,
+            true // clearable - multiselect always allows clearing
+          )
+
+          // Set empty array - should write ?tags= since clearable=true
+          widgetMgr.setStringArrayValue(
+            widget,
+            [],
+            { fromUi: true },
+            undefined
+          )
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("tags=")
+        })
+
+        it("preserves empty value in URL when clearable=true (pills)", () => {
+          const widget = { id: "pills1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "pills1",
+            "selected",
+            "int_array_value",
+            [0],
+            undefined,
+            ["Red", "Green", "Blue"],
+            true // clearable - pills allows clearing
+          )
+
+          // Set empty array - should write ?selected= since clearable=true
+          widgetMgr.setIntArrayValue(widget, [], { fromUi: true }, undefined)
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("selected=")
+        })
+
+        it("preserves empty value in URL when clearable=true and empty differs from default (selectbox)", () => {
+          const widget = { id: "selectbox1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "selectbox1",
+            "choice",
+            "string_value",
+            "Red", // Non-null default
+            undefined,
+            undefined,
+            true // clearable - selectbox with index=None allows clearing
+          )
+
+          // Set null (cleared) - differs from default "Red", so write ?choice=
+          widgetMgr.setStringValue(widget, null, { fromUi: true }, undefined)
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("choice=")
+        })
+
+        it("clears URL when null equals null default (hide at default)", () => {
+          const widget = { id: "selectbox2", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "selectbox2",
+            "option",
+            "string_value",
+            null, // Null default
+            undefined,
+            undefined,
+            true // clearable
+          )
+
+          // First set a non-null value
+          widgetMgr.setStringValue(widget, "Blue", { fromUi: true }, undefined)
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("option=Blue")
+
+          // Set back to null - matches default, so clear param
+          mockOnQueryParamsChange.mockClear()
+          widgetMgr.setStringValue(widget, null, { fromUi: true }, undefined)
+
+          // Null matches default null, so param is cleared (not ?option=)
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+        })
+
+        it("clears URL param when clearable=false (checkbox)", () => {
+          const widget = { id: "checkbox1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "checkbox1",
+            "enabled",
+            "bool_value",
+            false,
+            undefined,
+            undefined,
+            false // not clearable - checkbox always has a value
+          )
+
+          // First set to non-default value to populate URL
+          widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("enabled=true")
+
+          // Clear mock and set back to default - should clear the param
+          mockOnQueryParamsChange.mockClear()
+          widgetMgr.setBoolValue(widget, false, { fromUi: true }, undefined)
+
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+        })
+
+        it("uses defaultValue fallback when clearable is not provided", () => {
+          const widget = { id: "text1", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "text1",
+            "name",
+            "string_value",
+            "default text" // non-null default
+            // no clearable parameter - uses null-default fallback (clearable=false)
+          )
+
+          // First set to default to establish baseline
+          widgetMgr.setStringValue(
+            widget,
+            "default text",
+            { fromUi: true },
+            undefined
+          )
+          // Default value - no URL param
+          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+
+          // Set to non-default value
+          widgetMgr.setStringValue(
+            widget,
+            "hello",
+            { fromUi: true },
+            undefined
+          )
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("name=hello")
+
+          // Set back to default - clears param
+          mockOnQueryParamsChange.mockClear()
+          widgetMgr.setStringValue(
+            widget,
+            "default text",
+            { fromUi: true },
+            undefined
+          )
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+        })
+
+        it("fallback with null default allows empty and hides at default", () => {
+          const widget = { id: "text2", formId: "" }
+          widgetMgr.registerQueryParamBinding(
+            "text2",
+            "bio",
+            "string_value",
+            null // null default - fallback makes it clearable
+            // no clearable parameter
+          )
+
+          // First set non-empty value
+          widgetMgr.setStringValue(
+            widget,
+            "hello",
+            { fromUi: true },
+            undefined
+          )
+          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("bio=hello")
+
+          // Set to empty string - matches null default, so clears param
+          mockOnQueryParamsChange.mockClear()
+          widgetMgr.setStringValue(widget, "", { fromUi: true }, undefined)
           expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
         })
       })

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1479,7 +1479,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "widget1",
           "my_key",
           "string_value",
-          "default"
+          "default",
+          false
         )
 
         expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
@@ -1491,6 +1492,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "color",
           "int_value",
           0,
+          false,
           undefined,
           ["Red", "Green", "Blue"]
         )
@@ -1504,6 +1506,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "tags",
           "string_array_value",
           [],
+          true,
           "comma"
         )
 
@@ -1516,7 +1519,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "widget1",
           "my_key",
           "string_value",
-          "default1"
+          "default1",
+          false
         )
         expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
 
@@ -1525,7 +1529,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "widget2",
           "my_key",
           "string_value",
-          "default2"
+          "default2",
+          false
         )
 
         // widget2 should be bound, widget1 should be cleaned up
@@ -1539,7 +1544,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "widget1",
           "my_key",
           "string_value",
-          "default1"
+          "default1",
+          false
         )
 
         // Same widget re-registers (e.g., on re-render) - should not break
@@ -1547,7 +1553,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "widget1",
           "my_key",
           "string_value",
-          "default2"
+          "default2",
+          false
         )
 
         expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
@@ -1560,7 +1567,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "widget1",
           "my_key",
           "string_value",
-          "default"
+          "default",
+          false
         )
         widgetMgr.unregisterQueryParamBinding("widget1")
 
@@ -1616,7 +1624,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "widget1",
             paramKey,
             valueType,
-            defaultVal
+            defaultVal,
+            false
           )
 
           // Call the appropriate setter based on value type
@@ -1656,6 +1665,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "checkbox1",
           "enabled",
           "bool_value",
+          false,
           false
         )
 
@@ -1681,6 +1691,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "checkbox1",
           "enabled",
           "bool_value",
+          false,
           false
         )
 
@@ -1697,7 +1708,13 @@ describe("Trigger JSON payloads (aggregated)", () => {
 
       it("clears URL param when nullable value is set to null", () => {
         const widget = { id: "number1", formId: "" }
-        widgetMgr.registerQueryParamBinding("number1", "count", "int_value", 0)
+        widgetMgr.registerQueryParamBinding(
+          "number1",
+          "count",
+          "int_value",
+          0,
+          false
+        )
 
         // Set a value first
         widgetMgr.setIntValue(widget, 5, { fromUi: true }, undefined)
@@ -1719,6 +1736,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "color",
           "int_value",
           0,
+          false,
           undefined,
           ["Red", "Green", "Blue"]
         )
@@ -1735,6 +1753,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "color",
           "int_value",
           0,
+          false,
           undefined,
           ["Red", "Green", "Blue"]
         )
@@ -1751,6 +1770,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
           "tags",
           "int_array_value",
           [],
+          true,
           undefined,
           ["Apple", "Banana", "Cherry"]
         )
@@ -1769,7 +1789,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "multiselect1",
             "tags",
             "string_array_value",
-            []
+            [],
+            true
           )
 
           widgetMgr.setStringArrayValue(
@@ -1791,6 +1812,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "tags",
             "string_array_value",
             [],
+            true,
             "comma"
           )
 
@@ -1814,6 +1836,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "range",
             "double_array_value",
             [0, 2],
+            false,
             undefined,
             ["Small", "Medium", "Large"]
           )
@@ -1836,7 +1859,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "slider1",
             "range",
             "double_array_value",
-            [0, 100]
+            [0, 100],
+            false
           )
 
           widgetMgr.setDoubleArrayValue(
@@ -1857,7 +1881,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "slider1",
             "range",
             "double_array_value",
-            [0, 100]
+            [0, 100],
+            false
           )
 
           widgetMgr.setDoubleArrayValue(
@@ -1878,7 +1903,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "slider1",
             "range",
             "double_array_value",
-            [0, 100]
+            [0, 100],
+            false
           )
 
           // First set a valid value to put something in the URL
@@ -1913,7 +1939,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "slider1",
             "range",
             "double_array_value",
-            [0, 100]
+            [0, 100],
+            false
           )
 
           widgetMgr.setDoubleArrayValue(
@@ -1936,7 +1963,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "slider1",
             "range",
             "double_array_value",
-            [0, 100]
+            [0, 100],
+            false
           )
 
           widgetMgr.setDoubleArrayValue(
@@ -1960,8 +1988,6 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "tags",
             "string_array_value",
             [], // default is empty array
-            undefined,
-            undefined,
             true // clearable
           )
 
@@ -1996,8 +2022,6 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "langs",
             "string_array_value",
             ["Python"], // default is non-empty
-            undefined,
-            undefined,
             true // clearable
           )
 
@@ -2022,8 +2046,6 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "tags",
             "string_array_value",
             ["default"],
-            undefined,
-            undefined,
             true // clearable - multiselect always allows clearing
           )
 
@@ -2045,9 +2067,9 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "selected",
             "int_array_value",
             [0],
+            true, // clearable - pills allows clearing
             undefined,
-            ["Red", "Green", "Blue"],
-            true // clearable - pills allows clearing
+            ["Red", "Green", "Blue"]
           )
 
           // Set empty array - should write ?selected= since clearable=true
@@ -2063,8 +2085,6 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "choice",
             "string_value",
             "Red", // Non-null default
-            undefined,
-            undefined,
             true // clearable - selectbox with index=None allows clearing
           )
 
@@ -2081,8 +2101,6 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "option",
             "string_value",
             null, // Null default
-            undefined,
-            undefined,
             true // clearable
           )
 
@@ -2105,8 +2123,6 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "enabled",
             "bool_value",
             false,
-            undefined,
-            undefined,
             false // not clearable - checkbox always has a value
           )
 
@@ -2121,14 +2137,14 @@ describe("Trigger JSON payloads (aggregated)", () => {
           expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
         })
 
-        it("uses defaultValue fallback when clearable is not provided", () => {
+        it("clears param when value matches non-null default (clearable=false)", () => {
           const widget = { id: "text1", formId: "" }
           widgetMgr.registerQueryParamBinding(
             "text1",
             "name",
             "string_value",
-            "default text" // non-null default
-            // no clearable parameter - uses null-default fallback (clearable=false)
+            "default text", // non-null default
+            false // not clearable
           )
 
           // First set to default to establish baseline
@@ -2161,14 +2177,14 @@ describe("Trigger JSON payloads (aggregated)", () => {
           expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
         })
 
-        it("fallback with null default allows empty and hides at default", () => {
+        it("clears param when value matches null default (clearable=true)", () => {
           const widget = { id: "text2", formId: "" }
           widgetMgr.registerQueryParamBinding(
             "text2",
             "bio",
             "string_value",
-            null // null default - fallback makes it clearable
-            // no clearable parameter
+            null, // null default
+            true // clearable
           )
 
           // First set non-empty value
@@ -2200,6 +2216,7 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "checkbox1",
             "enabled",
             "bool_value",
+            false,
             false
           )
 
@@ -2227,7 +2244,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "widget1",
             "my_key",
             "string_value",
-            "default"
+            "default",
+            false
           )
 
           // Set the widget value to update URL
@@ -2250,7 +2268,8 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "widget1",
             "color",
             "string_value",
-            "red"
+            "red",
+            false
           )
 
           // Set the widget value
@@ -2269,13 +2288,15 @@ describe("Trigger JSON payloads (aggregated)", () => {
             "widget1",
             "name",
             "string_value",
-            ""
+            "",
+            false
           )
           widgetMgr.registerQueryParamBinding(
             "widget2",
             "count",
             "int_value",
-            0
+            0,
+            false
           )
 
           // Set widget values

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -1316,13 +1316,12 @@ export class WidgetStateManager {
 
     // Check if value matches default (hide at default)
     // This applies to both empty values (when empty is valid) and non-empty values
-    if (urlValue === null) {
-      return isNullOrUndefined(binding.defaultValue)
-    }
+    // Note: urlValue cannot be null here - convertToUrlValue only returns null when
+    // isEmptyValueValid is false, and we already returned true for that case above.
     if (Array.isArray(urlValue)) {
       return this.isDefaultArrayValue(urlValue, binding)
     }
-    return this.isDefaultValue(urlValue, binding)
+    return this.isDefaultValue(urlValue as string, binding)
   }
 
   /**

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -1273,7 +1273,6 @@ export class WidgetStateManager {
    * Check if empty/cleared is a valid state for this widget.
    * Used to determine whether to write ?foo= (empty value) or remove the param entirely.
    *
-   * Uses the explicit `clearable` flag passed by widget components. If not provided,
    * Returns binding.clearable, which is explicitly set by each widget component.
    */
   private isEmptyValueValid(binding: QueryParamBinding): boolean {
@@ -1414,11 +1413,25 @@ export class WidgetStateManager {
     return undefined
   }
 
-  /** Check if value equals the widget's default (with type coercion). */
+  /**
+   * Check if value equals the widget's default (with type coercion).
+   *
+   * Note: For clearable scalar widgets, convertToUrlValue(null) returns "".
+   * If such a widget has an empty array default (unusual), "" should match [].
+   */
   private isDefaultValue(value: unknown, binding: QueryParamBinding): boolean {
     const defaultValue = binding.defaultValue
     if (isNullOrUndefined(defaultValue)) {
       return isNullOrUndefined(value) || value === ""
+    }
+    // Defensive: treat "" (cleared scalar) as matching [] (empty array default)
+    // This is an edge case - scalar widgets typically don't have array defaults
+    if (
+      value === "" &&
+      Array.isArray(defaultValue) &&
+      defaultValue.length === 0
+    ) {
+      return true
     }
     const valueStr = this.toStringPrimitive(value)
     const defaultStr = this.toStringPrimitive(defaultValue)
@@ -1443,15 +1456,12 @@ export class WidgetStateManager {
   ): boolean {
     const defaultValue = binding.defaultValue
     if (!Array.isArray(defaultValue)) {
-      // Defensive fallback: treat empty array as matching non-array default.
-      // In practice, widgets with non-array defaults that reach here with []
-      // should have clearable=false
-      if (values.length === 0) return true
       // Single-element array matches scalar default (e.g., slider: [5] == 5)
       if (values.length === 1 && defaultValue !== null) {
         const defaultStr = this.toStringPrimitive(defaultValue)
         return defaultStr !== undefined && values[0] === defaultStr
       }
+      // Empty array or multi-element array cannot match scalar default
       return false
     }
     if (values.length !== defaultValue.length) return false

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -69,14 +69,13 @@ export interface QueryParamBinding {
   paramKey: string
   valueType: WidgetValueType
   defaultValue: unknown
+  // Whether the widget allows clearing to empty state.
+  // When true, empty values write ?foo= to URL; when false, empty clears the param.
+  clearable: boolean
   urlFormat?: "comma" | "repeated" // How to serialize arrays
   // TODO(query-params): Remove options field after wire format changes from
   // index-based to string-based values for applicable widgets (selectbox, pills, etc.)
   options?: string[] // For index-based widgets, the formatted option strings
-  // Whether the widget allows clearing to empty state.
-  // When true, empty values write ?foo= to URL; when false, empty clears the param.
-  // Widget components pass this based on their UI clearing behavior.
-  clearable?: boolean
 }
 
 /**
@@ -1081,16 +1080,16 @@ export class WidgetStateManager {
    * @param options - For index-based widgets, the formatted option strings.
    *   TODO(query-params): Remove options param after wire format changes.
    * @param clearable - Whether the widget allows clearing to empty state.
-   *   Widget components pass this based on their UI clearing behavior.
+   *   Required - widget components must explicitly pass this based on their UI behavior.
    */
   public registerQueryParamBinding(
     widgetId: string,
     paramKey: string,
     valueType: WidgetValueType,
     defaultValue: unknown,
+    clearable: boolean,
     urlFormat?: "comma" | "repeated",
-    options?: string[],
-    clearable?: boolean
+    options?: string[]
   ): void {
     // Clean up old binding if a different widget was bound to this paramKey.
     // This keeps boundWidgets and paramKeyToWidgetId consistent.
@@ -1275,17 +1274,10 @@ export class WidgetStateManager {
    * Used to determine whether to write ?foo= (empty value) or remove the param entirely.
    *
    * Uses the explicit `clearable` flag passed by widget components. If not provided,
-   * falls back to checking if defaultValue is null/undefined (scalar widgets with
-   * null default typically allow clearing).
+   * Returns binding.clearable, which is explicitly set by each widget component.
    */
   private isEmptyValueValid(binding: QueryParamBinding): boolean {
-    // Use explicit clearable flag if provided by widget component
-    if (binding.clearable !== undefined) {
-      return binding.clearable
-    }
-
-    // Fallback: scalar types allow empty only if default is null/undefined
-    return isNullOrUndefined(binding.defaultValue)
+    return binding.clearable
   }
 
   /**

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -73,6 +73,10 @@ export interface QueryParamBinding {
   // TODO(query-params): Remove options field after wire format changes from
   // index-based to string-based values for applicable widgets (selectbox, pills, etc.)
   options?: string[] // For index-based widgets, the formatted option strings
+  // Whether the widget allows clearing to empty state.
+  // When true, empty values write ?foo= to URL; when false, empty clears the param.
+  // Widget components pass this based on their UI clearing behavior.
+  clearable?: boolean
 }
 
 /**
@@ -1076,6 +1080,8 @@ export class WidgetStateManager {
    *
    * @param options - For index-based widgets, the formatted option strings.
    *   TODO(query-params): Remove options param after wire format changes.
+   * @param clearable - Whether the widget allows clearing to empty state.
+   *   Widget components pass this based on their UI clearing behavior.
    */
   public registerQueryParamBinding(
     widgetId: string,
@@ -1083,7 +1089,8 @@ export class WidgetStateManager {
     valueType: WidgetValueType,
     defaultValue: unknown,
     urlFormat?: "comma" | "repeated",
-    options?: string[]
+    options?: string[],
+    clearable?: boolean
   ): void {
     // Clean up old binding if a different widget was bound to this paramKey.
     // This keeps boundWidgets and paramKeyToWidgetId consistent.
@@ -1123,6 +1130,7 @@ export class WidgetStateManager {
       defaultValue: normalizedDefault,
       urlFormat,
       options,
+      clearable,
     })
     this.paramKeyToWidgetId.set(paramKey, widgetId)
   }
@@ -1203,14 +1211,17 @@ export class WidgetStateManager {
   /**
    * Convert widget value to URL-safe format based on binding type.
    * Returns null to indicate the param should be removed from URL.
+   * Returns "" or [] to indicate an empty value that should be preserved as ?foo=
    */
   private convertToUrlValue(
     value: unknown,
     binding: QueryParamBinding
   ): string | string[] | null {
-    // Null values should clear the param
+    // Null values - check if empty is valid for this widget
     if (value === null) {
-      return null
+      // If empty is valid, return "" to preserve ?foo= in URL
+      // If empty is not valid, return null to signal removal
+      return this.isEmptyValueValid(binding) ? "" : null
     }
 
     switch (binding.valueType) {
@@ -1260,20 +1271,57 @@ export class WidgetStateManager {
   }
 
   /**
-   * Check if value should clear the URL param (is default or empty).
+   * Check if empty/cleared is a valid state for this widget.
+   * Used to determine whether to write ?foo= (empty value) or remove the param entirely.
+   *
+   * Uses the explicit `clearable` flag passed by widget components. If not provided,
+   * falls back to checking if defaultValue is null/undefined (scalar widgets with
+   * null default typically allow clearing).
+   */
+  private isEmptyValueValid(binding: QueryParamBinding): boolean {
+    // Use explicit clearable flag if provided by widget component
+    if (binding.clearable !== undefined) {
+      return binding.clearable
+    }
+
+    // Fallback: scalar types allow empty only if default is null/undefined
+    return isNullOrUndefined(binding.defaultValue)
+  }
+
+  /**
+   * Check if value should clear the URL param (remove it from URL entirely).
+   *
+   * Returns true to indicate the param should be removed when:
+   * - Empty value AND empty is not valid for this widget
+   * - Empty value AND empty equals the widget's default (hide at default)
+   * - Non-empty value matches the widget's default
+   *
+   * When empty IS valid AND differs from default (e.g., multiselect with
+   * default=["Python"] cleared to []), we preserve ?foo= in the URL.
    */
   private shouldClearUrlParam(
     urlValue: string | string[] | null,
     binding: QueryParamBinding
   ): boolean {
-    if (urlValue === null) return true
+    // Check if value is empty (null, [], or "")
+    const isEmpty =
+      urlValue === null ||
+      (Array.isArray(urlValue) && urlValue.length === 0) ||
+      urlValue === ""
 
-    if (Array.isArray(urlValue)) {
-      return (
-        urlValue.length === 0 || this.isDefaultArrayValue(urlValue, binding)
-      )
+    // Empty value that's not valid for this widget should always be cleared
+    if (isEmpty && !this.isEmptyValueValid(binding)) {
+      return true
     }
 
+    // Check if value matches default (hide at default)
+    // This applies to both empty values (when empty is valid) and non-empty values
+    if (urlValue === null) {
+      return isNullOrUndefined(binding.defaultValue)
+    }
+    if (Array.isArray(urlValue)) {
+      return this.isDefaultArrayValue(urlValue, binding)
+    }
     return this.isDefaultValue(urlValue, binding)
   }
 
@@ -1295,7 +1343,11 @@ export class WidgetStateManager {
       // Remove the param
       delete currentParams[paramKey]
     } else if (Array.isArray(value)) {
-      if (urlFormat === "comma") {
+      if (value.length === 0) {
+        // Empty array: write as empty string to produce ?key= in URL
+        // (queryString.stringify omits empty arrays, so we use "" instead)
+        currentParams[paramKey] = ""
+      } else if (urlFormat === "comma") {
         // Comma-separated: store as single joined string
         currentParams[paramKey] = value.join(",")
       } else {
@@ -1389,8 +1441,10 @@ export class WidgetStateManager {
    * Check if array equals the widget's default array (with type coercion).
    *
    * Handles edge cases where the widget's default may be a scalar but the
-   * current value is an array (e.g., slider with value=[5] and defaultValue=5),
-   * or where an empty array should match a non-array default (cleared state).
+   * current value is an array (e.g., slider with value=[5] and defaultValue=5).
+   *
+   * Note: For widgets that allow clearing (clearable=true), empty arrays that
+   * differ from default are handled by shouldClearUrlParam before this is called.
    */
   private isDefaultArrayValue(
     values: string[],
@@ -1398,7 +1452,9 @@ export class WidgetStateManager {
   ): boolean {
     const defaultValue = binding.defaultValue
     if (!Array.isArray(defaultValue)) {
-      // Empty array matches non-array default (widget cleared to empty state)
+      // Defensive fallback: treat empty array as matching non-array default.
+      // In practice, widgets with non-array defaults that reach here with []
+      // should have clearable=false
       if (values.length === 0) return true
       // Single-element array matches scalar default (e.g., slider: [5] == 5)
       if (values.length === 1 && defaultValue !== null) {

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -160,12 +160,11 @@ class WidgetMetadata(Generic[T]):
     # option strings in URLs when auto-correcting filtered values.
     formatted_options: list[str] | None = None
 
-    # Whether empty/cleared is a valid state for this widget when bound to query params.
+    # Whether the widget can be cleared to an empty state (reflects widget's UI behavior).
     # When True, an empty URL param (e.g., ?foo=) will seed the widget with an empty value.
     # When False, an empty URL param will be ignored and the widget uses its default.
-    # This should reflect the widget's UI clearing behavior (e.g., multiselect always
-    # allows empty, while checkbox never does).
-    allow_empty: bool = False
+    # Examples: multiselect is always clearable, checkbox is never clearable.
+    clearable: bool = False
 
     def __repr__(self) -> str:
         return util.repr_(self)

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -163,7 +163,10 @@ class WidgetMetadata(Generic[T]):
     # Whether the widget can be cleared to an empty state (reflects widget's UI behavior).
     # When True, an empty URL param (e.g., ?foo=) will seed the widget with an empty value.
     # When False, an empty URL param will be ignored and the widget uses its default.
-    # Examples: multiselect is always clearable, checkbox is never clearable.
+    # Examples:
+    #   - multiselect: always clearable (users can remove all selections)
+    #   - checkbox: never clearable (always has a boolean value)
+    #   - selectbox: clearable only if index=None (allows "no selection" state)
     clearable: bool = False
 
     def __repr__(self) -> str:

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -160,6 +160,13 @@ class WidgetMetadata(Generic[T]):
     # option strings in URLs when auto-correcting filtered values.
     formatted_options: list[str] | None = None
 
+    # Whether empty/cleared is a valid state for this widget when bound to query params.
+    # When True, an empty URL param (e.g., ?foo=) will seed the widget with an empty value.
+    # When False, an empty URL param will be ignored and the widget uses its default.
+    # This should reflect the widget's UI clearing behavior (e.g., multiselect always
+    # allows empty, while checkbox never does).
+    allow_empty: bool = False
+
     def __repr__(self) -> str:
         return util.repr_(self)
 

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -54,6 +54,25 @@ class WidgetBinding:
     script_hash: str  # For MPA: identifies main vs page script
 
 
+def is_empty_url_value(value: str | list[str]) -> bool:
+    """Check if URL value represents an empty parameter (e.g., ?foo= with no value).
+
+    Parameters
+    ----------
+    value : str | list[str]
+        The URL parameter value(s).
+
+    Returns
+    -------
+    bool
+        True if all values are empty strings ("" or [""] or ["", ""], etc.).
+        Returns False for mixed values like ["a", ""] which contain valid data.
+    """
+    if isinstance(value, list):
+        return len(value) > 0 and all(v == "" for v in value)
+    return value == ""
+
+
 def parse_url_param(value: str | list[str], value_type: str) -> Any:
     """Convert URL param to Python value based on WidgetState value type.
 
@@ -68,6 +87,10 @@ def parse_url_param(value: str | list[str], value_type: str) -> Any:
     -------
     Any
         The parsed Python value appropriate for the widget type.
+        For empty URL params (e.g., ?foo=):
+        - Array types return []
+        - string_value returns "" (empty string is valid)
+        - Other types return None (signaling "cleared" state)
 
     Raises
     ------
@@ -76,6 +99,17 @@ def parse_url_param(value: str | list[str], value_type: str) -> Any:
     """
     # For single-value types, get the last value if it's a list
     val = value[-1] if isinstance(value, list) else value
+
+    # Handle empty string values (e.g., ?foo= in URL)
+    if is_empty_url_value(value):
+        match value_type:
+            case "string_array_value" | "int_array_value" | "double_array_value":
+                return []  # Empty array
+            case "string_value":
+                return ""  # Empty string is a valid value for text inputs
+            case _:
+                # For other types (bool, int, double), empty signals "cleared"
+                return None
 
     match value_type:
         case "bool_value":
@@ -101,27 +135,37 @@ def parse_url_param(value: str | list[str], value_type: str) -> Any:
             return val
         case "string_array_value":
             # Repeated params: ?foo=a&foo=b -> ["a", "b"]
-            return list(value) if isinstance(value, list) else [value]
+            # Filter out empty strings (e.g., ?foo=a&foo= -> ["a"])
+            # Note: This means "" cannot be a valid option value in URL-bound widgets.
+            # We reserve "" to mean "cleared/empty" rather than a literal empty string option.
+            parts = list(value) if isinstance(value, list) else [value]
+            return [p for p in parts if p != ""]
         case "double_array_value":
             # Repeated params: ?foo=1.5&foo=2.5 -> [1.5, 2.5]
             # Also handles string values for select_slider option matching
+            # Filter out empty strings - "" is reserved for "cleared/empty" state
             parts = list(value) if isinstance(value, list) else [value]
             result_double: list[float | str] = []
             for part in parts:
+                if part == "":
+                    continue  # Skip empty strings
                 try:
                     result_double.append(float(part))
-                except ValueError:  # noqa: PERF203
+                except ValueError:
                     result_double.append(part)  # Keep as string for select_slider
             return result_double
         case "int_array_value":
             # Repeated params: ?foo=1&foo=2 -> [1, 2]
             # Also handles string values for option matching (pills, etc.)
+            # Filter out empty strings - "" is reserved for "cleared/empty" state
             parts = list(value) if isinstance(value, list) else [value]
             result_int: list[int | str] = []
             for part in parts:
+                if part == "":
+                    continue  # Skip empty strings
                 try:
                     result_int.append(int(part))
-                except ValueError:  # noqa: PERF203
+                except ValueError:
                     result_int.append(part)  # Keep as string
             return result_int
         case _:

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -54,6 +54,16 @@ class WidgetBinding:
     script_hash: str  # For MPA: identifies main vs page script
 
 
+def _to_non_empty_list(value: str | list[str]) -> list[str]:
+    """Convert URL param value to list, filtering out empty strings.
+
+    Empty strings are reserved to represent "cleared/empty" state, so they
+    are not valid as individual array elements.
+    """
+    parts = list(value) if isinstance(value, list) else [value]
+    return [p for p in parts if p != ""]
+
+
 def is_empty_url_value(value: str | list[str]) -> bool:
     """Check if URL value represents an empty parameter (e.g., ?foo= with no value).
 
@@ -135,38 +145,27 @@ def parse_url_param(value: str | list[str], value_type: str) -> Any:
             return val
         case "string_array_value":
             # Repeated params: ?foo=a&foo=b -> ["a", "b"]
-            # Filter out empty strings (e.g., ?foo=a&foo= -> ["a"])
-            # Note: This means "" cannot be a valid option value in URL-bound widgets.
-            # We reserve "" to mean "cleared/empty" rather than a literal empty string option.
-            parts = list(value) if isinstance(value, list) else [value]
-            return [p for p in parts if p != ""]
+            # Note: Empty strings are filtered - "" is reserved for "cleared/empty" state
+            return _to_non_empty_list(value)
         case "double_array_value":
             # Repeated params: ?foo=1.5&foo=2.5 -> [1.5, 2.5]
-            # Also handles string values for select_slider option matching
-            # Filter out empty strings - "" is reserved for "cleared/empty" state
-            parts = list(value) if isinstance(value, list) else [value]
+            # Strings kept for select_slider option matching; empty strings filtered
             result_double: list[float | str] = []
-            for part in parts:
-                if part == "":
-                    continue  # Skip empty strings
+            for part in _to_non_empty_list(value):
                 try:
                     result_double.append(float(part))
-                except ValueError:
-                    result_double.append(part)  # Keep as string for select_slider
+                except ValueError:  # noqa: PERF203
+                    result_double.append(part)
             return result_double
         case "int_array_value":
             # Repeated params: ?foo=1&foo=2 -> [1, 2]
-            # Also handles string values for option matching (pills, etc.)
-            # Filter out empty strings - "" is reserved for "cleared/empty" state
-            parts = list(value) if isinstance(value, list) else [value]
+            # Strings kept for option matching (pills, etc.); empty strings filtered
             result_int: list[int | str] = []
-            for part in parts:
-                if part == "":
-                    continue  # Skip empty strings
+            for part in _to_non_empty_list(value):
                 try:
                     result_int.append(int(part))
-                except ValueError:
-                    result_int.append(part)  # Keep as string
+                except ValueError:  # noqa: PERF203
+                    result_int.append(part)
             return result_int
         case _:
             # Unknown type, return as-is

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -46,7 +46,11 @@ from streamlit.runtime.state.common import (
     is_keyed_element_id,
 )
 from streamlit.runtime.state.presentation import apply_presenter
-from streamlit.runtime.state.query_params import QueryParams, parse_url_param
+from streamlit.runtime.state.query_params import (
+    QueryParams,
+    is_empty_url_value,
+    parse_url_param,
+)
 from streamlit.runtime.stats import (
     CACHE_MEMORY_FAMILY,
     CacheStat,
@@ -1003,14 +1007,21 @@ class SessionState:
         """Parse URL value, seed widget state, and auto-correct URL if needed.
 
         This method:
-        1. Parses the raw URL string using the widget's value_type
-        2. Deserializes to the widget's native value format
-        3. Handles invalid values (clears URL param, returns False)
-        4. Stores valid values in both widget state and session state
-        5. Auto-corrects the URL if the value was clamped/filtered
+        1. Checks if the URL value is empty and handles based on allow_empty
+        2. Parses the raw URL string using the widget's value_type
+        3. Deserializes to the widget's native value format
+        4. Handles invalid values (clears URL param, returns False)
+        5. Stores valid values in both widget state and session state
+        6. Auto-corrects the URL if the value was clamped/filtered
 
         Returns True if seeding succeeded, False if the URL value was invalid.
         """
+        # Check if URL value is empty (e.g., ?foo= with no value)
+        if is_empty_url_value(url_value) and not metadata.allow_empty:
+            # Widget doesn't allow empty state - clear the invalid param
+            self._clear_url_param(user_key)
+            return False
+
         try:
             parsed_value = parse_url_param(url_value, metadata.value_type)
             deserialized_value = metadata.deserializer(parsed_value)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1007,7 +1007,7 @@ class SessionState:
         """Parse URL value, seed widget state, and auto-correct URL if needed.
 
         This method:
-        1. Checks if the URL value is empty and handles based on allow_empty
+        1. Checks if the URL value is empty and handles based on clearable
         2. Parses the raw URL string using the widget's value_type
         3. Deserializes to the widget's native value format
         4. Handles invalid values (clears URL param, returns False)
@@ -1017,7 +1017,7 @@ class SessionState:
         Returns True if seeding succeeded, False if the URL value was invalid.
         """
         # Check if URL value is empty (e.g., ?foo= with no value)
-        if is_empty_url_value(url_value) and not metadata.allow_empty:
+        if is_empty_url_value(url_value) and not metadata.clearable:
             # Widget doesn't allow empty state - clear the invalid param
             self._clear_url_param(user_key)
             return False
@@ -1026,14 +1026,16 @@ class SessionState:
             parsed_value = parse_url_param(url_value, metadata.value_type)
             deserialized_value = metadata.deserializer(parsed_value)
 
-            # Handle case where all URL values were invalid (filtered to empty list)
-            if isinstance(deserialized_value, list) and len(deserialized_value) == 0:
-                url_had_values = (
-                    isinstance(parsed_value, list) and len(parsed_value) > 0
-                ) or (isinstance(parsed_value, str) and len(parsed_value) > 0)
-                if url_had_values:
-                    self._clear_url_param(user_key)
-                    return False
+            # Handle case where all URL values were invalid (filtered to empty list).
+            # For array types, parsed_value is always a list. If it had values that
+            # were all filtered by the deserializer (e.g., invalid options), clear URL.
+            if (
+                isinstance(deserialized_value, list)
+                and len(deserialized_value) == 0
+                and parsed_value  # Non-empty list means URL had values
+            ):
+                self._clear_url_param(user_key)
+                return False
 
             # Store the value in widget and session state
             self._new_widget_state.set_from_value(widget_id, deserialized_value)

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -52,7 +52,7 @@ def register_widget(
     # TODO(query-params): Remove formatted_options once all selection widgets use
     # string-based wire formats (string_value/string_array_value).
     formatted_options: list[str] | None = None,
-    clearable: bool = False,
+    clearable: bool | None = None,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
@@ -96,11 +96,11 @@ def register_widget(
         wire formats. Currently used for index-based widgets (pills, segmented_control,
         select_slider) to convert indices back to human-readable option strings
         in URLs when auto-correcting filtered values.
-    clearable : bool
+    clearable : bool or None
         Whether the widget can be cleared to an empty state (reflects widget's UI
         behavior). When True, an empty URL param (e.g., ?foo=) will seed the widget
         with an empty value. When False, an empty URL param will be ignored.
-        Default is False.
+        **Required when bind='query-params'**, otherwise defaults to False.
 
     Returns
     -------
@@ -140,6 +140,12 @@ def register_widget(
                 "parameter specified. This 'key' will be used as the name of the "
                 "query parameter."
             )
+        # Internal API check: clearable must be set for query param binding
+        if clearable is None:
+            raise ValueError(
+                "clearable must be explicitly set when bind='query-params'. "
+                "This is required for correct empty value handling."
+            )
 
     # Create the widget's updated metadata, and register it with session_state.
     metadata = WidgetMetadata(
@@ -155,7 +161,7 @@ def register_widget(
         presenter=presenter,
         bind=bind,
         formatted_options=formatted_options,
-        clearable=clearable,
+        clearable=clearable if clearable is not None else False,
     )
     return register_widget_from_metadata(metadata, ctx)
 

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -52,7 +52,7 @@ def register_widget(
     # TODO(query-params): Remove formatted_options once all selection widgets use
     # string-based wire formats (string_value/string_array_value).
     formatted_options: list[str] | None = None,
-    allow_empty: bool = False,
+    clearable: bool = False,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
@@ -96,9 +96,9 @@ def register_widget(
         wire formats. Currently used for index-based widgets (pills, segmented_control,
         select_slider) to convert indices back to human-readable option strings
         in URLs when auto-correcting filtered values.
-    allow_empty : bool
-        Whether empty/cleared is a valid state for this widget when bound to query
-        params. When True, an empty URL param (e.g., ?foo=) will seed the widget
+    clearable : bool
+        Whether the widget can be cleared to an empty state (reflects widget's UI
+        behavior). When True, an empty URL param (e.g., ?foo=) will seed the widget
         with an empty value. When False, an empty URL param will be ignored.
         Default is False.
 
@@ -155,7 +155,7 @@ def register_widget(
         presenter=presenter,
         bind=bind,
         formatted_options=formatted_options,
-        allow_empty=allow_empty,
+        clearable=clearable,
     )
     return register_widget_from_metadata(metadata, ctx)
 

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -52,6 +52,7 @@ def register_widget(
     # TODO(query-params): Remove formatted_options once all selection widgets use
     # string-based wire formats (string_value/string_array_value).
     formatted_options: list[str] | None = None,
+    allow_empty: bool = False,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
@@ -95,6 +96,11 @@ def register_widget(
         wire formats. Currently used for index-based widgets (pills, segmented_control,
         select_slider) to convert indices back to human-readable option strings
         in URLs when auto-correcting filtered values.
+    allow_empty : bool
+        Whether empty/cleared is a valid state for this widget when bound to query
+        params. When True, an empty URL param (e.g., ?foo=) will seed the widget
+        with an empty value. When False, an empty URL param will be ignored.
+        Default is False.
 
     Returns
     -------
@@ -149,6 +155,7 @@ def register_widget(
         presenter=presenter,
         bind=bind,
         formatted_options=formatted_options,
+        allow_empty=allow_empty,
     )
     return register_widget_from_metadata(metadata, ctx)
 

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -699,7 +699,7 @@ class IsEmptyUrlValueTest(DeltaGeneratorTestCase):
     ) -> None:
         """Test that is_empty_url_value correctly identifies empty vs non-empty values.
 
-        All-empty values like ["", ""] should be treated as empty (allow_empty applies).
+        All-empty values like ["", ""] should be treated as empty (clearable applies).
         Mixed values like ["a", ""] should NOT be considered empty because
         they contain valid data that should be processed.
         """

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -21,6 +21,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.state.query_params import (
     QueryParams,
     _set_item_in_dict,
+    is_empty_url_value,
     parse_url_param,
     process_query_params,
 )
@@ -563,6 +564,10 @@ class ParseUrlParamTest(DeltaGeneratorTestCase):
         [
             ("single_value", "a", "string_array_value", ["a"]),
             ("multiple_values", ["a", "b", "c"], "string_array_value", ["a", "b", "c"]),
+            # Empty strings should be filtered out from arrays
+            ("mixed_trailing_empty", ["a", ""], "string_array_value", ["a"]),
+            ("mixed_leading_empty", ["", "a"], "string_array_value", ["a"]),
+            ("mixed_middle_empty", ["a", "", "b"], "string_array_value", ["a", "b"]),
         ]
     )
     def test_parse_string_array_value(
@@ -581,6 +586,10 @@ class ParseUrlParamTest(DeltaGeneratorTestCase):
                 "int_array_value",
                 [1, "option_a"],
             ),
+            # Empty strings should be filtered out from arrays
+            ("mixed_trailing_empty", ["1", ""], "int_array_value", [1]),
+            ("mixed_leading_empty", ["", "2"], "int_array_value", [2]),
+            ("mixed_middle_empty", ["1", "", "3"], "int_array_value", [1, 3]),
         ]
     )
     def test_parse_int_array_value(
@@ -603,6 +612,15 @@ class ParseUrlParamTest(DeltaGeneratorTestCase):
                 "double_array_value",
                 [1.5, "option_a"],
             ),
+            # Empty strings should be filtered out from arrays
+            ("mixed_trailing_empty", ["1.5", ""], "double_array_value", [1.5]),
+            ("mixed_leading_empty", ["", "2.5"], "double_array_value", [2.5]),
+            (
+                "mixed_middle_empty",
+                ["1.5", "", "3.5"],
+                "double_array_value",
+                [1.5, 3.5],
+            ),
         ]
     )
     def test_parse_double_array_value(
@@ -623,6 +641,69 @@ class ParseUrlParamTest(DeltaGeneratorTestCase):
     def test_parse_unknown_type_returns_as_is(self) -> None:
         """Test that unknown value types return the value as-is."""
         assert parse_url_param("hello", "unknown_type") == "hello"
+
+    @parameterized.expand(
+        [
+            # Empty string returns empty array for array types
+            ("empty_string_array", "", "string_array_value", []),
+            ("empty_int_array", "", "int_array_value", []),
+            ("empty_double_array", "", "double_array_value", []),
+            # Empty list [""] also returns empty array
+            ("empty_list_string_array", [""], "string_array_value", []),
+            ("empty_list_int_array", [""], "int_array_value", []),
+            ("empty_list_double_array", [""], "double_array_value", []),
+            # Empty string returns empty string for string_value
+            ("empty_string_value", "", "string_value", ""),
+            # Empty string returns None for other scalar types
+            ("empty_bool_value", "", "bool_value", None),
+            ("empty_int_value", "", "int_value", None),
+            ("empty_double_value", "", "double_value", None),
+        ]
+    )
+    def test_parse_empty_string_values(
+        self, _name: str, value: str | list[str], value_type: str, expected: object
+    ) -> None:
+        """Test parsing empty string values from URL params (e.g., ?foo=).
+
+        Empty values should be handled appropriately for each type:
+        - Array types: return [] (empty array)
+        - string_value: return "" (empty string is valid)
+        - Other scalar types: return None (signaling "cleared" state)
+        """
+        assert parse_url_param(value, value_type) == expected
+
+
+class IsEmptyUrlValueTest(DeltaGeneratorTestCase):
+    """Tests for is_empty_url_value helper function."""
+
+    @parameterized.expand(
+        [
+            # Truly empty values should return True
+            ("empty_string", "", True),
+            ("empty_list", [""], True),
+            # Multiple empty values should also return True (e.g., ?foo=&foo=)
+            ("multiple_empty", ["", ""], True),
+            ("triple_empty", ["", "", ""], True),
+            # Non-empty values should return False
+            ("single_value", "a", False),
+            ("single_value_list", ["a"], False),
+            ("multiple_values", ["a", "b"], False),
+            # Mixed values with trailing empty should return False (has valid data)
+            ("mixed_trailing_empty", ["a", ""], False),
+            ("mixed_leading_empty", ["", "a"], False),
+            ("mixed_middle_empty", ["a", "", "b"], False),
+        ]
+    )
+    def test_is_empty_url_value(
+        self, _name: str, value: str | list[str], expected: bool
+    ) -> None:
+        """Test that is_empty_url_value correctly identifies empty vs non-empty values.
+
+        All-empty values like ["", ""] should be treated as empty (allow_empty applies).
+        Mixed values like ["a", ""] should NOT be considered empty because
+        they contain valid data that should be processed.
+        """
+        assert is_empty_url_value(value) == expected
 
 
 class WidgetBindingTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -71,6 +71,7 @@ def _create_test_widget_metadata(
     deserializer=None,
     serializer=None,
     formatted_options: list[str] | None = None,
+    allow_empty: bool = False,
 ) -> WidgetMetadata:
     """Helper to create widget metadata for query param binding tests."""
     return WidgetMetadata(
@@ -80,6 +81,7 @@ def _create_test_widget_metadata(
         value_type=value_type,
         bind="query-params",
         formatted_options=formatted_options,
+        allow_empty=allow_empty,
     )
 
 
@@ -1654,6 +1656,84 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
 
         assert seeded is False
         assert "tags" not in self.query_params._query_params
+
+    def test_seed_widget_with_empty_url_and_allow_empty_true(self) -> None:
+        """Test that empty URL values seed widget when allow_empty=True."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            deserializer=lambda x: x if x is not None else [],
+            allow_empty=True,
+        )
+
+        # Empty string from URL (e.g., ?tags=)
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "tags", "widget_1", ""
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == []
+
+    def test_seed_widget_with_empty_url_and_allow_empty_false(self) -> None:
+        """Test that empty URL values are ignored and cleared when allow_empty=False."""
+        # First, set the URL param so we can verify it gets cleared
+        self.query_params._query_params["toggle"] = ""
+
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="bool_value",
+            deserializer=lambda x: x if x is not None else False,
+            allow_empty=False,
+        )
+
+        # Empty string from URL (e.g., ?toggle=)
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "toggle", "widget_1", ""
+        )
+
+        assert seeded is False
+        assert "widget_1" not in self.session_state._new_widget_state
+        # URL param should be cleared (not left as stale ?toggle=)
+        assert "toggle" not in self.query_params._query_params
+
+    def test_seed_widget_with_empty_list_and_allow_empty_true(self) -> None:
+        """Test that empty list [''] seeds widget when allow_empty=True."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="int_array_value",
+            deserializer=lambda x: x if x is not None else [],
+            allow_empty=True,
+        )
+
+        # Empty list from URL parsing (e.g., ?items=)
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "items", "widget_1", [""]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == []
+
+    def test_seed_widget_with_empty_list_and_allow_empty_false(self) -> None:
+        """Test that empty list [''] is ignored and cleared when allow_empty=False."""
+        # First, set the URL param so we can verify it gets cleared
+        self.query_params._query_params["range"] = [""]
+
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="double_array_value",
+            deserializer=lambda x: x if x is not None else [0.0, 100.0],
+            allow_empty=False,
+        )
+
+        # Empty list from URL parsing (e.g., ?range=)
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "range", "widget_1", [""]
+        )
+
+        assert seeded is False
+        assert "widget_1" not in self.session_state._new_widget_state
+        # URL param should be cleared (not left as stale ?range=)
+        assert "range" not in self.query_params._query_params
 
 
 class AutoCorrectUrlTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -71,7 +71,7 @@ def _create_test_widget_metadata(
     deserializer=None,
     serializer=None,
     formatted_options: list[str] | None = None,
-    allow_empty: bool = False,
+    clearable: bool = False,
 ) -> WidgetMetadata:
     """Helper to create widget metadata for query param binding tests."""
     return WidgetMetadata(
@@ -81,7 +81,7 @@ def _create_test_widget_metadata(
         value_type=value_type,
         bind="query-params",
         formatted_options=formatted_options,
-        allow_empty=allow_empty,
+        clearable=clearable,
     )
 
 
@@ -1657,13 +1657,13 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is False
         assert "tags" not in self.query_params._query_params
 
-    def test_seed_widget_with_empty_url_and_allow_empty_true(self) -> None:
-        """Test that empty URL values seed widget when allow_empty=True."""
+    def test_seed_widget_with_empty_url_and_clearable_true(self) -> None:
+        """Test that empty URL values seed widget when clearable=True."""
         metadata = _create_test_widget_metadata(
             "widget_1",
             value_type="string_array_value",
             deserializer=lambda x: x if x is not None else [],
-            allow_empty=True,
+            clearable=True,
         )
 
         # Empty string from URL (e.g., ?tags=)
@@ -1674,8 +1674,8 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is True
         assert self.session_state._new_widget_state["widget_1"] == []
 
-    def test_seed_widget_with_empty_url_and_allow_empty_false(self) -> None:
-        """Test that empty URL values are ignored and cleared when allow_empty=False."""
+    def test_seed_widget_with_empty_url_and_clearable_false(self) -> None:
+        """Test that empty URL values are ignored and cleared when clearable=False."""
         # First, set the URL param so we can verify it gets cleared
         self.query_params._query_params["toggle"] = ""
 
@@ -1683,7 +1683,7 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
             "widget_1",
             value_type="bool_value",
             deserializer=lambda x: x if x is not None else False,
-            allow_empty=False,
+            clearable=False,
         )
 
         # Empty string from URL (e.g., ?toggle=)
@@ -1696,13 +1696,13 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         # URL param should be cleared (not left as stale ?toggle=)
         assert "toggle" not in self.query_params._query_params
 
-    def test_seed_widget_with_empty_list_and_allow_empty_true(self) -> None:
-        """Test that empty list [''] seeds widget when allow_empty=True."""
+    def test_seed_widget_with_empty_list_and_clearable_true(self) -> None:
+        """Test that empty list [''] seeds widget when clearable=True."""
         metadata = _create_test_widget_metadata(
             "widget_1",
             value_type="int_array_value",
             deserializer=lambda x: x if x is not None else [],
-            allow_empty=True,
+            clearable=True,
         )
 
         # Empty list from URL parsing (e.g., ?items=)
@@ -1713,8 +1713,8 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is True
         assert self.session_state._new_widget_state["widget_1"] == []
 
-    def test_seed_widget_with_empty_list_and_allow_empty_false(self) -> None:
-        """Test that empty list [''] is ignored and cleared when allow_empty=False."""
+    def test_seed_widget_with_empty_list_and_clearable_false(self) -> None:
+        """Test that empty list [''] is ignored and cleared when clearable=False."""
         # First, set the URL param so we can verify it gets cleared
         self.query_params._query_params["range"] = [""]
 
@@ -1722,7 +1722,7 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
             "widget_1",
             value_type="double_array_value",
             deserializer=lambda x: x if x is not None else [0.0, 100.0],
-            allow_empty=False,
+            clearable=False,
         )
 
         # Empty list from URL parsing (e.g., ?range=)

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -648,12 +648,12 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
             )
 
     def test_bind_query_params_with_key_succeeds(self):
-        """Test that bind='query-params' works when widget has a key.
+        """Test that bind='query-params' works when widget has a key and clearable.
 
         Note: With ctx=None, the function returns early with a fallback result.
         The important thing is that it doesn't raise the validation error.
         """
-        # Widget with user key should not raise the validation error
+        # Widget with user key and clearable should not raise the validation error
         # (it will return early due to ctx=None, but that's expected)
         result = register_widget(
             element_id="$$ID-some_hash-my_widget_key",  # Has user key
@@ -665,9 +665,26 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
             serializer=lambda x: x,
             value_type="string_value",
             bind="query-params",
+            clearable=True,
         )
         # Should return a fallback result without raising
         assert result is not None
+
+    def test_bind_query_params_requires_clearable(self):
+        """Test that bind='query-params' raises if clearable is not set."""
+        with pytest.raises(ValueError, match="clearable must be explicitly set"):
+            register_widget(
+                element_id="$$ID-some_hash-my_widget_key",  # Has user key
+                ctx=None,
+                on_change_handler=None,
+                args=None,
+                kwargs=None,
+                deserializer=lambda x: x if x is not None else "default",
+                serializer=lambda x: x,
+                value_type="string_value",
+                bind="query-params",
+                # clearable intentionally not provided
+            )
 
     def test_bind_none_does_not_require_key(self):
         """Test that bind=None (default) doesn't require a key."""


### PR DESCRIPTION
## Describe your changes
Adds support for empty query parameter values (`?foo=`) in widget URL binding, allowing clearable widgets (multiselect, pills, etc.) to represent their cleared state in the URL.

**Changes:**
- Add explicit empty-value handling for query param parsing and URL seeding
- Introduce clearable flags in backend/frontend bindings to control empty state behavior

**Note**: We reserve the empty string (`""`) to represent the cleared state in query params, so a literal empty‑string option isn’t supported. This avoids ambiguity between `?foo=` (cleared) and an empty option value

## Testing Plan
- JS & Python Unit Tests: ✅ Added
(Will be able to more explicitly test this behavior in widget implementations to come)