### PR TITLE
Fix spinner clear_transient race condition during rapid reruns

### DIFF
--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -267,6 +267,22 @@ describe("ClearStaleNodeVisitor", () => {
   })
 
   describe("visitTransientNode", () => {
+    it("restores anchor for transient cleared in current run", () => {
+      const currentRunId = "current"
+      const anchor = text("anchor", "old_run")
+      const clearedTransient = new TransientNode(
+        currentRunId,
+        anchor,
+        [],
+        1
+      )
+
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+      const result = visitor.visitTransientNode(clearedTransient)
+
+      expect(result).toBe(anchor)
+    })
+
     it("returns undefined when both anchor and transients are stale", () => {
       const t = new TransientNode(
         "runA",

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -270,12 +270,7 @@ describe("ClearStaleNodeVisitor", () => {
     it("restores anchor for transient cleared in current run", () => {
       const currentRunId = "current"
       const anchor = text("anchor", "old_run")
-      const clearedTransient = new TransientNode(
-        currentRunId,
-        anchor,
-        [],
-        1
-      )
+      const clearedTransient = new TransientNode(currentRunId, anchor, [], 1)
 
       const visitor = new ClearStaleNodeVisitor(currentRunId)
       const result = visitor.visitTransientNode(clearedTransient)

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -141,6 +141,16 @@ export class ClearStaleNodeVisitor implements AppNodeVisitor<
   }
 
   visitTransientNode(node: TransientNode): AppNode | undefined {
+    // If a transient was explicitly cleared in this run, restore its anchor directly.
+    // This prevents removing the anchor as stale before non-transient updates can reattach.
+    if (
+      node.scriptRunId === this.currentScriptRunId &&
+      node.transientNodes.length === 0 &&
+      node.anchor
+    ) {
+      return node.anchor
+    }
+
     // Check whether the anchor element and transient elements are stale
     const anchorNode = node.anchor?.accept(this)
     const transientNodes = node.updateTransientNodes(element => {


### PR DESCRIPTION
## Describe your changes

Fixes a frontend stale-node edge case where the first widget above a `@st.fragment` could disappear and be replaced by `div.stEmpty` after a cache miss.

**Root cause:** During stale-node cleanup, a `TransientNode` that had already been explicitly cleared in the current run (`transientNodes.length === 0`) could still hold a valid anchor element from a previous run. The existing stale filtering path treated that anchor as stale and removed it.

**Fix:** In `ClearStaleNodeVisitor.visitTransientNode`, return the anchor directly when the transient was cleared in the current run and has no transient children. This preserves the anchored widget instead of incorrectly dropping it.

## GitHub Issue Link (if applicable)

Closes #13634

## Testing Plan

- [x] Frontend unit test added in `ClearStaleNodeVisitor.test.ts`: `restores anchor for transient cleared in current run`
- [x] Targeted Vitest run:
  - `yarn vitest run lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts -t "restores anchor for transient cleared in current run"`
- [x] Manual reproduction validated in debug session: widget no longer disappears

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.