### PR TITLE
Auto-escape some markdown syntax in markdown labels

### DIFF
--- a/e2e_playwright/st_button.py
+++ b/e2e_playwright/st_button.py
@@ -141,3 +141,8 @@ st.button(
     icon_position="right",
     key="icon_right_material",
 )
+
+# Test for markdown syntax characters in labels (issue #7359)
+# These should display the literal characters, not be parsed as markdown
+st.button("+", key="markdown_plus_label")
+st.button("1. Something", key="markdown_numbered_label")

--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -29,7 +29,7 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-TOTAL_BUTTONS = 30
+TOTAL_BUTTONS = 32
 
 
 def test_button_widget_rendering(
@@ -286,3 +286,14 @@ def test_button_with_spinner_icon(app: Page):
     button = get_button(app, "Button with spinner icon")
     # Check that the spinner icon is visible:
     expect(button.get_by_test_id("stSpinnerIcon")).to_be_visible()
+
+
+def test_markdown_syntax_in_labels(app: Page):
+    """Test that markdown syntax characters in labels are displayed literally (issue #7359)."""
+    # Test that "+" is not parsed as a list marker
+    plus_button = get_element_by_key(app, "markdown_plus_label")
+    expect(plus_button).to_contain_text("+")
+
+    # Test that "1." is not parsed as an ordered list marker
+    numbered_button = get_element_by_key(app, "markdown_numbered_label")
+    expect(numbered_button).to_contain_text("1. Something")

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -745,7 +745,7 @@ describe("StreamlitMarkdown", () => {
   )
 
   it("renders emphasis markdown in labels", () => {
-    // *bold label* should render as emphasized text, not be escaped
+    // *italic label* should render as emphasized text, not be escaped
     render(
       <StreamlitMarkdown source="*italic label*" allowHTML={false} isLabel />
     )

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -605,23 +605,25 @@ describe("StreamlitMarkdown", () => {
     { input: table, tag: "tr", expected: tableText },
     { input: table, tag: "th", expected: tableText },
     { input: table, tag: "td", expected: tableText },
-    { input: "# Heading 1", tag: "h1", expected: "Heading 1" },
-    { input: "## Heading 2", tag: "h2", expected: "Heading 2" },
-    { input: "### Heading 3", tag: "h3", expected: "Heading 3" },
-    { input: "#### Heading 4", tag: "h4", expected: "Heading 4" },
-    { input: "##### Heading 5", tag: "h5", expected: "Heading 5" },
-    { input: "###### Heading 6", tag: "h6", expected: "Heading 6" },
-    { input: "- List Item 1", tag: "ul", expected: "List Item 1" },
-    { input: "- List Item 1", tag: "li", expected: "List Item 1" },
-    { input: "1. List Item 1", tag: "ol", expected: "List Item 1" },
-    { input: "1. List Item 1", tag: "li", expected: "List Item 1" },
+    // Markdown syntax is escaped in labels to preserve as text
+    // (see https://github.com/streamlit/streamlit/issues/7359)
+    { input: "# Heading 1", tag: "h1", expected: "# Heading 1" },
+    { input: "## Heading 2", tag: "h2", expected: "## Heading 2" },
+    { input: "### Heading 3", tag: "h3", expected: "### Heading 3" },
+    { input: "#### Heading 4", tag: "h4", expected: "#### Heading 4" },
+    { input: "##### Heading 5", tag: "h5", expected: "##### Heading 5" },
+    { input: "###### Heading 6", tag: "h6", expected: "###### Heading 6" },
+    { input: "- List Item 1", tag: "ul", expected: "- List Item 1" },
+    { input: "- List Item 1", tag: "li", expected: "- List Item 1" },
+    { input: "1. List Item 1", tag: "ol", expected: "1. List Item 1" },
+    { input: "1. List Item 1", tag: "li", expected: "1. List Item 1" },
     {
       input: "- [ ] Task List Item 1",
       tag: "input",
-      expected: "Task List Item 1",
+      expected: "- [ ] Task List Item 1",
     },
     { input: horizontalRule, tag: "hr", expected: "Horizontal rule" },
-    { input: "> Blockquote", tag: "blockquote", expected: "Blockquote" },
+    { input: "> Blockquote", tag: "blockquote", expected: "> Blockquote" },
   ]
 
   it.each(invalidCases)(
@@ -652,6 +654,105 @@ describe("StreamlitMarkdown", () => {
     )
     const tag = screen.getByText("Link text")
     expect(tag instanceof HTMLAnchorElement).toBe(false)
+  })
+
+  // Test for markdown syntax escaping in labels (https://github.com/streamlit/streamlit/issues/7359)
+  // These characters/patterns would normally create markdown elements that get stripped,
+  // leaving empty labels. Escaping preserves them as plain text.
+  const markdownEscapingCases = [
+    // Unordered list markers
+    { input: "-", expected: "-", description: "single hyphen" },
+    { input: "+", expected: "+", description: "single plus" },
+    { input: "*", expected: "*", description: "single asterisk" },
+    { input: "- text", expected: "- text", description: "hyphen with text" },
+    { input: "+ text", expected: "+ text", description: "plus with text" },
+    { input: "* text", expected: "* text", description: "asterisk with text" },
+    {
+      input: "  - indented",
+      expected: "- indented",
+      description: "indented hyphen",
+    },
+    // Ordered list markers
+    { input: "1.", expected: "1.", description: "single ordered marker" },
+    {
+      input: "1. text",
+      expected: "1. text",
+      description: "ordered with text",
+    },
+    { input: "99.", expected: "99.", description: "multi-digit ordered" },
+    { input: "1)", expected: "1)", description: "ordered with paren" },
+    // Blockquote markers
+    { input: ">", expected: ">", description: "single blockquote" },
+    {
+      input: "> text",
+      expected: "> text",
+      description: "blockquote with text",
+    },
+    // Heading markers
+    { input: "#", expected: "#", description: "single hash" },
+    { input: "##", expected: "##", description: "double hash" },
+    { input: "# text", expected: "# text", description: "heading with text" },
+  ]
+
+  it.each(markdownEscapingCases)(
+    "preserves markdown syntax in labels - $description",
+    ({ input, expected }) => {
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      const markdownText = screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
+
+      // Should be rendered as plain paragraph text, not special elements
+      const tagName = markdownText.nodeName.toLowerCase()
+      expect(tagName).toBe("p")
+
+      cleanup()
+    }
+  )
+
+  // Patterns that should NOT be escaped (no space after marker)
+  const nonEscapingCases = [
+    {
+      input: "not-a-list",
+      expected: "not-a-list",
+      description: "hyphen mid-word",
+    },
+    {
+      input: "#hashtag",
+      expected: "#hashtag",
+      description: "hash without space",
+    },
+    { input: "1.5", expected: "1.5", description: "decimal number" },
+    {
+      input: "1\\. Already escaped",
+      expected: "1. Already escaped",
+      description: "pre-escaped ordered list",
+    },
+    {
+      input: "\\- Already escaped",
+      expected: "- Already escaped",
+      description: "pre-escaped unordered list",
+    },
+  ]
+
+  it.each(nonEscapingCases)(
+    "does not escape non-markdown patterns in labels - $description",
+    ({ input, expected }) => {
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      const markdownText = screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
+      cleanup()
+    }
+  )
+
+  it("renders emphasis markdown in labels", () => {
+    // *bold label* should render as emphasized text, not be escaped
+    render(
+      <StreamlitMarkdown source="*italic label*" allowHTML={false} isLabel />
+    )
+    const emphasisText = screen.getByText("italic label")
+    expect(emphasisText).toBeInTheDocument()
+    expect(emphasisText.tagName.toLowerCase()).toBe("em")
+    cleanup()
   })
 
   it("renders smaller text sizing when isToast is true", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -1036,10 +1036,30 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     [overrideComponents]
   )
 
-  const processedSource = useMemo(
-    () => source.replaceAll(":material/", ":material_"),
-    [source]
-  )
+  const processedSource = useMemo(() => {
+    // Replace :material/ with :material_ to avoid conflicts with the directive plugin.
+    // The material icon regex in createMaterialIconPlugin uses :material_ to match.
+    let processed = source.replaceAll(":material/", ":material_")
+
+    if (isLabel) {
+      // Escape markdown syntax that would be stripped in labels, leaving empty content.
+      // See: https://github.com/streamlit/streamlit/issues/7359
+      //
+      // Escapes: "- item", "+ item", "* item", "# heading", "> quote"
+      // Does not escape: "not-a-list", "#hashtag", "1.5" (no space after marker)
+      //
+      // Unordered lists (-, +, *), headings (#), and blockquotes (>)
+      // Note: > doesn't need lookahead (always a blockquote), others need (?=\s|$)
+      processed = processed.replace(
+        /^(\s*)((?:[+\-*]|#+)(?=\s|$)|>)/gm,
+        "$1\\$2"
+      )
+      // Ordered lists (1., 2., etc.): escape only the punctuation, not the digits
+      processed = processed.replace(/^(\s*)(\d+)([.)])(?=\s|$)/gm, "$1$2\\$3")
+    }
+
+    return processed
+  }, [source, isLabel])
 
   const disallowed = useMemo(() => {
     if (!isLabel) return []


### PR DESCRIPTION
## Describe your changes

This PR fixes issue #7359 where widget labels containing markdown syntax characters (-, +, *, #, >, 1.) would render as empty labels because the markdown parser was interpreting them as list markers, headings, or blockquotes which are then stripped for labels.

The fix escapes these markdown syntax patterns when `isLabel` is true, converting them to literal text by adding backslash escapes before markdown is processed. The escaping only applies to patterns followed by whitespace or end of line (e.g., "- item" is escaped but "not-a-list" is not).

## GitHub Issue Link (if applicable)

Fixes #7359

## Testing Plan

- Unit Tests: 175 passing tests covering escaped patterns, non-escaped patterns, edge cases with pre-escaped text, and emphasis markdown
- E2E Tests: Added test cases for "+" and "1. Something" labels to verify they display correctly in buttons
- No additional manual testing needed beyond existing test coverage

---

Co-authored-by: sea-turt1e <25264827+sea-turt1e@users.noreply.github.com>

- See original PR https://github.com/streamlit/streamlit/pull/12695

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.