### PR TITLE
[DynamicContainers] Dynamic Tabs

### DIFF
--- a/e2e_playwright/st_tabs.py
+++ b/e2e_playwright/st_tabs.py
@@ -85,3 +85,111 @@ def hello():
 """,
     height="stretch",
 )
+
+# ============================================================================
+# Dynamic Tabs Tests (on_change="rerun")
+# ============================================================================
+
+if "tab_exec_counts" not in st.session_state:
+    st.session_state.tab_exec_counts = {"Data": 0, "Charts": 0, "Settings": 0}
+
+dyn_tabs = st.tabs(["Data", "Charts", "Settings"], on_change="rerun")
+
+if dyn_tabs[0].open:
+    with dyn_tabs[0]:
+        st.session_state.tab_exec_counts["Data"] += 1
+        st.write(f"Data tab executed {st.session_state.tab_exec_counts['Data']} times")
+
+if dyn_tabs[1].open:
+    with dyn_tabs[1]:
+        st.session_state.tab_exec_counts["Charts"] += 1
+        st.write(
+            f"Charts tab executed {st.session_state.tab_exec_counts['Charts']} times"
+        )
+
+if dyn_tabs[2].open:
+    with dyn_tabs[2]:
+        st.session_state.tab_exec_counts["Settings"] += 1
+        st.write(
+            f"Settings tab executed {st.session_state.tab_exec_counts['Settings']} times"
+        )
+
+st.write(
+    f"Tab executions - Data: {st.session_state.tab_exec_counts['Data']}, "
+    f"Charts: {st.session_state.tab_exec_counts['Charts']}, "
+    f"Settings: {st.session_state.tab_exec_counts['Settings']}"
+)
+
+
+def goto_tab(label: str) -> None:
+    st.session_state.prog_tabs = label
+
+
+col1, col2, col3 = st.columns(3)
+with col1:
+    st.button("Go to Alpha", on_click=goto_tab, args=("Alpha",), key="goto_alpha")
+with col2:
+    st.button("Go to Beta", on_click=goto_tab, args=("Beta",), key="goto_beta")
+with col3:
+    st.button("Go to Gamma", on_click=goto_tab, args=("Gamma",), key="goto_gamma")
+
+prog_tabs = st.tabs(["Alpha", "Beta", "Gamma"], key="prog_tabs", on_change="rerun")
+
+if prog_tabs[0].open:
+    with prog_tabs[0]:
+        st.write("Alpha tab content")
+
+if prog_tabs[1].open:
+    with prog_tabs[1]:
+        st.write("Beta tab content")
+
+if prog_tabs[2].open:
+    with prog_tabs[2]:
+        st.write("Gamma tab content")
+# Key-only (no on_change) — should NOT trigger reruns on tab switch
+# ============================================================================
+
+if "tabs_key_only_rerun_count" not in st.session_state:
+    st.session_state.tabs_key_only_rerun_count = 0
+st.session_state.tabs_key_only_rerun_count += 1
+
+key_only_tab1, key_only_tab2 = st.tabs(["KeyTab1", "KeyTab2"], key="key_only_tabs")
+
+with key_only_tab1:
+    st.write("Key-only tab 1 content")
+
+with key_only_tab2:
+    st.write("Key-only tab 2 content")
+
+st.write(f"Tabs key-only rerun count: {st.session_state.tabs_key_only_rerun_count}")
+
+# ============================================================================
+# Fragment Test — dynamic tabs inside a fragment
+# ============================================================================
+
+if "frag_tab_exec_counts" not in st.session_state:
+    st.session_state.frag_tab_exec_counts = {"Left": 0, "Right": 0}
+
+
+@st.fragment
+def tabs_fragment() -> None:
+    frag_tabs = st.tabs(["Left", "Right"], on_change="rerun")
+    if frag_tabs[0].open:
+        with frag_tabs[0]:
+            st.session_state.frag_tab_exec_counts["Left"] += 1
+            st.write(
+                f"Fragment Left executed {st.session_state.frag_tab_exec_counts['Left']} times"
+            )
+    if frag_tabs[1].open:
+        with frag_tabs[1]:
+            st.session_state.frag_tab_exec_counts["Right"] += 1
+            st.write(
+                f"Fragment Right executed {st.session_state.frag_tab_exec_counts['Right']} times"
+            )
+    st.write(
+        f"Fragment tab execs - Left: {st.session_state.frag_tab_exec_counts['Left']}, "
+        f"Right: {st.session_state.frag_tab_exec_counts['Right']}"
+    )
+
+
+tabs_fragment()

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -14,13 +14,17 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    check_top_level_class,
+    click_button,
+    get_expander,
+)
 
 
 def test_tabs_render_correctly(themed_app: Page, assert_snapshot: ImageCompareFunction):
     st_tabs = themed_app.get_by_test_id("stTabs")
-    expect(st_tabs).to_have_count(7)
+    expect(st_tabs).to_have_count(11)
 
     assert_snapshot(st_tabs.nth(0), name="st_tabs-sidebar")
     assert_snapshot(st_tabs.nth(1), name="st_tabs-text_input")
@@ -69,3 +73,121 @@ def test_tabs_with_code_layouts(app: Page, assert_snapshot: ImageCompareFunction
     # Switch to Tab 2 and test fixed height and stretched code
     tabs_with_code.get_by_role("tab", name="Tab 2").click()
     assert_snapshot(tabs_with_code, name="st_tabs-fixed_height_stretch_height")
+
+
+def test_dynamic_tabs_lazy_execution(app: Page):
+    """Test that dynamic tabs only execute content for the active tab."""
+    # Initially only Data tab should have executed
+    expect(
+        app.get_by_text("Tab executions - Data: 1, Charts: 0, Settings: 0")
+    ).to_be_visible()
+
+    # Switch to Charts tab
+    dyn_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="Charts"))
+        .first
+    )
+    dyn_tabs.get_by_role("tab", name="Charts").click()
+    wait_for_app_run(app)
+
+    # Charts executes, Data does not re-execute since it's not open
+    expect(app.get_by_text("Charts tab executed 1 times")).to_be_visible()
+    expect(
+        app.get_by_text("Tab executions - Data: 1, Charts: 1, Settings: 0")
+    ).to_be_visible()
+
+    # Switch to Settings
+    dyn_tabs.get_by_role("tab", name="Settings").click()
+    wait_for_app_run(app)
+
+    expect(
+        app.get_by_text("Tab executions - Data: 1, Charts: 1, Settings: 1")
+    ).to_be_visible()
+
+    # Switch back to Data
+    dyn_tabs.get_by_role("tab", name="Data").click()
+    wait_for_app_run(app)
+
+    expect(
+        app.get_by_text("Tab executions - Data: 2, Charts: 1, Settings: 1")
+    ).to_be_visible()
+
+
+def test_dynamic_tabs_programmatic_control(app: Page):
+    """Test programmatic control of dynamic tabs via session state."""
+    # Initially Alpha is active
+    prog_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="Alpha"))
+        .first
+    )
+    expect(prog_tabs.get_by_text("Alpha tab content")).to_be_visible()
+
+    # Click "Go to Beta" button
+    click_button(app, "Go to Beta")
+
+    # Beta should be active, Alpha not visible
+    expect(prog_tabs.get_by_text("Beta tab content")).to_be_visible()
+    expect(prog_tabs.get_by_text("Alpha tab content")).not_to_be_visible()
+
+    # Click "Go to Gamma" button
+    click_button(app, "Go to Gamma")
+
+    expect(prog_tabs.get_by_text("Gamma tab content")).to_be_visible()
+    expect(prog_tabs.get_by_text("Beta tab content")).not_to_be_visible()
+
+
+def test_tabs_key_only_does_not_trigger_rerun(app: Page):
+    """Test that tabs with key but no on_change does not trigger reruns."""
+    rerun_text = app.get_by_text("Tabs key-only rerun count:")
+    expect(rerun_text).to_be_visible()
+    initial_count = rerun_text.text_content()
+
+    # Switch to KeyTab2
+    key_only_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="KeyTab2"))
+        .first
+    )
+    key_only_tabs.get_by_role("tab", name="KeyTab2").click()
+
+    # Rerun count should NOT have changed
+    expect(rerun_text).to_have_text(initial_count or "")
+    # Tab 2 content should be visible, tab 1 content should not
+    expect(key_only_tabs.get_by_text("Key-only tab 2 content")).to_be_visible()
+    expect(key_only_tabs.get_by_text("Key-only tab 1 content")).not_to_be_visible()
+
+    # Switch back to KeyTab1
+    key_only_tabs.get_by_role("tab", name="KeyTab1").click()
+
+    # Still no rerun
+    expect(rerun_text).to_have_text(initial_count or "")
+    # Tab 1 content should be visible again, tab 2 should not
+    expect(key_only_tabs.get_by_text("Key-only tab 1 content")).to_be_visible()
+    expect(key_only_tabs.get_by_text("Key-only tab 2 content")).not_to_be_visible()
+
+
+def test_dynamic_tabs_in_fragment(app: Page):
+    """Test that dynamic tabs work correctly inside a fragment."""
+    # Initially Left tab is active (default first tab)
+    expect(app.get_by_text("Fragment tab execs - Left: 1, Right: 0")).to_be_visible()
+
+    # Switch to Right tab
+    frag_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="Right"))
+        .first
+    )
+    frag_tabs.get_by_role("tab", name="Right").click()
+    wait_for_app_run(app)
+
+    # Right should have executed once
+    expect(app.get_by_text("Fragment tab execs - Left: 1, Right: 1")).to_be_visible()
+
+    # Switch back to Left
+    frag_tabs.get_by_role("tab", name="Left").click()
+    wait_for_app_run(app)
+
+    # Left should have executed twice, Right still once
+    expect(app.get_by_text("Fragment tab execs - Left: 2, Right: 1")).to_be_visible()

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -404,6 +404,7 @@ export const BlockNodeRenderer = (
       renderTabContent,
       width: styles.width,
       flex: styles.flex,
+      fragmentId: node.fragmentId,
     }
     return <Tabs {...tabsProps} />
   }

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -15,13 +15,17 @@
  */
 
 import { screen, within } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
 import { BlockNode } from "~lib/AppNode"
 import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Tabs, { TabProps } from "./Tabs"
+
+vi.mock("~lib/WidgetStateManager")
 
 const FAKE_SCRIPT_HASH = "fake_script_hash"
 
@@ -33,12 +37,28 @@ function makeTab(label: string, children: BlockNode[] = []): BlockNode {
   )
 }
 
-function makeTabsNode(tabs: number): BlockNode {
+function makeTabsNode(
+  tabs: number,
+  options?: { blockId?: string; widgetId?: string }
+): BlockNode {
   return new BlockNode(
     FAKE_SCRIPT_HASH,
     Array.from({ length: tabs }, (_element, index) => makeTab(`Tab ${index}`)),
-    new BlockProto({ allowEmpty: true })
+    new BlockProto({
+      allowEmpty: true,
+      id: options?.blockId ?? "",
+      tabContainer: {
+        id: options?.widgetId ?? undefined,
+      },
+    })
   )
+}
+
+function createWidgetMgr(): WidgetStateManager {
+  return new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
 }
 
 const getProps = (props?: Partial<TabProps>): TabProps =>
@@ -46,6 +66,7 @@ const getProps = (props?: Partial<TabProps>): TabProps =>
     widgetsDisabled: false,
     node: makeTabsNode(5),
     isStale: false,
+    widgetMgr: createWidgetMgr(),
     ...props,
     renderTabContent: vi.fn(),
   })
@@ -108,6 +129,74 @@ describe("st.tabs", () => {
         return
       }
       expect(tabs[index]).not.toBeDisabled()
+    })
+  })
+
+  describe("dynamic tabs (widget state tracking)", () => {
+    it("calls widgetMgr.setStringValue on tab click for dynamic tabs", async () => {
+      const user = userEvent.setup()
+      const widgetId = "$$ID-abc123-my_tabs"
+      const widgetMgr = createWidgetMgr()
+
+      vi.spyOn(widgetMgr, "setStringValue")
+
+      // widgetId on tabContainer signals dynamic/widget mode
+      const node = makeTabsNode(3, { blockId: widgetId, widgetId })
+      render(<Tabs {...getProps({ node, widgetMgr })} />)
+
+      const tabs = screen.getAllByRole("tab")
+      await user.click(tabs[2])
+
+      expect(widgetMgr.setStringValue).toHaveBeenCalledWith(
+        { id: widgetId, formId: "" },
+        "Tab 2",
+        { fromUi: true },
+        undefined
+      )
+    })
+
+    it("does NOT call widgetMgr.setStringValue on tab click for non-dynamic tabs", async () => {
+      const user = userEvent.setup()
+      const widgetMgr = createWidgetMgr()
+
+      vi.spyOn(widgetMgr, "setStringValue")
+
+      // No widgetId on tabContainer → not dynamic
+      const node = makeTabsNode(3, { blockId: "$$ID-abc123-my_tabs" })
+      render(<Tabs {...getProps({ node, widgetMgr })} />)
+
+      const tabs = screen.getAllByRole("tab")
+      await user.click(tabs[1])
+
+      expect(tabs[1]).toHaveAttribute("aria-selected", "true")
+      expect(widgetMgr.setStringValue).not.toHaveBeenCalled()
+    })
+
+    it("syncs tab selection when defaultTabIndex changes programmatically", () => {
+      const widgetId = "$$ID-abc123-my_tabs"
+      const widgetMgr = createWidgetMgr()
+
+      const node = makeTabsNode(3, { blockId: widgetId, widgetId })
+      node.deltaBlock.tabContainer = { defaultTabIndex: 0, id: widgetId }
+
+      const { rerender } = render(<Tabs {...getProps({ node, widgetMgr })} />)
+
+      // Initially first tab is selected
+      let tabs = screen.getAllByRole("tab")
+      expect(tabs[0]).toHaveAttribute("aria-selected", "true")
+
+      // Simulate backend updating defaultTabIndex to 2
+      const updatedNode = makeTabsNode(3, { blockId: widgetId, widgetId })
+      updatedNode.deltaBlock.tabContainer = {
+        defaultTabIndex: 2,
+        id: widgetId,
+      }
+
+      rerender(<Tabs {...getProps({ node: updatedNode, widgetMgr })} />)
+
+      tabs = screen.getAllByRole("tab")
+      expect(tabs[2]).toHaveAttribute("aria-selected", "true")
+      expect(tabs[0]).toHaveAttribute("aria-selected", "false")
     })
   })
 })

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -19,6 +19,7 @@ import {
   ReactElement,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
@@ -43,15 +44,37 @@ export interface TabProps extends BlockPropsWithoutWidth {
   renderTabContent: (childProps: any) => ReactElement
   width: React.CSSProperties["width"]
   flex: React.CSSProperties["flex"]
+  fragmentId?: string
 }
 
 function Tabs(props: Readonly<TabProps>): ReactElement {
-  const { widgetsDisabled, node, isStale, width, flex } = props
+  const {
+    widgetsDisabled,
+    node,
+    isStale,
+    width,
+    flex,
+    widgetMgr,
+    fragmentId,
+  } = props
   const { scriptRunState, scriptRunId, fragmentIdsThisRun } =
     useContext(ScriptRunContext)
   const defaultTabIndex = node.deltaBlock?.tabContainer?.defaultTabIndex ?? 0
+  // id is only set when the backend registers tabs as a stateful widget
+  // (on_change="rerun"). block.id may still be set for CSS key styling.
+  const widgetId = node.deltaBlock?.tabContainer?.id
+  const isDynamic = Boolean(widgetId)
 
-  let allTabLabels: string[] = []
+  // Memoize tab labels to prevent unnecessary effect reruns
+  const allTabLabels = useMemo(
+    () =>
+      node.children.map((child, index) => {
+        const tabNode = child as BlockNode
+        return tabNode?.deltaBlock?.tab?.label ?? index.toString()
+      }),
+    [node.children]
+  )
+
   const [activeTabKey, setActiveTabKey] = useState<React.Key>(defaultTabIndex)
   const [activeTabName, setActiveTabName] = useState<string>(() => {
     const tab = node.children[defaultTabIndex] as BlockNode
@@ -63,6 +86,27 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
   const theme = useEmotionTheme()
 
   const [isOverflowing, setIsOverflowing] = useState(false)
+
+  // Track previous defaultTabIndex to detect backend changes
+  const prevDefaultTabIndexRef = useRef<number>(defaultTabIndex)
+
+  // Sync tab selection when defaultTabIndex changes programmatically
+  // (only for dynamic tabs with programmatic control)
+  useEffect(() => {
+    if (isDynamic && allTabLabels.length > 0) {
+      const tabIndexChanged =
+        defaultTabIndex !== prevDefaultTabIndexRef.current
+
+      if (tabIndexChanged) {
+        const newLabel = allTabLabels[defaultTabIndex]
+        if (newLabel) {
+          setActiveTabKey(defaultTabIndex)
+          setActiveTabName(newLabel)
+        }
+        prevDefaultTabIndexRef.current = defaultTabIndex
+      }
+    }
+  }, [defaultTabIndex, isDynamic, allTabLabels])
 
   // Reconciles active key & tab name
   useEffect(() => {
@@ -96,6 +140,7 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
 
   const TAB_HEIGHT = theme.sizes.tabHeight
   const TAB_BORDER_HEIGHT = theme.spacing.threeXS
+
   return (
     <StyledTabContainer
       className="stTabs"
@@ -111,6 +156,16 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
         onChange={({ activeKey }) => {
           setActiveTabKey(activeKey)
           setActiveTabName(allTabLabels[activeKey as number])
+
+          // Update widget state for dynamic tabs
+          if (isDynamic && widgetId && widgetMgr) {
+            widgetMgr.setStringValue(
+              { id: widgetId, formId: "" },
+              allTabLabels[activeKey as number],
+              { fromUi: true },
+              fragmentId
+            )
+          }
         }}
         /* renderAll on UITabs should always be set to true to avoid scrolling issue
            https://github.com/streamlit/streamlit/issues/5069
@@ -148,11 +203,6 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
         }}
       >
         {node.children.map((appNode: AppNode, index: number): ReactElement => {
-          // Reset available tab labels when rerendering
-          if (index === 0) {
-            allTabLabels = []
-          }
-
           // If the tab is stale, disable it
           const isStaleTab = isElementStale(
             appNode,
@@ -168,11 +218,7 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
             widgetsDisabled,
             node: appNode as BlockNode,
           }
-          let nodeLabel = index.toString()
-          if (childProps.node.deltaBlock?.tab?.label) {
-            nodeLabel = childProps.node.deltaBlock.tab.label
-          }
-          allTabLabels[index] = nodeLabel
+          const nodeLabel = allTabLabels[index] ?? index.toString()
 
           const isSelected = activeTabKey.toString() === index.toString()
           const isLast = index === node.children.length - 1

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -74,6 +74,19 @@ class _PopoverSerde:
         return ui_value if ui_value is not None else False
 
 
+@dataclass
+class _TabsSerde:
+    """Serializer/deserializer for tabs widget state (active tab label)."""
+
+    default_label: str
+
+    def serialize(self, v: str) -> str:
+        return str(v)
+
+    def deserialize(self, ui_value: str | None) -> str:
+        return ui_value if ui_value is not None else self.default_label
+
+
 class LayoutsMixin:
     @gather_metrics("container")
     def container(
@@ -589,6 +602,8 @@ class LayoutsMixin:
         *,
         width: WidthWithoutContent = "stretch",
         default: str | None = None,
+        key: Key | None = None,
+        on_change: Literal["ignore", "rerun"] | None = None,
     ) -> Sequence[TabContainer]:
         r"""Insert containers separated into tabs.
 
