### PR TITLE
feat(TextArea): extend programmatic value change detection to TextArea

### DIFF
--- a/e2e_playwright/st_text_area.py
+++ b/e2e_playwright/st_text_area.py
@@ -210,3 +210,9 @@ bound_area_max = st.text_area(
     max_chars=5,
 )
 st.write("bound area max value:", bound_area_max)
+
+if "rerun_counter" not in st.session_state:
+    st.session_state.rerun_counter = 0
+
+st.session_state.rerun_counter += 1
+st.write("Rerun counter:", st.session_state.rerun_counter)

--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -465,3 +465,48 @@ def test_text_area_query_param_max_chars_truncation(page: Page, app_port: int):
 
     # Should be truncated to 5 characters
     expect_prefixed_markdown(page, "bound area max value:", "veryl")
+
+
+def test_text_area_programmatic_value_change_commits_without_blur(app: Page):
+    """Test that programmatic value changes (e.g. password manager autofill)
+    commit the value without requiring manual blur or Ctrl+Enter.
+
+    Password managers like 1Password set the input value programmatically and
+    dispatch native input + change events (both bubbling, isTrusted: false).
+    The widget must detect this and commit the value immediately.
+    """
+    text_area = get_text_area(app, "text area 1 (default)")
+    text_area_field = text_area.locator("textarea").first
+
+    # Verify initial value is empty
+    expect_markdown(app, "value 1: ")
+
+    # Focus the textarea first (password managers typically fill focused fields)
+    text_area_field.focus()
+
+    # Simulate 1Password autofill: programmatically set value and dispatch
+    # native input + change events (both bubbling), just like the extension does.
+    text_area_field.evaluate(
+        """el => {
+            // Programmatically set the value (bypasses React's synthetic events)
+            const nativeInputValueSetter =
+                Object.getOwnPropertyDescriptor(
+                    HTMLTextAreaElement.prototype, 'value'
+                ).set;
+            nativeInputValueSetter.call(el, 'autofilled-text-123');
+
+            // Dispatch events matching 1Password's behavior:
+            // input event (bubbling) followed by change event (bubbling)
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+        }"""
+    )
+
+    # The value should be committed without needing blur or Ctrl+Enter
+    expect_prefixed_markdown(app, "value 1:", "autofilled-text-123")
+
+    # Verify the textarea field shows the new value
+    expect(text_area_field).to_have_value("autofilled-text-123")
+
+    # Verify that the rerun counter incremented (indicating a script rerun)
+    expect_markdown(app, "Rerun counter: 2")

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -176,6 +176,177 @@ describe("TextArea widget", () => {
     )
   })
 
