### PR TITLE
Fix mypy no-any-return errors for pandas DataFrame returns

### DIFF
--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -671,7 +671,7 @@ def _drop_unused_columns(df: pd.DataFrame, *column_names: str | None) -> pd.Data
         seen.add(x)
         keep.append(x)
 
-    return df[keep]
+    return df[keep]  # type: ignore[no-any-return, unused-ignore]
 
 
 def _maybe_convert_color_column_in_place(

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -299,4 +299,4 @@ def _use_display_values(df: DataFrame, styles: Mapping[str, Any]) -> DataFrame:
         # Batch-assign updates for this column using iloc for performance.
         new_df.iloc[row_indices, col_idx] = values
 
-    return new_df
+    return new_df  # type: ignore[no-any-return, unused-ignore]

--- a/lib/streamlit/hello/dataframe_demo.py
+++ b/lib/streamlit/hello/dataframe_demo.py
@@ -26,7 +26,7 @@ def data_frame_demo() -> None:
     def get_un_data() -> pd.DataFrame:
         aws_bucket_url = "https://streamlit-demo-data.s3-us-west-2.amazonaws.com"
         df = pd.read_csv(aws_bucket_url + "/agri.csv.gz")
-        return df.set_index("Region")
+        return df.set_index("Region")  # type: ignore[no-any-return, unused-ignore]
 
     try:
         df = get_un_data()


### PR DESCRIPTION
## Summary
- Added `# type: ignore[no-any-return, unused-ignore]` to three pandas DataFrame return statements that fail mypy in CI
- The `no-any-return` error occurs because pandas operations (`astype`, `set_index`, `__getitem__`) return `Any` in some environments depending on pandas-stubs version
- The `unused-ignore` suppression is needed because locally (with different pandas-stubs) the types resolve correctly and the ignore would be flagged as unused

### Files changed:
- `lib/streamlit/elements/lib/pandas_styler_utils.py:302` — `df.astype(str)` return
- `lib/streamlit/elements/lib/built_in_chart_utils.py:674` — `df[keep]` return
- `lib/streamlit/hello/dataframe_demo.py:29` — `df.set_index("Region")` return

## Test plan
- [ ] `make python-types` passes in CI (mypy + ty)