### PR TITLE
Add `client.allowedOrigins` config option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ check:
 		uv run ruff check --fix $$PY_FILES && \
 		echo "" && \
 		echo "=== Python: type check (ty) ===" && \
-		uv run ty check $$PY_FILES && \
+		uv run ty check && \
 		echo "" || PY_EXIT=1; \
 		if [ $$PY_EXIT -eq 0 ] && [ "$$FAST_CHECK" != "true" ]; then \
 			echo "=== Python: type check (mypy) ===" && \

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -630,6 +630,48 @@ _create_option(
     type_=str,
 )
 
+_DEFAULT_ALLOWED_MESSAGE_ORIGINS = [
+    # Community-cloud related domains.
+    # We can remove these in the future if community cloud
+    # provides those domains via the host-config endpoint.
+    "https://devel.streamlit.test",
+    "https://*.streamlit.apptest",
+    "https://*.streamlitapp.test",
+    "https://*.streamlitapp.com",
+    "https://share.streamlit.io",
+    "https://share-demo.streamlit.io",
+    "https://share-head.streamlit.io",
+    "https://share-staging.streamlit.io",
+    "https://*.demo.streamlit.run",
+    "https://*.head.streamlit.run",
+    "https://*.staging.streamlit.run",
+    "https://*.streamlit.run",
+    "https://*.demo.streamlit.app",
+    "https://*.head.streamlit.app",
+    "https://*.staging.streamlit.app",
+    "https://*.streamlit.app",
+]
+
+_create_option(
+    "client.allowedOrigins",
+    description="""
+        An allow-list of origins from which a deployed Streamlit app can receive
+        cross-origin messages via postMessage when embedded in an iframe. These
+        messages allow the parent frame to control the app (e.g., stop script,
+        rerun script, set auth tokens). If not specified, a default list of
+        origins is used for Community Cloud deployments.
+
+        Note: If the app code is untrusted, it is safer to override the
+        /_stcore/host-config endpoint on the host platform and return the
+        allowed origins directly, rather than relying on this config option.
+
+        Example: ['https://*.streamlit.app', 'https://*.demo.streamlit.app']
+    """,
+    visibility="hidden",
+    default_val=_DEFAULT_ALLOWED_MESSAGE_ORIGINS,
+    multiple=True,
+)
+
 # Config Section: Runner #
 
 _create_section("runner", "Settings for how Streamlit executes your script")

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -661,9 +661,11 @@ _create_option(
         rerun script, set auth tokens). If not specified, a default list of
         origins is used for Community Cloud deployments.
 
