### PR TITLE
[chore] Clarify typing test conventions in agent rules

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -33,9 +33,16 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 
 ### Typing Tests
 
-We also have typing tests in `lib/tests/streamlit/typing` for our public API to catch
+We have typing tests in `lib/tests/streamlit/typing` for our public API to catch
 typing errors in parameters or return types by using mypy and `assert_type`.
-Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration.
+
+- **These are NOT pytest tests** — they are checked by mypy only, never executed at runtime.
+- All assertions and imports go inside `if TYPE_CHECKING:` blocks.
+- Do **not** use `def test_*()` functions or `import streamlit as st`.
+- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`).
+- Always include `from __future__ import annotations` at the top.
+- Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration
+  (e.g. `radio_types.py`, `button_types.py`).
 
 ## Theming and Layout
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -31,9 +31,16 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 
 ### Typing Tests
 
-We also have typing tests in `lib/tests/streamlit/typing` for our public API to catch
+We have typing tests in `lib/tests/streamlit/typing` for our public API to catch
 typing errors in parameters or return types by using mypy and `assert_type`.
-Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration.
+
+- **These are NOT pytest tests** — they are checked by mypy only, never executed at runtime.
+- All assertions and imports go inside `if TYPE_CHECKING:` blocks.
+- Do **not** use `def test_*()` functions or `import streamlit as st`.
+- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`).
+- Always include `from __future__ import annotations` at the top.
+- Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration
+  (e.g. `radio_types.py`, `button_types.py`).
 
 ## Theming and Layout
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -27,9 +27,16 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 
 ### Typing Tests
 
-We also have typing tests in `lib/tests/streamlit/typing` for our public API to catch
+We have typing tests in `lib/tests/streamlit/typing` for our public API to catch
 typing errors in parameters or return types by using mypy and `assert_type`.
-Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration.
+
+- **These are NOT pytest tests** — they are checked by mypy only, never executed at runtime.
+- All assertions and imports go inside `if TYPE_CHECKING:` blocks.
+- Do **not** use `def test_*()` functions or `import streamlit as st`.
+- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`).
+- Always include `from __future__ import annotations` at the top.
+- Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration
+  (e.g. `radio_types.py`, `button_types.py`).
 
 ## Theming and Layout
 


### PR DESCRIPTION

## Describe your changes

Expands the typing test documentation in `lib/streamlit/AGENTS.md` (and its generated counterparts) to explicitly describe the established conventions:

- Typing tests are checked by **mypy only**, not executed by pytest at runtime
- All assertions and imports belong inside `if TYPE_CHECKING:` blocks
- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`), not `import streamlit as st`
- Do not use `def test_*()` function patterns
- Always include `from __future__ import annotations`
- References `radio_types.py` and `button_types.py` as concrete examples

This was identified as a gap when an AI agent created typing tests using the wrong pattern (pytest-style `def test_*()` functions with `import streamlit as st`), which technically "passed" but didn't follow the established conventions used by all other typing tests in the repo.

**Files changed:**
- `lib/streamlit/AGENTS.md` — source of truth, updated typing test section
- `.cursor/rules/python_lib.mdc` — regenerated from AGENTS.md
- `.github/instructions/python_lib.instructions.md` — regenerated from AGENTS.md

## Testing Plan

- No tests needed — this is a documentation-only change to agent rules. The generated files were verified by running `python scripts/generate_agent_rules.py` successfully.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
