### PR TITLE
fix: add border-radius to st.video and st.map components

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -23,8 +23,10 @@ interface StyledDeckGlChartProps {
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ isStretchHeight }) => ({
+  ({ isStretchHeight, theme }) => ({
     position: "relative",
+    borderRadius: theme.radii.default,
+    overflow: "hidden",
     height: "100%",
     width: "100%",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -38,7 +38,7 @@ export interface Subtitle {
   url: string
 }
 
-const VIDEO_STYLE = { width: "100%" }
+
 
 function Video({
   element,
@@ -253,7 +253,7 @@ function Video({
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -261,7 +261,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -277,7 +276,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -23,4 +23,11 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: theme.radii.default,
+  overflow: "hidden",
+}))
+
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: theme.radii.default,
 }))


### PR DESCRIPTION
## Summary

Add `theme.radii.default` border-radius rounding to `st.video` and `st.map`/`st.pydeck_chart` components for visual consistency with other Streamlit elements.

## Changes
- **Video (native)**: Replaced inline `<video>` element with `StyledVideo` styled component that includes `borderRadius: theme.radii.default`
- **Video (YouTube iframe)**: Added `borderRadius` and `overflow: "hidden"` to `StyledVideoIframe`
- **DeckGlJsonChart (map)**: Added `borderRadius` and `overflow: "hidden"` to `StyledDeckGlChart`

Previous PR for other elements: #11058

Fixes #12806