### PR TITLE
[DynamicContainers] refactoring of Expander to support more complex state handling

### DIFF
--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useEffect, useRef, useState } from "react"
+import { memo, ReactElement, useState } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
 import { DynamicIcon } from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
-import { notNullOrUndefined } from "~lib/util/utils"
 
 import {
-  BORDER_SIZE,
   StyledDetails,
   StyledDetailsPanel,
   StyledExpandableContainer,
@@ -31,6 +29,7 @@ import {
   StyledSummaryHeading,
   StyledSummaryLabelWrapper,
 } from "./styled-components"
+import { useDetailsAnimation } from "./useDetailsAnimation"
 
 export interface ExpanderIconProps {
   icon?: string
@@ -76,173 +75,45 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   isStale,
   children,
 }): ReactElement => {
-  const { label, expanded: initialExpanded } = element
-  const [expanded, setExpanded] = useState<boolean>(initialExpanded || false)
+  const { label, icon } = element
   const [isHovered, setIsHovered] = useState(false)
-  const detailsRef = useRef<HTMLDetailsElement>(null)
-  const summaryRef = useRef<HTMLElement>(null)
-  const animationRef = useRef<Animation | null>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const contentRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    // Only apply the expanded state if it was actually set in the proto.
-    if (notNullOrUndefined(initialExpanded)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- TODO: Do not set state in effect
-      setExpanded(initialExpanded)
-
-      // We manage the open attribute via the detailsRef and not with React state
-      if (detailsRef.current) {
-        detailsRef.current.open = initialExpanded
-      }
-    }
-
-    // Having `label` in the dependency array here is necessary because
-    // sometimes two distinct expanders look so similar that even the react
-    // diffing algorithm decides that they're the same element with updated
-    // props (this happens when something in the app removes one expander and
-    // replaces it with another in the same position).
-    //
-    // By adding `label` as a dependency, we ensure that we reset the
-    // expander's `expanded` state in this edge case.
-  }, [label, initialExpanded])
-
-  const onAnimationFinish = (open: boolean): void => {
-    if (!detailsRef.current) {
-      return
-    }
-
-    detailsRef.current.open = open
-    animationRef.current = null
-    detailsRef.current.style.height = ""
-    detailsRef.current.style.overflow = ""
-  }
-
-  const toggleAnimation = (
-    detailsEl: HTMLDetailsElement,
-    startHeight: number,
-    endHeight: number
-  ): void => {
-    const isOpen = endHeight > startHeight
-
-    if (animationRef.current) {
-      animationRef.current.cancel()
-
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
-    }
-
-    const animation = detailsEl.animate(
-      {
-        height: [`${startHeight}px`, `${endHeight}px`],
-      },
-      {
-        duration: 500,
-        easing: "cubic-bezier(0.23, 1, 0.32, 1)",
-      }
-    )
-
-    animation.addEventListener("finish", () => onAnimationFinish(isOpen))
-    animationRef.current = animation
-  }
-
-  const toggle = (e: React.MouseEvent<HTMLDetailsElement>): void => {
-    e.preventDefault()
-
-    setExpanded(!expanded)
-    const detailsEl = detailsRef.current
-    if (!detailsEl || !summaryRef.current) {
-      return
-    }
-
-    detailsEl.style.overflow = "hidden"
-    // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-    const detailsHeight = detailsEl.getBoundingClientRect().height
-    // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-    const summaryHeight = summaryRef.current.getBoundingClientRect().height
-
-    if (!expanded) {
-      detailsEl.style.height = `${detailsHeight}px`
-      detailsEl.open = true
-
-      window.requestAnimationFrame(() => {
-        // For expansion animations, we rely on the rendered width and height
-        // of the children content. However, in Safari, the children are not
-        // rendered because Safari doesn't paint elements that are not visible
-        // (in this case, the details element is not visible because it's
-        // not open). This operation produces inconsistent heights to animate.
-        // To work around this, we force a repaint by animating a tiny bit
-        // and animate the rest of it later.
-        toggleAnimation(
-          detailsEl,
-          detailsHeight,
-          summaryHeight + 2 * BORDER_SIZE + 5 // Arbitrary size of 5px
-        )
-
-        timeoutRef.current = setTimeout(() => {
-          if (!contentRef.current) {
-            return
-          }
-
-          const contentHeight =
-            // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-            contentRef.current.getBoundingClientRect().height
-          toggleAnimation(
-            detailsEl,
-            detailsHeight,
-            summaryHeight + contentHeight + 2 * BORDER_SIZE
-          )
-        }, 100)
-      })
-    } else {
-      toggleAnimation(
-        detailsEl,
-        detailsHeight,
-        summaryHeight + 2 * BORDER_SIZE
-      )
-    }
-  }
-
-  const handleMouseEnter = (): void => {
-    setIsHovered(true)
-  }
-
-  const handleMouseLeave = (): void => {
-    setIsHovered(false)
-  }
+  const { isOpen, detailsRef, summaryRef, contentRef, handleToggle } =
+    useDetailsAnimation({
+      backendExpanded: element.expanded,
+      label,
+    })
 
   // Determine which icon to show
