### PR TITLE
Add delta_description parameter to st.metric

### DIFF
--- a/e2e_playwright/st_metric.py
+++ b/e2e_playwright/st_metric.py
@@ -176,3 +176,33 @@ with format_col3:
 with format_col4:
     # Non-numeric string should NOT be formatted
     st.metric("Non-numeric (no format)", "70 °F", delta="+5%", format="compact")
+
+# Delta description tests
+desc_col1, desc_col2, desc_col3 = st.container(
+    key="metric_delta_description"
+).columns(3)
+
+with desc_col1:
+    st.metric(
+        "Revenue",
+        "$12.4k",
+        "+12%",
+        delta_description="vs. last month",
+        border=True,
+    )
+with desc_col2:
+    st.metric(
+        "Costs",
+        "$8.2k",
+        "-5%",
+        delta_color="inverse",
+        delta_description="month over month",
+        border=True,
+    )
+with desc_col3:
+    st.metric(
+        "Users",
+        "1,234",
+        delta_description="no delta, just description",
+        border=True,
+    )

--- a/e2e_playwright/st_metric_test.py
+++ b/e2e_playwright/st_metric_test.py
@@ -310,3 +310,32 @@ def test_custom_delta_color_render(
         get_metric(themed_app, "Primary delta"),
         name="st_metric-primary_delta",
     )
