### PR TITLE
Add typing tests for `chat_input` and `audio_input`

### DIFF
--- a/lib/tests/streamlit/typing/audio_input_types.py
+++ b/lib/tests/streamlit/typing/audio_input_types.py
@@ -1,0 +1,181 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform type checking tests for st.audio_input
+# The return type is always UploadedFile | None
+if TYPE_CHECKING:
+    from streamlit.elements.widgets.audio_input import AudioInputMixin
+    from streamlit.runtime.uploaded_file_manager import UploadedFile
+
+    audio_input = AudioInputMixin().audio_input
+
+    # =====================================================================
+    # Basic return type tests
+    # =====================================================================
+
+    assert_type(audio_input("Record audio"), UploadedFile | None)
+
+    # =====================================================================
+    # Test sample_rate parameter
+    # =====================================================================
+
+    # Default sample rate (16000)
+    assert_type(audio_input("Record audio", sample_rate=16000), UploadedFile | None)
+
+    # Other valid sample rates
+    assert_type(audio_input("Record audio", sample_rate=8000), UploadedFile | None)
+    assert_type(audio_input("Record audio", sample_rate=11025), UploadedFile | None)
+    assert_type(audio_input("Record audio", sample_rate=22050), UploadedFile | None)
+    assert_type(audio_input("Record audio", sample_rate=24000), UploadedFile | None)
+    assert_type(audio_input("Record audio", sample_rate=32000), UploadedFile | None)
+    assert_type(audio_input("Record audio", sample_rate=44100), UploadedFile | None)
+    assert_type(audio_input("Record audio", sample_rate=48000), UploadedFile | None)
+
+    # None for browser default
+    assert_type(audio_input("Record audio", sample_rate=None), UploadedFile | None)
+
+    # =====================================================================
+    # Test key parameter (str or int)
+    # =====================================================================
+
+    assert_type(audio_input("Record audio", key="audio_key"), UploadedFile | None)
+    assert_type(audio_input("Record audio", key=123), UploadedFile | None)
+    assert_type(audio_input("Record audio", key=None), UploadedFile | None)
+
+    # =====================================================================
+    # Test help parameter
+    # =====================================================================
+
+    assert_type(
+        audio_input("Record audio", help="Click to start recording"),
+        UploadedFile | None,
+    )
+    assert_type(audio_input("Record audio", help=None), UploadedFile | None)
+
+    # =====================================================================
+    # Test disabled parameter
+    # =====================================================================
+
+    assert_type(audio_input("Record audio", disabled=True), UploadedFile | None)
+    assert_type(audio_input("Record audio", disabled=False), UploadedFile | None)
+
+    # =====================================================================
+    # Test label_visibility parameter
+    # =====================================================================
+
+    assert_type(
+        audio_input("Record audio", label_visibility="visible"), UploadedFile | None
+    )
+    assert_type(
+        audio_input("Record audio", label_visibility="hidden"), UploadedFile | None
+    )
+    assert_type(
+        audio_input("Record audio", label_visibility="collapsed"), UploadedFile | None
+    )
+
+    # =====================================================================
+    # Test width parameter
+    # =====================================================================
+
+    assert_type(audio_input("Record audio", width="stretch"), UploadedFile | None)
+    assert_type(audio_input("Record audio", width=400), UploadedFile | None)
+
+    # =====================================================================
+    # Test callback parameters (on_change, args, kwargs)
+    # =====================================================================
+
+    def my_callback() -> None:
+        pass
+
+    def callback_with_args(x: int, y: str) -> None:
+        pass
+
+    assert_type(audio_input("Record audio", on_change=my_callback), UploadedFile | None)
+    assert_type(
+        audio_input("Record audio", on_change=callback_with_args, args=(1, "test")),
+        UploadedFile | None,
+    )
+    assert_type(
+        audio_input(
+            "Record audio", on_change=callback_with_args, kwargs={"x": 1, "y": "a"}
+        ),
+        UploadedFile | None,
+    )
+    assert_type(audio_input("Record audio", on_change=None), UploadedFile | None)
+
+    # =====================================================================
+    # Test with all parameters combined
+    # =====================================================================
+
+    assert_type(
+        audio_input(
+            "Full audio input",
+            sample_rate=44100,
+            key="full_audio",
+            help="Record your voice message",
+            on_change=my_callback,
+            args=None,
+            kwargs=None,
+            disabled=False,
+            label_visibility="visible",
+            width="stretch",
+        ),
+        UploadedFile | None,
+    )
+
+    # =====================================================================
+    # Test with all parameters combined (different values)
+    # =====================================================================
+
+    assert_type(
+        audio_input(
+            "High quality recording",
+            sample_rate=48000,
+            key=42,
+            help="This records in high fidelity",
+            on_change=callback_with_args,
+            args=(1, "audio"),
+            kwargs=None,
+            disabled=True,
+            label_visibility="hidden",
+            width=500,
+        ),
+        UploadedFile | None,
+    )
+
+    # =====================================================================
+    # Test with browser default sample rate
+    # =====================================================================
+
+    assert_type(
+        audio_input(
+            "Browser default audio",
+            sample_rate=None,
+            key="browser_default",
+            help=None,
+            on_change=None,
+            args=None,
+            kwargs=None,
+            disabled=False,
+            label_visibility="collapsed",
+            width=300,
+        ),
+        UploadedFile | None,
+    )

