### PR TITLE
Bind widgets to query params - `st.number_input`

### DIFF
--- a/e2e_playwright/st_number_input.py
+++ b/e2e_playwright/st_number_input.py
@@ -195,7 +195,7 @@ v21 = st.number_input(
 st.write("bound float value:", v21)
 
 v22 = st.number_input(
-    "Bound clamped",
+    "Bound with min/max",
     value=50,
     min_value=0,
     max_value=100,

--- a/e2e_playwright/st_number_input.py
+++ b/e2e_playwright/st_number_input.py
@@ -175,3 +175,31 @@ v19 = st.number_input(
     key="number_input_19",
 )
 st.write(f"number input 19 (small step decrement) - value: {v19:.7f}")
+
+# --- Bound widgets (query-params) ---
+
+v20 = st.number_input(
+    "Bound integer",
+    value=None,
+    key="bound_int",
+    bind="query-params",
+)
+st.write("bound int value:", v20)
+
+v21 = st.number_input(
+    "Bound float",
+    value=3.14,
+    key="bound_float",
+    bind="query-params",
+)
+st.write("bound float value:", v21)
+
+v22 = st.number_input(
+    "Bound clamped",
+    value=50,
+    min_value=0,
+    max_value=100,
+    key="bound_minmax",
+    bind="query-params",
+)
+st.write("bound minmax value:", v22)

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -554,6 +554,8 @@ def test_number_input_query_param_clamped_to_min_max(page: Page, app_port: int):
 
     # Number input should clamp to max value (100)
     expect_prefixed_markdown(page, "bound minmax value:", "100")
+    # URL should be corrected to the clamped value
+    expect(page).to_have_url(re.compile(r"[?&]bound_minmax=100"))
 
     # Now test below min
     page.goto(f"http://localhost:{app_port}/?bound_minmax=-50")
@@ -561,6 +563,8 @@ def test_number_input_query_param_clamped_to_min_max(page: Page, app_port: int):
 
     # Number input should clamp to min value (0)
     expect_prefixed_markdown(page, "bound minmax value:", "0")
+    # URL should be corrected to the clamped value
+    expect(page).to_have_url(re.compile(r"[?&]bound_minmax=0"))
 
 
 def test_number_input_query_param_invalid_value(page: Page, app_port: int):

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -496,8 +496,11 @@ def test_number_input_query_param_seeding_int(page: Page, app_port: int):
     page.goto(f"http://localhost:{app_port}/?bound_int=42")
     wait_for_app_loaded(page)
 
-    # Number input should show the seeded value
-    expect_prefixed_markdown(page, "bound int value:", "42")
+    # bound_int uses value=None (no type hints), so defaults to float type.
+    # Seeding with "42" from URL produces 42.0.
+    expect_prefixed_markdown(page, "bound int value:", "42.0", exact_match=True)
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
 
 
 def test_number_input_query_param_seeding_float(page: Page, app_port: int):
@@ -507,6 +510,8 @@ def test_number_input_query_param_seeding_float(page: Page, app_port: int):
 
     # Number input should show "2.718" (overriding "3.14" default)
     expect_prefixed_markdown(page, "bound float value:", "2.718")
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))
 
 
 def test_number_input_query_param_updates_url(app: Page):
@@ -577,3 +582,39 @@ def test_number_input_query_param_invalid_value(page: Page, app_port: int):
     expect_prefixed_markdown(page, "bound int value:", "None")
     # Invalid param should be removed from URL
     expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
+
+
+def test_number_input_query_param_invalid_value_non_clearable(
+    page: Page, app_port: int
+):
+    """Test that invalid URL values on non-clearable widget reset to default."""
+    # bound_float has value=3.14 (non-clearable)
+    page.goto(f"http://localhost:{app_port}/?bound_float=notanumber")
+    wait_for_app_loaded(page)
+
+    # Widget should show default value (3.14), invalid param should be cleared
+    expect_prefixed_markdown(page, "bound float value:", "3.14")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
+
+
+def test_number_input_query_param_clearable_empty_value(page: Page, app_port: int):
+    """Test that empty URL value clears a clearable number input to None."""
+    # bound_int has value=None (clearable)
+    page.goto(f"http://localhost:{app_port}/?bound_int=")
+    wait_for_app_loaded(page)
+
+    # Clearable number input should accept the empty value and show None
+    expect_prefixed_markdown(page, "bound int value:", "None")
+
+
+def test_number_input_query_param_non_clearable_empty_value(page: Page, app_port: int):
+    """Test that empty URL value is rejected for non-clearable number input."""
+    # bound_float has value=3.14 (non-clearable)
+    page.goto(f"http://localhost:{app_port}/?bound_float=")
+    wait_for_app_loaded(page)
+
+    # Non-clearable number input should reject empty value, show default 3.14
+    expect_prefixed_markdown(page, "bound float value:", "3.14")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -551,25 +551,27 @@ def test_number_input_query_param_default_override(page: Page, app_port: int):
     expect_prefixed_markdown(page, "bound float value:", "3.14")
 
 
