### PR TITLE
Pause component-lib dependency updates, enable security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,15 +95,13 @@ updates:
           # versions, it makes sense to keep these grouped together
           - "@swc/*"
 
-  # Keep component-lib package.json (& lockfiles) up to date
+  # Security updates are still included, but normal updates are paused
+  # until we made a decision on the future of CC v1.
   - package-ecosystem: "npm"
     directory: "/component-lib"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5
-
-    cooldown:
-      default-days: 5
+    open-pull-requests-limit: 0
 
     labels:
       - "change:chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,7 +96,7 @@ updates:
           - "@swc/*"
 
   # Security updates are still included, but normal updates are paused
-  # until we made a decision on the future of CC v1.
+  # until we make a decision on the future of CC v1.
   - package-ecosystem: "npm"
     directory: "/component-lib"
     schedule:


### PR DESCRIPTION
## Describe your changes

Pauses normal dependency updates for component-lib while keeping security updates active. This is temporary until a decision is made on the future of CC v1.

Changed:
- Set `open-pull-requests-limit: 0` to pause version updates
- Removed `cooldown` configuration as it's not needed
- Updated comment to clarify security updates are still included

## Testing Plan

- No tests needed, this is a configuration change to dependabot.yml