### PR TITLE
[refactor] extract Expander animation logic into useDetailsAnimation hook

### DIFF
--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useEffect, useRef, useState } from "react"
+import { memo, ReactElement, useState } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
 import { DynamicIcon } from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
-import { notNullOrUndefined } from "~lib/util/utils"
 
 import {
-  BORDER_SIZE,
   StyledDetails,
   StyledDetailsPanel,
   StyledExpandableContainer,
@@ -31,6 +29,7 @@ import {
   StyledSummaryHeading,
   StyledSummaryLabelWrapper,
 } from "./styled-components"
+import { useDetailsAnimation } from "./useDetailsAnimation"
 
 export interface ExpanderIconProps {
   icon?: string
@@ -76,134 +75,18 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   isStale,
   children,
 }): ReactElement => {
-  const { label, expanded: initialExpanded } = element
-  const [expanded, setExpanded] = useState<boolean>(initialExpanded || false)
+  const { label, icon } = element
   const [isHovered, setIsHovered] = useState(false)
-  const detailsRef = useRef<HTMLDetailsElement>(null)
-  const summaryRef = useRef<HTMLElement>(null)
-  const animationRef = useRef<Animation | null>(null)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const contentRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    // Only apply the expanded state if it was actually set in the proto.
-    if (notNullOrUndefined(initialExpanded)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- TODO: Do not set state in effect
-      setExpanded(initialExpanded)
+  const { isOpen, detailsRef, summaryRef, contentRef, handleToggle } =
+    useDetailsAnimation({
+      initialExpanded: element.expanded,
+      label,
+    })
 
-      // We manage the open attribute via the detailsRef and not with React state
-      if (detailsRef.current) {
-        detailsRef.current.open = initialExpanded
-      }
-    }
-
-    // Having `label` in the dependency array here is necessary because
-    // sometimes two distinct expanders look so similar that even the react
-    // diffing algorithm decides that they're the same element with updated
-    // props (this happens when something in the app removes one expander and
-    // replaces it with another in the same position).
-    //
-    // By adding `label` as a dependency, we ensure that we reset the
-    // expander's `expanded` state in this edge case.
-  }, [label, initialExpanded])
-
-  const onAnimationFinish = (open: boolean): void => {
-    if (!detailsRef.current) {
-      return
-    }
-
-    detailsRef.current.open = open
-    animationRef.current = null
-    detailsRef.current.style.height = ""
-    detailsRef.current.style.overflow = ""
-  }
-
-  const toggleAnimation = (
-    detailsEl: HTMLDetailsElement,
-    startHeight: number,
-    endHeight: number
-  ): void => {
-    const isOpen = endHeight > startHeight
-
-    if (animationRef.current) {
-      animationRef.current.cancel()
-
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
-    }
-
-    const animation = detailsEl.animate(
-      {
-        height: [`${startHeight}px`, `${endHeight}px`],
-      },
-      {
-        duration: 500,
-        easing: "cubic-bezier(0.23, 1, 0.32, 1)",
-      }
-    )
-
-    animation.addEventListener("finish", () => onAnimationFinish(isOpen))
-    animationRef.current = animation
-  }
-
-  const toggle = (e: React.MouseEvent<HTMLDetailsElement>): void => {
-    e.preventDefault()
-
-    setExpanded(!expanded)
-    const detailsEl = detailsRef.current
-    if (!detailsEl || !summaryRef.current) {
-      return
-    }
-
-    detailsEl.style.overflow = "hidden"
-    // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-    const detailsHeight = detailsEl.getBoundingClientRect().height
-    // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-    const summaryHeight = summaryRef.current.getBoundingClientRect().height
-
-    if (!expanded) {
-      detailsEl.style.height = `${detailsHeight}px`
-      detailsEl.open = true
-
-      window.requestAnimationFrame(() => {
-        // For expansion animations, we rely on the rendered width and height
-        // of the children content. However, in Safari, the children are not
-        // rendered because Safari doesn't paint elements that are not visible
-        // (in this case, the details element is not visible because it's
-        // not open). This operation produces inconsistent heights to animate.
-        // To work around this, we force a repaint by animating a tiny bit
-        // and animate the rest of it later.
-        toggleAnimation(
-          detailsEl,
-          detailsHeight,
-          summaryHeight + 2 * BORDER_SIZE + 5 // Arbitrary size of 5px
-        )
-
-        timeoutRef.current = setTimeout(() => {
-          if (!contentRef.current) {
-            return
-          }
-
-          const contentHeight =
-            // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-            contentRef.current.getBoundingClientRect().height
-          toggleAnimation(
-            detailsEl,
-            detailsHeight,
-            summaryHeight + contentHeight + 2 * BORDER_SIZE
-          )
-        }, 100)
-      })
-    } else {
-      toggleAnimation(
-        detailsEl,
-        detailsHeight,
-        summaryHeight + 2 * BORDER_SIZE
-      )
-    }
-  }
+  // Determine which icon to show
+  const showChevron = !icon || isHovered
+  const showUserIcon = icon && !isHovered
 
   const handleMouseEnter = (): void => {
     setIsHovered(true)
@@ -212,10 +95,6 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   const handleMouseLeave = (): void => {
     setIsHovered(false)
   }
-
-  // Determine which icon to show
-  const showChevron = !element.icon || isHovered
-  const showUserIcon = element.icon && !isHovered
 
   return (
     <StyledExpandableContainer className="stExpander" data-testid="stExpander">
@@ -226,23 +105,23 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
         onMouseLeave={handleMouseLeave}
       >
         <StyledSummary
-          onClick={toggle}
+          onClick={handleToggle}
           ref={summaryRef}
           isStale={isStale}
-          expanded={expanded}
+          expanded={isOpen}
         >
           <StyledSummaryHeading>
             {showChevron && (
               <DynamicIcon
                 iconValue={
-                  expanded
+                  isOpen
                     ? ":material/keyboard_arrow_down:"
                     : ":material/keyboard_arrow_right:"
                 }
                 size="lg"
               />
             )}
-            {showUserIcon && <ExpanderIcon icon={element.icon} />}
+            {showUserIcon && <ExpanderIcon icon={icon} />}
 
             <StyledSummaryLabelWrapper>
               <StreamlitMarkdown
@@ -259,7 +138,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
           ref={contentRef}
           // Exclude collapsed content from browser find-in-page (Cmd+F) searches.
           // Using "" instead of true for consistent behavior in jsdom tests.
-          inert={!expanded ? "" : undefined}
+          inert={!isOpen ? "" : undefined}
         >
           {children}
         </StyledDetailsPanel>

--- a/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { animateHeight } from "./animateHeight"
+
+describe("animateHeight", () => {
+  let element: HTMLDivElement
+  let mockAnimation: {
+    addEventListener: ReturnType<typeof vi.fn>
+    cancel: ReturnType<typeof vi.fn>
+  }
+
+  beforeEach(() => {
+    element = document.createElement("div")
+    document.body.appendChild(element)
+
+    // Mock the Web Animations API since JSDOM doesn't fully support it
+    mockAnimation = {
+      addEventListener: vi.fn(),
+      cancel: vi.fn(),
+    }
+    element.animate = vi.fn().mockReturnValue(mockAnimation)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(element)
+  })
+
+  describe("animation creation", () => {
+    it("calls element.animate with height keyframes", () => {
+      animateHeight(element, 0, 100)
+
+      expect(element.animate).toHaveBeenCalledWith(
+        { height: ["0px", "100px"] },
+        { duration: 500, easing: "cubic-bezier(0.23, 1, 0.32, 1)" }
+      )
+    })
+
+    it("uses custom duration when provided", () => {
+      animateHeight(element, 0, 100, { duration: 300 })
+
+      expect(element.animate).toHaveBeenCalledWith(
+        { height: ["0px", "100px"] },
+        { duration: 300, easing: "cubic-bezier(0.23, 1, 0.32, 1)" }
+      )
+    })
+
+    it("uses custom easing when provided", () => {
+      animateHeight(element, 0, 100, { easing: "ease-in-out" })
+
+      expect(element.animate).toHaveBeenCalledWith(
+        { height: ["0px", "100px"] },
+        { duration: 500, easing: "ease-in-out" }
+      )
+    })
+  })
+
+  describe("cancel", () => {
+    it("cancel() calls animation.cancel()", () => {
+      const handle = animateHeight(element, 0, 100)
+
+      handle.cancel()
+
+      expect(mockAnimation.cancel).toHaveBeenCalled()
+    })
+  })
+
+  describe("finish behavior", () => {
+    it("registers finish event listener", () => {
+      animateHeight(element, 0, 100)
+
+      expect(mockAnimation.addEventListener).toHaveBeenCalledWith(
+        "finish",
+        expect.any(Function)
+      )
+    })
+
+    it("clears styles and calls onFinish when animation finishes", () => {
+      const onFinish = vi.fn()
+      element.style.height = "50px"
+      element.style.overflow = "hidden"
+
+      animateHeight(element, 0, 100, { onFinish })
+
+      // Get the finish callback
+      const finishCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "finish"
+      )
+      const finishCallback = finishCall?.[1]
+
+      // Simulate finish
+      finishCallback?.()
+
+      expect(element.style.height).toBe("")
+      expect(element.style.overflow).toBe("")
+      expect(onFinish).toHaveBeenCalled()
+    })
+
+    it("resolves finished promise on finish", async () => {
+      const handle = animateHeight(element, 0, 100)
+
+      // Get the finish callback
+      const finishCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "finish"
+      )
+      const finishCallback = finishCall?.[1]
+
+      // Simulate finish
+      finishCallback?.()
+
+      // Should resolve without throwing
+      await expect(handle.finished).resolves.toBeUndefined()
+    })
+  })
+
+  describe("cancel behavior", () => {
+    it("registers cancel event listener", () => {
+      animateHeight(element, 0, 100)
+
+      expect(mockAnimation.addEventListener).toHaveBeenCalledWith(
+        "cancel",
+        expect.any(Function)
+      )
+    })
+
+    it("does NOT clear styles on cancel (caller responsibility)", () => {
+      element.style.height = "50px"
+      element.style.overflow = "hidden"
+
+      animateHeight(element, 0, 100)
+
+      // Get the cancel callback
+      const cancelCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "cancel"
+      )
+      const cancelCallback = cancelCall?.[1]
+
+      // Simulate cancel
+      cancelCallback?.()
+
+      // Styles should NOT be cleared - caller is responsible
+      expect(element.style.height).toBe("50px")
+      expect(element.style.overflow).toBe("hidden")
+    })
+
+    it("resolves finished promise on cancel", async () => {
+      const handle = animateHeight(element, 0, 100)
+
+      // Get the cancel callback
+      const cancelCall = mockAnimation.addEventListener.mock.calls.find(
+        call => call[0] === "cancel"
+      )
+      const cancelCallback = cancelCall?.[1]
+
+      // Simulate cancel
+      cancelCallback?.()
+
+      // Should resolve without throwing
+      await expect(handle.finished).resolves.toBeUndefined()
+    })
+  })
+})