-def test_number_input_query_param_clamped_to_min_max(page: Page, app_port: int):
-    """Test that URL values exceeding min/max are clamped."""
-    # Load app with value exceeding max=100
+def test_number_input_query_param_out_of_range_resets_to_default(
+    page: Page, app_port: int
+):
+    """Test that URL values exceeding min/max reset to default and URL is cleared."""
+    # Load app with value exceeding max=100 (default is 50)
     page.goto(f"http://localhost:{app_port}/?bound_minmax=999")
     wait_for_app_loaded(page)
 
-    # Number input should clamp to max value (100)
-    expect_prefixed_markdown(page, "bound minmax value:", "100")
-    # URL should be corrected to the clamped value
-    expect(page).to_have_url(re.compile(r"[?&]bound_minmax=100"))
+    # Number input should reset to default value (50)
+    expect_prefixed_markdown(page, "bound minmax value:", "50")
+    # URL param should be cleared (default values are not kept in URL)
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_minmax="))
 
     # Now test below min
     page.goto(f"http://localhost:{app_port}/?bound_minmax=-50")
     wait_for_app_loaded(page)
 
-    # Number input should clamp to min value (0)
-    expect_prefixed_markdown(page, "bound minmax value:", "0")
-    # URL should be corrected to the clamped value
-    expect(page).to_have_url(re.compile(r"[?&]bound_minmax=0"))
+    # Number input should reset to default value (50)
+    expect_prefixed_markdown(page, "bound minmax value:", "50")
+    # URL param should be cleared
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_minmax="))
 
 
 def test_number_input_query_param_invalid_value(page: Page, app_port: int):

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -20,6 +20,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -491,9 +492,9 @@ def test_number_input_scientific_notation_step_decrement(app: Page):
     )
 
 
-def test_number_input_query_param_seeding_int(page: Page, app_port: int):
+def test_number_input_query_param_seeding_int(page: Page, app_base_url: str):
     """Test that number input (int) value can be seeded from URL query params."""
-    page.goto(f"http://localhost:{app_port}/?bound_int=42")
+    page.goto(build_app_url(app_base_url, query={"bound_int": "42"}))
     wait_for_app_loaded(page)
 
     # bound_int uses value=None (no type hints), so defaults to float type.
@@ -503,9 +504,9 @@ def test_number_input_query_param_seeding_int(page: Page, app_port: int):
     expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
 
 
-def test_number_input_query_param_seeding_float(page: Page, app_port: int):
+def test_number_input_query_param_seeding_float(page: Page, app_base_url: str):
     """Test that number input (float) value can be seeded from URL query params."""
-    page.goto(f"http://localhost:{app_port}/?bound_float=2.718")
+    page.goto(build_app_url(app_base_url, query={"bound_float": "2.718"}))
     wait_for_app_loaded(page)
 
     # Number input should show "2.718" (overriding "3.14" default)
@@ -530,10 +531,10 @@ def test_number_input_query_param_updates_url(app: Page):
     expect_prefixed_markdown(app, "bound float value:", "2.718")
 
 
-def test_number_input_query_param_default_override(page: Page, app_port: int):
+def test_number_input_query_param_default_override(page: Page, app_base_url: str):
     """Test number input with custom default: seeding and param removal."""
     # Load app with query param overriding the "3.14" default
-    page.goto(f"http://localhost:{app_port}/?bound_float=9.99")
+    page.goto(build_app_url(app_base_url, query={"bound_float": "9.99"}))
     wait_for_app_loaded(page)
 
     # Number input should show "9.99"
