### PR TITLE
Attempt to fix firefox e2e test failures after Playwright 1.58 update

### DIFF
--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -40,6 +40,8 @@ import pytest
 import requests
 from PIL import Image
 from playwright.sync_api import (
+    Browser,
+    BrowserType,
     ElementHandle,
     FrameLocator,
     Locator,
@@ -593,6 +595,18 @@ def browser_type_launch_args(
                 "layout.css.devPixelsPerPx": "1.0",
                 "browser.display.use_system_colors": False,
                 "gfx.font_rendering.cleartype_params.rendering_mode": 5,
+                # Stability preferences to prevent unexpected browser closures
+                # (see Playwright 1.58+ Firefox 146 issues):
+                "toolkit.startup.max_resumed_crashes": -1,  # Disable crash recovery
+                "browser.sessionstore.resume_from_crash": False,
+                "browser.shell.checkDefaultBrowser": False,
+                "browser.tabs.crashReporting.sendReport": False,
+                "dom.ipc.reportProcessHangs": False,
+                # Disable features that can cause instability in automation:
+                "browser.safebrowsing.enabled": False,
+                "browser.safebrowsing.malware.enabled": False,
+                "datareporting.policy.dataSubmissionEnabled": False,
+                "toolkit.telemetry.enabled": False,
             },
         }
     return browser_type_launch_args
@@ -611,6 +625,90 @@ def browser_context_args(
         }
 
     return browser_context_args
