### PR TITLE
[fix] Add selection support for treemap and sunburst in `st.plotly_chart`

### DIFF
--- a/e2e_playwright/st_plotly_chart_select.py
+++ b/e2e_playwright/st_plotly_chart_select.py
@@ -167,3 +167,46 @@ if len(event_data["selection"]["points"]) > 0:
     st.write(f"Selected points: {len(filtered_df)}")
 else:
     st.write("Nothing is selected")
+
+
+# Treemap chart for hierarchical selection
+st.header("Treemap with Selection")
+df_gapminder = px.data.gapminder().query("year == 2007")
+fig_treemap = px.treemap(
+    df_gapminder, path=["continent", "country"], values="pop", title="World Population"
+)
+event_treemap = st.plotly_chart(
+    fig_treemap, on_select="rerun", key="treemap_chart", selection_mode="points"
+)
+if (
+    event_treemap and len(event_treemap.selection.get("points", [])) > 0  # type: ignore
+):
+    st.write("Treemap selection:")
+    point = event_treemap.selection["points"][0]  # type: ignore
+    st.write(f"Selected: {point.get('label', 'N/A')}")
+    st.write(f"ID: {point.get('id', 'N/A')}")
+    st.write(f"Parent: {point.get('parent', 'N/A')}")
+else:
+    st.write("No treemap selection")
+
+
+# Sunburst chart for hierarchical selection
+st.header("Sunburst with Selection")
+fig_sunburst = px.sunburst(
+    df_gapminder,
+    path=["continent", "country"],
+    values="pop",
+    title="World Population Sunburst",
+)
+event_sunburst = st.plotly_chart(
+    fig_sunburst, on_select="rerun", key="sunburst_chart", selection_mode="points"
+)
+if (
+    event_sunburst and len(event_sunburst.selection.get("points", [])) > 0  # type: ignore
+):
+    st.write("Sunburst selection:")
+    point = event_sunburst.selection["points"][0]  # type: ignore
+    st.write(f"Selected: {point.get('label', 'N/A')}")
+    st.write(f"ID: {point.get('id', 'N/A')}")
+else:
+    st.write("No sunburst selection")

--- a/e2e_playwright/st_plotly_chart_select_test.py
+++ b/e2e_playwright/st_plotly_chart_select_test.py
@@ -280,3 +280,49 @@ def test_check_top_level_class(app: Page):
 def test_custom_css_class_via_key(app: Page):
     """Test that the element can have a custom css class via the key argument."""
     expect(get_element_by_key(app, "line_chart")).to_be_visible()
+
+
+@pytest.mark.parametrize(
+    ("chart_index", "chart_type", "click_x_ratio", "click_y_ratio", "extra_fields"),
+    [
+        (7, "treemap", 0.25, 0.4, ["Parent:"]),
+        (8, "sunburst", 0.35, 0.35, []),
+    ],
+    ids=["treemap", "sunburst"],
+)
+def test_click_on_hierarchical_chart_displays_selection_data(
+    app: Page,
+    chart_index: int,
+    chart_type: str,
+    click_x_ratio: float,
+    click_y_ratio: float,
+    extra_fields: list[str],
+):
+    """Test that clicking on treemap/sunburst segments emits selection data."""
+    chart = app.get_by_test_id("stPlotlyChart").nth(chart_index)
+    chart.scroll_into_view_if_needed()
+    expect(chart).to_be_visible()
+
+    # Initially no selection
+    no_selection_text = f"No {chart_type} selection"
+    expect(app.get_by_text(no_selection_text)).to_be_attached()
+
+    # Click on a chart segment
+    chart.hover()
+    box = chart.bounding_box()
+    assert box is not None
+    app.mouse.click(
+        box["x"] + box["width"] * click_x_ratio,
+        box["y"] + box["height"] * click_y_ratio,
+    )
+    wait_for_app_run(app)
+
+    # Should now show selection data
+    selection_text = f"{chart_type.capitalize()} selection:"
+    expect(app.get_by_text(selection_text)).to_be_attached()
+    expect(app.get_by_text(no_selection_text)).not_to_be_attached()
+    # Should display the selected segment info
+    expect(app.get_by_text("Selected:")).to_be_attached()
+    expect(app.get_by_text("ID:")).to_be_attached()
+    for field in extra_fields:
+        expect(app.get_by_text(field)).to_be_attached()

--- a/e2e_playwright/st_plotly_chart_select_test.py
+++ b/e2e_playwright/st_plotly_chart_select_test.py
@@ -282,47 +282,56 @@ def test_custom_css_class_via_key(app: Page):
     expect(get_element_by_key(app, "line_chart")).to_be_visible()
 
 
