### PR TITLE
[DynamicContainers] Dynamic Expanders

### DIFF
--- a/e2e_playwright/st_expander.py
+++ b/e2e_playwright/st_expander.py
@@ -105,3 +105,108 @@ satisfying dance of creation that leaves you wanting more.')
 
 """
 st.expander("With code block:\n" + code_block)
+
+# ============================================================================
+# Dynamic Expander Tests (on_change="rerun")
+# ============================================================================
+
+if "lazy_exec_count" not in st.session_state:
+    st.session_state.lazy_exec_count = 0
+
+exp_lazy = st.expander("Dynamic lazy execution", on_change="rerun")
+
+if exp_lazy.open:
+    with exp_lazy:
+        st.session_state.lazy_exec_count += 1
+        st.write(f"Lazy content executed {st.session_state.lazy_exec_count} times")
+        st.write("This only runs when expander is open")
+
+st.write(f"Lazy execution count: {st.session_state.lazy_exec_count}")
+
+
+def open_dynamic_exp():
+    st.session_state.prog_exp = True
+
+
+def close_dynamic_exp():
+    st.session_state.prog_exp = False
+
+
+col1, col2 = st.columns(2)
+with col1:
+    st.button("Open Dynamic", on_click=open_dynamic_exp, key="open_dyn")
+with col2:
+    st.button("Close Dynamic", on_click=close_dynamic_exp, key="close_dyn")
+
+exp_prog = st.expander("Programmatic dynamic", key="prog_exp", on_change="rerun")
+
+if exp_prog.open:
+    with exp_prog:
+        st.write("Programmatically controlled")
+
+
+# Track execution for nested lazy loading
+if "nested_outer_exec" not in st.session_state:
+    st.session_state.nested_outer_exec = 0
+if "nested_inner_exec" not in st.session_state:
+    st.session_state.nested_inner_exec = 0
+
+
+def open_outer():
+    st.session_state.outer_dyn = True
+
+
+def close_outer():
+    st.session_state.outer_dyn = False
+
+
+def open_inner():
+    st.session_state.inner_dyn = True
+
+
+def close_inner():
+    st.session_state.inner_dyn = False
+
+
+# Buttons for programmatic control of nested expanders
+col1, col2, col3, col4 = st.columns(4)
+with col1:
+    st.button("Open Outer", on_click=open_outer, key="open_outer_btn")
+with col2:
+    st.button("Close Outer", on_click=close_outer, key="close_outer_btn")
+with col3:
+    st.button("Open Inner", on_click=open_inner, key="open_inner_btn")
+with col4:
+    st.button("Close Inner", on_click=close_inner, key="close_inner_btn")
+
+exp_outer_dyn = st.expander("Outer dynamic", key="outer_dyn", on_change="rerun")
+if exp_outer_dyn.open:
+    with exp_outer_dyn:
+        st.session_state.nested_outer_exec += 1
+        st.write(f"Outer executed {st.session_state.nested_outer_exec} times")
+
+        exp_inner_dyn = st.expander(
+            "Inner dynamic nested", key="inner_dyn", on_change="rerun"
+        )
+
+        if exp_inner_dyn.open:
+            with exp_inner_dyn:
+                st.session_state.nested_inner_exec += 1
+                st.write(f"Inner executed {st.session_state.nested_inner_exec} times")
+
+st.write(
+    f"Nested execution - Outer: {st.session_state.nested_outer_exec}, Inner: {st.session_state.nested_inner_exec}"
+)
+
+# Ignore mode (default) — should NOT trigger reruns on toggle
+# ============================================================================
+
+if "exp_ignore_rerun_count" not in st.session_state:
+    st.session_state.exp_ignore_rerun_count = 0
+
+st.session_state.exp_ignore_rerun_count += 1
+
+with st.expander("Ignore-mode expander"):
+    st.write("This expander uses the default on_change='ignore'")
+
+st.write(f"Expander ignore rerun count: {st.session_state.exp_ignore_rerun_count}")

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -21,7 +21,7 @@ from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
 
 EXPANDER_HEADER_IDENTIFIER = "summary"
 
-NUMBER_OF_EXPANDERS: Final = 15
+NUMBER_OF_EXPANDERS: Final = 19
 
 
 def test_expander_displays_correctly(
@@ -135,3 +135,197 @@ def test_expander_hover_states(themed_app: Page, assert_snapshot: ImageCompareFu
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stExpander")
+
+
+def test_dynamic_expander_lazy_execution(app: Page):
+    """Test that dynamic expander only executes content when open."""
+    # Initially closed — lazy content should not have executed
+    expect(app.get_by_text("Lazy execution count: 0")).to_be_visible()
+
+    # Open the dynamic expander
+    lazy_expander = get_expander(app, "Dynamic lazy execution")
+    lazy_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Content should have executed once
+    expect(app.get_by_text("Lazy content executed 1 times")).to_be_visible()
+    expect(app.get_by_text("Lazy execution count: 1")).to_be_visible()
+
+    # Close the expander
+    lazy_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Count should stay at 1 — content didn't execute while closed
+    expect(app.get_by_text("Lazy execution count: 1")).to_be_visible()
+
+
+def test_dynamic_expander_programmatic_control(app: Page):
+    """Test programmatic control of dynamic expander via session state."""
+    prog_expander = get_expander(app, "Programmatic dynamic")
+
+    # Initially closed — content not visible
+    expect(prog_expander.get_by_text("Programmatically controlled")).not_to_be_visible()
+
+    # Open via button
+    app.get_by_test_id("stButton").filter(has_text="Open Dynamic").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    # Expander should be open with content visible
+    expect(prog_expander.get_by_text("Programmatically controlled")).to_be_visible()
+
+    # Close via button
+    app.get_by_test_id("stButton").filter(has_text="Close Dynamic").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    # Content should not be visible
+    expect(prog_expander.get_by_text("Programmatically controlled")).not_to_be_visible()
+
+
+def test_dynamic_expander_nested(app: Page):
+    """Test nested dynamic expanders with lazy execution."""
+    # Initially both closed, neither should have executed
+    expect(app.get_by_text("Nested execution - Outer: 0, Inner: 0")).to_be_visible()
+
+    # Open outer expander — only outer should execute
+    outer_expander = get_expander(app, "Outer dynamic")
+    outer_expander.locator("summary").first.click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Outer executed 1 times")).to_be_visible()
+    expect(app.get_by_text("Nested execution - Outer: 1, Inner: 0")).to_be_visible()
+
+    # Open inner expander — both should execute (outer reruns, inner for first time)
+    inner_expander = outer_expander.get_by_test_id("stExpander").filter(
+        has=app.locator("summary").filter(has_text="Inner dynamic nested")
+    )
+    inner_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Outer executed 2 times")).to_be_visible()
+    expect(app.get_by_text("Inner executed 1 times")).to_be_visible()
+    expect(app.get_by_text("Nested execution - Outer: 2, Inner: 1")).to_be_visible()
+
+    # Close inner — outer executes but inner doesn't
+    inner_expander = outer_expander.get_by_test_id("stExpander").filter(
+        has=app.locator("summary").filter(has_text="Inner dynamic nested")
+    )
+    inner_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 3, Inner: 1")).to_be_visible()
+
+    # Close outer — neither executes
+    outer_expander.locator("summary").first.click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 3, Inner: 1")).to_be_visible()
+
+
+def test_dynamic_expander_nested_programmatic_control(app: Page):
+    """Test programmatic control of nested dynamic expanders via buttons."""
+    # Initially both closed
+    expect(app.get_by_text("Nested execution - Outer: 0, Inner: 0")).to_be_visible()
+
+    # Open outer via button
+    app.get_by_test_id("stButton").filter(has_text="Open Outer").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 1, Inner: 0")).to_be_visible()
+
+    # Open inner via button
+    app.get_by_test_id("stButton").filter(has_text="Open Inner").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 2, Inner: 1")).to_be_visible()
+
+    # Close inner via button
+    app.get_by_test_id("stButton").filter(has_text="Close Inner").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 3, Inner: 1")).to_be_visible()
+
+    # Close outer via button
+    app.get_by_test_id("stButton").filter(has_text="Close Outer").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 3, Inner: 1")).to_be_visible()
+
+
+def test_dynamic_expander_nested_state_preloading(app: Page):
+    """Test that setting inner expander state before outer is opened works.
+
+    Also verifies that widget state persists in session_state when a widget
+    is temporarily unmounted (consistent with all Streamlit widgets).
+    """
+    # Initially both closed
+    expect(app.get_by_text("Nested execution - Outer: 0, Inner: 0")).to_be_visible()
+
+    # Set inner state before outer is rendered
+    app.get_by_test_id("stButton").filter(has_text="Open Inner").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    # Outer still closed, neither executed
+    expect(app.get_by_text("Nested execution - Outer: 0, Inner: 0")).to_be_visible()
+
+    # Now open outer — inner should already be open because state was pre-set
+    app.get_by_test_id("stButton").filter(has_text="Open Outer").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    # Both should execute
+    expect(app.get_by_text("Nested execution - Outer: 1, Inner: 1")).to_be_visible()
+    expect(app.get_by_text("Inner executed 1 times")).to_be_visible()
+
+    # Close outer while inner is open (inner widget is unmounted)
+    app.get_by_test_id("stButton").filter(has_text="Close Outer").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    # Neither executes while outer is closed
+    expect(app.get_by_text("Nested execution - Outer: 1, Inner: 1")).to_be_visible()
+
+    # Reopen outer — inner state was preserved in session_state while unmounted,
+    # so inner should still be open (consistent with all Streamlit widget behavior)
+    app.get_by_test_id("stButton").filter(has_text="Open Outer").locator(
+        "button"
+    ).click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Nested execution - Outer: 2, Inner: 2")).to_be_visible()
+    expect(app.get_by_text("Inner executed 2 times")).to_be_visible()
+
+
+def test_expander_ignore_mode_does_not_trigger_rerun(app: Page):
+    """Test that an expander with default on_change='ignore' does not trigger reruns."""
+    rerun_text = app.get_by_text("Expander ignore rerun count:")
+    expect(rerun_text).to_be_visible()
+    initial_count = rerun_text.text_content()
+
+    # Expand the ignore-mode expander
+    ignore_expander = get_expander(app, "Ignore-mode expander")
+    ignore_expander.locator("summary").click()
+
+    # Rerun count should NOT have changed
+    expect(rerun_text).to_have_text(initial_count or "")
+
+    # Collapse it
+    ignore_expander.locator("summary").click()
+
+    # Still no rerun
+    expect(rerun_text).to_have_text(initial_count or "")

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -323,6 +323,9 @@ export const BlockNodeRenderer = (
       <Expander
         isStale={isStale}
         element={node.deltaBlock.expandable as BlockProto.Expandable}
+        widgetMgr={props.widgetMgr}
+        blockId={node.deltaBlock.id || undefined}
+        fragmentId={node.fragmentId}
       >
         {child}
       </Expander>

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -16,10 +16,12 @@
 
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
+import { vi } from "vitest"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
 import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Expander, { ExpanderProps } from "./Expander"
 
@@ -35,6 +37,12 @@ const getProps = (
   isStale: false,
   ...props,
 })
+
+const createWidgetMgr = (): WidgetStateManager =>
+  new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
 
 describe("Expander container", () => {
   it("renders without crashing", () => {
@@ -207,5 +215,97 @@ describe("Expander container", () => {
 
     await user.click(screen.getByText("hi"))
     expect(panel).toHaveAttribute("inert")
+  })
+})
+
+describe("widget mode (widgetMgr + element.id)", () => {
+  it("calls setBoolValue on toggle", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+    const props = getProps(
+      { expanded: false, id: "expander-123" },
+      { widgetMgr, fragmentId: "frag-1" }
+    )
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    await user.click(screen.getByText("hi"))
+
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: "expander-123" },
+      true,
+      { fromUi: true },
+      "frag-1"
+    )
+  })
+
+  it("does not call setBoolValue when element.id is not set", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+    // No element.id — non-widget mode (even though widgetMgr is provided)
+    const props = getProps({ expanded: false })
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    await user.click(screen.getByText("hi"))
+
+    expect(setBoolValueSpy).not.toHaveBeenCalled()
+  })
+
+  it("does not enter widget mode when only blockId is set (CSS key styling)", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+    // blockId set for CSS class but no element.id — should NOT be widget mode
+    const props = getProps(
+      { expanded: false },
+      { widgetMgr, blockId: "$$ID-abc123-my_expander" }
+    )
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    await user.click(screen.getByText("hi"))
+
+    expect(setBoolValueSpy).not.toHaveBeenCalled()
+  })
+
+  it("adds CSS class from blockId key", () => {
+    const props = getProps({}, { blockId: "$$ID-abc123-my_expander" })
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    const expander = screen.getByTestId("stExpander")
+    expect(expander).toHaveClass("st-key-my_expander")
+  })
+
+  it("does not add CSS class when blockId is absent", () => {
+    const props = getProps()
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    const expander = screen.getByTestId("stExpander")
+    expect(expander.className).not.toContain("st-key-")
   })
 })

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useState } from "react"
+import { memo, ReactElement, useCallback, useState } from "react"
+
+import classNames from "classnames"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
+import {
+  convertKeyToClassName,
+  getKeyFromId,
+} from "~lib/components/core/Block/utils"
 import { DynamicIcon } from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
   StyledDetails,
@@ -68,20 +75,49 @@ export const ExpanderIcon = (props: ExpanderIconProps): ReactElement => {
 export interface ExpanderProps {
   element: BlockProto.Expandable
   isStale: boolean
+  widgetMgr?: WidgetStateManager
+  /** Block-level ID for CSS key styling (may be set without widget mode). */
+  blockId?: string
+  fragmentId?: string
 }
 
 const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   element,
   isStale,
+  widgetMgr,
+  blockId,
+  fragmentId,
   children,
 }): ReactElement => {
   const { label, icon } = element
   const [isHovered, setIsHovered] = useState(false)
 
+  // element.id is only set when the backend registers the expander as a
+  // stateful widget (on_change="rerun"). block.id may still be set for
+  // CSS key styling without implying widget mode.
+  const widgetId = element.id || undefined
+  const isWidget = Boolean(widgetMgr && widgetId)
+
+  // Callback to notify backend of toggle (only used in widget mode)
+  const handleWidgetToggle = useCallback(
+    (newOpen: boolean): void => {
+      if (widgetMgr && widgetId) {
+        widgetMgr.setBoolValue(
+          { id: widgetId },
+          newOpen,
+          { fromUi: true },
+          fragmentId
+        )
+      }
+    },
+    [widgetMgr, widgetId, fragmentId]
+  )
+
   const { isOpen, detailsRef, summaryRef, contentRef, handleToggle } =
     useDetailsAnimation({
       backendExpanded: element.expanded,
       label,
+      onToggle: isWidget ? handleWidgetToggle : undefined,
     })
 
   // Determine which icon to show
@@ -96,8 +132,13 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
     setIsHovered(false)
   }
 
+  const userKey = getKeyFromId(blockId)
+
   return (
-    <StyledExpandableContainer className="stExpander" data-testid="stExpander">
+    <StyledExpandableContainer
+      className={classNames("stExpander", convertKeyToClassName(userKey))}
+      data-testid="stExpander"
+    >
       <StyledDetails
         isStale={isStale}
         ref={detailsRef}

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -30,10 +30,23 @@ import { BORDER_SIZE } from "./styled-components"
 
 /**
  * Debounce delay for ResizeObserver callbacks (ms).
- * 50ms (~3 frames at 60fps) lets rapid content changes settle
- * while still being responsive.
+ *
+ * ResizeObserver already coalesces all mutations within a single animation
+ * frame into one callback, so this debounce only needs to cover *cross-frame*
+ * resize sequences (e.g. children mounting over 2-3 frames, image loads, or
+ * font swaps).
+ *
+ * 10ms is chosen because:
+ * - It's above the browser `setTimeout` clamping floor (~4ms), so it
+ *   reliably spans at least one full frame on a 60fps display (~16.7ms).
+ * - Going shorter (e.g. 5ms) gives no practical benefit due to timer
+ *   clamping. Going longer (e.g. 50ms ≈ 3 frames) creates a visible
+ *   pause where content sits at the wrong height before the animation
+ *   starts.
+ * - Even if a resize is missed, `cancelAnimation()` + `getBoundingClientRect()`
+ *   recaptures the current height, so starting "too early" is visually safe.
  */
-const RESIZE_DEBOUNCE_MS = 50
+const RESIZE_DEBOUNCE_MS = 10
 
 /**
  * Minimum height difference (px) required to trigger a resize animation.
@@ -166,11 +179,12 @@ export function useDetailsAnimation({
           )
         }
         // If contentHeight is 0, leave inline height + overflow locked.
-        // This is only expected when a loading skeleton hasn't painted yet
-        // (in widget mode, a <TextLineSkeleton> renders immediately so
-        // contentHeight is normally > 0). Keeping styles locked lets the
-        // ResizeObserver animate from the collapsed height to the full
-        // content height once the skeleton (or real content) paints.
+        // This is rare in practice — StyledDetailsPanel always has padding,
+        // so even an empty expander measures > 0. It can only happen if
+        // getBoundingClientRect fires before the browser has laid out the
+        // content. Keeping styles locked lets the ResizeObserver animate
+        // from the collapsed height to the full content height once layout
+        // settles.
       } else {
         // Closing: animate to collapsed height, then set open=false
         const targetHeight = summaryHeight + 2 * BORDER_SIZE

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -64,6 +64,19 @@ SpecType: TypeAlias = int | Sequence[int | float]
 
 
 @dataclass
+class _ExpanderSerde:
+    """Serializer/deserializer for expander widget state."""
+
+    expanded: bool
+
+    def serialize(self, v: bool) -> bool:
+        return bool(v)
+
+    def deserialize(self, ui_value: bool | None) -> bool:
+        return ui_value if ui_value is not None else self.expanded
+
+
+@dataclass
 class _PopoverSerde:
     """Serializer/deserializer for popover widget state."""
 
@@ -865,8 +878,10 @@ class LayoutsMixin:
         label: str,
         expanded: bool = False,
         *,
+        key: Key | None = None,
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        on_change: Literal["ignore", "rerun"] = "ignore",
     ) -> ExpanderContainer:
         r"""Insert a multi-element container that can be expanded/collapsed.
 
