### PR TITLE
`MainMenu` accessibility improvements

### DIFF
--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -247,6 +247,10 @@ def test_keyboard_activates_menu_item(app: Page):
     expect(popover).not_to_be_visible()
 
 
+# WebKit (Safari) does not allow programmatic .focus() on buttons outside a
+# user-activation context. Our focus-return fires from a setTimeout callback,
+# which Chromium/Firefox accept but WebKit silently ignores.
+@pytest.mark.skip_browser("webkit")
 def test_focus_returns_to_menu_button_after_close(app: Page):
     """Test that focus returns to the menu button after the popover closes."""
     menu_button = app.get_by_test_id("stMainMenuButton")

--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -181,7 +181,7 @@ def test_menu_button_has_aria_attributes(app: Page):
     expect(menu_button).to_have_attribute("aria-expanded", "true")
 
 
-def test_menu_has_correct_roles(app: Page):
+def test_menu_has_correct_roles(app: Page, browser_name: str):
     """Test that the menu container and items have correct ARIA roles."""
     app.get_by_test_id("stMainMenuButton").click()
 
@@ -189,9 +189,14 @@ def test_menu_has_correct_roles(app: Page):
     expect(menu_list).to_have_attribute("role", "menu")
     expect(menu_list).to_have_attribute("aria-label", "Main menu")
 
-    # All menu items should have role="menuitem"
-    menu_items = app.get_by_role("menuitem")
-    expect(menu_items).to_have_count(6)
+    # Every expected menu item should be present with role="menuitem".
+    expected_labels = ["Rerun", "Settings", "Print", "Clear cache", "About"]
+    # "Record screen" requires the MediaRecorder API, which WebKit lacks.
+    if browser_name != "webkit":
+        expected_labels.append("Record screen")
+
+    for label in expected_labels:
+        expect(app.get_by_role("menuitem", name=label)).to_be_attached()
 
     # Dividers should have role="separator"
     dividers = app.get_by_test_id("stMainMenuDivider")