-        Note: If the app code is untrusted, it is safer to override the
-        /_stcore/host-config endpoint on the host platform and return the
-        allowed origins directly, rather than relying on this config option.
+        Note: This config option is not tamper-proof since app code can modify
+        the configuration. For platforms hosting untrusted app code, it is
+        recommended to override the /_stcore/host-config endpoint at the
+        platform or proxy level and return the allowed origins from that
+        endpoint instead.
 
         Example: ['https://*.streamlit.app', 'https://*.demo.streamlit.app']
     """,

--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -225,33 +225,12 @@ class HealthHandler(_SpecialRequestHandler):
             self.write(msg)
 
 
-_DEFAULT_ALLOWED_MESSAGE_ORIGINS = [
-    # Community-cloud related domains.
-    # We can remove these in the future if community cloud
-    # provides those domains via the host-config endpoint.
-    "https://devel.streamlit.test",
-    "https://*.streamlit.apptest",
-    "https://*.streamlitapp.test",
-    "https://*.streamlitapp.com",
-    "https://share.streamlit.io",
-    "https://share-demo.streamlit.io",
-    "https://share-head.streamlit.io",
-    "https://share-staging.streamlit.io",
-    "https://*.demo.streamlit.run",
-    "https://*.head.streamlit.run",
-    "https://*.staging.streamlit.run",
-    "https://*.streamlit.run",
-    "https://*.demo.streamlit.app",
-    "https://*.head.streamlit.app",
-    "https://*.staging.streamlit.app",
-    "https://*.streamlit.app",
-]
-
-
 class HostConfigHandler(_SpecialRequestHandler):
     def initialize(self) -> None:
         # Make a copy of the allowedOrigins list, since we might modify it later:
-        self._allowed_origins = _DEFAULT_ALLOWED_MESSAGE_ORIGINS.copy()
+        self._allowed_origins: list[str] = list(
+            config.get_option("client.allowedOrigins")
+        )
 
         if (
             config.get_option("global.developmentMode")

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -37,7 +37,6 @@ from streamlit.web.server.component_file_utils import (
     guess_content_type,
 )
 from streamlit.web.server.routes import (
-    _DEFAULT_ALLOWED_MESSAGE_ORIGINS,
     allow_all_cross_origin_requests,
     is_allowed_origin,
 )
@@ -383,7 +382,7 @@ def create_host_config_routes(base_url: str | None) -> list[BaseRoute]:
     from starlette.routing import Route
 
     async def _host_config_endpoint(request: Request) -> JSONResponse:
-        allowed = list(_DEFAULT_ALLOWED_MESSAGE_ORIGINS)
+        allowed: list[str] = list(config.get_option("client.allowedOrigins"))
         if (
             config.get_option("global.developmentMode")
             and "http://localhost" not in allowed

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -1394,10 +1394,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", mock_open(read_data=global_config))
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
+        makedirs_patch.return_value = True
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == global_config_path  # ty: ignore[unresolved-attribute]
-
+        pathexists_patch.side_effect = lambda path: path == global_config_path
         with open_patch, makedirs_patch, pathexists_patch:
             config.get_config_options()
 
@@ -1420,10 +1419,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", mock_open(read_data=local_config))
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
+        makedirs_patch.return_value = True
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == local_config_path  # ty: ignore[unresolved-attribute]
-
+        pathexists_patch.side_effect = lambda path: path == local_config_path
         with open_patch, makedirs_patch, pathexists_patch:
             config.get_config_options()
 
@@ -1458,9 +1456,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", file_open)
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
+        makedirs_patch.return_value = True
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path in {  # ty: ignore[unresolved-attribute]
+        pathexists_patch.side_effect = lambda path: path in {
             global_config_path,
             local_config_path,
         }
@@ -1506,9 +1504,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", file_open)
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
+        makedirs_patch.return_value = True
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path in {  # ty: ignore[unresolved-attribute]
+        pathexists_patch.side_effect = lambda path: path in {
             global_config_path,
             local_config_path,
         }
@@ -1532,10 +1530,9 @@ class ConfigLoadingTest(unittest.TestCase):
 
         global_config_path = "/mock/home/folder/.streamlit/config.toml"
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
+        makedirs_patch.return_value = True
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == global_config_path  # ty: ignore[unresolved-attribute]
-
+        pathexists_patch.side_effect = lambda path: path == global_config_path
         global_config = """
         [theme]
         base = "dark"
@@ -1568,9 +1565,9 @@ class ConfigLoadingTest(unittest.TestCase):
 
         global_config_path = "/mock/home/folder/.streamlit/config.toml"
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
+        makedirs_patch.return_value = True
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == global_config_path  # ty: ignore[unresolved-attribute]
+        pathexists_patch.side_effect = lambda path: path == global_config_path
         mock_logger = get_logger()
 
         global_config = """

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -737,6 +737,7 @@ class ConfigTest(unittest.TestCase):
                 "browser.gatherUsageStats",
                 "browser.serverAddress",
                 "browser.serverPort",
+                "client.allowedOrigins",
                 "client.showErrorDetails",
                 "client.showErrorLinks",
                 "client.showSidebarNavigation",
@@ -1393,9 +1394,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", mock_open(read_data=global_config))
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True
+        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == global_config_path
+        pathexists_patch.side_effect = lambda path: path == global_config_path  # ty: ignore[unresolved-attribute]
 
         with open_patch, makedirs_patch, pathexists_patch:
             config.get_config_options()
@@ -1419,9 +1420,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", mock_open(read_data=local_config))
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True
+        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == local_config_path
+        pathexists_patch.side_effect = lambda path: path == local_config_path  # ty: ignore[unresolved-attribute]
 
         with open_patch, makedirs_patch, pathexists_patch:
             config.get_config_options()
@@ -1457,9 +1458,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", file_open)
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True
+        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path in {
+        pathexists_patch.side_effect = lambda path: path in {  # ty: ignore[unresolved-attribute]
             global_config_path,
             local_config_path,
         }
@@ -1505,9 +1506,9 @@ class ConfigLoadingTest(unittest.TestCase):
         open_patch = patch("streamlit.config.open", file_open)
         # patch streamlit.*.os.* instead of os.* for py35 compat
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True
+        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path in {
+        pathexists_patch.side_effect = lambda path: path in {  # ty: ignore[unresolved-attribute]
             global_config_path,
             local_config_path,
         }
@@ -1531,9 +1532,9 @@ class ConfigLoadingTest(unittest.TestCase):
 
         global_config_path = "/mock/home/folder/.streamlit/config.toml"
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True
+        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == global_config_path
+        pathexists_patch.side_effect = lambda path: path == global_config_path  # ty: ignore[unresolved-attribute]
 
         global_config = """
         [theme]
