### PR TITLE
Wrap categorical chart legends into configurable columns

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -628,6 +628,21 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "client.chartLegendMaxColumns",
+    description="""
+        Controls how many columns Streamlit uses by default for categorical
+        chart legends (for example in `st.scatter_chart`).
+
+        Increasing this value can reduce vertical space for legends, while
+        lowering it encourages wrapping into more rows so labels are less
+        likely to overflow the available width.
+    """,
+    default_val=3,
+    type_=int,
+    scriptable=True,
+)
+
 # Config Section: Runner #
 
 _create_section("runner", "Settings for how Streamlit executes your script")

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -21,7 +21,7 @@ from datetime import date
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypedDict, cast
 
-from streamlit import dataframe_util, type_util
+from streamlit import config, dataframe_util, type_util
 from streamlit.elements.lib.color_util import (
     Color,
     is_builtin_color_name,
@@ -112,6 +112,7 @@ class ChartType(Enum):
 # NOTE #2: In theory, we could move COLOR_LEGEND_SETTINGS into
 # ArrowVegaLiteChart/CustomTheme.tsx, but this would impact existing behavior.
 # (See https://github.com/streamlit/streamlit/pull/7164#discussion_r1307707345)
+_DEFAULT_LEGEND_MAX_COLUMNS: Final = 3
 _COLOR_LEGEND_SETTINGS: Final = {"titlePadding": 5, "offset": 5, "orient": "bottom"}
 _SIZE_LEGEND_SETTINGS: Final = {"titlePadding": 0.5, "offset": 5, "orient": "bottom"}
 
@@ -131,6 +132,23 @@ _MELTED_COLOR_COLUMN_NAME: Final = _MELTED_COLOR_COLUMN_TITLE + _PROTECTION_SUFF
 # rendering bug
 # where empty charts need x, y encodings set in order to take up space.
 _NON_EXISTENT_COLUMN_NAME: Final = "DOES_NOT_EXIST" + _PROTECTION_SUFFIX
+
+
+def normalize_legend_columns(value: object) -> int:
+    """Normalize legend column counts into a safe positive integer."""
+    if isinstance(value, bool):
+        return _DEFAULT_LEGEND_MAX_COLUMNS
+    if isinstance(value, int):
+        return max(1, min(value, 12))
+    return _DEFAULT_LEGEND_MAX_COLUMNS
+
+
+def get_color_legend_settings() -> dict[str, int | str | float]:
+    """Get color legend settings including the configured column count."""
+    legend_columns = normalize_legend_columns(
+        config.get_option("client.chartLegendMaxColumns")
+    )
+    return {**_COLOR_LEGEND_SETTINGS, "columns": legend_columns}
 
 
 def maybe_raise_stack_warning(
@@ -1114,7 +1132,7 @@ def _get_color_encoding(
             return alt.Color(
                 field=color_column if color_column is not None else alt.Undefined,
                 scale=alt.Scale(domain=y_column_list, range=resolved_colors),
-                legend=_COLOR_LEGEND_SETTINGS,
+                legend=get_color_legend_settings(),
                 type="nominal",
                 title=" ",
             )
@@ -1131,7 +1149,7 @@ def _get_color_encoding(
         )
 
         color_enc = alt.Color(
-            field=color_column, legend=_COLOR_LEGEND_SETTINGS, type=column_type
+            field=color_column, legend=get_color_legend_settings(), type=column_type
         )
 
         # Fix title if DF was melted

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -35,7 +35,7 @@ from typing import (
 
 from typing_extensions import Required
 
-from streamlit import dataframe_util, type_util
+from streamlit import config, dataframe_util, type_util
 from streamlit.deprecation_util import (
     make_deprecated_name_warning,
     show_deprecation_warning,
@@ -47,6 +47,7 @@ from streamlit.elements.lib.built_in_chart_utils import (
     ChartType,
     generate_chart,
     maybe_raise_stack_warning,
+    normalize_legend_columns,
 )
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.layout_utils import (
@@ -279,6 +280,38 @@ def _patch_null_legend_titles(spec: VegaLiteSpec) -> None:
         legend["title"] = " "
 
 
+def _patch_color_legend_columns(spec: VegaLiteSpec) -> None:
+    """Apply a default column count to color legends when not user-defined."""
+    encoding = spec.get("encoding")
+    if not isinstance(encoding, dict):
+        return
+
+    color_spec = encoding.get("color")
+    if not isinstance(color_spec, dict):
+        return
+
+    # Keep quantitative gradients as-is. This patch targets categorical legends.
+    if color_spec.get("type") == "quantitative":
+        return
+
+    legend_columns = normalize_legend_columns(
+        config.get_option("client.chartLegendMaxColumns")
+    )
+    legend = color_spec.get("legend")
+
+    if legend is None:
+        color_spec["legend"] = {"columns": legend_columns}
+        return
+
+    if isinstance(legend, bool):
+        if legend:
+            color_spec["legend"] = {"columns": legend_columns}
+        return
+
+    if isinstance(legend, dict):
+        legend.setdefault("columns", legend_columns)
+
+
 def _has_nested_composition(spec: VegaLiteSpec) -> bool:
     """Check if a vconcat spec contains nested composition operators.
 
@@ -374,6 +407,7 @@ def _prepare_vega_lite_spec(
             spec["autosize"] = {"type": "fit", "contains": "padding"}
 
     _patch_null_legend_titles(spec)
+    _patch_color_legend_columns(spec)
 
     return spec
 

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -48,6 +48,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cached_message_replay
 from streamlit.type_util import is_altair_version_less_than
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.testutil import patch_config_options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1317,6 +1318,23 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
         assert "title" in legend
         assert legend["title"] == " "
 
+    def test_altair_chart_adds_default_legend_columns(self):
+        chart = (
+            alt.Chart(
+                pd.DataFrame(
+                    {"x": [1, 2, 3], "y": [4, 5, 6], "category": ["A", "B", "C"]}
+                )
+            )
+            .mark_circle()
+            .encode(x="x:Q", y="y:Q", color="category:N")
+        )
+
+        st.altair_chart(chart)
+        proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+        spec_dict = json.loads(proto.spec)
+
+        assert spec_dict["encoding"]["color"]["legend"]["columns"] == 3
+
 
 ST_CHART_ARGS = [
     (st.area_chart, "area"),
@@ -1353,6 +1371,22 @@ class BuiltInChartTest(DeltaGeneratorTestCase):
             convert_arrow_bytes_to_pandas_df(proto.datasets[0].data.data),
             EXPECTED_DATAFRAME,
         )
+
+    @patch_config_options({"client.chartLegendMaxColumns": 2})
+    def test_scatter_chart_legend_columns_respect_config(self):
+        df = pd.DataFrame(
+            {
+                "x": [1, 2, 3, 4],
+                "y": [10, 11, 12, 13],
+                "group": ["alpha", "beta", "gamma", "delta"],
+            }
+        )
+
+        st.scatter_chart(df, x="x", y="y", color="group")
+        proto = self.get_delta_from_queue().new_element.arrow_vega_lite_chart
+        chart_spec = json.loads(proto.spec)
+
+        assert chart_spec["encoding"]["color"]["legend"]["columns"] == 2
 
     @parameterized.expand(ST_CHART_ARGS)
     def test_chart_with_implicit_x_and_y(


### PR DESCRIPTION
## Describe your changes
- Added a new client config option to control default legend column count for categorical chart legends.
- Applied legend column patching for Vega/Altair color legends when columns are not user-defined.
- Updated built-in chart legend generation to use the same configurable column behavior, improving long legend readability for scatter charts.
## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8204
## Testing Plan

- Explanation of why no additional tests are needed: Added backend spec-level tests that assert legend column behavior.
- Unit Tests (JS and/or Python): Added/updated tests in: lib/tests/streamlit/elements/vega_charts_test.py
- E2E Tests: Not run.
- Any manual testing needed?: Recommended: render st.scatter_chart with many categories and verify legend wraps into multiple rows.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
