### PR TITLE
[DynamicContainers] Dynamic Popovers

### DIFF
--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -83,3 +83,76 @@ with st.popover("popover 18 (primary)", type="primary"):
 
 with st.popover("popover 19 (tertiary)", type="tertiary"):
     st.markdown("Dummy content")
+
+# ============================================================================
+# Dynamic Popover Tests (on_change="rerun")
+# ============================================================================
+
+if "pop_exec_count" not in st.session_state:
+    st.session_state.pop_exec_count = 0
+
+pop_dyn = st.popover("Dynamic popover", on_change="rerun")
+
+if pop_dyn.open:
+    with pop_dyn:
+        st.session_state.pop_exec_count += 1
+        st.write(f"Popover content executed {st.session_state.pop_exec_count} times")
+
+st.write(f"Popover execution count: {st.session_state.pop_exec_count}")
+
+
+def open_pop() -> None:
+    st.session_state.prog_pop = True
+
+
+def close_pop() -> None:
+    st.session_state.prog_pop = False
+
+
+col1, col2 = st.columns(2)
+with col1:
+    st.button("Open Popover", on_click=open_pop, key="open_pop_btn")
+with col2:
+    st.button("Close Popover", on_click=close_pop, key="close_pop_btn")
+
+pop_prog = st.popover("Programmatic popover", key="prog_pop", on_change="rerun")
+
+if pop_prog.open:
+    with pop_prog:
+        st.write("Programmatically controlled popover")
+
+# ============================================================================
+# Key-only (no on_change) — should NOT trigger reruns on toggle
+# ============================================================================
+
+if "key_only_rerun_count" not in st.session_state:
+    st.session_state.key_only_rerun_count = 0
+st.session_state.key_only_rerun_count += 1
+
+with st.popover("Key-only popover", key="key_only_pop"):
+    st.write("This popover has a key but no on_change")
+
+st.write(f"Key-only rerun count: {st.session_state.key_only_rerun_count}")
+
+# ============================================================================
+# Fragment Test — dynamic popover inside a fragment
+# ============================================================================
+
+if "frag_exec_count" not in st.session_state:
+    st.session_state.frag_exec_count = 0
+
+
+@st.fragment
+def popover_fragment() -> None:
+    pop_frag = st.popover("Fragment popover", on_change="rerun")
+    if pop_frag.open:
+        with pop_frag:
+            st.session_state.frag_exec_count += 1
+            st.write(
+                f"Fragment popover content executed {st.session_state.frag_exec_count} times"
+            )
+
+    st.write(f"Fragment popover exec count: {st.session_state.frag_exec_count}")
+
+
+popover_fragment()

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -17,6 +17,7 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
+    click_button,
     expect_markdown,
     get_element_by_key,
     get_popover,
@@ -29,7 +30,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(14)
+    expect(popover_elements).to_have_count(18)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -204,3 +205,86 @@ def test_show_tooltip_on_hover(app: Page):
 def test_check_top_level_class(app: Page):
     """Check that the top level class is correctly set."""
     check_top_level_class(app, "stPopover")