@@ -552,11 +553,11 @@ def test_number_input_query_param_default_override(page: Page, app_port: int):
 
 
 def test_number_input_query_param_out_of_range_resets_to_default(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ):
     """Test that URL values exceeding min/max reset to default and URL is cleared."""
     # Load app with value exceeding max=100 (default is 50)
-    page.goto(f"http://localhost:{app_port}/?bound_minmax=999")
+    page.goto(build_app_url(app_base_url, query={"bound_minmax": "999"}))
     wait_for_app_loaded(page)
 
     # Number input should reset to default value (50)
@@ -565,7 +566,7 @@ def test_number_input_query_param_out_of_range_resets_to_default(
     expect(page).not_to_have_url(re.compile(r"[?&]bound_minmax="))
 
     # Now test below min
-    page.goto(f"http://localhost:{app_port}/?bound_minmax=-50")
+    page.goto(build_app_url(app_base_url, query={"bound_minmax": "-50"}))
     wait_for_app_loaded(page)
 
     # Number input should reset to default value (50)
@@ -574,10 +575,10 @@ def test_number_input_query_param_out_of_range_resets_to_default(
     expect(page).not_to_have_url(re.compile(r"[?&]bound_minmax="))
 
 
-def test_number_input_query_param_invalid_value(page: Page, app_port: int):
+def test_number_input_query_param_invalid_value(page: Page, app_base_url: str):
     """Test that invalid URL values are cleared and widget uses default."""
     # Load app with invalid query param value (not a number)
-    page.goto(f"http://localhost:{app_port}/?bound_int=notanumber")
+    page.goto(build_app_url(app_base_url, query={"bound_int": "notanumber"}))
     wait_for_app_loaded(page)
 
     # Number input should use default (None), and invalid param should be cleared
@@ -589,11 +590,11 @@ def test_number_input_query_param_invalid_value(page: Page, app_port: int):
 
 
 def test_number_input_query_param_invalid_value_non_clearable(
-    page: Page, app_port: int
+    page: Page, app_base_url: str
 ):
     """Test that invalid URL values on non-clearable widget reset to default."""
     # bound_float has value=3.14 (non-clearable)
-    page.goto(f"http://localhost:{app_port}/?bound_float=notanumber")
+    page.goto(build_app_url(app_base_url, query={"bound_float": "notanumber"}))
     wait_for_app_loaded(page)
 
     # Widget should show default value (3.14), invalid param should be cleared
@@ -601,20 +602,22 @@ def test_number_input_query_param_invalid_value_non_clearable(
     expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
 
 
-def test_number_input_query_param_clearable_empty_value(page: Page, app_port: int):
+def test_number_input_query_param_clearable_empty_value(page: Page, app_base_url: str):
     """Test that empty URL value clears a clearable number input to None."""
     # bound_int has value=None (clearable)
-    page.goto(f"http://localhost:{app_port}/?bound_int=")
+    page.goto(build_app_url(app_base_url, query={"bound_int": ""}))
     wait_for_app_loaded(page)
 
     # Clearable number input should accept the empty value and show None
     expect_prefixed_markdown(page, "bound int value:", "None")
 
 
-def test_number_input_query_param_non_clearable_empty_value(page: Page, app_port: int):
+def test_number_input_query_param_non_clearable_empty_value(
+    page: Page, app_base_url: str
+):
     """Test that empty URL value is rejected for non-clearable number input."""
     # bound_float has value=3.14 (non-clearable)
-    page.goto(f"http://localhost:{app_port}/?bound_float=")
+    page.goto(build_app_url(app_base_url, query={"bound_float": ""}))
     wait_for_app_loaded(page)
 
     # Non-clearable number input should reject empty value, show default 3.14

--- a/e2e_playwright/st_number_input_test.py
+++ b/e2e_playwright/st_number_input_test.py
@@ -18,7 +18,11 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -30,7 +34,7 @@ from e2e_playwright.shared.app_utils import (
     reset_hovering,
 )
 
-NUMBER_INPUT_COUNT = 20
+NUMBER_INPUT_COUNT = 23
 
 
 def test_number_input_widget_display(
@@ -485,3 +489,87 @@ def test_number_input_scientific_notation_step_decrement(app: Page):
     expect_prefixed_markdown(
         app, "number input 19 (small step decrement) - value:", "0.0000000"
     )
+
+
+def test_number_input_query_param_seeding_int(page: Page, app_port: int):
+    """Test that number input (int) value can be seeded from URL query params."""
+    page.goto(f"http://localhost:{app_port}/?bound_int=42")
+    wait_for_app_loaded(page)
+
+    # Number input should show the seeded value
+    expect_prefixed_markdown(page, "bound int value:", "42")
+
+
+def test_number_input_query_param_seeding_float(page: Page, app_port: int):
+    """Test that number input (float) value can be seeded from URL query params."""
+    page.goto(f"http://localhost:{app_port}/?bound_float=2.718")
+    wait_for_app_loaded(page)
+
+    # Number input should show "2.718" (overriding "3.14" default)
+    expect_prefixed_markdown(page, "bound float value:", "2.718")
+
+
+def test_number_input_query_param_updates_url(app: Page):
+    """Test that changing a bound number input updates the URL."""
+    # Use the float widget which has a default value (easier to test)
+    number_input = get_element_by_key(app, "bound_float")
+    input_field = number_input.get_by_test_id("stNumberInputField")
+
+    # Change from default (3.14) to a new value
+    input_field.fill("2.718")
+    input_field.press("Enter")
+    wait_for_app_run(app)
+
+    # URL should now contain the query param
+    expect(app).to_have_url(re.compile(r"[?&]bound_float=2\.718"))
+    expect_prefixed_markdown(app, "bound float value:", "2.718")
+
+
+def test_number_input_query_param_default_override(page: Page, app_port: int):
+    """Test number input with custom default: seeding and param removal."""
+    # Load app with query param overriding the "3.14" default
+    page.goto(f"http://localhost:{app_port}/?bound_float=9.99")
+    wait_for_app_loaded(page)
+
+    # Number input should show "9.99"
+    expect_prefixed_markdown(page, "bound float value:", "9.99")
+
+    # Change back to default ("3.14")
+    number_input = get_element_by_key(page, "bound_float")
+    input_field = number_input.get_by_test_id("stNumberInputField")
+    input_field.fill("3.14")
+    input_field.press("Enter")
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
+    expect_prefixed_markdown(page, "bound float value:", "3.14")
+
+
+def test_number_input_query_param_clamped_to_min_max(page: Page, app_port: int):
+    """Test that URL values exceeding min/max are clamped."""
+    # Load app with value exceeding max=100
+    page.goto(f"http://localhost:{app_port}/?bound_minmax=999")
+    wait_for_app_loaded(page)
+
+    # Number input should clamp to max value (100)
+    expect_prefixed_markdown(page, "bound minmax value:", "100")
+
+    # Now test below min
+    page.goto(f"http://localhost:{app_port}/?bound_minmax=-50")
+    wait_for_app_loaded(page)
+
+    # Number input should clamp to min value (0)
+    expect_prefixed_markdown(page, "bound minmax value:", "0")
+
+
+def test_number_input_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    # Load app with invalid query param value (not a number)
+    page.goto(f"http://localhost:{app_port}/?bound_int=notanumber")
+    wait_for_app_loaded(page)
+
+    # Number input should use default (None), and invalid param should be cleared
+    expect_prefixed_markdown(page, "bound int value:", "None")
+    # Invalid param should be removed from URL
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -1451,3 +1451,71 @@ describe("NumberInput widget", () => {
     })
   })
 })