--- a/frontend/lib/src/components/elements/Expander/animateHeight.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Animation handle returned by animateHeight.
+ * Provides cancel capability and completion promise.
+ */
+export interface AnimationHandle {
+  /** Cancel the running animation */
+  cancel: () => void
+  /** Promise that resolves when animation completes (finish or cancel) */
+  finished: Promise<void>
+}
+
+/** Default animation duration in milliseconds */
+const DEFAULT_DURATION = 500
+
+/** Default easing function for smooth animation */
+const DEFAULT_EASING = "cubic-bezier(0.23, 1, 0.32, 1)"
+
+/**
+ * Animate an element's height using the Web Animations API.
+ *
+ * IMPORTANT: On cancel, styles are NOT cleared. The caller is responsible
+ * for setting new styles after cancelling (typically to lock at current height
+ * before starting a new animation).
+ *
+ * On finish, styles ARE cleared to allow natural layout.
+ *
+ * @param element - The HTML element to animate
+ * @param from - Starting height in pixels
+ * @param to - Target height in pixels
+ * @param options - Optional configuration
+ * @returns AnimationHandle with cancel() and finished promise
+ */
+export function animateHeight(
+  element: HTMLElement,
+  from: number,
+  to: number,
+  options: {
+    duration?: number
+    easing?: string
+    onFinish?: () => void
+  } = {}
+): AnimationHandle {
+  const {
+    duration = DEFAULT_DURATION,
+    easing = DEFAULT_EASING,
+    onFinish,
+  } = options
+
+  const animation = element.animate(
+    { height: [`${from}px`, `${to}px`] },
+    { duration, easing }
+  )
+
+  const finished = new Promise<void>(resolve => {
+    animation.addEventListener("finish", () => {
+      // Clean up styles on successful finish
+      element.style.height = ""
+      element.style.overflow = ""
+      onFinish?.()
+      resolve()
+    })
+
+    animation.addEventListener("cancel", () => {
+      // DON'T clean up on cancel - caller will set new styles
+      resolve()
+    })
+  })
+
+  return {
+    cancel: () => animation.cancel(),
+    finished,
+  }
+}

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MouseEvent } from "react"
+
+import { act, renderHook } from "@testing-library/react"
+
+import { useDetailsAnimation } from "./useDetailsAnimation"
+
+describe("useDetailsAnimation", () => {
+  describe("initial state", () => {
+    it("returns isOpen=true when initialExpanded is true", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: true,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("returns isOpen=false when initialExpanded is false", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: false,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("returns isOpen=false when initialExpanded is null", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: null,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("returns isOpen=false when initialExpanded is undefined", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: undefined,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+    })
+  })
+
+  describe("handleToggle", () => {
+    it("toggles isOpen state from false to true", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: false,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(false)
+
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("toggles isOpen state from true to false", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: true,
+          label: "Test",
+        })
+      )
+
+      expect(result.current.isOpen).toBe(true)
+
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("prevents default event behavior", () => {
+      const preventDefault = vi.fn()
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: false,
+          label: "Test",
+        })
+      )
+
+      act(() => {
+        const mockEvent = {
+          preventDefault,
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(preventDefault).toHaveBeenCalled()
+    })
+  })
+
+  describe("backend sync", () => {
+    it("syncs isOpen when initialExpanded changes", () => {
+      const { result, rerender } = renderHook(
+        ({ initialExpanded }) =>
+          useDetailsAnimation({
+            initialExpanded,
+            label: "Test",
+          }),
+        { initialProps: { initialExpanded: false as boolean | null } }
+      )
+
+      expect(result.current.isOpen).toBe(false)
+
+      rerender({ initialExpanded: true })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    it("preserves state when initialExpanded is null (ClearField)", () => {
+      const { result, rerender } = renderHook(
+        ({ initialExpanded }) =>
+          useDetailsAnimation({
+            initialExpanded,
+            label: "Test",
+          }),
+        { initialProps: { initialExpanded: true as boolean | null } }
+      )
+
+      expect(result.current.isOpen).toBe(true)
+
+      // User manually toggles closed
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(false)
+
+      // Backend sends null (ClearField) — should NOT change state
+      rerender({ initialExpanded: null })
+
+      expect(result.current.isOpen).toBe(false)
+    })
+
+    it("resets state when label changes (new expander)", () => {
+      const { result, rerender } = renderHook(
+        ({ initialExpanded, label }) =>
+          useDetailsAnimation({
+            initialExpanded,
+            label,
+          }),
+        {
+          initialProps: {
+            initialExpanded: true as boolean | null,
+            label: "Old Label",
+          },
+        }
+      )
+
+      // Toggle to false locally
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(false)
+
+      // Change label (simulates new expander) - should reset to initialExpanded
+      rerender({ initialExpanded: true, label: "New Label" })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+  })
+
+  describe("cleanup", () => {
+    it("does not throw on unmount", () => {
+      const { unmount } = renderHook(() =>
+        useDetailsAnimation({
+          initialExpanded: false,
+          label: "Test",
+        })
+      )
+
+      expect(() => unmount()).not.toThrow()
+    })
+  })
+})

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MouseEvent,
+  RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { notNullOrUndefined } from "~lib/util/utils"
+
+import { animateHeight, AnimationHandle } from "./animateHeight"
+import { BORDER_SIZE } from "./styled-components"
+
+/**
+ * Delay before measuring content height for the Safari repaint workaround (ms).
+ *
+ * In Safari, <details> content is not painted synchronously when opened,
+ * so we first animate a tiny amount (5px) to force a repaint, then measure
+ * the real content height after this delay.
+ */
+const SAFARI_REPAINT_DELAY_MS = 100
+
+/**
+ * Arbitrary height (px) used to force a Safari repaint when expanding.
+ * This is added to the collapsed height to create a small initial animation
+ * that forces Safari to paint the <details> content.
+ */
+const SAFARI_REPAINT_HEIGHT = 5
+
+export interface UseDetailsAnimationOptions {
+  /**
+   * Expanded state from the backend proto.
+   *
+   * - `true` / `false` – explicit state from the proto.
+   * - `null` / `undefined` – the field was not set (e.g. `ClearField("expanded")`
+   *   during `st.status().update()`). In this case the hook preserves the
+   *   current open/closed state and defaults to `false` on initial render.
+   */
+  initialExpanded: boolean | null | undefined
+  /** Label used to detect "new expander" replacing old one */
+  label: string
+}
+
+export interface UseDetailsAnimationResult {
+  /** Current open state */
+  isOpen: boolean
+  /** Ref to attach to <details> element */
+  detailsRef: RefObject<HTMLDetailsElement>
+  /** Ref to attach to <summary> element */
+  summaryRef: RefObject<HTMLElement>
+  /** Ref to attach to content panel */
+  contentRef: RefObject<HTMLDivElement>
+  /** Click handler for summary (toggle) */
+  handleToggle: (e: MouseEvent) => void
+}
+
+/**
+ * Custom hook for managing animated <details> element open/close state.
+ */
+export function useDetailsAnimation({
+  initialExpanded,
+  label,
+}: UseDetailsAnimationOptions): UseDetailsAnimationResult {
+  const [isOpen, setIsOpen] = useState<boolean>(initialExpanded || false)
+
+  const detailsRef = useRef<HTMLDetailsElement>(null)
+  const summaryRef = useRef<HTMLElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  // Track current animation for cancellation
+  const animationRef = useRef<AnimationHandle | null>(null)
+
+  // Track Safari repaint timeout
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  /**
+   * Cancel any running animation and pending timeouts.
+   */
+  const cancelAnimation = useCallback((): void => {
+    if (animationRef.current) {
+      animationRef.current.cancel()
+      animationRef.current = null
+    }
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  // Sync with backend/proto state changes.
+  // Only apply the expanded state if it was actually set in the proto.
+  // The label dependency ensures we reset when a "new expander" replaces
+  // the old one in the same position (React may reuse the same DOM element).
+  useEffect(() => {
+    if (notNullOrUndefined(initialExpanded)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Syncing with external proto state
+      setIsOpen(initialExpanded)
+
+      // We manage the open attribute via the detailsRef and not with React state
+      if (detailsRef.current) {
+        detailsRef.current.open = initialExpanded
+      }
+    }
+  }, [label, initialExpanded])
+
+  /**
+   * Run the height animation between two values.
+   * Cancels any in-progress animation before starting.
+   */
+  const startAnimation = useCallback(
+    (
+      detailsEl: HTMLElement,
+      startHeight: number,
+      endHeight: number,
+      onFinish?: () => void
+    ): void => {
+      cancelAnimation()
+
+      animationRef.current = animateHeight(detailsEl, startHeight, endHeight, {
+        onFinish,
+      })
+    },
+    [cancelAnimation]
+  )
+
+  /**
+   * Handle user click on summary to toggle open/closed.
+   * Uses a two-step animation for expansion as a Safari repaint workaround.
+   */
+  const handleToggle = useCallback(
+    (e: MouseEvent): void => {
+      e.preventDefault()
+
+      setIsOpen(prev => !prev)
+
+      const detailsEl = detailsRef.current
+      if (!detailsEl || !summaryRef.current) {
+        return
+      }
+
+      detailsEl.style.overflow = "hidden"
+      // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Need current heights to calculate animation start/end values
+      const detailsHeight = detailsEl.getBoundingClientRect().height
+      // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Need current heights to calculate animation start/end values
+      const summaryHeight = summaryRef.current.getBoundingClientRect().height
+
+      if (!isOpen) {
+        // === OPENING ===
+        detailsEl.style.height = `${detailsHeight}px`
+        detailsEl.open = true
+
+        window.requestAnimationFrame(() => {
+          // Safari workaround: Safari doesn't paint <details> content
+          // synchronously when opened. Force a repaint by animating a tiny
+          // bit first, then animate to the real height after a short delay.
+          startAnimation(
+            detailsEl,
+            detailsHeight,
+            summaryHeight + 2 * BORDER_SIZE + SAFARI_REPAINT_HEIGHT
+          )
+
+          timeoutRef.current = setTimeout(() => {
+            if (!contentRef.current) {
+              return
+            }
+
+            const contentHeight =
+              // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Need content height to calculate animation end value
+              contentRef.current.getBoundingClientRect().height
+            startAnimation(
+              detailsEl,
+              detailsHeight,
+              summaryHeight + contentHeight + 2 * BORDER_SIZE
+            )
+          }, SAFARI_REPAINT_DELAY_MS)
+        })
+      } else {
+        // === CLOSING ===
+        startAnimation(
+          detailsEl,
+          detailsHeight,
+          summaryHeight + 2 * BORDER_SIZE,
+          () => {
+            // Set open=false after the close animation finishes
+            if (detailsRef.current) {
+              detailsRef.current.open = false
+            }
+          }
+        )
+      }
+    },
+    [isOpen, startAnimation]
+  )
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cancelAnimation()
+    }
+  }, [cancelAnimation])
+
+  return {
+    isOpen,
+    detailsRef,
+    summaryRef,
+    contentRef,
+    handleToggle,
+  }
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -68,7 +68,7 @@ console.warn = (...args) => {
 // Add fake animate method to Elements
 Element.prototype.animate = vi
   .fn()
-  .mockImplementation(() => ({ addEventListener: vi.fn() }))
+  .mockImplementation(() => ({ addEventListener: vi.fn(), cancel: vi.fn() }))
 
 class ResizeObserverMock {
   public callback: (


### PR DESCRIPTION
## Describe your changes

Extracts the `<details>` open/close animation logic from `Expander.tsx` into a reusable `useDetailsAnimation` hook and a standalone `animateHeight` utility.

- `useDetailsAnimation` manages open state, backend sync, and the toggle animation (including the Safari two-step repaint workaround)
- `animateHeight` wraps the Web Animations API with a cancellable `AnimationHandle` that distinguishes finish vs cancel cleanup semantics

## Testing Plan

- [x] Unit Tests (JS)
  - `useDetailsAnimation.test.ts` — initial state, toggle behavior, backend sync, label-based reset, cleanup
  - `animateHeight.test.ts` — animation creation, custom options, finish/cancel lifecycle, promise resolution