+
+
+def test_dynamic_popover_lazy_execution(app: Page):
+    """Test that dynamic popover only executes content when open."""
+    # Initially closed — content should not have executed
+    expect(app.get_by_text("Popover execution count: 0")).to_be_visible()
+
+    # Open the dynamic popover
+    open_popover(app, "Dynamic popover")
+    wait_for_app_run(app)
+
+    # Content should have executed once
+    expect(app.get_by_text("Popover execution count: 1")).to_be_visible()
+
+    # Close the popover by pressing Escape
+    app.keyboard.press("Escape")
+    wait_for_app_run(app)
+
+    # Count should stay at 1
+    expect(app.get_by_text("Popover execution count: 1")).to_be_visible()
+
+    # Popover content should not be visible when closed
+    expect(app.get_by_text("Popover content executed 1 times")).not_to_be_visible()
+
+
+def test_dynamic_popover_programmatic_control(app: Page):
+    """Test programmatic control of dynamic popover via session state."""
+    # Open via button
+    click_button(app, "Open Popover")
+
+    # Popover content should be visible
+    expect(app.get_by_text("Programmatically controlled popover")).to_be_visible()
+
+    # Close via button
+    click_button(app, "Close Popover")
+
+    # Content should not be visible
+    expect(app.get_by_text("Programmatically controlled popover")).not_to_be_visible()
+
+
+def test_popover_key_only_does_not_trigger_rerun(app: Page):
+    """Test that a popover with key but no on_change does not trigger reruns."""
+    # Record the initial rerun count
+    rerun_text = app.get_by_text("Key-only rerun count:")
+    expect(rerun_text).to_be_visible()
+    initial_count = rerun_text.text_content()
+
+    # Open the key-only popover
+    open_popover(app, "Key-only popover")
+
+    # Rerun count should NOT have changed (no rerun triggered)
+    expect(rerun_text).to_have_text(initial_count or "")
+
+    # Close via Escape
+    app.keyboard.press("Escape")
+
+    # Still no rerun
+    expect(rerun_text).to_have_text(initial_count or "")
+
+
+def test_dynamic_popover_in_fragment(app: Page):
+    """Test that a dynamic popover works correctly inside a fragment."""
+    # Initially closed — fragment content should not have executed
+    expect(app.get_by_text("Fragment popover exec count: 0")).to_be_visible()
+
+    # Open the fragment popover
+    open_popover(app, "Fragment popover")
+    wait_for_app_run(app)
+
+    # Content should have executed once
+    expect(app.get_by_text("Fragment popover exec count: 1")).to_be_visible()
+
+    # Close the popover
+    app.keyboard.press("Escape")
+    wait_for_app_run(app)
+
+    # Count should stay at 1
+    expect(app.get_by_text("Fragment popover exec count: 1")).to_be_visible()
+
+    # Popover content should not be visible when closed
+    expect(
+        app.get_by_text("Fragment popover content executed 1 times")
+    ).not_to_be_visible()

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -335,6 +335,8 @@ export const BlockNodeRenderer = (
         empty={node.isEmpty}
         element={node.deltaBlock.popover as BlockProto.Popover}
         stretchWidth={shouldWidthStretch(node.deltaBlock.widthConfig)}
+        widgetMgr={props.widgetMgr}
+        fragmentId={node.fragmentId}
       >
         {child}
       </Popover>

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -16,12 +16,20 @@
 
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
+import { Mocked } from "vitest"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
-import { render } from "~lib/test_util"
+import { ScriptRunState } from "~lib/ScriptRunState"
+import { render, renderWithContexts } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Popover, { PopoverProps } from "./Popover"
+
+const createMockWidgetMgr = (): Mocked<WidgetStateManager> =>
+  ({
+    setBoolValue: vi.fn(),
+  }) as unknown as Mocked<WidgetStateManager>
 
 const getProps = (
   elementProps: Partial<BlockProto.Popover> = {},
@@ -123,5 +131,202 @@ describe("Popover container", () => {
 
     const popoverButtonWidget = screen.getByRole("button")
     expect(popoverButtonWidget).toHaveStyle("width: 100%")
+  })
+})
+
+describe("Dynamic popover (widget mode)", () => {
+  it("calls widgetMgr.setBoolValue on toggle for widget popovers", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createMockWidgetMgr()
+
+    const widgetId = "popover-widget-id"
+    const fragmentId = "frag-1"
+    // id on the element signals widget mode
+    const props = getProps({ id: widgetId }, { widgetMgr, fragmentId })
+
+    render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    await user.click(screen.getByText("label"))
+
+    expect(widgetMgr.setBoolValue).toHaveBeenCalledWith(
+      { id: widgetId },
+      true,
+      { fromUi: true },
+      fragmentId
+    )
+  })
+
+  it("does NOT call widgetMgr.setBoolValue for non-widget popovers", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createMockWidgetMgr()
+
+    // No id → not a widget (even though widgetMgr is available)
+    const props = getProps({}, { widgetMgr })
+
+    render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    await user.click(screen.getByText("label"))
+
+    expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
+  })
+
+  it("sends false when closing a widget popover", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createMockWidgetMgr()
+
+    const widgetId = "popover-widget-id"
+    const fragmentId = "frag-1"
+    const props = getProps({ id: widgetId }, { widgetMgr, fragmentId })
+
+    render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    // Open the popover
+    await user.click(screen.getByText("label"))
+    expect(widgetMgr.setBoolValue).toHaveBeenLastCalledWith(
+      { id: widgetId },
+      true,
+      { fromUi: true },
+      fragmentId
+    )
+
+    // Close by clicking the button again
+    await user.click(screen.getByText("label"))
+    expect(widgetMgr.setBoolValue).toHaveBeenLastCalledWith(
+      { id: widgetId },
+      false,
+      { fromUi: true },
+      fragmentId
+    )
+  })
+
+  it("does NOT sync element.open for non-widget popovers", () => {
+    const widgetMgr = createMockWidgetMgr()
+
+    // No id — non-widget popover
+    const props = getProps({ open: false }, { widgetMgr })
+
+    const { rerender } = render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    const trigger = screen.getByRole("button").closest("[aria-expanded]")
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+    // Rerender with open=true but still no id
+    const updatedProps = getProps({ open: true }, { widgetMgr })
+
+    rerender(
+      <Popover {...updatedProps}>
+        <div>content</div>
+      </Popover>
+    )
+
+    // Should remain closed — non-widget popovers ignore element.open changes
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
+  })
+
+  it("syncs open state when element.open changes programmatically", () => {
+    const widgetMgr = createMockWidgetMgr()
+
+    const widgetId = "popover-widget-id"
+    const props = getProps({ open: false, id: widgetId }, { widgetMgr })
+
+    const { rerender } = render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    // Initially closed — trigger element should indicate collapsed state
+    const trigger = screen.getByRole("button").closest("[aria-expanded]")
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+    // Backend sets open=true (programmatic control via session_state)
+    const updatedProps = getProps({ open: true, id: widgetId }, { widgetMgr })
+
+    rerender(
+      <Popover {...updatedProps}>
+        <div>content</div>
+      </Popover>
+    )
+
+    // Trigger should now indicate expanded state
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+
+    // The sync effect should only update local UI state, not send a value
+    // back to the backend (which would cause a feedback loop).
+    expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
+  })
+
+  it("does not show skeleton during unrelated script runs after loading completes", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createMockWidgetMgr()
+
+    const widgetId = "popover-widget-id"
+    const props = getProps({ id: widgetId }, { widgetMgr, empty: true })
+
+    // Start with NOT_RUNNING, scriptRunId = "run-1"
+    const { rerenderWithContexts } = renderWithContexts(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>,
+      {
+        scriptRunContext: {
+          scriptRunState: ScriptRunState.NOT_RUNNING,
+          scriptRunId: "run-1",
+        },
+      }
+    )
+
+    // User opens the empty widget popover → skeleton should show
+    await user.click(screen.getByText("label"))
+    expect(screen.queryByTestId("stPopoverSkeleton")).toBeVisible()
+
+    // Triggered run completes: new scriptRunId, back to NOT_RUNNING
+    rerenderWithContexts(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>,
+      {
+        scriptRunContext: {
+          scriptRunState: ScriptRunState.NOT_RUNNING,
+          scriptRunId: "run-2",
+        },
+      }
+    )
+
+    // Skeleton should be gone (run completed, content still empty)
+    expect(screen.queryByTestId("stPopoverSkeleton")).not.toBeInTheDocument()
+
+    // An unrelated script run starts (e.g. user interacted with another widget)
+    rerenderWithContexts(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>,
+      {
+        scriptRunContext: {
+          scriptRunState: ScriptRunState.RUNNING,
+          scriptRunId: "run-3",
+        },
+      }
+    )
+
+    // Skeleton must NOT reappear — this is an unrelated run
+    expect(screen.queryByTestId("stPopoverSkeleton")).not.toBeInTheDocument()
   })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useContext, useState } from "react"
