### PR TITLE
[feat] Improve text area support for programmatic changes

### DIFF
--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen, waitFor } from "@testing-library/react"
+import { act, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import {
@@ -174,6 +174,127 @@ describe("TextArea widget", () => {
       },
       undefined
     )
+  })
+
+  it("commits programmatic value changes on blur", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextArea {...props} />)
+
+    // First call happens on mount.
+    expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+    const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+    await user.click(textArea)
+
+    // Simulate password manager autofill by setting the DOM value directly
+    // without firing an onChange/input event.
+    textArea.value = "TEST"
+    await user.tab()
+
+    await waitFor(() => {
+      expect(setStringValueSpy).toHaveBeenCalledTimes(2)
+    })
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(
+      props.element,
+      "TEST",
+      { fromUi: true },
+      undefined
+    )
+  })
+
+  it("detects programmatic value changes via native input events", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextArea {...props} />)
+
+    // First call happens on mount.
+    expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+    const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+    await user.click(textArea)
+
+    // Simulate programmatic value changes with a non-bubbling native event.
+    textArea.value = "TEST"
+    act(() => {
+      textArea.dispatchEvent(new Event("input", { bubbles: false }))
+    })
+
+    // Ctrl+Enter should commit if the textarea was marked dirty.
+    await user.keyboard("{Control>}{Enter}")
+
+    await waitFor(() => {
+      expect(setStringValueSpy).toHaveBeenCalledTimes(2)
+    })
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(
+      props.element,
+      "TEST",
+      { fromUi: true },
+      undefined
+    )
+  })
+
+  it("ignores non-bubbling native input events when disabled", () => {
+    vi.useFakeTimers()
+    try {
+      const props = getProps({ formId: "formId" }, { disabled: true })
+      const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+      render(<TextArea {...props} />)
+      const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+
+      // First call happens on mount.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+      textArea.value = "TEST"
+      act(() => {
+        textArea.dispatchEvent(new Event("input", { bubbles: false }))
+      })
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not double-process bubbling input events handled by React", () => {
+    vi.useFakeTimers()
+    try {
+      const props = getProps({ formId: "formId" })
+      const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+      render(<TextArea {...props} />)
+
+      const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+
+      // Mount call + one onChange for the bubbling input event.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+      textArea.value = "A"
+      act(() => {
+        textArea.dispatchEvent(new Event("input", { bubbles: true }))
+      })
+
+      // Flush deferred native reconciliation to verify it does not emit
+      // another synthetic change for standard bubbling input events.
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(setStringValueSpy).toHaveBeenCalledTimes(2)
+      expect(setStringValueSpy).toHaveBeenLastCalledWith(
+        props.element,
+        "A",
+        { fromUi: true },
+        undefined
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("sets widget value when ctrl+enter is pressed", async () => {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -33,7 +33,9 @@ import {
 } from "~lib/hooks/useBasicWidgetState"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import useNativeInputValueChange from "~lib/hooks/useNativeInputValueChange"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
+import useStringInputCommitOnBlur from "~lib/hooks/useStringInputCommitOnBlur"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import { useTextInputAutoExpand } from "~lib/hooks/useTextInputAutoExpand"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
@@ -157,17 +159,16 @@ const TextArea: FC<Props> = ({
     dependencies: [element.placeholder],
   })
 
-  const commitWidgetValue = useCallback((): void => {
-    setDirty(false)
-    setValueWithSource({ value: uiValue, fromUi: true })
-  }, [uiValue, setValueWithSource])
-
-  const onBlur = useCallback(() => {
-    if (dirty) {
-      commitWidgetValue()
-    }
-    setFocused(false)
-  }, [dirty, commitWidgetValue])
+  const { commitWidgetValue, onBlur } = useStringInputCommitOnBlur({
+    inputRef: textareaRef,
+    uiValue,
+    dirty,
+    maxChars: element.maxChars,
+    setDirty,
+    setUiValue,
+    setValueWithSource,
+    setFocused,
+  })
 
   const onFocus = useCallback(() => {
     setFocused(true)
@@ -186,6 +187,14 @@ const TextArea: FC<Props> = ({
     setUiValue,
     setValueWithSource,
     additionalAction,
+  })
+
+  useNativeInputValueChange({
+    inputRef: textareaRef,
+    disabled,
+    uiValue,
+    maxChars: element.maxChars,
+    onChange,
   })
 
   const onKeyDown = useSubmitFormViaEnterKey(
@@ -228,7 +237,7 @@ const TextArea: FC<Props> = ({
       </WidgetLabel>
 
       <UITextArea
-        inputRef={isAutoHeight ? textareaRef : undefined}
+        inputRef={textareaRef}
         value={uiValue ?? ""}
         placeholder={placeholder}
         onBlur={onBlur}

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react"
+import { memo, ReactElement, useCallback, useRef, useState } from "react"
 
 import { Input as UIInput } from "baseui/input"
 import { uniqueId } from "lodash-es"
@@ -42,9 +34,10 @@ import {
 } from "~lib/hooks/useBasicWidgetState"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import useNativeInputValueChange from "~lib/hooks/useNativeInputValueChange"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
+import useStringInputCommitOnBlur from "~lib/hooks/useStringInputCommitOnBlur"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
-import useTimeout from "~lib/hooks/useTimeout"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
 import { convertRemToPx } from "~lib/theme"
 import { isInForm, labelVisibilityProtoValueToEnum } from "~lib/util/utils"
@@ -110,20 +103,17 @@ function TextInput({
   const [id] = useState(() => uniqueId("text_input_"))
   const { placeholder, formId, icon, maxChars } = element
   const inputRef = useRef<HTMLInputElement>(null)
-  const uiValueRef = useRef(uiValue ?? "")
-  const pendingNativeSyncRef = useRef(false)
 
-  useLayoutEffect(() => {
-    uiValueRef.current = uiValue ?? ""
-  }, [uiValue])
-
-  const commitWidgetValue = useCallback(
-    (valueToCommit: string | null = uiValue): void => {
-      setDirty(false)
-      setValueWithSource({ value: valueToCommit, fromUi: true })
-    },
-    [uiValue, setValueWithSource]
-  )
+  const { commitWidgetValue, onBlur } = useStringInputCommitOnBlur({
+    inputRef,
+    uiValue,
+    dirty,
+    maxChars,
+    setDirty,
+    setUiValue,
+    setValueWithSource,
+    setFocused,
+  })
 
   // Show "Please enter" instructions if in a form & allowed, or not in form and state is dirty.
   const allowEnterToSubmit = isInForm({ formId })
@@ -133,31 +123,6 @@ function TextInput({
   // Hide input instructions for small widget sizes.
   const shouldShowInstructions =
     focused && width > convertRemToPx(theme.breakpoints.hideWidgetDetails)
-
-  const onBlur = useCallback((): void => {
-    // Password managers can programmatically set the <input>.value without
-    // dispatching an event that React/BaseWeb picks up. In that case, the DOM
-    // shows the updated value but Streamlit's internal state is stale.
-    //
-    // Reconcile the DOM value on blur so that a subsequent rerun (e.g. button
-    // click) sees the updated value.
-    const domValue = inputRef.current?.value ?? ""
-    const currentUiValue = uiValue ?? ""
-
-    if (!dirty && domValue !== currentUiValue) {
-      if (maxChars !== 0 && domValue.length > maxChars) {
-        setFocused(false)
-        return
-      }
-
-      setUiValue(domValue)
-      commitWidgetValue(domValue)
-    } else if (dirty) {
-      commitWidgetValue()
-    }
-
-    setFocused(false)
-  }, [dirty, commitWidgetValue, maxChars, uiValue])
 
   const onFocus = useCallback((): void => {
     setFocused(true)
@@ -171,65 +136,13 @@ function TextInput({
     setValueWithSource,
   })
 
-  const handleDeferredNativeValueChange = useCallback((): void => {
-    if (!pendingNativeSyncRef.current) {
-      return
-    }
-    pendingNativeSyncRef.current = false
-
-    const domValue = inputRef.current?.value ?? ""
-    const currentUiValue = uiValueRef.current
-
-    // Defer reconciliation until after the native event so React/BaseWeb has
-    // a chance to process standard bubbling input events first.
-    if (domValue === currentUiValue) {
-      return
-    }
-
-    // Match regular input behavior: reject values beyond maxChars and
-    // immediately restore the controlled value in the DOM.
-    if (maxChars !== 0 && domValue.length > maxChars) {
-      if (inputRef.current) {
-        inputRef.current.value = currentUiValue
-      }
-      return
-    }
-
-    onChange({ target: { value: domValue } })
-  }, [maxChars, onChange])
-
-  const { clear: clearNativeSyncTimeout, restart: restartNativeSyncTimeout } =
-    useTimeout(handleDeferredNativeValueChange, 0)
-
-  const handleNativeValueChange = useCallback((): void => {
-    pendingNativeSyncRef.current = true
-    clearNativeSyncTimeout()
-    restartNativeSyncTimeout()
-  }, [clearNativeSyncTimeout, restartNativeSyncTimeout])
-
-  useEffect(() => {
-    const el = inputRef.current
-    if (!el || disabled) {
-      return
-    }
-
-    // Capture phase so we still see events even if propagation is stopped.
-    const listenerOptions: AddEventListenerOptions = { capture: true }
-
-    el.addEventListener("input", handleNativeValueChange, listenerOptions)
-    el.addEventListener("change", handleNativeValueChange, listenerOptions)
-
-    return () => {
-      el.removeEventListener("input", handleNativeValueChange, listenerOptions)
-      el.removeEventListener(
-        "change",
-        handleNativeValueChange,
-        listenerOptions
-      )
-      pendingNativeSyncRef.current = false
-      clearNativeSyncTimeout()
-    }
-  }, [clearNativeSyncTimeout, disabled, handleNativeValueChange])
+  useNativeInputValueChange({
+    inputRef,
+    disabled,
+    uiValue,
+    maxChars,
+    onChange,
+  })
 
   const onKeyPress = useSubmitFormViaEnterKey(
     formId,

--- a/frontend/lib/src/hooks/useNativeInputValueChange.test.ts
+++ b/frontend/lib/src/hooks/useNativeInputValueChange.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+
+import useNativeInputValueChange from "./useNativeInputValueChange"
+
+describe("useNativeInputValueChange", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("forwards deferred native input events when DOM value differs", () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+
+    renderHook(() =>
+      useNativeInputValueChange({
+        inputRef,
+        disabled: false,
+        uiValue: "",
+        onChange,
+      })
+    )
+
+    inputRef.current.value = "autofilled@example.com"
+
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("input", { bubbles: false }))
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(onChange).toHaveBeenCalledWith({
+      target: { value: "autofilled@example.com" },
+    })
+  })
+
+  it("forwards deferred native change events when DOM value differs", () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+
+    renderHook(() =>
+      useNativeInputValueChange({
+        inputRef,
+        disabled: false,
+        uiValue: "",
+        onChange,
+      })
+    )
+
+    inputRef.current.value = "changed@example.com"
+
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("change", { bubbles: false }))
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(onChange).toHaveBeenCalledWith({
+      target: { value: "changed@example.com" },
+    })
+  })
+
+  it("rejects deferred native values that exceed maxChars", () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+
+    renderHook(() =>
+      useNativeInputValueChange({
+        inputRef,
+        disabled: false,
+        uiValue: "",
+        maxChars: 3,
+        onChange,
+      })
+    )
+
+    inputRef.current.value = "TOOLONG"
+
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("input", { bubbles: false }))
+      vi.runAllTimers()
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(inputRef.current).toHaveValue("")
+  })
+
+  it("does not double-process bubbling events already handled by React", () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+
+    const { rerender } = renderHook(
+      ({ uiValue }: { uiValue: string | null }) =>
+        useNativeInputValueChange({
+          inputRef,
+          disabled: false,
+          uiValue,
+          onChange,
+        }),
+      {
+        initialProps: { uiValue: "" },
+      }
+    )
+
+    inputRef.current.value = "same-value"
+
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    rerender({ uiValue: "same-value" })
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("does not attach listeners when disabled", () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+
+    renderHook(() =>
+      useNativeInputValueChange({
+        inputRef,
+        disabled: true,
+        uiValue: "",
+        onChange,
+      })
+    )
+
+    inputRef.current.value = "autofilled@example.com"
+
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("input"))
+      inputRef.current.dispatchEvent(new Event("change"))
+      vi.runAllTimers()
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("does not re-register native listeners on rerender", () => {
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+    const addEventListenerSpy = vi.spyOn(inputRef.current, "addEventListener")
+    const removeEventListenerSpy = vi.spyOn(
+      inputRef.current,
+      "removeEventListener"
+    )
+    const onChange = vi.fn()
+
+    const { rerender, unmount } = renderHook(
+      ({ uiValue }: { uiValue: string | null }) =>
+        useNativeInputValueChange({
+          inputRef,
+          disabled: false,
+          uiValue,
+          onChange,
+        }),
+      {
+        initialProps: { uiValue: "" },
+      }
+    )
+
+    rerender({ uiValue: "a" })
+    rerender({ uiValue: "ab" })
+    rerender({ uiValue: "abc" })
+
+    const nativeEventTypes = new Set(["input", "change"])
+    const addCallsForInput = addEventListenerSpy.mock.calls.filter(call =>
+      nativeEventTypes.has(String(call[0]))
+    )
+    const removeCallsForInput = removeEventListenerSpy.mock.calls.filter(
+      call => nativeEventTypes.has(String(call[0]))
+    )
+
+    expect(addCallsForInput).toHaveLength(2)
+    expect(removeCallsForInput).toHaveLength(0)
+
+    unmount()
+
+    const removeCallsAfterUnmount = removeEventListenerSpy.mock.calls.filter(
+      call => nativeEventTypes.has(String(call[0]))
+    )
+    expect(removeCallsAfterUnmount).toHaveLength(2)
+  })
+
+  it("uses latest onChange callback for deferred reconciliation", () => {
+    vi.useFakeTimers()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+    const firstOnChange = vi.fn()
+    const secondOnChange = vi.fn()
+
+    const { rerender } = renderHook(
+      ({
+        onChange,
+      }: {
+        onChange: (event: { target: { value: string } }) => void
+      }) =>
+        useNativeInputValueChange({
+          inputRef,
+          disabled: false,
+          uiValue: "",
+          onChange,
+        }),
+      {
+        initialProps: { onChange: firstOnChange },
+      }
+    )
+
+    rerender({ onChange: secondOnChange })
+    inputRef.current.value = "latest-value"
+
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("input", { bubbles: false }))
+      vi.runAllTimers()
+    })
+
+    expect(firstOnChange).not.toHaveBeenCalled()
+    expect(secondOnChange).toHaveBeenCalledWith({
+      target: { value: "latest-value" },
+    })
+  })
+
+  it("clears pending deferred reconciliation on unmount", () => {
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    const inputRef = {
+      current: document.createElement("input"),
+    }
+
+    const { unmount } = renderHook(() =>
+      useNativeInputValueChange({
+        inputRef,
+        disabled: false,
+        uiValue: "",
+        onChange,
+      })
+    )
+
+    inputRef.current.value = "autofilled@example.com"
+    act(() => {
+      inputRef.current.dispatchEvent(new Event("input", { bubbles: false }))
+    })
+
+    unmount()
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/hooks/useNativeInputValueChange.ts
+++ b/frontend/lib/src/hooks/useNativeInputValueChange.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react"
+
+import { OnInputChangeEventType } from "~lib/hooks/useOnInputChange"
+import useTimeout from "~lib/hooks/useTimeout"
+
+interface UseNativeInputValueChangeProps {
+  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>
+  disabled: boolean
+  uiValue: string | null
+  maxChars?: number
+  onChange: (e: OnInputChangeEventType) => void
+}
+
+/**
+ * Attaches native DOM listeners as a fallback for cases where third-party tools
+ * (e.g. password managers) update input values through native events that React
+ * might not observe.
+ */
+export default function useNativeInputValueChange({
+  inputRef,
+  disabled,
+  uiValue,
+  maxChars = 0,
+  onChange,
+}: UseNativeInputValueChangeProps): void {
+  const uiValueRef = useRef(uiValue ?? "")
+  const onChangeRef = useRef(onChange)
+  const pendingNativeSyncRef = useRef(false)
+
+  useLayoutEffect(() => {
+    uiValueRef.current = uiValue ?? ""
+    onChangeRef.current = onChange
+  }, [onChange, uiValue])
+
+  const handleDeferredNativeValueChange = useCallback((): void => {
+    if (!pendingNativeSyncRef.current) {
+      return
+    }
+    pendingNativeSyncRef.current = false
+
+    const domValue = inputRef.current?.value ?? ""
+    const currentUiValue = uiValueRef.current
+
+    // Defer reconciliation until after the native event so React/BaseWeb has
+    // a chance to process standard bubbling input events first.
+    if (domValue === currentUiValue) {
+      return
+    }
+
+    // Match regular input behavior: reject values beyond maxChars and
+    // immediately restore the controlled value in the DOM.
+    if (maxChars !== 0 && domValue.length > maxChars) {
+      if (inputRef.current) {
+        inputRef.current.value = currentUiValue
+      }
+      return
+    }
+
+    onChangeRef.current({ target: { value: domValue } })
+  }, [inputRef, maxChars])
+
+  const { clear: clearNativeSyncTimeout, restart: restartNativeSyncTimeout } =
+    useTimeout(handleDeferredNativeValueChange, 0)
+
+  const handleNativeValueChange = useCallback((): void => {
+    pendingNativeSyncRef.current = true
+    clearNativeSyncTimeout()
+    restartNativeSyncTimeout()
+  }, [clearNativeSyncTimeout, restartNativeSyncTimeout])
+
+  useEffect(() => {
+    const el = inputRef.current
+    if (!el || disabled) {
+      return
+    }
+
+    // Capture phase so we still see events even if propagation is stopped.
+    const listenerOptions: AddEventListenerOptions = { capture: true }
+
+    el.addEventListener("input", handleNativeValueChange, listenerOptions)
+    el.addEventListener("change", handleNativeValueChange, listenerOptions)
+
+    return () => {
+      el.removeEventListener("input", handleNativeValueChange, listenerOptions)
+      el.removeEventListener(
+        "change",
+        handleNativeValueChange,
+        listenerOptions
+      )
+      pendingNativeSyncRef.current = false
+      clearNativeSyncTimeout()
+    }
+  }, [clearNativeSyncTimeout, disabled, handleNativeValueChange, inputRef])
+}

--- a/frontend/lib/src/hooks/useOnInputChange.ts
+++ b/frontend/lib/src/hooks/useOnInputChange.ts
@@ -19,7 +19,7 @@ import { Dispatch, SetStateAction, useCallback } from "react"
 import { ValueWithSource } from "~lib/hooks/useBasicWidgetState"
 import { isInForm } from "~lib/util/utils"
 
-type OnInputChangeEventType = {
+export type OnInputChangeEventType = {
   target: {
     value: HTMLInputElement["value"]
   }

--- a/frontend/lib/src/hooks/useStringInputCommitOnBlur.test.ts
+++ b/frontend/lib/src/hooks/useStringInputCommitOnBlur.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+
+import useStringInputCommitOnBlur from "./useStringInputCommitOnBlur"
+
+describe("useStringInputCommitOnBlur", () => {
+  it("commits current ui value by default", () => {
+    const setDirty = vi.fn()
+    const setUiValue = vi.fn()
+    const setValueWithSource = vi.fn()
+    const setFocused = vi.fn()
+    const inputRef = { current: document.createElement("input") }
+
+    const { result } = renderHook(() =>
+      useStringInputCommitOnBlur({
+        inputRef,
+        uiValue: "abc",
+        dirty: false,
+        maxChars: 0,
+        setDirty,
+        setUiValue,
+        setValueWithSource,
+        setFocused,
+      })
+    )
+
+    act(() => {
+      result.current.commitWidgetValue()
+    })
+
+    expect(setDirty).toHaveBeenCalledWith(false)
+    expect(setValueWithSource).toHaveBeenCalledWith({
+      value: "abc",
+      fromUi: true,
+    })
+    expect(setUiValue).not.toHaveBeenCalled()
+    expect(setFocused).not.toHaveBeenCalled()
+  })
+
+  it("reconciles and commits DOM value on blur when not dirty", () => {
+    const setDirty = vi.fn()
+    const setUiValue = vi.fn()
+    const setValueWithSource = vi.fn()
+    const setFocused = vi.fn()
+    const inputRef = { current: document.createElement("input") }
+    inputRef.current.value = "autofilled@example.com"
+
+    const { result } = renderHook(() =>
+      useStringInputCommitOnBlur({
+        inputRef,
+        uiValue: "",
+        dirty: false,
+        maxChars: 0,
+        setDirty,
+        setUiValue,
+        setValueWithSource,
+        setFocused,
+      })
+    )
+
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(setUiValue).toHaveBeenCalledWith("autofilled@example.com")
+    expect(setDirty).toHaveBeenCalledWith(false)
+    expect(setValueWithSource).toHaveBeenCalledWith({
+      value: "autofilled@example.com",
+      fromUi: true,
+    })
+    expect(setFocused).toHaveBeenCalledWith(false)
+  })
+
+  it("commits existing ui value on blur when dirty", () => {
+    const setDirty = vi.fn()
+    const setUiValue = vi.fn()
+    const setValueWithSource = vi.fn()
+    const setFocused = vi.fn()
+    const inputRef = { current: document.createElement("input") }
+    inputRef.current.value = "ignored-dom-value"
+
+    const { result } = renderHook(() =>
+      useStringInputCommitOnBlur({
+        inputRef,
+        uiValue: "typed-value",
+        dirty: true,
+        maxChars: 0,
+        setDirty,
+        setUiValue,
+        setValueWithSource,
+        setFocused,
+      })
+    )
+
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(setValueWithSource).toHaveBeenCalledWith({
+      value: "typed-value",
+      fromUi: true,
+    })
+    expect(setUiValue).not.toHaveBeenCalled()
+    expect(setFocused).toHaveBeenCalledWith(false)
+  })
+
+  it("does not reconcile when DOM value exceeds maxChars", () => {
+    const setDirty = vi.fn()
+    const setUiValue = vi.fn()
+    const setValueWithSource = vi.fn()
+    const setFocused = vi.fn()
+    const inputRef = { current: document.createElement("input") }
+    inputRef.current.value = "12345"
+
+    const { result } = renderHook(() =>
+      useStringInputCommitOnBlur({
+        inputRef,
+        uiValue: "",
+        dirty: false,
+        maxChars: 3,
+        setDirty,
+        setUiValue,
+        setValueWithSource,
+        setFocused,
+      })
+    )
+
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(setUiValue).not.toHaveBeenCalled()
+    expect(setValueWithSource).not.toHaveBeenCalled()
+    expect(setDirty).not.toHaveBeenCalled()
+    expect(setFocused).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/lib/src/hooks/useStringInputCommitOnBlur.ts
+++ b/frontend/lib/src/hooks/useStringInputCommitOnBlur.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dispatch, RefObject, SetStateAction, useCallback } from "react"
+
+import { ValueWithSource } from "~lib/hooks/useBasicWidgetState"
+
+interface UseStringInputCommitOnBlurProps {
+  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>
+  uiValue: string | null
+  dirty: boolean
+  maxChars: number
+  setDirty: Dispatch<SetStateAction<boolean>>
+  setUiValue: Dispatch<SetStateAction<string | null>>
+  setValueWithSource: Dispatch<
+    SetStateAction<ValueWithSource<string | null> | null>
+  >
+  setFocused: Dispatch<SetStateAction<boolean>>
+}
+
+interface UseStringInputCommitOnBlurResult {
+  commitWidgetValue: (valueToCommit?: string | null) => void
+  onBlur: () => void
+}
+
+/**
+ * Shared commit + blur reconciliation logic for string-based inputs.
+ *
+ * This reconciles programmatic DOM value changes (e.g. password manager
+ * autofill) that can bypass React change handlers, and commits them on blur.
+ */
+export default function useStringInputCommitOnBlur({
+  inputRef,
+  uiValue,
+  dirty,
+  maxChars,
+  setDirty,
+  setUiValue,
+  setValueWithSource,
+  setFocused,
+}: UseStringInputCommitOnBlurProps): UseStringInputCommitOnBlurResult {
+  const commitWidgetValue = useCallback(
+    (valueToCommit: string | null = uiValue): void => {
+      setDirty(false)
+      setValueWithSource({ value: valueToCommit, fromUi: true })
+    },
+    [uiValue, setDirty, setValueWithSource]
+  )
+
+  const onBlur = useCallback((): void => {
+    // Password managers can programmatically set the input value without
+    // dispatching an event that React/BaseWeb picks up.
+    const domValue = inputRef.current?.value ?? ""
+    const currentUiValue = uiValue ?? ""
+
+    if (!dirty && domValue !== currentUiValue) {
+      if (maxChars !== 0 && domValue.length > maxChars) {
+        setFocused(false)
+        return
+      }
+
+      setUiValue(domValue)
+      commitWidgetValue(domValue)
+    } else if (dirty) {
+      commitWidgetValue()
+    }
+
+    setFocused(false)
+  }, [
+    commitWidgetValue,
+    dirty,
+    inputRef,
+    maxChars,
+    setFocused,
+    setUiValue,
+    uiValue,
+  ])
+
+  return { commitWidgetValue, onBlur }
+}


### PR DESCRIPTION
## Describe your changes

Added support for detecting and handling programmatic input value changes in text inputs and text areas. This addresses cases where password managers or other tools autofill form fields without triggering React's change events.

The implementation:
1. Extracts shared logic into two new hooks:
   - `useNativeInputValueChange`: Listens for native DOM input events to detect value changes
   - `useStringInputCommitOnBlur`: Reconciles DOM values with React state on blur

2. Updates both TextInput and TextArea components to use these hooks

## Testing Plan

- Unit Tests: Added comprehensive tests for both new hooks and updated TextArea tests to verify the behavior with programmatic value changes
- The implementation was tested with various password managers to ensure autofilled values are properly detected and committed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.