### PR TITLE
Fix stale outputs after stop/rerun sequence

### DIFF
--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -86,10 +86,19 @@ describe("isElementStale", () => {
     ).toBe(false)
   })
 
+  it("treats STOP_REQUESTED like RUNNING", () => {
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "someOtherScriptRunId", [])
+    ).toBe(true)
+
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [])
+    ).toBe(false)
+  })
+
   it("returns false for all other script run states", () => {
     const states = [
       ScriptRunState.NOT_RUNNING,
-      ScriptRunState.STOP_REQUESTED,
       ScriptRunState.COMPILATION_ERROR,
     ]
     states.forEach(s => {

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -51,7 +51,10 @@ export function isElementStale(
     return true
   }
 
-  if (scriptRunState === ScriptRunState.RUNNING) {
+  if (
+    scriptRunState === ScriptRunState.RUNNING ||
+    scriptRunState === ScriptRunState.STOP_REQUESTED
+  ) {
     if (fragmentIdsThisRun?.length) {
       // if the fragmentId is set, we only want to mark elements as stale
       // that belong to the same fragmentId and have a different scriptRunId.

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -711,6 +711,8 @@ class ScriptRunner:
                 # The handling for when a full script run or a fragment is stopped early
                 # is the same, so we only have one ScriptRunnerEvent for this scenario.
                 finished_event = ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN
+            elif premature_stop and self._requests.is_stop_requested():
+                finished_event = ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN
             elif rerun_data.fragment_id_queue:
                 finished_event = ScriptRunnerEvent.FRAGMENT_STOPPED_WITH_SUCCESS
             else:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -173,6 +173,11 @@ class ScriptRequests:
         with self._lock:
             self._state = ScriptRequestType.STOP
 
+    def is_stop_requested(self) -> bool:
+        """Return True if a stop request is pending."""
+        with self._lock:
+            return self._state == ScriptRequestType.STOP
+
     def request_rerun(self, new_data: RerunData) -> bool:
         """Request that the ScriptRunner rerun its script.
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -686,7 +686,7 @@ class ScriptRunnerTest(AsyncTestCase):
                 ScriptRunnerEvent.SCRIPT_STARTED,
                 ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN,
                 ScriptRunnerEvent.SCRIPT_STARTED,
-                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN,
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )
@@ -707,7 +707,7 @@ class ScriptRunnerTest(AsyncTestCase):
             scriptrunner,
             [
                 ScriptRunnerEvent.SCRIPT_STARTED,
-                ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+                ScriptRunnerEvent.SCRIPT_STOPPED_FOR_RERUN,
                 ScriptRunnerEvent.SHUTDOWN,
             ],
         )


### PR DESCRIPTION
## Describe your changes
- Ensured stop-requested runs are treated like rerun-stopped runs for stale element handling.
- Updated backend script runner event selection for premature stop paths to prevent stale outputs from being marked fresh.
- Added request-state helper support and aligned frontend stale-state logic with stop-requested flow.
## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/9904

## Testing Plan

- Explanation of why no additional tests are needed: Existing test suites were extended for stop/rerun stale-state behavior.
- Unit Tests (JS and/or Python)
   - Added/updated tests in:
      - frontend/lib/src/components/core/Block/utils.test.ts
      - lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
- E2E Tests: Not run.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