@@ -908,6 +923,16 @@ class LayoutsMixin:
             If True, initializes the expander in "expanded" state. Defaults to
             False (collapsed).
 
+        key : str or int
+            An optional string or integer to use as the unique key for the
+            widget. Only used when ``on_change`` is set to ``"rerun"``.
+            If this is omitted, a key will be generated for the widget
+            based on its content. No two widgets may have the same key.
+
+            If ``key`` is provided along with ``on_change="rerun"``, it will
+            also be used as a CSS class name prefixed with ``st-key-``, and
+            the expanded state is accessible via ``st.session_state[key]``.
+
         icon : str, None
             An optional emoji or icon to display next to the expander label. If ``icon``
             is ``None`` (default), no icon is displayed. If ``icon`` is a
@@ -936,6 +961,21 @@ class LayoutsMixin:
               fixed width. If the specified width is greater than the width of
               the parent container, the width of the container matches the width
               of the parent container.
+
+        on_change : "ignore" or "rerun"
+            How the expander should respond to user toggle events. This controls
+            whether the expander tracks state and triggers reruns when toggled.
+            ``on_change`` can be one of the following:
+
+            - ``"ignore"`` (default): Streamlit will not track the expander's
+              state. The ``.open`` attribute will return ``None``. The expander
+              can be used inside ``@st.cache_data`` decorated functions.
+
+            - ``"rerun"``: Streamlit will rerun the app when the user expands
+              or collapses the expander. The ``.open`` attribute will return
+              the current state (``True`` if expanded, ``False`` if collapsed).
+              The expander cannot be used inside ``@st.cache_data`` decorated
+              functions.
 
         Examples
         --------
