### PR TITLE
[chore] Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,60 @@
+###############################################################################
+# Streamlit git attributes
+#
+# Goals:
+# - Reduce diff noise by normalizing text line endings
+# - Avoid treating binary files as text
+# - Mark generated/vendored files so GitHub Linguist excludes them from language
+#   stats and (often) from diffs/search emphasis
+###############################################################################
+
+# Normalize line endings across platforms.
+# This matches our `.editorconfig` (end_of_line = lf).
+* text=auto eol=lf
+
+###############################################################################
+# Binary files (prevent text conversions / diffs)
+###############################################################################
+
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.pdf   binary
+*.zip   binary
+*.gz    binary
+*.tgz   binary
+*.bz2   binary
+*.xz    binary
+*.7z    binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary
+*.mp3   binary
+*.mp4   binary
+*.webm  binary
+*.wav   binary
+
+###############################################################################
+# Generated files (GitHub Linguist)
+###############################################################################
+
+# Generated lookup tables
+lib/streamlit/emojis.py linguist-generated=true
+lib/streamlit/material_icon_names.py linguist-generated=true
+
+# Lockfiles (treat as generated/noise for language stats)
+frontend/yarn.lock linguist-generated=true
+component-lib/yarn.lock linguist-generated=true
+
+# NOTE: Keeping E2E snapshots marked as not generated so that GitHub reviews
+# don't auto-collapse them.
+
+###############################################################################
+# Vendored code (GitHub Linguist)
+###############################################################################
+
+lib/streamlit/vendor/** linguist-vendored=true

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -57,7 +57,7 @@ IGNORE_PATTERN = re.compile(
     r"|py\.typed$"
     # Exclude dev-tools configuration files, because they don't have any
     # degree of creativity.
-    r"|^(\.dockerignore|\.editorconfig|\.gitignore|\.gitmodules)$"
+    r"|^(\.dockerignore|\.editorconfig|\.gitattributes|\.gitignore|\.gitmodules)$"
     r"|^frontend/(\.dockerignore|\.eslintrc.js|\.prettierignore)$"
     r"|^frontend/\.yarn"  # Exclude everything in the .yarn folder
     r"|^component-lib/\.yarn"
@@ -66,7 +66,8 @@ IGNORE_PATTERN = re.compile(
     r"|^.*-requirements\.txt$"
     r"|min-constraints-gen\.txt"
     r"|\.isort\.cfg$"
-    # Exclude all .gitignore files
+    # Exclude all .gitattributes / .gitignore files
+    r"|\.gitattributes$"
     r"|\.gitignore$"
     # Excluding test files, because adding headers may cause tests to fail.
     r"|/(fixtures|__snapshots__|test_data|data|test)/"


### PR DESCRIPTION
## Describe your changes

Added a `.gitattributes` file to:
- Normalize line endings across platforms to LF
- Properly identify binary files to prevent text conversions
- Mark generated files (lookup tables, lockfiles) for GitHub Linguist and GitHub PRs
- Mark vendored code in `lib/streamlit/vendor/`

## Testing Plan

- No additional tests needed as this is a repository configuration change that doesn't affect runtime behavior.
- The changes have been verified locally to ensure proper file classification.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.