### PR TITLE
Bind widgets to query params - `st.radio` & `st.selectbox`

### DIFF
--- a/e2e_playwright/st_radio.py
+++ b/e2e_playwright/st_radio.py
@@ -174,3 +174,31 @@ else:
         format_func=lambda x: x.capitalize(),
     )
     st.write("Initial radio value:", dr_value)
+
+# --- Bound widgets (query-params) ---
+
+v_bound = st.radio(
+    "Bound radio",
+    ["cat", "dog", "bird"],
+    key="bound_radio",
+    bind="query-params",
+)
+st.write("bound radio value:", v_bound)
+
+v_bound_fmt = st.radio(
+    "Bound formatted",
+    ["cat", "dog"],
+    format_func=str.upper,
+    key="bound_radio_fmt",
+    bind="query-params",
+)
+st.write("bound radio fmt value:", v_bound_fmt)
+
+v_bound_clear = st.radio(
+    "Bound clearable",
+    ["red", "green", "blue"],
+    index=None,
+    key="bound_radio_clear",
+    bind="query-params",
+)
+st.write("bound radio clear value:", v_bound_clear)

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -295,6 +295,9 @@ def test_radio_query_param_seeding(page: Page, app_port: int):
     wait_for_app_loaded(page)
 
     expect_prefixed_markdown(page, "bound radio value:", "dog")
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio_fmt="))
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio_clear="))
 
 
 def test_radio_query_param_updates_url(app: Page):
@@ -330,6 +333,9 @@ def test_radio_query_param_invalid_value(page: Page, app_port: int):
     # Widget should show default value ("cat"), invalid param should be cleared
     expect_prefixed_markdown(page, "bound radio value:", "cat")
     expect(page).not_to_have_url(re.compile(r"[?&]bound_radio="))
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio_fmt="))
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio_clear="))
 
 
 def test_radio_query_param_format_func(page: Page, app_port: int):

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -16,7 +16,11 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -29,7 +33,7 @@ from e2e_playwright.shared.app_utils import (
     select_radio_option,
 )
 
