### PR TITLE
[chore] clarify anti-regression test assertion rules for AI agents

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -29,7 +29,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Under `lib/tests/streamlit`, add a new test file
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
-- Anti-regression checks: When adding/modifying unit tests, include at least one negative assertion when practical (the inverse condition, invalid input, or a forbidden side effect) alongside the positive assertion. For example, if you assert a flag becomes `True`, also assert a mutually exclusive flag remains `False` (see `lib/tests/AGENTS.md` for more examples).
+- Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
 
 ### Typing Tests
 

--- a/.cursor/rules/python_tests.mdc
+++ b/.cursor/rules/python_tests.mdc
@@ -17,11 +17,12 @@ We aim for high unit test coverage (90% or higher) of our Python code in `lib/st
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason (e.g., integration requirements, circular import issues, testing import behavior, or within `AppTest` functions).
 - Skip tests (via `pytest.mark.skipif`) requiring CI secrets if the environment variables are not set.
 - Parameterized Tests: Use `@parameterized.expand` whenever it is possible to combine overlapping tests with varying inputs.
-- Include a negative / anti-regression assertion when practical: Don't only test that the “right” behavior happens; also test that a plausible “wrong” behavior does **not** happen.
-  - Examples:
-    - If you assert a flag becomes `True`, also assert a mutually exclusive flag remains `False`.
-    - If you expect a function to return a value, also assert it doesn't return a plausible-but-wrong value.
-    - If you expect success, also cover one relevant failure mode (invalid input, boundary condition, or raised exception) when practical.
+- Anti-regression assertions: Where practical, go beyond testing the happy path by also covering a plausible failure mode or edge case. Good examples:
+  - Test that invalid input raises the expected exception.
+  - Test a boundary condition (empty list, zero, `None`, max length).
+  - Assert that a side effect does **not** occur (e.g., a read-only operation must not mutate state).
+  - Assert that a return value does not contain a plausible-but-wrong entry (e.g., a filter function must not include excluded items).
+  - **Do NOT** add assertions that are logically implied by an earlier assertion in the same test. For example, if you already assert `x is True`, do not also assert `x is not False` — that is a tautology and adds no value. Similarly, do not assert both sides of a simple boolean or enum when one implies the other.
 - Prefer targeted negatives over exhaustive matrices: Add one high-signal negative check per behavior; don't balloon test cases without a regression history.
 
 ## Running tests

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -27,7 +27,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Under `lib/tests/streamlit`, add a new test file
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
-- Anti-regression checks: When adding/modifying unit tests, include at least one negative assertion when practical (the inverse condition, invalid input, or a forbidden side effect) alongside the positive assertion. For example, if you assert a flag becomes `True`, also assert a mutually exclusive flag remains `False` (see `lib/tests/AGENTS.md` for more examples).
+- Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
 
 ### Typing Tests
 

--- a/.github/instructions/python_tests.instructions.md
+++ b/.github/instructions/python_tests.instructions.md
@@ -15,11 +15,12 @@ We aim for high unit test coverage (90% or higher) of our Python code in `lib/st
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason (e.g., integration requirements, circular import issues, testing import behavior, or within `AppTest` functions).
 - Skip tests (via `pytest.mark.skipif`) requiring CI secrets if the environment variables are not set.
 - Parameterized Tests: Use `@parameterized.expand` whenever it is possible to combine overlapping tests with varying inputs.
-- Include a negative / anti-regression assertion when practical: Don't only test that the “right” behavior happens; also test that a plausible “wrong” behavior does **not** happen.
-  - Examples:
-    - If you assert a flag becomes `True`, also assert a mutually exclusive flag remains `False`.
-    - If you expect a function to return a value, also assert it doesn't return a plausible-but-wrong value.
-    - If you expect success, also cover one relevant failure mode (invalid input, boundary condition, or raised exception) when practical.
+- Anti-regression assertions: Where practical, go beyond testing the happy path by also covering a plausible failure mode or edge case. Good examples:
+  - Test that invalid input raises the expected exception.
+  - Test a boundary condition (empty list, zero, `None`, max length).
+  - Assert that a side effect does **not** occur (e.g., a read-only operation must not mutate state).
+  - Assert that a return value does not contain a plausible-but-wrong entry (e.g., a filter function must not include excluded items).
+  - **Do NOT** add assertions that are logically implied by an earlier assertion in the same test. For example, if you already assert `x is True`, do not also assert `x is not False` — that is a tautology and adds no value. Similarly, do not assert both sides of a simple boolean or enum when one implies the other.
 - Prefer targeted negatives over exhaustive matrices: Add one high-signal negative check per behavior; don't balloon test cases without a regression history.
 
 ## Running tests

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -23,7 +23,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Under `lib/tests/streamlit`, add a new test file
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
-- Anti-regression checks: When adding/modifying unit tests, include at least one negative assertion when practical (the inverse condition, invalid input, or a forbidden side effect) alongside the positive assertion. For example, if you assert a flag becomes `True`, also assert a mutually exclusive flag remains `False` (see `lib/tests/AGENTS.md` for more examples).
+- Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
 
 ### Typing Tests
 

--- a/lib/tests/AGENTS.md
+++ b/lib/tests/AGENTS.md
@@ -11,11 +11,12 @@ We aim for high unit test coverage (90% or higher) of our Python code in `lib/st
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason (e.g., integration requirements, circular import issues, testing import behavior, or within `AppTest` functions).
 - Skip tests (via `pytest.mark.skipif`) requiring CI secrets if the environment variables are not set.
 - Parameterized Tests: Use `@parameterized.expand` whenever it is possible to combine overlapping tests with varying inputs.
-- Include a negative / anti-regression assertion when practical: Don't only test that the “right” behavior happens; also test that a plausible “wrong” behavior does **not** happen.
-  - Examples:
-    - If you assert a flag becomes `True`, also assert a mutually exclusive flag remains `False`.
-    - If you expect a function to return a value, also assert it doesn't return a plausible-but-wrong value.
-    - If you expect success, also cover one relevant failure mode (invalid input, boundary condition, or raised exception) when practical.
+- Anti-regression assertions: Where practical, go beyond testing the happy path by also covering a plausible failure mode or edge case. Good examples:
+  - Test that invalid input raises the expected exception.
+  - Test a boundary condition (empty list, zero, `None`, max length).
+  - Assert that a side effect does **not** occur (e.g., a read-only operation must not mutate state).
+  - Assert that a return value does not contain a plausible-but-wrong entry (e.g., a filter function must not include excluded items).
+  - **Do NOT** add assertions that are logically implied by an earlier assertion in the same test. For example, if you already assert `x is True`, do not also assert `x is not False` — that is a tautology and adds no value. Similarly, do not assert both sides of a simple boolean or enum when one implies the other.
 - Prefer targeted negatives over exhaustive matrices: Add one high-signal negative check per behavior; don't balloon test cases without a regression history.
 
 ## Running tests


### PR DESCRIPTION

## Describe your changes

Rewrites the anti-regression assertion guidance in `AGENTS.md` test rules to prevent AI agents from producing tautological assertions (e.g. asserting `x is True` then also asserting `x is not False`).

- Replaces the "mutually exclusive flag" example with actionable categories: invalid input, boundary conditions, side-effect absence, and wrong-but-plausible return values
- Adds an explicit **"Do NOT"** rule prohibiting logically-implied assertions

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: documentation-only changes to agent rule files, no behavior modifications.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