+
+describe("NumberInput query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getIntProps({ queryParamKey: "my_number" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_number",
+      "double_value",
+      props.element.default,
+      false,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getIntProps({ queryParamKey: "my_number" })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<NumberInput {...props} />)
+
+    // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getIntProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers with float default value", () => {
+    const props = getProps({
+      queryParamKey: "my_float",
+      dataType: NumberInputProto.DataType.FLOAT,
+      default: 3.14,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_float",
+      "double_value",
+      3.14,
+      false,
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -1518,4 +1518,24 @@ describe("NumberInput query param binding", () => {
       undefined
     )
   })
+
+  it("registers with clearable=true when no default", () => {
+    const props = getProps({
+      queryParamKey: "my_number",
+      default: null,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<NumberInput {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_number",
+      "double_value",
+      null,
+      true,
+      undefined,
+      undefined
+    )
+  })
 })

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -144,6 +144,13 @@ const NumberInput: React.FC<Props> = ({
       setDirty(false)
       setFormattedValue(formatCurrentValue(newValue))
     }, [elementDefault, formatCurrentValue]),
+    queryParamBinding: element.queryParamKey
+      ? {
+          paramKey: element.queryParamKey,
+          valueType: "double_value" as const,
+          clearable: false,
+        }
+      : undefined,
   })
 
   // Additional local state for UI interactions

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -126,6 +126,14 @@ const NumberInput: React.FC<Props> = ({
     })
   })
 
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "double_value" as const,
+        clearable: isNullOrUndefined(element.default),
+      }
+    : undefined
+
   // Use useBasicWidgetState for core value management
   const [value, setValueWithSource] = useBasicWidgetState<
     number | null,
