### PR TITLE
[refactor] improve Expander animation with ResizeObserver, smooth interruption, and nullable expanded handling

### DIFF
--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -80,7 +80,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
 
   const { isOpen, detailsRef, summaryRef, contentRef, handleToggle } =
     useDetailsAnimation({
-      initialExpanded: element.expanded,
+      backendExpanded: element.expanded,
       label,
     })
 

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-import { MouseEvent } from "react"
+import { createElement, MouseEvent } from "react"
 
-import { act, renderHook } from "@testing-library/react"
+import { act, render, renderHook, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 
-import { useDetailsAnimation } from "./useDetailsAnimation"
+import {
+  useDetailsAnimation,
+  UseDetailsAnimationOptions,
+} from "./useDetailsAnimation"
 
 describe("useDetailsAnimation", () => {
   describe("initial state", () => {
-    it("returns isOpen=true when initialExpanded is true", () => {
+    it("returns isOpen=true when backendExpanded is true", () => {
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: true,
+          backendExpanded: true,
           label: "Test",
         })
       )
@@ -33,10 +37,10 @@ describe("useDetailsAnimation", () => {
       expect(result.current.isOpen).toBe(true)
     })
 
-    it("returns isOpen=false when initialExpanded is false", () => {
+    it("returns isOpen=false when backendExpanded is false", () => {
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: false,
+          backendExpanded: false,
           label: "Test",
         })
       )
@@ -44,10 +48,10 @@ describe("useDetailsAnimation", () => {
       expect(result.current.isOpen).toBe(false)
     })
 
-    it("returns isOpen=false when initialExpanded is null", () => {
+    it("returns isOpen=false when backendExpanded is null", () => {
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: null,
+          backendExpanded: null,
           label: "Test",
         })
       )
@@ -55,10 +59,10 @@ describe("useDetailsAnimation", () => {
       expect(result.current.isOpen).toBe(false)
     })
 
-    it("returns isOpen=false when initialExpanded is undefined", () => {
+    it("returns isOpen=false when backendExpanded is undefined", () => {
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: undefined,
+          backendExpanded: undefined,
           label: "Test",
         })
       )
@@ -71,7 +75,7 @@ describe("useDetailsAnimation", () => {
     it("toggles isOpen state from false to true", () => {
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: false,
+          backendExpanded: false,
           label: "Test",
         })
       )
@@ -91,7 +95,7 @@ describe("useDetailsAnimation", () => {
     it("toggles isOpen state from true to false", () => {
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: true,
+          backendExpanded: true,
           label: "Test",
         })
       )
@@ -108,11 +112,50 @@ describe("useDetailsAnimation", () => {
       expect(result.current.isOpen).toBe(false)
     })
 
+    it("calls onToggle callback with new state", () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+          onToggle,
+        })
+      )
+
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(onToggle).toHaveBeenCalledWith(true)
+    })
+
+    it("does not call onToggle when not provided", () => {
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      // Should not throw when onToggle is undefined
+      act(() => {
+        const mockEvent = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent)
+      })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
     it("prevents default event behavior", () => {
       const preventDefault = vi.fn()
       const { result } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: false,
+          backendExpanded: false,
           label: "Test",
         })
       )
@@ -126,34 +169,66 @@ describe("useDetailsAnimation", () => {
 
       expect(preventDefault).toHaveBeenCalled()
     })
-  })
 
-  describe("backend sync", () => {
-    it("syncs isOpen when initialExpanded changes", () => {
-      const { result, rerender } = renderHook(
-        ({ initialExpanded }) =>
-          useDetailsAnimation({
-            initialExpanded,
-            label: "Test",
-          }),
-        { initialProps: { initialExpanded: false as boolean | null } }
+    it("handles rapid double-toggle correctly", () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() =>
+        useDetailsAnimation({
+          backendExpanded: false,
+          label: "Test",
+          onToggle,
+        })
       )
 
       expect(result.current.isOpen).toBe(false)
 
-      rerender({ initialExpanded: true })
+      // Simulate two rapid clicks before React re-renders
+      act(() => {
+        const mockEvent1 = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        const mockEvent2 = {
+          preventDefault: vi.fn(),
+        } as unknown as MouseEvent
+        result.current.handleToggle(mockEvent1)
+        result.current.handleToggle(mockEvent2)
+      })
+
+      // Should end up back at the original state (false -> true -> false)
+      expect(result.current.isOpen).toBe(false)
+      // Both toggles should have fired with correct values
+      expect(onToggle).toHaveBeenCalledTimes(2)
+      expect(onToggle).toHaveBeenNthCalledWith(1, true)
+      expect(onToggle).toHaveBeenNthCalledWith(2, false)
+    })
+  })
+
+  describe("backend sync", () => {
+    it("syncs isOpen when backendExpanded changes", () => {
+      const { result, rerender } = renderHook(
+        ({ backendExpanded }) =>
+          useDetailsAnimation({
+            backendExpanded,
+            label: "Test",
+          }),
+        { initialProps: { backendExpanded: false as boolean | null } }
+      )
+
+      expect(result.current.isOpen).toBe(false)
+
+      rerender({ backendExpanded: true })
 
       expect(result.current.isOpen).toBe(true)
     })
 
-    it("preserves state when initialExpanded is null (ClearField)", () => {
+    it("preserves current state when backendExpanded is null (ClearField)", () => {
       const { result, rerender } = renderHook(
-        ({ initialExpanded }) =>
+        ({ backendExpanded }) =>
           useDetailsAnimation({
-            initialExpanded,
+            backendExpanded,
             label: "Test",
           }),
-        { initialProps: { initialExpanded: true as boolean | null } }
+        { initialProps: { backendExpanded: true as boolean | null } }
       )
 
       expect(result.current.isOpen).toBe(true)
@@ -168,22 +243,44 @@ describe("useDetailsAnimation", () => {
 
       expect(result.current.isOpen).toBe(false)
 
-      // Backend sends null (ClearField) — should NOT change state
-      rerender({ initialExpanded: null })
+      // Backend sends null (ClearField) - should NOT change state
+      rerender({ backendExpanded: null })
 
       expect(result.current.isOpen).toBe(false)
     })
 
+    it("preserves current state when backendExpanded becomes undefined", () => {
+      const { result, rerender } = renderHook(
+        ({ backendExpanded }) =>
+          useDetailsAnimation({
+            backendExpanded,
+            label: "Test",
+          }),
+        {
+          initialProps: {
+            backendExpanded: true as boolean | null | undefined,
+          },
+        }
+      )
+
+      expect(result.current.isOpen).toBe(true)
+
+      // Backend sends undefined - should NOT change state
+      rerender({ backendExpanded: undefined })
+
+      expect(result.current.isOpen).toBe(true)
+    })
+
     it("resets state when label changes (new expander)", () => {
       const { result, rerender } = renderHook(
-        ({ initialExpanded, label }) =>
+        ({ backendExpanded, label }) =>
           useDetailsAnimation({
-            initialExpanded,
+            backendExpanded,
             label,
           }),
         {
           initialProps: {
-            initialExpanded: true as boolean | null,
+            backendExpanded: true as boolean | null,
             label: "Old Label",
           },
         }
@@ -199,8 +296,8 @@ describe("useDetailsAnimation", () => {
 
       expect(result.current.isOpen).toBe(false)
 
-      // Change label (simulates new expander) - should reset to initialExpanded
-      rerender({ initialExpanded: true, label: "New Label" })
+      // Change label (simulates new expander) - should reset to backendExpanded
+      rerender({ backendExpanded: true, label: "New Label" })
 
       expect(result.current.isOpen).toBe(true)
     })
@@ -210,12 +307,337 @@ describe("useDetailsAnimation", () => {
     it("does not throw on unmount", () => {
       const { unmount } = renderHook(() =>
         useDetailsAnimation({
-          initialExpanded: false,
+          backendExpanded: false,
           label: "Test",
         })
       )
 
       expect(() => unmount()).not.toThrow()
+    })
+  })
+
+  describe("ResizeObserver", () => {
+    let triggerResize: (() => void) | null
+    let mockObserve: ReturnType<typeof vi.fn>
+    let mockDisconnect: ReturnType<typeof vi.fn>
+    const OriginalResizeObserver = globalThis.ResizeObserver
+
+    /** Wrapper component that renders DOM elements wired to the hook's refs. */
+    function TestHarness(
+      props: UseDetailsAnimationOptions
+    ): ReturnType<typeof createElement> {
+      const result = useDetailsAnimation(props)
+      return createElement(
+        "details",
+        { ref: result.detailsRef, "data-testid": "details" },
+        createElement(
+          "summary",
+          {
+            ref: result.summaryRef,
+            "data-testid": "summary",
+            onClick: result.handleToggle,
+          },
+          props.label
+        ),
+        createElement(
+          "div",
+          { ref: result.contentRef, "data-testid": "content" },
+          "Content"
+        )
+      )
+    }
+
+    function mockElementHeight(element: Element, height: number): void {
+      vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 0,
+        height,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      } as DOMRect)
+    }
+
+    /** Assert that the ResizeObserver was constructed and fire its callback. */
+    function fireResize(): void {
+      expect(triggerResize).not.toBeNull()
+      triggerResize?.()
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      triggerResize = null
+      mockObserve = vi.fn()
+      mockDisconnect = vi.fn()
+
+      globalThis.ResizeObserver = class {
+        constructor(cb: ResizeObserverCallback) {
+          triggerResize = () => cb([], this as unknown as ResizeObserver)
+        }
+
+        observe = mockObserve
+
+        unobserve = vi.fn()
+
+        disconnect = mockDisconnect
+      } as unknown as typeof ResizeObserver
+    })
+
+    afterEach(() => {
+      vi.runOnlyPendingTimers()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+      globalThis.ResizeObserver = OriginalResizeObserver
+    })
+
+    it("observes content element and disconnects on unmount", () => {
+      const { unmount } = render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+      const content = screen.getByTestId("content")
+
+      expect(mockObserve).toHaveBeenCalledWith(content)
+      expect(mockDisconnect).not.toHaveBeenCalled()
+
+      unmount()
+      expect(mockDisconnect).toHaveBeenCalled()
+    })
+
+    it("does not trigger animation when details is closed", () => {
+      render(
+        createElement(TestHarness, {
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      fireResize()
+      // Advance past debounce (50ms = RESIZE_DEBOUNCE_MS)
+      vi.advanceTimersByTime(50)
+
+      expect(Element.prototype.animate).not.toHaveBeenCalled()
+    })
+
+    it("debounces rapid resize events into a single animation", () => {
+      render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // target = 40 + 200 + 2*1(BORDER_SIZE) = 242, current = 100, diff = 142 > 5
+      mockElementHeight(details, 100)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 200)
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      // Three rapid resize events
+      fireResize()
+      fireResize()
+      fireResize()
+
+      // Before debounce expires — no animation yet
+      expect(Element.prototype.animate).not.toHaveBeenCalled()
+
+      // After debounce — exactly one animation
+      vi.advanceTimersByTime(50)
+      expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not trigger animation during close mode (isOpenRef is false)", async () => {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      })
+
+      render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      // Click summary to toggle closed: sets isOpenRef.current = false synchronously.
+      // details.open stays true because the mock animate never fires onFinish.
+      await user.click(screen.getByTestId("summary"))
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // Dimensions that would trigger animation if guards didn't prevent it
+      mockElementHeight(details, 100)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 200)
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      fireResize()
+      vi.advanceTimersByTime(50)
+
+      // No resize animation because isOpenRef.current is false
+      expect(Element.prototype.animate).not.toHaveBeenCalled()
+    })
+
+    it("does not animate when height difference is within threshold", () => {
+      render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // target = 40 + 58 + 2*1 = 100, current = 103, diff = 3 ≤ 5(RESIZE_THRESHOLD_PX)
+      mockElementHeight(details, 103)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 58)
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      fireResize()
+      vi.advanceTimersByTime(50)
+
+      expect(Element.prototype.animate).not.toHaveBeenCalled()
+    })
+
+    it("animates when height difference exceeds threshold", () => {
+      render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // target = 40 + 200 + 2*1 = 242, current = 100, diff = 142 > 5(RESIZE_THRESHOLD_PX)
+      mockElementHeight(details, 100)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 200)
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      fireResize()
+      vi.advanceTimersByTime(50)
+
+      expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
+    })
+
+    it("locks inline styles when content height is zero so ResizeObserver can animate later", async () => {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      })
+
+      render(
+        createElement(TestHarness, {
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // Summary has height, but content returns 0 (e.g. widget mode where
+      // content hasn't loaded yet)
+      mockElementHeight(details, 42)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 0)
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      // Click to expand — animateTo(true) hits the contentHeight === 0 branch
+      await user.click(screen.getByTestId("summary"))
+
+      // No animation should have been started (nothing to animate to yet)
+      expect(Element.prototype.animate).not.toHaveBeenCalled()
+      // Inline styles should remain LOCKED so the ResizeObserver can later
+      // animate from this height to the full content height once it loads
+      expect(details.style.height).toBe("42px")
+      expect(details.style.overflow).toBe("hidden")
+      // Element should still be set to open for content to render
+      expect(details).toHaveAttribute("open")
+    })
+
+    it("animates from locked height when content loads after zero-content open", async () => {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      })
+
+      render(
+        createElement(TestHarness, {
+          backendExpanded: false,
+          label: "Test",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // Initially: summary=40, content=0, details=42
+      mockElementHeight(details, 42)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 0)
+
+      // Click to expand — locks height at 42px (content is 0)
+      await user.click(screen.getByTestId("summary"))
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      // Content loads: now content=200, but details is still locked at 42px
+      // (the ResizeObserver reads the locked details height)
+      mockElementHeight(content, 200)
+      // details stays locked at 42 since style.height="42px"
+      // target = 40 + 200 + 2*1 = 242, current = 42, diff = 200 > 5
+
+      fireResize()
+      vi.advanceTimersByTime(50)
+
+      // ResizeObserver should trigger an animation from locked height to full
+      expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
+    })
+
+    it("clears pending debounce timeout on unmount", () => {
+      const { unmount } = render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Test",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      mockElementHeight(details, 100)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 200)
+      ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
+
+      // Start a resize (begins debounce timeout)
+      fireResize()
+
+      // Unmount before timeout fires
+      unmount()
+
+      // Advance past debounce — no animation should fire
+      vi.advanceTimersByTime(50)
+
+      expect(Element.prototype.animate).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -23,39 +23,38 @@ import {
   useState,
 } from "react"
 
-import { notNullOrUndefined } from "~lib/util/utils"
+import { isNullOrUndefined } from "~lib/util/utils"
 
 import { animateHeight, AnimationHandle } from "./animateHeight"
 import { BORDER_SIZE } from "./styled-components"
 
 /**
- * Delay before measuring content height for the Safari repaint workaround (ms).
- *
- * In Safari, <details> content is not painted synchronously when opened,
- * so we first animate a tiny amount (5px) to force a repaint, then measure
- * the real content height after this delay.
+ * Debounce delay for ResizeObserver callbacks (ms).
+ * 50ms (~3 frames at 60fps) lets rapid content changes settle
+ * while still being responsive.
  */
-const SAFARI_REPAINT_DELAY_MS = 100
+const RESIZE_DEBOUNCE_MS = 50
 
 /**
- * Arbitrary height (px) used to force a Safari repaint when expanding.
- * This is added to the collapsed height to create a small initial animation
- * that forces Safari to paint the <details> content.
+ * Minimum height difference (px) required to trigger a resize animation.
+ * Prevents micro-animations from sub-pixel rounding or trivial layout shifts.
  */
-const SAFARI_REPAINT_HEIGHT = 5
+const RESIZE_THRESHOLD_PX = 5
 
 export interface UseDetailsAnimationOptions {
   /**
-   * Expanded state from the backend proto.
+   * Open state from backend (initial or controlled).
    *
    * - `true` / `false` – explicit state from the proto.
    * - `null` / `undefined` – the field was not set (e.g. `ClearField("expanded")`
    *   during `st.status().update()`). In this case the hook preserves the
    *   current open/closed state and defaults to `false` on initial render.
    */
-  initialExpanded: boolean | null | undefined
+  backendExpanded: boolean | null | undefined
   /** Label used to detect "new expander" replacing old one */
   label: string
+  /** Callback when user toggles (for widget mode) */
+  onToggle?: (newOpen: boolean) => void
 }
 
 export interface UseDetailsAnimationResult {
@@ -73,12 +72,20 @@ export interface UseDetailsAnimationResult {
 
 /**
  * Custom hook for managing animated <details> element open/close state.
+ *
+ * Features:
+ * - Optimistic updates: animates immediately on user toggle
+ * - Backend sync: animates when backend state changes
+ * - Content resize: animates when content changes size (e.g. lazy-loaded)
+ * - Smooth interruption: animations can be interrupted without visual flicker
+ * - Proper cleanup: all timeouts and animations cleaned up on unmount
  */
 export function useDetailsAnimation({
-  initialExpanded,
+  backendExpanded,
   label,
+  onToggle,
 }: UseDetailsAnimationOptions): UseDetailsAnimationResult {
-  const [isOpen, setIsOpen] = useState<boolean>(initialExpanded || false)
+  const [isOpen, setIsOpen] = useState(backendExpanded ?? false)
 
   const detailsRef = useRef<HTMLDetailsElement>(null)
   const summaryRef = useRef<HTMLElement>(null)
@@ -87,134 +94,257 @@ export function useDetailsAnimation({
   // Track current animation for cancellation
   const animationRef = useRef<AnimationHandle | null>(null)
 
-  // Track Safari repaint timeout
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Track resize debounce timeout
+  const resizeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Track isOpen in ref to avoid stale closures in callbacks.
+  // Updated explicitly in handleToggle and the backend sync effect
+  // (not during render, to satisfy react-hooks/refs).
+  const isOpenRef = useRef(isOpen)
+
+  // Track previous label for detecting "new expander" replacements
+  const prevLabelRef = useRef(label)
+
+  // Track if component has mounted (to skip animation on initial render)
+  const hasMountedRef = useRef(false)
 
   /**
-   * Cancel any running animation and pending timeouts.
+   * Cancel any running animation.
    */
   const cancelAnimation = useCallback((): void => {
-    if (animationRef.current) {
-      animationRef.current.cancel()
-      animationRef.current = null
-    }
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = null
-    }
+    animationRef.current?.cancel()
+    animationRef.current = null
   }, [])
 
-  // Sync with backend/proto state changes.
-  // Only apply the expanded state if it was actually set in the proto.
-  // The label dependency ensures we reset when a "new expander" replaces
-  // the old one in the same position (React may reuse the same DOM element).
-  useEffect(() => {
-    if (notNullOrUndefined(initialExpanded)) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Syncing with external proto state
-      setIsOpen(initialExpanded)
-
-      // We manage the open attribute via the detailsRef and not with React state
-      if (detailsRef.current) {
-        detailsRef.current.open = initialExpanded
-      }
-    }
-  }, [label, initialExpanded])
-
   /**
-   * Run the height animation between two values.
-   * Cancels any in-progress animation before starting.
+   * Animate to a target open/closed state.
+   * Handles interruption smoothly by capturing current height before cancelling.
+   *
+   * Performance note: This function triggers 1-2 forced reflows via getBoundingClientRect().
+   * This is acceptable because:
+   * - It only runs on user click or backend state change (infrequent)
+   * - Reflows are batched where possible (reads before writes)
+   * - Accurate measurements are required for smooth animation
    */
-  const startAnimation = useCallback(
-    (
-      detailsEl: HTMLElement,
-      startHeight: number,
-      endHeight: number,
-      onFinish?: () => void
-    ): void => {
-      cancelAnimation()
+  const animateTo = useCallback(
+    (targetOpen: boolean): void => {
+      const details = detailsRef.current
+      const summary = summaryRef.current
+      const content = contentRef.current
+      if (!details || !summary) {
+        return
+      }
 
-      animationRef.current = animateHeight(detailsEl, startHeight, endHeight, {
-        onFinish,
-      })
+      // === BATCH READ PHASE (1 reflow) ===
+      // Read all layout properties BEFORE making any style changes to minimize reflows
+      /* eslint-disable streamlit-custom/no-force-reflow-access -- Batched reads for animation */
+      const currentHeight = details.getBoundingClientRect().height
+      const summaryHeight = summary.getBoundingClientRect().height
+      /* eslint-enable streamlit-custom/no-force-reflow-access */
+
+      // === WRITE PHASE ===
+      cancelAnimation()
+      details.style.height = `${currentHeight}px`
+      details.style.overflow = "hidden"
+
+      if (targetOpen) {
+        // Set open so content renders
+        details.open = true
+
+        // === SECOND READ (1 reflow) ===
+        // Must happen AFTER details.open = true so content is in the DOM
+        // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Required after DOM change
+        const contentHeight = content?.getBoundingClientRect().height ?? 0
+
+        // Animate to full height (summary + content + borders)
+        if (contentHeight > 0) {
+          const targetHeight = summaryHeight + contentHeight + 2 * BORDER_SIZE
+          animationRef.current = animateHeight(
+            details,
+            currentHeight,
+            targetHeight
+          )
+        }
+        // If contentHeight is 0, leave inline height + overflow locked.
+        // This is only expected when a loading skeleton hasn't painted yet
+        // (in widget mode, a <TextLineSkeleton> renders immediately so
+        // contentHeight is normally > 0). Keeping styles locked lets the
+        // ResizeObserver animate from the collapsed height to the full
+        // content height once the skeleton (or real content) paints.
+      } else {
+        // Closing: animate to collapsed height, then set open=false
+        const targetHeight = summaryHeight + 2 * BORDER_SIZE
+        animationRef.current = animateHeight(
+          details,
+          currentHeight,
+          targetHeight,
+          {
+            onFinish: () => {
+              if (detailsRef.current) {
+                detailsRef.current.open = false
+              }
+            },
+          }
+        )
+      }
     },
     [cancelAnimation]
   )
 
   /**
-   * Handle user click on summary to toggle open/closed.
-   * Uses a two-step animation for expansion as a Safari repaint workaround.
+   * Animate content resize (when content height changes while open).
    */
-  const handleToggle = useCallback(
-    (e: MouseEvent): void => {
-      e.preventDefault()
-
-      setIsOpen(prev => !prev)
-
-      const detailsEl = detailsRef.current
-      if (!detailsEl || !summaryRef.current) {
+  const animateResize = useCallback(
+    (currentHeight: number, targetHeight: number): void => {
+      const details = detailsRef.current
+      if (!details) {
         return
       }
 
-      detailsEl.style.overflow = "hidden"
-      // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Need current heights to calculate animation start/end values
-      const detailsHeight = detailsEl.getBoundingClientRect().height
-      // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Need current heights to calculate animation start/end values
-      const summaryHeight = summaryRef.current.getBoundingClientRect().height
+      // Capture and lock (same pattern as animateTo)
+      cancelAnimation()
+      details.style.height = `${currentHeight}px`
+      details.style.overflow = "hidden"
 
-      if (!isOpen) {
-        // === OPENING ===
-        detailsEl.style.height = `${detailsHeight}px`
-        detailsEl.open = true
-
-        window.requestAnimationFrame(() => {
-          // Safari workaround: Safari doesn't paint <details> content
-          // synchronously when opened. Force a repaint by animating a tiny
-          // bit first, then animate to the real height after a short delay.
-          startAnimation(
-            detailsEl,
-            detailsHeight,
-            summaryHeight + 2 * BORDER_SIZE + SAFARI_REPAINT_HEIGHT
-          )
-
-          timeoutRef.current = setTimeout(() => {
-            if (!contentRef.current) {
-              return
-            }
-
-            const contentHeight =
-              // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Need content height to calculate animation end value
-              contentRef.current.getBoundingClientRect().height
-            startAnimation(
-              detailsEl,
-              detailsHeight,
-              summaryHeight + contentHeight + 2 * BORDER_SIZE
-            )
-          }, SAFARI_REPAINT_DELAY_MS)
-        })
-      } else {
-        // === CLOSING ===
-        startAnimation(
-          detailsEl,
-          detailsHeight,
-          summaryHeight + 2 * BORDER_SIZE,
-          () => {
-            // Set open=false after the close animation finishes
-            if (detailsRef.current) {
-              detailsRef.current.open = false
-            }
-          }
-        )
-      }
+      animationRef.current = animateHeight(
+        details,
+        currentHeight,
+        targetHeight
+      )
     },
-    [isOpen, startAnimation]
+    [cancelAnimation]
   )
+
+  // Sync with backend state changes (also handles initial mount).
+  useEffect(() => {
+    const isInitialMount = !hasMountedRef.current
+    hasMountedRef.current = true
+
+    const labelChanged = label !== prevLabelRef.current
+    prevLabelRef.current = label
+
+    // If label changed, this is a "new expander" - cancel animations and reset.
+    // Clear any stale inline styles that cancelAnimation leaves behind.
+    if (labelChanged) {
+      cancelAnimation()
+      const newOpen = backendExpanded ?? false
+      isOpenRef.current = newOpen
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Syncing with external backend state (label change = new expander)
+      setIsOpen(newOpen)
+      if (detailsRef.current) {
+        detailsRef.current.style.height = ""
+        detailsRef.current.style.overflow = ""
+        detailsRef.current.open = newOpen
+      }
+      return
+    }
+
+    // If backendExpanded is null/undefined, the field was deliberately omitted
+    // (e.g. ClearField("expanded") in st.status().update()). This means
+    // "keep the current expanded state" — do nothing.
+    if (isNullOrUndefined(backendExpanded)) {
+      return
+    }
+
+    if (isInitialMount) {
+      // Initial mount - set DOM state directly, no animation.
+      if (detailsRef.current) {
+        detailsRef.current.open = backendExpanded
+      }
+      return
+    }
+
+    // Subsequent renders: sync with animation if backend state differs from local.
+    // After the null check above, backendExpanded is narrowed to boolean.
+    if (backendExpanded !== isOpenRef.current) {
+      isOpenRef.current = backendExpanded
+      setIsOpen(backendExpanded)
+      animateTo(backendExpanded)
+    }
+  }, [backendExpanded, label, cancelAnimation, animateTo])
+
+  // ResizeObserver for content size changes
+  useEffect(() => {
+    const content = contentRef.current
+    const details = detailsRef.current
+    const summary = summaryRef.current
+    if (!content || !details || !summary) {
+      return
+    }
+
+    const observer = new ResizeObserver(() => {
+      // Only observe when open
+      if (!details.open) {
+        return
+      }
+
+      // Debounce to let rapid content changes settle
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current)
+      }
+
+      resizeTimeoutRef.current = setTimeout(() => {
+        // Don't interfere if we're in "closing" mode - let the close animation finish
+        // isOpenRef tracks the INTENDED state, not the current animation state
+        if (!isOpenRef.current) {
+          return
+        }
+
+        // === BATCH READ PHASE (1 reflow) ===
+        // All reads happen before any writes, so only one reflow is triggered.
+        // This only runs on content size changes (debounced), not in hot loops.
+        /* eslint-disable streamlit-custom/no-force-reflow-access -- Batched reads for resize animation */
+        const contentHeight = content.getBoundingClientRect().height
+        const summaryHeight = summary.getBoundingClientRect().height
+        const currentHeight = details.getBoundingClientRect().height
+        /* eslint-enable streamlit-custom/no-force-reflow-access */
+
+        const targetHeight = summaryHeight + contentHeight + 2 * BORDER_SIZE
+
+        // === WRITE PHASE ===
+        // Animate if significant difference (threshold avoids micro-animations)
+        if (Math.abs(currentHeight - targetHeight) > RESIZE_THRESHOLD_PX) {
+          animateResize(currentHeight, targetHeight)
+        }
+      }, RESIZE_DEBOUNCE_MS)
+    })
+
+    observer.observe(content)
+    return () => {
+      observer.disconnect()
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current)
+      }
+    }
+  }, [animateResize])
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       cancelAnimation()
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current)
+      }
     }
   }, [cancelAnimation])
+
+  // Handle user toggle
+  const handleToggle = useCallback(
+    (e: MouseEvent): void => {
+      e.preventDefault()
+
+      const newOpen = !isOpenRef.current
+      isOpenRef.current = newOpen
+
+      // Optimistic update: always animate immediately
+      setIsOpen(newOpen)
+      animateTo(newOpen)
+
+      // Notify caller if callback provided
+      onToggle?.(newOpen)
+    },
+    [onToggle, animateTo]
+  )
 
   return {
     isOpen,


### PR DESCRIPTION
## Describe your changes

Extracts `<details>` open/close animation logic from `Expander.tsx` into a `useDetailsAnimation` hook and `animateHeight` utility, then replaces the Safari two-step repaint workaround with a `ResizeObserver`-based approach.

- **ResizeObserver replaces Safari timeout hack**: Instead of animating 5px → waiting 100ms → measuring real height, the hook now measures immediately after `details.open = true` and falls back to a debounced `ResizeObserver` when content isn't yet painted (Safari) or loads asynchronously
- **Smooth interruption**: Captures current computed height via `getBoundingClientRect()` before cancelling a running animation, so mid-animation toggles start from the actual visual position instead of jumping
- **Nullable `expanded` handling**: Explicit branching for `null`/`undefined` (preserve current state), label changes (reset without animation), and initial mount (set DOM directly, skip animation)
- **`onToggle` callback**: Hook accepts an optional callback for notifying callers on user toggle, preparing for widget mode in Dynamic Expanders

## Testing Plan

- [x] Unit Tests (JS)
  - `useDetailsAnimation.test.ts` — initial state, toggle behavior, backend sync, nullable handling, label-based reset, `onToggle` callback, rapid double-toggle, cleanup, ResizeObserver (observe/disconnect lifecycle, closed-details guard, debouncing, close-mode guard, threshold check, unmount timeout cleanup)
  - `useDetailsAnimation.test.ts` — initial state, toggle behavior, backend sync, nullable handling, label-based reset, `onToggle` callback, rapid double-toggle, cleanup
  - `animateHeight.test.ts` — animation creation, custom options, finish/cancel lifecycle, promise resolution
- [x] Manual verification (Safari)
  - Verified expand/collapse animation, rapid toggling, content resize via ResizeObserver, backend-synced state changes, nullable expanded handling, label swap reset, and nested expanders in Safari
