### PR TITLE
Pin `pandas-stubs` version to prevent CI breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,9 @@ dev = [
   "types-toml",
   "types-cachetools",
   "types-Authlib",
-  # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version
-  "pandas-stubs==3.0.0.260204",
+  # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version.
+  # We need to pin 2.3.3.260113 since higher versions require a min Python 3.11 support.
+  "pandas-stubs==2.3.3.260113",
 ]
 
 # Test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ dev = [
   "types-toml",
   "types-cachetools",
   "types-Authlib",
-  "pandas-stubs>=2.3.3.251219",
+  # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version
+  "pandas-stubs==3.0.0.260204",
 ]
 
 # Test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@
 name = "streamlit-dev"
 version = "0.0.0"
 description = "Development environment for Streamlit"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 # Empty dependencies - the actual package is installed via [tool.uv.sources]
 dependencies = []
 
@@ -73,8 +73,7 @@ dev = [
   "types-cachetools",
   "types-Authlib",
   # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version.
-  # We need to pin 2.3.3.260113 since higher versions require a min Python 3.11 support.
-  "pandas-stubs==2.3.3.260113",
+  "pandas-stubs==3.0.0.260204",
 ]
 
 # Test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@
 name = "streamlit-dev"
 version = "0.0.0"
 description = "Development environment for Streamlit"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 # Empty dependencies - the actual package is installed via [tool.uv.sources]
 dependencies = []
 
@@ -73,7 +73,8 @@ dev = [
   "types-cachetools",
   "types-Authlib",
   # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version.
-  "pandas-stubs==3.0.0.260204",
+  # We need to pin 2.3.3.260113 since higher versions require a min Python 3.11 support.
+  "pandas-stubs==2.3.3.260113",
 ]
 
 # Test dependencies


### PR DESCRIPTION
## Describe your changes

`pandas-stubs` updates have caused CI issues a couple of times. Therefore, we are pinning it to a specific version so that it gets updated via dependabot instead.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
