### PR TITLE
Bind widgets to query params - `st.checkbox` & `st.toggle`

### DIFF
--- a/e2e_playwright/st_checkbox.py
+++ b/e2e_playwright/st_checkbox.py
@@ -105,3 +105,20 @@ else:
         kwargs={"param": "initial kwarg param"},
     )
     st.write("Initial checkbox state:", state)
+
+# Query param binding checkboxes
+st.markdown("Query param binding:")
+bound_cb = st.checkbox(
+    "Bound checkbox (default False)",
+    key="bound_checkbox",
+    bind="query-params",
+)
+st.write("bound checkbox value:", bound_cb)
+
+bound_cb_true = st.checkbox(
+    "Bound checkbox (default True)",
+    value=True,
+    key="bound_true",
+    bind="query-params",
+)
+st.write("bound checkbox true value:", bound_cb_true)

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -224,7 +224,7 @@ def test_checkbox_query_param_updates_url(app: Page):
     """Test that clicking a bound checkbox updates the URL."""
     # Initially default False, no query param in URL
     expect_prefixed_markdown(app, "bound checkbox value:", "False")
-    expect(app).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+    expect(app).not_to_have_url(re.compile(r"bound_checkbox"))
 
     # Click the checkbox -> True
     click_checkbox(app, "Bound checkbox (default False)")
@@ -238,7 +238,7 @@ def test_checkbox_query_param_updates_url(app: Page):
     expect_prefixed_markdown(app, "bound checkbox value:", "False")
 
     # Query param should be removed since value is back to default
-    expect(app).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+    expect(app).not_to_have_url(re.compile(r"bound_checkbox"))
 
 
 def test_checkbox_query_param_default_true(page: Page, app_port: int):
@@ -255,7 +255,7 @@ def test_checkbox_query_param_default_true(page: Page, app_port: int):
     expect_prefixed_markdown(page, "bound checkbox true value:", "True")
 
     # Query param should be removed since value is back to default (True)
-    expect(page).to_have_url(re.compile(r"^((?!bound_true).)*$"))
+    expect(page).not_to_have_url(re.compile(r"bound_true"))
 
 
 def test_checkbox_query_param_invalid_value(page: Page, app_port: int):
@@ -265,4 +265,4 @@ def test_checkbox_query_param_invalid_value(page: Page, app_port: int):
 
     # Checkbox should use default (False), and invalid param should be cleared
     expect_prefixed_markdown(page, "bound checkbox value:", "False")
-    expect(page).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+    expect(page).not_to_have_url(re.compile(r"bound_checkbox"))

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -15,7 +15,11 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_checkbox,
@@ -28,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-CHECKBOX_ELEMENTS = 17
+CHECKBOX_ELEMENTS = 19
 
 
 def test_checkbox_widget_display(
@@ -206,3 +210,59 @@ def test_dynamic_checkbox_props(app: Page, assert_snapshot: ImageCompareFunction
     # Click the checkbox
     click_checkbox(app, "Updated dynamic checkbox")
     expect_prefixed_markdown(app, "Updated checkbox state:", "False")
+
+
+def test_checkbox_query_param_seeding(page: Page, app_port: int):
+    """Test that checkbox value can be seeded from URL query params."""
+    page.goto(f"http://localhost:{app_port}/?bound_checkbox=true")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound checkbox value:", "True")
+
+
+def test_checkbox_query_param_updates_url(app: Page):
+    """Test that clicking a bound checkbox updates the URL."""
+    # Initially default False, no query param in URL
+    expect_prefixed_markdown(app, "bound checkbox value:", "False")
+    expect(app).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+
+    # Click the checkbox -> True
+    click_checkbox(app, "Bound checkbox (default False)")
+    expect_prefixed_markdown(app, "bound checkbox value:", "True")
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_checkbox=true"))
+
+    # Click again -> back to default False
+    click_checkbox(app, "Bound checkbox (default False)")
+    expect_prefixed_markdown(app, "bound checkbox value:", "False")
+
+    # Query param should be removed since value is back to default
+    expect(app).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))
+
+
+def test_checkbox_query_param_default_true(page: Page, app_port: int):
+    """Test checkbox with default True: seeding and param removal."""
+    # Load app with query param overriding the True default
+    page.goto(f"http://localhost:{app_port}/?bound_true=false")
+    wait_for_app_loaded(page)
+
+    # Checkbox should be unchecked (overriding True default)
+    expect_prefixed_markdown(page, "bound checkbox true value:", "False")
+
+    # Click to re-check (back to default True)
+    click_checkbox(page, "Bound checkbox (default True)")
+    expect_prefixed_markdown(page, "bound checkbox true value:", "True")
+
+    # Query param should be removed since value is back to default (True)
+    expect(page).to_have_url(re.compile(r"^((?!bound_true).)*$"))
+
+
+def test_checkbox_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    page.goto(f"http://localhost:{app_port}/?bound_checkbox=invalid")
+    wait_for_app_loaded(page)
+
+    # Checkbox should use default (False), and invalid param should be cleared
+    expect_prefixed_markdown(page, "bound checkbox value:", "False")
+    expect(page).to_have_url(re.compile(r"^((?!bound_checkbox).)*$"))