--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -167,42 +167,6 @@ def test_renders_clear_cache_dialog_properly(
     assert_snapshot(dialog.get_by_role("dialog"), name="clear_cache_dialog")
 
 
-def test_menu_button_has_aria_attributes(app: Page):
-    """Test that the menu button has correct ARIA attributes before and after opening."""
-    menu_button = app.get_by_test_id("stMainMenuButton")
-
-    expect(menu_button).to_have_attribute("aria-label", "Main menu")
-    expect(menu_button).to_have_attribute("aria-haspopup", "menu")
-    expect(menu_button).to_have_attribute("aria-expanded", "false")
-
-    # Open the menu
-    menu_button.click()
-    expect(app.get_by_test_id("stMainMenuPopover")).to_be_visible()
-    expect(menu_button).to_have_attribute("aria-expanded", "true")
-
-
-def test_menu_has_correct_roles(app: Page, browser_name: str):
-    """Test that the menu container and items have correct ARIA roles."""
-    app.get_by_test_id("stMainMenuButton").click()
-
-    menu_list = app.get_by_test_id("stMainMenuList")
-    expect(menu_list).to_have_attribute("role", "menu")
-    expect(menu_list).to_have_attribute("aria-label", "Main menu")
-
-    # Every expected menu item should be present with role="menuitem".
-    expected_labels = ["Rerun", "Settings", "Print", "Clear cache", "About"]
-    # "Record screen" requires the MediaRecorder API, which WebKit lacks.
-    if browser_name != "webkit":
-        expected_labels.append("Record screen")
-
-    for label in expected_labels:
-        expect(app.get_by_role("menuitem", name=label)).to_be_attached()
-
-    # Dividers should have role="separator"
-    dividers = app.get_by_test_id("stMainMenuDivider")
-    expect(dividers.first).to_have_attribute("role", "separator")
-
-
 def test_keyboard_opens_menu_and_navigates(app: Page):
     """Test full keyboard flow: open with Enter, navigate with arrows, close with Escape."""
     menu_button = app.get_by_test_id("stMainMenuButton")
@@ -251,8 +215,9 @@ def test_keyboard_activates_menu_item(app: Page):
 
 
 # WebKit (Safari) does not allow programmatic .focus() on buttons outside a
-# user-activation context. Our focus-return fires from a setTimeout callback,
-# which Chromium/Firefox accept but WebKit silently ignores.
+# user-activation context. Our focus-return fires from react-focus-lock's
+# returnFocus callback (after BaseWeb's close animation timer), which
+# Chromium/Firefox accept but WebKit silently ignores.
 @pytest.mark.skip_browser("webkit")
 def test_focus_returns_to_menu_button_after_close(app: Page):
     """Test that focus returns to the menu button after the popover closes."""

--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -167,6 +167,113 @@ def test_renders_clear_cache_dialog_properly(
     assert_snapshot(dialog.get_by_role("dialog"), name="clear_cache_dialog")
 
 
+def test_menu_button_has_aria_attributes(app: Page):
+    """Test that the menu button has correct ARIA attributes before and after opening."""
+    menu_button = app.get_by_test_id("stMainMenuButton")
+
+    expect(menu_button).to_have_attribute("aria-label", "Main menu")
+    expect(menu_button).to_have_attribute("aria-haspopup", "menu")
+    expect(menu_button).to_have_attribute("aria-expanded", "false")
+
+    # Open the menu
+    menu_button.click()
+    expect(app.get_by_test_id("stMainMenuPopover")).to_be_visible()
+    expect(menu_button).to_have_attribute("aria-expanded", "true")
+
+
+def test_menu_has_correct_roles(app: Page):
+    """Test that the menu container and items have correct ARIA roles."""
+    app.get_by_test_id("stMainMenu").click()
+
+    menu_list = app.get_by_test_id("stMainMenuList")
+    expect(menu_list).to_have_attribute("role", "menu")
+    expect(menu_list).to_have_attribute("aria-label", "Main menu")
+
+    # All menu items should have role="menuitem"
+    menu_items = app.get_by_role("menuitem")
+    expect(menu_items.first).to_be_visible()
+    count = menu_items.count()
+    assert count > 0, "Expected at least one menuitem"
+
+    # Dividers should have role="separator"
+    dividers = app.get_by_test_id("stMainMenuDivider")
+    expect(dividers.first).to_have_attribute("role", "separator")
+
+
+def test_keyboard_opens_menu_and_navigates(app: Page):
+    """Test full keyboard flow: open with Enter, navigate with arrows, close with Escape."""
+    menu_button = app.get_by_test_id("stMainMenuButton")
+    menu_button.focus()
+
+    # Open menu with Enter
+    app.keyboard.press("Enter")
+    popover = app.get_by_test_id("stMainMenuPopover")
+    expect(popover).to_be_visible()
+
+    # First enabled item should be focused
+    first_item = app.get_by_test_id("stMainMenuItem-Rerun")
+    expect(first_item).to_be_focused()
+
+    # Arrow down moves focus to next item
+    app.keyboard.press("ArrowDown")
+    second_item = app.get_by_test_id("stMainMenuItem-Settings")
+    expect(second_item).to_be_focused()
+
+    # Arrow up moves focus back
+    app.keyboard.press("ArrowUp")
+    expect(first_item).to_be_focused()
+
+    # Escape closes the menu
+    app.keyboard.press("Escape")
+    expect(popover).not_to_be_visible()
+
+
+def test_keyboard_activates_menu_item(app: Page):
+    """Test that Enter activates a focused menu item."""
+    app.get_by_test_id("stMainMenuButton").focus()
+    app.keyboard.press("Enter")
+
+    popover = app.get_by_test_id("stMainMenuPopover")
+    expect(popover).to_be_visible()
+
+    # Navigate to Settings and activate with Enter
+    app.keyboard.press("ArrowDown")
+    expect(app.get_by_test_id("stMainMenuItem-Settings")).to_be_focused()
+    app.keyboard.press("Enter")
+
+    # Settings dialog should open, menu should close
+    dialog = app.get_by_test_id("stDialog")
+    expect(dialog).to_be_visible()
+    expect(popover).not_to_be_visible()
+
+
+def test_focus_returns_to_menu_button_after_close(app: Page):
+    """Test that focus returns to the menu button after the popover closes."""
+    menu_button = app.get_by_test_id("stMainMenuButton")
+    menu_button.focus()
+
+    # Open and close via Escape
+    app.keyboard.press("Enter")
+    expect(app.get_by_test_id("stMainMenuPopover")).to_be_visible()
+    app.keyboard.press("Escape")
+    expect(app.get_by_test_id("stMainMenuPopover")).not_to_be_visible()
+
+    # Focus should return to the menu button
+    expect(menu_button).to_be_focused()
+
+
+def test_tab_closes_menu(app: Page):
+    """Test that pressing Tab inside the menu closes it."""
+    app.get_by_test_id("stMainMenuButton").focus()
+    app.keyboard.press("Enter")
+
+    popover = app.get_by_test_id("stMainMenuPopover")
+    expect(popover).to_be_visible()
+
+    app.keyboard.press("Tab")
+    expect(popover).not_to_be_visible()
+
+
 def test_cached_preference_persists_on_reload(app: Page):
     """Test that the cached preference persists across full page reload."""
     # Set the browser preference to light to ensure user preference overrides system preference

--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -183,7 +183,7 @@ def test_menu_button_has_aria_attributes(app: Page):
 
 def test_menu_has_correct_roles(app: Page):
     """Test that the menu container and items have correct ARIA roles."""
-    app.get_by_test_id("stMainMenu").click()
+    app.get_by_test_id("stMainMenuButton").click()
 
     menu_list = app.get_by_test_id("stMainMenuList")
     expect(menu_list).to_have_attribute("role", "menu")
@@ -191,9 +191,7 @@ def test_menu_has_correct_roles(app: Page):
 
     # All menu items should have role="menuitem"
     menu_items = app.get_by_role("menuitem")
-    expect(menu_items.first).to_be_visible()
-    count = menu_items.count()
-    assert count > 0, "Expected at least one menuitem"
+    expect(menu_items).to_have_count(6)
 
     # Dividers should have role="separator"
     dividers = app.get_by_test_id("stMainMenuDivider")
@@ -267,8 +265,13 @@ def test_focus_returns_to_menu_button_after_close(app: Page):
 
 
 def test_tab_closes_menu(app: Page):
-    """Test that pressing Tab inside the menu closes it."""
-    app.get_by_test_id("stMainMenuButton").focus()
+    """Test that pressing Tab inside the menu closes it without returning focus to trigger.
+
+    Per WAI-ARIA menu-button pattern, Tab/Shift+Tab should close the menu and
+    allow focus to advance rather than snapping back to the trigger button.
+    """
+    menu_button = app.get_by_test_id("stMainMenuButton")
+    menu_button.focus()
     app.keyboard.press("Enter")
 
     popover = app.get_by_test_id("stMainMenuPopover")
@@ -276,6 +279,9 @@ def test_tab_closes_menu(app: Page):
 
     app.keyboard.press("Tab")
     expect(popover).not_to_be_visible()
+
+    # Focus should NOT return to the menu button (Tab lets focus advance)
+    expect(menu_button).not_to_be_focused()
 
 
 def test_cached_preference_persists_on_reload(app: Page):

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1991,10 +1991,8 @@ export class App extends PureComponent<Props, State> {
       const newDialog: DialogProps = {
         type: DialogType.CLEAR_CACHE,
         confirmCallback: this.clearCache,
-        defaultAction: this.clearCache,
         onClose: () => {},
       }
-      // This will be called if enter is pressed.
       this.openDialog(newDialog)
     } else {
       LOG.error("Cannot clear cache: disconnected from server")

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { MetricsManager } from "@streamlit/app/src/MetricsManager"
@@ -86,6 +86,302 @@ describe("MainMenu", () => {
       expect(screen.getByTestId("stMainMenuPopover")).toBeVisible()
     }
   )
+
+  it("moves focus with arrow keys", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const menuItems = screen.getAllByRole("menuitem")
+
+    expect(menuItems[0]).toHaveFocus()
+
+    await user.keyboard("{ArrowDown}")
+    expect(menuItems[1]).toHaveFocus()
+
+    await user.keyboard("{ArrowUp}")
+    expect(menuItems[0]).toHaveFocus()
+  })
+
+  it("moves focus to first and last items with Home/End", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const menuItems = screen.getAllByRole("menuitem")
+
+    await user.keyboard("{End}")
+    expect(menuItems[menuItems.length - 1]).toHaveFocus()
+
+    await user.keyboard("{Home}")
+    expect(menuItems[0]).toHaveFocus()
+  })
+
+  it("wraps focus when navigating past the ends", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const menuItems = screen.getAllByRole("menuitem")
+
+    await user.keyboard("{End}")
+    expect(menuItems[menuItems.length - 1]).toHaveFocus()
+
+    await user.keyboard("{ArrowDown}")
+    expect(menuItems[0]).toHaveFocus()
+
+    await user.keyboard("{ArrowUp}")
+    expect(menuItems[menuItems.length - 1]).toHaveFocus()
+  })
+
+  it("skips disabled items when moving focus", async () => {
+    const props = getProps({
+      isServerConnected: false,
+      developmentMode: true,
+    })
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+    const printItem = screen.getByTestId("stMainMenuItem-Print")
+
+    expect(settingsItem).toHaveFocus()
+
+    await user.keyboard("{ArrowDown}")
+    expect(printItem).toHaveFocus()
+  })
+
+  it("focuses first enabled item when leading items are disabled", async () => {
+    const props = getProps({
+      isServerConnected: false,
+      developmentMode: true,
+    })
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    // Rerun and Clear cache are disabled when disconnected.
+    // First focusable item should be Settings.
+    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+    expect(settingsItem).toHaveFocus()
+  })
+
+  it("skips multiple consecutive disabled items when navigating", async () => {
+    // Both Rerun and Clear cache are disabled when disconnected
+    const props = getProps({
+      isServerConnected: false,
+      developmentMode: true,
+    })
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+    const printItem = screen.getByTestId("stMainMenuItem-Print")
+
+    // Focus starts on Settings (first enabled item)
+    expect(settingsItem).toHaveFocus()
+
+    // ArrowDown should skip disabled Clear cache and land on Print
+    await user.keyboard("{ArrowDown}")
+    expect(printItem).toHaveFocus()
+
+    // ArrowUp should skip disabled Clear cache and land back on Settings
+    await user.keyboard("{ArrowUp}")
+    expect(settingsItem).toHaveFocus()
+  })
+
+  it("activates a focused menu item with Enter", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    // Navigate to Settings (second item)
+    await user.keyboard("{ArrowDown}")
+    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+    expect(settingsItem).toHaveFocus()
+
+    // Press Enter to activate
+    await user.keyboard("{Enter}")
+    expect(props.settingsCallback).toHaveBeenCalled()
+  })
+
+  it("activates a focused menu item with Space", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    // Navigate to Settings (second item)
+    await user.keyboard("{ArrowDown}")
+    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+    expect(settingsItem).toHaveFocus()
+
+    // Press Space to activate
+    await user.keyboard(" ")
+    expect(props.settingsCallback).toHaveBeenCalled()
+  })
+
+  it("closes the menu when Escape is pressed inside menu content", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    // Press Escape while focus is inside the menu
+    await user.keyboard("{Escape}")
+    // Flush React state updates and BaseWeb's animateOut timers
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+  })
+
+  it("closes the menu when Tab is pressed inside menu content", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    await user.keyboard("{Tab}")
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+  })
+
+  it("closes the menu when Shift+Tab is pressed inside menu content", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    await user.keyboard("{Shift>}{Tab}{/Shift}")
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+  })
+
+  it("returns focus to menu button after popover closes", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    await openMenu()
+
+    // Click a menu item to close the popover (triggers onClose → handlePopoverClose)
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    await user.click(screen.getByTestId("stMainMenuItem-Settings"))
+
+    // Flush BaseWeb's animateOut cycle (20ms + 0ms animateOutComplete),
+    // then our 30ms focus-return timer, within separate act() calls so
+    // React can commit state between timer phases.
+    act(() => {
+      vi.advanceTimersByTime(25)
+    })
+    act(() => {
+      vi.advanceTimersByTime(25)
+    })
+
+    // Get a fresh reference since DOM may have been recreated during re-renders
+    expect(screen.getByTestId("stMainMenuButton")).toHaveFocus()
+  })
+
+  it("applies roving tabindex: focused item has tabIndex 0, others -1", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const menuItems = screen.getAllByRole("menuitem")
+
+    // First item should be focused with tabIndex 0
+    expect(menuItems[0]).toHaveAttribute("tabindex", "0")
+
+    // All other items should have tabIndex -1
+    for (let i = 1; i < menuItems.length; i++) {
+      expect(menuItems[i]).toHaveAttribute("tabindex", "-1")
+    }
+
+    // Navigate down - tabindex should follow focus
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    await user.keyboard("{ArrowDown}")
+
+    expect(menuItems[0]).toHaveAttribute("tabindex", "-1")
+    expect(menuItems[1]).toHaveAttribute("tabindex", "0")
+  })
+
+  it("renders menu container with role='menu' and aria-label", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const menuContainer = screen.getByTestId("stMainMenuList")
+    expect(menuContainer).toHaveAttribute("role", "menu")
+    expect(menuContainer).toHaveAttribute("aria-label", "Main menu")
+  })
+
+  it("renders menu items with role='menuitem'", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const menuItems = screen.getAllByRole("menuitem")
+    expect(menuItems.length).toBeGreaterThan(0)
+    menuItems.forEach(item => {
+      expect(item).toHaveAttribute("role", "menuitem")
+    })
+  })
+
+  it("renders disabled items with aria-disabled", async () => {
+    const props = getProps({
+      isServerConnected: false,
+      developmentMode: true,
+    })
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const rerunItem = screen.getByTestId("stMainMenuItem-Rerun")
+    const clearCacheItem = screen.getByTestId("stMainMenuItem-Clearcache")
+    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+
+    expect(rerunItem).toHaveAttribute("aria-disabled", "true")
+    expect(clearCacheItem).toHaveAttribute("aria-disabled", "true")
+    // Settings is not disabled and should not have aria-disabled=true
+    expect(settingsItem).not.toHaveAttribute("aria-disabled", "true")
+  })
+
+  it("renders dividers with role='separator'", async () => {
+    const props = getProps({ developmentMode: true })
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const dividers = screen.getAllByTestId("stMainMenuDivider")
+    expect(dividers.length).toBeGreaterThan(0)
+    dividers.forEach(divider => {
+      expect(divider).toHaveAttribute("role", "separator")
+      expect(divider).toHaveAttribute("aria-hidden", "true")
+    })
+  })
+
+  it("menu button has accessible aria-label", () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    const menuButton = screen.getByTestId("stMainMenuButton")
+    expect(menuButton).toHaveAttribute("aria-label", "Main menu")
+  })
 
   it("should render host menu items", async () => {
     const items: IMenuItem[] = [
@@ -634,12 +930,4 @@ describe("MainMenu", () => {
       screen.queryByTestId("stMainMenuRecordingIndicator")
     ).not.toBeInTheDocument()
   })
-
-  // Note: ARIA menu attributes (aria-haspopup, aria-expanded, role="menu", role="menuitem")
-  // will be added in the dedicated accessibility PR along with keyboard navigation.
-
-  // Note: Escape key closing behavior is provided by BaseWeb's StatefulPopover but
-  // cannot be reliably tested in JSDOM. Unlike StatefulTooltip (used by Tooltip),
-  // StatefulPopover uses react-focus-lock which captures keyboard events in ways
-  // that don't translate well to JSDOM's synthetic event handling.
 })

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -409,6 +409,34 @@ describe("MainMenu", () => {
     expect(menuButton).toHaveAttribute("aria-expanded", "true")
   })
 
