### PR TITLE
Bind widgets to query params - FE hooks & `color_picker` support

### DIFF
--- a/e2e_playwright/st_color_picker.py
+++ b/e2e_playwright/st_color_picker.py
@@ -124,3 +124,21 @@ if "runs" not in st.session_state:
     st.session_state.runs = 0
 st.session_state.runs += 1
 st.write("Runs:", st.session_state.runs)
+
+# Query param binding color picker (no provided default = black)
+st.markdown("Query param binding:")
+bound_color = st.color_picker(
+    "Bound color (no provided default)",
+    key="bound_color",
+    bind="query-params",
+)
+st.write("bound color value:", bound_color)
+
+# Query param binding color picker with custom default
+bound_color_custom = st.color_picker(
+    "Bound color (default red)",
+    value="#ff0000",
+    key="bound_red",
+    bind="query-params",
+)
+st.write("bound color red value:", bound_color_custom)

--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
@@ -26,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
 )
 
-NUM_COLOR_PICKERS = 13
+NUM_COLOR_PICKERS = 15
 
 
 def test_color_picker_widget_display_themed(
@@ -191,6 +197,94 @@ def test_typing_new_hsl_color_on_color_picker_works(
     wait_for_app_run(app)
     expect(app.get_by_text("#ffffff")).to_be_visible()
     assert_snapshot(default_picker, name="st_color_picker-typed_new_hsl_color")
+
+
+def test_color_picker_query_param_seeding(page: Page, app_port: int):
+    """Test that color picker value can be seeded from URL query params."""
+    # Load app with query param set (URL-encoded # is %23)
+    page.goto(f"http://localhost:{app_port}/?bound_color=%23FF5733")
+    wait_for_app_loaded(page)
+
+    # Color picker should show the seeded color (displayed uppercase)
+    expect_prefixed_markdown(page, "bound color value:", "#FF5733")
+
+
+def test_color_picker_query_param_updates_url(app: Page):
+    """Test that changing a bound color picker updates the URL."""
+    # Initially default black, no query param in URL
+    expect_prefixed_markdown(app, "bound color value:", "#000000")
+    expect(app).to_have_url(re.compile(r"^((?!bound_color=).)*$"))
+
+    # Change the color
+    color_picker = get_color_picker(app, "Bound color (no provided default)")
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+    text_input = app.get_by_test_id("stColorPickerPopover").locator("input")
+    text_input.fill("#00ff00")
+    # Click outside to close popover
+    app.get_by_text("Bound color (no provided default)").click()
+    wait_for_app_run(app)
+
+    # URL should now contain the query param (URL-encoded)
+    expect(app).to_have_url(re.compile(r"bound_color=%2300ff00"))
+    expect_prefixed_markdown(app, "bound color value:", "#00ff00")
+
+    # Reset to default (black)
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+    text_input = app.get_by_test_id("stColorPickerPopover").locator("input")
+    text_input.fill("#000000")
+    app.get_by_text("Bound color (no provided default)").click()
+    wait_for_app_run(app)
+
+    # Query param should be removed since value is back to default
+    expect(app).to_have_url(re.compile(r"^((?!bound_color=).)*$"))
+    expect_prefixed_markdown(app, "bound color value:", "#000000")
+
+
+def test_color_picker_query_param_default_custom(page: Page, app_port: int):
+    """Test color picker with custom default: seeding and param removal."""
+    # Load app with query param overriding the red default
+    page.goto(f"http://localhost:{app_port}/?bound_red=%2300FF00")
+    wait_for_app_loaded(page)
+
+    # Color picker should show green (overriding red default, case preserved from URL)
+    expect_prefixed_markdown(page, "bound color red value:", "#00FF00")
+
+    # Change back to default (red) - use lowercase since react-color outputs lowercase
+    color_picker = get_color_picker(page, "Bound color (default red)")
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+    text_input = page.get_by_test_id("stColorPickerPopover").locator("input")
+    text_input.fill("#ff0000")
+    page.get_by_text("Bound color (default red)").click()
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default (red)
+    expect(page).to_have_url(re.compile(r"^((?!bound_red).)*$"))
+    expect_prefixed_markdown(page, "bound color red value:", "#ff0000")
+
+
+def test_color_picker_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    # Load app with invalid query param value (not a valid hex color)
+    page.goto(f"http://localhost:{app_port}/?bound_color=notacolor")
+    wait_for_app_loaded(page)
+
+    # Color picker should use default (black), and invalid param should be cleared
+    expect_prefixed_markdown(page, "bound color value:", "#000000")
+    # Invalid param should be removed from URL
+    expect(page).to_have_url(re.compile(r"^((?!bound_color).)*$"))
+
+
+def test_color_picker_query_param_3char_hex(page: Page, app_port: int):
+    """Test that 3-char hex shorthand colors (e.g., #F00) work in URL params."""
+    # Load app with 3-char hex color (URL-encoded # is %23)
+    # #F00 is shorthand for #FF0000 (red)
+    page.goto(f"http://localhost:{app_port}/?bound_color=%23F00")
+    wait_for_app_loaded(page)
+
+    # Color picker should accept the 3-char hex and display it
+    # Note: The color picker may expand to 6-char or keep 3-char depending on implementation
+    # We just verify it's treated as valid (red color)
+    expect_prefixed_markdown(page, "bound color value:", "#F00")
 
 
 def test_in_form_selection_and_session_state(app: Page):

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -175,3 +175,74 @@ describe("ColorPicker widget", () => {
     )
   })
 })