--- a/e2e_playwright/st_color_picker_test.py
+++ b/e2e_playwright/st_color_picker_test.py
@@ -213,7 +213,7 @@ def test_color_picker_query_param_updates_url(app: Page):
     """Test that changing a bound color picker updates the URL."""
     # Initially default black, no query param in URL
     expect_prefixed_markdown(app, "bound color value:", "#000000")
-    expect(app).to_have_url(re.compile(r"^((?!bound_color=).)*$"))
+    expect(app).not_to_have_url(re.compile(r"bound_color"))
 
     # Change the color
     color_picker = get_color_picker(app, "Bound color (no provided default)")
@@ -236,7 +236,7 @@ def test_color_picker_query_param_updates_url(app: Page):
     wait_for_app_run(app)
 
     # Query param should be removed since value is back to default
-    expect(app).to_have_url(re.compile(r"^((?!bound_color=).)*$"))
+    expect(app).not_to_have_url(re.compile(r"bound_color"))
     expect_prefixed_markdown(app, "bound color value:", "#000000")
 
 
@@ -258,7 +258,7 @@ def test_color_picker_query_param_default_custom(page: Page, app_port: int):
     wait_for_app_run(page)
 
     # Query param should be removed since value is back to default (red)
-    expect(page).to_have_url(re.compile(r"^((?!bound_red).)*$"))
+    expect(page).not_to_have_url(re.compile(r"bound_red"))
     expect_prefixed_markdown(page, "bound color red value:", "#ff0000")
 
 
@@ -271,7 +271,7 @@ def test_color_picker_query_param_invalid_value(page: Page, app_port: int):
     # Color picker should use default (black), and invalid param should be cleared
     expect_prefixed_markdown(page, "bound color value:", "#000000")
     # Invalid param should be removed from URL
-    expect(page).to_have_url(re.compile(r"^((?!bound_color).)*$"))
+    expect(page).not_to_have_url(re.compile(r"bound_color"))
 
 
 def test_color_picker_query_param_3char_hex(page: Page, app_port: int):

--- a/e2e_playwright/st_toggle.py
+++ b/e2e_playwright/st_toggle.py
@@ -95,3 +95,20 @@ else:
         kwargs={"param": "initial kwarg param"},
     )
     st.write("Initial toggle state:", state)
+
+# Query param binding toggles
+st.markdown("Query param binding:")
+bound_toggle = st.toggle(
+    "Bound toggle (default False)",
+    key="bound_toggle",
+    bind="query-params",
+)
+st.write("bound toggle value:", bound_toggle)
+
+bound_toggle_true = st.toggle(
+    "Bound toggle (default True)",
+    value=True,
+    key="bound_toggle_true",
+    bind="query-params",
+)
+st.write("bound toggle true value:", bound_toggle_true)

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -198,7 +198,7 @@ def test_toggle_query_param_updates_url(app: Page):
     """Test that clicking a bound toggle updates the URL."""
     # Initially default False, no query param in URL
     expect_prefixed_markdown(app, "bound toggle value:", "False")
-    expect(app).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+    expect(app).not_to_have_url(re.compile(r"bound_toggle"))
 
     # Click the toggle -> True
     click_toggle(app, "Bound toggle (default False)")
@@ -212,7 +212,7 @@ def test_toggle_query_param_updates_url(app: Page):
     expect_prefixed_markdown(app, "bound toggle value:", "False")
 
     # Query param should be removed since value is back to default