-NUM_RADIO_ELEMENTS = 18
+NUM_RADIO_ELEMENTS = 21
 
 
 def test_radio_widget_rendering(
@@ -280,3 +284,87 @@ def test_dynamic_radio_props(app: Page, assert_snapshot: ImageCompareFunction):
     # Selection should be PRESERVED since "mango" is in both option sets
     # If this was reset, it would show "apple" (initial default), not "mango"
     expect_prefixed_markdown(app, "Initial radio value:", "mango")
+
+
+# --- Query param binding tests ---
+
+
+def test_radio_query_param_seeding(page: Page, app_port: int):
+    """Test that radio value can be seeded from URL query params."""
+    page.goto(f"http://localhost:{app_port}/?bound_radio=dog")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound radio value:", "dog")
+
+
+def test_radio_query_param_updates_url(app: Page):
+    """Test that changing a bound radio updates the URL."""
+    select_radio_option(app, option="dog", label="Bound radio")
+    wait_for_app_run(app)
+
+    expect(app).to_have_url(re.compile(r"[?&]bound_radio=dog"))
+    expect_prefixed_markdown(app, "bound radio value:", "dog")
+
+
+def test_radio_query_param_default_override(page: Page, app_port: int):
+    """Test radio with query param: seed then revert to default clears param."""
+    page.goto(f"http://localhost:{app_port}/?bound_radio=bird")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound radio value:", "bird")
+
+    # Change back to default ("cat", index 0)
+    select_radio_option(page, option="cat", label="Bound radio")
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio="))
+    expect_prefixed_markdown(page, "bound radio value:", "cat")
+
+
+def test_radio_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    page.goto(f"http://localhost:{app_port}/?bound_radio=invalid_option")
+    wait_for_app_loaded(page)
+
+    # Widget should show default value ("cat"), invalid param should be cleared
+    expect_prefixed_markdown(page, "bound radio value:", "cat")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio="))
+
+
+def test_radio_query_param_format_func(page: Page, app_port: int):
+    """Test that formatted option string works in URL."""
+    # The format_func is str.upper, so options in URL are "CAT" and "DOG"
+    page.goto(f"http://localhost:{app_port}/?bound_radio_fmt=DOG")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound radio fmt value:", "dog")
+
+
+def test_radio_query_param_clearable_empty_value(page: Page, app_port: int):
+    """Test that empty URL value clears a clearable radio to None."""
+    page.goto(f"http://localhost:{app_port}/?bound_radio_clear=")
+    wait_for_app_loaded(page)
+
+    # Clearable radio should accept the empty value and show None
+    expect_prefixed_markdown(page, "bound radio clear value:", "None")
+
+
+def test_radio_query_param_clearable_invalid_value(page: Page, app_port: int):
+    """Test that invalid value on clearable radio resets to None default."""
+    page.goto(f"http://localhost:{app_port}/?bound_radio_clear=invalid")
+    wait_for_app_loaded(page)
+
+    # Invalid value should reset to default (None for clearable widget)
+    expect_prefixed_markdown(page, "bound radio clear value:", "None")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio_clear="))
+
+
+def test_radio_query_param_non_clearable_empty_value(page: Page, app_port: int):
+    """Test that empty URL value is rejected for non-clearable radio."""
+    page.goto(f"http://localhost:{app_port}/?bound_radio=")
+    wait_for_app_loaded(page)
+
+    # Non-clearable radio should reject empty value, show default "cat"
+    expect_prefixed_markdown(page, "bound radio value:", "cat")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_radio="))

--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -204,3 +204,22 @@ v20 = st.selectbox(
     key="selectbox20",
 )
 st.write("value 20:", v20)
+
+# --- Bound widgets (query-params) ---
+
+v_bound = st.selectbox(
+    "Bound selectbox",
+    ["cat", "dog", "bird"],
+    key="bound_select",
+    bind="query-params",
+)
+st.write("bound select value:", v_bound)
+
+v_bound_clear = st.selectbox(
+    "Bound clearable",
+    ["red", "green", "blue"],
+    index=None,
+    key="bound_select_clear",
+    bind="query-params",
+)
+st.write("bound select clear value:", v_bound_clear)

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -248,6 +248,8 @@ def test_handles_callback_on_change_correctly(app: Page):
     empty_selectbox_input.type("female")
     empty_selectbox_input.press("Enter")
 
+    wait_for_app_run(app)
+
     expect_markdown(app, "value 1: female")
     expect_markdown(app, "value 8: male")
     expect_markdown(app, "selectbox changed: False")

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -479,6 +479,8 @@ def test_selectbox_query_param_seeding(page: Page, app_port: int):
     wait_for_app_loaded(page)
 
     expect_prefixed_markdown(page, "bound select value:", "dog")
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_select_clear="))
 
 
 def test_selectbox_query_param_updates_url(app: Page):
@@ -514,6 +516,8 @@ def test_selectbox_query_param_invalid_value(page: Page, app_port: int):
     # Widget should show default value ("cat"), invalid param should be cleared
     expect_prefixed_markdown(page, "bound select value:", "cat")
     expect(page).not_to_have_url(re.compile(r"[?&]bound_select="))
+    # Guard against cross-widget pollution
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_select_clear="))
 
 
 def test_selectbox_query_param_clearable(page: Page, app_port: int):

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from playwright.sync_api import Locator, Page, expect
 
+from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     from e2e_playwright.conftest import ImageCompareFunction
 
 
-NUM_SELECTBOXES = 21
+NUM_SELECTBOXES = 23
 
 
 def get_selectbox_input(
@@ -467,3 +468,86 @@ def test_selectbox_session_state_sync_after_open_close(app: Page):
     # The selectbox should still display "female" (not revert to initial "male")
     expect(selectbox.get_by_text("female", exact=True)).to_be_visible()
     expect_markdown(app, "value 20: female")
+
+
+# --- Query param binding tests ---
+
+
+def test_selectbox_query_param_seeding(page: Page, app_port: int):
+    """Test that selectbox value can be seeded from URL query params."""
+    page.goto(f"http://localhost:{app_port}/?bound_select=dog")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound select value:", "dog")
+
+
+def test_selectbox_query_param_updates_url(app: Page):
+    """Test that changing a bound selectbox updates the URL."""
+    select_selectbox_option(app, option="dog", label="Bound selectbox")
+    wait_for_app_run(app)
+
+    expect(app).to_have_url(re.compile(r"[?&]bound_select=dog"))
+    expect_prefixed_markdown(app, "bound select value:", "dog")
+
+
+def test_selectbox_query_param_default_override(page: Page, app_port: int):
+    """Test selectbox with query param: seed then revert to default clears param."""
+    page.goto(f"http://localhost:{app_port}/?bound_select=bird")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound select value:", "bird")
+
+    # Change back to default ("cat", index 0)
+    select_selectbox_option(page, option="cat", label="Bound selectbox")
+    wait_for_app_run(page)
+
+    # Query param should be removed since value is back to default
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_select="))
+    expect_prefixed_markdown(page, "bound select value:", "cat")
+
+
+def test_selectbox_query_param_invalid_value(page: Page, app_port: int):
+    """Test that invalid URL values are cleared and widget uses default."""
+    page.goto(f"http://localhost:{app_port}/?bound_select=invalid_option")
+    wait_for_app_loaded(page)
+
+    # Widget should show default value ("cat"), invalid param should be cleared
+    expect_prefixed_markdown(page, "bound select value:", "cat")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_select="))
+
+
+def test_selectbox_query_param_clearable(page: Page, app_port: int):
+    """Test that clearable selectbox can be seeded from URL."""
+    page.goto(f"http://localhost:{app_port}/?bound_select_clear=green")
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "bound select clear value:", "green")
+
+
+def test_selectbox_query_param_clearable_empty_value(page: Page, app_port: int):
+    """Test that empty URL value clears a clearable selectbox to None."""
+    page.goto(f"http://localhost:{app_port}/?bound_select_clear=")
+    wait_for_app_loaded(page)
+
+    # Clearable selectbox should accept the empty value and show None
+    expect_prefixed_markdown(page, "bound select clear value:", "None")
+
+
+def test_selectbox_query_param_clearable_invalid_value(page: Page, app_port: int):
+    """Test that invalid value on clearable selectbox resets to None default."""
+    page.goto(f"http://localhost:{app_port}/?bound_select_clear=invalid")
+    wait_for_app_loaded(page)
+
+    # Invalid value should reset to default (None for clearable widget)
+    expect_prefixed_markdown(page, "bound select clear value:", "None")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_select_clear="))
+
+
+def test_selectbox_query_param_non_clearable_empty_value(page: Page, app_port: int):
+    """Test that empty URL value is rejected for non-clearable selectbox."""
+    page.goto(f"http://localhost:{app_port}/?bound_select=")
+    wait_for_app_loaded(page)
+
+    # Non-clearable selectbox should reject empty value, show default "cat"
+    expect_prefixed_markdown(page, "bound select value:", "cat")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_select="))

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -228,3 +228,67 @@ describe("Radio widget", () => {
     )
   })
 })