+import { memo, ReactElement, useCallback, useContext, useState } from "react"
 
 import { PLACEMENT, TRIGGER_TYPE, Popover as UIPopover } from "baseui/popover"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
+import { notNullOrUndefined } from "@streamlit/utils"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
+import { ScriptRunContext } from "~lib/components/core/ScriptRunContext"
+import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components"
 import { Box } from "~lib/components/shared/Base/styled-components"
 import BaseButton, {
   BaseButtonKind,
@@ -31,6 +34,9 @@ import BaseButton, {
 import { DynamicIcon } from "~lib/components/shared/Icon"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
+import { ScriptRunState } from "~lib/ScriptRunState"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
   StyledPopoverExpansionIcon,
@@ -43,6 +49,8 @@ export interface PopoverProps {
   // TODO (lawilby): This is can probably be simplified if we
   // rewrite the min width calculation to translate rem to px.
   stretchWidth: boolean
+  widgetMgr?: WidgetStateManager
+  fragmentId?: string
 }
 
 const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
@@ -50,17 +58,106 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   empty,
   children,
   stretchWidth,
+  widgetMgr,
+  fragmentId,
 }): ReactElement => {
-  const [open, setOpen] = useState(false)
   const isInSidebar = useContext(IsSidebarContext)
+  const { scriptRunState, scriptRunId } = useContext(ScriptRunContext)
 
   const theme = useEmotionTheme()
+
+  // id is only set when the backend registers the popover as a
+  // stateful widget (on_change="rerun").
+  const widgetId = element.id
+
+  // Single state with optimistic updates for instant UI feedback.
+  // Initialize from backend state.
+  const [open, setOpen] = useState(element.open ?? false)
+
+  // Tracks the scriptRunId at the time the user opened an empty widget
+  // popover. Used to derive isLoadingContent: we show the skeleton until
+  // a *different* script run completes (meaning our triggered run finished)
+  // or content arrives.
+  const [loadingStartScriptRunId, setLoadingStartScriptRunId] = useState<
+    string | null
+  >(null)
+
+  // Sync backend state changes (for programmatic control via session_state).
+  // Uses render-time comparison instead of useEffect — no DOM side effects needed.
+  useExecuteWhenChanged(() => {
+    if (!widgetId || !notNullOrUndefined(element.open)) {
+      return
+    }
+    setOpen(element.open)
+    setLoadingStartScriptRunId(null)
+  }, [widgetId, element.open])
+
+  // Clear loadingStartScriptRunId once the triggered run completes,
+  // so unrelated script runs don't re-activate the skeleton.
+  useExecuteWhenChanged(() => {
+    if (
+      loadingStartScriptRunId !== null &&
+      scriptRunState === ScriptRunState.NOT_RUNNING &&
+      scriptRunId !== loadingStartScriptRunId
+    ) {
+      setLoadingStartScriptRunId(null)
+    }
+  }, [scriptRunState, scriptRunId])
+
+  // Loading is active when: widget mode, popover is open, content is empty, loading
+  // was initiated by the user, and the script run that would populate
+  // content hasn't completed yet.
+  const isLoadingContent =
+    Boolean(widgetId) &&
+    open &&
+    empty &&
+    loadingStartScriptRunId !== null &&
+    !(
+      scriptRunState === ScriptRunState.NOT_RUNNING &&
+      scriptRunId !== loadingStartScriptRunId
+    )
 
   // It would be nice to remove this since it uses a resize observer
   // and therefore has a performance overhead. However, this is needed
   // to link the width of the button to the popover width. I think we
   // can remove the need for this as part of the BaseWeb migration.
   const { width: calculatedWidth, elementRef } = useCalculatedDimensions()
+
+  // Handle popover toggle with optimistic updates
+  const handleToggle = useCallback((): void => {
+    const newOpen = !open
+
+    // Optimistic update
+    setOpen(newOpen)
+
+    if (widgetId) {
+      // Track loading start when opening an empty widget popover.
+      // isLoadingContent is derived from this + other state.
+      setLoadingStartScriptRunId(newOpen && empty ? scriptRunId : null)
+
+      // Send state update to backend
+      widgetMgr?.setBoolValue(
+        { id: widgetId },
+        newOpen,
+        { fromUi: true },
+        fragmentId
+      )
+    }
+  }, [open, empty, scriptRunId, widgetMgr, widgetId, fragmentId])
+
+  const handleClose = useCallback((): void => {
+    setOpen(false)
+
+    if (widgetId) {
+      setLoadingStartScriptRunId(null)
+      widgetMgr?.setBoolValue(
+        { id: widgetId },
+        false,
+        { fromUi: true },
+        fragmentId
+      )
+    }
+  }, [widgetMgr, widgetId, fragmentId])
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
@@ -74,14 +171,20 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       <UIPopover
         triggerType={TRIGGER_TYPE.click}
         placement={PLACEMENT.bottomLeft}
-        content={() => children}
+        content={() =>
+          isLoadingContent ? (
+            <SquareSkeleton data-testid="stPopoverSkeleton" />
+          ) : (
+            children
+          )
+        }
         isOpen={open}
-        onClickOutside={() => setOpen(false)}
+        onClickOutside={handleClose}
         // We need to handle the click here as well to allow closing the
         // popover when the user clicks next to the button in the available
         // width in the surrounding container.
-        onClick={() => (open ? setOpen(false) : undefined)}
-        onEsc={() => setOpen(false)}
+        onClick={() => (open ? handleClose() : undefined)}
+        onEsc={handleClose}
         ignoreBoundary={isInSidebar}
         // TODO(lukasmasuch): We currently use renderAll to have a consistent
         // width during the first and subsequent opens of the popover. Once we ,
@@ -145,9 +248,9 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
               data-testid="stPopoverButton"
               kind={kind}
               size={BaseButtonSize.SMALL}
-              disabled={empty || element.disabled}
+              disabled={(empty && !widgetId) || element.disabled}
               containerWidth={true}
-              onClick={() => setOpen(!open)}
+              onClick={handleToggle}
             >
               <StyledPopoverLabelContainer>
                 <DynamicButtonLabel

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
@@ -35,15 +36,19 @@ from streamlit.elements.lib.layout_utils import (
     validate_vertical_alignment,
     validate_width,
 )
+from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, compute_and_register_element_id, to_key
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitInvalidColumnSpecError,
     StreamlitInvalidVerticalAlignmentError,
+    StreamlitValueError,
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.GapSize_pb2 import GapConfig
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.runtime.state import register_widget
 from streamlit.string_util import validate_icon_or_emoji
 
 if TYPE_CHECKING:
@@ -56,6 +61,17 @@ if TYPE_CHECKING:
     from streamlit.runtime.state import WidgetCallback
 
 SpecType: TypeAlias = int | Sequence[int | float]
+
+
+@dataclass
+class _PopoverSerde:
+    """Serializer/deserializer for popover widget state."""
+
+    def serialize(self, v: bool) -> bool:
+        return bool(v)
+
+    def deserialize(self, ui_value: bool | None) -> bool:
+        return ui_value if ui_value is not None else False
 
 
 class LayoutsMixin:
@@ -897,15 +913,21 @@ class LayoutsMixin:
         disabled: bool = False,
         use_container_width: bool | None = None,
         width: Width = "content",
+        key: Key | None = None,
+        on_change: Literal["ignore", "rerun"] = "ignore",
     ) -> PopoverContainer:
         r"""Insert a popover container.
 
         Inserts a multi-element container as a popover. It consists of a button-like
         element and a container that opens when the button is clicked.
 
-        Opening and closing the popover will not trigger a rerun. Interacting
-        with widgets inside of an open popover will rerun the app while keeping
-        the popover open. Clicking outside of the popover will close it.
+        By default, opening and closing the popover will not trigger a rerun.
+        Use ``on_change="rerun"`` to trigger a rerun when the popover is
+        opened or closed. Each popover's ``.open`` property indicates whether
+        it is currently open, letting you conditionally render content.
+        Interacting with widgets inside of an open popover will rerun the
+        app while keeping the popover open. Clicking outside of the popover
+        will close it.
 
         To add elements to the returned container, you can use the "with"
         notation (preferred) or just call methods directly on the returned object.
@@ -1012,6 +1034,29 @@ class LayoutsMixin:
             button. The popover container may be wider than its button to fit
             the container's contents.
 
+        key : str or int
+            An optional string or integer to use as the unique key for the
+            widget. If this is omitted, a key will be generated for the widget
+            based on its content. No two widgets may have the same key.
+
+            When ``on_change`` is set to ``"rerun"``, the open/closed state
+            is also accessible via ``st.session_state[key]``.
+
+        on_change : "ignore" or "rerun"
+            How the popover should respond to user open/close events. This
+            controls whether the popover tracks state and triggers reruns.
+            ``on_change`` can be one of the following:
+
+            - ``"ignore"`` (default): Streamlit will not track the popover's
+              state. The ``.open`` attribute will return ``None``. The popover
+              can be used inside ``@st.cache_data`` decorated functions.
+
+            - ``"rerun"``: Streamlit will rerun the app when the user opens or
+              closes the popover. The ``.open`` attribute will return the
+              current state (``True`` if open, ``False`` if closed). The
+              popover cannot be used inside ``@st.cache_data`` decorated
+              functions.
+
         Examples
         --------
         You can use the ``with`` notation to insert any element into a popover:
@@ -1059,14 +1104,66 @@ class LayoutsMixin:
                 f'\nThe argument passed was "{type}".'
             )
 
+        if on_change not in {"ignore", "rerun"}:
+            raise StreamlitValueError("on_change", ["'rerun'", "'ignore'"])
+
+        key = to_key(key)
+        is_stateful = on_change == "rerun"
+
+        current_open = False
+        element_id: str | None = None
+
+        if is_stateful:
+            # TODO: Set on_change and enable_check_callback_rules correctly
+            # when user-defined callbacks are supported for popovers.
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=None,
+                default_value=None,
+                writes_allowed=True,
+                enable_check_callback_rules=False,
+            )
+
+            ctx = get_script_run_ctx()
+
+            element_id = compute_and_register_element_id(
+                "popover",
+                user_key=key,
+                key_as_main_identity=False,
+                dg=self.dg,
+                label=label,
+                type=type,
+                help=help,
+                icon=icon,
+                disabled=disabled,
+                width=width,
+            )
+
+            serde = _PopoverSerde()
+
+            popover_state = register_widget(
+                element_id,
+                deserializer=serde.deserialize,
+                serializer=serde.serialize,
+                ctx=ctx,
+                value_type="bool_value",
+            )
+
+            current_open = popover_state.value
+
         popover_proto = BlockProto.Popover()
         popover_proto.label = label
         popover_proto.disabled = disabled
         popover_proto.type = type
+        popover_proto.open = current_open
         if help:
             popover_proto.help = str(help)
         if icon is not None:
             popover_proto.icon = validate_icon_or_emoji(icon)
+
+        if is_stateful and element_id is not None:
+            popover_proto.id = element_id
 
         block_proto = BlockProto()
         block_proto.allow_empty = True
@@ -1075,13 +1172,18 @@ class LayoutsMixin:
         validate_width(width, allow_content=True)
         block_proto.width_config.CopyFrom(get_width_config(width))
 
-        return cast(
+        popover_dg = cast(
             "PopoverContainer",
             self.dg._block(
                 block_proto=block_proto,
                 dg_type=get_dg_singleton_instance().popover_container_cls,
             ),
         )
+
+        if is_stateful:
+            popover_dg.open = current_open
+
+        return popover_dg
 
     @gather_metrics("status")
     def status(

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -794,6 +794,43 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         popover = st.popover("label")
         assert popover.open is None
 
+    def test_invalid_on_change_raises(self):
+        """Test that invalid on_change values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.popover("label", on_change="invalid")
+
+    def test_on_change_rerun_sets_open_false(self):
+        """Test that on_change='rerun' with open=False sets .open to False."""
+        popover = st.popover("label", on_change="rerun")
+        assert popover.open is False
+
+    def test_on_change_rerun_sets_id(self):
+        """Test that on_change='rerun' sets id on the popover proto."""
+        st.popover("label", on_change="rerun")
+        popover_block = self.get_delta_from_queue()
+        assert popover_block.add_block.popover.id != ""
+
+    def test_on_change_ignore_does_not_set_id(self):
+        """Test that on_change='ignore' does not set id."""
+        st.popover("label", on_change="ignore")
+        popover_block = self.get_delta_from_queue()
+        assert not popover_block.add_block.popover.HasField("id")
+
+    def test_on_change_rerun_with_key_accessible_via_session_state(self):
+        """Test that on_change='rerun' with key stores the open state."""
+        st.popover("label", key="my_pop", on_change="rerun")
+        assert "my_pop" in st.session_state
+        assert st.session_state.my_pop is False
+
+    def test_on_change_ignore_with_key_open_remains_none(self):
+        """Test that on_change='ignore' with a key keeps .open as None,
+        does not register widget state, and does not set block id."""
+        popover = st.popover("label", key="my_pop", on_change="ignore")
+        assert popover.open is None
+        assert "my_pop" not in st.session_state
+        popover_block = self.get_delta_from_queue()
+        assert popover_block.add_block.id == ""
+
 
 class StatusContainerTest(DeltaGeneratorTestCase):
     def test_label_required(self):

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -146,6 +146,11 @@ message Block {
     string type = 6;
     // Initial open state (used with on_change).
     optional bool open = 7;
+    // Widget ID for dynamic popovers. Only set when on_change="rerun",
+    // signaling the frontend to treat this as a stateful widget.
+    // When absent, the popover may still have a block-level id for CSS
+    // key styling but should not trigger reruns on toggle.
+    optional string id = 8;
 
     reserved 2;
   }