+
+describe("ColorPicker query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_color" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_color",
+      "string_value",
+      props.element.default,
+      false,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_color" })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<ColorPicker {...props} />)
+
+    // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding with custom default color", () => {
+    const props = getProps({
+      queryParamKey: "theme_color",
+      default: "#750dc5",
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ColorPicker {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "theme_color",
+      "string_value",
+      "#750dc5",
+      false,
+      undefined,
+      undefined
+    )
+
+    // Verify the widget displays the custom default color
+    const colorBlock = screen.getByTestId("stColorPickerBlock")
+    expect(colorBlock).toHaveStyle("background-color: #750dc5")
+  })
+})

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -49,13 +49,17 @@ const getStateFromWidgetMgr = (
 const getDefaultStateFromProto = (
   element: ColorPickerProto
 ): ColorPickerValue => {
-  return element.default ?? null
+  // Default to a sensible color if proto default is not set
+  // Defensive as backend always sets default
+  return element.default ?? "#000000"
 }
 
 const getCurrStateFromProto = (
   element: ColorPickerProto
 ): ColorPickerValue => {
-  return element.value ?? null
+  // Return the current value, falling back to default if not set
+  // Defensive as backend always sets default
+  return element.value ?? element.default ?? "#000000"
 }
 
 const updateWidgetMgrState = (
@@ -89,6 +93,13 @@ const ColorPicker: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "string_value",
+          clearable: false,
+        }
+      : undefined,
   })
 
   const handleColorClose = useCallback(

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -19,6 +19,7 @@ import { renderHook } from "@testing-library/react"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
+  type QueryParamBindingConfig,
   useBasicWidgetState,
   type ValueWithSource,
 } from "./useBasicWidgetState"
@@ -27,6 +28,7 @@ import {
 interface MockProto {
   formId: string
   setValue: boolean
+  id: string
   value: string | number | string[] | number[]
   default: string | number | string[] | number[]
 }
@@ -66,6 +68,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-1",
         value: "url-seeded-value",
         default: "default-value",
       }
@@ -89,6 +92,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-2",
         value: "some-value",
         default: "default-value",
       }
@@ -115,6 +119,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-3",
         value: "different-value",
         default: "default-value",
       }
@@ -144,6 +149,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-4",
         value: "proto-value",
         default: "default-value",
       }
@@ -172,6 +178,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-5",
         value: "new-backend-value",
         default: "default-value",
       }
@@ -197,6 +204,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-6",
         value: [3, 4, 5],
         default: [1, 2],
       }
@@ -219,6 +227,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-7",
         value: [3, 4, 5],
         default: [1, 2],
       }
@@ -243,6 +252,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: true,
+        id: "widget-8",
         value: 42,
         default: 0,
       }
@@ -265,6 +275,7 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       const element: MockProto = {
         formId: "",
         setValue: false,
+        id: "widget-9",
         value: 42,
         default: 0,
       }
@@ -281,6 +292,153 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       )
 
       expect(result.current[0]).toBe(0)