-    expect(app).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+    expect(app).not_to_have_url(re.compile(r"bound_toggle"))
 
 
 def test_toggle_query_param_default_true(page: Page, app_port: int):
@@ -229,7 +229,7 @@ def test_toggle_query_param_default_true(page: Page, app_port: int):
     expect_prefixed_markdown(page, "bound toggle true value:", "True")
 
     # Query param should be removed since value is back to default (True)
-    expect(page).to_have_url(re.compile(r"^((?!bound_toggle_true).)*$"))
+    expect(page).not_to_have_url(re.compile(r"bound_toggle_true"))
 
 
 def test_toggle_query_param_invalid_value(page: Page, app_port: int):
@@ -239,4 +239,4 @@ def test_toggle_query_param_invalid_value(page: Page, app_port: int):
 
     # Toggle should use default (False), and invalid param should be cleared
     expect_prefixed_markdown(page, "bound toggle value:", "False")
-    expect(page).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+    expect(page).not_to_have_url(re.compile(r"bound_toggle"))

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -16,7 +16,11 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -28,7 +32,7 @@ from e2e_playwright.shared.app_utils import (
     get_toggle,
 )
 
-TOGGLE_ELEMENTS = 17
+TOGGLE_ELEMENTS = 19
 
 
 def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -180,3 +184,59 @@ def test_dynamic_toggle_props(app: Page, assert_snapshot: ImageCompareFunction):
     # Click the toggle
     click_toggle(app, "Updated dynamic toggle")
     expect_prefixed_markdown(app, "Updated toggle state:", "False")
+
+
+def test_toggle_query_param_seeding(page: Page, app_port: int):
+    """Test that toggle value can be seeded from URL query params."""
+    page.goto(f"http://localhost:{app_port}/?bound_toggle=true")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound toggle value:", "True")
+
+
+def test_toggle_query_param_updates_url(app: Page):
+    """Test that clicking a bound toggle updates the URL."""
+    # Initially default False, no query param in URL
+    expect_prefixed_markdown(app, "bound toggle value:", "False")
+    expect(app).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+
+    # Click the toggle -> True
+    click_toggle(app, "Bound toggle (default False)")
+    expect_prefixed_markdown(app, "bound toggle value:", "True")
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"bound_toggle=true"))
+
+    # Click again -> back to default False
+    click_toggle(app, "Bound toggle (default False)")
+    expect_prefixed_markdown(app, "bound toggle value:", "False")
+
+    # Query param should be removed since value is back to default
+    expect(app).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))
+
+
+def test_toggle_query_param_default_true(page: Page, app_port: int):
+    """Test toggle with default True: seeding and param removal."""
+    # Load app with query param overriding the True default
+    page.goto(f"http://localhost:{app_port}/?bound_toggle_true=false")
+    wait_for_app_loaded(page)
+
+    # Toggle should be off (overriding True default)
+    expect_prefixed_markdown(page, "bound toggle true value:", "False")
+
+    # Click to re-toggle (back to default True)
+    click_toggle(page, "Bound toggle (default True)")
+    expect_prefixed_markdown(page, "bound toggle true value:", "True")
+
+    # Query param should be removed since value is back to default (True)
+    expect(page).to_have_url(re.compile(r"^((?!bound_toggle_true).)*$"))
+
+
+def test_toggle_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    page.goto(f"http://localhost:{app_port}/?bound_toggle=invalid")
+    wait_for_app_loaded(page)
+
+    # Toggle should use default (False), and invalid param should be cleared
+    expect_prefixed_markdown(page, "bound toggle value:", "False")
+    expect(page).to_have_url(re.compile(r"^((?!bound_toggle).)*$"))

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -198,7 +198,7 @@ def test_toggle_query_param_updates_url(app: Page):
     """Test that clicking a bound toggle updates the URL."""
     # Initially default False, no query param in URL
     expect_prefixed_markdown(app, "bound toggle value:", "False")
-    expect(app).not_to_have_url(re.compile(r"bound_toggle"))
+    expect(app).not_to_have_url(re.compile(r"bound_toggle="))
 
     # Click the toggle -> True
     click_toggle(app, "Bound toggle (default False)")
@@ -212,7 +212,7 @@ def test_toggle_query_param_updates_url(app: Page):
     expect_prefixed_markdown(app, "bound toggle value:", "False")
 
     # Query param should be removed since value is back to default