-@pytest.mark.parametrize(
-    ("chart_index", "chart_type", "click_x_ratio", "click_y_ratio", "extra_fields"),
-    [
-        (7, "treemap", 0.25, 0.4, ["Parent:"]),
-        (8, "sunburst", 0.35, 0.35, []),
-    ],
-    ids=["treemap", "sunburst"],
-)
-def test_click_on_hierarchical_chart_displays_selection_data(
-    app: Page,
-    chart_index: int,
-    chart_type: str,
-    click_x_ratio: float,
-    click_y_ratio: float,
-    extra_fields: list[str],
-):
-    """Test that clicking on treemap/sunburst segments emits selection data."""
-    chart = app.get_by_test_id("stPlotlyChart").nth(chart_index)
+def test_click_on_treemap_displays_selection_data(app: Page):
+    """Test that clicking on treemap segments emits selection data."""
+    chart = get_element_by_key(app, "treemap_chart")
     chart.scroll_into_view_if_needed()
     expect(chart).to_be_visible()
 
     # Initially no selection
-    no_selection_text = f"No {chart_type} selection"
-    expect(app.get_by_text(no_selection_text)).to_be_attached()
+    expect(app.get_by_text("No treemap selection")).to_be_attached()
 
     # Click on a chart segment
     chart.hover()
     box = chart.bounding_box()
     assert box is not None
     app.mouse.click(
-        box["x"] + box["width"] * click_x_ratio,
-        box["y"] + box["height"] * click_y_ratio,
+        box["x"] + box["width"] * 0.25,
+        box["y"] + box["height"] * 0.4,
     )
     wait_for_app_run(app)
 
     # Should now show selection data
-    selection_text = f"{chart_type.capitalize()} selection:"
-    expect(app.get_by_text(selection_text)).to_be_attached()
-    expect(app.get_by_text(no_selection_text)).not_to_be_attached()
+    expect(app.get_by_text("Treemap selection:")).to_be_attached()
+    expect(app.get_by_text("No treemap selection")).not_to_be_attached()
     # Should display the selected segment info
     expect(app.get_by_text("Selected:")).to_be_attached()
     expect(app.get_by_text("ID:")).to_be_attached()