+    })
+  })
+
+  describe("query param binding integration", () => {
+    it("registers binding when queryParamBinding config is provided", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-with-binding",
+        value: "test",
+        default: "default",
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "my_param",
+        valueType: "string_value",
+        clearable: false,
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          queryParamBinding,
+        })
+      )
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        "widget-with-binding",
+        "my_param",
+        "string_value",
+        "default",
+        false,
+        undefined,
+        undefined
+      )
+    })
+
+    it("does not register binding when queryParamBinding is undefined", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-no-binding",
+        value: "test",
+        default: "default",
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          // No queryParamBinding
+        })
+      )
+
+      expect(registerSpy).not.toHaveBeenCalled()
+    })
+
+    it("unregisters binding on unmount", () => {
+      const unregisterSpy = vi.spyOn(widgetMgr, "unregisterQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-unmount-test",
+        value: "test",
+        default: "default",
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "unmount_param",
+        valueType: "bool_value",
+        clearable: false,
+      }
+
+      const { unmount } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          queryParamBinding,
+        })
+      )
+
+      // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+      unregisterSpy.mockClear()
+
+      unmount()
+
+      expect(unregisterSpy).toHaveBeenCalledWith("widget-unmount-test")
+    })
+
+    it("passes urlFormat and optionStrings correctly", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-with-options",
+        value: 0,
+        default: 0,
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "color",
+        valueType: "int_value",
+        clearable: false,
+        urlFormat: "comma",
+        optionStrings: ["Red", "Green", "Blue"],
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          queryParamBinding,
+        })
+      )
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        "widget-with-options",
+        "color",
+        "int_value",
+        0,
+        false,
+        "comma",
+        ["Red", "Green", "Blue"]
+      )
     })
   })
 })

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -259,8 +259,7 @@ export function useBasicWidgetState<
   const defaultValueForBinding = useMemo(
     () =>
       hasQueryParamBinding ? getDefaultStateFromProto(element) : undefined,
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- element and getDefaultStateFromProto are stable per interface contract
-    [hasQueryParamBinding, element]
+    [hasQueryParamBinding, element, getDefaultStateFromProto]
   )
 
   const optionStringsKey = queryParamBinding?.optionStrings

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -19,12 +19,19 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react"
 
 import { useFormClearHelper } from "~lib/components/widgets/Form"
 import { isNullOrUndefined } from "~lib/util/utils"
-import { Source, WidgetStateManager } from "~lib/WidgetStateManager"
+import {
+  Source,
+  WidgetStateManager,
+  WidgetValueType,
+} from "~lib/WidgetStateManager"
+
+import { useQueryParamBinding } from "./useQueryParamBinding"
 
 export type ValueWithSource<T> = {
   value: T
@@ -144,9 +151,35 @@ export function useBasicWidgetClientState<
   return [currentValue, setNextValueWithSource]
 }
 
-// Interface for a proto that has a setValue, and .formId
+// Interface for a proto that has a setValue, id, and .formId
 interface ValueElementProtoInterfaceWithSetValue extends ValueElementProtoInterface {
   setValue: boolean
+  id: string
+}
+
+/**
+ * Configuration for query parameter binding integration.
+ * When provided to useBasicWidgetState, the hook will automatically
+ * register/unregister the widget's URL query parameter binding.
+ */
+export interface QueryParamBindingConfig {
+  /** The URL query parameter key */
+  paramKey: string
+  /** The widget value type for URL conversion */
+  valueType: WidgetValueType
+  /**
+   * Whether the widget allows clearing to empty state.
+   * Required - widget components must explicitly pass this based on their UI behavior.
+   */
+  clearable: boolean
+  /** How to serialize arrays in the URL ("comma" or "repeated") */
+  urlFormat?: "comma" | "repeated"
+  /**
+   * For index-based widgets, the formatted option strings to use in URLs.
+   * TODO(query-params): Remove after wire format changes from index-based
+   * to string-based values for applicable widgets (selectbox, pills, etc.)
+   */
+  optionStrings?: string[]
 }
 
 export interface UseBasicWidgetStateArgs<
@@ -157,6 +190,12 @@ export interface UseBasicWidgetStateArgs<
   // either declare them at the module level or wrap in useCallback.
   getDefaultStateFromProto: (el: P) => T
   getCurrStateFromProto: (el: P) => T
