### PR TITLE
[chore] Update opus-4.5 -> opus-4.6 in GH workflows

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -14,12 +14,12 @@ on:
         description: "Model to use for the triage"
         required: false
         type: string
-        default: "opus-4.5-thinking"
+        default: "opus-4.6-thinking"
 
 # Computed issue number and model for use in jobs
 env:
   ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-  MODEL: ${{ github.event.inputs.model || 'opus-4.5-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'opus-4.6-thinking' }}
 
 jobs:
   # Job 1: AI performs the triage analysis with READ-ONLY access

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model to use for the review"
         required: false
         type: string
-        default: "opus-4.5-thinking"
+        default: "opus-4.6-thinking"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'opus-4.5-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'opus-4.6-thinking' }}
 
 jobs:
   # Job 1: AI performs the review with READ-ONLY access


### PR DESCRIPTION
## Describe your changes

Updated the default AI model from `opus-4.5-thinking` to `opus-4.6-thinking` in both the issue triage and PR review GitHub workflows.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No additional tests needed as this is a configuration change to GitHub workflows
- The updated model will be automatically used when the workflows run

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.