### PR TITLE
Increase coverage change threshold to 0.05%

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -174,7 +174,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const COVERAGE_CHANGE_THRESHOLD = 0.03; // 0.03%
+            const COVERAGE_CHANGE_THRESHOLD = 0.05; // 0.05%
             const fs = require('fs');
 
             try {

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -316,7 +316,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const COVERAGE_CHANGE_THRESHOLD = 0.03; // 0.03%
+            const COVERAGE_CHANGE_THRESHOLD = 0.05; // 0.05%
 
             try {
               // Read current coverage from the existing file


### PR DESCRIPTION
## Describe your changes

Raises the coverage change detection threshold in CI workflows from 0.03% to 0.05% for both frontend (JavaScript) and Python tests. This reduces noise in PR comments caused by minor coverage variations while still alerting to meaningful changes.

## Testing Plan

No additional tests required. This change only affects the threshold for posting coverage comments on pull requests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.