+
+
+class ResilientBrowser:
+    """Wrapper around Browser that can recover from unexpected browser closures.
+
+    This is a workaround for Firefox stability issues in Playwright 1.58+ (Firefox 146).
+    When the browser closes unexpectedly, subsequent tests fail with TargetClosedError.
+    This wrapper detects the closure and relaunches the browser automatically.
+    """
+
+    def __init__(
+        self,
+        browser_type: BrowserType,
+        launch_args: dict[str, Any],
+    ):
+        self._browser_type = browser_type
+        self._launch_args = launch_args
+        self._browser: Browser | None = None
+
+    def _launch(self) -> Browser:
+        """Launch a new browser instance."""
+        return self._browser_type.launch(**self._launch_args)
+
+    def _ensure_connected(self) -> Browser:
+        """Ensure browser is connected, relaunching if necessary."""
+        if self._browser is None or not self._browser.is_connected():
+            if self._browser is not None:
+                print(
+                    "Firefox browser disconnected unexpectedly. Relaunching...",
+                    flush=True,
+                )
+            self._browser = self._launch()
+        return self._browser
+
+    def new_context(self, **kwargs: Any) -> Any:
+        """Create a new browser context, relaunching browser if needed."""
+        browser = self._ensure_connected()
+        return browser.new_context(**kwargs)
+
+    def close(self) -> None:
+        """Close the browser."""
+        if self._browser is not None and self._browser.is_connected():
+            self._browser.close()
+        self._browser = None
+
+    @property
+    def contexts(self) -> list[Any]:
+        """Return list of browser contexts."""
+        if self._browser is None:
+            return []
+        return self._browser.contexts
+
+    @property
+    def browser_type(self) -> BrowserType:
+        """Return the browser type."""
+        return self._browser_type
+
+    def is_connected(self) -> bool:
+        """Check if browser is connected."""
+        return self._browser is not None and self._browser.is_connected()
+
+
+@pytest.fixture(scope="session")
+def browser(
+    browser_type: BrowserType,
+    browser_type_launch_args: dict[str, Any],
+    browser_name: str,
+    launch_browser: Callable[[], Browser],
+) -> Generator[Browser | ResilientBrowser, None, None]:
+    """Override pytest-playwright's browser fixture to handle Firefox crashes.
+
+    For Firefox, we use a ResilientBrowser wrapper that can recover from unexpected
+    browser closures. For other browsers, we use the standard launch_browser callable.
+    """
+    if browser_name == "firefox":
+        resilient = ResilientBrowser(browser_type, browser_type_launch_args)
+        # Launch the browser initially to match pytest-playwright behavior
+        resilient._ensure_connected()
+        yield resilient
+        resilient.close()
+    else:
+        browser = launch_browser()
+        yield browser
+        browser.close()
 
 
 @pytest.fixture(params=["light_theme", "dark_theme"])

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -41,6 +41,7 @@ import requests
 from PIL import Image
 from playwright.sync_api import (
     Browser,
+    BrowserContext,
     BrowserType,
     ElementHandle,
     FrameLocator,
@@ -643,6 +644,8 @@ class ResilientBrowser:
         self._browser_type = browser_type
         self._launch_args = launch_args
         self._browser: Browser | None = None
+        # Launch browser eagerly to match pytest-playwright behavior
+        self._ensure_connected()
 
     def _launch(self) -> Browser:
         """Launch a new browser instance."""
@@ -659,7 +662,7 @@ class ResilientBrowser:
             self._browser = self._launch()
         return self._browser
 
-    def new_context(self, **kwargs: Any) -> Any:
+    def new_context(self, **kwargs: Any) -> BrowserContext:
         """Create a new browser context, relaunching browser if needed."""
         browser = self._ensure_connected()
         return browser.new_context(**kwargs)
@@ -667,15 +670,28 @@ class ResilientBrowser:
     def close(self) -> None:
         """Close the browser."""
         if self._browser is not None and self._browser.is_connected():
-            self._browser.close()
+            try:
+                self._browser.close()
+            except Exception as exc:
+                # Browser may disconnect between is_connected() and close().
+                # Log the error but continue cleanup.
+                print(
+                    f"Error while closing browser in ResilientBrowser.close: {exc}",
+                    flush=True,
+                )
         self._browser = None
 
     @property
-    def contexts(self) -> list[Any]:
+    def contexts(self) -> list[BrowserContext]:
         """Return list of browser contexts."""
-        if self._browser is None:
+        if self._browser is None or not self._browser.is_connected():
             return []
-        return self._browser.contexts
+        try:
+            return self._browser.contexts
+        except Exception:
+            # The browser may disconnect between the connectivity check and accessing
+            # the contexts attribute. In that case, behave as if there are no contexts.
+            return []
 
     @property
     def browser_type(self) -> BrowserType:
@@ -701,8 +717,6 @@ def browser(
     """
     if browser_name == "firefox":
         resilient = ResilientBrowser(browser_type, browser_type_launch_args)
-        # Launch the browser initially to match pytest-playwright behavior
-        resilient._ensure_connected()
         yield resilient
         resilient.close()
     else:

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -703,6 +703,28 @@ class ResilientBrowser:
         return self._browser is not None and self._browser.is_connected()
 
 
+@pytest.fixture(scope="session")
+def browser(
+    browser_type: BrowserType,
+    browser_type_launch_args: dict[str, Any],
+    browser_name: str,
+    launch_browser: Callable[[], Browser],
+) -> Generator[Browser | ResilientBrowser, None, None]:
+    """Override pytest-playwright's browser fixture to handle Firefox crashes.
+
+    For Firefox, we use a ResilientBrowser wrapper that can recover from unexpected
+    browser closures. For other browsers, we use the standard launch_browser callable.
+    """
+    if browser_name == "firefox":
+        resilient = ResilientBrowser(browser_type, browser_type_launch_args)
+        yield resilient
+        resilient.close()
+    else:
+        browser = launch_browser()
+        yield browser
+        browser.close()
+
+
 @pytest.fixture(params=["light_theme", "dark_theme"])
 def app_theme(request: pytest.FixtureRequest) -> str:
     """Fixture that returns the theme name."""

--- a/e2e_playwright/conftest.py
+++ b/e2e_playwright/conftest.py
@@ -703,28 +703,6 @@ class ResilientBrowser:
         return self._browser is not None and self._browser.is_connected()
 
 
-@pytest.fixture(scope="session")
-def browser(
-    browser_type: BrowserType,
-    browser_type_launch_args: dict[str, Any],
-    browser_name: str,
-    launch_browser: Callable[[], Browser],
-) -> Generator[Browser | ResilientBrowser, None, None]:
-    """Override pytest-playwright's browser fixture to handle Firefox crashes.
-
-    For Firefox, we use a ResilientBrowser wrapper that can recover from unexpected
-    browser closures. For other browsers, we use the standard launch_browser callable.
-    """
-    if browser_name == "firefox":
-        resilient = ResilientBrowser(browser_type, browser_type_launch_args)
-        yield resilient
-        resilient.close()
-    else:
-        browser = launch_browser()
-        yield browser
-        browser.close()
-
-
 @pytest.fixture(params=["light_theme", "dark_theme"])
 def app_theme(request: pytest.FixtureRequest) -> str:
     """Fixture that returns the theme name."""


### PR DESCRIPTION
## Describe your changes

After the Playwright 1.58 update (Firefox 146.0.1), Firefox e2e tests began failing with `TargetClosedError: Browser.new_context: Target page, context or browser has been closed`. This was caused by Firefox browser crashes during long test sessions, which with the session-scoped pytest-playwright `browser` fixture causes all subsequent tests to fail.

**Changes:**
1. Added Firefox stability preferences to reduce crashes (disabling crash recovery, safe browsing, telemetry)
2. Created `ResilientBrowser` wrapper class that detects browser disconnection and automatically relaunches Firefox
3. Override the pytest-playwright `browser` fixture for Firefox to use the resilient wrapper

## Testing Plan

- Manual testing confirms Firefox tests now pass (previously failing with TargetClosedError)
- Chromium and WebKit browsers unaffected (use standard pytest-playwright behavior)
- No additional tests needed (this is a test infrastructure fix)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.