@@ -144,13 +152,7 @@ const NumberInput: React.FC<Props> = ({
       setDirty(false)
       setFormattedValue(formatCurrentValue(newValue))
     }, [elementDefault, formatCurrentValue]),
-    queryParamBinding: element.queryParamKey
-      ? {
-          paramKey: element.queryParamKey,
-          valueType: "double_value" as const,
-          clearable: false,
-        }
-      : undefined,
+    queryParamBinding,
   })
 
   // Additional local state for UI interactions

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -85,9 +85,10 @@ class NumberInputSerde:
             # Clamp to [min_value, max_value]. Primarily needed for
             # out-of-range values seeded from URL query params; a no-op
             # for frontend values since the UI already enforces bounds.
-            # Side effect: When min/max change dynamically between reruns,
-            # a previously-valid value that is now out of range will be clamped
-            # to the nearest bound instead of resetting to the default.
+            # Note: This only runs on *serialized* values (URL seeding,
+            # fresh frontend submissions). Already-deserialized values
+            # from previous runs are handled by the bounds-reset check
+            # in _number_input (see "Validate the current value" block).
             val = max(self.min_value, min(self.max_value, val))
 
         return val
@@ -673,8 +674,12 @@ class NumberInputMixin:
 
         # Validate the current value against the new min/max bounds.
         # If the value is no longer valid (outside bounds), reset to default.
-        # This handles the case where min_value/max_value change dynamically and the
-        # previously entered value is no longer within bounds.
+        # This handles the case where min_value/max_value change dynamically
+        # and the previously entered value is no longer within bounds.
+        # Note: This is NOT redundant with the serde clamping above — the
+        # serde only runs on serialized values (URL seeding, frontend
+        # submissions), while this catches already-deserialized values
+        # carried over from a previous rerun with different bounds.
         current_value = widget_state.value
         value_needs_reset = False
 

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -669,7 +669,9 @@ class NumberInputMixin:
             ctx=ctx,
             value_type="double_value",
             bind=bind,
-            clearable=False,
+            # Clearable when value=None: the widget can be in an empty state,
+            # so ?key= (empty URL param) should clear the widget to None.
+            clearable=(value is None),
         )
 
         # Validate the current value against the new min/max bounds.

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -82,14 +82,13 @@ class NumberInputSerde:
         if val is not None:
             if self.data_type == NumberInputProto.INT:
                 val = int(val)
-            # Clamp to [min_value, max_value]. Primarily needed for
-            # out-of-range values seeded from URL query params; a no-op
-            # for frontend values since the UI already enforces bounds.
-            # Note: This only runs on *serialized* values (URL seeding,
-            # fresh frontend submissions). Already-deserialized values
-            # from previous runs are handled by the bounds-reset check
-            # in _number_input (see "Validate the current value" block).
-            val = max(self.min_value, min(self.max_value, val))
+            # Reset to default if outside [min_value, max_value]. This
+            # rejects out-of-range values seeded from URL query params;
+            # a no-op for frontend values since the UI enforces bounds.
+            # Returning the default triggers _seed_widget_from_url's
+            # "deserialized == default" check, which clears the URL param.
+            if val < self.min_value or val > self.max_value:
+                return self.value
 
         return val
 
@@ -389,10 +388,10 @@ class NumberInputMixin:
             If set to ``"query-params"``, the widget's value will be synced
             with a URL query parameter. When the widget value changes, the URL
             is updated; when the page loads with a query parameter, the widget
-            is initialized from it. Values from URL are automatically clamped
-            to ``min_value`` and ``max_value`` if set. Requires a ``key`` to
-            be set, which will be used as the query parameter name. The
-            default is ``None``.
+            is initialized from it. Out-of-range URL values (outside
+            ``min_value``/``max_value``) are ignored, reverting the widget to
+            its default value. Requires a ``key`` to be set, which will be used
+            as the query parameter name. The default is ``None``.
 
         Returns
         -------
