### PR TITLE
Fix nested static asset routing for deep URLs

### DIFF
--- a/lib/streamlit/web/server/routes.py
+++ b/lib/streamlit/web/server/routes.py
@@ -24,6 +24,7 @@ from streamlit import config, file_util
 from streamlit.web.server.server_util import (
     allowlisted_origins,
     emit_endpoint_deprecation_notice,
+    extract_nested_subpath,
     is_xsrf_enabled,
 )
 
@@ -100,6 +101,12 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
                     url_path = url_path.replace(os.path.sep, "/")
                 if any(url_path.endswith(x) for x in self._reserved_paths):
                     raise
+
+                static_subpath = extract_nested_subpath(url_path, marker="/static/")
+                if static_subpath:
+                    self.path = self.parse_url_path(static_subpath)
+                    absolute_path = self.get_absolute_path(self.root, self.path)
+                    return super().validate_absolute_path(root, absolute_path)
 
                 self.path = self.parse_url_path(self.default_filename or "index.html")
                 absolute_path = self.get_absolute_path(self.root, self.path)

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -151,6 +151,13 @@ HOST_CONFIG_ENDPOINT: Final = r"_stcore/host-config"
 SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
     r"(?:script-health-check|_stcore/script-health-check)"
 )
+STATIC_HANDLER_RESERVED_ENDPOINTS: Final[tuple[str, ...]] = (
+    NEW_HEALTH_ENDPOINT,
+    HOST_CONFIG_ENDPOINT,
+    STREAM_ENDPOINT,
+    METRIC_ENDPOINT,
+    MESSAGE_ENDPOINT,
+)
 
 OAUTH2_CALLBACK_ENDPOINT: Final = "/oauth2callback"
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
@@ -490,12 +497,7 @@ class Server:
                         {
                             "path": f"{static_path}/",
                             "default_filename": "index.html",
-                            "reserved_paths": [
-                                # These paths are required for identifying
-                                # the base url path.
-                                NEW_HEALTH_ENDPOINT,
-                                HOST_CONFIG_ENDPOINT,
-                            ],
+                            "reserved_paths": list(STATIC_HANDLER_RESERVED_ENDPOINTS),
                         },
                     ),
                     (

--- a/lib/streamlit/web/server/server_util.py
+++ b/lib/streamlit/web/server/server_util.py
@@ -174,6 +174,23 @@ def make_url_path_regex(
     return path_format % "/".join(filtered_paths)
 
 
+def extract_nested_subpath(url_path: str, marker: str) -> str | None:
+    """Extract a nested subpath that starts with a marker segment.
+
+    Example:
+    - url_path="/foo/bar/static/js/app.js", marker="/static/"
+    - returns "static/js/app.js"
+    """
+    normalized_path = f"/{url_path.lstrip('/')}"
+    marker_index = normalized_path.find(marker)
+    if marker_index <= 0:
+        return None
+
+    # We strip the first slash because Tornado StaticFileHandler internally
+    # treats `self.path` as a relative path within the static root.
+    return normalized_path[marker_index + 1 :]
+
+
 def get_url(host_ip: str) -> str:
     """Get the URL for any app served at the given host_ip.
 

--- a/lib/tests/streamlit/web/server/routes_test.py
+++ b/lib/tests/streamlit/web/server/routes_test.py
@@ -131,6 +131,13 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         # The manifest file must not have a prefix - create it manually in the tmpdir
         self._tmp_manifest_filename = os.path.join(self._tmpdir.name, "manifest.json")
         Path(self._tmp_manifest_filename).touch()
+        self._static_dir = os.path.join(self._tmpdir.name, "static")
+        os.makedirs(self._static_dir, exist_ok=True)
+        self._static_filename = "asset.js"
+        self._static_contents = b"console.log('nested static');"
+        Path(os.path.join(self._static_dir, self._static_filename)).write_bytes(
+            self._static_contents
+        )
 
         self._filename = os.path.basename(self._tmpfile.name)
         self._js_filename = os.path.basename(self._tmp_js_file.name)
@@ -192,6 +199,8 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         responses = [
             self.fetch("/nonexistent/_stcore/health"),
             self.fetch("/page2/_stcore/host-config"),
+            self.fetch("/foo/_stcore/stream"),
+            self.fetch("/foo/_stcore/metrics"),
         ]
 
         for r in responses:
@@ -212,6 +221,14 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         r = self.fetch(f"/{self._css_filename}")
         assert r.headers["Cache-Control"] == "public, immutable, max-age=31536000"
+
+    def test_nested_static_assets_are_served(self):
+        response = self.fetch(f"/page1/static/{self._static_filename}")
+        assert response.code == 200
+        assert response.body == self._static_contents
+
+        response = self.fetch("/page1/static/missing.js")
+        assert response.code == 200
 
     def test_mimetype_is_overridden_by_server(self):
         """Test get_content_type function."""

--- a/lib/tests/streamlit/web/server/server_util_test.py
+++ b/lib/tests/streamlit/web/server/server_util_test.py
@@ -149,6 +149,19 @@ class ServerUtilTest(unittest.TestCase):
 
     @parameterized.expand(
         [
+            ("/foo/static/app.js", "/static/", "static/app.js"),
+            ("foo/bar/static/js/main.js", "/static/", "static/js/main.js"),
+            ("/static/app.js", "/static/", None),
+            ("/foo/assets/app.js", "/static/", None),
+        ]
+    )
+    def test_extract_nested_subpath(
+        self, url_path: str, marker: str, expected: str | None
+    ):
+        assert server_util.extract_nested_subpath(url_path, marker) == expected
+
+    @parameterized.expand(
+        [
             ("0.0.0.0", "localhost"),
             ("::", "localhost"),
             ("127.0.0.1", "127.0.0.1"),


### PR DESCRIPTION
## Describe your changes
- Fixed fallback static routing so deep URLs like /a/a don’t cause a blank page when the app shell should be served.
- Added nested static subpath extraction and used it in StaticFileHandler to correctly resolve /.../static/... assets.
- Tightened reserved endpoint handling for the static handler to avoid swallowing internal API routes.

## Screenshot or video (only for visual changes)
- Not applicable (server-side routing fix).
## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8013
## Testing Plan

- Explanation of why no additional tests are needed: Routing behavior is covered by updated server unit tests.
- Unit Tests (JS and/or Python):
     Added/updated tests in:
      lib/tests/streamlit/web/server/routes_test.py
      lib/tests/streamlit/web/server/server_util_test.py
- E2E Tests: Not run.
- Any manual testing needed?:
Optional: run app locally and verify /a/a shows app shell (and frontend 404 behavior) instead of a blank page.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
