### PR TITLE
Add support for cachetools 7.x

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   # See: https://github.com/streamlit/streamlit/issues/12064
   "altair>=4.0,<7,!=5.4.0,!=5.4.1",
   "blinker>=1.5.0,<2",
-  "cachetools>=5.5,<7",
+  "cachetools>=5.5,<8",
   "click>=7.0,<9",
   "gitpython>=3.0.7,<4,!=3.1.19",
   "numpy>=1.23,<3",


### PR DESCRIPTION
## Describe your changes

Update the cachetools dependency upper bound from `<7` to `<8` to support cachetools 7.x. Streamlit only uses `TTLCache` directly from cachetools, which is not affected by the breaking changes to `@cached` and `@cachedmethod` decorators introduced in cachetools 7.0.0.

## GitHub Issue Link

Closes #13801

## Testing Plan

All existing caching-related tests (378 tests) passed, validating that the TTLCache usage is compatible with the new version constraint. No additional tests are needed.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.