@@ -601,11 +616,11 @@ class LayoutsMixin:
         the examples below.
 
         .. note::
-            All content within every tab is computed and sent to the frontend,
-            regardless of which tab is selected. Tabs do not currently support
-            conditional rendering. If you have a slow-loading tab, consider
-            using a widget like ``st.segmented_control`` to conditionally
-            render content instead.
+            By default, all tab content is computed and sent to the frontend
+            regardless of which tab is selected. Use ``on_change="rerun"`` to
+            enable lazy execution, where only the active tab's content runs.
+            Each tab's ``.open`` property indicates whether it is the currently
+            active tab, letting you conditionally render expensive content.
 
         Parameters
         ----------
@@ -643,6 +658,28 @@ class LayoutsMixin:
             tab is selected. If this is a string, it must be one of the tab
             labels. If two tabs have the same label as ``default``, the first
             one is selected.
+
+        key : str or int
+            An optional string or integer to use as the unique key for the
+            widget. If this is omitted, a key will be generated for the widget
+            based on its content. No two widgets may have the same key.
+
+            When ``on_change`` is set to ``"rerun"``, the active tab label is
+            also accessible via ``st.session_state[key]``.
+
+        on_change : "ignore", "rerun", or None
+            How the tabs should respond to user tab changes. This controls
+            whether tabs track state and trigger reruns when switched.
+            ``on_change`` can be one of the following:
+
+            - ``None`` (default): Current behavior — always execute all tabs,
+              no state tracking. The ``.open`` attribute will return ``None``
+              for all tabs.
+            - ``"ignore"``: Equivalent to ``None`` — no state tracking.
+            - ``"rerun"``: Streamlit will rerun the app when the user switches
+              tabs. The ``.open`` attribute will return ``True`` for the active
+              tab and ``False`` for inactive tabs. Allows lazy execution of
+              tab content.
 
         Returns
         -------