-    expect(app).not_to_have_url(re.compile(r"bound_toggle"))
+    expect(app).not_to_have_url(re.compile(r"bound_toggle="))
 
 
 def test_toggle_query_param_default_true(page: Page, app_port: int):
@@ -239,4 +239,4 @@ def test_toggle_query_param_invalid_value(page: Page, app_port: int):
 
     # Toggle should use default (False), and invalid param should be cleared
     expect_prefixed_markdown(page, "bound toggle value:", "False")
-    expect(page).not_to_have_url(re.compile(r"bound_toggle"))
+    expect(page).not_to_have_url(re.compile(r"bound_toggle="))

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -194,3 +194,71 @@ describe("Checkbox widget", () => {
     )
   })
 })
+
+describe("Checkbox query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_checkbox" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Checkbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_checkbox",
+      "bool_value",
+      props.element.default,
+      false,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_checkbox" })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<Checkbox {...props} />)
+
+    // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Checkbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers query param binding for toggle widget with default true", () => {
+    const props = getProps({
+      queryParamKey: "my_toggle",
+      default: true,
+      type: CheckboxProto.StyleType.TOGGLE,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Checkbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_toggle",
+      "bool_value",
+      true,
+      false,
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -51,6 +51,15 @@ function Checkbox({
   widgetMgr,
   fragmentId,
 }: Readonly<Props>): ReactElement {
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "bool_value" as const,
+        // Checkbox/toggle is not clearable (always true or false)
+        clearable: false,
+      }
+    : undefined
+
   const [value, setValueWithSource] = useBasicWidgetState<
     boolean,
     CheckboxProto
@@ -62,6 +71,7 @@ function Checkbox({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding,
   })
 
   const onChange = useCallback(
@@ -235,11 +245,11 @@ function getStateFromWidgetMgr(
 }
 
 function getDefaultStateFromProto(element: CheckboxProto): boolean {
-  return element.default ?? null
+  return element.default ?? false
 }
 
 function getCurrStateFromProto(element: CheckboxProto): boolean {
-  return element.value ?? null
+  return element.value ?? false
 }
 
 function updateWidgetMgrState(

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -82,6 +82,15 @@ const ColorPicker: FC<Props> = ({
   widgetMgr,
   fragmentId,
 }) => {
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "string_value" as const,
+        // Color picker is not clearable (always defaults to black)
+        clearable: false,
+      }
+    : undefined
+
   const [value, setValueWithSource] = useBasicWidgetState<
     ColorPickerValue,
     ColorPickerProto
@@ -93,13 +102,7 @@ const ColorPicker: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
-    queryParamBinding: element.queryParamKey
-      ? {
-          paramKey: element.queryParamKey,
-          valueType: "string_value",
-          clearable: false,
-        }
-      : undefined,
+    queryParamBinding,
   })
 
   const handleColorClose = useCallback(

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -39,6 +39,7 @@ from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -75,6 +76,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> bool:
         r"""Display a checkbox widget.
 
@@ -152,6 +154,13 @@ class CheckboxMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         bool
@@ -185,6 +194,7 @@ class CheckboxMixin:
             type=CheckboxProto.StyleType.DEFAULT,
             ctx=ctx,
             width=width,
+            bind=bind,
         )
 
     @gather_metrics("toggle")
@@ -201,6 +211,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> bool:
         r"""Display a toggle widget.
 
@@ -278,6 +289,13 @@ class CheckboxMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Requires a ``key`` to be set, which will
+            be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         bool
@@ -311,6 +329,7 @@ class CheckboxMixin:
             type=CheckboxProto.StyleType.TOGGLE,
             ctx=ctx,
             width=width,
+            bind=bind,
         )
 
     def _checkbox(
@@ -328,6 +347,7 @@ class CheckboxMixin:
         type: CheckboxProto.StyleType.ValueType = CheckboxProto.StyleType.DEFAULT,
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
+        bind: BindOption = None,
     ) -> bool:
         key = to_key(key)
 
@@ -364,6 +384,10 @@ class CheckboxMixin:
         if help is not None:
             checkbox_proto.help = dedent(help)
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            checkbox_proto.query_param_key = str(key)
+
         validate_width(width, allow_content=True)
         layout_config = LayoutConfig(width=width)
 
@@ -378,6 +402,9 @@ class CheckboxMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="bool_value",
+            bind=bind,
+            # Checkbox/toggle is not clearable (always true or false)
+            clearable=False,
         )
 
         if checkbox_state.value_changed:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1026,17 +1026,15 @@ class SessionState:
             parsed_value = parse_url_param(url_value, metadata.value_type)
             deserialized_value = metadata.deserializer(parsed_value)
             default_value = metadata.deserializer(None)
-            serialized_default = metadata.serializer(default_value)
 
-            # If the deserialized value equals the default but the URL value differs
-            # from the serialized default, clear the param. This handles two cases:
-            # 1. Invalid input that the deserializer rejected and fell back to default
-            # 2. Valid input that normalized to match the default (e.g., "000000" -> "#000000")
-            # In both cases, keeping the default in the URL is unnecessary clutter.
-            if (
-                deserialized_value == default_value
-                and parsed_value != serialized_default
-                and not is_empty_url_value(url_value)
+            # If the deserialized value equals the default, clear the param.
+            # Default values should not be kept in the URL — this matches the
+            # frontend's shouldClearUrlParam behavior. This handles:
+            # 1. Valid input that equals the default (e.g., ?dark_mode=FALSE)
+            # 2. Invalid input that the deserializer rejected and fell back to default
+            # 3. Valid input that normalized to match the default (e.g., "000000" -> "#000000")
+            if deserialized_value == default_value and not is_empty_url_value(
+                url_value
             ):
                 self._clear_url_param(user_key)
                 return False

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1033,9 +1033,7 @@ class SessionState:
             # 1. Valid input that equals the default (e.g., ?dark_mode=FALSE)
             # 2. Invalid input that the deserializer rejected and fell back to default
             # 3. Valid input that normalized to match the default (e.g., "000000" -> "#000000")
-            if deserialized_value == default_value and not is_empty_url_value(
-                url_value
-            ):
+            if deserialized_value == default_value:
                 self._clear_url_param(user_key)
                 return False
 

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.policies import _LOGGER
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -359,3 +359,64 @@ hello
             == WidthConfigFields.USE_CONTENT.value
         )
         assert el.width_config.use_content is True
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_bind_query_params_sets_query_param_key(
+        self, _name: str, widget_func: object
+    ) -> None:
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        widget_func("the label", key="my_widget", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.query_param_key == "my_widget"
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_bind_query_params_without_key_raises_exception(
+        self, _name: str, widget_func: object
+    ) -> None:
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            widget_func("the label", bind="query-params")
+
+        assert "must have a unique 'key' parameter" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_no_bind_does_not_set_query_param_key(
+        self, _name: str, widget_func: object
+    ) -> None:
+        """Test that without bind parameter, query_param_key is not set."""
+        widget_func("the label", key="my_widget")
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.query_param_key == ""
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_invalid_bind_value_raises_exception(
+        self, _name: str, widget_func: object
+    ) -> None:
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError) as exc:
+            widget_func("the label", key="my_widget", bind="invalid-value")
+
+        assert "invalid-value" in str(exc.value)
+        assert "query-params" in str(exc.value)

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1663,7 +1663,7 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
             "widget_1",
             value_type="bool_value",
             deserializer=lambda x: x if x is not None else False,
-            serializer=lambda x: bool(x),
+            serializer=bool,
         )
 
         seeded = self.session_state._seed_widget_from_url(
@@ -1700,7 +1700,9 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert "tags" not in self.query_params._query_params
 
     def test_seed_widget_with_empty_url_and_clearable_true(self) -> None:
-        """Test that empty URL values seed widget when clearable=True."""
+        """Test that empty URL values matching the default are cleared, even for clearable widgets."""
+        self.query_params._query_params["tags"] = ""
+
         metadata = _create_test_widget_metadata(
             "widget_1",
             value_type="string_array_value",
@@ -1708,7 +1710,26 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
             clearable=True,
         )
 
-        # Empty string from URL (e.g., ?tags=)
+        # Empty string from URL (e.g., ?tags=) — default is also [], so param is cleared
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "tags", "widget_1", ""
+        )
+
+        assert seeded is False
+        assert "tags" not in self.query_params._query_params
+
+    def test_seed_widget_with_empty_url_and_clearable_true_non_empty_default(
+        self,
+    ) -> None:
+        """Test that empty URL seeds widget when clearable=True and default is non-empty."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            deserializer=lambda x: x if x is not None else ["Python"],
+            clearable=True,
+        )
+
+        # Empty string from URL (e.g., ?tags=) — default is ["Python"], so [] differs
         seeded = self.session_state._seed_widget_from_url(
             metadata, "tags", "widget_1", ""
         )
@@ -1739,7 +1760,9 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert "toggle" not in self.query_params._query_params
 
     def test_seed_widget_with_empty_list_and_clearable_true(self) -> None:
-        """Test that empty list [''] seeds widget when clearable=True."""
+        """Test that empty list [''] matching the default is cleared, even for clearable widgets."""
+        self.query_params._query_params["items"] = [""]
+
         metadata = _create_test_widget_metadata(
             "widget_1",
             value_type="int_array_value",
@@ -1747,13 +1770,13 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
             clearable=True,
         )
 
-        # Empty list from URL parsing (e.g., ?items=)
+        # Empty list from URL parsing (e.g., ?items=) — default is also [], so param is cleared
         seeded = self.session_state._seed_widget_from_url(
             metadata, "items", "widget_1", [""]
         )
 
-        assert seeded is True
-        assert self.session_state._new_widget_state["widget_1"] == []
+        assert seeded is False
+        assert "items" not in self.query_params._query_params
 
     def test_seed_widget_with_empty_list_and_clearable_false(self) -> None:
         """Test that empty list [''] is ignored and cleared when clearable=False."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1655,6 +1655,24 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is False
         assert "color" not in self.query_params._query_params
 
+    def test_seed_widget_clears_valid_value_that_equals_default(self) -> None:
+        """Test that valid URL values matching the default are cleared from the URL."""
+        self.query_params._query_params["my_bool"] = "false"
+
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="bool_value",
+            deserializer=lambda x: x if x is not None else False,
+            serializer=lambda x: bool(x),
+        )
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "my_bool", "widget_1", "false"
+        )
+
+        assert seeded is False
+        assert "my_bool" not in self.query_params._query_params
+
     def test_seed_widget_clears_when_all_options_filtered(self) -> None:
         """Test that URL is cleared when all options are invalid."""
         self.query_params._query_params["tags"] = ["InvalidA", "InvalidB"]