-  const showChevron = !element.icon || isHovered
-  const showUserIcon = element.icon && !isHovered
+  const showChevron = !icon || isHovered
+  const showUserIcon = icon && !isHovered
 
   return (
     <StyledExpandableContainer className="stExpander" data-testid="stExpander">
       <StyledDetails
         isStale={isStale}
         ref={detailsRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
       >
         <StyledSummary
-          onClick={toggle}
+          onClick={handleToggle}
           ref={summaryRef}
           isStale={isStale}
-          expanded={expanded}
+          expanded={isOpen}
         >
           <StyledSummaryHeading>
             {showChevron && (
               <DynamicIcon
                 iconValue={
-                  expanded
+                  isOpen
                     ? ":material/keyboard_arrow_down:"
                     : ":material/keyboard_arrow_right:"
                 }
                 size="lg"
               />
             )}
-            {showUserIcon && <ExpanderIcon icon={element.icon} />}
+            {showUserIcon && <ExpanderIcon icon={icon} />}
 
             <StyledSummaryLabelWrapper>
               <StreamlitMarkdown
@@ -259,7 +130,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
           ref={contentRef}
           // Exclude collapsed content from browser find-in-page (Cmd+F) searches.
           // Using "" instead of true for consistent behavior in jsdom tests.
-          inert={!expanded ? "" : undefined}
+          inert={!isOpen ? "" : undefined}
         >
           {children}
         </StyledDetailsPanel>

--- a/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { animateHeight } from "./animateHeight"
+
+describe("animateHeight", () => {
+  let element: HTMLDivElement
+  let mockAnimation: {
+    addEventListener: ReturnType<typeof vi.fn>
+    cancel: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    element = document.createElement("div")
+    document.body.appendChild(element)
+
+    // Mock the Web Animations API since JSDOM doesn't fully support it
+    mockAnimation = {
+      addEventListener: vi.fn(),
+      cancel: vi.fn(),
+    }
+    element.animate = vi.fn().mockReturnValue(mockAnimation)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(element)
+  })
+
+  describe("animation creation", () => {
+    it("calls element.animate with height keyframes", () => {
+      animateHeight(element, 0, 100)
+
+      expect(element.animate).toHaveBeenCalledWith(
+        { height: ["0px", "100px"] },
+        { duration: 500, easing: "cubic-bezier(0.23, 1, 0.32, 1)" }
+      )
+    })
+
+    it("uses custom duration when provided", () => {
+      animateHeight(element, 0, 100, { duration: 300 })
+
+      expect(element.animate).toHaveBeenCalledWith(
+        { height: ["0px", "100px"] },
+        { duration: 300, easing: "cubic-bezier(0.23, 1, 0.32, 1)" }
+      )
+    })
+
+    it("uses custom easing when provided", () => {
+      animateHeight(element, 0, 100, { easing: "ease-in-out" })
+
+      expect(element.animate).toHaveBeenCalledWith(
+        { height: ["0px", "100px"] },
+        { duration: 500, easing: "ease-in-out" }
+      )
+    })
+  })
+
+  describe("cancel", () => {
+    it("cancel() calls animation.cancel()", () => {
+      const handle = animateHeight(element, 0, 100)
+
+      handle.cancel()
+
+      expect(mockAnimation.cancel).toHaveBeenCalled()
+    })
+  })
+
+  describe("finish behavior", () => {
+    it("registers finish event listener", () => {
+      animateHeight(element, 0, 100)
+
+      expect(mockAnimation.addEventListener).toHaveBeenCalledWith(
+        "finish",
+        expect.any(Function)
+      )
+    })
+
+    it("clears styles and calls onFinish when animation finishes", () => {
+      const onFinish = vi.fn()
+      element.style.height = "50px"
+      element.style.overflow = "hidden"
+
+      animateHeight(element, 0, 100, { onFinish })
+
+      // Get the finish callback
+      const finishCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "finish"
+      )
+      const finishCallback = finishCall?.[1]
+
+      // Simulate finish
+      finishCallback?.()
+
+      expect(element.style.height).toBe("")
+      expect(element.style.overflow).toBe("")
+      expect(onFinish).toHaveBeenCalled()
+    })
+
+    it("resolves finished promise on finish", async () => {
+      const handle = animateHeight(element, 0, 100)
+
+      // Get the finish callback
+      const finishCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "finish"
+      )
+      const finishCallback = finishCall?.[1]
+
+      // Simulate finish
+      finishCallback?.()
+
+      // Should resolve without throwing
+      await expect(handle.finished).resolves.toBeUndefined()
+    })
+  })
+
+  describe("cancel behavior", () => {
+    it("registers cancel event listener", () => {
+      animateHeight(element, 0, 100)
+
+      expect(mockAnimation.addEventListener).toHaveBeenCalledWith(
+        "cancel",
+        expect.any(Function)
+      )
+    })
+
+    it("does NOT clear styles on cancel (caller responsibility)", () => {
+      element.style.height = "50px"
+      element.style.overflow = "hidden"
+
+      animateHeight(element, 0, 100)
+
+      // Get the cancel callback
+      const cancelCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "cancel"
+      )
+      const cancelCallback = cancelCall?.[1]
+
+      // Simulate cancel
+      cancelCallback?.()
+
+      // Styles should NOT be cleared - caller is responsible
+      expect(element.style.height).toBe("50px")
+      expect(element.style.overflow).toBe("hidden")
+    })
+
+    it("resolves finished promise on cancel", async () => {
+      const handle = animateHeight(element, 0, 100)
+
+      // Get the cancel callback
+      const cancelCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "cancel"
+      )
+      const cancelCallback = cancelCall?.[1]
+
+      // Simulate cancel
+      cancelCallback?.()
+
+      // Should resolve without throwing
+      await expect(handle.finished).resolves.toBeUndefined()
+    })
+  })
+})

