### PR TITLE
Consolidate `prettier` dependencies to frontend workspace root

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,15 +33,14 @@ repos:
   - repo: local
     hooks:
       # Single prettier hook for all frontend source files.
-      # Calls prettier directly from node_modules/.bin to avoid yarn exec issues in CI.
       # Uses run_in_subdirectory.py to handle path translation for subdirectory files.
       # See: https://github.com/pre-commit/pre-commit/issues/1417
       - id: prettier-frontend
         name: Prettier Frontend
-        entry: ./scripts/run_in_subdirectory.py frontend node_modules/.bin/prettier --write
+        entry: ./scripts/run_in_subdirectory.py frontend yarn exec prettier --write
         files: ^frontend/(app|lib|connection|utils)/.*\.(js|jsx|ts|tsx)$
         exclude: /vendor/
-        language: system
+        language: node
         pass_filenames: true
       - id: prettier-yaml
         name: Prettier-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,19 +45,13 @@ repos:
         pass_filenames: true
       - id: prettier-yaml
         name: Prettier-yaml
-        # NOTE: This hook currently does not work on Windows due to "yarn" not being an executable and win32api.CreateProcess
-        # turning `subprocess.run(["yarn", "prettier", "--write"])` into a call to `yarn.exe prettier --write` which does not exist
-        # We perform this in the app directory because prettier is installed there. TODO: Break this out to a new package
-        entry: ./scripts/run_in_subdirectory.py frontend/app yarn prettier "../../.github/**/*.{yml,yaml}" --write
+        entry: ./scripts/run_in_subdirectory.py frontend yarn exec prettier "../.github/**/*.{yml,yaml}" --write
         files: ^.github/.*\.(yml|yaml)$
         language: node
         pass_filenames: false
       - id: prettier-vscode-devcontainer-json
         name: Prettier VSCode/devcontainer JSON
-        # NOTE: This hook currently does not work on Windows due to "yarn" not being an executable and win32api.CreateProcess
-        # turning `subprocess.run(["yarn", "prettier", "--write"])` into a call to `yarn.exe prettier --write` which does not exist
-        # We perform this in the app directory because prettier is installed there. TODO: Break this out to a new package
-        entry: ./scripts/run_in_subdirectory.py frontend/app yarn prettier "../../.vscode/*.json" "../../.devcontainer/*.json" --write --config ../.prettierrc
+        entry: ./scripts/run_in_subdirectory.py frontend yarn exec prettier "../.vscode/*.json" "../.devcontainer/*.json" --write --config ./.prettierrc
         files: ^(.vscode/.*\.json|\.devcontainer/.*\.json)$
         language: node
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ debug:
 .PHONY: frontend-lint
 # Lint and check formatting of frontend files.
 frontend-lint:
-	cd frontend/ ; yarn workspaces foreach --all --parallel run formatCheck
+	cd frontend/ ; yarn formatCheck
 	cd frontend/ ; yarn lint
 
 .PHONY: frontend-types
@@ -340,7 +340,7 @@ frontend-types:
 .PHONY: frontend-format
 # Format frontend files.
 frontend-format:
-	cd frontend/ ; yarn workspaces foreach --all --parallel run format
+	cd frontend/ ; yarn format
 
 .PHONY: frontend-tests
 # Run frontend unit tests and generate coverage report.

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -17,8 +17,8 @@
     "lint:fix": "yarn run -T eslint --cache --max-warnings 0 --fix src",
     "typecheck": "yarn run typecheck:all",
     "lighthouse:run": "node ./performance/lighthouse/run.mjs",
-    "format": "prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
-    "formatCheck": "prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "format": "yarn run -T prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "formatCheck": "yarn run -T prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
     "typesync": "typesync",
     "typesync:ci": "typesync --dry=fail"
   },
@@ -85,7 +85,6 @@
     "chrome-launcher": "^1.2.1",
     "jsdom": "24.1.3",
     "lighthouse": "^13.0.1",
-    "prettier": "^3.8.1",
     "prop-types": "^15.7.2",
     "source-map-explorer": "^2.5.3",
     "tree-kill": "^1.2.2",

