### PR TITLE
Attempt to fix e2e test hangs at 99% completion

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -125,21 +125,34 @@ class AsyncSubprocess:
         self._proc = None
         self._stdout_file = None
 
+    def _stop_process(self) -> None:
+        """Stop the subprocess with timeout handling.
+
+        Attempts graceful termination first, then force kills if needed.
+        Handles race conditions where process may exit between operations.
+        """
+        if self._proc is None:
+            return
+
+        self._proc.terminate()
+        try:
+            # Wait up to 20 seconds for graceful termination
+            self._proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            # Force kill if it doesn't terminate gracefully
+            try:
+                self._proc.kill()
+            except ProcessLookupError:
+                pass  # Process already exited between timeout and kill
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass  # Give up, but don't hang
+        self._proc = None
+
     def terminate(self) -> str | None:
         """Terminate the process and return its stdout/stderr in a string."""
-        if self._proc is not None:
-            self._proc.terminate()
-            try:
-                # Wait up to 20 seconds for graceful termination
-                self._proc.wait(timeout=20)
-            except subprocess.TimeoutExpired:
-                # Force kill if it doesn't terminate gracefully
-                self._proc.kill()
-                try:
-                    self._proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass  # Give up, but don't hang
-            self._proc = None
+        self._stop_process()
 
         # Read the stdout file and close it
         stdout = None
@@ -177,17 +190,7 @@ class AsyncSubprocess:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        if self._proc is not None:
-            self._proc.terminate()
-            try:
-                self._proc.wait(timeout=20)
-            except subprocess.TimeoutExpired:
-                self._proc.kill()
-                try:
-                    self._proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-            self._proc = None
+        self._stop_process()
         if self._stdout_file is not None:
             self._stdout_file.close()
             self._stdout_file = None

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -140,6 +140,7 @@ class AsyncSubprocess:
             self._proc.wait(timeout=20)
         except subprocess.TimeoutExpired:
             # Force kill if it doesn't terminate gracefully
+            print("Process did not terminate gracefully, force killing...", flush=True)
             try:
                 self._proc.kill()
             except ProcessLookupError:

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -129,7 +129,16 @@ class AsyncSubprocess:
         """Terminate the process and return its stdout/stderr in a string."""
         if self._proc is not None:
             self._proc.terminate()
-            self._proc.wait()
+            try:
+                # Wait up to 20 seconds for graceful termination
+                self._proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                # Force kill if it doesn't terminate gracefully
+                self._proc.kill()
+                try:
+                    self._proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass  # Give up, but don't hang
             self._proc = None
 
         # Read the stdout file and close it
@@ -170,6 +179,14 @@ class AsyncSubprocess:
     ) -> None:
         if self._proc is not None:
             self._proc.terminate()
+            try:
+                self._proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                try:
+                    self._proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
             self._proc = None
         if self._stdout_file is not None:
             self._stdout_file.close()

--- a/e2e_playwright/pytest.ini
+++ b/e2e_playwright/pytest.ini
@@ -16,4 +16,5 @@ filterwarnings =
     # Benchmarks are disabled when running with xdist (parallel execution).
     ignore:Benchmarks are automatically disabled.*::pytest_benchmark.*:
 addopts = --output ./test-results/ --video retain-on-failure --screenshot only-on-failure --full-page-screenshot -r aR -v --durations=5 --reruns 0 --reruns-delay 1 --rerun-except "Missing snapshot" --tb=short
-timeout = 300
+timeout = 180
+timeout_func_only = true

--- a/e2e_playwright/shared/performance.py
+++ b/e2e_playwright/shared/performance.py
@@ -181,27 +181,27 @@ def measure_performance(
             # Run the test
             yield
         finally:
+            # Calculate execution time immediately to exclude cleanup from measurement
+            execution_time = time.time() - start_time
+
             # Clean up event listeners to prevent hangs during teardown
             try:
                 page.remove_listener("websocket", on_web_socket)
             except Exception:
-                pass
+                pass  # Listener may already be removed or page closed
 
             # Clean up websocket frame handlers
             for ws, event, handler in websocket_handlers:
                 try:
                     ws.remove_listener(event, handler)
                 except Exception:
-                    pass
+                    pass  # Handler may already be removed or websocket closed
 
             # Clean up CDP client listener
             try:
                 client.send("Network.disable")
             except Exception:
-                pass
-
-        # Calculate execution time
-        execution_time = time.time() - start_time
+                pass  # CDP session may already be detached
 
         # Add custom metrics
         custom_metrics = [

--- a/e2e_playwright/shared/performance.py
+++ b/e2e_playwright/shared/performance.py
@@ -90,8 +90,15 @@ def with_cdp_session(page: Page) -> Generator[CDPSession, None, None]:
         )
 
     client = page.context.new_cdp_session(page)
-    yield client
-    client.detach()
+    try:
+        yield client
+    finally:
+        try:
+            client.detach()
+        except Exception:
+            # Ignore errors during detach - the session may already be closed
+            # or the browser context may have been destroyed
+            pass
 
 
 @contextmanager
@@ -138,6 +145,9 @@ def measure_performance(
         total_websocket_messages_sent = 0
         total_websocket_messages_received = 0
 
+        # Track websocket handlers for cleanup
+        websocket_handlers: list[tuple[WebSocket, str, Any]] = []
+
         def on_web_socket(ws: WebSocket) -> None:
             def on_frame_sent(payload: str | bytes) -> None:
                 nonlocal total_websocket_sent_size_bytes, total_websocket_messages_sent
@@ -157,6 +167,9 @@ def measure_performance(
 
             ws.on("framesent", on_frame_sent)
             ws.on("framereceived", on_frame_received)
+            # Track handlers for cleanup
+            websocket_handlers.append((ws, "framesent", on_frame_sent))
+            websocket_handlers.append((ws, "framereceived", on_frame_received))
 
         # Register websocket handler
         page.on("websocket", on_web_socket)
@@ -164,8 +177,28 @@ def measure_performance(
         # Start timing
         start_time = time.time()
 
-        # Run the test
-        yield
+        try:
+            # Run the test
+            yield
+        finally:
+            # Clean up event listeners to prevent hangs during teardown
+            try:
+                page.remove_listener("websocket", on_web_socket)
+            except Exception:
+                pass
+
+            # Clean up websocket frame handlers
+            for ws, event, handler in websocket_handlers:
+                try:
+                    ws.remove_listener(event, handler)
+                except Exception:
+                    pass
+
+            # Clean up CDP client listener
+            try:
+                client.send("Network.disable")
+            except Exception:
+                pass
 
         # Calculate execution time
         execution_time = time.time() - start_time


### PR DESCRIPTION
## Describe your changes

Attempt to fix e2e tests hanging at 99% completion. This might be due to unbounded subprocess termination waits. The `AsyncSubprocess` class now uses proper timeouts during cleanup to prevent indefinite hangs when Streamlit servers don't shut down gracefully.

**Key changes:**
- Add 20-second timeout for graceful process termination in `AsyncSubprocess.terminate()` and `__exit__()`
- Force kill with 5-second timeout if graceful termination fails
- Reduce per-test timeout from 300s to 180s to catch hanging tests faster
- Set `timeout_func_only = true` to allow fixture teardown after test timeout
- Add event listener cleanup in performance profiling to prevent resource leaks

## Testing Plan

- These changes address infrastructure/CI issues and don't affect functionality
- No new tests needed; the fixes prevent existing tests from hanging

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.