### PR TITLE
Fix `st.select_slider` `format_func` regression in AppTest

### DIFF
--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1157,10 +1157,10 @@ class SelectSlider(Widget, Generic[T]):
     @property
     def _widget_state(self) -> WidgetState:
         # Build formatted options mapping
+        # Note: self.options already contains formatted strings from the proto,
+        # so we should NOT apply format_func to them again
         format_func = self.format_func
-        formatted_option_to_index = {
-            format_func(opt): idx for idx, opt in enumerate(self.options)
-        }
+        formatted_option_to_index = {opt: idx for idx, opt in enumerate(self.options)}
 
         # Determine if this is a range value
         is_range = isinstance(self.value, (list, tuple)) and len(self.value) == 2

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -651,3 +651,58 @@ def test_select_slider_dynamic_options_with_enum():
     assert "Selected: GREEN" in at.get("markdown")[-1].value
     # Negative assertion: BLUE should not be preserved
     assert "Selected: BLUE" not in at.get("markdown")[-1].value
+
+
+def test_select_slider_format_func_multiple_runs():
+    """Regression test for GitHub issue #13832.
+
+    Ensures that select_slider with format_func works correctly on subsequent
+    AppTest runs. The bug occurred because the testing framework was applying
+    format_func to options that were already formatted strings in the proto,
+    causing a ValueError on the second run. This test implicitly validates
+    that no ValueError is raised during subsequent runs.
+    """
+
+    def script():
+        import streamlit as st
+
+        st.select_slider(
+            "Percentage",
+            value=0.40,
+            options=(0.00, 0.20, 0.40, 0.45),
+            format_func="{:.0%}".format,
+        )
+        st.select_slider(
+            "Range",
+            value=(0.20, 0.45),
+            options=(0.00, 0.20, 0.40, 0.45),
+            format_func="{:.0%}".format,
+        )
+
+    # First run
+    at = AppTest.from_function(script).run()
+    assert at.select_slider[0].value == 0.40
+    assert at.select_slider[1].value == (0.20, 0.45)
+
+    # Second run - this failed before the fix with:
+    # ValueError: Unknown format code '%' for object of type 'str'
+    at = at.run()
+    assert at.select_slider[0].value == 0.40
+    assert at.select_slider[1].value == (0.20, 0.45)
+
+    # Third run to ensure stability
+    at = at.run()
+    assert at.select_slider[0].value == 0.40
+    assert at.select_slider[1].value == (0.20, 0.45)
+
+    # Test changing values and re-running
+    at.select_slider[0].set_value(0.20)
+    at.select_slider[1].set_range(0.00, 0.40)
+    at = at.run()
+    assert at.select_slider[0].value == 0.20
+    assert at.select_slider[1].value == (0.00, 0.40)
+
+    # Another run after value change
+    at = at.run()
+    assert at.select_slider[0].value == 0.20
+    assert at.select_slider[1].value == (0.00, 0.40)


### PR DESCRIPTION
## Describe your changes

Fixed a regression in select_slider where format_func was being applied to options that were already formatted strings from the proto during subsequent AppTest runs. The issue occurred because self.options already contains formatted strings, so applying format_func again caused a ValueError.

## GitHub Issue Link (if applicable)

Fixes #13832

## Testing Plan

- Added regression test `test_select_slider_format_func_multiple_runs` in select_slider_test.py to test multiple AppTest runs with format_func
- Added regression test `test_select_slider_with_format_func` in element_tree_test.py
- All 115 select_slider unit tests pass
- All 48 element_tree tests pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.