### PR TITLE
Keep sidebar collapse control visible

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -515,6 +515,8 @@ export class App extends PureComponent<Props, State> {
       disableFullscreenMode: hostConfig.disableFullscreenMode,
       enforceDownloadInNewTab: hostConfig.enforceDownloadInNewTab,
       resourceCrossOriginMode: hostConfig.resourceCrossOriginMode,
+      // Keep sidebar header visible for long sidebars.
+      stickySidebarHeader: hostConfig.stickySidebarHeader,
     })
 
     if (Object.keys(libConfig).length > 0) {
@@ -575,6 +577,7 @@ export class App extends PureComponent<Props, State> {
           blockErrorDialogs,
           setAnonymousCrossOriginPropertyOnMediaElements,
           resourceCrossOriginMode,
+          stickySidebarHeader,
         } = reconciledConfig
 
         const appConfig: AppConfig = {
@@ -595,6 +598,8 @@ export class App extends PureComponent<Props, State> {
             (setAnonymousCrossOriginPropertyOnMediaElements
               ? "anonymous"
               : undefined),
+          // Keep sidebar header visible for long sidebars.
+          stickySidebarHeader,
         }
 
         // Set the metrics configuration:

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -71,6 +71,7 @@ function renderSidebar(
       appRootRef?: boolean
     }
     navigationContext?: Partial<NavigationContextProps>
+    libConfigContext?: { stickySidebarHeader?: boolean }
   }
 ): RenderWithContextsResult {
   const contextOptions: RenderWithContextsOptions = {
@@ -79,6 +80,7 @@ function renderSidebar(
       ...options?.sidebarConfigContext,
     },
     navigationContext: options?.navigationContext,
+    libConfigContext: options?.libConfigContext,
   }
 
   return renderWithContexts(
@@ -126,6 +128,26 @@ describe("Sidebar Component", () => {
   it("should render without crashing", () => {
     renderSidebar()
     expect(screen.getByTestId("stSidebar")).toBeInTheDocument()
+  })
+
+  it("pins the header when stickySidebarHeader is enabled", () => {
+    renderSidebar({}, { libConfigContext: { stickySidebarHeader: true } })
+
+    const header = screen.getByTestId("stSidebarHeader")
+    const content = screen.getByTestId("stSidebarContent")
+
+    expect(header).toHaveStyle({ position: "sticky" })
+    expect(content).toHaveAttribute("data-sticky-header", "true")
+  })
+
+  it("does not pin the header when stickySidebarHeader is disabled", () => {
+    renderSidebar({}, { libConfigContext: { stickySidebarHeader: false } })
+
+    const header = screen.getByTestId("stSidebarHeader")
+    const content = screen.getByTestId("stSidebarContent")
+
+    expect(header).not.toHaveStyle({ position: "sticky" })
+    expect(content).toHaveAttribute("data-sticky-header", "false")
   })
 
   describe("Collapse/Expand Behavior", () => {

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -41,6 +41,7 @@ import {
   BaseButtonKind,
   DynamicIcon,
   IsSidebarContext,
+  LibConfigContext,
   NavigationContext,
   SidebarConfigContext,
   useEmotionTheme,
@@ -92,6 +93,10 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   const { hideSidebarNav, appLogo, initialSidebarWidth, appRootRef } =
     useContext(SidebarConfigContext)
+
+  const { stickySidebarHeader } = useContext(LibConfigContext)
+  const isStickyHeader = stickySidebarHeader ?? true
+  const shouldPinHeader = isStickyHeader && !isCollapsed
 
   const scrollbarGutterSize = useScrollbarGutterSize()
 
@@ -289,12 +294,16 @@ const Sidebar: React.FC<SidebarProps> = ({
     >
       <StyledSidebarContent
         data-testid="stSidebarContent"
+        data-sticky-header={shouldPinHeader}
         ref={sidebarRef}
         onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}
         scrollbarGutterSize={scrollbarGutterSize}
       >
-        <StyledSidebarHeaderContainer data-testid="stSidebarHeader">
+        <StyledSidebarHeaderContainer
+          data-testid="stSidebarHeader"
+          isSticky={shouldPinHeader}
+        >
           {renderLogoContent()}
           <StyledCollapseSidebarButton
             showSidebarCollapse={showSidebarCollapse}

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -112,6 +112,8 @@ export const StyledSidebarContent = styled.div<StyledSidebarContentProps>(
     height: "100%",
     width: "100%",
     overflow: "auto",
+    display: "flex",
+    flexDirection: "column",
     /**
      * Ensure that space is reserved for scrollbars, even when they are not
      * visible. This is necessary to prevent layout shifts when the scrollbars
@@ -144,13 +146,22 @@ export const StyledResizeHandle = styled.div(({ theme }) => ({
   },
 }))
 
-export const StyledSidebarHeaderContainer = styled.div(({ theme }) => ({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  marginBottom: theme.spacing.lg,
-  height: theme.sizes.headerHeight,
-}))
+export interface StyledSidebarHeaderContainerProps {
+  isSticky: boolean
+}
+
+export const StyledSidebarHeaderContainer =
+  styled.div<StyledSidebarHeaderContainerProps>(({ theme, isSticky }) => ({
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: theme.spacing.lg,
+    height: theme.sizes.headerHeight,
+    position: isSticky ? "sticky" : "relative",
+    top: isSticky ? 0 : "auto",
+    zIndex: isSticky ? theme.zIndices.header + 2 : "auto",
+    backgroundColor: theme.colors.bgColor,
+  }))
 
 export const StyledLogoLink = styled.a({
   "&:hover": {

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -56,6 +56,7 @@ type LibConfigContextValues = {
   mapboxToken?: string
   enforceDownloadInNewTab?: boolean
   resourceCrossOriginMode?: undefined | "anonymous" | "use-credentials"
+  stickySidebarHeader?: boolean
   showErrorLinks?: Config.ShowErrorLinks
 }
 
@@ -121,6 +122,7 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   mapboxToken,
   enforceDownloadInNewTab,
   resourceCrossOriginMode,
+  stickySidebarHeader,
   showErrorLinks,
   // NavigationContext
   pageLinkBaseUrl,
@@ -158,6 +160,7 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       mapboxToken,
       enforceDownloadInNewTab,
       resourceCrossOriginMode,
+      stickySidebarHeader,
       showErrorLinks,
     }),
     [
@@ -165,6 +168,7 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       mapboxToken,
       enforceDownloadInNewTab,
       resourceCrossOriginMode,
+      stickySidebarHeader,
       showErrorLinks,
     ]
   )

--- a/frontend/app/src/util/hostConfigHelpers.ts
+++ b/frontend/app/src/util/hostConfigHelpers.ts
@@ -125,6 +125,11 @@ export function reconcileHostConfigValues(
       windowConfig.resourceCrossOriginMode,
       endpointConfig.resourceCrossOriginMode
     ),
+    // Sidebar UX: keep collapse control visible for long sidebars.
+    stickySidebarHeader: preferWindowValue(
+      windowConfig.stickySidebarHeader,
+      endpointConfig.stickySidebarHeader
+    ),
     // Deprecated field - preserve from endpoint (not overridable via window)
     // This is used as a fallback for resourceCrossOriginMode in App.tsx
     setAnonymousCrossOriginPropertyOnMediaElements:

--- a/frontend/lib/src/components/core/LibConfigContext.tsx
+++ b/frontend/lib/src/components/core/LibConfigContext.tsx
@@ -50,6 +50,14 @@ import { Config } from "@streamlit/protobuf"
  *   @see LogoComponent
  *   @see StreamlitMarkdown
  *
+ * - `stickySidebarHeader`: Whether the sidebar header remains pinned while the
+ *   sidebar content scrolls. This keeps the collapse control visible for long
+ *   sidebars.
+ *   When disabled, the header scrolls with the content.
+ *   This is useful for embedded contexts that want full scroll control.
+ *   Consumed by:
+ *   @see Sidebar
+ *
  * Note: `disableFullscreenMode` is intentionally omitted from LibConfig and passed
  * as a prop instead for better performance (avoids unnecessary re-renders).
  */
@@ -96,6 +104,7 @@ export const LibConfigContext = createContext<LibConfigContextProps>({
   mapboxToken: undefined,
   enforceDownloadInNewTab: undefined,
   resourceCrossOriginMode: undefined,
+  stickySidebarHeader: undefined,
   showErrorLinks: Config.ShowErrorLinks.SHOW_ERROR_LINKS_AUTO,
 })
 

--- a/frontend/utils/src/config/index.ts
+++ b/frontend/utils/src/config/index.ts
@@ -45,6 +45,14 @@ export type LibConfig = {
    */
   resourceCrossOriginMode?: undefined | "anonymous" | "use-credentials"
 
+  /**
+   * Whether the sidebar header should remain pinned while the sidebar content scrolls.
+   * When enabled, the sidebar collapse control stays visible for long sidebars.
+   * This improves usability when sidebars contain many widgets or long nav lists.
+   * Defaults to true and can be overridden by host configuration.
+   */
+  stickySidebarHeader?: boolean
+
   /** Deprecated. Use resourceCrossOriginMode instead. If set to true, the value of resourceCrossOriginMode will be "anonymous". */
   setAnonymousCrossOriginPropertyOnMediaElements?: boolean
 }

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -618,6 +618,18 @@ _create_option(
 )
 
 _create_option(
+    "client.sidebarStickyHeader",
+    description="""
+        Controls whether the sidebar header remains visible when the sidebar
+        content is scrollable. When enabled, the collapse control stays pinned
+        to the top of the sidebar so it does not scroll out of view.
+    """,
+    default_val=True,
+    type_=bool,
+    scriptable=True,
+)
+
+_create_option(
     "client.showErrorLinks",
     description="""
         Controls whether to show external help links (Google, ChatGPT) in

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -247,6 +247,10 @@ class HostConfigHandler(_SpecialRequestHandler):
             self._allowed_origins.append("http://localhost")
 
     async def get(self) -> None:
+        sticky_sidebar_header = bool(
+            config.get_option("client.sidebarStickyHeader")
+        )
+
         self.write(
             {
                 "allowedOrigins": self._allowed_origins,
@@ -254,6 +258,8 @@ class HostConfigHandler(_SpecialRequestHandler):
                 # Default host configuration settings.
                 "enableCustomParentMessages": False,
                 "enforceDownloadInNewTab": False,
+                # Keep the sidebar collapse control visible when scrolling.
+                "stickySidebarHeader": sticky_sidebar_header,
                 "metricsUrl": "",
                 "blockErrorDialogs": False,
                 # Determines whether the crossOrigin attribute is set on some elements, e.g. img, video, audio, and if


### PR DESCRIPTION
## Describe your changes
- Pin the sidebar header so the collapse control stays visible when sidebar content scrolls.
- Add a client.sidebarStickyHeader config and plumb it through host config → lib config → sidebar rendering.
- Add sidebar unit tests for sticky vs non-sticky header behavior.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)
#11671 

## Testing Plan

- Explanation of why no additional tests are needed: Unit coverage added for the new behavior; no other flows are impacted.
- Unit Tests (JS and/or Python): Not run (recommended: cd frontend && yarn test app/src/components/Sidebar/Sidebar.test.tsx)
- E2E Tests: Not run.
- Any manual testing needed?: Not performed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
