### PR TITLE
Add agent rules for skills directory

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -15,6 +15,8 @@ hooks/*
 # Allow specific skills
 !skills/
 skills/*
+!skills/AGENTS.md
+!skills/CLAUDE.md
 !skills/checking-changes/
 !skills/debugging-streamlit/
 !skills/discovering-make-commands/

--- a/.claude/skills/AGENTS.md
+++ b/.claude/skills/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Cursor, Copilot, etc.) when working with skills in this repository.
+
+## Overview
+
+This directory contains Agent Skills for developing the Streamlit library. Skills are instruction sets that enhance AI coding assistants' capabilities for specific tasks in the Streamlit codebase.
+
+These skills are for **Streamlit library development** (backend, frontend, protobufs), not for building Streamlit applications.
+
+## Skill structure
+
+Each skill is a directory containing a required `SKILL.md` file and optional supporting directories:
+
+```
+skills/
+└── skill-name/
+    ├── SKILL.md          # Required: Instructions for the AI agent
+    ├── scripts/          # Optional: Executable code
+    ├── references/       # Optional: Additional documentation
+    └── assets/           # Optional: Static resources
+```
+
+### SKILL.md format
+
+The `SKILL.md` file must include YAML frontmatter and markdown instructions:
+
+```yaml
+---
+name: skill-name
+description: Clear description of what this skill does and when to use it.
+---
+
+# Skill Name
+
+Instructions for the AI agent...
+```
+
+### Required frontmatter fields
+
+| Field | Description | Constraints |
+|-------|-------------|-------------|
+| `name` | Unique skill identifier | Lowercase letters, numbers, and hyphens only; max 64 chars |
+| `description` | What the skill does and when to use it | Non-empty; max 1024 chars; include keywords |
+
+## Naming conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Skill directory | lowercase-with-hyphens (gerund form preferred) | `debugging-streamlit` |
+| Skill file | Always `SKILL.md` | `SKILL.md` |
+| Frontmatter name | Matches directory name | `name: debugging-streamlit` |
+
+Use **gerund form** (verb + -ing) for skill names:
+- `checking-changes`
+- `debugging-streamlit`
+- `implementing-new-features`
+
+Avoid vague names (`helper`, `utils`) or reserved words (`anthropic-*`, `claude-*`).
+
+## Best practices
+
+For comprehensive guidance on writing effective skills, see the official [Agent Skills Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md).
+
+Key points:
+
+- **Be concise** - The context window is shared
+- **Write specific descriptions** - Include what the skill does AND when to use it
+- **Use third person** in descriptions (e.g., "Validates code changes" not "I validate code changes")
+- **Keep file references one level deep** from SKILL.md
+- **Use sentence casing** for titles and headers - Capitalize only the first word and proper nouns (e.g., "Creating a new skill" not "Creating a New Skill")
+- **Verify all links are publicly accessible** - Ensure URLs point to existing, publicly available resources
+- **Prefer `make` targets** - Skills should use existing `make` commands when available
+- **Use `uv run`** - Any Python commands should use `uv run` (e.g., `uv run pytest`)
+
+## Creating a new skill
+
+1. Create a new directory in `.claude/skills/` with a descriptive name
+2. Add a `SKILL.md` file with the required frontmatter
+3. Write clear, actionable instructions for the AI agent
+
+## Contributing
+
+When adding or modifying skills:
+
+1. Follow the existing skill structure
+2. Ensure the skill is focused on a specific, well-defined task
+3. Include practical examples and commands
+4. Review against the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)

--- a/.claude/skills/AGENTS.md
+++ b/.claude/skills/AGENTS.md
@@ -86,4 +86,5 @@ When adding or modifying skills:
 1. Follow the existing skill structure
 2. Ensure the skill is focused on a specific, well-defined task
 3. Include practical examples and commands
-4. Review against the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)
+4. Read the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)
+5. Review the skill against the best practices you just read

--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -24,6 +24,7 @@ rules/*
 !rules/protobuf.mdc
 !rules/e2e_playwright.mdc
 !rules/overview.mdc
+!rules/skills.mdc
 
 # Ignore all hooks
 hooks/*

--- a/.cursor/rules/skills.mdc
+++ b/.cursor/rules/skills.mdc
@@ -92,4 +92,5 @@ When adding or modifying skills:
 1. Follow the existing skill structure
 2. Ensure the skill is focused on a specific, well-defined task
 3. Include practical examples and commands
-4. Review against the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)
+4. Read the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)
+5. Review the skill against the best practices you just read

--- a/.cursor/rules/skills.mdc
+++ b/.cursor/rules/skills.mdc
@@ -1,0 +1,95 @@
+---
+description:
+globs: .claude/skills/**/*
+alwaysApply: false
+---
+
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Cursor, Copilot, etc.) when working with skills in this repository.
+
+## Overview
+
+This directory contains Agent Skills for developing the Streamlit library. Skills are instruction sets that enhance AI coding assistants' capabilities for specific tasks in the Streamlit codebase.
+
+These skills are for **Streamlit library development** (backend, frontend, protobufs), not for building Streamlit applications.
+
+## Skill structure
+
+Each skill is a directory containing a required `SKILL.md` file and optional supporting directories:
+
+```
+skills/
+└── skill-name/
+    ├── SKILL.md          # Required: Instructions for the AI agent
+    ├── scripts/          # Optional: Executable code
+    ├── references/       # Optional: Additional documentation
+    └── assets/           # Optional: Static resources
+```
+
+### SKILL.md format
+
+The `SKILL.md` file must include YAML frontmatter and markdown instructions:
+
+```yaml
+---
+name: skill-name
+description: Clear description of what this skill does and when to use it.
+---
+
+# Skill Name
+
+Instructions for the AI agent...
+```
+
+### Required frontmatter fields
+
+| Field | Description | Constraints |
+|-------|-------------|-------------|
+| `name` | Unique skill identifier | Lowercase letters, numbers, and hyphens only; max 64 chars |
+| `description` | What the skill does and when to use it | Non-empty; max 1024 chars; include keywords |
+
+## Naming conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Skill directory | lowercase-with-hyphens (gerund form preferred) | `debugging-streamlit` |
+| Skill file | Always `SKILL.md` | `SKILL.md` |
+| Frontmatter name | Matches directory name | `name: debugging-streamlit` |
+
+Use **gerund form** (verb + -ing) for skill names:
+- `checking-changes`
+- `debugging-streamlit`
+- `implementing-new-features`
+
+Avoid vague names (`helper`, `utils`) or reserved words (`anthropic-*`, `claude-*`).
+
+## Best practices
+
+For comprehensive guidance on writing effective skills, see the official [Agent Skills Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md).
+
+Key points:
+
+- **Be concise** - The context window is shared
+- **Write specific descriptions** - Include what the skill does AND when to use it
+- **Use third person** in descriptions (e.g., "Validates code changes" not "I validate code changes")
+- **Keep file references one level deep** from SKILL.md
+- **Use sentence casing** for titles and headers - Capitalize only the first word and proper nouns (e.g., "Creating a new skill" not "Creating a New Skill")
+- **Verify all links are publicly accessible** - Ensure URLs point to existing, publicly available resources
+- **Prefer `make` targets** - Skills should use existing `make` commands when available
+- **Use `uv run`** - Any Python commands should use `uv run` (e.g., `uv run pytest`)
+
+## Creating a new skill
+
+1. Create a new directory in `.claude/skills/` with a descriptive name
+2. Add a `SKILL.md` file with the required frontmatter
+3. Write clear, actionable instructions for the AI agent
+
+## Contributing
+
+When adding or modifying skills:
+
+1. Follow the existing skill structure
+2. Ensure the skill is focused on a specific, well-defined task
+3. Include practical examples and commands
+4. Review against the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -9,3 +9,4 @@ instructions/*
 !instructions/typescript.instructions.md
 !instructions/typescript_tests.instructions.md
 !instructions/e2e_playwright.instructions.md
+!instructions/skills.instructions.md

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -90,4 +90,5 @@ When adding or modifying skills:
 1. Follow the existing skill structure
 2. Ensure the skill is focused on a specific, well-defined task
 3. Include practical examples and commands
-4. Review against the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)
+4. Read the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)
+5. Review the skill against the best practices you just read

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,0 +1,93 @@
+---
+applyTo: ".claude/skills/**/*"
+---
+
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Cursor, Copilot, etc.) when working with skills in this repository.
+
+## Overview
+
+This directory contains Agent Skills for developing the Streamlit library. Skills are instruction sets that enhance AI coding assistants' capabilities for specific tasks in the Streamlit codebase.
+
+These skills are for **Streamlit library development** (backend, frontend, protobufs), not for building Streamlit applications.
+
+## Skill structure
+
+Each skill is a directory containing a required `SKILL.md` file and optional supporting directories:
+
+```
+skills/
+└── skill-name/
+    ├── SKILL.md          # Required: Instructions for the AI agent
+    ├── scripts/          # Optional: Executable code
+    ├── references/       # Optional: Additional documentation
+    └── assets/           # Optional: Static resources
+```
+
+### SKILL.md format
+
+The `SKILL.md` file must include YAML frontmatter and markdown instructions:
+
+```yaml
+---
+name: skill-name
+description: Clear description of what this skill does and when to use it.
+---
+
+# Skill Name
+
+Instructions for the AI agent...
+```
+
+### Required frontmatter fields
+
+| Field | Description | Constraints |
+|-------|-------------|-------------|
+| `name` | Unique skill identifier | Lowercase letters, numbers, and hyphens only; max 64 chars |
+| `description` | What the skill does and when to use it | Non-empty; max 1024 chars; include keywords |
+
+## Naming conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Skill directory | lowercase-with-hyphens (gerund form preferred) | `debugging-streamlit` |
+| Skill file | Always `SKILL.md` | `SKILL.md` |
+| Frontmatter name | Matches directory name | `name: debugging-streamlit` |
+
+Use **gerund form** (verb + -ing) for skill names:
+- `checking-changes`
+- `debugging-streamlit`
+- `implementing-new-features`
+
+Avoid vague names (`helper`, `utils`) or reserved words (`anthropic-*`, `claude-*`).
+
+## Best practices
+
+For comprehensive guidance on writing effective skills, see the official [Agent Skills Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md).
+
+Key points:
+
+- **Be concise** - The context window is shared
+- **Write specific descriptions** - Include what the skill does AND when to use it
+- **Use third person** in descriptions (e.g., "Validates code changes" not "I validate code changes")
+- **Keep file references one level deep** from SKILL.md
+- **Use sentence casing** for titles and headers - Capitalize only the first word and proper nouns (e.g., "Creating a new skill" not "Creating a New Skill")
+- **Verify all links are publicly accessible** - Ensure URLs point to existing, publicly available resources
+- **Prefer `make` targets** - Skills should use existing `make` commands when available
+- **Use `uv run`** - Any Python commands should use `uv run` (e.g., `uv run pytest`)
+
+## Creating a new skill
+
+1. Create a new directory in `.claude/skills/` with a descriptive name
+2. Add a `SKILL.md` file with the required frontmatter
+3. Write clear, actionable instructions for the AI agent
+
+## Contributing
+
+When adding or modifying skills:
+
+1. Follow the existing skill structure
+2. Ensure the skill is focused on a specific, well-defined task
+3. Include practical examples and commands
+4. Review against the [best practices for skill writing](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md)

--- a/scripts/generate_agent_rules.py
+++ b/scripts/generate_agent_rules.py
@@ -114,6 +114,13 @@ AGENT_RULE_FILES: Final[list[AgentRuleFile]] = [
         "always_apply": False,
     },
     {
+        "cursor_mdc": ".cursor/rules/skills.mdc",
+        "github_copilot": ".github/instructions/skills.instructions.md",
+        "agents_md": ".claude/skills/AGENTS.md",
+        "globs": ".claude/skills/**/*",
+        "always_apply": False,
+    },
+    {
         "cursor_mdc": ".cursor/rules/overview.mdc",
         # Use repository-wide instructions file:
         "github_copilot": ".github/copilot-instructions.md",


### PR DESCRIPTION
## Describe your changes

Added AGENTS.md and CLAUDE.md files to the .claude/skills directory to provide guidance to AI coding agents when working with skills. The AGENTS.md file documents the skill structure, SKILL.md format requirements, naming conventions, best practices, and contribution guidelines. The CLAUDE.md file references AGENTS.md as the configuration. Updated .gitignore to allow these files to be tracked by git.

## Testing Plan

- This is documentation only, no code functionality to test