### PR TITLE
Add protobuf linting and formatting via `buf`

### DIFF
--- a/.claude/skills/discovering-make-commands/SKILL.md
+++ b/.claude/skills/discovering-make-commands/SKILL.md
@@ -14,6 +14,8 @@ all-dev                   Install all dependencies and editable Streamlit, but d
 init                      Install all dependencies and build protobufs.
 clean                     Remove all generated files.
 protobuf                  Recompile Protobufs for Python and the frontend.
+proto-lint                Lint and check formatting of protobuf files (buf).
+proto-format              Format protobuf files (buf).
 python-init               Install Python dependencies and Streamlit in editable mode.
 python-lint               Lint and check formatting of Python files.
 python-format             Format Python files.

--- a/.claude/skills/discovering-make-commands/SKILL.md
+++ b/.claude/skills/discovering-make-commands/SKILL.md
@@ -14,8 +14,8 @@ all-dev                   Install all dependencies and editable Streamlit, but d
 init                      Install all dependencies and build protobufs.
 clean                     Remove all generated files.
 protobuf                  Recompile Protobufs for Python and the frontend.
-proto-lint                Lint and check formatting of protobuf files (buf).
-proto-format              Format protobuf files (buf).
+protobuf-lint             Lint and check formatting of protobuf files (buf).
+protobuf-format           Format protobuf files (buf).
 python-init               Install Python dependencies and Streamlit in editable mode.
 python-lint               Lint and check formatting of Python files.
 python-format             Format Python files.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,18 @@ repos:
         language: system
         pass_filenames: false
         files: ^(lib/dev-requirements\.txt|\.pre-commit-config\.yaml)$
+      - id: proto-format
+        name: Buf Format Protos
+        entry: ./frontend/node_modules/.bin/buf format -w proto
+        files: ^proto/.*\.proto$
+        language: system
+        pass_filenames: false
+      - id: proto-lint
+        name: Buf Lint Protos
+        entry: ./frontend/node_modules/.bin/buf lint proto
+        files: ^proto/.*\.proto$
+        language: system
+        pass_filenames: false
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -118,15 +118,15 @@ protobuf:
 	@# JS/TS protobuf generation
 	cd frontend/ ; yarn workspace @streamlit/protobuf run generate-protobuf
 
-.PHONY: proto-lint
+.PHONY: protobuf-lint
 # Lint and check formatting of protobuf files (buf).
-proto-lint:
+protobuf-lint:
 	cd frontend && yarn buf format ../proto --diff --exit-code
 	cd frontend && yarn buf lint ../proto
 
-.PHONY: proto-format
+.PHONY: protobuf-format
 # Format protobuf files (buf).
-proto-format:
+protobuf-format:
 	cd frontend && yarn buf format ../proto -w
 
 .PHONY: python-init

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,16 @@ protobuf:
 	@# JS/TS protobuf generation
 	cd frontend/ ; yarn workspace @streamlit/protobuf run generate-protobuf
 