--- a/frontend/lib/src/components/elements/Expander/animateHeight.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Animation handle returned by animateHeight.
+ * Provides cancel capability and completion promise.
+ */
+export interface AnimationHandle {
+  /** Cancel the running animation */
+  cancel: () => void
+  /** Promise that resolves when animation completes (finish or cancel) */
+  finished: Promise<void>
+}
+
+/** Default animation duration in milliseconds */
+const DEFAULT_DURATION = 500
+
+/** Default easing function for smooth animation */
+const DEFAULT_EASING = "cubic-bezier(0.23, 1, 0.32, 1)"
+
+/**
+ * Animate an element's height using the Web Animations API.
+ *
+ * IMPORTANT: On cancel, styles are NOT cleared. The caller is responsible
+ * for setting new styles after cancelling (typically to lock at current height
+ * before starting a new animation).
+ *
+ * On finish, styles ARE cleared to allow natural layout.
+ *
+ * @param element - The HTML element to animate
+ * @param from - Starting height in pixels
+ * @param to - Target height in pixels
+ * @param options - Optional configuration
+ * @returns AnimationHandle with cancel() and finished promise
+ */
+export function animateHeight(
+  element: HTMLElement,
+  from: number,
+  to: number,
+  options: {
+    duration?: number
+    easing?: string
+    onFinish?: () => void
+  } = {}
+): AnimationHandle {
+  const {
+    duration = DEFAULT_DURATION,
+    easing = DEFAULT_EASING,
+    onFinish,
+  } = options
+
+  const animation = element.animate(
+    { height: [`${from}px`, `${to}px`] },
+    { duration, easing }
+  )
+
+  const finished = new Promise<void>(resolve => {
+    animation.addEventListener("finish", () => {
+      // Clean up styles on successful finish
+      element.style.height = ""
+      element.style.overflow = ""
+      onFinish?.()
+      resolve()
+    })
+
+    animation.addEventListener("cancel", () => {
+      // DON'T clean up on cancel - caller will set new styles
+      resolve()
+    })
+  })
+
+  return {
+    cancel: () => animation.cancel(),
+    finished,
+  }
+}

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MouseEvent } from "react"
+
+import { act, renderHook } from "@testing-library/react"
+
+import { useDetailsAnimation } from "./useDetailsAnimation"
+
+describe("useDetailsAnimation", () => {
+  describe("initial state", () => {
+    it("returns isOpen=true when backendExpanded is true", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("returns isOpen=false when backendExpanded is false", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("returns isOpen=false when backendExpanded is null", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: null,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("returns isOpen=false when backendExpanded is undefined", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: undefined,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+    })
+  })
+
+  describe("handleToggle", () => {
+    it("toggles isOpen state from false to true", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("toggles isOpen state from true to false", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(true)
+
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("calls onToggle callback with new state", () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+          onToggle,
+        })
+      )
+
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(onToggle).toHaveBeenCalledWith(true)
+    })
+
+    it("does not call onToggle when not provided", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      // Should not throw when onToggle is undefined
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("prevents default event behavior", () => {
+      const preventDefault = vi.fn()
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      act(() => {
+        const mockEvent = {
+          preventDefault,
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(preventDefault).toHaveBeenCalled()
+    })
+
+    it("handles rapid double-toggle correctly", () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+          onToggle,
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+
+      // Simulate two rapid clicks before React re-renders
+      act(() => {
+        const mockEvent1 = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        const mockEvent2 = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent1)
+        result.current.handleToggle(mockEvent2)
+      })
+
+      // Should end up back at the original state (false -> true -> false)
+      expect(result.current.isOpen).toBe(false)
+      // Both toggles should have fired with correct values
+      expect(onToggle).toHaveBeenCalledTimes(2)
+      expect(onToggle).toHaveBeenNthCalledWith(1, true)
+      expect(onToggle).toHaveBeenNthCalledWith(2, false)
+    })
+  })
+
+  describe("backend sync", () => {
+    it("syncs isOpen when backendExpanded changes", () => {
+      const { result, rerender } = renderHook(
+        ({ backendExpanded }) =>
+          useDetailsAnimation({
+            backendExpanded,
+            label: "Test",
+          }),
+        { initialProps: { backendExpanded: false as boolean | null } }
+      )
+
+      expect(result.current.isOpen).toBe(false)
+
+      rerender({ backendExpanded: true })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("preserves current state when backendExpanded is null (ClearField)", () => {
+      const { result, rerender } = renderHook(
+        ({ backendExpanded }) =>
+          useDetailsAnimation({
+            backendExpanded,
+            label: "Test",
+          }),
+        { initialProps: { backendExpanded: true as boolean | null } }
+      )
+
+      expect(result.current.isOpen).toBe(true)
+
+      // User manually toggles closed
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(false)
+
+      // Backend sends null (ClearField) - should NOT change state
+      rerender({ backendExpanded: null })
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("preserves current state when backendExpanded becomes undefined", () => {
+      const { result, rerender } = renderHook(
+        ({ backendExpanded }) =>
+          useDetailsAnimation({
+            backendExpanded,
+            label: "Test",
+          }),
+        {
+          initialProps: {
+            backendExpanded: true as boolean | null | undefined,
+          },
+        }
+      )
+
+      expect(result.current.isOpen).toBe(true)
+
+      // Backend sends undefined - should NOT change state
+      rerender({ backendExpanded: undefined })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("resets state when label changes (new expander)", () => {
+      const { result, rerender } = renderHook(
+        ({ backendExpanded, label }) =>
+          useDetailsAnimation({
+            backendExpanded,
+            label,
+          }),
+        {
+          initialProps: {
+            backendExpanded: true as boolean | null,
+            label: "Old Label",
+          },
+        }
+      )
+
+      // Toggle to false locally
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(false)
+
+      // Change label (simulates new expander) - should reset to backendExpanded
+      rerender({ backendExpanded: true, label: "New Label" })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+  })
+
+  describe("cleanup", () => {
+    it("does not throw on unmount", () => {
+      const { unmount } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      expect(() => unmount()).not.toThrow()
+    })
+  })
+})

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -1,0 +1,354 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MouseEvent,
+  RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { isNullOrUndefined } from "~lib/util/utils"
+
+import { animateHeight, AnimationHandle } from "./animateHeight"
+import { BORDER_SIZE } from "./styled-components"
+
+/**
+ * Debounce delay for ResizeObserver callbacks (ms).
+ * 50ms (~3 frames at 60fps) lets rapid content changes settle
+ * while still being responsive.
+ */
+const RESIZE_DEBOUNCE_MS = 50
+
+export interface UseDetailsAnimationOptions {
+  /**
+   * Open state from backend (initial or controlled).
+   *
+   * - `true` / `false` – explicit state from the proto.
+   * - `null` / `undefined` – the field was not set (e.g. `ClearField("expanded")`
+   *   during `st.status().update()`). In this case the hook preserves the
+   *   current open/closed state and defaults to `false` on initial render.
+   */
+  backendExpanded: boolean | null | undefined
+  /** Label used to detect "new expander" replacing old one */
+  label: string
+  /** Callback when user toggles (for widget mode) */
+  onToggle?: (newOpen: boolean) => void
+}
+
+export interface UseDetailsAnimationResult {
+  /** Current open state */
+  isOpen: boolean
+  /** Ref to attach to <details> element */
+  detailsRef: RefObject<HTMLDetailsElement>
+  /** Ref to attach to <summary> element */
+  summaryRef: RefObject<HTMLElement>
+  /** Ref to attach to content panel */
+  contentRef: RefObject<HTMLDivElement>
+  /** Click handler for summary (toggle) */
+  handleToggle: (e: MouseEvent) => void
+}
+
+/**
+ * Custom hook for managing animated <details> element open/close state.
+ *
+ * Features:
+ * - Optimistic updates: animates immediately on user toggle
+ * - Backend sync: animates when backend state changes
+ * - Content resize: animates when content changes size (e.g. lazy-loaded)
+ * - Smooth interruption: animations can be interrupted without visual flicker
+ * - Proper cleanup: all timeouts and animations cleaned up on unmount
+ */
+export function useDetailsAnimation({
+  backendExpanded,
+  label,
+  onToggle,
+}: UseDetailsAnimationOptions): UseDetailsAnimationResult {
+  const [isOpen, setIsOpen] = useState(backendExpanded ?? false)
+
+  const detailsRef = useRef<HTMLDetailsElement>(null)
+  const summaryRef = useRef<HTMLElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  // Track current animation for cancellation
+  const animationRef = useRef<AnimationHandle | null>(null)
+
+  // Track resize debounce timeout
+  const resizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Track isOpen in ref to avoid stale closures in effects
+  const isOpenRef = useRef(isOpen)
+  isOpenRef.current = isOpen
+
+  // Track previous label for detecting "new expander" replacements
+  const prevLabelRef = useRef(label)
+
+  // Track if component has mounted (to skip animation on initial render)
+  const hasMountedRef = useRef(false)
+
+  /**
+   * Cancel any running animation.
+   */
+  const cancelAnimation = useCallback((): void => {
+    animationRef.current?.cancel()
+    animationRef.current = null
+  }, [])
+
+  /**
+   * Animate to a target open/closed state.
+   * Handles interruption smoothly by capturing current height before cancelling.
+   *
+   * Performance note: This function triggers 1-2 forced reflows via getBoundingClientRect().
+   * This is acceptable because:
+   * - It only runs on user click or backend state change (infrequent)
+   * - Reflows are batched where possible (reads before writes)
+   * - Accurate measurements are required for smooth animation
+   */
+  const animateTo = useCallback(
+    (targetOpen: boolean): void => {
+      const details = detailsRef.current
+      const summary = summaryRef.current
+      const content = contentRef.current
+      if (!details || !summary) {
+        return
+      }
+
+      // === BATCH READ PHASE (1 reflow) ===
+      // Read all layout properties BEFORE making any style changes to minimize reflows
+      /* eslint-disable streamlit-custom/no-force-reflow-access -- Batched reads for animation */
+      const currentHeight = details.getBoundingClientRect().height
+      const summaryHeight = summary.getBoundingClientRect().height
+      /* eslint-enable streamlit-custom/no-force-reflow-access */
+
+      // === WRITE PHASE ===
+      cancelAnimation()
+      details.style.height = `${currentHeight}px`
+      details.style.overflow = "hidden"
+
+      if (targetOpen) {
+        // Set open so content renders
+        details.open = true
+
+        // === SECOND READ (1 reflow) ===
+        // Must happen AFTER details.open = true so content is in the DOM
+        // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Required after DOM change
+        const contentHeight = content?.getBoundingClientRect().height ?? 0
+
+        // Animate to full height (summary + content + borders)
+        if (contentHeight > 0) {
+          const targetHeight = summaryHeight + contentHeight + 2 * BORDER_SIZE
+          animationRef.current = animateHeight(
+            details,
+            currentHeight,
+            targetHeight
+          )
+        } else {
+          // Clear locked styles since no animation will clean them up.
+          // If content arrives later (e.g. widget mode), the ResizeObserver
+          // will animate from the natural height to the full height.
+          details.style.height = ""
+          details.style.overflow = ""
+        }
+      } else {
+        // Closing: animate to collapsed height, then set open=false
+        const targetHeight = summaryHeight + 2 * BORDER_SIZE
+        animationRef.current = animateHeight(
+          details,
+          currentHeight,
+          targetHeight,
+          {
+            onFinish: () => {
+              if (detailsRef.current) {
+                detailsRef.current.open = false
+              }
+            },
+          }
+        )
+      }
+    },
+    [cancelAnimation]
+  )
+
+  /**
+   * Animate content resize (when content height changes while open).
+   */
+  const animateResize = useCallback(
+    (currentHeight: number, targetHeight: number): void => {
+      const details = detailsRef.current
+      if (!details) {
+        return
+      }
+
+      // Capture and lock (same pattern as animateTo)
+      cancelAnimation()
+      details.style.height = `${currentHeight}px`
+      details.style.overflow = "hidden"
+
+      animationRef.current = animateHeight(
+        details,
+        currentHeight,
+        targetHeight
+      )
+    },
+    [cancelAnimation]
+  )
+
+  // Sync with backend state changes
+  useEffect(() => {
+    const labelChanged = label !== prevLabelRef.current
+
+    prevLabelRef.current = label
+
+    // If label changed, this is a "new expander" - cancel animations and reset.
+    // Clear any stale inline styles that cancelAnimation leaves behind.
+    if (labelChanged) {
+      cancelAnimation()
+      const newOpen = backendExpanded ?? false
+      setIsOpen(newOpen)
+      if (detailsRef.current) {
+        detailsRef.current.style.height = ""
+        detailsRef.current.style.overflow = ""
+        detailsRef.current.open = newOpen
+      }
+      return
+    }
+
+    // If backendExpanded is null/undefined, the field was deliberately omitted
+    // (e.g. ClearField("expanded") in st.status().update()). This means
+    // "keep the current expanded state" — do nothing.
+    if (isNullOrUndefined(backendExpanded)) {
+      return
+    }
+
+    // If backend state differs from local, sync (with animation if mounted).
+    // After the null check above, backendExpanded is narrowed to boolean.
+    if (backendExpanded !== isOpenRef.current) {
+      setIsOpen(backendExpanded)
+
+      if (hasMountedRef.current) {
+        animateTo(backendExpanded)
+      } else {
+        // Initial mount - set DOM state directly, no animation
+        if (detailsRef.current) {
+          detailsRef.current.open = backendExpanded
+        }
+      }
+    }
+  }, [backendExpanded, label, cancelAnimation, animateTo])
+
+  // Set initial open state on mount (before marking as mounted)
+  useEffect(() => {
+    if (detailsRef.current) {
+      detailsRef.current.open = backendExpanded ?? false
+    }
+    hasMountedRef.current = true
+    // Only run on mount - backendExpanded changes are handled by the sync effect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // ResizeObserver for content size changes
+  useEffect(() => {
+    const content = contentRef.current
+    const details = detailsRef.current
+    const summary = summaryRef.current
+    if (!content || !details || !summary) {
+      return
+    }
+
+    const observer = new ResizeObserver(() => {
+      // Only observe when open
+      if (!details.open) {
+        return
+      }
+
+      // Debounce to let rapid content changes settle
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current)
+      }
+
+      resizeTimeoutRef.current = setTimeout(() => {
+        // Don't interfere if we're in "closing" mode - let the close animation finish
+        // isOpenRef tracks the INTENDED state, not the current animation state
+        if (!isOpenRef.current) {
+          return
+        }
+
+        // === BATCH READ PHASE (1 reflow) ===
+        // All reads happen before any writes, so only one reflow is triggered.
+        // This only runs on content size changes (debounced), not in hot loops.
+        /* eslint-disable streamlit-custom/no-force-reflow-access -- Batched reads for resize animation */
+        const contentHeight = content.getBoundingClientRect().height
+        const summaryHeight = summary.getBoundingClientRect().height
+        const currentHeight = details.getBoundingClientRect().height
+        /* eslint-enable streamlit-custom/no-force-reflow-access */
+
+        const targetHeight = summaryHeight + contentHeight + 2 * BORDER_SIZE
+
+        // === WRITE PHASE ===
+        // Animate if significant difference (> 5px threshold avoids micro-animations)
+        if (Math.abs(currentHeight - targetHeight) > 5) {
+          animateResize(currentHeight, targetHeight)
+        }
+      }, RESIZE_DEBOUNCE_MS)
+    })
+
+    observer.observe(content)
+    return () => {
+      observer.disconnect()
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current)
+      }
+    }
+  }, [animateResize])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cancelAnimation()
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current)
+      }
+    }
+  }, [cancelAnimation])
+
+  // Handle user toggle
+  const handleToggle = useCallback(
+    (e: MouseEvent): void => {
+      e.preventDefault()
+
+      const newOpen = !isOpenRef.current
+      isOpenRef.current = newOpen
+
+      // Optimistic update: always animate immediately
+      setIsOpen(newOpen)
+      animateTo(newOpen)
+
+      // Notify caller if callback provided
+      onToggle?.(newOpen)
+    },
+    [onToggle, animateTo]
+  )
+
+  return {
+    isOpen,
+    detailsRef,
+    summaryRef,
+    contentRef,
+    handleToggle,
+  }
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -68,7 +68,7 @@ console.warn = (...args) => {
 // Add fake animate method to Elements
 Element.prototype.animate = vi
   .fn()
-  .mockImplementation(() => ({ addEventListener: vi.fn() }))
+  .mockImplementation(() => ({ addEventListener: vi.fn(), cancel: vi.fn() }))
 
 class ResizeObserverMock {
   public callback: (

--- a/lib/streamlit/elements/lib/mutable_expander_container.py
+++ b/lib/streamlit/elements/lib/mutable_expander_container.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 
 class ExpanderContainer(DeltaGenerator):
+    """DeltaGenerator subclass returned by ``st.expander``.
+
+    Provides the ``.open`` property for checking expander state when
+    ``on_change`` is used.
+    """
+
     def __init__(
         self,
         root_container: int | None,
@@ -35,6 +41,24 @@ class ExpanderContainer(DeltaGenerator):
         block_type: str | None,
     ) -> None:
         super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        """The open/collapsed state of the expander.
+
+        Returns
+        -------
+        bool or None
+            ``True`` if expanded, ``False`` if collapsed, or ``None`` if
+            state tracking is not enabled (``on_change`` was not set or
+            set to ``"ignore"``).
+        """
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
 
     def __enter__(self) -> Self:  # type: ignore[override]
         super().__enter__()

--- a/lib/streamlit/elements/lib/mutable_popover_container.py
+++ b/lib/streamlit/elements/lib/mutable_popover_container.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 
 class PopoverContainer(DeltaGenerator):
+    """DeltaGenerator subclass returned by ``st.popover``.
+
+    Provides the ``.open`` property for checking popover state when
+    ``on_change`` is used.
+    """
+
     def __init__(
         self,
         root_container: int | None,
@@ -35,6 +41,24 @@ class PopoverContainer(DeltaGenerator):
         block_type: str | None,
     ) -> None:
         super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        """The open/closed state of the popover.
+
+        Returns
+        -------
+        bool or None
+            ``True`` if open, ``False`` if closed, or ``None`` if state
+            tracking is not enabled (``on_change`` was not set or set to
+            ``"ignore"``).
+        """
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
 
     def __enter__(self) -> Self:  # type: ignore[override]
         super().__enter__()

--- a/lib/streamlit/elements/lib/mutable_tab_container.py
+++ b/lib/streamlit/elements/lib/mutable_tab_container.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 
 class TabContainer(DeltaGenerator):
+    """DeltaGenerator subclass returned for each tab in ``st.tabs``.
+
+    Provides the ``.open`` property for checking whether this tab is active
+    when ``on_change`` is used.
+    """
+
     def __init__(
         self,
         root_container: int | None,
@@ -35,6 +41,24 @@ class TabContainer(DeltaGenerator):
         block_type: str | None,
     ) -> None:
         super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        """Whether this tab is the currently active tab.
+
+        Returns
+        -------
+        bool or None
+            ``True`` if this tab is active, ``False`` if inactive, or ``None``
+            if state tracking is not enabled (``on_change`` was not set or
+            set to ``"ignore"``).
+        """
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
 
     def __enter__(self) -> Self:  # type: ignore[override]
         super().__enter__()

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -407,6 +407,16 @@ class ExpanderTest(DeltaGeneratorTestCase):
             st.expander("label", icon=icon)
         assert "is not a valid Material icon" in str(e.value)
 
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None when on_change is not set."""
+        expander = st.expander("label")
+        assert expander.open is None
+
+    def test_open_returns_none_when_expanded_true(self):
+        """Test that .open returns None even with expanded=True (no state tracking)."""
+        expander = st.expander("label", expanded=True)
+        assert expander.open is None
+
 
 class ContainerTest(DeltaGeneratorTestCase):
     def test_border_parameter(self):
@@ -779,6 +789,11 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.popover("label", width=invalid_width)
 
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None when on_change is not set."""
+        popover = st.popover("label")
+        assert popover.open is None
+
 
 class StatusContainerTest(DeltaGeneratorTestCase):
     def test_label_required(self):
@@ -993,6 +1008,18 @@ class TabsTest(DeltaGeneratorTestCase):
         tab_container_block = all_deltas[0]
 
         assert tab_container_block.add_block.tab_container.default_tab_index == 1
+
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None on all tabs when on_change is not set."""
+        tabs = st.tabs(["A", "B", "C"])
+        for tab in tabs:
+            assert tab.open is None
+
+    def test_open_returns_none_with_default_tab(self):
+        """Test that .open returns None even with a default tab (no state tracking)."""
+        tabs = st.tabs(["A", "B", "C"], default="B")
+        for tab in tabs:
+            assert tab.open is None
 
 
 class DialogTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/typing/expander_container_types.py
+++ b/lib/tests/streamlit/typing/expander_container_types.py
@@ -39,3 +39,6 @@ if TYPE_CHECKING:
     # Context manager returns Self
     with expander("Test") as ctx:
         assert_type(ctx, ExpanderContainer)
+
+    # .open property returns bool | None
+    assert_type(expander("Test").open, bool | None)

--- a/lib/tests/streamlit/typing/popover_container_types.py
+++ b/lib/tests/streamlit/typing/popover_container_types.py
@@ -39,3 +39,6 @@ if TYPE_CHECKING:
     # Context manager returns Self
     with popover("Test") as ctx:
         assert_type(ctx, PopoverContainer)
+
+    # .open property returns bool | None
+    assert_type(popover("Test").open, bool | None)

--- a/lib/tests/streamlit/typing/tab_container_types.py
+++ b/lib/tests/streamlit/typing/tab_container_types.py
@@ -47,3 +47,6 @@ if TYPE_CHECKING:
     # Context manager returns Self
     with tabs(["A", "B"])[0] as ctx:
         assert_type(ctx, TabContainer)
+
+    # .open property returns bool | None
+    assert_type(tabs(["A", "B"])[0].open, bool | None)

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -144,6 +144,8 @@ message Block {
     bool disabled = 4;
     string icon = 5;
     string type = 6;
+    // Initial open state (used with on_change).
+    optional bool open = 7;
 
     reserved 2;
   }


### PR DESCRIPTION
## Describe your changes

This feature expands the state management of Expander so that sometimes there is a delay in loading the expander content when the expander is a widget and we need to wait for the script re-run to complete. The existing handling of state and automations for expanding proved too limited to handle this case with a smooth animation. Some refactoring is added to better support the new requirements of expanders. 

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