@@ -979,25 +1019,80 @@ class LayoutsMixin:
         if label is None:
             raise StreamlitAPIException("A label is required for an expander")
 
+        if on_change not in {"ignore", "rerun"}:
+            raise StreamlitValueError("on_change", ["'rerun'", "'ignore'"])
+
+        key = to_key(key)
+        is_stateful = on_change == "rerun"
+
+        current_expanded = expanded
+        element_id: str | None = None
+
+        if is_stateful:
+            # TODO: Set on_change and enable_check_callback_rules correctly
+            # when user-defined callbacks are supported for expanders.
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=None,
+                default_value=None,
+                writes_allowed=True,
+                enable_check_callback_rules=False,
+            )
+
+            ctx = get_script_run_ctx()
+
+            element_id = compute_and_register_element_id(
+                "expander",
+                user_key=key,
+                key_as_main_identity=False,
+                dg=self.dg,
+                label=label,
+                expanded=expanded,
+                icon=icon,
+                width=width,
+            )
+
+            serde = _ExpanderSerde(expanded=expanded)
+
+            expander_state = register_widget(
+                element_id,
+                deserializer=serde.deserialize,
+                serializer=serde.serialize,
+                ctx=ctx,
+                value_type="bool_value",
+            )
+
+            current_expanded = expander_state.value
         expandable_proto = BlockProto.Expandable()
