### PR TITLE
[feature] add width auto parameter to st.markdown

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementContainerConfig.test.ts
+++ b/frontend/lib/src/components/core/Block/ElementContainerConfig.test.ts
@@ -75,6 +75,35 @@ describe("ElementContainerConfig", () => {
         ElementContainerConfig.MEDIUM_ELEMENT.styleOverrides
       ).toBeUndefined()
     })
+
+    it("FIT_CONTENT_ELEMENT has FIT_CONTENT min stretch width", () => {
+      expect(ElementContainerConfig.FIT_CONTENT_ELEMENT.minStretchWidth).toBe(
+        MinStretchWidth.FIT_CONTENT
+      )
+      expect(
+        ElementContainerConfig.FIT_CONTENT_ELEMENT.styleOverrides
+      ).toBeUndefined()
+    })
+
+    it("FULL_WIDTH has width 100% style override", () => {
+      expect(ElementContainerConfig.FULL_WIDTH.minStretchWidth).toBe(
+        MinStretchWidth.NONE
+      )
+      expect(ElementContainerConfig.FULL_WIDTH.styleOverrides).toEqual({
+        width: "100%",
+      })
+    })
+
+    it("LARGE_OVERFLOW_VISIBLE has LARGE min stretch width and overflow visible", () => {
+      expect(
+        ElementContainerConfig.LARGE_OVERFLOW_VISIBLE.minStretchWidth
+      ).toBe(MinStretchWidth.LARGE)
+      expect(
+        ElementContainerConfig.LARGE_OVERFLOW_VISIBLE.styleOverrides
+      ).toEqual({
+        overflow: "visible",
+      })
+    })
   })
 
   describe("with()", () => {
@@ -189,95 +218,6 @@ describe("ElementContainerConfig", () => {
         minStretchWidth: MinStretchWidth.FIT_CONTENT,
       })
       expect(config.getMinStretchBehavior()).toBe(MinStretchWidth.FIT_CONTENT)
-    })
-  })
-
-  describe("create() caching", () => {
-    it("returns the same instance for identical options", () => {
-      const config1 = ElementContainerConfig.create({
-        styleOverrides: { width: "100%" },
-      })
-      const config2 = ElementContainerConfig.create({
-        styleOverrides: { width: "100%" },
-      })
-
-      expect(config1).toBe(config2)
-    })
-
-    it("returns the same instance regardless of styleOverrides key order", () => {
-      const config1 = ElementContainerConfig.create({
-        styleOverrides: { width: "100%", height: "auto" },
-      })
-      const config2 = ElementContainerConfig.create({
-        styleOverrides: { height: "auto", width: "100%" },
-      })
-
-      expect(config1).toBe(config2)
-    })
-
-    it("returns different instances for different styleOverrides values", () => {
-      const config1 = ElementContainerConfig.create({
-        styleOverrides: { width: "100%" },
-      })
-      const config2 = ElementContainerConfig.create({
-        styleOverrides: { width: "fit-content" },
-      })
-
-      expect(config1).not.toBe(config2)
-    })
-
-    it("returns different instances for different minStretchWidth values", () => {
-      const config1 = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.LARGE,
-      })
-      const config2 = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.MEDIUM,
-      })
-
-      expect(config1).not.toBe(config2)
-    })
-
-    it("returns the same instance for identical minStretchWidth and styleOverrides", () => {
-      const config1 = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides: { overflow: "visible" },
-      })
-      const config2 = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides: { overflow: "visible" },
-      })
-
-      expect(config1).toBe(config2)
-    })
-
-    it("returns different instances when only minStretchWidth differs", () => {
-      const config1 = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides: { overflow: "visible" },
-      })
-      const config2 = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.MEDIUM,
-        styleOverrides: { overflow: "visible" },
-      })
-
-      expect(config1).not.toBe(config2)
-    })
-
-    it("returns the same instance for empty options", () => {
-      const config1 = ElementContainerConfig.create({})
-      const config2 = ElementContainerConfig.create({})
-
-      expect(config1).toBe(config2)
-    })
-
-    it("creates config with correct values", () => {
-      const config = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.MEDIUM,
-        styleOverrides: { width: "100%", flex: "1" },
-      })
-
-      expect(config.minStretchWidth).toBe(MinStretchWidth.MEDIUM)
-      expect(config.styleOverrides).toEqual({ width: "100%", flex: "1" })
     })
   })
 })

--- a/frontend/lib/src/components/core/Block/ElementContainerConfig.test.ts
+++ b/frontend/lib/src/components/core/Block/ElementContainerConfig.test.ts
@@ -191,4 +191,93 @@ describe("ElementContainerConfig", () => {
       expect(config.getMinStretchBehavior()).toBe(MinStretchWidth.FIT_CONTENT)
     })
   })