+
+def test_delta_description_with_delta(app: Page):
+    """Test that delta description renders alongside delta text."""
+    metric = get_metric(app, "Revenue")
+    expect(metric.get_by_test_id("stMetricValue")).to_have_text("$12.4k")
+    expect(metric.get_by_test_id("stMetricDelta")).to_have_text("+12%")
+    expect(metric.get_by_test_id("stMetricDeltaDescription")).to_have_text(
+        "vs. last month"
+    )
+
+
+def test_delta_description_without_delta(app: Page):
+    """Test that delta description renders even without a delta value."""
+    metric = get_metric(app, "Users")
+    expect(metric.get_by_test_id("stMetricDeltaDescription")).to_have_text(
+        "no delta, just description"
+    )
+    expect(metric.get_by_test_id("stMetricDelta")).to_have_count(0)
+
+
+def test_delta_description_snapshot(
+    themed_app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test the visual appearance of delta descriptions."""
+    assert_snapshot(
+        get_element_by_key(themed_app, "metric_delta_description"),
+        name="st_metric-delta_description",
+    )
+

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -658,4 +658,84 @@ describe("Metric element", () => {
       })
     })
   })
+
+  // Delta description tests
+  describe("Delta description", () => {
+    it("renders delta description when provided", () => {
+      const props = getProps({ deltaDescription: "vs. last month" })
+      render(<Metric {...props} />)
+
+      const descriptionElement = screen.getByTestId(
+        "stMetricDeltaDescription"
+      )
+      expect(descriptionElement).toBeVisible()
+      expect(descriptionElement).toHaveTextContent("vs. last month")
+    })
+
+    it("does not render delta description when empty", () => {
+      const props = getProps({ deltaDescription: "" })
+      render(<Metric {...props} />)
+
+      expect(
+        screen.queryByTestId("stMetricDeltaDescription")
+      ).not.toBeInTheDocument()
+    })
+
+    it("does not render delta description when not provided", () => {
+      const props = getProps()
+      render(<Metric {...props} />)
+
+      expect(
+        screen.queryByTestId("stMetricDeltaDescription")
+      ).not.toBeInTheDocument()
+    })
+
+    it("renders delta description alongside delta text", () => {
+      const props = getProps({
+        delta: "+5%",
+        deltaDescription: "month over month",
+      })
+      render(<Metric {...props} />)
+
+      expect(screen.getByTestId("stMetricDelta")).toBeVisible()
+      expect(
+        screen.getByTestId("stMetricDeltaDescription")
+      ).toBeVisible()
+      expect(
+        screen.getByTestId("stMetricDeltaDescription")
+      ).toHaveTextContent("month over month")
+    })
+
+    it("renders delta description without delta", () => {
+      const props = getProps({
+        delta: "",
+        deltaDescription: "vs. last quarter",
+      })
+      render(<Metric {...props} />)
+
+      expect(
+        screen.queryByTestId("stMetricDelta")
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByTestId("stMetricDeltaDescription")
+      ).toBeVisible()
+      expect(
+        screen.getByTestId("stMetricDeltaDescription")
+      ).toHaveTextContent("vs. last quarter")
+    })
+
+    it("renders markdown in delta description", () => {
+      const props = getProps({
+        deltaDescription: "**bold** description",
+      })
+      render(<Metric {...props} />)
+
+      const descriptionElement = screen.getByTestId(
+        "stMetricDeltaDescription"
+      )
+      expect(descriptionElement.querySelector("strong")).toBeVisible()
+      expect(descriptionElement).toHaveTextContent("bold description")
+    })
+  })
+
 })

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -43,6 +43,7 @@ import {
   StyledMetricChart,
   StyledMetricContainer,
   StyledMetricContent,
+  StyledMetricDeltaDescription,
   StyledMetricDeltaText,
   StyledMetricLabelText,
   StyledMetricValueText,
@@ -274,6 +275,7 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
     chartData,
     chartType,
     format,
+    deltaDescription,
   } = element
 
   // Apply number formatting if a format is specified and the value is numeric
@@ -396,6 +398,18 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
               />
             </StyledTruncateText>
           </StyledMetricDeltaText>
+        )}
+        {deltaDescription && (
+          <StyledMetricDeltaDescription data-testid="stMetricDeltaDescription">
+            <StyledTruncateText>
+              <StreamlitMarkdown
+                source={deltaDescription}
+                allowHTML={false}
+                isLabel
+                inheritFont
+              />
+            </StyledTruncateText>
+          </StyledMetricDeltaDescription>
         )}
       </StyledMetricContent>
       {chartData && chartData.length > 0 && (

--- a/frontend/lib/src/components/elements/Metric/styled-components.ts
+++ b/frontend/lib/src/components/elements/Metric/styled-components.ts
@@ -122,3 +122,11 @@ export const StyledMetricDeltaText = styled.div<StyledMetricDeltaTextProps>(
     }),
   })
 )
+
+export const StyledMetricDeltaDescription = styled.div(({ theme }) => ({
+  fontSize: theme.fontSizes.sm,
+  color: theme.colors.fadedText60,
+  marginTop: theme.spacing.twoXS,
+  maxWidth: "100%",
+}))
+

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -104,6 +104,7 @@ class MetricMixin:
         chart_data: OptionSequence[Any] | None = None,
         chart_type: Literal["line", "bar", "area"] = "line",
         delta_arrow: DeltaArrow = "auto",
+        delta_description: str | None = None,
         format: str | NumberFormat | None = None,
     ) -> DeltaGenerator:
         r"""Display a metric in big bold font, with an optional indicator of how the metric changed.
@@ -237,6 +238,13 @@ class MetricMixin:
               specified direction.
             - ``"off"``: No arrow is shown, but the delta value remains
               visible.
+
+        delta_description : str or None
+            An optional description displayed next to the delta indicator in
+            small, muted text. This is useful for providing context about the
+            timeframe or basis of comparison for the delta, such as
+            "vs. last month" or "month over month". If this is ``None``
+            (default), no description is shown.
 
         format : str or None
             A format string controlling how numbers are displayed for ``value``
@@ -405,6 +413,9 @@ class MetricMixin:
 
         if format is not None:
             metric_proto.format = format
+
+        if delta_description is not None:
+            metric_proto.delta_description = delta_description
 
         validate_height(height, allow_content=True)
         validate_width(width, allow_content=True)

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -701,6 +701,7 @@ class Metric(Element):
     delta: str
     color: str
     help: str
+    delta_description: str
 
     def __init__(self, proto: MetricProto, root: ElementTree) -> None:
         self.proto = proto

--- a/lib/tests/streamlit/elements/metric_test.py
+++ b/lib/tests/streamlit/elements/metric_test.py
@@ -601,3 +601,49 @@ class MetricTest(DeltaGeneratorTestCase):
         assert c.label == "label_test"
         assert c.body == "123"
         assert c.format == expected_proto_value
+
+    def test_delta_description_none(self):
+        """Test that metric works with default delta_description=None."""
+        st.metric("label_test", "123", 5)
+
+        c = self.get_delta_from_queue().new_element.metric
+        assert c.label == "label_test"
+        assert c.body == "123"
+        assert c.delta_description == ""
+
+    def test_delta_description_string(self):
+        """Test that metric can be called with delta_description param."""
+        st.metric("label_test", "123", 5, delta_description="vs. last month")
+
+        c = self.get_delta_from_queue().new_element.metric
+        assert c.label == "label_test"
+        assert c.body == "123"
+        assert c.delta == "5"
+        assert c.delta_description == "vs. last month"
+
+    def test_delta_description_without_delta(self):
+        """Test that delta_description can be set even without delta."""
+        st.metric("label_test", "123", delta_description="month over month")
+
+        c = self.get_delta_from_queue().new_element.metric
+        assert c.label == "label_test"
+        assert c.body == "123"
+        assert c.delta == ""
+        assert c.delta_description == "month over month"
+
+    def test_delta_description_with_delta_color(self):
+        """Test that delta_description works alongside delta_color."""
+        st.metric(
+            "label_test",
+            "123",
+            -5,
+            delta_color="inverse",
+            delta_description="vs. last quarter",
+        )
+
+        c = self.get_delta_from_queue().new_element.metric
+        assert c.label == "label_test"
+        assert c.delta == "-5"
+        assert c.delta_description == "vs. last quarter"
+        assert c.color == MetricProto.MetricColor.GREEN
+        assert c.direction == MetricProto.MetricDirection.DOWN

--- a/proto/streamlit/proto/Metric.proto
+++ b/proto/streamlit/proto/Metric.proto
@@ -55,4 +55,7 @@ message Metric {
 
   // Format string for the value and delta (applied only if they are numeric).
   string format = 11;
+
+  // Optional description text shown next to the delta indicator.
+  string delta_description = 12;
 }


### PR DESCRIPTION
## Summary
- Adds a new `delta_description` parameter to `st.metric` that displays contextual text next to the delta indicator in small, muted font
- Useful for showing timeframe or basis of comparison (e.g., "vs. last month", "month over month")
- The description renders below the delta pill in `caption`-style text (small, gray)
- Works with or without a delta value

Closes #13690

## Changes
- **Proto**: Added `delta_description` string field (field 12) to `Metric.proto`
- **Python backend**: Added `delta_description: str | None = None` keyword-only parameter to `st.metric()`
- **Frontend**: Added `StyledMetricDeltaDescription` styled component and rendering logic in `Metric.tsx`
- **AppTest**: Exposed `delta_description` field on the `Metric` element in `element_tree.py`
- **Tests**: Added Python unit tests, frontend React tests, and e2e Playwright tests

## Example usage
```python
st.metric(
    "Revenue",
    "$12.4k",
    "+12%",
    delta_description="vs. last month",
    border=True,
)
```

## Test plan
- [x] 4 new Python unit tests pass (69 total)
- [ ] Frontend unit tests (6 new tests added to Metric.test.tsx)
- [ ] E2E tests (3 new tests added to st_metric_test.py)
- [ ] CI checks pass