@@ -1567,9 +1568,9 @@ class ConfigLoadingTest(unittest.TestCase):
 
         global_config_path = "/mock/home/folder/.streamlit/config.toml"
         makedirs_patch = patch("streamlit.config.os.makedirs")
-        makedirs_patch.return_value = True
+        makedirs_patch.return_value = True  # ty: ignore[unresolved-attribute]
         pathexists_patch = patch("streamlit.config.os.path.exists")
-        pathexists_patch.side_effect = lambda path: path == global_config_path
+        pathexists_patch.side_effect = lambda path: path == global_config_path  # ty: ignore[unresolved-attribute]
         mock_logger = get_logger()
 
         global_config = """

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import tornado.testing
 import tornado.web
 
-from streamlit.web.server.routes import _DEFAULT_ALLOWED_MESSAGE_ORIGINS
+from streamlit.config import _DEFAULT_ALLOWED_MESSAGE_ORIGINS
 from streamlit.web.server.server import (
     HEALTH_ENDPOINT,
     HOST_CONFIG_ENDPOINT,

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -369,3 +369,23 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
         response_body = json.loads(response.body)
         assert response.code == 200
         assert response_body["allowedOrigins"] == []
+
+    @patch_config_options(
+        {
+            "global.developmentMode": True,
+            "client.allowedOrigins": [
+                "https://custom.example.com",
+                "https://another.example.com",
+            ],
+        }
+    )
+    def test_custom_allowed_origins_with_dev_mode(self):
+        """Test that localhost is appended to custom origins in dev mode."""
+        response = self.fetch("/_stcore/host-config")
+        response_body = json.loads(response.body)
+        assert response.code == 200
+        # Custom origins should be present
+        assert "https://custom.example.com" in response_body["allowedOrigins"]
+        assert "https://another.example.com" in response_body["allowedOrigins"]
+        # localhost should be appended in dev mode
+        assert "http://localhost" in response_body["allowedOrigins"]

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -335,3 +335,37 @@ class HostConfigHandlerTest(tornado.testing.AsyncHTTPTestCase):
         # Check that localhost has been appended/allowed in dev mode
         origins_list = json.loads(response.body)["allowedOrigins"]
         assert "http://localhost" in origins_list
+
+    @patch_config_options(
+        {
+            "global.developmentMode": False,
+            "client.allowedOrigins": [
+                "https://custom.example.com",
+                "https://another.example.com",
+            ],
+        }
+    )
+    def test_custom_allowed_message_origins(self):
+        """Test that custom client.allowedOrigins values are used."""
+        response = self.fetch("/_stcore/host-config")
+        response_body = json.loads(response.body)
+        assert response.code == 200
+        assert response_body["allowedOrigins"] == [
+            "https://custom.example.com",
+            "https://another.example.com",
+        ]
+        # Verify defaults are NOT included when custom values are set
+        assert "https://*.streamlit.app" not in response_body["allowedOrigins"]
+
+    @patch_config_options(
+        {
+            "global.developmentMode": False,
+            "client.allowedOrigins": [],
+        }
+    )
+    def test_empty_allowed_message_origins(self):
+        """Test that empty client.allowedOrigins results in empty list."""
+        response = self.fetch("/_stcore/host-config")
+        response_body = json.loads(response.body)
+        assert response.code == 200
+        assert response_body["allowedOrigins"] == []

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -676,6 +676,72 @@ def test_host_config_includes_localhost_in_dev(tmp_path: Path) -> None:
     monkeypatch.undo()
 
 
+@patch_config_options(
+    {
+        "global.developmentMode": False,
+        "client.allowedOrigins": [
+            "https://custom.example.com",
+            "https://another.example.com",
+        ],
+    }
+)
+def test_host_config_custom_allowed_origins(tmp_path: Path) -> None:
+    """Test that custom client.allowedOrigins values are used."""
+    component_dir = tmp_path / "component"
+    component_dir.mkdir()
+    (component_dir / "index.html").write_text("component")
+
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(file_util, "get_static_dir", lambda: str(static_dir))
+
+    runtime = _DummyRuntime(component_dir)
+    app = create_starlette_app(runtime)
+    client = TestClient(app)
+
+    response = client.get("/_stcore/host-config")
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["allowedOrigins"] == [
+        "https://custom.example.com",
+        "https://another.example.com",
+    ]
+    # Verify defaults are NOT included when custom values are set
+    assert "https://*.streamlit.app" not in body["allowedOrigins"]
+
+    monkeypatch.undo()
+
+
+@patch_config_options(
+    {
+        "global.developmentMode": False,
+        "client.allowedOrigins": [],
+    }
+)
+def test_host_config_empty_allowed_origins(tmp_path: Path) -> None:
+    """Test that empty client.allowedOrigins results in empty list."""
+    component_dir = tmp_path / "component"
+    component_dir.mkdir()
+    (component_dir / "index.html").write_text("component")
+
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(file_util, "get_static_dir", lambda: str(static_dir))
+
+    runtime = _DummyRuntime(component_dir)
+    app = create_starlette_app(runtime)
+    client = TestClient(app)
+
+    response = client.get("/_stcore/host-config")
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["allowedOrigins"] == []
+
+    monkeypatch.undo()
+
+
 @patch_config_options({"global.developmentMode": True})
 def test_static_files_skipped_in_dev_mode(tmp_path: Path) -> None:
     """Test that static file serving is skipped in development mode."""

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -742,6 +742,42 @@ def test_host_config_empty_allowed_origins(tmp_path: Path) -> None:
     monkeypatch.undo()
 
 
+@patch_config_options(
+    {
+        "global.developmentMode": True,
+        "client.allowedOrigins": [
+            "https://custom.example.com",
+            "https://another.example.com",
+        ],
+    }
+)
+def test_host_config_custom_origins_with_dev_mode(tmp_path: Path) -> None:
+    """Test that localhost is appended to custom origins in dev mode."""
+    component_dir = tmp_path / "component"
+    component_dir.mkdir()
+    (component_dir / "index.html").write_text("component")
+
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(file_util, "get_static_dir", lambda: str(static_dir))
+
+    runtime = _DummyRuntime(component_dir)
+    app = create_starlette_app(runtime)
+    client = TestClient(app)
+
+    response = client.get("/_stcore/host-config")
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    # Custom origins should be present
+    assert "https://custom.example.com" in body["allowedOrigins"]
+    assert "https://another.example.com" in body["allowedOrigins"]
+    # localhost should be appended in dev mode
+    assert "http://localhost" in body["allowedOrigins"]
+
+    monkeypatch.undo()
+
+
 @patch_config_options({"global.developmentMode": True})
 def test_static_files_skipped_in_dev_mode(tmp_path: Path) -> None:
     """Test that static file serving is skipped in development mode."""


### PR DESCRIPTION
## Describe your changes

Implement a new `client.allowedOrigins` configuration option to allow deployers to customize which origins can send cross-origin postMessage commands to embedded Streamlit apps. The default list of Community Cloud origins is now configurable via `config.toml` instead of being hardcoded.

## Github Issues

- Closes https://github.com/streamlit/streamlit/issues/6389

## Testing Plan

- All existing unit tests pass (127 tests)
- Configuration option is properly validated and accessible via `config.get_option()`
- Both Tornado and Starlette server implementations use the config option

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>f20b7b5</u></sup><!-- /BUGBOT_STATUS -->