--- a/lib/tests/streamlit/typing/chat_input_types.py
+++ b/lib/tests/streamlit/typing/chat_input_types.py
@@ -1,0 +1,268 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform type checking tests for st.chat_input
+# The return type depends on accept_file and accept_audio parameters:
+# - accept_file=False and accept_audio=False (default) -> returns str | None
+# - accept_file=True/multiple/directory OR accept_audio=True -> returns ChatInputValue | None
+if TYPE_CHECKING:
+    from streamlit.elements.widgets.chat import ChatInputValue, ChatMixin
+
+    chat_input = ChatMixin().chat_input
+
+    # =====================================================================
+    # Basic return type tests based on accept_file and accept_audio
+    # =====================================================================
+
+    # Default (no file/audio acceptance) returns str | None
+    assert_type(chat_input(), str | None)
+    assert_type(chat_input("Your message"), str | None)
+    assert_type(chat_input(placeholder="Ask me anything"), str | None)
+
+    # accept_file=False explicitly still returns str | None
+    assert_type(chat_input("Message", accept_file=False), str | None)
+    assert_type(
+        chat_input("Message", accept_file=False, accept_audio=False), str | None
+    )
+
+    # accept_file=True returns ChatInputValue | None
+    assert_type(chat_input("Message", accept_file=True), ChatInputValue | None)
+
+    # accept_file="multiple" returns ChatInputValue | None
+    assert_type(chat_input("Message", accept_file="multiple"), ChatInputValue | None)
+
+    # accept_file="directory" returns ChatInputValue | None
+    assert_type(chat_input("Message", accept_file="directory"), ChatInputValue | None)
+
+    # accept_audio=True returns ChatInputValue | None
+    assert_type(chat_input("Message", accept_audio=True), ChatInputValue | None)
+
+    # Both accept_file and accept_audio enabled returns ChatInputValue | None
+    assert_type(
+        chat_input("Message", accept_file=True, accept_audio=True),
+        ChatInputValue | None,
+    )
+    assert_type(
+        chat_input("Message", accept_file="multiple", accept_audio=True),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test key parameter (str or int)
+    # =====================================================================
+
+    assert_type(chat_input("Message", key="chat_key"), str | None)
+    assert_type(chat_input("Message", key=123), str | None)
+    assert_type(chat_input("Message", key=None), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, key="chat_key"), ChatInputValue | None
+    )
+
+    # =====================================================================
+    # Test max_chars parameter
+    # =====================================================================
+
+    assert_type(chat_input("Message", max_chars=500), str | None)
+    assert_type(chat_input("Message", max_chars=None), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, max_chars=1000), ChatInputValue | None
+    )
+
+    # =====================================================================
+    # Test max_upload_size parameter
+    # =====================================================================
+
+    assert_type(chat_input("Message", max_upload_size=10), str | None)
+    assert_type(chat_input("Message", max_upload_size=None), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, max_upload_size=50),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test file_type parameter
+    # =====================================================================
+
+    assert_type(chat_input("Message", file_type="csv"), str | None)
+    assert_type(chat_input("Message", file_type=["jpg", "png"]), str | None)
+    assert_type(chat_input("Message", file_type=None), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, file_type="pdf"), ChatInputValue | None
+    )
+    assert_type(
+        chat_input("Message", accept_file="multiple", file_type=["doc", "docx"]),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test audio_sample_rate parameter (only with accept_audio=True)
+    # =====================================================================
+
+    assert_type(
+        chat_input("Message", accept_audio=True, audio_sample_rate=16000),
+        ChatInputValue | None,
+    )
+    assert_type(
+        chat_input("Message", accept_audio=True, audio_sample_rate=44100),
+        ChatInputValue | None,
+    )
+    assert_type(
+        chat_input("Message", accept_audio=True, audio_sample_rate=None),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test disabled parameter
+    # =====================================================================
+
+    assert_type(chat_input("Message", disabled=True), str | None)
+    assert_type(chat_input("Message", disabled=False), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, disabled=True), ChatInputValue | None
+    )
+
+    # =====================================================================
+    # Test width parameter
+    # =====================================================================
+
+    assert_type(chat_input("Message", width="stretch"), str | None)
+    assert_type(chat_input("Message", width=400), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, width="stretch"), ChatInputValue | None
+    )
+    assert_type(
+        chat_input("Message", accept_file=True, width=500), ChatInputValue | None
+    )
+
+    # =====================================================================
+    # Test callback parameters (on_submit, args, kwargs)
+    # =====================================================================
+
+    def my_callback() -> None:
+        pass
+
+    def callback_with_args(x: int, y: str) -> None:
+        pass
+
+    assert_type(chat_input("Message", on_submit=my_callback), str | None)
+    assert_type(
+        chat_input("Message", on_submit=callback_with_args, args=(1, "test")),
+        str | None,
+    )
+    assert_type(
+        chat_input("Message", on_submit=callback_with_args, kwargs={"x": 1, "y": "a"}),
+        str | None,
+    )
+    assert_type(chat_input("Message", on_submit=None), str | None)
+    assert_type(
+        chat_input("Message", accept_file=True, on_submit=my_callback),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test with all parameters combined (no file/audio - returns str | None)
+    # =====================================================================
+
+    assert_type(
+        chat_input(
+            placeholder="Ask me anything",
+            key="full_chat",
+            max_chars=1000,
+            max_upload_size=None,
+            accept_file=False,
+            file_type=None,
+            accept_audio=False,
+            disabled=False,
+            on_submit=my_callback,
+            args=None,
+            kwargs=None,
+            width="stretch",
+        ),
+        str | None,
+    )
+
+    # =====================================================================
+    # Test with all parameters combined (accept_file=True - returns ChatInputValue | None)
+    # =====================================================================
+
+    assert_type(
+        chat_input(
+            placeholder="Upload files",
+            key="file_chat",
+            max_chars=500,
+            max_upload_size=100,
+            accept_file=True,
+            file_type=["pdf", "doc"],
+            accept_audio=False,
+            audio_sample_rate=16000,
+            disabled=False,
+            on_submit=my_callback,
+            args=None,
+            kwargs=None,
+            width=600,
+        ),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test with all parameters combined (accept_audio=True - returns ChatInputValue | None)
+    # =====================================================================
+
+    assert_type(
+        chat_input(
+            placeholder="Record audio",
+            key="audio_chat",
+            max_chars=200,
+            max_upload_size=50,
+            accept_file=False,
+            file_type=None,
+            accept_audio=True,
+            audio_sample_rate=48000,
+            disabled=False,
+            on_submit=my_callback,
+            args=None,
+            kwargs=None,
+            width="stretch",
+        ),
+        ChatInputValue | None,
+    )
+
+    # =====================================================================
+    # Test with all parameters combined (both file and audio - returns ChatInputValue | None)
+    # =====================================================================
+
+    assert_type(
+        chat_input(
+            placeholder="Files and audio",
+            key="full_media_chat",
+            max_chars=1000,
+            max_upload_size=200,
+            accept_file="multiple",
+            file_type=["jpg", "png", "gif"],
+            accept_audio=True,
+            audio_sample_rate=44100,
+            disabled=False,
+            on_submit=my_callback,
+            args=None,
+            kwargs=None,
+            width=800,
+        ),
+        ChatInputValue | None,
+    )


### PR DESCRIPTION
## Describe your changes

Add comprehensive type checking tests for `st.chat_input` and `st.audio_input` widgets to verify that the return types correctly match the expected behavior based on parameters. The tests validate all overloads and parameter combinations using `typing_extensions.assert_type`.

For `st.chat_input`, the tests verify that the return type changes based on `accept_file` and `accept_audio` parameters:
- Returns `str | None` when both are `False` (default)
- Returns `ChatInputValue | None` when either is enabled

For `st.audio_input`, the tests verify that it always returns `UploadedFile | None`.

## Testing Plan

- These are type-checking tests only, using `assert_type` from `typing_extensions`
- Tests pass with both `mypy` and `ty` type checkers
- All linting and formatting checks pass
- No additional runtime tests needed as the type tests are purely static analysis

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.