### PR TITLE
[chore] Update CODEOWNERS for .github instructions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@ scripts/audit_frontend_licenses.py @streamlit/open-source-release-team
 # Ensure changes to our GitHub Actions and related files are reviewed by
 # someone closely familiar with how our CI works.
 .github/ @streamlit/open-source-release-team
+# Exception: allow `.github/instructions` to be changed without requiring
+# review from the release team.
+.github/instructions/
 
 # Changes to the following files/directories are likely to have backwards
 # compatibility implications for platforms that host Streamlit apps, so we need


### PR DESCRIPTION
## Describe your changes

- Updated the CODEOWNERS file to exclude `.github/instructions/` from requiring review by the open-source-release-team.
- Maintain this behavior for all `.github` files and dirs

## Testing Plan

- No additional tests are needed as this is a simple configuration change to the CODEOWNERS file

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.