--- a/lib/tests/streamlit/typing/checkbox_types.py
+++ b/lib/tests/streamlit/typing/checkbox_types.py
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
     assert_type(checkbox("Accept terms", width="content"), bool)
     assert_type(checkbox("Accept terms", width="stretch"), bool)
     assert_type(checkbox("Accept terms", width=200), bool)
+    assert_type(
+        checkbox("Accept terms", key="bind_checkbox", bind="query-params"), bool
+    )
 
     def my_callback() -> None:
         pass
@@ -107,6 +110,7 @@ if TYPE_CHECKING:
     assert_type(toggle("Enable feature", width="content"), bool)
     assert_type(toggle("Enable feature", width="stretch"), bool)
     assert_type(toggle("Enable feature", width=150), bool)
+    assert_type(toggle("Enable feature", key="bind_toggle", bind="query-params"), bool)
 
     assert_type(toggle("Enable feature", on_change=my_callback), bool)
     assert_type(

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -34,4 +34,6 @@ message Checkbox {
   bool disabled = 8;
   LabelVisibility label_visibility = 9;
   StyleType type = 10;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 11;
 }

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -34,6 +34,6 @@ message Checkbox {
   bool disabled = 8;
   LabelVisibility label_visibility = 9;
   StyleType type = 10;
-  // If set, widget value is bound to this query parameter key
+  // If set, widget value is bound to this query parameter key.
   optional string query_param_key = 11;
 }


### PR DESCRIPTION
## Describe your changes
Adds the bind parameter to `st.checkbox` & `st.toggle` to enable two-way sync between widget values and URL query parameters.

Also includes clean up / improvements from the `st.color_picker` implementation:
- Default values cleared from URL on seed — if the URL contains a value that matches the widget's default (e.g., ?dark_mode=false when default is False), the param is now removed. This aligns backend behavior with the frontend's `shouldClearUrlParam` logic.
- `getDefaultStateFromProto` / `getCurrStateFromProto` fallback — checkbox now falls back to `false` instead of `null` when proto fields are unset, matching the boolean type contract.
- `queryParamBinding` construction — `color_picker` aligned to use the same extracted-const pattern as checkbox for consistency.

## Testing Plan
- JS & Python Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 