### PR TITLE
Fix dialog callback toasts by resetting callback DG state

### DIFF
--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, cast
 
+from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
 from streamlit.proto.Toast_pb2 import Toast as ToastProto
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.string_util import clean_text, validate_icon_or_emoji
 
@@ -32,6 +34,15 @@ def validate_text(toast_text: SupportsStr) -> SupportsStr:
             "Toast body cannot be blank - please provide a message."
         )
     return toast_text
+
+
+def _get_toast_dg(dg: "DeltaGenerator") -> "DeltaGenerator":
+    """Route toast elements to the event layer when possible."""
+    if dg._root_container is None:
+        return dg
+    if dg._root_container == RootContainer.SIDEBAR:
+        return dg
+    return get_dg_singleton_instance().event_dg
 
 
 class ToastMixin:
@@ -167,7 +178,8 @@ class ToastMixin:
                 "duration", ["short", "long", "infinite", "a positive integer"]
             )
 
-        return self.dg._enqueue("toast", toast_proto)
+        toast_dg = _get_toast_dg(self.dg)
+        return toast_dg._enqueue("toast", toast_proto)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -25,9 +25,11 @@ from typing import (
     TypeAlias,
 )
 
-from streamlit.errors import (
-    NoSessionContext,
+from streamlit.delta_generator_singletons import (
+    context_dg_stack,
+    get_default_dg_stack_value,
 )
+from streamlit.errors import NoSessionContext
 from streamlit.logger import get_logger
 from streamlit.runtime.forward_msg_cache import (
     create_reference_msg,
@@ -179,6 +181,17 @@ class ScriptRunContext:
 
     def on_script_start(self) -> None:
         self._has_script_started = True
+
+    def reset_dg_stack_for_callback(self) -> None:
+        """Reset cursors and the DG stack before running a widget callback.
+
+        Callbacks execute before a script or fragment rerun, so the current
+        cursor and dg stack can still point at a locked element from a previous
+        run. Resetting these ensures elements emitted in callbacks are written
+        to a valid container and avoids invalid delta paths.
+        """
+        self.cursors.clear()
+        context_dg_stack.set(get_default_dg_stack_value())
 
     def enqueue(self, msg: ForwardMsg) -> None:
         """Enqueue a ForwardMsg for this context's session."""

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -282,12 +282,20 @@ class WStates(MutableMapping[str, Any]):
         kwargs = metadata.callback_kwargs or {}
 
         ctx = get_script_run_ctx()
+        _reset_callback_context(ctx)
         if ctx and metadata.fragment_id is not None:
             ctx.in_fragment_callback = True
             callback(*args, **kwargs)
             ctx.in_fragment_callback = False
         else:
             callback(*args, **kwargs)
+
+
+def _reset_callback_context(ctx: ScriptRunContext | None) -> None:
+    """Normalize cursors and DG stack before widget callbacks run."""
+    if ctx is None:
+        return
+    ctx.reset_dg_stack_for_callback()
 
 
 def _missing_key_error_message(key: str) -> str:
@@ -658,6 +666,7 @@ class SessionState:
         from streamlit.runtime.scriptrunner import RerunException
 
         ctx = get_script_run_ctx()
+        _reset_callback_context(ctx)
         if ctx and cb_metadata.fragment_id is not None:
             ctx.in_fragment_callback = True
             try:

--- a/lib/tests/streamlit/toast_test.py
+++ b/lib/tests/streamlit/toast_test.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -35,6 +36,8 @@ class ToastTest(DeltaGeneratorTestCase):
         assert c.body == "toast text"
         assert c.icon == ""
         assert c.duration == 4.0
+        msg = self.get_message_from_queue()
+        assert msg.metadata.delta_path[0] == RootContainer.EVENT
 
     def test_no_text(self):
         """Test that an error is raised if no text is provided."""
@@ -50,6 +53,15 @@ class ToastTest(DeltaGeneratorTestCase):
         assert c.body == "toast text"
         assert c.icon == "🦄"
         assert c.duration == 4.0
+        msg = self.get_message_from_queue()
+        assert msg.metadata.delta_path[0] == RootContainer.EVENT
+
+    def test_sidebar_toast_uses_sidebar_container(self):
+        """Ensure sidebar toast preserves sidebar routing for errors."""
+        st.sidebar.toast("toast text")
+
+        msg = self.get_message_from_queue()
+        assert msg.metadata.delta_path[0] == RootContainer.SIDEBAR
 
     def test_invalid_icon(self):
         """Test that an error is raised if an invalid icon is provided."""


### PR DESCRIPTION
## Describe your changes
- Reset cursors and DG stack before widget callbacks to avoid invalid delta paths when elements are emitted from callbacks.
- Route st.toast output to the event container by default (preserve sidebar behavior) and add tests for container routing.
## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)
issue: https://github.com/streamlit/streamlit/issues/11367
## Testing Plan

- Explanation of why no additional tests are needed: Existing unit tests cover the routing changes; no UI changes requiring screenshots.
- Unit Tests (JS and/or Python) : Not run (not requested).
- E2E Tests: Not run (not requested).
- Any manual testing needed? : Not run (not requested).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
