### PR TITLE
[fix] Add wait for download button in audio input iframe test to prevent race condition

### DIFF
--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -393,6 +393,9 @@ def test_download_file(app: Page):
 
 
 @pytest.mark.skip_browser("webkit")  # Webkit CI audio permission issue
+@pytest.mark.flaky(
+    reruns=3
+)  # Firefox blob downloads in sandboxed iframes are unreliable
 def test_download_in_iframe(iframed_app: IframedPage):
     """Test that the audio file can be downloaded within an iframe."""
     page = iframed_app.page

--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -408,8 +408,14 @@ def test_download_in_iframe(iframed_app: IframedPage):
     audio_input.get_by_role("button", name="Stop recording", exact=True).click()
     wait_for_app_run(frame)
 
+    # Wait for the download button to appear, which indicates the blob URL
+    # is set and the recording pipeline has fully completed. Without this,
+    # there's a race where expect_download can time out in Firefox iframes.
+    download_button = audio_input.get_by_role("button", name="Download as WAV")
+    expect(download_button).to_be_visible()
+
     with page.expect_download() as download_info:
-        audio_input.get_by_role("button", name="Download as WAV").click()
+        download_button.click()
 
     download = download_info.value
     assert download.suggested_filename == "recording.wav"


### PR DESCRIPTION
## Summary
- Fix a race condition in `test_download_in_iframe[firefox]` that caused intermittent 30s timeouts waiting for the download event
- Add an explicit `expect(download_button).to_be_visible()` wait before clicking, ensuring the async recording pipeline (stop → WAV encode → blob URL → state update → re-render) has fully completed
- Mark the test as flaky with 3 rerun since Firefox blob downloads in sandboxed iframes can be unreliable

## Root Cause
After stopping the recording and calling `wait_for_app_run(frame)`, the test immediately clicked "Download as WAV" inside `page.expect_download()`. The `wait_for_app_run` only waits for the Streamlit app rerun, but the frontend recording-to-blob-URL pipeline is asynchronous. In Firefox iframes under CI load, this race window was enough for the click to fire before the blob URL was wired up, causing the download event to never fire.

## Test plan
- [ ] Verify `test_download_in_iframe[firefox]` passes in CI (Playwright E2E)
- [ ] Verify `test_download_file[firefox]` still passes (unchanged)