+  /**
+   * Optional query parameter binding configuration.
+   * When provided, the hook will automatically register the widget
+   * for URL query parameter synchronization.
+   */
+  queryParamBinding?: QueryParamBindingConfig
 }
 
 /**
@@ -181,6 +220,7 @@ export function useBasicWidgetState<
   widgetMgr,
   fragmentId,
   onFormCleared,
+  queryParamBinding,
 }: UseBasicWidgetStateArgs<T, P>): [
   T,
   Dispatch<SetStateAction<ValueWithSource<T> | null>>,
@@ -210,11 +250,53 @@ export function useBasicWidgetState<
     onFormCleared,
   })
 
+  // Memoize values to prevent unnecessary effect re-runs in useQueryParamBinding.
+  // We track individual primitive properties and use JSON.stringify for arrays
+  // to provide value-based comparison instead of reference-based.
+  const hasQueryParamBinding = !isNullOrUndefined(queryParamBinding)
+
+  // Memoize default value since getDefaultStateFromProto may return new references.
+  // When hasQueryParamBinding is false, we pass undefined - this is safe because
+  // useQueryParamBinding early-returns when queryParamKey is null/undefined.
+  const defaultValueForBinding = useMemo(
+    () =>
+      hasQueryParamBinding ? getDefaultStateFromProto(element) : undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- element and getDefaultStateFromProto are stable per interface contract
+    [hasQueryParamBinding, element]
+  )
+
+  // Memoize options object. Use JSON.stringify for optionStrings to ensure
+  // value-based comparison (callers may pass new array references with same values).
+  const optionStringsKey = queryParamBinding?.optionStrings
+    ? JSON.stringify(queryParamBinding.optionStrings)
+    : undefined
+  const queryParamBindingOptions = useMemo(
+    () =>
+      hasQueryParamBinding
+        ? {
+            urlFormat: queryParamBinding?.urlFormat,
+            optionStrings: queryParamBinding?.optionStrings,
+          }
+        : undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- optionStringsKey provides value-based comparison
+    [hasQueryParamBinding, queryParamBinding?.urlFormat, optionStringsKey]
+  )
+
+  // Query param binding registration (optional, integrated for convenience)
+  useQueryParamBinding(
+    widgetMgr,
+    element.id,
+    queryParamBinding?.paramKey ?? null,
+    queryParamBinding?.valueType ?? "string_value",
+    defaultValueForBinding,
+    queryParamBinding?.clearable ?? false,
+    queryParamBindingOptions
+  )
+
   // Respond to value changes via session_state. This is also set via an
   // "event", this time using the .setValue property of the proto.
   useEffect(() => {
     if (!element.setValue) return
-    // eslint-disable-next-line react-hooks/immutability -- TODO: Update to match React best practices
     element.setValue = false // Clear "event".
 
     setNextValueWithSource({

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -250,14 +250,12 @@ export function useBasicWidgetState<
     onFormCleared,
   })
 
-  // Memoize values to prevent unnecessary effect re-runs in useQueryParamBinding.
-  // We track individual primitive properties and use JSON.stringify for arrays
-  // to provide value-based comparison instead of reference-based.
+  // Memoize values for useQueryParamBinding to prevent unnecessary effect re-runs.
+  // - defaultValueForBinding: getDefaultStateFromProto may return new references
+  // - queryParamBindingOptions: uses JSON.stringify for value-based array comparison
+  // When hasQueryParamBinding is false, fallback values are unused (hook early-returns).
   const hasQueryParamBinding = !isNullOrUndefined(queryParamBinding)
 
-  // Memoize default value since getDefaultStateFromProto may return new references.
-  // When hasQueryParamBinding is false, we pass undefined - this is safe because
-  // useQueryParamBinding early-returns when queryParamKey is null/undefined.
   const defaultValueForBinding = useMemo(
     () =>
       hasQueryParamBinding ? getDefaultStateFromProto(element) : undefined,
@@ -265,8 +263,6 @@ export function useBasicWidgetState<
     [hasQueryParamBinding, element]
   )
 
-  // Memoize options object. Use JSON.stringify for optionStrings to ensure
-  // value-based comparison (callers may pass new array references with same values).
   const optionStringsKey = queryParamBinding?.optionStrings
     ? JSON.stringify(queryParamBinding.optionStrings)
     : undefined

--- a/frontend/lib/src/hooks/useQueryParamBinding.test.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest"
+
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import { useQueryParamBinding } from "./useQueryParamBinding"
+
+describe("useQueryParamBinding", () => {
+  let mockWidgetMgr: {
+    registerQueryParamBinding: Mock
+    unregisterQueryParamBinding: Mock
+  }
+
+  beforeEach(() => {
+    mockWidgetMgr = {
+      registerQueryParamBinding: vi.fn(),
+      unregisterQueryParamBinding: vi.fn(),
+    }
+  })
+
+  it("registers binding when queryParamKey is provided", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "my_key",
+        "string_value",
+        "default",
+        false
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123",
+      "my_key",
+      "string_value",
+      "default",
+      false,
+      undefined,
+      undefined
+    )
+  })
+
+  it("does not register when queryParamKey is undefined", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        undefined,
+        "string_value",
+        "default",
+        false
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("unregisters binding on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "my_key",
+        "bool_value",
+        false,
+        false
+      )
+    )
+
+    expect(mockWidgetMgr.unregisterQueryParamBinding).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(mockWidgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123"
+    )
+  })
+
+  it("does not unregister on unmount when queryParamKey is undefined", () => {
+    const { unmount } = renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        undefined,
+        "bool_value",
+        false,
+        false
+      )
+    )
+
+    unmount()
+
+    expect(mockWidgetMgr.unregisterQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("passes urlFormat option correctly", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "tags",
+        "string_array_value",
+        [],
+        true,
+        { urlFormat: "comma" }
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123",
+      "tags",
+      "string_array_value",
+      [],
+      true,
+      "comma",
+      undefined
+    )
+  })
+
+  it("passes optionStrings option correctly", () => {
+    renderHook(() =>
+      useQueryParamBinding(
+        mockWidgetMgr as unknown as WidgetStateManager,
+        "widget-123",
+        "color",
+        "int_value",
+        0,
+        false,
+        { optionStrings: ["Red", "Green", "Blue"] }
+      )
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123",
+      "color",
+      "int_value",
+      0,
+      false,
+      undefined,
+      ["Red", "Green", "Blue"]
+    )
+  })
+
+  it("re-registers when queryParamKey changes", () => {
+    const { rerender } = renderHook(
+      ({ queryParamKey }: { queryParamKey: string | undefined }) =>
+        useQueryParamBinding(
+          mockWidgetMgr as unknown as WidgetStateManager,
+          "widget-123",
+          queryParamKey,
+          "string_value",
+          "default",
+          false
+        ),
+      { initialProps: { queryParamKey: "key1" } }
+    )
+
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledTimes(1)
+
+    rerender({ queryParamKey: "key2" })
+
+    // Should unregister old and register new
+    expect(mockWidgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      "widget-123"
+    )
+    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/lib/src/hooks/useQueryParamBinding.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from "react"
+
+import { WidgetStateManager, WidgetValueType } from "~lib/WidgetStateManager"
+
+export interface QueryParamBindingOptions {
+  /** How to serialize arrays in the URL ("comma" for comma-separated, "repeated" for ?key=a&key=b) */
+  urlFormat?: "comma" | "repeated"
+  /** For index-based widgets, the formatted option strings to use in URLs */
+  optionStrings?: string[]
+}
+
+/**
+ * Custom hook to register a widget's binding to a URL query parameter.
+ *
+ * This hook handles:
+ * - Registering the binding on mount (if queryParamKey is provided)
+ * - Unregistering the binding on unmount
+ * - Re-registering if dependencies change
+ *
+ * @param widgetMgr - The WidgetStateManager instance
+ * @param widgetId - The unique widget ID
+ * @param queryParamKey - The query parameter key (null/undefined if not bound)
+ * @param valueType - The widget value type (e.g., "bool_value", "string_value")
+ * @param defaultValue - The widget's default value (for clearing URL when value equals default)
+ * @param clearable - Whether the widget allows clearing to empty state.
+ *   Widget components must explicitly pass this based on their UI behavior.
+ * @param options - Optional configuration for URL format and option strings
+ */
+export function useQueryParamBinding(
+  widgetMgr: WidgetStateManager,
+  widgetId: string,
+  queryParamKey: string | null | undefined,
+  valueType: WidgetValueType,
+  defaultValue: unknown,
+  clearable: boolean,
+  options?: QueryParamBindingOptions
+): void {
+  useEffect(() => {
+    // Treat null and undefined the same - no binding
+    if (!queryParamKey) {
+      return
+    }
+
+    widgetMgr.registerQueryParamBinding(
+      widgetId,
+      queryParamKey,
+      valueType,
+      defaultValue,
+      clearable,
+      options?.urlFormat,
+      options?.optionStrings
+    )
+
+    return () => {
+      widgetMgr.unregisterQueryParamBinding(widgetId)
+    }
+  }, [
+    widgetMgr,
+    widgetId,
+    queryParamKey,
+    valueType,
+    defaultValue,
+    clearable,
+    options,
+  ])
+}