@@ -736,6 +773,55 @@ class LayoutsMixin:
                 "The tabs input list to st.tabs is only allowed to contain strings."
             )
 
+        if on_change is not None and on_change not in {"ignore", "rerun"}:
+            raise StreamlitValueError("on_change", ["'rerun'", "'ignore'", "None"])
+
+        key = to_key(key)
+        default_index = tabs.index(default) if default else 0
+        is_stateful = on_change is not None and on_change != "ignore"
+
+        element_id: str | None = None
+        current_tab_label = tabs[default_index]
+
+        if is_stateful:
+            # TODO: Set on_change and enable_check_callback_rules correctly
+            # when user-defined callbacks are supported for tabs.
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=None,
+                default_value=None,
+                writes_allowed=True,
+                enable_check_callback_rules=False,
+            )
+
+            ctx = get_script_run_ctx()
+
+            element_id = compute_and_register_element_id(
+                "tabs",
+                user_key=key,
+                key_as_main_identity=False,
+                dg=self.dg,
+                tabs=tuple(tabs),
+                width=width,
+                default=default,
+            )
+
+            serde = _TabsSerde(default_label=tabs[default_index])
+
+            tabs_state = register_widget(
+                element_id,
+                deserializer=serde.deserialize,
+                serializer=serde.serialize,
+                ctx=ctx,
+                value_type="string_value",
+            )
+
+            current_tab_label = tabs_state.value
+            # Validate that the label exists in the tab list
+            if current_tab_label not in tabs:
+                current_tab_label = tabs[default_index]
+
         def tab_proto(label: str) -> BlockProto:
             tab_proto = BlockProto()
             tab_proto.tab.label = label