-    for field in extra_fields:
-        expect(app.get_by_text(field)).to_be_attached()
+    expect(app.get_by_text("Parent:")).to_be_attached()
+
+
+def test_click_on_sunburst_displays_selection_data(app: Page):
+    """Test that clicking on sunburst segments emits selection data."""
+    chart = get_element_by_key(app, "sunburst_chart")
+    chart.scroll_into_view_if_needed()
+    expect(chart).to_be_visible()
+
+    # Initially no selection
+    expect(app.get_by_text("No sunburst selection")).to_be_attached()
+
+    # Click on a chart segment
+    chart.hover()
+    box = chart.bounding_box()
+    assert box is not None
+    app.mouse.click(
+        box["x"] + box["width"] * 0.35,
+        box["y"] + box["height"] * 0.35,
+    )
+    wait_for_app_run(app)
+
+    # Should now show selection data
+    expect(app.get_by_text("Sunburst selection:")).to_be_attached()
+    expect(app.get_by_text("No sunburst selection")).not_to_be_attached()
+    # Should display the selected segment info
+    expect(app.get_by_text("Selected:")).to_be_attached()
+    expect(app.get_by_text("ID:")).to_be_attached()

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -357,6 +357,8 @@ export function PlotlyChart({
     (event: Readonly<Plotly.PlotMouseEvent>): void => {
       handleClickEvent(event, widgetMgr, element, fragmentId)
     },
+    // We are using element.id here instead of element since
+    // shallow reference equality will not work correctly for element.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
     [element.id, widgetMgr, fragmentId]
   )
@@ -488,7 +490,7 @@ export function PlotlyChart({
         onSelected={isSelectionActivated ? handleSelectionCallback : () => {}}
         // Handle click events for hierarchical charts (treemap, sunburst)
         // that don't emit plotly_selected but do emit plotly_click
-        onClick={isSelectionActivated ? handleClickCallback : undefined}
+        onClick={isPointsSelectionActivated ? handleClickCallback : undefined}
         // Double click is needed to make it easier to the user to
         // reset the selection. The default handling can be a bit annoying
         // sometimes.

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -344,9 +344,9 @@ export function PlotlyChart({
     (event: Readonly<Plotly.PlotSelectionEvent>): void => {
       handleSelection(event, widgetMgr, element, fragmentId)
     },
-    // We are using element.id here instead of element since we don't
-    // shallow reference equality will not work correctly for element.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
+    // Using element.id instead of element: the proto object gets a new reference
+    // on each render, but element.id only changes when the element actually changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [element.id, widgetMgr, fragmentId]
   )
 
@@ -357,9 +357,9 @@ export function PlotlyChart({
     (event: Readonly<Plotly.PlotMouseEvent>): void => {
       handleClickEvent(event, widgetMgr, element, fragmentId)
     },
-    // We are using element.id here instead of element since
-    // shallow reference equality will not work correctly for element.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
+    // Using element.id instead of element: the proto object gets a new reference
+    // on each render, but element.id only changes when the element actually changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [element.id, widgetMgr, fragmentId]
   )
 
@@ -399,9 +399,9 @@ export function PlotlyChart({
         }, RESET_SELECTION_TIMEOUT_MS)
       }
     },
-    // We are using element.id here instead of element since we don't
-    // shallow reference equality will not work correctly for element.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
+    // Using element.id instead of element: the proto object gets a new reference
+    // on each render, but element.id only changes when the element actually changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [element.id, widgetMgr, fragmentId]
   )
 

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -37,7 +37,12 @@ import { useRequiredContext } from "~lib/hooks/useRequiredContext"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import { StyledPlotlyChartContainer } from "./styled-components"
-import { applyTheming, handleSelection, sendEmptySelection } from "./utils"
+import {
+  applyTheming,
+  handleClickEvent,
+  handleSelection,
+  sendEmptySelection,
+} from "./utils"
 
 // Minimum width for Plotly charts
 const MIN_WIDTH = 150
@@ -346,6 +351,17 @@ export function PlotlyChart({
   )
 
   /**
+   * Callback to handle click events on hierarchical charts (treemap, sunburst).
+   */
+  const handleClickCallback = useCallback(
+    (event: Readonly<Plotly.PlotMouseEvent>): void => {
+      handleClickEvent(event, widgetMgr, element, fragmentId)
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
+    [element.id, widgetMgr, fragmentId]
+  )
+
+  /**
    * Callback resets selections in the chart and
    * sends out an empty selection state.
    */
@@ -470,6 +486,9 @@ export function PlotlyChart({
           overflow: "hidden",
         }}
         onSelected={isSelectionActivated ? handleSelectionCallback : () => {}}
+        // Handle click events for hierarchical charts (treemap, sunburst)
+        // that don't emit plotly_selected but do emit plotly_click
+        onClick={isSelectionActivated ? handleClickCallback : undefined}
         // Double click is needed to make it easier to the user to
         // reset the selection. The default handling can be a bit annoying
         // sometimes.

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { waitFor } from "@testing-library/dom"
+import Plotly from "plotly.js"
 
 import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"
 
@@ -24,6 +25,7 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 import { applyStreamlitTheme, layoutWithThemeDefaults } from "./CustomTheme"
 import {
   applyTheming,
+  handleClickEvent,
   handleSelection,
   parseBoxSelection,
   parseLassoPath,
@@ -462,6 +464,125 @@ describe("PlotlyChart utils", () => {
           undefined
         )
       })
+    })
+  })
+
+  describe("handleClickEvent", () => {
+    const mockFragmentId = "testFragment"
+    const proto = {
+      id: "plotly_chart",
+      selectionMode: [0, 1, 2],
+    } as PlotlyChartProto
+
+    it.each([
+      ["undefined event", undefined],
+      ["event with empty points array", { points: [] }],
+      [
+        "non-hierarchical chart click (no id/parent)",
+        { points: [{ x: 100, y: 200, pointIndex: 1 }] },
+      ],
+    ])("should return early for %s", (_desc, event) => {
+      const widgetMgr = getWidgetMgr()
+      vi.spyOn(widgetMgr, "setStringValue")
+
+      handleClickEvent(
+        event as unknown as Plotly.PlotMouseEvent,
+        widgetMgr,
+        proto,
+        mockFragmentId
+      )
+      expect(widgetMgr.setStringValue).not.toHaveBeenCalled()
+    })
+
+    it("should process treemap/sunburst clicks correctly", () => {
+      const event = {
+        points: [
+          {
+            label: "China",
+            id: "Asia/China",
+            parent: "Asia",
+            value: 1318683096,
+            currentPath: "/Asia/",
+            percentRoot: 0.21,
+            percentEntry: 0.21,
+            percentParent: 0.35,
+            pointNumber: 25,
+            curveNumber: 0,
+          },
+        ],
+      } as unknown as Plotly.PlotMouseEvent
+      const widgetMgr = getWidgetMgr()
+      vi.spyOn(widgetMgr, "setStringValue")
+
+      handleClickEvent(event, widgetMgr, proto, mockFragmentId)
+
+      expect(widgetMgr.setStringValue).toHaveBeenCalledWith(
+        proto,
+        '{"selection":{"points":[{"label":"China","id":"Asia/China","parent":"Asia","value":1318683096,"current_path":"/Asia/","percent_root":0.21,"percent_entry":0.21,"percent_parent":0.35,"point_number":25,"curve_number":0}],"point_indices":[25],"box":[],"lasso":[]}}',
+        { fromUi: true },
+        mockFragmentId
+      )
+    })
+
+    it("should handle treemap click with undefined pointNumber", () => {
+      const event = {
+        points: [
+          {
+            label: "Root",
+            id: "",
+            parent: "",
+            value: 1000,
+          },
+        ],
+      } as unknown as Plotly.PlotMouseEvent
+      const widgetMgr = getWidgetMgr()
+      vi.spyOn(widgetMgr, "setStringValue")
+
+      handleClickEvent(event, widgetMgr, proto, mockFragmentId)
+
+      expect(widgetMgr.setStringValue).toHaveBeenCalledWith(
+        proto,
+        expect.stringContaining('"point_indices":[]'),
+        { fromUi: true },
+        mockFragmentId
+      )
+    })
+
+    it("should not rerun if selection state is unchanged", () => {
+      const event = {
+        points: [
+          {
+            label: "China",
+            id: "Asia/China",
+            parent: "Asia",
+            value: 1318683096,
+            currentPath: "/Asia/",
+            percentRoot: 0.21,
+            percentEntry: 0.21,
+            percentParent: 0.35,
+            pointNumber: 25,
+            curveNumber: 0,
+          },
+        ],
+      } as unknown as Plotly.PlotMouseEvent
+      const widgetMgr = getWidgetMgr()
+      vi.spyOn(widgetMgr, "setStringValue")
+
+      // Pre-set the state to match what the click would produce
+      widgetMgr.setStringValue(
+        proto,
+        '{"selection":{"points":[{"label":"China","id":"Asia/China","parent":"Asia","value":1318683096,"current_path":"/Asia/","percent_root":0.21,"percent_entry":0.21,"percent_parent":0.35,"point_number":25,"curve_number":0}],"point_indices":[25],"box":[],"lasso":[]}}',
+        { fromUi: true },
+        mockFragmentId
+      )
+
+      // Clear the mock to only count the handleClickEvent call
+      vi.clearAllMocks()
+
+      handleClickEvent(event, widgetMgr, proto, mockFragmentId)
+
+      // Should not call setStringValue again since state is unchanged
+      expect(widgetMgr.setStringValue).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.ts
@@ -320,3 +320,69 @@ export function sendEmptySelection(
     fragmentId
   )
 }
+
+/**
+ * Handles click events from hierarchical charts (treemap, sunburst) that don't
+ * emit plotly_selected events but do emit plotly_click events.
+ * The click data is sent as selection state to maintain API consistency.
+ *
+ * @param event The Plotly click event
+ * @param widgetMgr The widget manager
+ * @param element The PlotlyChartProto element
+ * @param fragmentId The fragment id
+ */
+export function handleClickEvent(
+  event: Readonly<Plotly.PlotMouseEvent>,
+  widgetMgr: WidgetStateManager,
+  element: PlotlyChartProto,
+  fragmentId: string | undefined
+): void {
+  if (!event?.points?.length) {
+    return
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plotly event types are incomplete
+  const point = event.points[0] as any
+
+  // Check if this is a hierarchical chart click (treemap/sunburst)
+  // These charts have 'id' and 'parent' properties in their click events
+  if (point.id === undefined || point.parent === undefined) {
+    // Not a treemap/sunburst click, ignore
+    return
+  }
+
+  const selectionState: PlotlyWidgetState = {
+    selection: {
+      points: [
+        keysToSnakeCase({
+          label: point.label,
+          id: point.id,
+          parent: point.parent,
+          value: point.value,
+          currentPath: point.currentPath,
+          percentRoot: point.percentRoot,
+          percentEntry: point.percentEntry,
+          percentParent: point.percentParent,
+          pointNumber: point.pointNumber,
+          curveNumber: point.curveNumber,
+        }),
+      ],
+      point_indices: notNullOrUndefined(point.pointNumber)
+        ? [point.pointNumber]
+        : [],
+      box: [],
+      lasso: [],
+    },
+  }
+
+  const currentSelectionState = widgetMgr.getStringValue(element)
+  const newSelectionState = JSON.stringify(selectionState)
+  if (currentSelectionState !== newSelectionState) {
+    widgetMgr.setStringValue(
+      element,
+      newSelectionState,
+      { fromUi: true },
+      fragmentId
+    )
+  }
+}


### PR DESCRIPTION
## Describe your changes

- Adds `onClick` handler to capture click events from treemap and sunburst charts
- Hierarchical charts don't emit `plotly_selected` events, but do emit `plotly_click` events
- Selection data sent with consistent format including `id`, `parent`, `label`, `value`, and hierarchy-specific fields

## GitHub Issue Link (if applicable)

Closes #9001

## Testing Plan

- [x] Unit Tests (JS)
- [x] E2E Tests (treemap and sunburst selection)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.