### PR TITLE
[DynamicContainers] foundational work adding .open properties

### DIFF
--- a/lib/streamlit/elements/lib/mutable_expander_container.py
+++ b/lib/streamlit/elements/lib/mutable_expander_container.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 
 class ExpanderContainer(DeltaGenerator):
+    """DeltaGenerator subclass returned by ``st.expander``.
+
+    Provides the ``.open`` property for checking expander state when
+    ``on_change`` is used.
+    """
+
     def __init__(
         self,
         root_container: int | None,
@@ -35,6 +41,24 @@ class ExpanderContainer(DeltaGenerator):
         block_type: str | None,
     ) -> None:
         super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        """The open/collapsed state of the expander.
+
+        Returns
+        -------
+        bool or None
+            ``True`` if expanded, ``False`` if collapsed, or ``None`` if
+            state tracking is not enabled (``on_change`` was not set or
+            set to ``"ignore"``).
+        """
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
 
     def __enter__(self) -> Self:  # type: ignore[override]
         super().__enter__()

--- a/lib/streamlit/elements/lib/mutable_popover_container.py
+++ b/lib/streamlit/elements/lib/mutable_popover_container.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 
 class PopoverContainer(DeltaGenerator):
+    """DeltaGenerator subclass returned by ``st.popover``.
+
+    Provides the ``.open`` property for checking popover state when
+    ``on_change`` is used.
+    """
+
     def __init__(
         self,
         root_container: int | None,
@@ -35,6 +41,24 @@ class PopoverContainer(DeltaGenerator):
         block_type: str | None,
     ) -> None:
         super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        """The open/closed state of the popover.
+
+        Returns
+        -------
+        bool or None
+            ``True`` if open, ``False`` if closed, or ``None`` if state
+            tracking is not enabled (``on_change`` was not set or set to
+            ``"ignore"``).
+        """
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
 
     def __enter__(self) -> Self:  # type: ignore[override]
         super().__enter__()

--- a/lib/streamlit/elements/lib/mutable_tab_container.py
+++ b/lib/streamlit/elements/lib/mutable_tab_container.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 
 class TabContainer(DeltaGenerator):
+    """DeltaGenerator subclass returned for each tab in ``st.tabs``.
+
+    Provides the ``.open`` property for checking whether this tab is active
+    when ``on_change`` is used.
+    """
+
     def __init__(
         self,
         root_container: int | None,
@@ -35,6 +41,24 @@ class TabContainer(DeltaGenerator):
         block_type: str | None,
     ) -> None:
         super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        """Whether this tab is the currently active tab.
+
+        Returns
+        -------
+        bool or None
+            ``True`` if this tab is active, ``False`` if inactive, or ``None``
+            if state tracking is not enabled (``on_change`` was not set or
+            set to ``"ignore"``).
+        """
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
 
     def __enter__(self) -> Self:  # type: ignore[override]
         super().__enter__()

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -407,6 +407,16 @@ class ExpanderTest(DeltaGeneratorTestCase):
             st.expander("label", icon=icon)
         assert "is not a valid Material icon" in str(e.value)
 
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None when on_change is not set."""
+        expander = st.expander("label")
+        assert expander.open is None
+
+    def test_open_returns_none_when_expanded_true(self):
+        """Test that .open returns None even with expanded=True (no state tracking)."""
+        expander = st.expander("label", expanded=True)
+        assert expander.open is None
+
 
 class ContainerTest(DeltaGeneratorTestCase):
     def test_border_parameter(self):
@@ -779,6 +789,11 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.popover("label", width=invalid_width)
 
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None when on_change is not set."""
+        popover = st.popover("label")
+        assert popover.open is None
+
 
 class StatusContainerTest(DeltaGeneratorTestCase):
     def test_label_required(self):
@@ -993,6 +1008,18 @@ class TabsTest(DeltaGeneratorTestCase):
         tab_container_block = all_deltas[0]
 
         assert tab_container_block.add_block.tab_container.default_tab_index == 1
+
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None on all tabs when on_change is not set."""
+        tabs = st.tabs(["A", "B", "C"])
+        for tab in tabs:
+            assert tab.open is None
+
+    def test_open_returns_none_with_default_tab(self):
+        """Test that .open returns None even with a default tab (no state tracking)."""
+        tabs = st.tabs(["A", "B", "C"], default="B")
+        for tab in tabs:
+            assert tab.open is None
 
 
 class DialogTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/typing/expander_container_types.py
+++ b/lib/tests/streamlit/typing/expander_container_types.py
@@ -39,3 +39,6 @@ if TYPE_CHECKING:
     # Context manager returns Self
     with expander("Test") as ctx:
         assert_type(ctx, ExpanderContainer)
+
+    # .open property returns bool | None
+    assert_type(expander("Test").open, bool | None)

--- a/lib/tests/streamlit/typing/popover_container_types.py
+++ b/lib/tests/streamlit/typing/popover_container_types.py
@@ -39,3 +39,6 @@ if TYPE_CHECKING:
     # Context manager returns Self
     with popover("Test") as ctx:
         assert_type(ctx, PopoverContainer)
+
+    # .open property returns bool | None
+    assert_type(popover("Test").open, bool | None)

--- a/lib/tests/streamlit/typing/tab_container_types.py
+++ b/lib/tests/streamlit/typing/tab_container_types.py
@@ -47,3 +47,6 @@ if TYPE_CHECKING:
     # Context manager returns Self
     with tabs(["A", "B"])[0] as ctx:
         assert_type(ctx, TabContainer)
+
+    # .open property returns bool | None
+    assert_type(tabs(["A", "B"])[0].open, bool | None)

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -144,6 +144,8 @@ message Block {
     bool disabled = 4;
     string icon = 5;
     string type = 6;
+    // Initial open state (used with on_change).
+    optional bool open = 7;
 
     reserved 2;
   }


### PR DESCRIPTION
## Describe your changes

Adds the `.open` properties to the new delta generators for Expander, Tabs and Popover. Adds a new proto property for Popover to send open state to FE. 

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Type tests. 
- Unit tests.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