### PR DESCRIPTION
## Describe your changes

Test App: https://dynamic-popover.streamlit.app/

**Stacked on #13867.**

Adds `open`, `key`, and `on_change` parameters to `st.popover`, enabling stateful, lazily-executed popovers. When `on_change="rerun"`, opening or closing a popover triggers a rerun and the `.open` property returns `True` when open and `False` when closed. This lets apps skip expensive work inside closed popovers:

```python
pop = st.popover("Details", on_change="rerun")

if pop.open:
    with pop:
        run_expensive_query()
```

Programmatic control is supported via `st.session_state`:

```python
def show_settings():
    st.session_state.settings_pop = True

st.button("Settings", on_click=show_settings)
pop = st.popover("Settings", key="settings_pop", on_change="rerun")

if pop.open:
    with pop:
        st.write("Settings panel")
```

### Backend

- Adds `open`, `key`, and `on_change` parameters to `st.popover()`. When `on_change="rerun"`, registers the popover as a widget via `register_widget`, tracking its open/closed state as a boolean. Sets `.open` on the returned `PopoverContainer` to the current state. Without `on_change="rerun"`, `.open` remains `None`.
- `open` sets the initial open/closed state (default `False`); `st.session_state[key]` allows programmatic control.
- **Note:** `st-key-` CSS class support for popovers is deferred to a follow-up PR. A `key` without `on_change="rerun"` currently has no effect.