--- a/frontend/component-v2-lib/package.json
+++ b/frontend/component-v2-lib/package.json
@@ -30,13 +30,12 @@
     "testWatch": "vitest",
     "lint": "yarn run -T eslint --cache --max-warnings 0 src",
     "typecheck": "yarn run typecheck:all",
-    "format": "prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
-    "formatCheck": "prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "format": "yarn run -T prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "formatCheck": "yarn run -T prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
     "typesync": "typesync",
     "typesync:ci": "typesync --dry=fail"
   },
   "devDependencies": {
-    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typesync": "^0.14.3",
     "vite": "^7.3.1",

--- a/frontend/connection/package.json
+++ b/frontend/connection/package.json
@@ -24,8 +24,8 @@
     "lint": "yarn run -T eslint --cache --max-warnings 0 src",
     "lint:fix": "yarn run -T eslint --cache --max-warnings 0 --fix src",
     "typecheck": "yarn run typecheck:all",
-    "format": "prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
-    "formatCheck": "prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "format": "yarn run -T prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "formatCheck": "yarn run -T prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
     "typesync": "typesync",
     "typesync:ci": "typesync --dry=fail"
   },
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@types/lodash-es": "^4.17.12",
     "axios-mock-adapter": "^2.1.0",
-    "prettier": "^3.8.1",
     "typesync": "^0.14.3",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",

--- a/frontend/eslint-plugin-streamlit-custom/package.json
+++ b/frontend/eslint-plugin-streamlit-custom/package.json
@@ -9,8 +9,8 @@
     "src"
   ],
   "scripts": {
-    "format": "prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
-    "formatCheck": "prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "format": "yarn run -T prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "formatCheck": "yarn run -T prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
     "lint": "eslint --cache --max-warnings 0 src",
     "test": "vitest run",
     "testWatch": "vitest",
@@ -24,7 +24,6 @@
     "@typescript-eslint/utils": "^8.53.1",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",
-    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typesync": "^0.14.3",
     "vitest": "^4.0.18"

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -29,8 +29,8 @@
     "testWatch": "vitest",
     "lint": "yarn run -T eslint --cache --max-warnings 0 src",
     "lint:fix": "yarn run -T eslint --cache --max-warnings 0 --fix src",
-    "format": "prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
-    "formatCheck": "prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "format": "yarn run -T prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "formatCheck": "yarn run -T prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
     "typesync": "typesync",
     "typesync:ci": "typesync --dry=fail"
   },
@@ -160,7 +160,6 @@
     "axios-mock-adapter": "^2.1.0",
     "node-fetch": "3.3.2",
     "postinstall-postinstall": "^2.1.0",
-    "prettier": "^3.8.1",
     "timezone-mock": "^1.4.0",
     "tsc-alias": "^1.8.16",
     "typesync": "^0.14.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
     "test": "vitest run",
     "testWatch": "vitest",
     "testCoverage": "vitest run --coverage",
+    "format": "yarn workspaces foreach --all --parallel run format",
+    "formatCheck": "yarn workspaces foreach --all --parallel run formatCheck",
     "lint": "yarn workspaces foreach --all --parallel run lint",
     "lint:fix": "yarn workspaces foreach --all --parallel run lint:fix"
   },
@@ -66,6 +68,7 @@
     "eslint-plugin-testing-library": "^7.15.4",
     "globals": "^17.1.0",
     "jiti": "^2.6.1",
+    "prettier": "^3.8.1",
     "typescript-eslint": "^8.54.0",
     "vitest": "^4.0.18"
   }

--- a/frontend/utils/package.json
+++ b/frontend/utils/package.json
@@ -24,13 +24,12 @@
     "lint": "yarn run -T eslint --cache --max-warnings 0 src",
     "lint:fix": "yarn run -T eslint --cache --max-warnings 0 --fix src",
     "typecheck": "yarn run typecheck:all",