+  it("commits programmatic value changes on blur", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextArea {...props} />)
+
+    // First call happens on mount.
+    expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+    const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+    await user.click(textArea)
+
+    // Simulate password manager autofill by setting the DOM value directly
+    // without firing an onChange/input event.
+    textArea.value = "TEST"
+    await user.tab()
+
+    await waitFor(() => {
+      expect(setStringValueSpy).toHaveBeenCalledTimes(2)
+    })
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(
+      props.element,
+      "TEST",
+      { fromUi: true },
+      undefined
+    )
+  })
+
+  it("detects programmatic value changes via native input events", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextArea {...props} />)
+
+    // First call happens on mount.
+    expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+    const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+    await user.click(textArea)
+
+    // Simulate programmatic value changes with a non-bubbling native event.
+    textArea.value = "TEST"
+    act(() => {
+      textArea.dispatchEvent(new Event("input", { bubbles: false }))
+    })
+
+    // Ctrl+Enter should commit if the textarea was marked dirty.
+    await user.keyboard("{Control>}{Enter}")
+
+    await waitFor(() => {
+      expect(setStringValueSpy).toHaveBeenCalledTimes(2)
+    })
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(
+      props.element,
+      "TEST",
+      { fromUi: true },
+      undefined
+    )
+  })
+
+  it("ignores non-bubbling native input events when disabled", () => {
+    vi.useFakeTimers()
+    try {
+      const props = getProps({ formId: "formId" }, { disabled: true })
+      const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+      render(<TextArea {...props} />)
+      const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+
+      // First call happens on mount.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+      textArea.value = "TEST"
+      act(() => {
+        textArea.dispatchEvent(new Event("input", { bubbles: false }))
+      })
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not double-process bubbling input events handled by React", () => {
+    vi.useFakeTimers()
+    try {
+      const props = getProps({ formId: "formId" })
+      const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+      render(<TextArea {...props} />)
+
+      const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+
+      // Mount call + one onChange for the bubbling input event.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+      textArea.value = "A"
+      act(() => {
+        textArea.dispatchEvent(new Event("input", { bubbles: true }))
+      })
+
+      // Flush deferred native reconciliation to verify it does not emit
+      // another synthetic change for standard bubbling input events.
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(setStringValueSpy).toHaveBeenCalledTimes(2)
+      expect(setStringValueSpy).toHaveBeenLastCalledWith(
+        props.element,
+        "A",
+        { fromUi: true },
+        undefined
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not commit programmatic blur value changes that exceed maxChars", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ maxChars: 3 })
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+    render(<TextArea {...props} />)
+
+    // First call happens on mount.
+    expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+    const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+    await user.click(textArea)
+
+    // Simulate password manager autofill with a value that violates maxChars.
+    textArea.value = "TOOLONG"
+    await user.tab()
+
+    await waitFor(() => {
+      // onBlur reconciliation should reject this value and avoid committing.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(textArea).toHaveValue("")
+  })
+
+  it("rejects over-max native programmatic changes and restores the DOM value", () => {
+    vi.useFakeTimers()
+    try {
+      const props = getProps({ formId: "formId", maxChars: 3 })
+      const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+      render(<TextArea {...props} />)
+      const textArea = screen.getByRole<HTMLTextAreaElement>("textbox")
+
+      // First call happens on mount.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+
+      textArea.value = "TOOLONG"
+      act(() => {
+        textArea.dispatchEvent(new Event("input", { bubbles: false }))
+      })
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      // Overflow value should be ignored and immediately reverted.
+      expect(setStringValueSpy).toHaveBeenCalledTimes(1)
+      expect(textArea).toHaveValue("")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("sets widget value when ctrl+enter is pressed", async () => {
     const user = userEvent.setup()
     const props = getProps()

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -32,7 +32,7 @@ import {
 } from "~lib/hooks/useBasicWidgetState"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import useOnInputChange from "~lib/hooks/useOnInputChange"
+import useStringInputHandlers from "~lib/hooks/useStringInputHandlers"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import { useTextInputAutoExpand } from "~lib/hooks/useTextInputAutoExpand"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
@@ -167,36 +167,26 @@ const TextArea: FC<Props> = ({
     dependencies: [element.placeholder, value],
   })
 
-  const commitWidgetValue = useCallback((): void => {
-    setDirty(false)
-    setValueWithSource({ value: uiValue, fromUi: true })
-  }, [uiValue, setValueWithSource])
-
-  const onBlur = useCallback(() => {
-    if (dirty) {
-      commitWidgetValue()
-    }
-    setFocused(false)
-  }, [dirty, commitWidgetValue])
-
-  const onFocus = useCallback(() => {
-    setFocused(true)
-  }, [])
-
-  const additionalAction = useCallback(() => {
+  const additionalOnChangeAction = useCallback(() => {
     if (isAutoHeight) {
       updateScrollHeight()
     }
   }, [isAutoHeight, updateScrollHeight])
 
-  const onChange = useOnInputChange({
-    formId: element.formId,
-    maxChars: element.maxChars,
-    setDirty,
-    setUiValue,
-    setValueWithSource,
-    additionalAction,
-  })
+  const { onChange, onBlur, onFocus, commitWidgetValue } =
+    useStringInputHandlers({
+      inputRef: textareaRef,
+      disabled,
+      formId: element.formId,
+      maxChars: element.maxChars,
+      uiValue,
+      dirty,
+      setDirty,
+      setUiValue,
+      setValueWithSource,
+      setFocused,
+      additionalOnChangeAction,
+    })
 
   const onKeyDown = useSubmitFormViaEnterKey(
     element.formId,
@@ -238,7 +228,7 @@ const TextArea: FC<Props> = ({
       </WidgetLabel>
 
       <UITextArea
-        inputRef={isAutoHeight ? textareaRef : undefined}
+        inputRef={textareaRef}
         value={uiValue ?? ""}
         placeholder={placeholder}
         onBlur={onBlur}


### PR DESCRIPTION
## Describe your changes

This PR improves text area handling for programmatic value changes, particularly for password manager autofill scenarios. The changes include:

- Added detection and handling of native input events that don't bubble through React's synthetic event system
- Implemented proper validation and rejection of programmatic changes that exceed `maxChars` limits
- Enhanced blur event handling to commit programmatic value changes while respecting validation rules
- Refactored text area to use the new `useStringInputHandlers` hook for consistent input handling behavior
- Added rerun counter tracking to the test application for better test verification

## Testing Plan

- **Unit Tests (JS)**: Added comprehensive test coverage for programmatic value changes, including blur handling, native input event detection, disabled state behavior, double-processing prevention, and maxChars validation
- **E2E Tests**: Added end-to-end test that simulates 1Password autofill behavior by programmatically setting values and dispatching native events, verifying the value commits without manual blur or Ctrl+Enter
- **Manual testing**: Password manager integration can be tested by using browser extensions like 1Password or LastPass to autofill text areas

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.