+
+describe("Radio query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_radio" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Radio {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_radio",
+      "string_value",
+      "a",
+      false,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_radio" })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<Radio {...props} />)
+
+    // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Radio {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers with clearable=true when no default", () => {
+    const props = getProps({ queryParamKey: "my_radio", default: null })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Radio {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_radio",
+      "string_value",
+      null,
+      true,
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.tsx
@@ -49,6 +49,14 @@ function Radio({
   widgetMgr,
   fragmentId,
 }: Readonly<Props>): ReactElement {
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "string_value" as const,
+        clearable: isNullOrUndefined(element.default),
+      }
+    : undefined
+
   const [value, setValueWithSource] = useBasicWidgetState<
     RadioValue,
     RadioProto
@@ -60,6 +68,7 @@ function Radio({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding,
   })
 
   const { horizontal, options, captions, label, labelVisibility, help } =

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -178,3 +178,67 @@ describe("Selectbox widget", () => {
     expect(screen.getByText("Please select an option...")).toBeInTheDocument()
   })
 })
+
+describe("Selectbox query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_select" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Selectbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_select",
+      "string_value",
+      "a",
+      false,
+      undefined,
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_select" })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<Selectbox {...props} />)
+
+    // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Selectbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+
+  it("registers with clearable=true when no default", () => {
+    const props = getProps({ queryParamKey: "my_select", default: null })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Selectbox {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_select",
+      "string_value",
+      null,
+      true,
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -88,6 +88,15 @@ const Selectbox: FC<Props> = ({
     placeholder,
     acceptNewOptions,
   } = element
+
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "string_value" as const,
+        clearable: isNullOrUndefined(element.default),
+      }
+    : undefined
+
   const [value, setValueWithSource] = useBasicWidgetState<
     SelectboxValue,
     SelectboxProto
@@ -99,6 +108,7 @@ const Selectbox: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding,
   })
 
   const onChange = useCallback(

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -515,8 +515,12 @@ class RadioMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
-            # Clearable when index=None
+            # Clearable when index=None: the widget can be in an empty state,
+            # so ?key= (empty URL param) should clear the widget to None.
             clearable=(index is None),
+            # Pass formatted_options so _seed_widget_from_url can reject
+            # invalid option strings from URLs (e.g., ?size=Random).
+            formatted_options=formatted_options,
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)
 

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -48,6 +48,7 @@ from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -155,6 +156,7 @@ class RadioMixin:
         captions: Sequence[str] | None = None,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> None: ...
 
     @overload
@@ -175,6 +177,7 @@ class RadioMixin:
         captions: Sequence[str] | None = None,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> T: ...
 
     @overload
@@ -195,6 +198,7 @@ class RadioMixin:
         captions: Sequence[str] | None = None,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> T | None: ...
 
     @gather_metrics("radio")
@@ -215,6 +219,7 @@ class RadioMixin:
         captions: Sequence[str] | None = None,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> T | None:
         r"""Display a radio button widget.
 
@@ -317,6 +322,14 @@ class RadioMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            Enables two-way binding between the widget value and the URL
+            query string. When set to ``"query-params"``, the widget's
+            ``key`` is used as the URL parameter name. Requires ``key``
+            to be set. The URL displays the formatted option string
+            (e.g., ``?color=Red``). Invalid URL values are reset to the
+            default option and removed from the URL.
+
         Returns
         -------
         any
@@ -379,6 +392,7 @@ class RadioMixin:
             horizontal=horizontal,
             captions=captions,
             label_visibility=label_visibility,
+            bind=bind,
             ctx=ctx,
             width=width,
         )
@@ -399,7 +413,8 @@ class RadioMixin:
         horizontal: bool = False,
         label_visibility: LabelVisibility = "visible",
         captions: Sequence[str] | None = None,
-        ctx: ScriptRunContext | None,
+        bind: BindOption = None,
+        ctx: ScriptRunContext | None = None,
         width: Width = "content",
     ) -> T | None:
         key = to_key(key)
@@ -478,6 +493,10 @@ class RadioMixin:
         if help is not None:
             radio_proto.help = dedent(help)
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            radio_proto.query_param_key = str(key)
+
         serde = RadioSerde(
             opt,
             formatted_options=formatted_options,
@@ -495,6 +514,8 @@ class RadioMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_value",
+            bind=bind,
+            clearable=(index is None),
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)
 

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -515,6 +515,7 @@ class RadioMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            # Clearable when index=None
             clearable=(index is None),
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -638,6 +638,7 @@ class SelectboxMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            # Clearable when index=None
             clearable=(index is None),
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -638,8 +638,13 @@ class SelectboxMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
-            # Clearable when index=None
+            # Clearable when index=None: the widget can be in an empty state,
+            # so ?key= (empty URL param) should clear the widget to None.
             clearable=(index is None),
+            # Pass formatted_options so _seed_widget_from_url can reject
+            # invalid option strings from URLs. Not passed when
+            # accept_new_options=True since any string is valid.
+            formatted_options=None if accept_new_options else formatted_options,
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)
 

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -55,6 +55,7 @@ from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -186,6 +187,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[False] = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> None: ...  # Returns None if options is empty and accept_new_options is False
 
     @overload
@@ -206,6 +208,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[False] = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T: ...
 
     @overload
@@ -226,6 +229,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[True] = True,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | str: ...
 
     @overload
@@ -246,6 +250,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[False] = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | None: ...
 
     @overload
@@ -266,6 +271,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[True] = True,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | str | None: ...
 
     @overload
@@ -286,6 +292,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: bool = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | str | None: ...
 
     @gather_metrics("selectbox")
@@ -306,6 +313,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: bool = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | str | None:
         r"""Display a select widget.
 
@@ -420,6 +428,14 @@ class SelectboxMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            Enables two-way binding between the widget value and the URL
+            query string. When set to ``"query-params"``, the widget's
+            ``key`` is used as the URL parameter name. Requires ``key``
+            to be set. The URL displays the formatted option string
+            (e.g., ``?color=Red``). Invalid URL values are reset to the
+            default option and removed from the URL.
+
         Returns
         -------
         any
@@ -504,6 +520,7 @@ class SelectboxMixin:
             label_visibility=label_visibility,
             accept_new_options=accept_new_options,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -524,6 +541,7 @@ class SelectboxMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: bool = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> T | str | None:
         key = to_key(key)
@@ -599,6 +617,10 @@ class SelectboxMixin:
         if help is not None:
             selectbox_proto.help = dedent(help)
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            selectbox_proto.query_param_key = str(key)
+
         serde = SelectboxSerde(
             opt,
             formatted_options=formatted_options,
@@ -615,6 +637,8 @@ class SelectboxMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_value",
+            bind=bind,
+            clearable=(index is None),
         )
         widget_state = maybe_coerce_enum(widget_state, options, opt)
 

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -154,10 +154,11 @@ class WidgetMetadata(Generic[T]):
     # Optional binding for the widget's value to external state (e.g. query params)
     bind: BindOption = None
 
-    # TODO(query-params): Remove formatted_options once all selection widgets use
-    # string-based wire formats (string_value/string_array_value).
-    # Currently used for query param binding to convert indices back to human-readable
-    # option strings in URLs when auto-correcting filtered values.
+    # The list of valid formatted option strings for selection widgets.
+    # When set, _seed_widget_from_url validates URL values against this list and
+    # rejects any that aren't valid options (e.g., ?foo=invalid). Widgets with a fixed set
+    # of options (radio, selectbox) pass this; widgets that accept arbitrary values (selectbox
+    # with accept_new_options=True) should not, since any string is valid.
     formatted_options: list[str] | None = None
 
     # Whether the widget can be cleared to an empty state (reflects widget's UI behavior).

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1048,6 +1048,20 @@ class SessionState:
                 self._clear_url_param(user_key)
                 return False
 
+            # For string_value selection widgets (radio, selectbox), validate
+            # that the parsed URL value is a known option. The deserializer
+            # passes unknown options through as-is (needed for dynamic option
+            # changes and accept_new_options), so we check here instead.
+            # Widgets opt in by passing formatted_options to register_widget.
+            if (
+                metadata.formatted_options is not None
+                and metadata.value_type == "string_value"
+                and isinstance(parsed_value, str)
+                and parsed_value not in metadata.formatted_options
+            ):
+                self._clear_url_param(user_key)
+                return False
+
             # Store the value in widget and session state
             self._new_widget_state.set_from_value(widget_id, deserialized_value)
             self._new_session_state[user_key] = deserialized_value

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -23,7 +23,7 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.testing.v1.app_test import AppTest
 from streamlit.testing.v1.util import patch_config_options
@@ -677,3 +677,56 @@ def test_custom_objects_without_eq() -> None:
     # Verify it didn't reset to None or become invalid
     assert at.radio[0].value is not None
     assert "Selected: opt_a" in at.text[0].value
+
+
+class RadioBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for radio bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.radio("the label", ["a", "b", "c"], key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.radio
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.radio("the label", ["a", "b", "c"], bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.radio("the label", ["a", "b", "c"], key="my_key")
+
+        c = self.get_delta_from_queue().new_element.radio
+        assert c.query_param_key == ""
+        assert c.label == "the label"
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.radio("the label", ["a", "b"], key="my_key", bind="invalid-value")
+
+    def test_bind_with_format_func(self):
+        """Test that bind works with format_func."""
+        st.radio(
+            "the label",
+            ["cat", "dog"],
+            format_func=str.upper,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.radio
+        assert c.query_param_key == "my_key"
+        assert list(c.options) == ["CAT", "DOG"]
+
+    def test_bind_with_index_none(self):
+        """Test that bind works with index=None (clearable)."""
+        st.radio(
+            "the label", ["a", "b", "c"], index=None, key="my_key", bind="query-params"
+        )
+
+        c = self.get_delta_from_queue().new_element.radio
+        assert c.query_param_key == "my_key"
+        assert not c.HasField("default")

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -25,7 +25,11 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.elements.lib.options_selector_utils import create_mappings
 from streamlit.elements.widgets.selectbox import SelectboxSerde
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidWidthError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidBindValueError,
+    StreamlitInvalidWidthError,
+)
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.testing.v1.app_test import AppTest
 from streamlit.testing.v1.util import patch_config_options
@@ -850,3 +854,74 @@ class TestSelectboxSerde:
         # This should work correctly using format_func comparison
         res = serde.serialize(deepcopied_value)
         assert res == "a"
+
+
+class SelectboxBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for selectbox bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.selectbox("the label", ["a", "b", "c"], key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.selectbox("the label", ["a", "b", "c"], bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.selectbox("the label", ["a", "b", "c"], key="my_key")
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.query_param_key == ""
+        assert c.label == "the label"
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.selectbox("the label", ["a", "b"], key="my_key", bind="invalid-value")
+
+    def test_bind_with_format_func(self):
+        """Test that bind works with format_func."""
+        st.selectbox(
+            "the label",
+            ["cat", "dog"],
+            format_func=str.upper,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.query_param_key == "my_key"
+        assert list(c.options) == ["CAT", "DOG"]
+
+    def test_bind_with_index_none(self):
+        """Test that bind works with index=None (clearable)."""
+        st.selectbox(
+            "the label",
+            ["a", "b", "c"],
+            index=None,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.query_param_key == "my_key"
+        assert not c.HasField("default")
+
+    def test_bind_with_accept_new_options(self):
+        """Test that bind works with accept_new_options=True."""
+        st.selectbox(
+            "the label",
+            ["a", "b", "c"],
+            key="my_key",
+            bind="query-params",
+            accept_new_options=True,
+        )
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.query_param_key == "my_key"
+        assert c.accept_new_options

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1800,6 +1800,56 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         # URL param should be cleared (not left as stale ?range=)
         assert "range" not in self.query_params._query_params
 
+    def test_formatted_options_rejects_invalid_option(self) -> None:
+        """Test that invalid option is rejected when formatted_options is set."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            formatted_options=["Small", "Medium", "Large"],
+        )
+        self.query_params._query_params["size"] = "Random"
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "size", "widget_1", "Random"
+        )
+
+        assert seeded is False
+        assert "widget_1" not in self.session_state._new_widget_state
+        assert "size" not in self.query_params._query_params
+
+    def test_formatted_options_accepts_valid_option(self) -> None:
+        """Test that valid option is accepted when formatted_options is set."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            formatted_options=["Small", "Medium", "Large"],
+        )
+        self.query_params._query_params["size"] = "Medium"
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "size", "widget_1", "Medium"
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == "Medium"
+
+    def test_no_formatted_options_accepts_any_string(self) -> None:
+        """Test that any string is accepted when formatted_options is None.
+
+        This is the behavior for widgets like text_input, or selectbox
+        with accept_new_options=True.
+        """
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            formatted_options=None,
+        )
+        self.query_params._query_params["text"] = "anything"
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "text", "widget_1", "anything"
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == "anything"
+
 
 class AutoCorrectUrlTest(DeltaGeneratorTestCase):
     """Tests for _auto_correct_url_if_needed method."""

--- a/lib/tests/streamlit/typing/radio_types.py
+++ b/lib/tests/streamlit/typing/radio_types.py
@@ -45,3 +45,9 @@ if TYPE_CHECKING:
     assert_type(radio("foo", [Alfred.HITCHCOCK, Alfred.GREENE]), Alfred)
     assert_type(radio("foo", Alfred, index=None), Alfred | None)
     assert_type(radio("foo", [1, Alfred.HITCHCOCK, "five"], index=None), object)
+
+    # Check bind parameter
+    assert_type(radio("foo", ["a", "b"], bind="query-params"), str)
+    assert_type(radio("foo", [1, 2, 3], bind="query-params"), int)
+    assert_type(radio("foo", ["a", "b"], bind=None), str)
+    assert_type(radio("foo", ["a", "b"], index=None, bind="query-params"), str | None)

--- a/lib/tests/streamlit/typing/selectbox_types.py
+++ b/lib/tests/streamlit/typing/selectbox_types.py
@@ -68,3 +68,11 @@ if TYPE_CHECKING:
         ),
         Alfred | str | None,
     )
+
+    # Check bind parameter
+    assert_type(selectbox("foo", ["a", "b"], bind="query-params"), str)
+    assert_type(selectbox("foo", [1, 2, 3], bind="query-params"), int)
+    assert_type(selectbox("foo", ["a", "b"], bind=None), str)
+    assert_type(
+        selectbox("foo", ["a", "b"], index=None, bind="query-params"), str | None
+    )

--- a/proto/streamlit/proto/Radio.proto
+++ b/proto/streamlit/proto/Radio.proto
@@ -32,6 +32,9 @@ message Radio {
   bool horizontal = 10;
   LabelVisibility label_visibility = 11;
   repeated string captions = 12;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 14;
 
   reserved 7;
+  // Next: 15
 }

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -31,6 +31,9 @@ message Selectbox {
   LabelVisibility label_visibility = 10;
   string placeholder = 11;
   optional bool accept_new_options = 12;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 14;
 
   reserved 7;
+  // Next: 16
 }

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -35,5 +35,5 @@ message Selectbox {
   optional string query_param_key = 14;
 
   reserved 7;
-  // Next: 16
+  // Next: 15
 }


### PR DESCRIPTION
## Describe your changes
Adds the bind parameter to `st.radio` & `st.selectbox` to enable two-way sync between widget values and URL query parameters.

**Key changes:**
- Added `bind="query-params"` support to `st.radio` and `st.selectbox`
- Added centralized validation in `_seed_widget_from_url` to reject invalid URL option strings by checking against `formatted_options`. This ensures that invalid query params (e.g., `?size=Random` for a radio with options `["Small", "Medium", "Large"]`) are removed from the URL and the widget falls back to its default. This replaces the previous TODO on `formatted_options` in `WidgetMetadata`
- Clearability is tied to `index=None`: when the widget is registered with no default selection, an empty URL param (`?key=`) clears the widget to `None`. When `index` is set, empty URL params are ignored.
- For `st.selectbox` with `accept_new_options=True`, `formatted_options` is intentionally not passed, so any string value from the URL is accepted.
- `format_func` is handled naturally: the URL contains formatted option strings (what the user sees), and validation checks against the same formatted list.


## Testing Plan
- JS & Python Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 