--- a/frontend/lib/src/hooks/useQueryParamBinding.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.ts
@@ -40,7 +40,9 @@ export interface QueryParamBindingOptions {
  * @param defaultValue - The widget's default value (for clearing URL when value equals default)
  * @param clearable - Whether the widget allows clearing to empty state.
  *   Widget components must explicitly pass this based on their UI behavior.
- * @param options - Optional configuration for URL format and option strings
+ * @param options - Optional configuration for URL format and option strings.
+ *   Note: This object is included in the useEffect dependency array. Callers should
+ *   memoize the options object (e.g., via useMemo) to avoid unnecessary effect re-runs.
  */
 export function useQueryParamBinding(
   widgetMgr: WidgetStateManager,

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -29,6 +29,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
     in_cached_function,
 )
 from streamlit.runtime.state import WidgetCallback, get_session_state
+from streamlit.runtime.state.common import require_valid_user_key
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -174,6 +175,8 @@ def check_widget_policies(
     check_cache_replay_rules()
     if enable_check_callback_rules:
         check_callback_rules(dg, on_change)
+    if key is not None:
+        require_valid_user_key(key)
     check_session_state_rules(
         default_value=default_value, key=key, writes_allowed=writes_allowed
     )

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -41,6 +41,7 @@ from streamlit.proto.ColorPicker_pb2 import ColorPicker as ColorPickerProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -51,6 +52,17 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 
+# Compiled regex for validating hex colors (#RGB or #RRGGBB format)
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
+
+
+def _normalize_hex_color(color: str) -> str:
+    """Normalize a hex color to include the # prefix."""
+    if not color.startswith("#"):
+        return f"#{color}"
+    return color
+
+
 @dataclass
 class ColorPickerSerde:
     value: str
@@ -59,7 +71,14 @@ class ColorPickerSerde:
         return str(v)
 
     def deserialize(self, ui_value: str | None) -> str:
-        return str(ui_value if ui_value is not None else self.value)
+        # None or empty string means use default
+        if ui_value is None or ui_value == "":
+            return self.value
+        # Normalize first (add # prefix if missing), then validate
+        normalized = _normalize_hex_color(ui_value)
+        if not _HEX_COLOR_RE.match(normalized):
+            return self.value
+        return normalized
 
 
 class ColorPickerMixin:
@@ -77,6 +96,7 @@ class ColorPickerMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> str:
         r"""Display a color picker widget.
 
@@ -156,6 +176,13 @@ class ColorPickerMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         str
@@ -185,6 +212,7 @@ class ColorPickerMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -201,6 +229,7 @@ class ColorPickerMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str:
         key = to_key(key)
@@ -246,9 +275,7 @@ like '#00FFAA' or '#000'.
 """)
 
         # validate the value and expects a hex string
-        match = re.match(r"^#(?:[0-9a-fA-F]{3}){1,2}$", value)
-
-        if not match:
+        if not _HEX_COLOR_RE.match(value):
             raise StreamlitAPIException(f"""
 '{value}' is not a valid hex code for colors. Valid ones are like
 '#00FFAA' or '#000'.
@@ -267,6 +294,10 @@ like '#00FFAA' or '#000'.
         if help is not None:
             color_picker_proto.help = dedent(help)
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            color_picker_proto.query_param_key = str(key)
+
         serde = ColorPickerSerde(value)
 
         widget_state = register_widget(
@@ -278,6 +309,8 @@ like '#00FFAA' or '#000'.
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_value",
+            bind=bind,
+            clearable=False,
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -310,6 +310,7 @@ like '#00FFAA' or '#000'.
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            # Color picker is not clearable (defaults to black)
             clearable=False,
         )
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -286,6 +286,17 @@ class StreamlitInvalidTextAlignmentError(LocalizableStreamlitException):
         )
 
 
+class StreamlitInvalidBindValueError(LocalizableStreamlitException):
+    """Exception raised when an invalid value is specified for the bind parameter."""
+
+    def __init__(self, bind_value: Any) -> None:
+        super().__init__(
+            'Invalid `bind` value: "{bind_value}". '
+            'Supported values are: `"query-params"` or `None`.',
+            bind_value=bind_value,
+        )
+
+
 # st.multiselect
 class StreamlitSelectionCountExceedsMaxError(LocalizableStreamlitException):
     """Exception raised when there are more default selections specified than the max allowable selections."""

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -233,6 +233,8 @@ def is_keyed_element_id(key: str) -> bool:
 
 def require_valid_user_key(key: str) -> None:
     """Raise an Exception if the given user_key is invalid."""
+    if key == "":
+        raise StreamlitAPIException("The `key` argument must be non-empty.")
     if is_element_id(key):
         raise StreamlitAPIException(
             f"Keys beginning with {GENERATED_ELEMENT_ID_PREFIX} are reserved."

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1025,6 +1025,18 @@ class SessionState:
         try:
             parsed_value = parse_url_param(url_value, metadata.value_type)
             deserialized_value = metadata.deserializer(parsed_value)
+            default_value = metadata.deserializer(None)
+            serialized_default = metadata.serializer(default_value)
+
+            # If the URL value doesn't round-trip and the deserializer fell back
+            # to default, treat it as invalid and clear the param.
+            if (
+                deserialized_value == default_value
+                and parsed_value != serialized_default
+                and not is_empty_url_value(url_value)
+            ):
+                self._clear_url_param(user_key)
+                return False
 
             # Handle case where all URL values were invalid (filtered to empty list).
             # For array types, parsed_value is always a list. If it had values that

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1028,8 +1028,11 @@ class SessionState:
             default_value = metadata.deserializer(None)
             serialized_default = metadata.serializer(default_value)
 
-            # If the URL value doesn't round-trip and the deserializer fell back
-            # to default, treat it as invalid and clear the param.
+            # If the deserialized value equals the default but the URL value differs
+            # from the serialized default, clear the param. This handles two cases:
+            # 1. Invalid input that the deserializer rejected and fell back to default
+            # 2. Valid input that normalized to match the default (e.g., "000000" -> "#000000")
+            # In both cases, keeping the default in the URL is unnecessary clutter.
             if (
                 deserialized_value == default_value
                 and parsed_value != serialized_default

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.runtime.state.common import (
     BindOption,
     RegisterWidgetResult,
@@ -130,6 +130,10 @@ def register_widget(
         raise StreamlitAPIException(
             "Cannot provide both `on_change` and `callbacks` to a widget."
         )
+
+    # Validate bind parameter value
+    if bind is not None and bind != "query-params":
+        raise StreamlitInvalidBindValueError(bind)
 
     # Validate that widget with bind="query-params" has a provided key
     if bind == "query-params":

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -283,3 +283,25 @@ class TestColorPickerSerde:
         serde = ColorPickerSerde("#000000")
 
         assert serde.deserialize("00ff00") == "#00ff00"
+
+    def test_empty_string_returns_default(self) -> None:
+        """Test that empty string returns the default value."""
+        serde = ColorPickerSerde("#ff0000")
+
+        assert serde.deserialize("") == "#ff0000"
+
+    def test_serialize_deserialize_round_trip(self) -> None:
+        """Test that serialize/deserialize round-trips correctly."""
+        serde = ColorPickerSerde("#000000")
+
+        original = "#abcdef"
+        serialized = serde.serialize(original)
+        deserialized = serde.deserialize(serialized)
+
+        assert deserialized == original
+
+    def test_double_hash_falls_back_to_default(self) -> None:
+        """Test that a double hash (##000000) falls back to default."""
+        serde = ColorPickerSerde("#ff0000")
+
+        assert serde.deserialize("##000000") == "#ff0000"

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -20,7 +20,8 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException
+from streamlit.elements.widgets.color_picker import ColorPickerSerde
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
@@ -231,3 +232,49 @@ class ColorPickerTest(DeltaGeneratorTestCase):
             c2 = self.get_delta_from_queue().new_element.color_picker
             id2 = c2.id
             assert id1 == id2
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.color_picker("the label", key="my_color", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.color_picker
+        assert c.query_param_key == "my_color"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.color_picker("the label", bind="query-params")
+
+        assert "must have a unique 'key' parameter" in str(exc.value)
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.color_picker("the label", key="my_color")
+
+        c = self.get_delta_from_queue().new_element.color_picker
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            st.color_picker("the label", key="my_color", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)
+
+
+class TestColorPickerSerde:
+    """Tests for the ColorPickerSerde serializer/deserializer."""
+
+    def test_invalid_value_falls_back_to_default(self) -> None:
+        """Test that invalid UI values fall back to default."""
+        serde = ColorPickerSerde("#000000")
+
+        assert serde.deserialize("notacolor") == "#000000"
+        assert serde.deserialize("notacolor") != "notacolor"
+
+    def test_value_is_normalized_with_hash_prefix(self) -> None:
+        """Test that valid hex values are normalized with a # prefix."""
+        serde = ColorPickerSerde("#000000")
+
+        assert serde.deserialize("00ff00") == "#00ff00"

--- a/lib/tests/streamlit/elements/color_picker_test.py
+++ b/lib/tests/streamlit/elements/color_picker_test.py
@@ -262,6 +262,11 @@ class ColorPickerTest(DeltaGeneratorTestCase):
         assert "invalid-value" in str(exc.value)
         assert "query-params" in str(exc.value)
 
+    def test_empty_key_raises_exception(self) -> None:
+        """Test that an empty key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"`key`.*non-empty"):
+            st.color_picker("the label", key="")
+
 
 class TestColorPickerSerde:
     """Tests for the ColorPickerSerde serializer/deserializer."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1631,6 +1631,30 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is False
         assert "my_bool" not in self.query_params._query_params
 
+    def test_seed_widget_clears_invalid_value_that_falls_back_to_default(self) -> None:
+        """Test that invalid URL values are cleared when deserializer falls back."""
+        self.query_params._query_params["color"] = "invalid"
+
+        def color_deserializer(value):
+            default = "#000000"
+            if value is None:
+                return default
+            return value if value.startswith("#") else default
+
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_value",
+            deserializer=color_deserializer,
+            serializer=lambda x: x,
+        )
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "color", "widget_1", "invalid"
+        )
+
+        assert seeded is False
+        assert "color" not in self.query_params._query_params
+
     def test_seed_widget_clears_when_all_options_filtered(self) -> None:
         """Test that URL is cleared when all options are invalid."""
         self.query_params._query_params["tags"] = ["InvalidA", "InvalidB"]

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -344,6 +344,8 @@ EXCLUDED_KWARGS_FOR_ELEMENT_ID_COMPUTATION = {
     "on_submit",
     # Key should be provided via `user_key` instead.
     "key",
+    # bind controls URL syncing, not widget identity
+    "bind",
 }
 
 

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -688,6 +688,24 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
                 # clearable intentionally not provided
             )
 
+    def test_bind_invalid_value_raises(self) -> None:
+        """Test that invalid bind values raise StreamlitInvalidBindValueError."""
+        with pytest.raises(
+            errors.StreamlitInvalidBindValueError, match="Invalid `bind` value"
+        ):
+            register_widget(
+                element_id="$$ID-some_hash-my_widget_key",
+                ctx=None,
+                on_change_handler=None,
+                args=None,
+                kwargs=None,
+                deserializer=lambda x: x if x is not None else "default",
+                serializer=lambda x: x,
+                value_type="string_value",
+                bind="not-a-valid-binding",
+                clearable=True,
+            )
+
     def test_bind_none_does_not_require_key(self):
         """Test that bind=None (default) doesn't require a key."""
         # Should not raise even without a user key

--- a/proto/streamlit/proto/ColorPicker.proto
+++ b/proto/streamlit/proto/ColorPicker.proto
@@ -28,4 +28,6 @@ message ColorPicker {
   bool set_value = 7;
   bool disabled = 8;
   LabelVisibility label_visibility = 9;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 10;
 }


### PR DESCRIPTION
## Describe your changes
This PR introduces a reusable frontend hook for query‑param binding and adds the `bind` parameter to `st.color_picker` to enable two-way sync between widget values and URL query parameters.

- **URL seeding** - Widget initializes from URL on page load
- **URL sync** - user interaction updates the URL
- **`useQueryParamBinding` hook** - Extracted reusable hook for registering/unregistering query param bindings
- **Default cleanup** - param removed when value returns to default
- **Invalid URL handling** — invalid values are cleared (not corrected to default)
- **Bind validation** — StreamlitInvalidBindValueError for unsupported bind values

`st.color_picker`:
- **Hex validation** - accepts 3/6‑char hex with or without #, normalize to include # prefix (supports both #RGB and #RRGGBB formats, case preserved)

Also, for hardening:
- **Empty widget keys now raise an error**: Previously, passing `key=""` to any widget 
was silently accepted (though non-functional). This PR adds validation that raises 
`StreamlitAPIException` if an empty string is provided as a widget key. This is a 
defensive hardening to catch likely user errors early.

## Testing Plan
- Python/JS Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 