-    "format": "prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
-    "formatCheck": "prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "format": "yarn run -T prettier --write --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
+    "formatCheck": "yarn run -T prettier --check --cache --config ../.prettierrc --ignore-path ../.prettierignore './src/**/*.{js,ts,jsx,tsx}'",
     "typesync": "typesync",
     "typesync:ci": "typesync --dry=fail"
   },
   "devDependencies": {
-    "prettier": "^3.8.1",
     "typesync": "^0.14.3",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3366,7 +3366,6 @@ __metadata:
     lodash-es: "npm:^4.17.23"
     loglevel: "npm:^1.9.2"
     moment: "npm:^2.29.4"
-    prettier: "npm:^3.8.1"
     prop-types: "npm:^15.7.2"
     rc-overflow: "npm:^1.5.0"
     re-resizable: "npm:^6.11.2"
@@ -3402,7 +3401,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@streamlit/component-v2-lib@workspace:component-v2-lib"
   dependencies:
-    prettier: "npm:^3.8.1"
     typescript: "npm:^5.9.3"
     typesync: "npm:^0.14.3"
     vite: "npm:^7.3.1"
@@ -3423,7 +3421,6 @@ __metadata:
     axios-mock-adapter: "npm:^2.1.0"
     lodash-es: "npm:^4.17.23"
     loglevel: "npm:^1.9.2"
-    prettier: "npm:^3.8.1"
     typesync: "npm:^0.14.3"
     vite: "npm:^7.3.1"
     vite-plugin-dts: "npm:^4.5.4"
@@ -3517,7 +3514,6 @@ __metadata:
     numbro: "npm:^2.5.0"
     plotly.js: "npm:^3.3.1"
     postinstall-postinstall: "npm:^2.1.0"
-    prettier: "npm:^3.8.1"
     protobufjs: "npm:^8.0.0"
     query-string: "npm:^9.3.1"
     re-resizable: "npm:^6.11.2"
@@ -3589,7 +3585,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@streamlit/utils@workspace:utils"
   dependencies:
-    prettier: "npm:^3.8.1"
     typesync: "npm:^0.14.3"
     vite: "npm:^7.3.1"
     vite-plugin-dts: "npm:^4.5.4"
@@ -9494,7 +9489,6 @@ __metadata:
     "@typescript-eslint/utils": "npm:^8.53.1"
     "@vitest/coverage-v8": "npm:^4.0.18"
     eslint: "npm:^9.39.2"
-    prettier: "npm:^3.8.1"
     typescript: "npm:^5.9.3"
     typesync: "npm:^0.14.3"
     vitest: "npm:^4.0.18"
@@ -16872,6 +16866,7 @@ __metadata:
     eslint-plugin-testing-library: "npm:^7.15.4"
     globals: "npm:^17.1.0"
     jiti: "npm:^2.6.1"
+    prettier: "npm:^3.8.1"
     typescript-eslint: "npm:^8.54.0"
     vitest: "npm:^4.0.18"
   languageName: unknown

--- a/scripts/sync_vscode_devcontainer.py
+++ b/scripts/sync_vscode_devcontainer.py
@@ -190,16 +190,17 @@ class DevcontainerSync:
 
             cmd = [
                 "./scripts/run_in_subdirectory.py",
-                "frontend/app",
+                "frontend",
                 "yarn",
+                "exec",
                 "prettier",
                 "--write",
                 "--config",
-                "../.prettierrc",
+                "./.prettierrc",
             ]
 
             # Add file paths with proper relative path prefix
-            cmd.extend(f"../../{relative_path}" for relative_path in relative_paths)
+            cmd.extend(f"../{relative_path}" for relative_path in relative_paths)
 
             print("Formatting JSON files with prettier...")
             result = subprocess.run(


### PR DESCRIPTION
## Describe your changes

Moved `prettier` and related dependencies from individual workspace package.json files (app, lib, connection, utils, component-v2-lib, eslint-plugin-streamlit-custom) into the root `frontend/package.json`. Updated format/formatCheck scripts to use `yarn run -T prettier` for consistency with eslint. Updated pre-commit hooks and `scripts/sync_vscode_devcontainer.py` to use `yarn exec prettier` from the root workspace.

## Testing Plan

- Frontend lint passes: `make frontend-lint`
- All prettier format/formatCheck scripts work in each workspace
- Pre-commit hooks work correctly
- Net result: 22 insertions, 35 deletions (-13 lines)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.