### PR TITLE
Add accessibility review section to AI PR review workflow

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -114,6 +114,7 @@ jobs:
           - The python library changes follow the best practices documented in .cursor/rules/python_lib.mdc and .cursor/rules/python.mdc
           - If proto files have been changed, please check with .cursor/rules/protobuf.mdc if the changes look good.
           - No risky aspects that could cause security issues or regressions.
+          - Frontend changes follow accessibility best practices.
           - The code follows other best practices from the Streamlit code base.
 
           # Instructions:
@@ -148,6 +149,10 @@ jobs:
           ## Security & Risk
 
           [Any security concerns or regression risks identified.]
+
+          ## Accessibility
+
+          [Assessment of accessibility considerations for frontend changes.]
 
           ## Recommendations
 


### PR DESCRIPTION
## Describe your changes

Added a dedicated Accessibility section to the AI PR review workflow to ensure frontend changes follow accessibility best practices.

Changes include:
- Added accessibility requirement to the review checklist
- Added Accessibility section to the PR review output format

## Testing Plan

No additional tests needed - this is a configuration change to the workflow that doesn't affect core functionality. The AI reviewer will use this new section as guidance for evaluating accessibility in frontend PRs.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.