-        expandable_proto.expanded = expanded
+        expandable_proto.expanded = current_expanded
         expandable_proto.label = label
         if icon is not None:
             expandable_proto.icon = validate_icon_or_emoji(icon)
 
+        if is_stateful and element_id is not None:
+            expandable_proto.id = element_id
+
         block_proto = BlockProto()
         block_proto.allow_empty = True
+        if element_id is not None:
+            block_proto.id = element_id
         block_proto.expandable.CopyFrom(expandable_proto)
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
 
-        return cast(
+        expander_dg = cast(
             "ExpanderContainer",
             self.dg._block(
                 block_proto=block_proto,
                 dg_type=get_dg_singleton_instance().expander_container_cls,
             ),
         )
+
+        if is_stateful:
+            expander_dg.open = current_expanded
+
+        return expander_dg
 
     @gather_metrics("popover")
     def popover(

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -417,6 +417,71 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander = st.expander("label", expanded=True)
         assert expander.open is None
 
+    def test_invalid_on_change_raises(self):
+        """Test that invalid on_change values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.expander("label", on_change="invalid")
+
+    def test_on_change_rerun_sets_open_false(self):
+        """Test that on_change='rerun' with expanded=False sets .open to False."""
+        expander = st.expander("label", on_change="rerun")
+        assert expander.open is False
+
+    def test_on_change_rerun_sets_open_true(self):
+        """Test that on_change='rerun' with expanded=True sets .open to True."""
+        expander = st.expander("label", expanded=True, on_change="rerun")
+        assert expander.open is True
+
+    def test_on_change_rerun_sets_block_id(self):
+        """Test that on_change='rerun' sets the block id in the proto."""
+        st.expander("label", on_change="rerun")
+        expander_block = self.get_delta_from_queue()
+        assert expander_block.add_block.id != ""
+
+    def test_on_change_rerun_sets_id(self):
+        """Test that on_change='rerun' sets id in the expandable proto."""
+        st.expander("label", on_change="rerun")
+        expander_block = self.get_delta_from_queue()
+        assert expander_block.add_block.expandable.id != ""
+        assert expander_block.add_block.expandable.id == expander_block.add_block.id
+
+    def test_on_change_ignore_does_not_set_block_id(self):
+        """Test that on_change='ignore' does not set the block id."""
+        st.expander("label", on_change="ignore")
+        expander_block = self.get_delta_from_queue()
+        assert expander_block.add_block.id == ""
+
+    def test_on_change_ignore_does_not_set_id(self):
+        """Test that on_change='ignore' does not set id."""
+        st.expander("label", on_change="ignore")
+        expander_block = self.get_delta_from_queue()
+        assert not expander_block.add_block.expandable.HasField("id")
+
+    def test_key_without_on_change_does_not_set_block_id(self):
+        """Test that key alone (without on_change='rerun') does not set block id."""
+        st.expander("label", key="my_expander")
+        expander_block = self.get_delta_from_queue()
+        assert expander_block.add_block.id == ""
+
+    def test_on_change_rerun_with_key_accessible_via_session_state(self):
+        """Test that on_change='rerun' with key makes state accessible."""
+        st.expander("label", key="my_exp", on_change="rerun")
+        assert "my_exp" in st.session_state
+        assert st.session_state.my_exp is False
+
+    def test_on_change_rerun_expanded_true_session_state(self):
+        """Test that expanded=True is reflected in session_state."""
+        st.expander("label", key="my_exp", expanded=True, on_change="rerun")
+        assert st.session_state.my_exp is True
+
+    def test_on_change_rerun_expanded_state_uses_widget_value(self):
+        """Test that the expanded proto state comes from widget registration."""
+        expander = st.expander("label", expanded=False, on_change="rerun")
+        expander_block = self.get_delta_from_queue()
+        # Widget state should match the initial expanded value
+        assert not expander_block.add_block.expandable.expanded
+        assert expander.open is False
+
 
 class ContainerTest(DeltaGeneratorTestCase):
     def test_border_parameter(self):

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -102,6 +102,9 @@ message Block {
     string label = 1;
     optional bool expanded = 2;
     string icon = 3;
+    // ID for dynamic expanders. Only set when on_change="rerun",
+    // signaling the frontend to treat this as a stateful widget.
+    optional string id = 4;
   }
 
   message Dialog {

--- a/specs/2026-01-14-dynamic-tabs-expander/product-spec.md
+++ b/specs/2026-01-14-dynamic-tabs-expander/product-spec.md
@@ -218,9 +218,9 @@ if "current_filter" in st.session_state:
 
 #### New parameter: `key`
 
-- **Type:** `str | None`
+- **Type:** `str | int | None`
 - **Default:** `None`
-- **Purpose:** Makes state accessible via `st.session_state[key]` for programmatic control. Not required for callbacks to work (widgets auto-generate internal IDs), but needed to access/control state programmatically.
+- **Purpose:** Makes state accessible via `st.session_state[key]` for programmatic control. Not required for callbacks to work (widgets auto-generate internal IDs), but needed to access/control state programmatically. Consistent with all other Streamlit widgets that accept `str | int` keys.
 - **State value:** `str` (label of active tab) for tabs, `bool` for expander and popover
 
 #### New attribute: `.open` (on DeltaGenerator)


### PR DESCRIPTION
Demo App: https://dynamic-expander.streamlit.app/

## Describe your changes

Adds `key` and `on_change` parameters to `st.expander`, enabling stateful dynamic expanders that persist user toggle state across reruns. Reworks the frontend animation system with a `useDetailsAnimation` hook and `animateHeight` utility.

- **`on_change="rerun"`**: Registers the expander as a widget so toggling triggers a rerun; expanded state is accessible via `st.session_state[key]` and `.open`
- **`on_change="ignore"` (default)**: No state tracking — preserves current non-widget behavior
- **ResizeObserver-based animation**: Replaces the Safari two-step repaint workaround with immediate measurement + `ResizeObserver` fallback, smooth mid-animation interruption via `getBoundingClientRect()`, and nullable `expanded` handling for backend-synced state changes
- **Widget-consistent loading skeleton**: Uses `SquareSkeleton` (same as other widgets) instead of `TextLineSkeleton` for the loading placeholder when opening an empty dynamic expander

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `useDetailsAnimation.test.ts` — toggle behavior, backend sync, nullable handling, ResizeObserver lifecycle, rapid double-toggle, cleanup
  - `animateHeight.test.ts` — animation creation, custom options, finish/cancel lifecycle
  - `Expander.test.tsx` — widget mode rendering, skeleton, CSS key class, `onToggle` callback wiring
  - `layouts_test.py` — `on_change` validation, widget registration, session state access, widget ID assignment, ignore-mode negative checks
- [x] E2E Tests
  - `st_expander_test.py` — stateful expand/collapse reruns, nested expanders, ignore-mode no-rerun verification

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
