### PR TITLE
[fix] Mark audio recording test as flaky with reruns for Firefox

### DIFF
--- a/e2e_playwright/st_audio_input_test.py
+++ b/e2e_playwright/st_audio_input_test.py
@@ -250,6 +250,7 @@ def test_help_tooltip(app: Page):
 
 
 @pytest.mark.skip_browser("webkit")  # Webkit CI audio permission issue
+@pytest.mark.flaky(reruns=3)  # Firefox occasionally crashes during media API usage
 def test_recording_lifecycle(app: Page):
     """Test complete recording lifecycle: record, stop, clear, re-record."""
     grant_microphone_permissions(app)


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.flaky(reruns=3)` to `test_recording_lifecycle` to handle intermittent Firefox browser crashes during media API usage
- Firefox occasionally crashes mid-test with `TargetClosedError` when using the MediaRecorder API in CI
- The `ResilientBrowser` wrapper relaunches Firefox for subsequent tests, but the crashing test itself needs a rerun to pass

## Context
The error is:
```
playwright._impl._errors.TargetClosedError: Locator.wait_for: Target page, context or browser has been closed
```
This is a browser-level crash, not a test logic issue — the test passes consistently on rerun. This matches the pattern used for `st_pydeck_chart_select_test.py` tests that also use `@pytest.mark.flaky(reruns=N)`.

## Stack
- #13869 - Fix flaky test_download_in_iframe[firefox] (race condition)
- #13870 - This PR (Firefox crash retry)

## Test plan
- [ ] Verify test_recording_lifecycle[firefox] passes in CI (with rerun on crash)
- [ ] Verify no other tests are affected