@@ -678,10 +677,11 @@ class NumberInputMixin:
         # If the value is no longer valid (outside bounds), reset to default.
         # This handles the case where min_value/max_value change dynamically
         # and the previously entered value is no longer within bounds.
-        # Note: This is NOT redundant with the serde clamping above — the
+        # Note: This is NOT redundant with the serde bounds check — the
         # serde only runs on serialized values (URL seeding, frontend
         # submissions), while this catches already-deserialized values
         # carried over from a previous rerun with different bounds.
+        # Both paths reset to the widget's default value for consistency.
         current_value = widget_state.value
         value_needs_reset = False
 

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -48,6 +48,7 @@ from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -69,6 +70,8 @@ FloatOrNone = TypeVar("FloatOrNone", float, None)
 class NumberInputSerde:
     value: Number | None
     data_type: int
+    min_value: Number
+    max_value: Number
 
     def serialize(self, v: Number | None) -> Number | None:
         return v
@@ -76,8 +79,16 @@ class NumberInputSerde:
     def deserialize(self, ui_value: Number | None) -> Number | None:
         val: Number | None = ui_value if ui_value is not None else self.value
 
-        if val is not None and self.data_type == NumberInputProto.INT:
-            val = int(val)
+        if val is not None:
+            if self.data_type == NumberInputProto.INT:
+                val = int(val)
+            # Clamp to [min_value, max_value]. Primarily needed for
+            # out-of-range values seeded from URL query params; a no-op
+            # for frontend values since the UI already enforces bounds.
+            # Side effect: When min/max change dynamically between reruns,
+            # a previously-valid value that is now out of range will be clamped
+            # to the nearest bound instead of resetting to the default.
+            val = max(self.min_value, min(self.max_value, val))
 
         return val
 
@@ -107,6 +118,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int | IntOrNone: ...
 
     # If "max_value: int" is given and all other numerical inputs are
@@ -133,6 +145,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int | IntOrNone: ...
 
     # If "value=int" is given and all other numerical inputs are "int"s
@@ -157,6 +170,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int: ...
 
     # If "step=int" is given and all other numerical inputs are "int"s
@@ -183,6 +197,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int | IntOrNone: ...
 
     # If all numerical inputs are floats (with value optionally being "min")
@@ -209,6 +224,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> float | FloatOrNone: ...
 
     @gather_metrics("number_input")
