### PR TITLE
Prevent AppTest rerun KeyError on stale widget IDs

### DIFF
--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -118,6 +118,11 @@ class SafeSessionState:
         with self._lock:
             return key in self._state
 
+    def get(self, key: str, default: Any = None) -> Any:
+        self._yield_callback()
+        with self._lock:
+            return self._state.get(key, default)
+
     def __getattr__(self, key: str) -> Any:
         try:
             return self[key]

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -394,7 +394,8 @@ class AppTest:
             self
 
         """
-        return self._tree.run(timeout=timeout)
+        widget_states = self._tree.get_widget_states()
+        return self._run(widget_states, timeout=timeout)
 
     def switch_page(self, page_path: str) -> AppTest:
         """Switch to another page of the app.

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -197,6 +197,12 @@ class Widget(Element, ABC):
         self._value = v
         return self
 
+    def _get_session_state_value(self) -> Any:
+        """Read value from session_state and tolerate missing stale widget IDs."""
+        state = self.root.session_state
+        assert state is not None
+        return state.get(self.id)
+
     @property
     @abstractmethod
     def _widget_state(self) -> WidgetState: ...
@@ -551,9 +557,7 @@ class DateInput(Widget):
         if not isinstance(self._value, InitialValue):
             parsed, _ = _parse_date_value(self._value)
             return tuple(parsed) if parsed is not None else None  # type: ignore
-        state = self.root.session_state
-        assert state
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
 
 @dataclass(repr=False)
@@ -918,11 +922,7 @@ class NumberInput(Widget):
         """Get the current value of the ``st.number_input`` widget."""
         if not isinstance(self._value, InitialValue):
             return self._value
-        state = self.root.session_state
-        assert state
-
-        # Awkward to do this with `cast`
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
     def increment(self) -> NumberInput:
         """Increment the ``st.number_input`` widget as if the user clicked "+"."""
@@ -1130,10 +1130,7 @@ class SelectSlider(Widget, Generic[T]):
         """The currently selected value or range. (Any or Sequence of Any)"""  # noqa: D400
         if self._value is not None:
             return self._value
-        state = self.root.session_state
-        assert state
-        # Awkward to do this with `cast`
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
     @property
     def format_func(self) -> Callable[[Any], Any]:
@@ -1191,10 +1188,7 @@ class Slider(Widget, Generic[SliderValueT]):
         """The currently selected value or range. (Any or Sequence of Any)"""  # noqa: D400
         if self._value is not None:
             return self._value
-        state = self.root.session_state
-        assert state
-        # Awkward to do this with `cast`
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
     def set_range(
         self, lower: SliderValueT, upper: SliderValueT
@@ -1271,10 +1265,7 @@ class TextArea(Widget):
         """The current value of the widget. (str)"""  # noqa: D400
         if not isinstance(self._value, InitialValue):
             return self._value
-        state = self.root.session_state
-        assert state
-        # Awkward to do this with `cast`
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
     def input(self, v: str) -> TextArea:
         """
@@ -1323,10 +1314,7 @@ class TextInput(Widget):
         """The current value of the widget. (str)"""  # noqa: D400
         if not isinstance(self._value, InitialValue):
             return self._value
-        state = self.root.session_state
-        assert state
-        # Awkward to do this with `cast`
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
     def input(self, v: str) -> TextInput:
         """
@@ -1381,9 +1369,7 @@ class TimeInput(Widget):
         if not isinstance(self._value, InitialValue):
             v = self._value
             return v.time() if isinstance(v, datetime) else v
-        state = self.root.session_state
-        assert state
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
     def increment(self) -> TimeInput:
         """Select the next available time."""
@@ -1448,9 +1434,7 @@ class DateTimeInput(Widget):
         """The current value of the widget. (datetime)"""  # noqa: D400
         if not isinstance(self._value, InitialValue):
             return self._value
-        state = self.root.session_state
-        assert state
-        return state[self.id]  # type: ignore
+        return self._get_session_state_value()
 
 
 @dataclass(repr=False)

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -206,6 +206,32 @@ def test_trigger_recursion():
     at.button[0].click().run()
 
 
+def test_dynamic_widget_tree_rerun_does_not_raise_keyerror():
+    # Regression test for #12566
+    def script():
+        import streamlit as st
+
+        if "_string_value" not in st.session_state:
+            st.session_state._string_value = "string1"
+
+        if st.session_state.get("_bool_value", False):
+            with st.container(key="k_container"):
+                st.html("<span style='color:red'>red</span>")
+
+        with st.container():
+            st.text_input("Text", value=st.session_state._string_value)
+            if st.button("Button", key="k_button"):
+                st.session_state._string_value = "string2"
+                st.session_state._bool_value = True
+                st.rerun()
+
+    at = AppTest.from_function(script).run()
+    at.button(key="k_button").click().run()
+    # Third run previously raised KeyError for a stale auto-generated widget id.
+    at.run()
+    assert at.text_input[0].value == "string2"
+
+
 def test_switch_page():
     at = AppTest.from_file("test_data/main.py").run()
     assert at.text[0].value == "main page"


### PR DESCRIPTION
## Describe your changes
- Fixed AppTest rerun flow where dynamically changing widget trees could reference stale widget IDs and raise KeyError.
- Added safer state access (get) path for test-time session state reads and adjusted widget value retrieval to tolerate missing stale IDs.
- Updated AppTest rerun path to build widget states explicitly before rerun and added a regression test matching the issue pattern.

## Screenshot or video (only for visual changes)
- Not applicable (testing/runtime logic fix).

## GitHub Issue Link (if applicable)
- https://github.com/streamlit/streamlit/issues/12566

## Testing Plan

- Explanation of why no additional tests are needed: A dedicated regression test was added for this failure mode.
- Unit Tests (JS and/or Python): Added test in:lib/tests/streamlit/testing/app_test_test.py
- E2E Tests: Not run.
- Any manual testing needed?: Not required; issue is in AppTest runtime path.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
