### PR TITLE
[feat] Support running multiple `make debug` sessions simultaneously

### DIFF
--- a/.claude/skills/debugging-streamlit/SKILL.md
+++ b/.claude/skills/debugging-streamlit/SKILL.md
@@ -11,7 +11,7 @@ description: Debug Streamlit frontend and backend changes using make debug with 
 make debug my_app.py
 ```
 
-This starts both backend (Streamlit/Python) and frontend (Vite/React) with hot-reload. The app is available at http://localhost:3000.
+This starts both backend (Streamlit/Python) and frontend (Vite/React) with hot-reload. The app URL is printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if other debug sessions are running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 
 **Hot-reload behavior:**
 - **Frontend**: Changes to `frontend/` code are applied within seconds.
@@ -19,29 +19,31 @@ This starts both backend (Streamlit/Python) and frontend (Vite/React) with hot-r
 
 ## Log Files
 
-All debug output goes to `work-tmp/debug/`:
+Each `make debug` run writes logs to a per-session directory under `work-tmp/debug/` and updates `work-tmp/debug/latest/` to point at the most recent session.
+Because `latest/*` is a symlink, **it can move** if multiple debug sessions are starting/stopping concurrently—prefer using the session directory path printed by `make debug` when you need stable log references.
+You can find the exact session directory in the `make debug` startup output under the `Log files` section.
 
 | File | Content |
 |------|---------|
-| `work-tmp/debug/backend.log` | Python `print()` statements, Streamlit logs, errors |
-| `work-tmp/debug/frontend.log` | Browser `console.log()`, React errors, Vite output |
+| `work-tmp/debug/latest/backend.log` | Python `print()` statements, Streamlit logs, errors |
+| `work-tmp/debug/latest/frontend.log` | Browser `console.log()`, React errors, Vite output |
 
-Logs are cleared on each `make debug` run but persist after exit for post-mortem analysis.
+Logs are cleared at the start of each session and persist after exit for post-mortem analysis.
 
-**Log size warning:** Logs can grow large during extended debugging sessions. Instead of reading entire log files, use `grep` to search for specific patterns:
+**Log size warning:** Logs can grow large during extended debugging sessions. Instead of reading entire log files, use `rg` to search for specific patterns:
 
 ```bash
 # Search for specific debug messages
-grep "DEBUG:" work-tmp/debug/backend.log
+rg "DEBUG:" work-tmp/debug/latest/backend.log
 
 # Search for errors (case-insensitive)
-grep -i "error\|exception\|traceback" work-tmp/debug/backend.log
+rg -i "error|exception|traceback" work-tmp/debug/latest/backend.log
 
 # Search with context (3 lines before/after)
-grep -C 3 "my_function" work-tmp/debug/backend.log
+rg -C 3 "my_function" work-tmp/debug/latest/backend.log
 
 # Search frontend logs for specific component
-grep "MyComponent" work-tmp/debug/frontend.log
+rg "MyComponent" work-tmp/debug/latest/frontend.log
 ```
 
 Use this directory for all debugging artifacts (scripts, screenshots, etc.) to keep them organized.
@@ -58,26 +60,26 @@ print(f"DEBUG: session_state = {st.session_state}")
 console.log("DEBUG: props =", props)
 ```
 
-Frontend `console.log()` output appears in `work-tmp/debug/frontend.log`.
+Frontend `console.log()` output appears in `work-tmp/debug/latest/frontend.log` (or the current session's `frontend.log` file).
 
 ## Workflow
 
 1. Create or use a test script in `work-tmp/debug/` (e.g., `work-tmp/debug/test_feature.py`)
 2. Run `make debug work-tmp/debug/test_feature.py`
-3. **Verify startup**: Check `work-tmp/debug/backend.log` for `Error` or `Exception` and `work-tmp/debug/frontend.log` for console errors to ensure both servers started correctly
-4. Access http://localhost:3000 in browser or via Playwright
-5. **Verify script execution**: Check `work-tmp/debug/backend.log` again for any errors after the first app access
-6. Monitor logs: `tail -n 100 -f work-tmp/debug/backend.log` or `tail -n 100 -f work-tmp/debug/frontend.log`
+3. **Verify startup**: Check `work-tmp/debug/latest/backend.log` for `Error`/`Exception` and `work-tmp/debug/latest/frontend.log` for console errors to ensure both servers started correctly
+4. Access the printed App URL in your browser (default `http://localhost:3001`, but it may be `3002+`)
+5. **Verify script execution**: Check `work-tmp/debug/latest/backend.log` again for any errors after the first app access
+6. Monitor logs by inspecting `work-tmp/debug/latest/backend.log` and `work-tmp/debug/latest/frontend.log`
 7. Edit code - changes apply automatically via hot-reload
 8. Check logs for debug output
 
 **Quick error check:**
 ```bash
 # Backend errors
-grep -i "error\|exception" work-tmp/debug/backend.log
+rg -i "error|exception" work-tmp/debug/latest/backend.log
 
 # Frontend console errors
-grep -i "error" work-tmp/debug/frontend.log
+rg -i "error" work-tmp/debug/latest/frontend.log
 ```
 
 ## Temporary Playwright Scripts for Screenshots & Testing
@@ -90,7 +92,8 @@ For simple screenshots and interactions, use `@playwright/cli` (available in fro
 
 ```bash
 cd frontend
-yarn playwright-cli open http://localhost:3000
+STREAMLIT_APP_URL=http://localhost:3001
+yarn playwright-cli open "$STREAMLIT_APP_URL"
 yarn playwright-cli screenshot --filename ../work-tmp/debug/screenshot.png --full-page
 yarn playwright-cli close
 ```
@@ -104,6 +107,7 @@ For complex interactions, create temporary Playwright scripts in `work-tmp/debug
 ```python
 # work-tmp/debug/debug_screenshot.py
 """Temporary Playwright script for debugging - run against make debug."""
+import os
 from playwright.sync_api import sync_playwright, expect
 
 from e2e_playwright.shared.app_utils import get_text_input, click_button
@@ -111,12 +115,13 @@ from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
 
 
 def main():
+    app_url = os.environ.get("STREAMLIT_APP_URL", "http://localhost:3001")
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         page = browser.new_page(viewport={"width": 1280, "height": 720})
 
         # Connect to app started with `make debug`
-        page.goto("http://localhost:3000")
+        page.goto(app_url)
         wait_for_app_loaded(page)
 
         # Interact with the app
@@ -139,9 +144,10 @@ if __name__ == "__main__":
 
 ### Running Temporary Scripts
 
-Ensure `make debug <app.py>` is running first (start it in a background task if needed). Wait for the server to be ready on port 3000, then run the Playwright script:
+Ensure `make debug <app.py>` is running first (start it in a background task if needed). If your `make debug` session is using a non-default port, set `STREAMLIT_APP_URL` accordingly, then run the Playwright script:
 
 ```bash
+STREAMLIT_APP_URL=http://localhost:3001 \
 PYTHONPATH=. uv run python work-tmp/debug/debug_screenshot.py
 ```
 
@@ -172,26 +178,18 @@ element.screenshot(path="work-tmp/debug/dataframe.png")
 
 ## Troubleshooting
 
-**Port already in use:**
-```bash
-# Check what's using the ports
-lsof -ti:3000  # Vite dev server
-lsof -ti:8501  # Streamlit backend
-```
-
-If ports are in use, **ask the user first** before killing processes. They may have other debug sessions or applications running intentionally. Only after user confirmation:
-```bash
-# Kill processes (only after user confirms)
-kill $(lsof -ti:3000) $(lsof -ti:8501)
-```
+**Port already in use / multiple sessions:**
+- `make debug` will automatically pick a free frontend port (typically in the `3001-3100` range) so multiple debug sessions can run simultaneously.
+- Frontend port `3000` is reserved for manual `make frontend-dev` sessions.
+- If you have a hard requirement for a specific frontend port, you can pin it with `VITE_PORT=3002 make debug <app.py>` (last resort).
 
 **Hot-reload not working:**
 - Backend: Only the app script is watched. Changes to `lib/streamlit/` require restarting `make debug`.
-- Frontend: Check `work-tmp/debug/frontend.log` for Vite errors. TypeScript errors can break HMR.
+- Frontend: Check `work-tmp/debug/latest/frontend.log` for Vite errors. TypeScript errors can break HMR.
 
 **Playwright script fails to connect:**
 - Verify `make debug` is running and healthy
-- Check http://localhost:3000 is accessible in browser
+- Check the printed App URL is accessible in the browser
 - Ensure `wait_for_app_loaded(page)` is called after `page.goto()`
 
 ## Cleanup

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -76,9 +76,10 @@ Selection of `make` commands for development (run in the repo root):
 - `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`.
   - Frontend hot-reload: Changes to frontend code (`frontend/`) are applied within seconds.
   - Backend hot-reload: Only changes to the **app script** trigger a rerun. Changes to the Streamlit library itself (`lib/streamlit/`) require restarting `make debug`.
-  - Logs are written to `work-tmp/debug/backend.log` (Python/Streamlit) and `work-tmp/debug/frontend.log` (Vite/browser console).
-  - Log files are cleared on each run but persist after exit for post-mortem analysis.
-  - Browser `console.log()` output appears in `work-tmp/debug/frontend.log`.
+  - Logs are written to a per-session directory under `work-tmp/debug/` (e.g. `work-tmp/debug/<session>/backend.log` and `work-tmp/debug/<session>/frontend.log`).
+  - `work-tmp/debug/latest/` is a symlink to the most recent debug session (e.g. `work-tmp/debug/latest/backend.log`). If multiple sessions are running simultaneously, this symlink can move—prefer using the session directory printed by `make debug`.
+  - Log files are cleared at the start of each session and persist after exit for post-mortem analysis.
+  - Browser `console.log()` output appears in the session’s `frontend.log`.
   - See [.claude/skills/debugging-streamlit/SKILL.md](.claude/skills/debugging-streamlit/SKILL.md) for the full debugging guide.
 
 ### Development Tips
@@ -86,7 +87,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Follow existing patterns**: Check neighboring files for conventions.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
-- Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app will be available at <http://localhost:3000>.
+- Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app URL will be printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if you have other sessions running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 - Run `make check` after completing changes to run formatting, linting, type checking, and unit tests on all uncommitted files.
 - The main branch of this repository is `develop`.
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,30 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "forwardPorts": [3000],
+  "forwardPorts": [3000, 3001, 3002, 3003, 3004, 3005],
   "portsAttributes": {
     "3000": {
-      "label": "Dev Server",
+      "label": "Dev Server (3000)",
+      "onAutoForward": "notify"
+    },
+    "3001": {
+      "label": "Dev Server (3001)",
+      "onAutoForward": "notify"
+    },
+    "3002": {
+      "label": "Dev Server (3002)",
+      "onAutoForward": "notify"
+    },
+    "3003": {
+      "label": "Dev Server (3003)",
+      "onAutoForward": "notify"
+    },
+    "3004": {
+      "label": "Dev Server (3004)",
+      "onAutoForward": "notify"
+    },
+    "3005": {
+      "label": "Dev Server (3005)",
       "onAutoForward": "notify"
     }
   },

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,9 +70,10 @@ Selection of `make` commands for development (run in the repo root):
 - `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`.
   - Frontend hot-reload: Changes to frontend code (`frontend/`) are applied within seconds.
   - Backend hot-reload: Only changes to the **app script** trigger a rerun. Changes to the Streamlit library itself (`lib/streamlit/`) require restarting `make debug`.
-  - Logs are written to `work-tmp/debug/backend.log` (Python/Streamlit) and `work-tmp/debug/frontend.log` (Vite/browser console).
-  - Log files are cleared on each run but persist after exit for post-mortem analysis.
-  - Browser `console.log()` output appears in `work-tmp/debug/frontend.log`.
+  - Logs are written to a per-session directory under `work-tmp/debug/` (e.g. `work-tmp/debug/<session>/backend.log` and `work-tmp/debug/<session>/frontend.log`).
+  - `work-tmp/debug/latest/` is a symlink to the most recent debug session (e.g. `work-tmp/debug/latest/backend.log`). If multiple sessions are running simultaneously, this symlink can move—prefer using the session directory printed by `make debug`.
+  - Log files are cleared at the start of each session and persist after exit for post-mortem analysis.
+  - Browser `console.log()` output appears in the session’s `frontend.log`.
   - See [.claude/skills/debugging-streamlit/SKILL.md](.claude/skills/debugging-streamlit/SKILL.md) for the full debugging guide.
 
 ### Development Tips
@@ -80,7 +81,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Follow existing patterns**: Check neighboring files for conventions.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
-- Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app will be available at <http://localhost:3000>.
+- Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app URL will be printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if you have other sessions running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 - Run `make check` after completing changes to run formatting, linting, type checking, and unit tests on all uncommitted files.
 - The main branch of this repository is `develop`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,10 @@ Selection of `make` commands for development (run in the repo root):
 - `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`.
   - Frontend hot-reload: Changes to frontend code (`frontend/`) are applied within seconds.
   - Backend hot-reload: Only changes to the **app script** trigger a rerun. Changes to the Streamlit library itself (`lib/streamlit/`) require restarting `make debug`.
-  - Logs are written to `work-tmp/debug/backend.log` (Python/Streamlit) and `work-tmp/debug/frontend.log` (Vite/browser console).
-  - Log files are cleared on each run but persist after exit for post-mortem analysis.
-  - Browser `console.log()` output appears in `work-tmp/debug/frontend.log`.
+  - Logs are written to a per-session directory under `work-tmp/debug/` (e.g. `work-tmp/debug/<session>/backend.log` and `work-tmp/debug/<session>/frontend.log`).
+  - `work-tmp/debug/latest/` is a symlink to the most recent debug session (e.g. `work-tmp/debug/latest/backend.log`). If multiple sessions are running simultaneously, this symlink can move—prefer using the session directory printed by `make debug`.
+  - Log files are cleared at the start of each session and persist after exit for post-mortem analysis.
+  - Browser `console.log()` output appears in the session’s `frontend.log`.
   - See [.claude/skills/debugging-streamlit/SKILL.md](.claude/skills/debugging-streamlit/SKILL.md) for the full debugging guide.
 
 ### Development Tips
@@ -80,7 +81,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Follow existing patterns**: Check neighboring files for conventions.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
-- Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app will be available at <http://localhost:3000>.
+- Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app URL will be printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if you have other sessions running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 - Run `make check` after completing changes to run formatting, linting, type checking, and unit tests on all uncommitted files.
 - The main branch of this repository is `develop`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,9 @@ $ brew install protobuf
 
 # (Recommended) Install GitHub CLI - used by AI agents for PR and issue management
 $ brew install gh
+
+# (Recommended) Install ripgrep - used by AI agents for fast log/code search
+$ brew install ripgrep
 ```
 
 **Installing Node JS and yarn**
@@ -78,6 +81,9 @@ $ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # (Recommended) Install GitHub CLI - used by AI agents for PR and issue management
 # See https://cli.github.com/ for installation instructions
+
+# (Recommended) Install ripgrep - used by AI agents for fast log/code search
+$ sudo apt-get install -y ripgrep
 ```
 
 #### Windows
@@ -111,7 +117,7 @@ The virtual environment and dependencies will be automatically created and manag
 
 ## How to develop Streamlit
 
-The basic developer workflow is that you run a React development server on port 3000 in one terminal and run Streamlit CLI commands in another terminal.
+The basic developer workflow is that you run a React development server (default port `3000`) in one terminal and run Streamlit CLI commands in another terminal.
 
 ### 1. One-time setup
 
@@ -134,7 +140,9 @@ make frontend-dev
 ```
 
 > [!Note]
-> This server listens on port `3000` rather than `8501` (i.e. Streamlit's production port). Normally you don't have to worry about this, but it may matter when you're developing certain features. The server is automatically updating to the changes you apply in the frontend code (hot-reloading).
+> This server defaults to port `3000` rather than `8501` (i.e. Streamlit's production port), but you can change it with `VITE_PORT` (or `PORT`), for example: `VITE_PORT=3002 make frontend-dev`.
+> To point the frontend dev server at a different backend, set `DEV_SERVER_BACKEND_URL`, for example: `DEV_SERVER_BACKEND_URL=http://localhost:8502 make frontend-dev`.
+> The server automatically updates when frontend code changes (hot-reloading).
 
 ### 4. Run Streamlit
 

--- a/Makefile
+++ b/Makefile
@@ -262,65 +262,157 @@ debug:
 		echo "Error: Script '$$SCRIPT' not found"; \
 		exit 1; \
 	fi; \
-	PORT_3000_PID=$$(lsof -ti:3000 2>/dev/null | tr '\n' ' '); \
-	PORT_8501_PID=$$(lsof -ti:8501 2>/dev/null | tr '\n' ' '); \
-	if [[ -n "$$PORT_3000_PID" ]] || [[ -n "$$PORT_8501_PID" ]]; then \
-		echo "Error: Required ports are already in use."; \
-		if [[ -n "$$PORT_3000_PID" ]]; then \
-			echo "  Port 3000 (Vite): PID(s) $$PORT_3000_PID"; \
-		fi; \
-		if [[ -n "$$PORT_8501_PID" ]]; then \
-			echo "  Port 8501 (Streamlit): PID(s) $$PORT_8501_PID"; \
-		fi; \
-		echo ""; \
-		echo "Please stop these processes and try again."; \
-		echo "To kill them: kill $$PORT_3000_PID$$PORT_8501_PID"; \
-		exit 1; \
+	if [[ ! -f "frontend/utils/dist/streamlit-utils.es.js" ]]; then \
+		echo "Frontend workspace build artifacts are missing. Building required frontend packages..."; \
+		( \
+			cd frontend && \
+			yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build \
+		) || exit 1; \
 	fi; \
-	DEBUG_DIR="$$(pwd)/work-tmp/debug"; \
+	DEBUG_ROOT="$$(pwd)/work-tmp/debug"; \
+	mkdir -p "$$DEBUG_ROOT"; \
+	SCRIPT_SAFE_NAME="$$(basename "$$SCRIPT" | sed 's/[^[:alnum:]._-]/_/g')"; \
+	SESSION_STAMP="$$(date +%Y%m%d-%H%M%S)-$$SCRIPT_SAFE_NAME-$$$$"; \
+	DEBUG_DIR="$$DEBUG_ROOT/$$SESSION_STAMP"; \
 	mkdir -p "$$DEBUG_DIR"; \
+	ln -sfn "$$DEBUG_DIR" "$$DEBUG_ROOT/latest"; \
 	> "$$DEBUG_DIR/backend.log"; \
 	> "$$DEBUG_DIR/frontend.log"; \
+	BACKEND_PID=""; \
+	FRONTEND_PID=""; \
+	BACKEND_PORT=""; \
+	FRONTEND_PORT=""; \
+	REQUESTED_BACKEND_PORT="$${STREAMLIT_SERVER_PORT:-}"; \
+	if [[ -n "$$REQUESTED_BACKEND_PORT" ]]; then \
+		echo "Error: STREAMLIT_SERVER_PORT is not supported by make debug."; \
+		echo "Reason: global.developmentMode=true forbids manual server.port overrides."; \
+		echo "Unset STREAMLIT_SERVER_PORT and rerun make debug."; \
+		exit 1; \
+	fi; \
+	if [[ -n "$$VITE_PORT" ]]; then \
+		if [[ ! "$$VITE_PORT" =~ ^[0-9]+$$ ]] || (( $$VITE_PORT < 1 || $$VITE_PORT > 65535 )); then \
+			echo "Error: VITE_PORT must be an integer between 1 and 65535."; \
+			exit 1; \
+		fi; \
+		FRONTEND_PORT=$$VITE_PORT; \
+		if lsof -nP -iTCP:$$FRONTEND_PORT -sTCP:LISTEN > /dev/null 2>&1; then \
+			echo "Error: Requested VITE_PORT=$$FRONTEND_PORT is already in use."; \
+			exit 1; \
+		fi; \
+	else \
+		for candidate_port in $$(seq 3001 3100); do \
+			if ! lsof -nP -iTCP:$$candidate_port -sTCP:LISTEN > /dev/null 2>&1; then \
+				FRONTEND_PORT=$$candidate_port; \
+				break; \
+			fi; \
+		done; \
+	fi; \
+	if [[ -z "$$FRONTEND_PORT" ]]; then \
+		echo "Error: Could not find a free frontend port in range 3001-3100."; \
+		exit 1; \
+	fi; \
 	cleanup() { \
 		echo ""; \
-		echo "Stopping servers... logs saved to work-tmp/debug/"; \
-		lsof -ti:3000 | xargs kill 2>/dev/null || true; \
-		lsof -ti:8501 | xargs kill 2>/dev/null || true; \
+		echo "Stopping servers... logs saved to $$DEBUG_DIR/"; \
+		if [[ -n "$$FRONTEND_PID" ]]; then \
+			pkill -P "$$FRONTEND_PID" 2>/dev/null || true; \
+			kill "$$FRONTEND_PID" 2>/dev/null || true; \
+			wait "$$FRONTEND_PID" 2>/dev/null || true; \
+		fi; \
+		if [[ -n "$$BACKEND_PID" ]]; then \
+			pkill -P "$$BACKEND_PID" 2>/dev/null || true; \
+			kill "$$BACKEND_PID" 2>/dev/null || true; \
+			wait "$$BACKEND_PID" 2>/dev/null || true; \
+		fi; \
 	}; \
 	trap cleanup EXIT; \
-	uv run streamlit run "$$SCRIPT" \
+	VITE_PORT="$$FRONTEND_PORT" uv run streamlit run "$$SCRIPT" \
 		--server.headless=true \
 		--server.runOnSave=true \
 		--browser.gatherUsageStats=false \
 		--global.developmentMode=true \
 		>> "$$DEBUG_DIR/backend.log" 2>&1 & \
-	cd frontend && DEBUG_TO_CONSOLE=1 yarn start >> "$$DEBUG_DIR/frontend.log" 2>&1 & \
+	BACKEND_PID=$$!; \
 	echo ""; \
 	echo "Starting debug session: $$SCRIPT"; \
 	BACKEND_READY=false; \
-	FRONTEND_READY=false; \
 	for i in $$(seq 1 60); do \
-		if [[ "$$BACKEND_READY" == "false" ]] && curl -s http://localhost:8501/_stcore/health > /dev/null 2>&1; then \
+		if ! kill -0 "$$BACKEND_PID" > /dev/null 2>&1; then \
+			echo "Error: Streamlit backend exited before startup completed. Check $$DEBUG_DIR/backend.log"; \
+			exit 1; \
+		fi; \
+		if [[ -z "$$BACKEND_PORT" ]]; then \
+			BACKEND_PORT=$$(awk '/Server started on port [0-9]+/ {print $$NF; exit}' "$$DEBUG_DIR/backend.log"); \
+		fi; \
+		if [[ -n "$$BACKEND_PORT" ]] && curl -fsS "http://localhost:$$BACKEND_PORT/_stcore/health" > /dev/null 2>&1; then \
+			BACKEND_READY=true; \
+			break; \
+		fi; \
+		sleep 1; \
+	done; \
+	if [[ -z "$$BACKEND_PORT" ]]; then \
+		echo "Error: Could not determine backend port for debug session. Check $$DEBUG_DIR/backend.log"; \
+		exit 1; \
+	fi; \
+	if [[ "$$BACKEND_READY" == "false" ]]; then \
+		echo "Error: Streamlit backend did not become healthy on port $$BACKEND_PORT. Check $$DEBUG_DIR/backend.log"; \
+		exit 1; \
+	fi; \
+	if lsof -nP -iTCP:$$FRONTEND_PORT -sTCP:LISTEN > /dev/null 2>&1; then \
+		if [[ -n "$$VITE_PORT" ]]; then \
+			echo "Error: Requested VITE_PORT=$$FRONTEND_PORT became unavailable before frontend startup."; \
+		else \
+			echo "Error: Selected frontend port $$FRONTEND_PORT became unavailable before frontend startup."; \
+		fi; \
+		echo "Please rerun make debug."; \
+		exit 1; \
+	fi; \
+	( \
+		cd frontend && \
+		DEBUG_TO_CONSOLE=1 \
+		DEV_SERVER_BACKEND_URL="http://localhost:$$BACKEND_PORT" \
+		VITE_PORT="$$FRONTEND_PORT" yarn start -- --strictPort \
+	) >> "$$DEBUG_DIR/frontend.log" 2>&1 & \
+	FRONTEND_PID=$$!; \
+	BACKEND_READY=true; \
+	FRONTEND_READY=false; \
+	PROXY_READY=false; \
+	for i in $$(seq 1 60); do \
+		if ! kill -0 "$$BACKEND_PID" > /dev/null 2>&1; then \
+			echo "Error: Streamlit backend exited before startup completed. Check $$DEBUG_DIR/backend.log"; \
+			exit 1; \
+		fi; \
+		if [[ "$$FRONTEND_READY" == "false" ]] && ! kill -0 "$$FRONTEND_PID" > /dev/null 2>&1; then \
+			echo "Error: Frontend dev server exited before startup completed. Check $$DEBUG_DIR/frontend.log"; \
+			exit 1; \
+		fi; \
+		if [[ "$$BACKEND_READY" == "false" ]] && curl -fsS "http://localhost:$$BACKEND_PORT/_stcore/health" > /dev/null 2>&1; then \
 			BACKEND_READY=true; \
 		fi; \
-		if [[ "$$FRONTEND_READY" == "false" ]] && curl -s http://localhost:3000 > /dev/null 2>&1; then \
+		if [[ "$$FRONTEND_READY" == "false" ]] && curl -fsS "http://localhost:$$FRONTEND_PORT" > /dev/null 2>&1; then \
 			FRONTEND_READY=true; \
 		fi; \
-		if [[ "$$BACKEND_READY" == "true" ]] && [[ "$$FRONTEND_READY" == "true" ]]; then \
+		if [[ "$$PROXY_READY" == "false" ]] && curl -fsS "http://localhost:$$FRONTEND_PORT/_stcore/health" > /dev/null 2>&1; then \
+			PROXY_READY=true; \
+		fi; \
+		if [[ "$$BACKEND_READY" == "true" ]] && [[ "$$FRONTEND_READY" == "true" ]] && [[ "$$PROXY_READY" == "true" ]]; then \
 			break; \
 		fi; \
 		sleep 1; \
 	done; \
 	echo ""; \
-	if [[ "$$BACKEND_READY" == "false" ]] || [[ "$$FRONTEND_READY" == "false" ]]; then \
+	if [[ "$$BACKEND_READY" == "false" ]] || [[ "$$FRONTEND_READY" == "false" ]] || [[ "$$PROXY_READY" == "false" ]]; then \
 		echo "Warning: Servers may not have started correctly. Check log files."; \
 		echo ""; \
 	fi; \
-	echo "  App URL: http://localhost:3000"; \
+	echo "  App URL:      http://localhost:$$FRONTEND_PORT"; \
+	echo "  Backend URL:  http://localhost:$$BACKEND_PORT"; \
+	echo "  Proxy target: http://localhost:$$FRONTEND_PORT -> http://localhost:$$BACKEND_PORT"; \
 	echo ""; \
 	echo "  Log files:"; \
-	echo "    work-tmp/debug/backend.log  - Streamlit/Python output"; \
-	echo "    work-tmp/debug/frontend.log - Vite/browser console output"; \
+	echo "    $$DEBUG_DIR/backend.log  - Streamlit/Python output"; \
+	echo "    $$DEBUG_DIR/frontend.log - Vite/browser console output"; \
+	echo "    $$DEBUG_ROOT/latest      - Symlink to latest debug session"; \
 	echo ""; \
 	echo "Press Ctrl+C to stop."; \
 	echo ""; \

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -32,6 +32,41 @@ const IS_PROFILER_BUILD = Boolean(process.env.IS_PROFILER_BUILD)
 const ANALYZE_BUNDLE = Boolean(process.env.ANALYZE_BUNDLE)
 // Enable terminal plugin to pipe browser console logs to terminal (for coding agents)
 const DEBUG_TO_CONSOLE = Boolean(process.env.DEBUG_TO_CONSOLE)
+// Default frontend dev server port for local development.
+const DEFAULT_DEV_SERVER_PORT = 3000
+// Valid TCP/UDP user port range.
+const MIN_PORT = 1
+const MAX_PORT = 65535
+
+/**
+ * Resolve the frontend dev-server port from environment variables.
+ *
+ * Precedence:
+ * 1) VITE_PORT
+ * 2) PORT
+ *
+ * If the value is missing, non-integer, or out of range, we safely fall back
+ * to `DEFAULT_DEV_SERVER_PORT` to avoid passing invalid values to Vite.
+ */
+const getDevServerPort = (): number => {
+  const rawPort = process.env.VITE_PORT ?? process.env.PORT
+  if (!rawPort) {
+    return DEFAULT_DEV_SERVER_PORT
+  }
+
+  const parsedPort = Number(rawPort)
+  if (
+    !Number.isInteger(parsedPort) ||
+    parsedPort < MIN_PORT ||
+    parsedPort > MAX_PORT
+  ) {
+    return DEFAULT_DEV_SERVER_PORT
+  }
+
+  return parsedPort
+}
+// Frontend dev server port used by Vite.
+const DEV_SERVER_PORT = getDevServerPort()
 // The URL of the backend server to proxy to:
 // Can be changed to run against a remote server or different port:
 const DEV_SERVER_BACKEND_URL =