+
+  describe("create() caching", () => {
+    it("returns the same instance for identical options", () => {
+      const config1 = ElementContainerConfig.create({
+        styleOverrides: { width: "100%" },
+      })
+      const config2 = ElementContainerConfig.create({
+        styleOverrides: { width: "100%" },
+      })
+
+      expect(config1).toBe(config2)
+    })
+
+    it("returns the same instance regardless of styleOverrides key order", () => {
+      const config1 = ElementContainerConfig.create({
+        styleOverrides: { width: "100%", height: "auto" },
+      })
+      const config2 = ElementContainerConfig.create({
+        styleOverrides: { height: "auto", width: "100%" },
+      })
+
+      expect(config1).toBe(config2)
+    })
+
+    it("returns different instances for different styleOverrides values", () => {
+      const config1 = ElementContainerConfig.create({
+        styleOverrides: { width: "100%" },
+      })
+      const config2 = ElementContainerConfig.create({
+        styleOverrides: { width: "fit-content" },
+      })
+
+      expect(config1).not.toBe(config2)
+    })
+
+    it("returns different instances for different minStretchWidth values", () => {
+      const config1 = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.LARGE,
+      })
+      const config2 = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.MEDIUM,
+      })
+
+      expect(config1).not.toBe(config2)
+    })
+
+    it("returns the same instance for identical minStretchWidth and styleOverrides", () => {
+      const config1 = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.LARGE,
+        styleOverrides: { overflow: "visible" },
+      })
+      const config2 = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.LARGE,
+        styleOverrides: { overflow: "visible" },
+      })
+
+      expect(config1).toBe(config2)
+    })
+
+    it("returns different instances when only minStretchWidth differs", () => {
+      const config1 = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.LARGE,
+        styleOverrides: { overflow: "visible" },
+      })
+      const config2 = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.MEDIUM,
+        styleOverrides: { overflow: "visible" },
+      })
+
+      expect(config1).not.toBe(config2)
+    })
+
+    it("returns the same instance for empty options", () => {
+      const config1 = ElementContainerConfig.create({})
+      const config2 = ElementContainerConfig.create({})
+
+      expect(config1).toBe(config2)
+    })
+
+    it("creates config with correct values", () => {
+      const config = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.MEDIUM,
+        styleOverrides: { width: "100%", flex: "1" },
+      })
+
+      expect(config.minStretchWidth).toBe(MinStretchWidth.MEDIUM)
+      expect(config.styleOverrides).toEqual({ width: "100%", flex: "1" })
+    })
+  })
 })