+.PHONY: proto-lint
+# Lint and check formatting of protobuf files (buf).
+proto-lint:
+	cd frontend && yarn buf format ../proto --diff --exit-code
+	cd frontend && yarn buf lint ../proto
+
+.PHONY: proto-format
+# Format protobuf files (buf).
+proto-format:
+	cd frontend && yarn buf format ../proto -w
 
 .PHONY: python-init
 # Install Python dependencies and Streamlit in editable mode.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
   ],
   "packageManager": "yarn@4.5.3",
   "devDependencies": {
+    "@bufbuild/buf": "^1.50.0",
     "@playwright/cli": "^0.0.62",
     "@vitest/coverage-v8": "^4.0.18",
     "concurrently": "^9.2.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -204,6 +204,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bufbuild/buf-darwin-arm64@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-darwin-arm64@npm:1.65.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf-darwin-x64@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-darwin-x64@npm:1.65.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf-linux-aarch64@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-linux-aarch64@npm:1.65.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf-linux-armv7@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-linux-armv7@npm:1.65.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf-linux-x64@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-linux-x64@npm:1.65.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf-win32-arm64@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-win32-arm64@npm:1.65.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf-win32-x64@npm:1.65.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf-win32-x64@npm:1.65.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@bufbuild/buf@npm:^1.50.0":
+  version: 1.65.0
+  resolution: "@bufbuild/buf@npm:1.65.0"
+  dependencies:
+    "@bufbuild/buf-darwin-arm64": "npm:1.65.0"
+    "@bufbuild/buf-darwin-x64": "npm:1.65.0"
+    "@bufbuild/buf-linux-aarch64": "npm:1.65.0"
+    "@bufbuild/buf-linux-armv7": "npm:1.65.0"
+    "@bufbuild/buf-linux-x64": "npm:1.65.0"
+    "@bufbuild/buf-win32-arm64": "npm:1.65.0"
+    "@bufbuild/buf-win32-x64": "npm:1.65.0"
+  dependenciesMeta:
+    "@bufbuild/buf-darwin-arm64":
+      optional: true
+    "@bufbuild/buf-darwin-x64":
+      optional: true
+    "@bufbuild/buf-linux-aarch64":
+      optional: true
+    "@bufbuild/buf-linux-armv7":
+      optional: true
+    "@bufbuild/buf-linux-x64":
+      optional: true
+    "@bufbuild/buf-win32-arm64":
+      optional: true
+    "@bufbuild/buf-win32-x64":
+      optional: true
+  bin:
+    buf: bin/buf
+    protoc-gen-buf-breaking: bin/protoc-gen-buf-breaking
+    protoc-gen-buf-lint: bin/protoc-gen-buf-lint
+  checksum: 10c0/aabd930c6b9deda345210046ed8eac6adc76e19f503da1cde506e25f0d021e2dc09a49b1112a3334eb7eb3afa32517828965458cc43f431dbbc6799a81fca418
+  languageName: node
+  linkType: hard
+
 "@carto/api-client@npm:^0.4.4":
   version: 0.4.6
   resolution: "@carto/api-client@npm:0.4.6"
@@ -16794,6 +16877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "streamlit@workspace:."
   dependencies:
+    "@bufbuild/buf": "npm:^1.50.0"
     "@playwright/cli": "npm:^0.0.62"
     "@vitest/coverage-v8": "npm:^4.0.18"
     concurrently: "npm:^9.2.1"

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: v2
+modules:
+  - path: .
+lint:
+  use:
+    - STANDARD
+  except:
+    # Package-related rules - current proto files have mixed package declarations
+    # (some have none, some have 'streamlit', openmetrics_data_model.proto has 'openmetrics')
+    - DIRECTORY_SAME_PACKAGE
+    - PACKAGE_DEFINED
+    - PACKAGE_DIRECTORY_MATCH
+    - PACKAGE_SAME_DIRECTORY
+    # Naming conventions that would require mass renaming
+    - FILE_LOWER_SNAKE_CASE
+    - ENUM_VALUE_PREFIX
+    - ENUM_ZERO_VALUE_SUFFIX
+    - PACKAGE_VERSION_SUFFIX

--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/WidthConfig.proto";
 
 // NOTE: This proto type is used by some external services so needs to remain

--- a/proto/streamlit/proto/AppPage.proto
+++ b/proto/streamlit/proto/AppPage.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // A page in the app. Includes both the name of the page as well as the full
 // path to the corresponding script file.
 //

--- a/proto/streamlit/proto/ArrowNamedDataSet.proto
+++ b/proto/streamlit/proto/ArrowNamedDataSet.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ArrowData.proto";
 
 // A dataset that can be referenced by name.

--- a/proto/streamlit/proto/Audio.proto
+++ b/proto/streamlit/proto/Audio.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/WidthConfig.proto";
 
 message Audio {

--- a/proto/streamlit/proto/AudioInput.proto
+++ b/proto/streamlit/proto/AudioInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message AudioInput {

--- a/proto/streamlit/proto/AuthRedirect.proto
+++ b/proto/streamlit/proto/AuthRedirect.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message AuthRedirect {
   string url = 1; // URL TO REDIRECT TO
 }

--- a/proto/streamlit/proto/AutoRerun.proto
+++ b/proto/streamlit/proto/AutoRerun.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message AutoRerun {
   // The interval of reruns in seconds
   float interval = 1;

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ClientState.proto";
 import "streamlit/proto/Common.proto";
 

--- a/proto/streamlit/proto/Balloons.proto
+++ b/proto/streamlit/proto/Balloons.proto
@@ -16,9 +16,8 @@
 
 syntax = "proto3";
 
-
 message Balloons {
-  bool show = 3;  // Dummy boolean because protos need to have something.
+  bool show = 3; // Dummy boolean because protos need to have something.
 
   reserved 1, 2;
 }

--- a/proto/streamlit/proto/BidiComponent.proto
+++ b/proto/streamlit/proto/BidiComponent.proto
@@ -16,51 +16,50 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ArrowData.proto";
 
 // Mixed data structure that allows JSON with embedded Arrow references
 message MixedData {
-    // The main JSON structure with arrow references replaced by placeholders
-    string json = 1;
+  // The main JSON structure with arrow references replaced by placeholders
+  string json = 1;
 
-    // Map of arrow data blobs keyed by reference ID
-    map<string, ArrowData> arrow_blobs = 2;
+  // Map of arrow data blobs keyed by reference ID
+  map<string, ArrowData> arrow_blobs = 2;
 }
 
 // Represents an instance of a bidirectional component.
 message BidiComponent {
-    // The ID of the widget instance.
-    string id = 1;
-    // The registered name of the component.
-    string component_name = 2;
-    // The JavaScript content provided by the developer.
-    optional string js_content = 3;
-    // The source path for the JavaScript content.
-    optional string js_source_path = 4;
-    // The ID of the form this component belongs to, if any.
-    string form_id = 5;
-    // The HTML content provided by the developer.
-    optional string html_content = 6;
-    // The CSS content provided by the developer.
-    optional string css_content = 7;
-    // The source path for the CSS content.
-    optional string css_source_path = 8;
-    // Whether to isolate styles from the parent.
-    bool isolate_styles = 9;
-    // The component's data payload. Exactly one of the following fields
-    // will be set at any given time.
-    oneof data {
-      // JSON-serialized value for generic data payloads.
-      string json = 10;
+  // The ID of the widget instance.
+  string id = 1;
+  // The registered name of the component.
+  string component_name = 2;
+  // The JavaScript content provided by the developer.
+  optional string js_content = 3;
+  // The source path for the JavaScript content.
+  optional string js_source_path = 4;
+  // The ID of the form this component belongs to, if any.
+  string form_id = 5;
+  // The HTML content provided by the developer.
+  optional string html_content = 6;
+  // The CSS content provided by the developer.
+  optional string css_content = 7;
+  // The source path for the CSS content.
+  optional string css_source_path = 8;
+  // Whether to isolate styles from the parent.
+  bool isolate_styles = 9;
+  // The component's data payload. Exactly one of the following fields
+  // will be set at any given time.
+  oneof data {
+    // JSON-serialized value for generic data payloads.
+    string json = 10;
 
-      // Data-only Apache Arrow buffer for dataframe-like payloads.
-      ArrowData arrow_data = 11;
+    // Data-only Apache Arrow buffer for dataframe-like payloads.
+    ArrowData arrow_data = 11;
 
-      // Arbitrary bytes payload.
-      bytes bytes = 12;
+    // Arbitrary bytes payload.
+    bytes bytes = 12;
 
-      // Mixed data with JSON structure + embedded Arrow references
-      MixedData mixed = 13;
-    }
+    // Mixed data with JSON structure + embedded Arrow references
+    MixedData mixed = 13;
+  }
 }

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -16,10 +16,9 @@
 
 syntax = "proto3";
 
-
-import "streamlit/proto/WidthConfig.proto";
-import "streamlit/proto/HeightConfig.proto";
 import "streamlit/proto/GapSize.proto";
+import "streamlit/proto/HeightConfig.proto";
+import "streamlit/proto/WidthConfig.proto";
 
 message Block {
   oneof type {
@@ -148,7 +147,6 @@ message Block {
 
     reserved 2;
   }
-
 
   message ChatMessage {
     enum AvatarType {

--- a/proto/streamlit/proto/Button.proto
+++ b/proto/streamlit/proto/Button.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 
 message Button {

--- a/proto/streamlit/proto/ButtonGroup.proto
+++ b/proto/streamlit/proto/ButtonGroup.proto
@@ -16,13 +16,12 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message ButtonGroup {
   enum ClickMode {
-      SINGLE_SELECT = 0;
-      MULTI_SELECT = 1;
+    SINGLE_SELECT = 0;
+    MULTI_SELECT = 1;
   }
 
   message Option {

--- a/proto/streamlit/proto/ButtonLikeIconPosition.proto
+++ b/proto/streamlit/proto/ButtonLikeIconPosition.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 package streamlit;
 
 // Shared enum for icon positions used by button-like elements.

--- a/proto/streamlit/proto/CameraInput.proto
+++ b/proto/streamlit/proto/CameraInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message CameraInput {

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message ChatInput {
   string id = 1;
   string placeholder = 2;

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message Checkbox {

--- a/proto/streamlit/proto/ClientState.proto
+++ b/proto/streamlit/proto/ClientState.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/WidgetStates.proto";
 
 message ContextInfo {

--- a/proto/streamlit/proto/Code.proto
+++ b/proto/streamlit/proto/Code.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // st.code
 message Code {
   // Content to display.

--- a/proto/streamlit/proto/ColorPicker.proto
+++ b/proto/streamlit/proto/ColorPicker.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message ColorPicker {

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Message types that are common to multiple protobufs.
 
 message StringArray {
@@ -42,7 +41,6 @@ message SInt64Array {
 message UInt32Array {
   repeated uint32 data = 1;
 }
-
 
 // DEPRECATED: This proto message is deprecated and unused. The ChatInputValue
 // proto message should be used instead.
@@ -93,7 +91,6 @@ message FileUploaderState {
 
   reserved 1;
 }
-
 
 message ChatInputValue {
   optional string data = 1;

--- a/proto/streamlit/proto/Components.proto
+++ b/proto/streamlit/proto/Components.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message ComponentInstance {
   // The instance's "widget ID", used to uniquely identify it.
   string id = 1;

--- a/proto/streamlit/proto/DateInput.proto
+++ b/proto/streamlit/proto/DateInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message DateInput {

--- a/proto/streamlit/proto/DateTimeInput.proto
+++ b/proto/streamlit/proto/DateTimeInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message DateTimeInput {

--- a/proto/streamlit/proto/DeckGlJsonChart.proto
+++ b/proto/streamlit/proto/DeckGlJsonChart.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message DeckGlJsonChart {
   // The json of the pydeck object (https://deckgl.readthedocs.io/en/latest/deck.html)
   string json = 1;

--- a/proto/streamlit/proto/Delta.proto
+++ b/proto/streamlit/proto/Delta.proto
@@ -16,10 +16,9 @@
 
 syntax = "proto3";
 
-
+import "streamlit/proto/ArrowNamedDataSet.proto";
 import "streamlit/proto/Block.proto";
 import "streamlit/proto/Element.proto";
-import "streamlit/proto/ArrowNamedDataSet.proto";
 import "streamlit/proto/Transient.proto";
 
 // A change to an element.

--- a/proto/streamlit/proto/DocString.proto
+++ b/proto/streamlit/proto/DocString.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Formatted text
 message DocString {
   // The doc string.
@@ -40,7 +39,6 @@ message DocString {
 
   reserved 1, 2;
 }
-
 
 message Member {
   // The name of the object.

--- a/proto/streamlit/proto/DownloadButton.proto
+++ b/proto/streamlit/proto/DownloadButton.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 
 message DownloadButton {

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -16,67 +16,65 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/Alert.proto";
-import "streamlit/proto/Dataframe.proto";
 import "streamlit/proto/Audio.proto";
-import "streamlit/proto/Table.proto";
 import "streamlit/proto/AudioInput.proto";
 import "streamlit/proto/Balloons.proto";
-import "streamlit/proto/VegaLiteChart.proto";
+import "streamlit/proto/BidiComponent.proto";
 import "streamlit/proto/Button.proto";
 import "streamlit/proto/ButtonGroup.proto";
-import "streamlit/proto/DownloadButton.proto";
 import "streamlit/proto/CameraInput.proto";
 import "streamlit/proto/ChatInput.proto";
 import "streamlit/proto/Checkbox.proto";
 import "streamlit/proto/Code.proto";
 import "streamlit/proto/ColorPicker.proto";
+import "streamlit/proto/Components.proto";
+import "streamlit/proto/Dataframe.proto";
 import "streamlit/proto/DateInput.proto";
 import "streamlit/proto/DateTimeInput.proto";
 import "streamlit/proto/DeckGlJsonChart.proto";
 import "streamlit/proto/DocString.proto";
+import "streamlit/proto/DownloadButton.proto";
 import "streamlit/proto/Empty.proto";
 import "streamlit/proto/Exception.proto";
 import "streamlit/proto/Favicon.proto";
 import "streamlit/proto/Feedback.proto";
 import "streamlit/proto/FileUploader.proto";
 import "streamlit/proto/GraphVizChart.proto";
+import "streamlit/proto/Heading.proto";
+import "streamlit/proto/HeightConfig.proto";
 import "streamlit/proto/Html.proto";
 import "streamlit/proto/IFrame.proto";
 import "streamlit/proto/Image.proto";
 import "streamlit/proto/Json.proto";
 import "streamlit/proto/LinkButton.proto";
-import "streamlit/proto/NumberInput.proto";
 import "streamlit/proto/Markdown.proto";
 import "streamlit/proto/Metric.proto";
 import "streamlit/proto/MultiSelect.proto";
+import "streamlit/proto/NumberInput.proto";
 import "streamlit/proto/PageLink.proto";
 import "streamlit/proto/PlotlyChart.proto";
-import "streamlit/proto/Components.proto";
 import "streamlit/proto/Progress.proto";
-import "streamlit/proto/Snow.proto";
-import "streamlit/proto/Spinner.proto";
 import "streamlit/proto/Radio.proto";
 import "streamlit/proto/Selectbox.proto";
 import "streamlit/proto/Skeleton.proto";
 import "streamlit/proto/Slider.proto";
+import "streamlit/proto/Snow.proto";
 import "streamlit/proto/Space.proto";
+import "streamlit/proto/Spinner.proto";
+import "streamlit/proto/Table.proto";
 import "streamlit/proto/Text.proto";
+import "streamlit/proto/TextAlignmentConfig.proto";
 import "streamlit/proto/TextArea.proto";
 import "streamlit/proto/TextInput.proto";
 import "streamlit/proto/TimeInput.proto";
 import "streamlit/proto/Toast.proto";
+import "streamlit/proto/VegaLiteChart.proto";
 import "streamlit/proto/Video.proto";
-import "streamlit/proto/Heading.proto";
-import "streamlit/proto/BidiComponent.proto";
-import "streamlit/proto/HeightConfig.proto";
 import "streamlit/proto/WidthConfig.proto";
-import "streamlit/proto/TextAlignmentConfig.proto";
 
 // An element which can be displayed on the screen.
 message Element {
-
   // Layout configuration for elements
   optional streamlit.HeightConfig height_config = 57;
   optional streamlit.WidthConfig width_config = 58;

--- a/proto/streamlit/proto/Empty.proto
+++ b/proto/streamlit/proto/Empty.proto
@@ -16,7 +16,5 @@
 
 syntax = "proto3";
 
-
 // A python empty.
-message Empty {
-}
+message Empty {}

--- a/proto/streamlit/proto/Exception.proto
+++ b/proto/streamlit/proto/Exception.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/WidthConfig.proto";
 
 // A python exception.
@@ -25,7 +24,6 @@ import "streamlit/proto/WidthConfig.proto";
 // relatively stable. While it isn't entirely set in stone, changing it
 // may require a good amount of effort so should be avoided if possible.
 message Exception {
-
   // The type of the exception. This can be any string, but is usually a valid
   // Python exception type, like 'RuntimeError'.
   string type = 1;

--- a/proto/streamlit/proto/Favicon.proto
+++ b/proto/streamlit/proto/Favicon.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message Favicon {
   string url = 1;
 }

--- a/proto/streamlit/proto/FileUploader.proto
+++ b/proto/streamlit/proto/FileUploader.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 // file_uploader widget

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-
+import "streamlit/proto/AuthRedirect.proto";
 import "streamlit/proto/AutoRerun.proto";
 import "streamlit/proto/Common.proto";
 import "streamlit/proto/Delta.proto";
@@ -26,12 +26,11 @@ import "streamlit/proto/Navigation.proto";
 import "streamlit/proto/NewSession.proto";
 import "streamlit/proto/PageConfig.proto";
 import "streamlit/proto/PageInfo.proto";
-import "streamlit/proto/PageProfile.proto";
 import "streamlit/proto/PageNotFound.proto";
+import "streamlit/proto/PageProfile.proto";
 import "streamlit/proto/ParentMessage.proto";
 import "streamlit/proto/SessionEvent.proto";
 import "streamlit/proto/SessionStatus.proto";
-import "streamlit/proto/AuthRedirect.proto";
 
 // A message sent from Proxy to the browser
 message ForwardMsg {

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 package streamlit;
 
 enum GapSize {

--- a/proto/streamlit/proto/GitInfo.proto
+++ b/proto/streamlit/proto/GitInfo.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Message used to update page metadata.
 message GitInfo {
   string repository = 1;

--- a/proto/streamlit/proto/GraphVizChart.proto
+++ b/proto/streamlit/proto/GraphVizChart.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message GraphVizChart {
   // A specification of the GraphViz graph in the "Dot" language.
   string spec = 1;

--- a/proto/streamlit/proto/Heading.proto
+++ b/proto/streamlit/proto/Heading.proto
@@ -16,15 +16,14 @@
 
 syntax = "proto3";
 
-
 message Heading {
-    // h1, h2, h3, div, etc
-    string tag = 1;
+  // h1, h2, h3, div, etc
+  string tag = 1;
 
-    string anchor = 2;
-    string body = 3;
+  string anchor = 2;
+  string body = 3;
 
-    string help = 4;
-    bool hide_anchor = 5;
-    string divider = 6;
+  string help = 4;
+  bool hide_anchor = 5;
+  string divider = 6;
 }

--- a/proto/streamlit/proto/HeightConfig.proto
+++ b/proto/streamlit/proto/HeightConfig.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 package streamlit;
 
 message HeightConfig {

--- a/proto/streamlit/proto/Html.proto
+++ b/proto/streamlit/proto/Html.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // st.html
 message Html {
   string body = 1;

--- a/proto/streamlit/proto/IFrame.proto
+++ b/proto/streamlit/proto/IFrame.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message IFrame {
   oneof type {
     // A URL to load

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // An image which can be displayed on the screen.
 message Image {
   string url = 3;

--- a/proto/streamlit/proto/Json.proto
+++ b/proto/streamlit/proto/Json.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message Json {
   // Content to display.
   string body = 1;

--- a/proto/streamlit/proto/LabelVisibility.proto
+++ b/proto/streamlit/proto/LabelVisibility.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message LabelVisibility {
   // We use a separate LabelVisibility message instead of just defining an Enum
   // and using it in other widgets proto files due to a protobuf.js error when

--- a/proto/streamlit/proto/LinkButton.proto
+++ b/proto/streamlit/proto/LinkButton.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 
 message LinkButton {

--- a/proto/streamlit/proto/Logo.proto
+++ b/proto/streamlit/proto/Logo.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Handle the logo for an app
 message Logo {
   // Type of the logo image (image file, emoji, or material icon)

--- a/proto/streamlit/proto/Markdown.proto
+++ b/proto/streamlit/proto/Markdown.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Formatted text
 message Markdown {
   // Content to display.
@@ -24,10 +23,10 @@ message Markdown {
 
   bool allow_html = 2;
 
-  reserved 3;  // Formerly is_caption, now derived from element_type == CAPTION
+  reserved 3; // Formerly is_caption, now derived from element_type == CAPTION
 
   enum Type {
-    UNSPECIFIED = 0;  // This is recommended to be reserved for proto files backwards compatibility reasons.
+    UNSPECIFIED = 0; // This is recommended to be reserved for proto files backwards compatibility reasons.
     NATIVE = 1;
     CAPTION = 2;
     CODE = 3;

--- a/proto/streamlit/proto/Metric.proto
+++ b/proto/streamlit/proto/Metric.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message Metric {

--- a/proto/streamlit/proto/MetricsEvent.proto
+++ b/proto/streamlit/proto/MetricsEvent.proto
@@ -16,12 +16,10 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/PageProfile.proto";
 
 // Metrics events:
 message MetricsEvent {
-
   // Common Event Fields:
   string event = 1;
   string anonymous_id = 2;
@@ -56,10 +54,8 @@ message MetricsEvent {
   string context_locale = 20;
   string context_user_agent = 21;
 
-
   // Menu Click Event field:
   string label = 22;
-
 
   // Page Profile Event fields:
   // Same as PageProfile msg
@@ -75,7 +71,7 @@ message MetricsEvent {
   bool is_fragment_run = 32;
 
   // Addtl for page profile metrics
-  int64 numPages = 34;
+  int64 num_pages = 34;
   string page_script_hash = 37;
   string active_theme = 38;
   int64 total_load_time = 39;

--- a/proto/streamlit/proto/MultiSelect.proto
+++ b/proto/streamlit/proto/MultiSelect.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message MultiSelect {

--- a/proto/streamlit/proto/Navigation.proto
+++ b/proto/streamlit/proto/Navigation.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-
-
 import "streamlit/proto/AppPage.proto";
 
 message Navigation {

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/AppPage.proto";
 import "streamlit/proto/SessionStatus.proto";
 

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message NumberInput {

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Properties of the page that the app creator may configure.
 message PageConfig {
   string title = 1;

--- a/proto/streamlit/proto/PageInfo.proto
+++ b/proto/streamlit/proto/PageInfo.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Message used to update page metadata.
 message PageInfo {
   // The page's query string, if the user decided to set it.

--- a/proto/streamlit/proto/PageLink.proto
+++ b/proto/streamlit/proto/PageLink.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 
 message PageLink {

--- a/proto/streamlit/proto/PageNotFound.proto
+++ b/proto/streamlit/proto/PageNotFound.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Message used to tell the client that the requested page does not exist.
 message PageNotFound {
   string page_name = 1;

--- a/proto/streamlit/proto/PageProfile.proto
+++ b/proto/streamlit/proto/PageProfile.proto
@@ -16,8 +16,6 @@
 
 syntax = "proto3";
 
-
-
 message PageProfile {
   repeated Command commands = 1;
   int64 exec_time = 2;

--- a/proto/streamlit/proto/ParentMessage.proto
+++ b/proto/streamlit/proto/ParentMessage.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // NOTE: This proto type is used by some external services so needs to remain
 // relatively stable. While it isn't entirely set in stone, changing it
 // may require a good amount of effort so should be avoided if possible.

--- a/proto/streamlit/proto/PlotlyChart.proto
+++ b/proto/streamlit/proto/PlotlyChart.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message PlotlyChart {
   // override the properties with a theme. Currently, only "streamlit" or None are accepted.
   string theme = 6;
@@ -38,9 +37,9 @@ message PlotlyChart {
 
   // Available selection modes:
   enum SelectionMode {
-      POINTS = 0; // Point selection mode
-      BOX = 1; // Box selection mode
-      LASSO = 2; // Lasso selection mode
+    POINTS = 0; // Point selection mode
+    BOX = 1; // Box selection mode
+    LASSO = 2; // Lasso selection mode
   }
 
   reserved 1, 2, 3, 4, 5;

--- a/proto/streamlit/proto/Progress.proto
+++ b/proto/streamlit/proto/Progress.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message Progress {
   uint32 value = 1;
   string text = 2;

--- a/proto/streamlit/proto/Radio.proto
+++ b/proto/streamlit/proto/Radio.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message Radio {

--- a/proto/streamlit/proto/RootContainer.proto
+++ b/proto/streamlit/proto/RootContainer.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Constants for our "RootContainers" - the top-level containers
 // that `st.foo` and `st.sidebar.foo` write to. Each value corresponds
 // to the first index in any `delta_path` that uses these containers.

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message Selectbox {

--- a/proto/streamlit/proto/SessionEvent.proto
+++ b/proto/streamlit/proto/SessionEvent.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/Exception.proto";
 
 // A transient event sent to all browsers connected to an associated app.

--- a/proto/streamlit/proto/SessionStatus.proto
+++ b/proto/streamlit/proto/SessionStatus.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Status for a session. Sent as part of the Initialize message, and also
 // on AppSession status change events.
 //

--- a/proto/streamlit/proto/Skeleton.proto
+++ b/proto/streamlit/proto/Skeleton.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // An empty-like element that displays an app skeleton.
 message Skeleton {
   enum SkeletonStyle {

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message Slider {

--- a/proto/streamlit/proto/Snow.proto
+++ b/proto/streamlit/proto/Snow.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message Snow {
-  bool show = 1;  // Dummy boolean because protos need to have something.
+  bool show = 1; // Dummy boolean because protos need to have something.
 }

--- a/proto/streamlit/proto/Space.proto
+++ b/proto/streamlit/proto/Space.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // A space element for adding vertical or horizontal spacing.
 // The size and direction are controlled via Element.width_config and
 // Element.height_config. The frontend uses FlexContext to determine which

--- a/proto/streamlit/proto/Spinner.proto
+++ b/proto/streamlit/proto/Spinner.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 message Spinner {
   // A message to display while executing that block.
   string text = 1;

--- a/proto/streamlit/proto/Text.proto
+++ b/proto/streamlit/proto/Text.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 // Preformatted text
 message Text {
   // Content to display.

--- a/proto/streamlit/proto/TextAlignmentConfig.proto
+++ b/proto/streamlit/proto/TextAlignmentConfig.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 package streamlit;
 
 // Text alignment configuration for text elements

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message TextArea {

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message TextInput {

--- a/proto/streamlit/proto/TimeInput.proto
+++ b/proto/streamlit/proto/TimeInput.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/LabelVisibility.proto";
 
 message TimeInput {

--- a/proto/streamlit/proto/Toast.proto
+++ b/proto/streamlit/proto/Toast.proto
@@ -16,16 +16,15 @@
 
 syntax = "proto3";
 
-
 message Toast {
-    // Display message
-    string body = 1;
+  // Display message
+  string body = 1;
 
-    // Emoji
-    string icon = 2;
+  // Emoji
+  string icon = 2;
 
-    // The time to display the toast message in seconds.
-    // If not set, the toast will be displayed for 4 seconds. A value of 0
-    // indicates that the toast should not be automatically dismissed.
-    optional int32 duration = 3;
+  // The time to display the toast message in seconds.
+  // If not set, the toast will be displayed for 4 seconds. A value of 0
+  // indicates that the toast should not be automatically dismissed.
+  optional int32 duration = 3;
 }

--- a/proto/streamlit/proto/Transient.proto
+++ b/proto/streamlit/proto/Transient.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/Element.proto";
 
 message Transient {

--- a/proto/streamlit/proto/VegaLiteChart.proto
+++ b/proto/streamlit/proto/VegaLiteChart.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/ArrowData.proto";
 import "streamlit/proto/ArrowNamedDataSet.proto";
 

--- a/proto/streamlit/proto/Video.proto
+++ b/proto/streamlit/proto/Video.proto
@@ -16,12 +16,11 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/WidthConfig.proto";
 
 message SubtitleTrack {
-    string label = 1;  // Label for the subtitle e.g. "English" or "Spanish".
-    string url = 2;
+  string label = 1; // Label for the subtitle e.g. "English" or "Spanish".
+  string url = 2;
 }
 
 message Video {
@@ -29,7 +28,7 @@ message Video {
   string url = 6;
 
   enum Type {
-    UNUSED = 0;  // This should always exist.
+    UNUSED = 0; // This should always exist.
     NATIVE = 1;
     YOUTUBE_IFRAME = 2;
   }
@@ -57,5 +56,5 @@ message Video {
 
   optional streamlit.WidthConfig width_config = 13;
 
-  reserved 1,2,4;
+  reserved 1, 2, 4;
 }

--- a/proto/streamlit/proto/WidgetStates.proto
+++ b/proto/streamlit/proto/WidgetStates.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 import "streamlit/proto/Common.proto";
 import "streamlit/proto/Components.proto";
 

--- a/proto/streamlit/proto/WidthConfig.proto
+++ b/proto/streamlit/proto/WidthConfig.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-
 package streamlit;
 
 message WidthConfig {

--- a/proto/streamlit/proto/openmetrics_data_model.proto
+++ b/proto/streamlit/proto/openmetrics_data_model.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
-
-// The OpenMetrics protobuf schema which defines the protobuf wire format. 
+// The OpenMetrics protobuf schema which defines the protobuf wire format.
 // Ensure to interpret "required" as semantically required for a valid message.
 // All string fields MUST be UTF-8 encoded strings.
 package openmetrics;
@@ -143,7 +142,7 @@ message HistogramValue {
 
   // Bucket is the number of values for a bucket in the histogram
   // with an optional exemplar.
-  message Bucket {  
+  message Bucket {
     // Required.
     uint64 count = 1;
 
@@ -189,13 +188,13 @@ message InfoValue {
 
 // Value for SUMMARY MetricPoint.
 message SummaryValue {
-  // Optional. 
+  // Optional.
   oneof sum {
     double double_value = 1;
     int64 int_value = 2;
   }
 
-  // Optional. 
+  // Optional.
   uint64 count = 3;
 
   // The time sum and count values began being collected for this summary.
@@ -206,7 +205,7 @@ message SummaryValue {
   repeated Quantile quantile = 5;
 
   message Quantile {
-    // Required. 
+    // Required.
     double quantile = 1;
 
     // Required.


### PR DESCRIPTION
## Describe your changes

Add lightweight protobuf linting and formatting using [buf](https://buf.build/). Enforces STANDARD lint rules (minus package-related rules and mass-renaming conventions that don't apply to existing codebase). Auto-formats all protos on commit via pre-commit hooks.

## Changes

- Add `@bufbuild/buf` npm dependency
- Create `proto/buf.yaml` with STANDARD lint rules (9 exceptions for existing patterns)
- Add `make proto-format` and `make proto-lint` targets
- Add pre-commit hooks for format + lint (runs in ~0.5s on all 87 proto files)
- Auto-formatted all proto files (spacing, blank lines)

## Testing Plan

All proto files pass linting and formatting checks. Pre-commit hooks verified to run locally and in CI.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.