### PR TITLE
Add `component-lib` to dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,21 @@ updates:
           # versions, it makes sense to keep these grouped together
           - "@swc/*"
 
+  # Keep component-lib package.json (& lockfiles) up to date
+  - package-ecosystem: "npm"
+    directory: "/component-lib"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+    cooldown:
+      default-days: 5
+
+    labels:
+      - "change:chore"
+      - "impact:internal"
+      - "autofix"
+
   # Keep python dependencies up to date (via uv)
   # Root pyproject.toml contains dev/test dependency groups
   - package-ecosystem: "uv"


### PR DESCRIPTION
## Describe your changes

Added `/component-lib` to Dependabot configuration to enable automated dependency version updates for the component library package. Uses the same daily schedule and configuration as the existing `/frontend` npm ecosystem entry.

## Testing Plan

- No additional tests needed. This is a configuration change that enables Dependabot to monitor `/component-lib` dependencies for security and version updates.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.