@@ -231,6 +247,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> Number | None:
         r"""Display a numeric input widget.
 
@@ -367,6 +384,15 @@ class NumberInputMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Values from URL are automatically clamped
+            to ``min_value`` and ``max_value`` if set. Requires a ``key`` to
+            be set, which will be used as the query parameter name. The
+            default is ``None``.
+
         Returns
         -------
         int or float or None
@@ -416,6 +442,7 @@ class NumberInputMixin:
             label_visibility=label_visibility,
             icon=icon,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -438,6 +465,7 @@ class NumberInputMixin:
         label_visibility: LabelVisibility = "visible",
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> Number | None:
         key = to_key(key)
@@ -617,7 +645,19 @@ class NumberInputMixin:
         if icon is not None:
             number_input_proto.icon = validate_icon_or_emoji(icon)
 
-        serde = NumberInputSerde(value, data_type)
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            number_input_proto.query_param_key = str(key)
+
+        # min_value and max_value are guaranteed to be Number (not None) after
+        # the JSNumber defaults above. The casts are needed for ty (which doesn't
+        # narrow the type), but mypy sees them as redundant.
+        serde = NumberInputSerde(
+            value,
+            data_type,
+            cast("Number", min_value),  # type: ignore[redundant-cast]
+            cast("Number", max_value),  # type: ignore[redundant-cast]
+        )
         widget_state = register_widget(
             number_input_proto.id,
             on_change_handler=on_change,
@@ -627,6 +667,8 @@ class NumberInputMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="double_value",
+            bind=bind,
+            clearable=False,
         )
 
         # Validate the current value against the new min/max bounds.

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -21,8 +21,10 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.js_number import JSNumber
+from streamlit.elements.widgets.number_input import NumberInputSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidBindValueError,
     StreamlitInvalidWidthError,
     StreamlitValueAboveMaxError,
 )
@@ -728,3 +730,84 @@ def test_dynamic_bounds_with_float_values():
     at = at.run()
     # Now min_value=5.0, so 2.5 is invalid and should reset to default (7.5)
     assert at.number_input[0].value == 7.5
+
+
+class NumberInputBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for number_input bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.number_input("the label", key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.number_input("the label", bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.number_input("the label", key="my_key", value=0)
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == ""
+        assert c.label == "the label"
+        assert c.default == 0
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.number_input("the label", key="my_key", bind="invalid-value")
+
+    def test_bind_query_params_with_int_value(self):
+        """Test that bind works with integer values."""
+        st.number_input("the label", value=42, key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+        assert c.data_type == NumberInput.INT
+
+    def test_bind_query_params_with_float_value(self):
+        """Test that bind works with float values."""
+        st.number_input("the label", value=3.14, key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+        assert c.data_type == NumberInput.FLOAT
+
+    def test_bind_query_params_with_min_max(self):
+        """Test that bind works with min/max constraints."""
+        st.number_input(
+            "the label",
+            min_value=0,
+            max_value=100,
+            value=50,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.query_param_key == "my_key"
+        assert c.has_min
+        assert c.min == 0
+        assert c.has_max
+        assert c.max == 100
+
+
+@pytest.mark.parametrize(
+    ("ui_value", "expected"),
+    [
+        (150, 100),  # Above max -> clamped to max
+        (-50, 0),  # Below min -> clamped to min
+        (50, 50),  # In range -> unchanged
+        (None, 50),  # None -> returns default value
+    ],
+)
+def test_serde_clamps_to_min_max(ui_value, expected):
+    """Test that NumberInputSerde.deserialize clamps values outside min/max range."""
+    serde = NumberInputSerde(
+        value=50, data_type=NumberInput.INT, min_value=0, max_value=100
+    )
+    assert serde.deserialize(ui_value) == expected

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -799,14 +799,16 @@ class NumberInputBindQueryParamsTest(DeltaGeneratorTestCase):
 @pytest.mark.parametrize(
     ("ui_value", "expected"),
     [
-        (150, 100),  # Above max -> clamped to max
-        (-50, 0),  # Below min -> clamped to min
+        (150, 50),  # Above max -> reset to default
+        (-50, 50),  # Below min -> reset to default
         (50, 50),  # In range -> unchanged
+        (0, 0),  # At min -> unchanged
+        (100, 100),  # At max -> unchanged
         (None, 50),  # None -> returns default value
     ],
 )
-def test_serde_clamps_to_min_max(ui_value, expected):
-    """Test that NumberInputSerde.deserialize clamps values outside min/max range."""
+def test_serde_resets_out_of_range_to_default(ui_value, expected):
+    """Test that NumberInputSerde.deserialize resets out-of-range values to default."""
     serde = NumberInputSerde(
         value=50, data_type=NumberInput.INT, min_value=0, max_value=100
     )

--- a/lib/tests/streamlit/typing/number_input_types.py
+++ b/lib/tests/streamlit/typing/number_input_types.py
@@ -82,3 +82,9 @@ if TYPE_CHECKING:
 
     # Check "min" value
     assert_type(number_input("foo", value="min"), float)
+
+    # Check bind parameter
+    assert_type(number_input("foo", min_value=1, bind="query-params"), int)
+    assert_type(number_input("foo", value=3.14, bind="query-params"), float)
+    assert_type(number_input("foo", bind=None), float)
+    assert_type(number_input("foo", value=None, bind="query-params"), float | None)

--- a/proto/streamlit/proto/NumberInput.proto
+++ b/proto/streamlit/proto/NumberInput.proto
@@ -46,6 +46,8 @@ message NumberInput {
   LabelVisibility label_visibility = 22;
   string placeholder = 23;
   string icon = 24;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 25;
 
   reserved 4, 5, 6, 7, 9, 10;
 }


### PR DESCRIPTION
## Describe your changes
Adds the bind parameter to `st.number_input` to enable two-way sync between widget values and URL query parameters.

**Key changes:**
- Added `bind="query-params"` support to `st.number_input`
- Invalid (out of bounds, non-numeric) URL values are caught during deserialization and the query param is removed, falling back to the widget default.
- Clearability is tied to `value=None`: when the widget is registered with no default value, an empty URL param (`?key=`) clears the widget to `None`. When `value` is set, empty URL params are ignored.


## Testing Plan
- JS & Python Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 