--- a/frontend/lib/src/components/core/Block/ElementContainerConfig.ts
+++ b/frontend/lib/src/components/core/Block/ElementContainerConfig.ts
@@ -98,6 +98,9 @@ export class ElementContainerConfig {
   readonly minStretchWidth: MinStretchWidth
   readonly styleOverrides?: CSSProperties
 
+  // Cache for configs created via create() to ensure referential stability
+  private static readonly cache = new Map<string, ElementContainerConfig>()
+
   // Pre-defined configurations for common patterns
   static readonly DEFAULT = new ElementContainerConfig({})
 
@@ -115,8 +118,47 @@ export class ElementContainerConfig {
   }
 
   /**
+   * Creates or retrieves a cached config for the given options.
+   * Ensures referential stability across renders without needing to
+   * predefine every possible configuration combination.
+   *
+   * @example
+   * ```typescript
+   * // These will return the same cached instance:
+   * ElementContainerConfig.create({ styleOverrides: { width: "100%" } })
+   * ElementContainerConfig.create({ styleOverrides: { width: "100%" } })
+   * ```
+   */
+  static create(
+    options: ElementContainerConfigOptions
+  ): ElementContainerConfig {
+    // Create a stable cache key from options
+    // Sort styleOverrides keys for consistent key generation
+    const { styleOverrides } = options
+    const styleKey = styleOverrides
+      ? JSON.stringify(
+          Object.keys(styleOverrides)
+            .sort()
+            .reduce<Record<string, unknown>>((acc, key) => {
+              acc[key] = styleOverrides[key as keyof CSSProperties]
+              return acc
+            }, {})
+        )
+      : ""
+    const key = `${options.minStretchWidth ?? "none"}_${styleKey}`
+
+    let config = this.cache.get(key)
+    if (!config) {
+      config = new ElementContainerConfig(options)
+      this.cache.set(key, config)
+    }
+    return config
+  }
+
+  /**
    * Creates a new config by merging this config with overrides.
    * Useful for extending pre-defined configs with element-specific adjustments.
+   * Returns a cached instance for referential stability.
    *
    * @example
    * ```typescript
@@ -126,7 +168,7 @@ export class ElementContainerConfig {
   with(
     overrides: Partial<ElementContainerConfigOptions>
   ): ElementContainerConfig {
-    return new ElementContainerConfig({
+    return ElementContainerConfig.create({
       minStretchWidth: overrides.minStretchWidth ?? this.minStretchWidth,
       styleOverrides:
         overrides.styleOverrides !== undefined

--- a/frontend/lib/src/components/core/Block/ElementContainerConfig.ts
+++ b/frontend/lib/src/components/core/Block/ElementContainerConfig.ts
@@ -91,17 +91,15 @@ export interface ElementContainerConfigOptions {
  *
  * // Using pre-defined configs
  * ElementContainerConfig.LARGE_ELEMENT
- * ElementContainerConfig.MEDIUM_ELEMENT.with({ overflowVisible: true })
+ * ElementContainerConfig.LARGE_OVERFLOW_VISIBLE
  * ```
  */
 export class ElementContainerConfig {
   readonly minStretchWidth: MinStretchWidth
   readonly styleOverrides?: CSSProperties
 
-  // Cache for configs created via create() to ensure referential stability
-  private static readonly cache = new Map<string, ElementContainerConfig>()
-
-  // Pre-defined configurations for common patterns
+  // Pre-defined configurations for common patterns.
+  // Use these static constants where possible for referential stability.
   static readonly DEFAULT = new ElementContainerConfig({})
 
   static readonly LARGE_ELEMENT = new ElementContainerConfig({
@@ -112,53 +110,27 @@ export class ElementContainerConfig {
     minStretchWidth: MinStretchWidth.MEDIUM,
   })
 
+  static readonly FIT_CONTENT_ELEMENT = new ElementContainerConfig({
+    minStretchWidth: MinStretchWidth.FIT_CONTENT,
+  })
+
+  static readonly FULL_WIDTH = new ElementContainerConfig({
+    styleOverrides: { width: "100%" },
+  })
+
+  static readonly LARGE_OVERFLOW_VISIBLE = new ElementContainerConfig({
+    minStretchWidth: MinStretchWidth.LARGE,
+    styleOverrides: { overflow: "visible" },
+  })
+
   constructor(options: ElementContainerConfigOptions = {}) {
     this.minStretchWidth = options.minStretchWidth ?? MinStretchWidth.NONE
     this.styleOverrides = options.styleOverrides
   }
 
   /**
-   * Creates or retrieves a cached config for the given options.
-   * Ensures referential stability across renders without needing to
-   * predefine every possible configuration combination.
-   *
-   * @example
-   * ```typescript
-   * // These will return the same cached instance:
-   * ElementContainerConfig.create({ styleOverrides: { width: "100%" } })
-   * ElementContainerConfig.create({ styleOverrides: { width: "100%" } })
-   * ```
-   */
-  static create(
-    options: ElementContainerConfigOptions
-  ): ElementContainerConfig {
-    // Create a stable cache key from options
-    // Sort styleOverrides keys for consistent key generation
-    const { styleOverrides } = options
-    const styleKey = styleOverrides
-      ? JSON.stringify(
-          Object.keys(styleOverrides)
-            .sort()
-            .reduce<Record<string, unknown>>((acc, key) => {
-              acc[key] = styleOverrides[key as keyof CSSProperties]
-              return acc
-            }, {})
-        )
-      : ""
-    const key = `${options.minStretchWidth ?? "none"}_${styleKey}`
-
-    let config = this.cache.get(key)
-    if (!config) {
-      config = new ElementContainerConfig(options)
-      this.cache.set(key, config)
-    }
-    return config
-  }
-
-  /**
    * Creates a new config by merging this config with overrides.
    * Useful for extending pre-defined configs with element-specific adjustments.
-   * Returns a cached instance for referential stability.
    *
    * @example
    * ```typescript
@@ -168,7 +140,7 @@ export class ElementContainerConfig {
   with(
     overrides: Partial<ElementContainerConfigOptions>
   ): ElementContainerConfig {
-    return ElementContainerConfig.create({
+    return new ElementContainerConfig({
       minStretchWidth: overrides.minStretchWidth ?? this.minStretchWidth,
       styleOverrides:
         overrides.styleOverrides !== undefined

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -407,7 +407,7 @@ const RawElementNodeRenderer = (
       const isUsingStretch =
         !node.element.widthConfig || node.element.widthConfig.useStretch
 
-      const config = new ElementContainerConfig({
+      const config = ElementContainerConfig.create({
         styleOverrides: { width: isUsingStretch ? "100%" : "auto" },
       })
 
@@ -438,14 +438,13 @@ const RawElementNodeRenderer = (
       // When markdown has no explicit width config, apply container-aware sizing:
       // - In horizontal layouts: content width (fit-content)
       // - In vertical layouts: stretch (100%)
-      let config = ElementContainerConfig.DEFAULT
-      if (!node.element.widthConfig) {
-        config = new ElementContainerConfig({
-          styleOverrides: {
-            width: isInHorizontalLayout ? "fit-content" : "100%",
-          },
-        })
-      }
+      const config = node.element.widthConfig
+        ? ElementContainerConfig.DEFAULT
+        : ElementContainerConfig.create({
+            styleOverrides: {
+              width: isInHorizontalLayout ? "fit-content" : "100%",
+            },
+          })
 
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>
@@ -514,21 +513,22 @@ const RawElementNodeRenderer = (
         </ElementContainer>
       )
 
-    case "skeleton": {
+    case "skeleton":
       // Without this style, the skeleton width relies on the flex container that
       // wraps the page contents having align-items: stretch. There was a regression
       // where this default was changed. It is more robust to ensure that the skeleton
       // has this width.
-      const config = new ElementContainerConfig({
-        styleOverrides: { width: "100%" },
-      })
-
       return (
-        <ElementContainer node={node} config={config} isStale={isStale}>
+        <ElementContainer
+          node={node}
+          config={ElementContainerConfig.create({
+            styleOverrides: { width: "100%" },
+          })}
+          isStale={isStale}
+        >
           <Skeleton element={node.element.skeleton as SkeletonProto} />
         </ElementContainer>
       )
-    }
 
     case "snow":
       // Specifically use node.scriptRunId vs. scriptRunId from context
@@ -623,17 +623,16 @@ const RawElementNodeRenderer = (
       const dataframeProto = node.element.dataframe as DataframeProto
       widgetProps.disabled = widgetProps.disabled || dataframeProto.disabled
 
-      const styleOverrides: React.CSSProperties = { overflow: "visible" }
-      if (node.element.widthConfig?.useContent && isInRoot) {
-        // Resizable dataframes measure parent container width for the resize feature.
-        // Parent needs defined width (not fit-content) for measurement to work.
-        // Only needed in root where resize is enabled; disabled in nested containers.
-        styleOverrides.width = "100%"
-      }
-
-      const config = new ElementContainerConfig({
+      // Resizable dataframes measure parent container width for the resize feature.
+      // Parent needs defined width (not fit-content) for measurement to work.
+      // Only needed in root where resize is enabled; disabled in nested containers.
+      const needsFullWidth = node.element.widthConfig?.useContent && isInRoot
+      const config = ElementContainerConfig.create({
         minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides,
+        styleOverrides: {
+          overflow: "visible",
+          ...(needsFullWidth && { width: "100%" }),
+        },
       })
 
       return (
@@ -655,21 +654,19 @@ const RawElementNodeRenderer = (
     case "arrowVegaLiteChart": {
       const vegaLiteElement = node.vegaLiteChartElement
 
-      const styleOverrides: React.CSSProperties = { overflow: "visible" }
-      if (node.element.widthConfig?.useContent && isInRoot) {
-        // VegaLite charts with embedded dataframes need a defined parent width
-        // (not fit-content) for proper measurement and rendering due to the resize feature.
-        // Resize is disabled in nested containers, so this is only necessary in the root container.
-        styleOverrides.width = "100%"
-      }
-      if (isInHorizontalLayout && !node.element.widthConfig) {
-        // TODO (lawilby): See if we can remove this once the new width style is implemented for all of the vega charts.
-        styleOverrides.flex = "1 1 14rem"
-      }
-
-      const config = new ElementContainerConfig({
+      // VegaLite charts with embedded dataframes need a defined parent width
+      // (not fit-content) for proper measurement and rendering due to the resize feature.
+      // Resize is disabled in nested containers, so this is only necessary in the root container.
+      const needsFullWidth = node.element.widthConfig?.useContent && isInRoot
+      // TODO (lawilby): See if we can remove this once the new width style is implemented for all of the vega charts.
+      const needsFlex = isInHorizontalLayout && !node.element.widthConfig
+      const config = ElementContainerConfig.create({
         minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides,
+        styleOverrides: {
+          overflow: "visible",
+          ...(needsFullWidth && { width: "100%" }),
+          ...(needsFlex && { flex: "1 1 14rem" }),
+        },
       })
 
       return (
@@ -770,12 +767,14 @@ const RawElementNodeRenderer = (
       widgetProps.disabled = widgetProps.disabled || feedbackProto.disabled
 
       // Feedback uses borderless button group style, should shrink to content size
-      const config = new ElementContainerConfig({
-        minStretchWidth: MinStretchWidth.FIT_CONTENT,
-      })
-
       return (
-        <ElementContainer node={node} config={config} isStale={isStale}>
+        <ElementContainer
+          node={node}
+          config={ElementContainerConfig.create({
+            minStretchWidth: MinStretchWidth.FIT_CONTENT,
+          })}
+          isStale={isStale}
+        >
           <Feedback
             key={feedbackProto.id}
             element={feedbackProto}
@@ -858,22 +857,23 @@ const RawElementNodeRenderer = (
         </ElementContainer>
       )
     }
-    case "componentInstance": {
+    case "componentInstance":
       // Because of how width is handled for custom components, we need the
       // element wrapper to be full width.
-      const config = new ElementContainerConfig({
-        styleOverrides: { width: "100%" },
-      })
-
       return (
-        <ElementContainer node={node} config={config} isStale={isStale}>
+        <ElementContainer
+          node={node}
+          config={ElementContainerConfig.create({
+            styleOverrides: { width: "100%" },
+          })}
+          isStale={isStale}
+        >
           <ComponentInstance
             element={node.element.componentInstance as ComponentInstanceProto}
             {...widgetProps}
           />
         </ElementContainer>
       )
-    }
 
     case "dateInput": {
       const dateInputProto = node.element.dateInput as DateInputProto
@@ -1036,24 +1036,14 @@ const RawElementNodeRenderer = (
       // is measuring only the input box so the pixel height must be set in the element
       // and the container must be allowed to expand. Additionally, we don't want the
       // flex with height to be set on the element container.
-      let config: ElementContainerConfig
-      if (node.element.heightConfig?.useStretch) {
-        config = new ElementContainerConfig({
-          minStretchWidth: MinStretchWidth.MEDIUM,
-          styleOverrides: { height: "100%", flex: "1 1 8rem" },
-        })
-      } else if (isInHorizontalLayout) {
-        config = new ElementContainerConfig({
-          minStretchWidth: MinStretchWidth.MEDIUM,
-          styleOverrides: { height: "auto" },
-        })
-      } else {
-        // Content height text area in vertical layout cannot have flex.
-        config = new ElementContainerConfig({
-          minStretchWidth: MinStretchWidth.MEDIUM,
-          styleOverrides: { height: "auto", flex: "" },
-        })
-      }
+      const useStretchHeight = node.element.heightConfig?.useStretch
+      const config = ElementContainerConfig.create({
+        minStretchWidth: MinStretchWidth.MEDIUM,
+        styleOverrides: useStretchHeight
+          ? { height: "100%", flex: "1 1 8rem" }
+          : // Content height text area in vertical layout cannot have flex.
+            { height: "auto", ...(isInHorizontalLayout ? {} : { flex: "" }) },
+      })
 
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -292,9 +292,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.LARGE_ELEMENT.with({
-            styleOverrides: { overflow: "visible" },
-          })}
+          config={ElementContainerConfig.LARGE_OVERFLOW_VISIBLE}
           isStale={isStale}
         >
           <DeckGlJsonChart
@@ -353,9 +351,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.LARGE_ELEMENT.with({
-            styleOverrides: { overflow: "visible" },
-          })}
+          config={ElementContainerConfig.LARGE_OVERFLOW_VISIBLE}
           isStale={isStale}
         >
           <GraphVizChart
@@ -383,9 +379,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.LARGE_ELEMENT.with({
-            styleOverrides: { overflow: "visible" },
-          })}
+          config={ElementContainerConfig.LARGE_OVERFLOW_VISIBLE}
           isStale={isStale}
         >
           <IFrame
@@ -407,9 +401,11 @@ const RawElementNodeRenderer = (
       const isUsingStretch =
         !node.element.widthConfig || node.element.widthConfig.useStretch
 
-      const config = ElementContainerConfig.create({
-        styleOverrides: { width: isUsingStretch ? "100%" : "auto" },
-      })
+      const config = isUsingStretch
+        ? ElementContainerConfig.FULL_WIDTH
+        : new ElementContainerConfig({
+            styleOverrides: { width: "auto" },
+          })
 
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>
@@ -440,11 +436,11 @@ const RawElementNodeRenderer = (
       // - In vertical layouts: stretch (100%)
       const config = node.element.widthConfig
         ? ElementContainerConfig.DEFAULT
-        : ElementContainerConfig.create({
-            styleOverrides: {
-              width: isInHorizontalLayout ? "fit-content" : "100%",
-            },
-          })
+        : isInHorizontalLayout
+          ? new ElementContainerConfig({
+              styleOverrides: { width: "fit-content" },
+            })
+          : ElementContainerConfig.FULL_WIDTH
 
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>
@@ -521,9 +517,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.create({
-            styleOverrides: { width: "100%" },
-          })}
+          config={ElementContainerConfig.FULL_WIDTH}
           isStale={isStale}
         >
           <Skeleton element={node.element.skeleton as SkeletonProto} />
@@ -627,13 +621,12 @@ const RawElementNodeRenderer = (
       // Parent needs defined width (not fit-content) for measurement to work.
       // Only needed in root where resize is enabled; disabled in nested containers.
       const needsFullWidth = node.element.widthConfig?.useContent && isInRoot
-      const config = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides: {
-          overflow: "visible",
-          ...(needsFullWidth && { width: "100%" }),
-        },
-      })
+      const config = needsFullWidth
+        ? new ElementContainerConfig({
+            minStretchWidth: MinStretchWidth.LARGE,
+            styleOverrides: { overflow: "visible", width: "100%" },
+          })
+        : ElementContainerConfig.LARGE_OVERFLOW_VISIBLE
 
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>
@@ -660,14 +653,17 @@ const RawElementNodeRenderer = (
       const needsFullWidth = node.element.widthConfig?.useContent && isInRoot
       // TODO (lawilby): See if we can remove this once the new width style is implemented for all of the vega charts.
       const needsFlex = isInHorizontalLayout && !node.element.widthConfig
-      const config = ElementContainerConfig.create({
-        minStretchWidth: MinStretchWidth.LARGE,
-        styleOverrides: {
-          overflow: "visible",
-          ...(needsFullWidth && { width: "100%" }),
-          ...(needsFlex && { flex: "1 1 14rem" }),
-        },
-      })
+      const config =
+        needsFullWidth || needsFlex
+          ? new ElementContainerConfig({
+              minStretchWidth: MinStretchWidth.LARGE,
+              styleOverrides: {
+                overflow: "visible",
+                ...(needsFullWidth && { width: "100%" }),
+                ...(needsFlex && { flex: "1 1 14rem" }),
+              },
+            })
+          : ElementContainerConfig.LARGE_OVERFLOW_VISIBLE
 
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>
@@ -770,9 +766,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.create({
-            minStretchWidth: MinStretchWidth.FIT_CONTENT,
-          })}
+          config={ElementContainerConfig.FIT_CONTENT_ELEMENT}
           isStale={isStale}
         >
           <Feedback
@@ -863,9 +857,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.create({
-            styleOverrides: { width: "100%" },
-          })}
+          config={ElementContainerConfig.FULL_WIDTH}
           isStale={isStale}
         >
           <ComponentInstance
@@ -1037,7 +1029,7 @@ const RawElementNodeRenderer = (
       // and the container must be allowed to expand. Additionally, we don't want the
       // flex with height to be set on the element container.
       const useStretchHeight = node.element.heightConfig?.useStretch
-      const config = ElementContainerConfig.create({
+      const config = new ElementContainerConfig({
         minStretchWidth: MinStretchWidth.MEDIUM,
         styleOverrides: useStretchHeight
           ? { height: "100%", flex: "1 1 8rem" }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -433,19 +433,29 @@ const RawElementNodeRenderer = (
         </ElementContainer>
       )
 
-    case "markdown":
+    case "markdown": {
+      // Markdown "auto" width behavior:
+      // When markdown has no explicit width config, apply container-aware sizing:
+      // - In horizontal layouts: content width (fit-content)
+      // - In vertical layouts: stretch (100%)
+      let config = ElementContainerConfig.DEFAULT
+      if (!node.element.widthConfig) {
+        config = new ElementContainerConfig({
+          styleOverrides: {
+            width: isInHorizontalLayout ? "fit-content" : "100%",
+          },
+        })
+      }
+
       return (
-        <ElementContainer
-          node={node}
-          config={ElementContainerConfig.DEFAULT}
-          isStale={isStale}
-        >
+        <ElementContainer node={node} config={config} isStale={isStale}>
           <Markdown
             element={node.element.markdown as MarkdownProto}
             {...elementProps}
           />
         </ElementContainer>
       )
+    }
 
     case "metric":
       return (

--- a/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
+++ b/frontend/lib/src/components/elements/Markdown/Markdown.test.tsx
@@ -14,12 +14,29 @@
  * limitations under the License.
  */
 
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
-import { Markdown as MarkdownProto } from "@streamlit/protobuf"
+import {
+  ForwardMsgMetadata,
+  Markdown as MarkdownProto,
+  streamlit,
+} from "@streamlit/protobuf"
 
+import { ElementNode } from "~lib/AppNode"
+import ElementNodeRenderer, {
+  ElementNodeRendererProps,
+} from "~lib/components/core/Block/ElementNodeRenderer"
+import {
+  FlexContext,
+  IFlexContext,
+} from "~lib/components/core/Layout/FlexContext"
+import { Direction } from "~lib/components/core/Layout/utils"
+import { ComponentRegistry } from "~lib/components/widgets/CustomComponent"
+import { FileUploadClient } from "~lib/FileUploadClient"
+import { mockEndpoints, mockSessionInfo } from "~lib/mocks/mocks"
 import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Markdown, { MarkdownProps } from "./Markdown"
 
@@ -321,5 +338,180 @@ describe("Markdown badge with help", () => {
     // Tooltip text should appear
     const tooltip = await screen.findByText("Tooltip with backslash")
     expect(tooltip).toBeVisible()
+  })
+})
+
+// Integration tests for Markdown auto width behavior via ElementNodeRenderer
+// These tests verify that width="auto" (no widthConfig) applies container-aware sizing
+describe("Markdown auto width behavior", () => {
+  const FAKE_SCRIPT_HASH = "fake_script_hash"
+
+  function createMarkdownNode(
+    scriptRunId: string,
+    widthConfig?: streamlit.WidthConfig
+  ): ElementNode {
+    const node = new ElementNode(
+      new MarkdownProto({
+        body: "Test markdown",
+        allowHtml: false,
+        elementType: MarkdownProto.Type.NATIVE,
+      }),
+      ForwardMsgMetadata.create({}),
+      scriptRunId,
+      FAKE_SCRIPT_HASH
+    )
+    node.element.type = "markdown"
+    if (widthConfig) {
+      node.element.widthConfig = widthConfig
+    }
+    return node
+  }
+
+  function getElementNodeRendererProps(
+    props: Partial<ElementNodeRendererProps> &
+      Pick<ElementNodeRendererProps, "node">
+  ): ElementNodeRendererProps {
+    const sessionInfo = mockSessionInfo()
+    const endpoints = mockEndpoints()
+    return {
+      endpoints: endpoints,
+      widgetMgr: new WidgetStateManager({
+        sendRerunBackMsg: vi.fn(),
+        formsDataChanged: vi.fn(),
+      }),
+      widgetsDisabled: false,
+      uploadClient: new FileUploadClient({
+        sessionInfo: sessionInfo,
+        endpoints,
+        formsWithPendingRequestsChanged: () => {},
+        requestFileURLs: vi.fn(),
+      }),
+      componentRegistry: new ComponentRegistry(endpoints),
+      ...props,
+    }
+  }
+
+  const renderMarkdownWithFlexContext = (
+    props: ElementNodeRendererProps,
+    flexContext: IFlexContext
+  ): void => {
+    render(
+      <FlexContext.Provider value={flexContext}>
+        <ElementNodeRenderer {...props} />
+      </FlexContext.Provider>
+    )
+  }
+
+  it("should use fit-content width in horizontal layout when no widthConfig", async () => {
+    const scriptRunId = "SCRIPT_RUN_ID"
+    const props = getElementNodeRendererProps({
+      node: createMarkdownNode(scriptRunId),
+    })
+
+    const horizontalFlexContext: IFlexContext = {
+      direction: Direction.HORIZONTAL,
+      isInHorizontalLayout: true,
+      isInRoot: false,
+      isInContentWidthContainer: false,
+    }
+
+    renderMarkdownWithFlexContext(props, horizontalFlexContext)
+
+    await waitFor(() => expect(screen.queryByTestId("stSkeleton")).toBeNull())
+
+    const container = screen.getByTestId("stElementContainer")
+    expect(container).toBeVisible()
+    expect(container).toHaveStyle({ width: "fit-content" })
+  })
+
+  it("should use 100% width in vertical layout when no widthConfig", async () => {
+    const scriptRunId = "SCRIPT_RUN_ID"
+    const props = getElementNodeRendererProps({
+      node: createMarkdownNode(scriptRunId),
+    })
+
+    const verticalFlexContext: IFlexContext = {
+      direction: Direction.VERTICAL,
+      isInHorizontalLayout: false,
+      isInRoot: false,
+      isInContentWidthContainer: false,
+    }
+
+    renderMarkdownWithFlexContext(props, verticalFlexContext)
+
+    await waitFor(() => expect(screen.queryByTestId("stSkeleton")).toBeNull())
+
+    const container = screen.getByTestId("stElementContainer")
+    expect(container).toBeVisible()
+    expect(container).toHaveStyle({ width: "100%" })
+  })
+
+  it("should apply stretch width when server sends useStretch config", async () => {
+    const scriptRunId = "SCRIPT_RUN_ID"
+    const widthConfig = new streamlit.WidthConfig({ useStretch: true })
+    const props = getElementNodeRendererProps({
+      node: createMarkdownNode(scriptRunId, widthConfig),
+    })
+
+    const horizontalFlexContext: IFlexContext = {
+      direction: Direction.HORIZONTAL,
+      isInHorizontalLayout: true,
+      isInRoot: false,
+      isInContentWidthContainer: false,
+    }
+
+    renderMarkdownWithFlexContext(props, horizontalFlexContext)
+
+    await waitFor(() => expect(screen.queryByTestId("stSkeleton")).toBeNull())
+
+    const container = screen.getByTestId("stElementContainer")
+    expect(container).toBeVisible()
+    expect(container).toHaveStyle({ width: "100%" })
+  })
+
+  it("should apply content width when server sends useContent config", async () => {
+    const scriptRunId = "SCRIPT_RUN_ID"
+    const widthConfig = new streamlit.WidthConfig({ useContent: true })
+    const props = getElementNodeRendererProps({
+      node: createMarkdownNode(scriptRunId, widthConfig),
+    })
+
+    const verticalFlexContext: IFlexContext = {
+      direction: Direction.VERTICAL,
+      isInHorizontalLayout: false,
+      isInRoot: false,
+      isInContentWidthContainer: false,
+    }
+
+    renderMarkdownWithFlexContext(props, verticalFlexContext)
+
+    await waitFor(() => expect(screen.queryByTestId("stSkeleton")).toBeNull())
+
+    const container = screen.getByTestId("stElementContainer")
+    expect(container).toBeVisible()
+    expect(container).toHaveStyle({ width: "fit-content" })
+  })
+
+  it("should apply pixel width when server sends pixelWidth config", async () => {
+    const scriptRunId = "SCRIPT_RUN_ID"
+    const widthConfig = new streamlit.WidthConfig({ pixelWidth: 150 })
+    const props = getElementNodeRendererProps({
+      node: createMarkdownNode(scriptRunId, widthConfig),
+    })
+
+    const verticalFlexContext: IFlexContext = {
+      direction: Direction.VERTICAL,
+      isInHorizontalLayout: false,
+      isInRoot: false,
+      isInContentWidthContainer: false,
+    }
+
+    renderMarkdownWithFlexContext(props, verticalFlexContext)
+
+    await waitFor(() => expect(screen.queryByTestId("stSkeleton")).toBeNull())
+
+    const container = screen.getByTestId("stElementContainer")
+    expect(container).toBeVisible()
+    expect(container).toHaveStyle({ width: "150px" })
   })
 })

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -44,7 +44,7 @@ class MarkdownMixin:
         unsafe_allow_html: bool = False,
         *,  # keyword-only arguments:
         help: str | None = None,
-        width: Width = "stretch",
+        width: Width | Literal["auto"] = "auto",
         text_alignment: TextAlignment = "left",
     ) -> DeltaGenerator:
         r"""Display string formatted as Markdown.
@@ -119,11 +119,14 @@ class MarkdownMixin:
             including the Markdown directives described in the ``body``
             parameter of ``st.markdown``.
 
-        width : "stretch", "content", or int
+        width : "auto", "stretch", "content", or int
             The width of the Markdown element. This can be one of the following:
 
-            - ``"stretch"`` (default): The width of the element matches the
-              width of the parent container.
+            - ``"auto"`` (default): The width adapts based on the container:
+              ``"stretch"`` in vertical containers and ``"content"`` in
+              horizontal containers.
+            - ``"stretch"``: The width of the element matches the width of
+              the parent container.
             - ``"content"``: The width of the element matches the width of its
               content, but doesn't exceed the width of the parent container.
             - An integer specifying the width in pixels: The element has a
@@ -178,8 +181,11 @@ class MarkdownMixin:
         if help:
             markdown_proto.help = help
 
-        validate_width(width, allow_content=True)
-        layout_config = LayoutConfig(width=width, text_alignment=text_alignment)
+        if width != "auto":
+            validate_width(width, allow_content=True)
+            layout_config = LayoutConfig(width=width, text_alignment=text_alignment)
+        else:
+            layout_config = LayoutConfig(text_alignment=text_alignment)
 
         return self.dg._enqueue("markdown", markdown_proto, layout_config=layout_config)
 

--- a/lib/tests/streamlit/elements/markdown_test.py
+++ b/lib/tests/streamlit/elements/markdown_test.py
@@ -95,8 +95,32 @@ class StMarkdownAPITest(DeltaGeneratorTestCase):
                 assert expected_error_message in str(exc.value)
 
     def test_st_markdown_default_width(self):
-        """Test that st.markdown defaults to stretch width."""
+        """Test that st.markdown defaults to auto width (no width config)."""
         st.markdown("some markdown")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.markdown.body == "some markdown"
+        # When width="auto" (default), no width config should be set
+        assert el.width_config.WhichOneof("width_spec") is None
+        # Verify that use_stretch is NOT set (negative assertion)
+        assert el.width_config.use_stretch is False
+        assert el.width_config.use_content is False
+
+    def test_st_markdown_auto_width(self):
+        """Test that st.markdown with width='auto' does not set width config."""
+        st.markdown("some markdown", width="auto")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.markdown.body == "some markdown"
+        # When width="auto", no width config should be set
+        assert el.width_config.WhichOneof("width_spec") is None
+        # Verify that neither stretch nor content is set (negative assertion)
+        assert el.width_config.use_stretch is False
+        assert el.width_config.use_content is False
+
+    def test_st_markdown_explicit_stretch_width(self):
+        """Test that st.markdown with explicit width='stretch' sets width config."""
+        st.markdown("some markdown", width="stretch")
 
         el = self.get_delta_from_queue().new_element
         assert el.markdown.body == "some markdown"


### PR DESCRIPTION

## Describe your changes

Adds `width="auto"` as the new default for `st.markdown`. When `auto`, the width adapts based on container context:
- **Vertical containers**: behaves like `width="stretch"` (fills available space)
- **Horizontal containers**: behaves like `width="content"` (shrinks to fit)

This enables markdown elements to naturally fit within horizontal layouts without requiring explicit `width="content"`.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/elements/markdown_test.py` - Tests `width="auto"` parameter acceptance and proto generation
  - `frontend/lib/src/components/elements/Markdown/Markdown.test.tsx` - Tests container-aware width behavior in horizontal/vertical layouts
- [ ] E2E Tests
- [x] Any manual testing needed?
  - Manually verified. 


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