+  it("menu button aria-expanded returns to 'false' after menu closes", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    await openMenu()
+    expect(screen.getByTestId("stMainMenuButton")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    )
+
+    // Close the menu by clicking a menu item
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    await user.click(screen.getByTestId("stMainMenuItem-Settings"))
+
+    // Flush BaseWeb's animateOut and our focus-return timer
+    act(() => {
+      vi.advanceTimersByTime(25)
+    })
+    act(() => {
+      vi.advanceTimersByTime(25)
+    })
+
+    expect(screen.getByTestId("stMainMenuButton")).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    )
+  })
+
   it("should render host menu items", async () => {
     const items: IMenuItem[] = [
       { type: "separator" },

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -285,14 +285,14 @@ describe("MainMenu", () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     await user.click(screen.getByTestId("stMainMenuItem-Settings"))
 
-    // Flush BaseWeb's animateOut cycle (20ms + 0ms animateOutComplete),
-    // then our 30ms focus-return timer, within separate act() calls so
+    // Flush BaseWeb's animateOut cycle (20ms + 0ms animateOutComplete)
+    // and our 50ms focus-return timer, within separate act() calls so
     // React can commit state between timer phases.
     act(() => {
-      vi.advanceTimersByTime(25)
+      vi.advanceTimersByTime(30)
     })
     act(() => {
-      vi.advanceTimersByTime(25)
+      vi.advanceTimersByTime(30)
     })
 
     // Get a fresh reference since DOM may have been recreated during re-renders
@@ -332,16 +332,14 @@ describe("MainMenu", () => {
     expect(menuContainer).toHaveAttribute("aria-label", "Main menu")
   })
 
-  it("renders menu items with role='menuitem'", async () => {
+  it("renders all visible items with role='menuitem'", async () => {
     const props = getProps()
     render(<MainMenu {...props} />)
     await openMenu()
 
     const menuItems = screen.getAllByRole("menuitem")
-    expect(menuItems.length).toBeGreaterThan(0)
-    menuItems.forEach(item => {
-      expect(item).toHaveAttribute("role", "menuitem")
-    })
+    // developmentMode: true gives Rerun, Settings, Clear cache, Print, Record screen
+    expect(menuItems).toHaveLength(5)
   })
 
   it("renders disabled items with aria-disabled", async () => {
@@ -423,12 +421,12 @@ describe("MainMenu", () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     await user.click(screen.getByTestId("stMainMenuItem-Settings"))
 
-    // Flush BaseWeb's animateOut and our focus-return timer
+    // Flush BaseWeb's animateOut and our 50ms focus-return timer
     act(() => {
-      vi.advanceTimersByTime(25)
+      vi.advanceTimersByTime(30)
     })
     act(() => {
-      vi.advanceTimersByTime(25)
+      vi.advanceTimersByTime(30)
     })
 
     expect(screen.getByTestId("stMainMenuButton")).toHaveAttribute(

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -383,6 +383,32 @@ describe("MainMenu", () => {
     expect(menuButton).toHaveAttribute("aria-label", "Main menu")
   })
 
+  it("menu button has aria-haspopup='menu'", () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    const menuButton = screen.getByTestId("stMainMenuButton")
+    expect(menuButton).toHaveAttribute("aria-haspopup", "menu")
+  })
+
+  it("menu button has aria-expanded='false' when closed", () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    const menuButton = screen.getByTestId("stMainMenuButton")
+    expect(menuButton).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("menu button has aria-expanded='true' when open", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    await openMenu()
+
+    const menuButton = screen.getByTestId("stMainMenuButton")
+    expect(menuButton).toHaveAttribute("aria-expanded", "true")
+  })
+
   it("should render host menu items", async () => {
     const items: IMenuItem[] = [
       { type: "separator" },

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -137,7 +137,9 @@ describe("MainMenu", () => {
     expect(menuItems[menuItems.length - 1]).toHaveFocus()
   })
 
-  it("skips disabled items when moving focus", async () => {
+  it("focuses disabled items when navigating (WAI-ARIA: all menuitems are focusable)", async () => {
+    // Menu order (dev mode, disconnected): Rerun*, Settings, Clear cache*, Print, ...
+    // (* = disabled when server disconnected)
     const props = getProps({
       isServerConnected: false,
       developmentMode: true,
@@ -146,16 +148,19 @@ describe("MainMenu", () => {
     await openMenu()
 
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const rerunItem = screen.getByTestId("stMainMenuItem-Rerun")
     const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
-    const printItem = screen.getByTestId("stMainMenuItem-Print")
 
-    expect(settingsItem).toHaveFocus()
+    // First item (Rerun) gets focus even though it's disabled
+    expect(rerunItem).toHaveFocus()
+    expect(rerunItem).toHaveAttribute("aria-disabled", "true")
 
+    // ArrowDown moves to Settings (next item in flat order)
     await user.keyboard("{ArrowDown}")
-    expect(printItem).toHaveFocus()
+    expect(settingsItem).toHaveFocus()
   })
 
-  it("focuses first enabled item when leading items are disabled", async () => {
+  it("focuses first item on mount even when it is disabled", async () => {
     const props = getProps({
       isServerConnected: false,
       developmentMode: true,
@@ -163,14 +168,15 @@ describe("MainMenu", () => {
     render(<MainMenu {...props} />)
     await openMenu()
 
-    // Rerun and Clear cache are disabled when disconnected.
-    // First focusable item should be Settings.
-    const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
-    expect(settingsItem).toHaveFocus()
+    // Rerun is disabled but still receives initial focus per WAI-ARIA.
+    const rerunItem = screen.getByTestId("stMainMenuItem-Rerun")
+    expect(rerunItem).toHaveFocus()
+    expect(rerunItem).toHaveAttribute("aria-disabled", "true")
   })
 
-  it("skips multiple consecutive disabled items when navigating", async () => {
-    // Both Rerun and Clear cache are disabled when disconnected
+  it("navigates through disabled items without skipping", async () => {
+    // Menu order (dev mode, disconnected): Rerun*, Settings, Clear cache*, Print, ...
+    // (* = disabled when server disconnected)
     const props = getProps({
       isServerConnected: false,
       developmentMode: true,
@@ -179,19 +185,30 @@ describe("MainMenu", () => {
     await openMenu()
 
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const rerunItem = screen.getByTestId("stMainMenuItem-Rerun")
     const settingsItem = screen.getByTestId("stMainMenuItem-Settings")
+    const clearCacheItem = screen.getByTestId("stMainMenuItem-Clearcache")
     const printItem = screen.getByTestId("stMainMenuItem-Print")
 
-    // Focus starts on Settings (first enabled item)
+    // Focus starts on Rerun (disabled)
+    expect(rerunItem).toHaveFocus()
+
+    // ArrowDown → Settings (enabled)
+    await user.keyboard("{ArrowDown}")
     expect(settingsItem).toHaveFocus()
 
-    // ArrowDown should skip disabled Clear cache and land on Print
+    // ArrowDown → Clear cache (disabled), not skipped
+    await user.keyboard("{ArrowDown}")
+    expect(clearCacheItem).toHaveFocus()
+    expect(clearCacheItem).toHaveAttribute("aria-disabled", "true")
+
+    // ArrowDown → Print (enabled)
     await user.keyboard("{ArrowDown}")
     expect(printItem).toHaveFocus()
 
-    // ArrowUp should skip disabled Clear cache and land back on Settings
+    // ArrowUp → Clear cache (disabled), not skipped
     await user.keyboard("{ArrowUp}")
-    expect(settingsItem).toHaveFocus()
+    expect(clearCacheItem).toHaveFocus()
   })
 
   it("activates a focused menu item with Enter", async () => {
@@ -798,8 +815,8 @@ describe("MainMenu", () => {
     const rerunButton = screen.getByTestId("stMainMenuItem-Rerun")
     const clearCacheButton = screen.getByTestId("stMainMenuItem-Clearcache")
 
-    expect(rerunButton).toBeDisabled()
-    expect(clearCacheButton).toBeDisabled()
+    expect(rerunButton).toHaveAttribute("aria-disabled", "true")
+    expect(clearCacheButton).toHaveAttribute("aria-disabled", "true")
   })
 
   it("should call callbacks when menu items are clicked", async () => {

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -288,14 +288,10 @@ describe("MainMenu", () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     await user.keyboard("{Escape}")
 
-    // Flush BaseWeb's animateOut cycle (20ms + 0ms animateOutComplete)
-    // and our 50ms focus-return timer, within separate act() calls so
-    // React can commit state between timer phases.
+    // Flush BaseWeb's animateOut timers so the popover unmounts and
+    // react-focus-lock invokes our returnFocus callback synchronously.
     act(() => {
-      vi.advanceTimersByTime(30)
-    })
-    act(() => {
-      vi.advanceTimersByTime(30)
+      vi.runAllTimers()
     })
 
     expect(screen.getByTestId("stMainMenuButton")).toHaveFocus()
@@ -311,14 +307,10 @@ describe("MainMenu", () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     await user.click(screen.getByTestId("stMainMenuItem-Settings"))
 
-    // Flush BaseWeb's animateOut cycle (20ms + 0ms animateOutComplete)
-    // and our 50ms focus-return timer, within separate act() calls so
-    // React can commit state between timer phases.
+    // Flush BaseWeb's animateOut timers so the popover unmounts and
+    // react-focus-lock invokes our returnFocus callback synchronously.
     act(() => {
-      vi.advanceTimersByTime(30)
-    })
-    act(() => {
-      vi.advanceTimersByTime(30)
+      vi.runAllTimers()
     })
 
     // Get a fresh reference since DOM may have been recreated during re-renders

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -357,6 +357,25 @@ describe("MainMenu", () => {
     expect(menuItems[1]).toHaveAttribute("tabindex", "0")
   })
 
+  it("syncs focusedIndex when an item receives focus directly (e.g. mouse click)", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+    await openMenu()
+
+    const menuItems = screen.getAllByRole("menuitem")
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    // Simulate mouse-driven focus by directly focusing item at index 2.
+    // The onFocus delegation handler should sync focusedIndex so the
+    // next ArrowDown starts from index 2, not from 0.
+    menuItems[2].focus()
+    expect(menuItems[2]).toHaveFocus()
+
+    await user.keyboard("{ArrowDown}")
+    expect(menuItems[3]).toHaveFocus()
+    expect(menuItems[3]).toHaveAttribute("tabindex", "0")
+  })
+
   it("renders menu container with role='menu' and aria-label", async () => {
     const props = getProps()
     render(<MainMenu {...props} />)

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -245,7 +245,7 @@ describe("MainMenu", () => {
     expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
   })
 
-  it("closes the menu when Tab is pressed inside menu content", async () => {
+  it("closes the menu when Tab is pressed without returning focus to trigger", async () => {
     const props = getProps()
     render(<MainMenu {...props} />)
     await openMenu()
@@ -258,9 +258,11 @@ describe("MainMenu", () => {
     })
 
     expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+    // Per WAI-ARIA, Tab should let focus advance — not force it back to trigger
+    expect(screen.getByTestId("stMainMenuButton")).not.toHaveFocus()
   })
 
-  it("closes the menu when Shift+Tab is pressed inside menu content", async () => {
+  it("closes the menu when Shift+Tab is pressed without returning focus to trigger", async () => {
     const props = getProps()
     render(<MainMenu {...props} />)
     await openMenu()
@@ -273,9 +275,33 @@ describe("MainMenu", () => {
     })
 
     expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+    // Per WAI-ARIA, Shift+Tab should let focus move back — not force it to trigger
+    expect(screen.getByTestId("stMainMenuButton")).not.toHaveFocus()
   })
 
-  it("returns focus to menu button after popover closes", async () => {
+  it("returns focus to menu button after Escape closes menu", async () => {
+    const props = getProps()
+    render(<MainMenu {...props} />)
+
+    await openMenu()
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    await user.keyboard("{Escape}")
+
+    // Flush BaseWeb's animateOut cycle (20ms + 0ms animateOutComplete)
+    // and our 50ms focus-return timer, within separate act() calls so
+    // React can commit state between timer phases.
+    act(() => {
+      vi.advanceTimersByTime(30)
+    })
+    act(() => {
+      vi.advanceTimersByTime(30)
+    })
+
+    expect(screen.getByTestId("stMainMenuButton")).toHaveFocus()
+  })
+
+  it("returns focus to menu button after item click closes menu", async () => {
     const props = getProps()
     render(<MainMenu {...props} />)
 

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { MetricsManager } from "@streamlit/app/src/MetricsManager"
 import ScreenCastRecorder from "@streamlit/app/src/util/ScreenCastRecorder"
@@ -66,6 +67,25 @@ describe("MainMenu", () => {
 
     expect(screen.getByTestId("stMainMenu")).toBeInTheDocument()
   })
+
+  // userEvent only emits modern key values; legacy Spacebar variants are handled
+  // in production but not emitted by userEvent in tests.
+  it.each([["{Enter}"], ["{Space}"]])(
+    "opens the menu with keyboard (%s)",
+    async key => {
+      const props = getProps()
+      render(<MainMenu {...props} />)
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      const menuButton = screen.getByTestId("stMainMenuButton")
+      menuButton.focus()
+
+      await user.keyboard(key)
+      vi.runOnlyPendingTimers()
+
+      expect(screen.getByTestId("stMainMenuPopover")).toBeVisible()
+    }
+  )
 
   it("should render host menu items", async () => {
     const items: IMenuItem[] = [

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -26,7 +26,7 @@ import {
 } from "react"
 
 import { MoreVert } from "@emotion-icons/material-rounded"
-import { PLACEMENT, StatefulPopover } from "baseui/popover"
+import { ACCESSIBILITY_TYPE, PLACEMENT, StatefulPopover } from "baseui/popover"
 import { getLogger } from "loglevel"
 
 import type { Steps } from "@streamlit/app/src/hocs/withScreencast/withScreencast"
@@ -616,12 +616,20 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     ]
   )
 
+  // Track popover open state for aria-expanded on the menu button.
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const handlePopoverOpen = useCallback((): void => {
+    setIsMenuOpen(true)
+  }, [])
+
   // Manually return focus to the menu button when the popover closes.
   // We bypass baseweb built-in returnFocus because its focus restoration
   // does not identify the right element.
   // The 30ms delay outlasts BaseWeb's Popover animateOut cycle (~20ms),
   // which briefly re-mounts FocusLock and would steal earlier focus.
   const handlePopoverClose = useCallback((): void => {
+    setIsMenuOpen(false)
     setTimeout(() => {
       const menuButton = document.querySelector<HTMLElement>(
         '[data-testid="stMainMenuButton"]'
@@ -653,6 +661,10 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     <StatefulPopover
       focusLock
       returnFocus={false}
+      // We handle aria-haspopup and aria-expanded on the <button> directly,
+      // so disable BaseWeb's ARIA on the wrapper div.
+      accessibilityType={ACCESSIBILITY_TYPE.none}
+      onOpen={handlePopoverOpen}
       onClose={handlePopoverClose}
       placement={PLACEMENT.bottomRight}
       content={({ close }) => (
@@ -684,6 +696,8 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
           kind={BaseButtonKind.HEADER_NO_PADDING}
           data-testid="stMainMenuButton"
           aria-label="Main menu"
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
         >
           <Icon content={MoreVert} size="lg" />
         </BaseButton>

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -359,7 +359,8 @@ interface MenuItemRowProps {
   item: MenuItemConfig
   onItemClick: (item: MenuItemConfig) => void
   tabIndex: number
-  itemRef: (element: HTMLButtonElement | null) => void
+  itemIndex: number
+  setItemRef: (index: number, element: HTMLButtonElement | null) => void
 }
 
 /**
@@ -370,17 +371,25 @@ const MenuItemRow = memo(function MenuItemRow({
   item,
   onItemClick,
   tabIndex,
-  itemRef,
+  itemIndex,
+  setItemRef,
 }: MenuItemRowProps): ReactElement {
   const handleClick = (): void => {
     if (item.disabled) return
     onItemClick(item)
   }
 
+  const handleRef = useCallback(
+    (element: HTMLButtonElement | null): void => {
+      setItemRef(itemIndex, element)
+    },
+    [setItemRef, itemIndex]
+  )
+
   return (
     <StyledMenuItemRow
       type="button"
-      ref={itemRef}
+      ref={handleRef}
       onClick={handleClick}
       disabled={item.disabled}
       role="menuitem"
@@ -453,6 +462,15 @@ function MenuContent({
       menuItemButtonsRef.current[focusedIndex]?.focus()
     }
   }, [focusedIndex])
+
+  // Stable ref setter so MenuItemRow's memo can bail out when item/tabIndex
+  // haven't changed (avoids creating a new closure per item per render).
+  const setItemRef = useCallback(
+    (index: number, element: HTMLButtonElement | null): void => {
+      menuItemButtonsRef.current[index] = element
+    },
+    []
+  )
 
   const handleItemClick = (item: MenuItemConfig): void => {
     metricsMgr.enqueue("menuClick", { label: item.label })
@@ -539,9 +557,8 @@ function MenuContent({
           item={item}
           onItemClick={handleItemClick}
           tabIndex={tabIndex}
-          itemRef={element => {
-            menuItemButtonsRef.current[currentIndex] = element
-          }}
+          itemIndex={currentIndex}
+          setItemRef={setItemRef}
         />
       )
 
@@ -622,6 +639,12 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   // Track popover open state for aria-expanded on the menu button.
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
+  // Timer ref for the delayed focus-return so we can clean up on unmount.
+  const focusReturnTimerRef = useRef<ReturnType<typeof setTimeout>>()
+  useEffect(() => {
+    return () => clearTimeout(focusReturnTimerRef.current)
+  }, [])
+
   const handlePopoverOpen = useCallback((): void => {
     setIsMenuOpen(true)
   }, [])
@@ -629,17 +652,17 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   // Manually return focus to the menu button when the popover closes.
   // We bypass BaseWeb's returnFocus because react-focus-lock's restoration
   // algorithm picks the wrong sibling (Deploy button) due to DOM ordering.
-  // The 30ms delay outlasts BaseWeb's Popover animateOut cycle (~20ms),
-  // which briefly re-mounts FocusLock and would steal earlier focus.
-  // Note: Uses a DOM query because BaseButton does not support forwardRef.
+  // 50ms provides comfortable margin to outlast BaseWeb's close sequence.
+  //
+  // Note: Uses a global DOM query because BaseWeb's StatefulPopover
+  // overwrites refs on its direct child via cloneElement.
   const handlePopoverClose = useCallback((): void => {
     setIsMenuOpen(false)
-    setTimeout(() => {
-      const menuButton = document.querySelector<HTMLElement>(
-        '[data-testid="stMainMenuButton"]'
-      )
-      menuButton?.focus()
-    }, 30)
+    focusReturnTimerRef.current = setTimeout(() => {
+      document
+        .querySelector<HTMLElement>('[data-testid="stMainMenuButton"]')
+        ?.focus()
+    }, 50)
   }, [])
 
   const handleMenuButtonKeyDown = useCallback(

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -391,9 +391,8 @@ const MenuItemRow = memo(function MenuItemRow({
       type="button"
       ref={handleRef}
       onClick={handleClick}
-      disabled={item.disabled}
       role="menuitem"
-      aria-disabled={item.disabled}
+      aria-disabled={item.disabled || undefined}
       tabIndex={tabIndex}
       isRecording={item.isRecording}
       data-testid={`stMainMenuItem-${item.label.replace(/\s+/g, "")}`}
@@ -436,50 +435,39 @@ function MenuContent({
   // Store button refs so roving tabindex can move focus without DOM queries.
   const menuItemButtonsRef = useRef<Array<HTMLButtonElement | null>>([])
   // Flatten sections to preserve visual grouping but allow linear navigation.
+  // All items are focusable, including disabled ones (WAI-ARIA: every menuitem
+  // in a menu is focusable, whether or not it is disabled).
   const flatItems = useMemo(
     () => sections.flatMap(section => section),
     [sections]
   )
-  // Track indices of focusable items (skip disabled, separators are not in sections).
-  const focusableIndices = useMemo(
-    () =>
-      flatItems
-        .map((item, index) => (item.disabled ? null : index))
-        .filter((index): index is number => index !== null),
-    [flatItems]
-  )
-  // Store position within focusableIndices to support roving tabIndex.
-  const [focusedPosition, setFocusedPosition] = useState(0)
-  const lastFocusablePosition = Math.max(0, focusableIndices.length - 1)
-  const clampedPosition =
-    focusableIndices.length === 0
-      ? -1
-      : Math.min(focusedPosition, lastFocusablePosition)
-  // Map roving position -> actual flatItems index.
-  const focusedIndex =
-    focusableIndices.length === 0 ? -1 : focusableIndices[clampedPosition]
 
-  // Focus the item at a roving position and update state for tabIndex
-  // tracking.  Called directly from keyboard handlers rather than going
-  // through a state → render → effect cycle.
-  const focusAndSetPosition = (position: number): void => {
-    setFocusedPosition(position)
-    const itemIndex = focusableIndices[position]
-    if (itemIndex !== undefined) {
-      menuItemButtonsRef.current[itemIndex]?.focus()
-    }
+  // Roving tabIndex: track which item index is currently focused.
+  const [focusedIndex, setFocusedIndex] = useState(0)
+  const lastIndex = Math.max(0, flatItems.length - 1)
+  // Defensive clamp: if items shrink while the menu is open (e.g., a
+  // conditional item is removed), keep focusedIndex within bounds.
+  const clampedIndex =
+    flatItems.length === 0 ? -1 : Math.min(focusedIndex, lastIndex)
+
+  // Focus the item at a given index and update state for tabIndex tracking.
+  // Called directly from keyboard handlers rather than going through a
+  // state → render → effect cycle.
+  const focusAndSetIndex = (index: number): void => {
+    setFocusedIndex(index)
+    menuItemButtonsRef.current[index]?.focus()
   }
 
-  // Focus the first focusable item when the menu list mounts.
+  // Focus the first item when the menu list mounts.
   // Child callback refs (MenuItemRow) fire before this parent ref
   // during React's commit phase, so menuItemButtonsRef is populated.
   const menuListRef = useCallback(
     (node: HTMLDivElement | null): void => {
-      if (node && focusableIndices.length > 0) {
-        menuItemButtonsRef.current[focusableIndices[0]]?.focus()
+      if (node && flatItems.length > 0) {
+        menuItemButtonsRef.current[0]?.focus()
       }
     },
-    [focusableIndices]
+    [flatItems]
   )
 
   // Stable ref setter so MenuItemRow's memo can bail out when item/tabIndex
@@ -498,36 +486,29 @@ function MenuContent({
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
-    if (focusableIndices.length === 0) {
+    if (flatItems.length === 0) {
       return
     }
-
-    // Clamp to valid range in case items change while menu is open.
-    const currentPosition = Math.min(focusedPosition, lastFocusablePosition)
 
     switch (event.key) {
       case "ArrowDown": {
         event.preventDefault()
-        const nextPosition =
-          currentPosition >= lastFocusablePosition ? 0 : currentPosition + 1
-        focusAndSetPosition(nextPosition)
+        focusAndSetIndex(clampedIndex >= lastIndex ? 0 : clampedIndex + 1)
         break
       }
       case "ArrowUp": {
         event.preventDefault()
-        const nextPosition =
-          currentPosition <= 0 ? lastFocusablePosition : currentPosition - 1
-        focusAndSetPosition(nextPosition)
+        focusAndSetIndex(clampedIndex <= 0 ? lastIndex : clampedIndex - 1)
         break
       }
       case "Home": {
         event.preventDefault()
-        focusAndSetPosition(0)
+        focusAndSetIndex(0)
         break
       }
       case "End": {
         event.preventDefault()
-        focusAndSetPosition(lastFocusablePosition)
+        focusAndSetIndex(lastIndex)
         break
       }
       case "Escape": {
@@ -576,8 +557,7 @@ function MenuContent({
     // Add items
     for (const item of section) {
       const currentIndex = itemIndex
-      const isFocusable = !item.disabled
-      const tabIndex = isFocusable && focusedIndex === currentIndex ? 0 : -1
+      const tabIndex = clampedIndex === currentIndex ? 0 : -1
 
       elements.push(
         <MenuItemRow

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -663,6 +663,7 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   }, [])
 
   const handlePopoverOpen = useCallback((): void => {
+    clearTimeout(focusReturnTimerRef.current)
     setIsMenuOpen(true)
   }, [])
 
@@ -683,6 +684,7 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     closeReasonRef.current = "other" // reset for next open/close cycle
 
     if (reason !== "tab") {
+      clearTimeout(focusReturnTimerRef.current)
       focusReturnTimerRef.current = setTimeout(() => {
         document
           .querySelector<HTMLElement>('[data-testid="stMainMenuButton"]')

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -410,9 +410,12 @@ const MenuItemRow = memo(function MenuItemRow({
   )
 })
 
+/** Why the menu was closed — drives focus-return behavior. */
+type CloseReason = "escape" | "tab" | "other"
+
 interface MenuContentProps {
   sections: MenuSection[]
-  closeMenu: () => void
+  closeMenu: (reason?: CloseReason) => void
   metricsMgr: MetricsManager
 }
 
@@ -511,12 +514,21 @@ function MenuContent({
         setFocusedPosition(lastFocusablePosition)
         break
       }
-      case "Escape":
-      case "Tab": {
-        // Per WAI-ARIA menu pattern, both Escape and Tab close the menu
-        // and return focus to the trigger button.
+      case "Escape": {
+        // Per WAI-ARIA, Escape closes the menu and returns focus to the
+        // trigger button.
         event.preventDefault()
-        closeMenu()
+        closeMenu("escape")
+        break
+      }
+      case "Tab": {
+        // Per WAI-ARIA, Tab/Shift+Tab close the menu and let focus move
+        // to the next/previous tabbable element.  preventDefault is still
+        // needed to stop react-focus-lock from cycling focus within the
+        // popover, but we do NOT return focus to the trigger — the close
+        // handler checks the reason and skips its focus-return logic.
+        event.preventDefault()
+        closeMenu("tab")
         break
       }
       default:
@@ -639,6 +651,11 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   // Track popover open state for aria-expanded on the menu button.
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
+  // Tracks *why* the menu was closed so handlePopoverClose can decide
+  // whether to restore focus to the trigger.  Set by MenuContent just
+  // before calling BaseWeb's close(), read + reset in handlePopoverClose.
+  const closeReasonRef = useRef<CloseReason>("other")
+
   // Timer ref for the delayed focus-return so we can clean up on unmount.
   const focusReturnTimerRef = useRef<ReturnType<typeof setTimeout>>()
   useEffect(() => {
@@ -649,7 +666,11 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     setIsMenuOpen(true)
   }, [])
 
-  // Manually return focus to the menu button when the popover closes.
+  // Manually return focus to the menu button when the popover closes,
+  // UNLESS the close was triggered by Tab/Shift+Tab. In that case the
+  // WAI-ARIA menu-button pattern says focus should move forward/backward
+  // through the page rather than returning to the trigger.
+  //
   // We bypass BaseWeb's returnFocus because react-focus-lock's restoration
   // algorithm picks the wrong sibling (Deploy button) due to DOM ordering.
   // 50ms provides comfortable margin to outlast BaseWeb's close sequence.
@@ -658,11 +679,16 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   // overwrites refs on its direct child via cloneElement.
   const handlePopoverClose = useCallback((): void => {
     setIsMenuOpen(false)
-    focusReturnTimerRef.current = setTimeout(() => {
-      document
-        .querySelector<HTMLElement>('[data-testid="stMainMenuButton"]')
-        ?.focus()
-    }, 50)
+    const reason = closeReasonRef.current
+    closeReasonRef.current = "other" // reset for next open/close cycle
+
+    if (reason !== "tab") {
+      focusReturnTimerRef.current = setTimeout(() => {
+        document
+          .querySelector<HTMLElement>('[data-testid="stMainMenuButton"]')
+          ?.focus()
+      }, 50)
+    }
   }, [])
 
   const handleMenuButtonKeyDown = useCallback(
@@ -696,7 +722,10 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
       content={({ close }) => (
         <MenuContent
           sections={sections}
-          closeMenu={close}
+          closeMenu={(reason?: CloseReason) => {
+            closeReasonRef.current = reason ?? "other"
+            close()
+          }}
           metricsMgr={metricsMgr}
         />
       )}

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -459,12 +459,28 @@ function MenuContent({
   const focusedIndex =
     focusableIndices.length === 0 ? -1 : focusableIndices[clampedPosition]
 
-  // Imperatively focus the current item when the roving index changes.
-  useEffect(() => {
-    if (focusedIndex >= 0) {
-      menuItemButtonsRef.current[focusedIndex]?.focus()
+  // Focus the item at a roving position and update state for tabIndex
+  // tracking.  Called directly from keyboard handlers rather than going
+  // through a state → render → effect cycle.
+  const focusAndSetPosition = (position: number): void => {
+    setFocusedPosition(position)
+    const itemIndex = focusableIndices[position]
+    if (itemIndex !== undefined) {
+      menuItemButtonsRef.current[itemIndex]?.focus()
     }
-  }, [focusedIndex])
+  }
+
+  // Focus the first focusable item when the menu list mounts.
+  // Child callback refs (MenuItemRow) fire before this parent ref
+  // during React's commit phase, so menuItemButtonsRef is populated.
+  const menuListRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      if (node && focusableIndices.length > 0) {
+        menuItemButtonsRef.current[focusableIndices[0]]?.focus()
+      }
+    },
+    [focusableIndices]
+  )
 
   // Stable ref setter so MenuItemRow's memo can bail out when item/tabIndex
   // haven't changed (avoids creating a new closure per item per render).
@@ -494,24 +510,24 @@ function MenuContent({
         event.preventDefault()
         const nextPosition =
           currentPosition >= lastFocusablePosition ? 0 : currentPosition + 1
-        setFocusedPosition(nextPosition)
+        focusAndSetPosition(nextPosition)
         break
       }
       case "ArrowUp": {
         event.preventDefault()
         const nextPosition =
           currentPosition <= 0 ? lastFocusablePosition : currentPosition - 1
-        setFocusedPosition(nextPosition)
+        focusAndSetPosition(nextPosition)
         break
       }
       case "Home": {
         event.preventDefault()
-        setFocusedPosition(0)
+        focusAndSetPosition(0)
         break
       }
       case "End": {
         event.preventDefault()
-        setFocusedPosition(lastFocusablePosition)
+        focusAndSetPosition(lastFocusablePosition)
         break
       }
       case "Escape": {
@@ -580,6 +596,7 @@ function MenuContent({
 
   return (
     <StyledMenuContainer
+      ref={menuListRef}
       data-testid="stMainMenuList"
       aria-label="Main menu"
       role="menu"

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -19,7 +19,6 @@ import {
   memo,
   ReactElement,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -27,6 +26,7 @@ import {
 
 import { MoreVert } from "@emotion-icons/material-rounded"
 import { ACCESSIBILITY_TYPE, PLACEMENT, StatefulPopover } from "baseui/popover"
+import { focusNextElement, focusPrevElement } from "focus-lock"
 import { getLogger } from "loglevel"
 
 import type { Steps } from "@streamlit/app/src/hocs/withScreencast/withScreencast"
@@ -411,7 +411,7 @@ const MenuItemRow = memo(function MenuItemRow({
 })
 
 /** Why the menu was closed — drives focus-return behavior. */
-type CloseReason = "escape" | "tab" | "other"
+type CloseReason = "escape" | "tab" | "shift-tab" | "other"
 
 interface MenuContentProps {
   sections: MenuSection[]
@@ -538,13 +538,13 @@ function MenuContent({
         break
       }
       case "Tab": {
-        // Per WAI-ARIA, Tab/Shift+Tab close the menu and let focus move
-        // to the next/previous tabbable element.  preventDefault is still
-        // needed to stop react-focus-lock from cycling focus within the
-        // popover, but we do NOT return focus to the trigger — the close
-        // handler checks the reason and skips its focus-return logic.
+        // Per WAI-ARIA, Tab/Shift+Tab close the menu and move focus to
+        // the next/previous tabbable element.  preventDefault is needed
+        // to stop react-focus-lock from cycling focus within the popover.
+        // The returnFocus callback uses focusNextElement/focusPrevElement
+        // to advance focus from the menu button after the popover unmounts.
         event.preventDefault()
-        closeMenu("tab")
+        closeMenu(event.shiftKey ? "shift-tab" : "tab")
         break
       }
       default:
@@ -668,46 +668,51 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   // Track popover open state for aria-expanded on the menu button.
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
-  // Tracks *why* the menu was closed so handlePopoverClose can decide
-  // whether to restore focus to the trigger.  Set by MenuContent just
-  // before calling BaseWeb's close(), read + reset in handlePopoverClose.
+  // Ref to the menu trigger button for returning focus after close.
+  const menuButtonRef = useRef<HTMLButtonElement>(null)
+
+  // Tracks *why* the menu was closed so the returnFocus callback can
+  // decide whether to restore focus to the trigger.  Set by MenuContent
+  // just before calling BaseWeb's close(), read + reset in handleReturnFocus.
   const closeReasonRef = useRef<CloseReason>("other")
 
-  // Timer ref for the delayed focus-return so we can clean up on unmount.
-  const focusReturnTimerRef = useRef<ReturnType<typeof setTimeout>>()
-  useEffect(() => {
-    return () => clearTimeout(focusReturnTimerRef.current)
-  }, [])
-
   const handlePopoverOpen = useCallback((): void => {
-    clearTimeout(focusReturnTimerRef.current)
     setIsMenuOpen(true)
   }, [])
 
-  // Manually return focus to the menu button when the popover closes,
-  // UNLESS the close was triggered by Tab/Shift+Tab. In that case the
-  // WAI-ARIA menu-button pattern says focus should move forward/backward
-  // through the page rather than returning to the trigger.
-  //
-  // We bypass BaseWeb's returnFocus because react-focus-lock's restoration
-  // algorithm picks the wrong sibling (Deploy button) due to DOM ordering.
-  // 50ms provides comfortable margin to outlast BaseWeb's close sequence.
-  //
-  // Note: Uses a global DOM query because BaseWeb's StatefulPopover
-  // overwrites refs on its direct child via cloneElement.
   const handlePopoverClose = useCallback((): void => {
     setIsMenuOpen(false)
+  }, [])
+
+  // Callback passed to BaseWeb's returnFocus prop, invoked by
+  // react-focus-lock when the popover unmounts.  Returning false tells
+  // focus-lock to skip its default restoration (which would land on the
+  // wrong sibling due to DOM ordering).
+  //
+  // - Escape / click-away: focus returns to the menu trigger button.
+  // - Tab: focus advances to the next tabbable element after the button.
+  // - Shift+Tab: focus moves to the previous tabbable element.
+  //
+  // Note: On WebKit (Safari), these focus calls may be ignored because
+  // react-focus-lock invokes the callback after BaseWeb's close animation
+  // timer, which puts it outside the user-activation context.
+  const handleReturnFocus = useCallback((_returnTo: Element): false => {
     const reason = closeReasonRef.current
     closeReasonRef.current = "other" // reset for next open/close cycle
 
-    if (reason !== "tab") {
-      clearTimeout(focusReturnTimerRef.current)
-      focusReturnTimerRef.current = setTimeout(() => {
-        document
-          .querySelector<HTMLElement>('[data-testid="stMainMenuButton"]')
-          ?.focus()
-      }, 50)
+    const button = menuButtonRef.current
+    if (button) {
+      if (reason === "tab") {
+        focusNextElement(button)
+      } else if (reason === "shift-tab") {
+        focusPrevElement(button)
+      } else {
+        button.focus()
+      }
     }
+    // Always return false to prevent react-focus-lock's default
+    // restoration, which targets the wrong element (Deploy button).
+    return false
   }, [])
 
   const handleMenuButtonKeyDown = useCallback(
@@ -731,7 +736,7 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   return (
     <StatefulPopover
       focusLock
-      returnFocus={false}
+      returnFocus={handleReturnFocus}
       // We handle aria-haspopup and aria-expanded on the <button> directly,
       // so disable BaseWeb's ARIA on the wrapper div.
       accessibilityType={ACCESSIBILITY_TYPE.none}
@@ -770,6 +775,7 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
         onKeyDown={handleMenuButtonKeyDown}
       >
         <BaseButton
+          ref={menuButtonRef}
           kind={BaseButtonKind.HEADER_NO_PADDING}
           data-testid="stMainMenuButton"
           aria-label="Main menu"

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -60,6 +60,9 @@ const SCREENCAST_LABEL: { [s: string]: string } = {
   RECORDING: "Stop recording",
 }
 
+/** Keys that open the menu when pressed on the menu button. */
+const MENU_OPEN_KEYS = new Set(["Enter", " ", "Space", "Spacebar"])
+
 /**
  * Opens a URL in a new browser tab/window with error handling.
  * Logs a warning if the popup is blocked or fails to open.
@@ -624,10 +627,11 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   }, [])
 
   // Manually return focus to the menu button when the popover closes.
-  // We bypass baseweb built-in returnFocus because its focus restoration
-  // does not identify the right element.
+  // We bypass BaseWeb's returnFocus because react-focus-lock's restoration
+  // algorithm picks the wrong sibling (Deploy button) due to DOM ordering.
   // The 30ms delay outlasts BaseWeb's Popover animateOut cycle (~20ms),
   // which briefly re-mounts FocusLock and would steal earlier focus.
+  // Note: Uses a DOM query because BaseButton does not support forwardRef.
   const handlePopoverClose = useCallback((): void => {
     setIsMenuOpen(false)
     setTimeout(() => {
@@ -638,23 +642,22 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     }, 30)
   }, [])
 
+  const handleMenuButtonKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLSpanElement>): void => {
+      if (MENU_OPEN_KEYS.has(event.key)) {
+        event.preventDefault()
+        event.currentTarget.click()
+      }
+    },
+    []
+  )
+
   // Check if menu has any content (for minimal mode visibility)
   const hasContent = sections.some(section => section.length > 0)
 
   // Hide menu entirely if minimal mode with no content
   if (isMinimalMode && !hasContent) {
     return null
-  }
-
-  const handleMenuButtonKeyDown = (
-    event: KeyboardEvent<HTMLSpanElement>
-  ): void => {
-    // Support legacy and modern Space key values for broader compatibility.
-    const menuOpenKeys = new Set(["Enter", " ", "Space", "Spacebar"])
-    if (menuOpenKeys.has(event.key)) {
-      event.preventDefault()
-      event.currentTarget.click()
-    }
   }
 
   return (
@@ -686,6 +689,9 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
         },
       }}
     >
+      {/* onKeyDown is on the span (not the button) because BaseWeb injects
+          its popover-opening click handler here via cloneElement. The handler
+          calls currentTarget.click() to trigger that injected handler. */}
       <StyledMainMenuContainer
         id="MainMenu"
         className="stMainMenu"

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -15,6 +15,7 @@
  */
 
 import {
+  FocusEvent,
   KeyboardEvent,
   memo,
   ReactElement,
@@ -479,6 +480,17 @@ function MenuContent({
     []
   )
 
+  // Sync focusedIndex when any item receives focus via mouse click or other
+  // non-keyboard means. Uses event delegation (focusin bubbles) so we don't
+  // need per-item onFocus props, keeping MenuItemRow's memo untouched.
+  const handleMenuFocus = (event: FocusEvent<HTMLDivElement>): void => {
+    const target = event.target as HTMLElement
+    const index = menuItemButtonsRef.current.findIndex(el => el === target)
+    if (index !== -1) {
+      setFocusedIndex(index)
+    }
+  }
+
   const handleItemClick = (item: MenuItemConfig): void => {
     metricsMgr.enqueue("menuClick", { label: item.label })
     item.onClick()
@@ -580,6 +592,7 @@ function MenuContent({
       data-testid="stMainMenuList"
       aria-label="Main menu"
       role="menu"
+      onFocus={handleMenuFocus}
       onKeyDown={handleKeyDown}
     >
       {elements}

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useMemo } from "react"
+import { KeyboardEvent, memo, ReactElement, useMemo } from "react"
 
 import { MoreVert } from "@emotion-icons/material-rounded"
 import { PLACEMENT, StatefulPopover } from "baseui/popover"
@@ -512,6 +512,17 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     return null
   }
 
+  const handleMenuButtonKeyDown = (
+    event: KeyboardEvent<HTMLSpanElement>
+  ): void => {
+    // Support legacy and modern Space key values for broader compatibility.
+    const menuOpenKeys = new Set(["Enter", " ", "Space", "Spacebar"])
+    if (menuOpenKeys.has(event.key)) {
+      event.preventDefault()
+      event.currentTarget.click()
+    }
+  }
+
   return (
     <StatefulPopover
       focusLock
@@ -539,6 +550,7 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
         id="MainMenu"
         className="stMainMenu"
         data-testid="stMainMenu"
+        onKeyDown={handleMenuButtonKeyDown}
       >
         <BaseButton
           kind={BaseButtonKind.HEADER_NO_PADDING}

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
-import { KeyboardEvent, memo, ReactElement, useMemo } from "react"
+import {
+  KeyboardEvent,
+  memo,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import { MoreVert } from "@emotion-icons/material-rounded"
 import { PLACEMENT, StatefulPopover } from "baseui/popover"
@@ -346,6 +355,8 @@ function buildAboutItem(
 interface MenuItemRowProps {
   item: MenuItemConfig
   onItemClick: (item: MenuItemConfig) => void
+  tabIndex: number
+  itemRef: (element: HTMLButtonElement | null) => void
 }
 
 /**
@@ -355,6 +366,8 @@ interface MenuItemRowProps {
 const MenuItemRow = memo(function MenuItemRow({
   item,
   onItemClick,
+  tabIndex,
+  itemRef,
 }: MenuItemRowProps): ReactElement {
   const handleClick = (): void => {
     if (item.disabled) return
@@ -364,8 +377,12 @@ const MenuItemRow = memo(function MenuItemRow({
   return (
     <StyledMenuItemRow
       type="button"
+      ref={itemRef}
       onClick={handleClick}
       disabled={item.disabled}
+      role="menuitem"
+      aria-disabled={item.disabled}
+      tabIndex={tabIndex}
       isRecording={item.isRecording}
       data-testid={`stMainMenuItem-${item.label.replace(/\s+/g, "")}`}
     >
@@ -401,15 +418,95 @@ function MenuContent({
   closeMenu,
   metricsMgr,
 }: MenuContentProps): ReactElement {
+  // Store button refs so roving tabindex can move focus without DOM queries.
+  const menuItemButtonsRef = useRef<Array<HTMLButtonElement | null>>([])
+  // Flatten sections to preserve visual grouping but allow linear navigation.
+  const flatItems = useMemo(
+    () => sections.flatMap(section => section),
+    [sections]
+  )
+  // Track indices of focusable items (skip disabled, separators are not in sections).
+  const focusableIndices = useMemo(
+    () =>
+      flatItems
+        .map((item, index) => (item.disabled ? null : index))
+        .filter((index): index is number => index !== null),
+    [flatItems]
+  )
+  // Store position within focusableIndices to support roving tabIndex.
+  const [focusedPosition, setFocusedPosition] = useState(0)
+  const lastFocusablePosition = Math.max(0, focusableIndices.length - 1)
+  const clampedPosition =
+    focusableIndices.length === 0
+      ? -1
+      : Math.min(focusedPosition, lastFocusablePosition)
+  // Map roving position -> actual flatItems index.
+  const focusedIndex =
+    focusableIndices.length === 0 ? -1 : focusableIndices[clampedPosition]
+
+  // Imperatively focus the current item when the roving index changes.
+  useEffect(() => {
+    if (focusedIndex >= 0) {
+      menuItemButtonsRef.current[focusedIndex]?.focus()
+    }
+  }, [focusedIndex])
+
   const handleItemClick = (item: MenuItemConfig): void => {
     metricsMgr.enqueue("menuClick", { label: item.label })
     item.onClick()
     closeMenu()
   }
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (focusableIndices.length === 0) {
+      return
+    }
+
+    // Clamp to valid range in case items change while menu is open.
+    const currentPosition = Math.min(focusedPosition, lastFocusablePosition)
+
+    switch (event.key) {
+      case "ArrowDown": {
+        event.preventDefault()
+        const nextPosition =
+          currentPosition >= lastFocusablePosition ? 0 : currentPosition + 1
+        setFocusedPosition(nextPosition)
+        break
+      }
+      case "ArrowUp": {
+        event.preventDefault()
+        const nextPosition =
+          currentPosition <= 0 ? lastFocusablePosition : currentPosition - 1
+        setFocusedPosition(nextPosition)
+        break
+      }
+      case "Home": {
+        event.preventDefault()
+        setFocusedPosition(0)
+        break
+      }
+      case "End": {
+        event.preventDefault()
+        setFocusedPosition(lastFocusablePosition)
+        break
+      }
+      case "Escape":
+      case "Tab": {
+        // Per WAI-ARIA menu pattern, both Escape and Tab close the menu
+        // and return focus to the trigger button.
+        event.preventDefault()
+        closeMenu()
+        break
+      }
+      default:
+        break
+    }
+  }
+
   // Render sections with dividers between non-empty sections
   const elements: ReactElement[] = []
   let dividerCount = 0
+  let itemIndex = 0
 
   for (const section of sections) {
     if (section.length === 0) continue
@@ -429,18 +526,33 @@ function MenuContent({
 
     // Add items
     for (const item of section) {
+      const currentIndex = itemIndex
+      const isFocusable = !item.disabled
+      const tabIndex = isFocusable && focusedIndex === currentIndex ? 0 : -1
+
       elements.push(
         <MenuItemRow
           key={item.key}
           item={item}
           onItemClick={handleItemClick}
+          tabIndex={tabIndex}
+          itemRef={element => {
+            menuItemButtonsRef.current[currentIndex] = element
+          }}
         />
       )
+
+      itemIndex += 1
     }
   }
 
   return (
-    <StyledMenuContainer data-testid="stMainMenuList" aria-label="Main menu">
+    <StyledMenuContainer
+      data-testid="stMainMenuList"
+      aria-label="Main menu"
+      role="menu"
+      onKeyDown={handleKeyDown}
+    >
       {elements}
     </StyledMenuContainer>
   )
@@ -504,6 +616,20 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     ]
   )
 
+  // Manually return focus to the menu button when the popover closes.
+  // We bypass baseweb built-in returnFocus because its focus restoration
+  // does not identify the right element.
+  // The 30ms delay outlasts BaseWeb's Popover animateOut cycle (~20ms),
+  // which briefly re-mounts FocusLock and would steal earlier focus.
+  const handlePopoverClose = useCallback((): void => {
+    setTimeout(() => {
+      const menuButton = document.querySelector<HTMLElement>(
+        '[data-testid="stMainMenuButton"]'
+      )
+      menuButton?.focus()
+    }, 30)
+  }, [])
+
   // Check if menu has any content (for minimal mode visibility)
   const hasContent = sections.some(section => section.length > 0)
 
@@ -526,6 +652,8 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   return (
     <StatefulPopover
       focusLock
+      returnFocus={false}
+      onClose={handlePopoverClose}
       placement={PLACEMENT.bottomRight}
       content={({ close }) => (
         <MenuContent

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -100,7 +100,6 @@ export const StyledMenuItemRow = styled.button<StyledMenuItemRowProps>(
     },
 
     "&:focus-visible": {
-      // TODO: Verify styling
       boxShadow: theme.shadows.focusRingMuted,
     },
 

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -103,12 +103,12 @@ export const StyledMenuItemRow = styled.button<StyledMenuItemRowProps>(
       boxShadow: theme.shadows.focusRingMuted,
     },
 
-    "&:disabled": {
+    '&[aria-disabled="true"]': {
       color: theme.colors.fadedText60,
       cursor: "not-allowed",
     },
 
-    "&:disabled:hover": {
+    '&[aria-disabled="true"]:hover': {
       backgroundColor: theme.colors.transparent,
     },
   })

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -95,9 +95,13 @@ export const StyledMenuItemRow = styled.button<StyledMenuItemRowProps>(
       backgroundColor: theme.colors.darkenedBgMix15,
     },
 
-    // TODO(accessibility): Add visible focus ring for keyboard navigation.
-    "&:focus-visible": {
+    "&:focus": {
       outline: "none",
+    },
+
+    "&:focus-visible": {
+      // TODO: Verify styling
+      boxShadow: theme.shadows.focusRingMuted,
     },
 
     "&:disabled": {

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.test.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.test.tsx
@@ -27,13 +27,12 @@ function flushPromises(): Promise<void> {
 }
 
 describe("StreamlitDialog", () => {
-  it("renders clear cache dialog and focuses clear cache button", async () => {
+  it("renders clear cache dialog and focuses cancel button", async () => {
     render(
       <Fragment>
         {StreamlitDialog({
           type: DialogType.CLEAR_CACHE,
           confirmCallback: () => {},
-          defaultAction: () => {},
           onClose: () => {},
         })}
       </Fragment>
@@ -42,10 +41,10 @@ describe("StreamlitDialog", () => {
     // Flush promises to give componentDidMount() a chance to run.
     await flushPromises()
 
-    const buttons = await screen.findAllByRole("button")
-    const targetButton = buttons[1]
-    expect(targetButton).toHaveTextContent("Clear caches")
-    expect(targetButton).toHaveFocus()
+    // Per WAI-ARIA best practice for destructive confirmation dialogs,
+    // focus should land on the non-destructive "Cancel" button.
+    const cancelButton = await screen.findByText("Cancel")
+    expect(cancelButton).toHaveFocus()
   })
 
   it("renders secondary dialog buttons properly", async () => {
@@ -54,7 +53,6 @@ describe("StreamlitDialog", () => {
         {StreamlitDialog({
           type: DialogType.CLEAR_CACHE,
           confirmCallback: () => {},
-          defaultAction: () => {},
           onClose: () => {},
         })}
       </Fragment>
@@ -72,7 +70,6 @@ describe("StreamlitDialog", () => {
         {StreamlitDialog({
           type: DialogType.CLEAR_CACHE,
           confirmCallback: () => {},
-          defaultAction: () => {},
           onClose: () => {},
         })}
       </Fragment>

--- a/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
+++ b/frontend/app/src/components/StreamlitDialog/StreamlitDialog.tsx
@@ -105,9 +105,6 @@ interface ClearCacheProps {
 
   /** callback to close the dialog */
   onClose: PlainEventHandler
-
-  /** callback to run the default action */
-  defaultAction: () => void
 }
 
 /**
@@ -133,11 +130,14 @@ function ClearCacheDialog(props: ClearCacheProps): ReactElement {
           <StreamlitMarkdown source={clearCacheInfo} allowHTML={false} />
         </ModalBody>
         <ModalFooter>
-          <ModalButton kind={BaseButtonKind.GHOST} onClick={props.onClose}>
+          <ModalButton
+            autoFocus
+            kind={BaseButtonKind.GHOST}
+            onClick={props.onClose}
+          >
             Cancel
           </ModalButton>
           <ModalButton
-            autoFocus
             kind={BaseButtonKind.SECONDARY}
             onClick={props.confirmCallback}
           >

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactElement } from "react"
+import { forwardRef, ReactElement, Ref } from "react"
 
 import {
   BaseButtonKind,
@@ -39,7 +39,10 @@ import {
   StyledTertiaryFormSubmitButton,
 } from "./styled-components"
 
-function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
+const BaseButton = forwardRef(function BaseButton(
+  props: Readonly<BaseButtonPropsT>,
+  ref: Ref<HTMLButtonElement>
+): ReactElement {
   const {
     kind,
     size,
@@ -88,6 +91,7 @@ function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
 
   return (
     <ComponentType
+      ref={ref}
       kind={kind}
       size={size ?? BaseButtonSize.MEDIUM}
       containerWidth={containerWidth || false}
@@ -102,7 +106,7 @@ function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
       {children}
     </ComponentType>
   )
-}
+})
 export type BaseButtonProps = BaseButtonPropsT
 export { BaseButtonKind, BaseButtonSize }
 export default BaseButton

--- a/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButton.tsx
@@ -96,6 +96,8 @@ function BaseButton(props: Readonly<BaseButtonPropsT>): ReactElement {
       autoFocus={autoFocus || false}
       data-testid={props["data-testid"] ?? `stBaseButton-${kind}`}
       aria-label={props["aria-label"] ?? ""}
+      aria-haspopup={props["aria-haspopup"]}
+      aria-expanded={props["aria-expanded"]}
     >
       {children}
     </ComponentType>

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -60,9 +60,16 @@ export interface BaseButtonProps {
   autoFocus?: boolean
   "data-testid"?: string
   "aria-label"?: string
+  "aria-haspopup"?: "menu" | "true" | "dialog" | "listbox" | "tree" | "grid"
+  "aria-expanded"?: boolean
 }
 
-type RequiredBaseButtonProps = Required<BaseButtonProps>
+// Most props become required via defaults in BaseButton, but ARIA popup
+// attributes stay optional so they only appear in the DOM when explicitly set.
+type RequiredBaseButtonProps = Required<
+  Omit<BaseButtonProps, "aria-haspopup" | "aria-expanded">
+> &
+  Pick<BaseButtonProps, "aria-haspopup" | "aria-expanded">
 
 function getSizeStyle(size: BaseButtonSize, theme: EmotionTheme): CSSObject {
   switch (size) {

--- a/frontend/lib/src/theme/getShadows.test.ts
+++ b/frontend/lib/src/theme/getShadows.test.ts
@@ -77,8 +77,14 @@ describe("createShadows", () => {
     it("computes focus ring shadows from colors", () => {
       // Primary focus ring uses same primary color
       expect(shadows.focusRing).toBe("0 0 0 0.2rem rgba(255, 75, 75, 0.5)")
+      // Subtle focus ring uses darkenedBgMix25 with 0.5 alpha
+      expect(shadows.focusRingSubtle).toMatch(/^0 0 0 0\.2rem rgba\(/)
       // Outline focus ring - same across themes
       expect(shadows.focusRingOutline).toBe("0 0 0 1px #ff4b4b")
+      // Muted focus ring uses gray10 with 0.8 alpha (0.2 opacity)
+      expect(shadows.focusRingMuted).toBe(
+        "0 0 0 0.2rem rgba(250, 250, 250, 0.2)"
+      )
     })
 
     it("includes none shadow for reset", () => {

--- a/frontend/lib/src/theme/getShadows.ts
+++ b/frontend/lib/src/theme/getShadows.ts
@@ -48,7 +48,8 @@ export type ThemeShadows = ElevationShadows & DerivedShadows
  *   - `bgColor`: Background color used to determine light/dark elevation shadows
  *   - `primary`: Primary color for focus ring and outline shadows
  *   - `darkenedBgMix25`: Used for subtle focus ring shadow
- *   - `gray90`: Used for muted focus ring shadow
+ *   - `gray10`: Used for muted focus ring shadow on dark backgrounds
+ *   - `gray90`: Used for muted focus ring shadow on light backgrounds
  * @returns Complete theme shadows object including elevation shadows (tooltip, popover,
  *   toolbar, sidebar, none) and focus ring shadows (focusRing, focusRingSubtle,
  *   focusRingOutline, focusRingMuted)

--- a/frontend/lib/src/theme/getShadows.ts
+++ b/frontend/lib/src/theme/getShadows.ts
@@ -56,7 +56,7 @@ export type ThemeShadows = ElevationShadows & DerivedShadows
 export const createShadows = (
   colors: Pick<
     EmotionThemeColors,
-    "bgColor" | "primary" | "darkenedBgMix25" | "gray90"
+    "bgColor" | "primary" | "darkenedBgMix25" | "gray10" | "gray90"
   >
 ): ThemeShadows => {
   // Auto-determine elevation shadows based on background luminance
@@ -66,6 +66,7 @@ export const createShadows = (
     : darkElevationShadows
 
   const width = sizes.focusRingWidth
+  const gray = isLightBg ? colors.gray90 : colors.gray10
   return {
     ...elevationShadows,
     // Primary focus ring - buttons, checkboxes, sliders, inputs
@@ -75,6 +76,6 @@ export const createShadows = (
     // Solid outline focus ring - FileUploader dropzone
     focusRingOutline: `0 0 0 1px ${colors.primary}`,
     // Muted focus ring - header link buttons
-    focusRingMuted: `0 0 0 ${width} ${transparentize(colors.gray90, 0.8)}`,
+    focusRingMuted: `0 0 0 ${width} ${transparentize(gray, 0.8)}`,
   }
 }


### PR DESCRIPTION
## Describe your changes
Adds full WAI-ARIA menu pattern support to the `MainMenu`, including keyboard navigation, proper ARIA semantics, and focus management.

**Keyboard navigation**
- **Open menu**: `Enter` / `Space` on the menu button (handles legacy `Spacebar` / `Space` key values)
- **Navigate items**: `ArrowDown` / `ArrowUp` with wrapping at boundaries
- **Jump to ends**: `Home` / `End`
- **Activate item**: `Enter` / `Space` on focused menu item
- **Close menu**: `Escape` returns focus to the trigger; `Tab` / `Shift+Tab` close the menu and advance focus to the next/previous tabbable element
- **Disabled items**: All items are focusable and navigable, including disabled ones (per [WAI-ARIA menuitem role guidance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitem_role)). Disabled items use `aria-disabled` instead of the native `disabled` attribute; clicks are blocked via the `onClick` handler.

**ARIA attributes**
- Menu button: `aria-haspopup="menu"`, `aria-expanded` (tracks open/close state), `aria-label="Main menu"`
- Menu container: `role="menu"`, `aria-label="Main menu"`
- Menu items: `role="menuitem"`, `aria-disabled` for disabled items (native `disabled` removed to keep items focusable)
- Dividers: `role="separator"`, `aria-hidden="true"`
- Roving tabindex: focused item gets `tabIndex={0}`, all others get `tabIndex={-1}`

**Focus management**
- Focus moves to the first menu item when the menu opens
- Focus returns to the menu button after `Escape` or item click, via react-focus-lock's `returnFocus` callback
- `Tab` / `Shift+Tab` close the menu and programmatically advance focus to the next/previous tabbable element using `focusNextElement`/`focusPrevElement` from `focus-lock`
- **WebKit limitation**: On Safari, focus restoration after menu close may not work because react-focus-lock invokes the `returnFocus` callback after BaseWeb's close animation timer, which puts the `.focus()` call outside the user-activation context

**Clear cache dialog (WAI-ARIA best practice)**
- Moves `autoFocus` from the destructive "Clear caches" button to the non-destructive "Cancel" button, per WAI-ARIA guidance for confirmation dialogs
- Removes the now-unnecessary `defaultAction` prop from `ClearCacheProps`

**Theme fix**
- `focusRingMuted` shadow now uses `gray10` on dark backgrounds (was using `gray90`, which was invisible)

## Testing Plan
- JS Unit Tests: ✅  Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 