### PR TITLE
Improve `autofix` workflow to simplify triggering CI for bot PRs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -72,6 +72,9 @@ jobs:
           git status --porcelain
           echo "changes=$(if git diff --staged --quiet; then echo false; else echo true; fi)" >> $GITHUB_OUTPUT
 
+      # When a bot PR has no autofix changes, we create an empty PR targeting the bot's branch.
+      # A contributor can merge this empty PR with one click, which triggers CI on the bot PR.
+      # This workaround is needed because GitHub doesn't run CI on commits from bots for security.
       - name: Create empty PR for bot PR to trigger CI
         if: steps.git-check.outputs.changes == 'false' && github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository
         env:
@@ -79,13 +82,16 @@ jobs:
           PR_BODY: |
             ## Trigger CI for bot PR
 
-            This PR was created to trigger CI checks for #${{ github.event.pull_request.number }} by creating an empty commit on the same branch as that PR.
+            This PR was created to trigger CI checks for #${{ github.event.pull_request.number }} by adding an empty commit to that branch.
 
-            PRs created by bots don't automatically run CI workflows for security reasons. Merging this PR will trigger CI on that branch and the associated PR, not directly on the base (target) branch.
+            GitHub doesn't run CI on commits from bots for security reasons. Merging this PR
+            adds a human-authored commit to the bot's branch, which triggers CI on the bot PR.
 
-            This PR contains no code changes and exists only to trigger CI; it can be merged without review.
+            This PR contains no code changes and can be merged without review.
         run: |
-          # Only create empty PR if source PR has a single commit
+          # Only create empty PR if source PR has a single commit.
+          # Multiple commits indicate a human has already pushed to the branch,
+          # so CI should already be running (no need for this workaround).
           commit_count=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits | length')
           if [[ "$commit_count" -ne 1 ]]; then
             echo "Skipping: PR has $commit_count commits (expected 1)"

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -79,11 +79,11 @@ jobs:
           PR_BODY: |
             ## Trigger CI for bot PR
 
-            This PR was created to trigger CI checks on #${{ github.event.pull_request.number }}.
+            This PR was created to trigger CI checks for #${{ github.event.pull_request.number }} by creating an empty commit on the same branch as that PR.
 
-            PRs created by bots don't automatically run CI workflows for security reasons. Merging this empty PR will trigger CI on the target branch.
+            PRs created by bots don't automatically run CI workflows for security reasons. Merging this PR will trigger CI on that branch and the associated PR, not directly on the base (target) branch.
 
-            This PR contains no changes and can be merged without review.
+            This PR contains no code changes and exists only to trigger CI; it can be merged without review.
         run: |
           # Only create empty PR if source PR has a single commit
           commit_count=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits | length')

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -34,6 +34,13 @@ jobs:
           submodules: "recursive"
           fetch-depth: 2
 
+      - name: Remove 'autofix' label to prevent re-triggers
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "autofix"
+
       - name: Set Python version vars
         uses: ./.github/actions/build_info
 
@@ -65,6 +72,39 @@ jobs:
           git status --porcelain
           echo "changes=$(if git diff --staged --quiet; then echo false; else echo true; fi)" >> $GITHUB_OUTPUT
 
+      - name: Create empty PR for bot PR to trigger CI
+        if: steps.git-check.outputs.changes == 'false' && github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: |
+            ## Trigger CI for bot PR
+
+            This PR was created to trigger CI checks on #${{ github.event.pull_request.number }}.
+
+            PRs created by bots don't automatically run CI workflows for security reasons. Merging this empty PR will trigger CI on the target branch.
+
+            This PR contains no changes and can be merged without review.
+        run: |
+          # Only create empty PR if source PR has a single commit
+          commit_count=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits | length')
+          if [[ "$commit_count" -ne 1 ]]; then
+            echo "Skipping: PR has $commit_count commits (expected 1)"
+            exit 0
+          fi
+
+          git config user.email "core+streamlitbot-github@streamlit.io"
+          git config user.name "Streamlit Bot"
+          fix_branch="autofix/${{ github.event.pull_request.number }}-${{ github.run_id }}"
+          git checkout -b "$fix_branch"
+          git commit --allow-empty -m "Trigger CI for bot PR #${{ github.event.pull_request.number }}"
+          git push --set-upstream origin "$fix_branch"
+
+          gh pr create \
+            --head "$fix_branch" \
+            --base "${{ github.head_ref }}" \
+            --title "[autofix] Trigger CI for #${{ github.event.pull_request.number }}" \
+            --body "$PR_BODY"
+
       - name: Commit changes to new branch
         if: steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
@@ -92,13 +132,6 @@ jobs:
             --base "${{ github.head_ref }}" \
             --title "[autofix] Automated fixes for #${{ github.event.pull_request.number }}" \
             --body "$PR_BODY"
-
-      - name: Remove 'autofix' label from source PR
-        if: steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "autofix"
 
       - name: Show notices for fork PRs
         if: steps.git-check.outputs.changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/bump-component-v2-lib.yml
+++ b/.github/workflows/bump-component-v2-lib.yml
@@ -90,7 +90,7 @@ jobs:
               draft: false,
             });
             const pr = created.data;
-            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, labels: ['change:chore','impact:internal'] });
+            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, labels: ['change:chore', 'impact:internal', 'autofix'] });
             core.setOutput('pr_url', pr.html_url);
 
       - name: Summary (@streamlit/component-v2-lib)

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -106,7 +106,7 @@ jobs:
 
             core.setOutput('pr_url', pr.html_url);
 
-            const labels = ['change:chore', 'impact:internal'];
+            const labels = ['change:chore', 'impact:internal', 'autofix'];
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/update-emojis-material-icons.yml
+++ b/.github/workflows/update-emojis-material-icons.yml
@@ -123,7 +123,7 @@ jobs:
 
             core.setOutput('pr_url', pr.html_url);
 
-            const labels = ['change:chore', 'impact:users'];
+            const labels = ['change:chore', 'impact:users', 'autofix', 'update-snapshots'];
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Describe your changes

- Reorganized autofix.yml to remove the 'autofix' label early to prevent re-triggers
- Added a new step to create an empty PR for bot PRs to trigger CI checks when no changes are needed
- Added 'autofix' label to dependency update PRs to enable autofix workflow
- Added 'update-snapshots' label to emoji/icons update workflow

## Testing Plan

- Tested with bot-created dependency update PRs to verify workflow runs correctly
- Verified that empty PRs are created when no autofix changes are needed
- Confirmed that the 'autofix' label prevents infinite re-triggers

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.