@@ -747,20 +833,31 @@ class LayoutsMixin:
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
 
-        default_index = tabs.index(default) if default else 0
+        # Compute the current tab index from the label
+        try:
+            current_tab_index = tabs.index(current_tab_label)
+        except ValueError:
+            current_tab_index = default_index
 
-        block_proto.tab_container.default_tab_index = default_index
+        block_proto.tab_container.default_tab_index = current_tab_index
+
+        if is_stateful and element_id is not None:
+            block_proto.tab_container.id = element_id
 
         tab_cls = get_dg_singleton_instance().tab_container_cls
         tab_container = self.dg._block(block_proto)
 
-        return tuple(
-            cast(
+        tab_dgs: list[TabContainer] = []
+        for tab_label in tabs:
+            tab_dg = cast(
                 "TabContainer",
-                tab_container._block(tab_proto(tab), dg_type=tab_cls),
+                tab_container._block(tab_proto(tab_label), dg_type=tab_cls),
             )
-            for tab in tabs
-        )
+            if is_stateful:
+                tab_dg.open = tab_label == current_tab_label
+            tab_dgs.append(tab_dg)
+
+        return tuple(tab_dgs)
 
     @gather_metrics("expander")
     def expander(

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -1058,6 +1058,73 @@ class TabsTest(DeltaGeneratorTestCase):
         for tab in tabs:
             assert tab.open is None
 
+    def test_invalid_on_change_raises(self):
+        """Test that invalid on_change values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.tabs(["A", "B"], on_change="invalid")
+
+    def test_on_change_rerun_sets_open_on_tabs(self):
+        """Test that on_change='rerun' sets .open correctly on each tab."""
+        tabs = st.tabs(["A", "B", "C"], on_change="rerun")
+        assert tabs[0].open is True
+        assert tabs[1].open is False
+        assert tabs[2].open is False
+
+    def test_on_change_rerun_with_default_sets_open(self):
+        """Test that on_change='rerun' with default sets the right tab as open."""
+        tabs = st.tabs(["A", "B", "C"], default="B", on_change="rerun")
+        assert tabs[0].open is False
+        assert tabs[1].open is True
+        assert tabs[2].open is False
+
+    def test_on_change_rerun_sets_id(self):
+        """Test that on_change='rerun' sets id on the tab container proto."""
+        st.tabs(["A", "B"], on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.tab_container.id != ""
+
+    def test_on_change_none_does_not_set_id(self):
+        """Test that on_change=None does not set id."""
+        st.tabs(["A", "B"])
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert not tab_container_block.add_block.tab_container.HasField("id")
+
+    def test_on_change_rerun_with_key_accessible_via_session_state(self):
+        """Test that on_change='rerun' with key stores the active tab label."""
+        st.tabs(["A", "B", "C"], key="my_tabs", on_change="rerun")
+        assert "my_tabs" in st.session_state
+        assert st.session_state.my_tabs == "A"
+
+    def test_on_change_rerun_with_default_session_state(self):
+        """Test that default tab is reflected in session_state."""
+        st.tabs(["A", "B", "C"], key="my_tabs", default="C", on_change="rerun")
+        assert st.session_state.my_tabs == "C"
+
+    def test_on_change_rerun_with_default_sets_correct_tab_index(self):
+        """Test that default + on_change='rerun' sets the correct tab index in proto."""
+        st.tabs(["A", "B", "C"], default="C", on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.tab_container.default_tab_index == 2
+
+    def test_on_change_rerun_falls_back_when_label_not_in_tabs(self):
+        """Test that a stale session state label falls back to the default tab."""
+        # Pre-populate session state with a label that won't be in the new tab list
+        st.session_state["my_tabs"] = "OldTab"
+        tabs = st.tabs(["X", "Y", "Z"], key="my_tabs", on_change="rerun")
+        # Should fall back to first tab since "OldTab" is not in ["X", "Y", "Z"]
+        assert tabs[0].open is True
+        assert tabs[1].open is False
+
+    def test_on_change_ignore_with_key_open_remains_none(self):
+        """Test that on_change='ignore' with key leaves .open as None and no widget state."""
+        tabs = st.tabs(["A", "B", "C"], key="my_tabs", on_change="ignore")
+        for tab in tabs:
+            assert tab.open is None
+        assert "my_tabs" not in st.session_state
+
 
 class DialogTest(DeltaGeneratorTestCase):
     """Run unit tests for the non-public delta-generator dialog and also the dialog

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -132,6 +132,11 @@ message Block {
 
   message TabContainer {
     int32 default_tab_index = 1;
+    // Widget ID for dynamic tabs. Only set when on_change="rerun",
+    // signaling the frontend to treat this as a stateful widget.
+    // When absent, tabs may still have a block-level id for CSS key
+    // styling but should not trigger reruns on tab change.
+    optional string id = 2;
   }
 
   message Tab {


### PR DESCRIPTION
## Describe your changes

Test Demo App: https://dynamic-tabs.streamlit.app/

**Stacked on #13867.**

Adds `key` and `on_change` parameters to `st.tabs`, enabling stateful, lazily-executed tabs. When `on_change="rerun"`, switching tabs triggers a rerun and each tab's `.open` property returns `True` for the active tab and `False` for inactive ones. This lets apps skip expensive work in hidden tabs:

```python
tabs = st.tabs(["Sales", "Customers"], on_change="rerun")

if tabs[0].open:
    with tabs[0]:
        expensive_sales_query()

if tabs[1].open:
    with tabs[1]:
        expensive_customer_query()
```

Programmatic tab switching is supported via `st.session_state`:

```python
def goto_settings():
    st.session_state.my_tabs = "Settings"

st.button("Go to Settings", on_click=goto_settings)
tabs = st.tabs(["Home", "Settings"], key="my_tabs", on_change="rerun")
```

### Backend

- Adds `key` and `on_change` parameters to `st.tabs()`.
- When `on_change="rerun"`, registers tabs as a widget via `register_widget`, tracking the active tab label as a string value. Sets `.open = True` on the active `TabContainer` and `.open = False` on the rest. Without `on_change`, `.open` remains `None`.
- Falls back to the default tab when the stored label is no longer in the tab list.
- **Note:** `st-key-` CSS class support for tabs is deferred to a follow-up PR to ensure the class is applied to the correct DOM element.

### Frontend

- On tab switch in dynamic tabs, sends the new tab label to the backend via `widgetMgr.setStringValue`.
- Syncs the selected tab when `defaultTabIndex` changes from the backend (programmatic control).
- Passes `fragmentId` to the `Tabs` component for correct fragment-scoped widget updates.

## GitHub Issue Link (if applicable)

#6004

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests
- [x] See demo app pointed to this PR for manual testing: https://dynamic-tabs.streamlit.app/

**Python unit tests** (`lib/tests/streamlit/elements/layouts_test.py`): 8 tests covering invalid `on_change` values, `.open` state with and without `default`, session state accessibility, and correct proto tab index.

**Frontend unit tests** (`frontend/lib/src/components/elements/Tabs/Tabs.test.tsx`): Tests for dynamic tab behavior including widget state updates on tab switch and programmatic sync from backend.

**E2E tests** (`e2e_playwright/st_tabs_test.py`): `test_dynamic_tabs_lazy_execution` verifies only the active tab's content executes on each rerun; `test_dynamic_tabs_programmatic_control` verifies switching tabs via session state buttons.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.