@@ -116,7 +151,7 @@ export default defineConfig(({ command }) => ({
   },
   server: {
     open: true,
-    port: 3000,
+    port: DEV_SERVER_PORT,
     host: true,
     proxy: {
       // These endpoints need to be kept in sync with the endpoints in

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Final, Literal, cast
 from urllib.parse import urljoin
 
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
 
 # The port used for internal development.
 DEVELOPMENT_PORT: Final = 3000
+VITE_PORT_ENV_VAR: Final = "VITE_PORT"
+PORT_ENV_VAR: Final = "PORT"
 
 AUTH_COOKIE_NAME: Final = "_streamlit_user"
 TOKENS_COOKIE_NAME: Final = "_streamlit_user_tokens"
@@ -208,6 +211,19 @@ def _get_browser_address_bar_port() -> int:
 
     """
     if config.get_option("global.developmentMode"):
+        for env_var in (VITE_PORT_ENV_VAR, PORT_ENV_VAR):
+            port_str = os.environ.get(env_var)
+            if not port_str:
+                continue
+
+            try:
+                port = int(port_str)
+            except ValueError:
+                continue
+
+            if 1 <= port <= 65535:
+                return port
+
         return DEVELOPMENT_PORT
     return int(config.get_option("browser.serverPort"))
 

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -130,6 +130,87 @@ class ServerUtilTest(unittest.TestCase):
 
         assert expected_url == actual_url
 
+    def test_get_url_development_mode_respects_dev_server_port_env_var(self):
+        """Test that dev mode respects the frontend dev server port override."""
+        options = {
+            "global.developmentMode": True,
+            "server.sslCertFile": None,
+            "server.baseUrlPath": "",
+        }
+        mock_get_option = testutil.build_mock_config_get_option(options)
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.dict("os.environ", {"VITE_PORT": "3007"}, clear=True),
+        ):
+            assert server_util.get_url("localhost") == "http://localhost:3007"
+
+    def test_get_url_development_mode_falls_back_to_port_env_var(self):
+        """Test that dev mode falls back to PORT when VITE_PORT is unset."""
+        options = {
+            "global.developmentMode": True,
+            "server.sslCertFile": None,
+            "server.baseUrlPath": "",
+        }
+        mock_get_option = testutil.build_mock_config_get_option(options)
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.dict("os.environ", {"PORT": "3008"}, clear=True),
+        ):
+            assert server_util.get_url("localhost") == "http://localhost:3008"
+
+    def test_get_url_development_mode_prefers_vite_port_over_port(self):
+        """Test that VITE_PORT takes precedence over PORT in dev mode."""
+        options = {
+            "global.developmentMode": True,
+            "server.sslCertFile": None,
+            "server.baseUrlPath": "",
+        }
+        mock_get_option = testutil.build_mock_config_get_option(options)
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.dict(
+                "os.environ",
+                {"VITE_PORT": "3010", "PORT": "3008"},
+                clear=True,
+            ),
+        ):
+            assert server_util.get_url("localhost") == "http://localhost:3010"
+
+    @parameterized.expand([("not-a-number",), ("0",), ("70000",)])
+    def test_get_url_development_mode_ignores_invalid_env_var(self, env_val: str):
+        """Test that invalid dev server port overrides are ignored."""
+        options = {
+            "global.developmentMode": True,
+            "server.sslCertFile": None,
+            "server.baseUrlPath": "",
+        }
+        mock_get_option = testutil.build_mock_config_get_option(options)
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.dict("os.environ", {"VITE_PORT": env_val}, clear=True),
+        ):
+            assert server_util.get_url("localhost") == "http://localhost:3000"
+
+    @parameterized.expand([("not-a-number",), ("0",), ("70000",)])
+    def test_get_url_development_mode_ignores_invalid_port_env_var(self, env_val: str):
+        """Test that invalid PORT values are ignored when VITE_PORT is unset."""
+        options = {
+            "global.developmentMode": True,
+            "server.sslCertFile": None,
+            "server.baseUrlPath": "",
+        }
+        mock_get_option = testutil.build_mock_config_get_option(options)
+
+        with (
+            patch.object(config, "get_option", new=mock_get_option),
+            patch.dict("os.environ", {"PORT": env_val}, clear=True),
+        ):
+            assert server_util.get_url("localhost") == "http://localhost:3000"
+
     def test_make_url_path_regex(self):
         assert (
             server_util.make_url_path_regex("foo") == r"^/foo/?$"


### PR DESCRIPTION
## Describe your changes

Improved the `make debug` command to support multiple concurrent debug sessions:

- Each debug session now uses a dedicated directory for logs (`work-tmp/debug/<session>/`)
  - Added a `latest` symlink that points to the most recent session
- Automatically selects available ports in the 3001-3100 range for the frontend
- Updated documentation to reflect these changes in multiple files
- Added port forwarding for additional ports in `devcontainer.json`
- Updated Playwright example to use the correct app URL from environment
- Added more detailed logging of server startup and connection information

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Manual testing of the `make debug` command with multiple concurrent sessions

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.