### Frontend

- On toggle in widget mode, sends the new state to the backend via `widgetMgr.setBoolValue` with optimistic UI updates for instant feedback.
- Syncs with backend state changes via `useEffect` for programmatic control through `session_state`.
- Shows a loading skeleton when opening an empty dynamic popover while waiting for content.
- Dynamic popovers (with `widget_id`) are not disabled when empty, unlike regular popovers, to allow lazy content loading.

## GitHub Issue Link (if applicable)

N/A — part of the DynamicContainers feature work.

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests
- [x] Any manual testing needed? Test manually with this app: https://dynamic-popover.streamlit.app/

**Python unit tests** (`lib/tests/streamlit/elements/layouts_test.py`): 10 tests covering invalid `on_change` values, `.open` state for both `open=False` and `open=True`, widget ID presence with and without `on_change`, session state accessibility, proto `open` field, and key-only behavior.

**Frontend unit tests** (`frontend/lib/src/components/elements/Popover/Popover.test.tsx`): 4 tests for dynamic popover behavior including widget state updates on toggle/close, non-widget popover passthrough, and programmatic state sync from backend.

**E2E tests** (`e2e_playwright/st_popover_test.py`): `test_dynamic_popover_lazy_execution` verifies content only executes when the popover is open; `test_dynamic_popover_programmatic_control` verifies opening/closing via session state buttons; `test_popover_key_only_does_not_trigger_rerun` verifies a key-only popover does not cause reruns on toggle.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.