### PR TITLE
Optimize agent rules

### DIFF
--- a/.claude/agents/simplifying-local-changes.md
+++ b/.claude/agents/simplifying-local-changes.md
@@ -144,6 +144,7 @@ For tests in `e2e_playwright/`:
 - Use shared `conftest.py` fixtures and `app_utils` methods where applicable
 - Prefer label- or key-based locators over index-based access (e.g., avoid `get_by_test_id().nth(0)`)
 - Group related tests into single, logical test files for CI efficiency and maximize coverage per test case
+- Do NOT simplify E2E tests using `@pytest.mark.parametrize`—E2E tests are expensive, and parameterization multiplies browser runs. Prefer iterating variants within a single test function instead.
 
 ## What NOT to Do
 

--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -64,11 +64,11 @@ Import from `conftest.py`:
 
 ## Best Practices
 
-- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run, not number of tiny test functions.
+- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run—test each aspect only once, prefer aggregated scenario tests over many micro-tests, and add new tests to existing test files when they fit the scope rather than creating new test scripts.
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.
 - As a guiding principle, tests should resemble how users interact with the UI.
 - Use `expect` for auto-wait assertions, not `assert` (reduces flakiness)
-- If `expect` is insufficient, use the `wait_until` utility. Never use `wait_for_timeout`.
+- If `expect` is insufficient, use the `wait_until` utility. Usage of `wait_for_timeout` is discouraged and should only be used when there is a specific purpose.
 - Add at least one “must NOT happen” check per scenario when practical: Alongside the positive UI outcome, assert the absence of a likely regression (e.g., no duplicate element appears, a tooltip is not shown until hover, a widget remains non-interactive when `disabled=True`, no unexpected rerun/state change, etc.).
 - Keep negatives high-signal: E2E is expensive—prefer one targeted negative assertion per scenario over large negative matrices.
 - Prefer label- or key-based locators over index-based access (e.g. `get_by_test_id().nth(0)`). The recommended order of priority is:
@@ -84,7 +84,6 @@ Import from `conftest.py`:
 - Ensure elements screenshotted are under 640px height to avoid clipping by the header.
 - Naming convention for command-related snapshots: `st_command-test_description`
 - Take a look at other tests in `e2e_playwright/` as inspiration.
-- Important: E2E tests are expensive, please test every aspect only one time. Prefer adding new tests to existing e2e test files if they fit the scope, instead of creating new test scripts.
 - Make use of shared `app_utils` methods (import from `e2e_playwright.shared.app_utils`) if applicable.
 - Make sure that the tests mix different ways of interactions (e.g. fill and type for input fields) for increased coverage.
 
@@ -110,6 +109,5 @@ When adding or modifying tests for an element, ensure the following are covered:
 - Single test file: `make run-e2e-test e2e_playwright/name_of_the_test.py`
 - Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py::test_name`
 - Pass any pytest arguments via `PYTEST_ADDOPTS`, e.g. `PYTEST_ADDOPTS='-k test_name -vvv' make run-e2e-test e2e_playwright/name_of_the_test.py`
-- Debug test (needs manual interactions): `make debug-e2e-test e2e_playwright/name_of_the_test.py`
 - If frontend logic was changed, it will require running `make frontend-fast` to update the frontend.
 - You can ignore missing or mismatched snapshot errors. These need to be updated manually.

--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -64,6 +64,7 @@ Import from `conftest.py`:
 
 ## Best Practices
 
+- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run, not number of tiny test functions.
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.
 - As a guiding principle, tests should resemble how users interact with the UI.
 - Use `expect` for auto-wait assertions, not `assert` (reduces flakiness)
@@ -76,6 +77,8 @@ Import from `conftest.py`:
   3. If the element doesn't support key or label, you can wrap it with an `st.container(key="my_key")` to better target it via `get_element_by_key`. E.g. `get_element_by_key("my_key").get_by_test_id("stComponent")`.
 - Prefer stable locators like `get_by_test_id`, `get_by_text` or `get_by_role` over CSS / XPath selectors via `.locator`.
 - Group related tests into single, logical test files (e.g., by widget or feature) for CI efficiency.
+- Prefer a single aggregated scenario test over many micro-tests when they share the same setup and page state. Reuse one app load, cover multiple assertions in sequence, and reduce browser loads.
+- Use `@pytest.mark.parametrize` sparingly in E2E. Avoid parameterizing over expensive flows and prefer iterating variants in one scenario test when setup dominates runtime.
 - Minimize screenshot surface area; screenshot specific elements, not the whole page unless necessary.
 - Use descriptive test names.
 - Ensure elements screenshotted are under 640px height to avoid clipping by the header.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -46,34 +46,34 @@ alwaysApply: true
 
 Selection of `make` commands for development (run in the repo root):
 
-- `help`: Show all available make commands.
-- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing.
-- `protobuf`: Recompile Protobufs for Python and the frontend.
-- `autofix`: Autofix linting and formatting errors.
+- `help`: Show all available make commands. [~1s]
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
+- `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
+- `autofix`: Autofix linting and formatting errors. [~30s]
 
 **Backend Development (Python):**
 
-- `python-lint`: Lint and check formatting of Python files (ruff).
-- `python-tests`: Run all Python unit tests (pytest).
-- `python-types`: Run the Python type checker (mypy & ty).
-- `python-format`: Format Python files (ruff).
+- `python-lint`: Lint and check formatting of Python files (ruff). [~1s]
+- `python-tests`: Run all Python unit tests (pytest). [~3min]
+- `python-types`: Run the Python type checker (mypy & ty). [~30s]
+- `python-format`: Format Python files (ruff). [~1s]
 
 **Frontend Development (TypeScript):**
 
-- `frontend-fast`: Build the frontend (vite).
-- `frontend-dev`: Start the frontend development server (hot-reload).
-- `frontend-lint`: Lint and check formatting of all frontend files (eslint).
-- `frontend-types`: Run the TypeScript type checker on all files (tsc).
-- `frontend-format`: Format all frontend files (eslint).
-- `frontend-tests`: Run all frontend unit tests (vitest).
+- `frontend-fast`: Build the frontend (vite). [~40s]
+- `frontend-dev`: Start the frontend development server (hot-reload). [until stopped]
+- `frontend-lint`: Lint and check formatting of all frontend files (eslint). [~45s]
+- `frontend-types`: Run the TypeScript type checker on all files (tsc). [~15s]
+- `frontend-format`: Format all frontend files (eslint). [~10s]
+- `frontend-tests`: Run all frontend unit tests (vitest). [~5min]
 
 **E2E Testing (Playwright):**
 
-- `run-e2e-test`: Run e2e test, via: `make run-e2e-test st_command_test.py`.
+- `run-e2e-test`: Run e2e test, via: `make run-e2e-test st_command_test.py`. [varies by test]
 
 **Debugging backend & frontend:**
 
-- `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`.
+- `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`. [until stopped]
   - Frontend hot-reload: Changes to frontend code (`frontend/`) are applied within seconds.
   - Backend hot-reload: Only changes to the **app script** trigger a rerun. Changes to the Streamlit library itself (`lib/streamlit/`) require restarting `make debug`.
   - Logs are written to a per-session directory under `work-tmp/debug/` (e.g. `work-tmp/debug/<session>/backend.log` and `work-tmp/debug/<session>/frontend.log`).
@@ -93,6 +93,7 @@ Selection of `make` commands for development (run in the repo root):
 
 ## Testing Strategy
 
+- Most new user-facing features should be covered by both unit tests and E2E tests.
 - **Python Unit Tests**: Test internal behavior without frontend. Located at `lib/tests/streamlit/<package>/<module>_test.py` mirroring `lib/streamlit/<package>/<module>.py` (legacy tests may vary).
 - **Frontend Unit Tests**: Test React components, hooks, and related functionality with Vitest and React Testing Library. Co-located as `<Component>.test.tsx` next to `<Component>.tsx`.
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`.

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -62,6 +62,16 @@ alwaysApply: false
   - Don't remove focus outlines without replacing them. Prefer `:focus-visible` styles and use `theme.shadows` values for consistent rings.
 - **Keyboard dismissal shouldn’t steal focus**: Popovers/tooltips/dialogs should support Escape to dismiss while keeping focus on the trigger unless there’s a strong reason to move it.
 
+## Logging
+
+- Use `loglevel`'s `getLogger` for logging (e.g. warnings / errors). Create a module-level `LOG` constant with a descriptive name:
+
+```tsx
+import { getLogger } from "loglevel"
+
+const LOG = getLogger("MyComponent")
+```
+
 ## Static Data Structures
 
 - Extract static lookup maps and constants to module-level scope outside functions/components

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,34 +40,34 @@
 
 Selection of `make` commands for development (run in the repo root):
 
-- `help`: Show all available make commands.
-- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing.
-- `protobuf`: Recompile Protobufs for Python and the frontend.
-- `autofix`: Autofix linting and formatting errors.
+- `help`: Show all available make commands. [~1s]
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
+- `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
+- `autofix`: Autofix linting and formatting errors. [~30s]
 
 **Backend Development (Python):**
 
-- `python-lint`: Lint and check formatting of Python files (ruff).
-- `python-tests`: Run all Python unit tests (pytest).
-- `python-types`: Run the Python type checker (mypy & ty).
-- `python-format`: Format Python files (ruff).
+- `python-lint`: Lint and check formatting of Python files (ruff). [~1s]
+- `python-tests`: Run all Python unit tests (pytest). [~3min]
+- `python-types`: Run the Python type checker (mypy & ty). [~30s]
+- `python-format`: Format Python files (ruff). [~1s]
 
 **Frontend Development (TypeScript):**
 
-- `frontend-fast`: Build the frontend (vite).
-- `frontend-dev`: Start the frontend development server (hot-reload).
-- `frontend-lint`: Lint and check formatting of all frontend files (eslint).
-- `frontend-types`: Run the TypeScript type checker on all files (tsc).
-- `frontend-format`: Format all frontend files (eslint).
-- `frontend-tests`: Run all frontend unit tests (vitest).
+- `frontend-fast`: Build the frontend (vite). [~40s]
+- `frontend-dev`: Start the frontend development server (hot-reload). [until stopped]
+- `frontend-lint`: Lint and check formatting of all frontend files (eslint). [~45s]
+- `frontend-types`: Run the TypeScript type checker on all files (tsc). [~15s]
+- `frontend-format`: Format all frontend files (eslint). [~10s]
+- `frontend-tests`: Run all frontend unit tests (vitest). [~5min]
 
 **E2E Testing (Playwright):**
 
-- `run-e2e-test`: Run e2e test, via: `make run-e2e-test st_command_test.py`.
+- `run-e2e-test`: Run e2e test, via: `make run-e2e-test st_command_test.py`. [varies by test]
 
 **Debugging backend & frontend:**
 
-- `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`.
+- `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`. [until stopped]
   - Frontend hot-reload: Changes to frontend code (`frontend/`) are applied within seconds.
   - Backend hot-reload: Only changes to the **app script** trigger a rerun. Changes to the Streamlit library itself (`lib/streamlit/`) require restarting `make debug`.
   - Logs are written to a per-session directory under `work-tmp/debug/` (e.g. `work-tmp/debug/<session>/backend.log` and `work-tmp/debug/<session>/frontend.log`).
@@ -87,6 +87,7 @@ Selection of `make` commands for development (run in the repo root):
 
 ## Testing Strategy
 
+- Most new user-facing features should be covered by both unit tests and E2E tests.
 - **Python Unit Tests**: Test internal behavior without frontend. Located at `lib/tests/streamlit/<package>/<module>_test.py` mirroring `lib/streamlit/<package>/<module>.py` (legacy tests may vary).
 - **Frontend Unit Tests**: Test React components, hooks, and related functionality with Vitest and React Testing Library. Co-located as `<Component>.test.tsx` next to `<Component>.tsx`.
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`.

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -62,6 +62,7 @@ Import from `conftest.py`:
 
 ## Best Practices
 
+- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run, not number of tiny test functions.
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.
 - As a guiding principle, tests should resemble how users interact with the UI.
 - Use `expect` for auto-wait assertions, not `assert` (reduces flakiness)
@@ -74,6 +75,8 @@ Import from `conftest.py`:
   3. If the element doesn't support key or label, you can wrap it with an `st.container(key="my_key")` to better target it via `get_element_by_key`. E.g. `get_element_by_key("my_key").get_by_test_id("stComponent")`.
 - Prefer stable locators like `get_by_test_id`, `get_by_text` or `get_by_role` over CSS / XPath selectors via `.locator`.
 - Group related tests into single, logical test files (e.g., by widget or feature) for CI efficiency.
+- Prefer a single aggregated scenario test over many micro-tests when they share the same setup and page state. Reuse one app load, cover multiple assertions in sequence, and reduce browser loads.
+- Use `@pytest.mark.parametrize` sparingly in E2E. Avoid parameterizing over expensive flows and prefer iterating variants in one scenario test when setup dominates runtime.
 - Minimize screenshot surface area; screenshot specific elements, not the whole page unless necessary.
 - Use descriptive test names.
 - Ensure elements screenshotted are under 640px height to avoid clipping by the header.

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -62,11 +62,11 @@ Import from `conftest.py`:
 
 ## Best Practices
 
-- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run, not number of tiny test functions.
+- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run—test each aspect only once, prefer aggregated scenario tests over many micro-tests, and add new tests to existing test files when they fit the scope rather than creating new test scripts.
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.
 - As a guiding principle, tests should resemble how users interact with the UI.
 - Use `expect` for auto-wait assertions, not `assert` (reduces flakiness)
-- If `expect` is insufficient, use the `wait_until` utility. Never use `wait_for_timeout`.
+- If `expect` is insufficient, use the `wait_until` utility. Usage of `wait_for_timeout` is discouraged and should only be used when there is a specific purpose.
 - Add at least one “must NOT happen” check per scenario when practical: Alongside the positive UI outcome, assert the absence of a likely regression (e.g., no duplicate element appears, a tooltip is not shown until hover, a widget remains non-interactive when `disabled=True`, no unexpected rerun/state change, etc.).
 - Keep negatives high-signal: E2E is expensive—prefer one targeted negative assertion per scenario over large negative matrices.
 - Prefer label- or key-based locators over index-based access (e.g. `get_by_test_id().nth(0)`). The recommended order of priority is:
@@ -82,7 +82,6 @@ Import from `conftest.py`:
 - Ensure elements screenshotted are under 640px height to avoid clipping by the header.
 - Naming convention for command-related snapshots: `st_command-test_description`
 - Take a look at other tests in `e2e_playwright/` as inspiration.
-- Important: E2E tests are expensive, please test every aspect only one time. Prefer adding new tests to existing e2e test files if they fit the scope, instead of creating new test scripts.
 - Make use of shared `app_utils` methods (import from `e2e_playwright.shared.app_utils`) if applicable.
 - Make sure that the tests mix different ways of interactions (e.g. fill and type for input fields) for increased coverage.
 
@@ -108,6 +107,5 @@ When adding or modifying tests for an element, ensure the following are covered:
 - Single test file: `make run-e2e-test e2e_playwright/name_of_the_test.py`
 - Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py::test_name`
 - Pass any pytest arguments via `PYTEST_ADDOPTS`, e.g. `PYTEST_ADDOPTS='-k test_name -vvv' make run-e2e-test e2e_playwright/name_of_the_test.py`
-- Debug test (needs manual interactions): `make debug-e2e-test e2e_playwright/name_of_the_test.py`
 - If frontend logic was changed, it will require running `make frontend-fast` to update the frontend.
 - You can ignore missing or mismatched snapshot errors. These need to be updated manually.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -60,6 +60,16 @@ applyTo: "**/*.ts, **/*.tsx"
   - Don't remove focus outlines without replacing them. Prefer `:focus-visible` styles and use `theme.shadows` values for consistent rings.
 - **Keyboard dismissal shouldn’t steal focus**: Popovers/tooltips/dialogs should support Escape to dismiss while keeping focus on the trigger unless there’s a strong reason to move it.
 
+## Logging
+
+- Use `loglevel`'s `getLogger` for logging (e.g. warnings / errors). Create a module-level `LOG` constant with a descriptive name:
+
+```tsx
+import { getLogger } from "loglevel"
+
+const LOG = getLogger("MyComponent")
+```
+
 ## Static Data Structures
 
 - Extract static lookup maps and constants to module-level scope outside functions/components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,34 +40,34 @@
 
 Selection of `make` commands for development (run in the repo root):
 
-- `help`: Show all available make commands.
-- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing.
-- `protobuf`: Recompile Protobufs for Python and the frontend.
-- `autofix`: Autofix linting and formatting errors.
+- `help`: Show all available make commands. [~1s]
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
+- `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
+- `autofix`: Autofix linting and formatting errors. [~30s]
 
 **Backend Development (Python):**
 
-- `python-lint`: Lint and check formatting of Python files (ruff).
-- `python-tests`: Run all Python unit tests (pytest).
-- `python-types`: Run the Python type checker (mypy & ty).
-- `python-format`: Format Python files (ruff).
+- `python-lint`: Lint and check formatting of Python files (ruff). [~1s]
+- `python-tests`: Run all Python unit tests (pytest). [~3min]
+- `python-types`: Run the Python type checker (mypy & ty). [~30s]
+- `python-format`: Format Python files (ruff). [~1s]
 
 **Frontend Development (TypeScript):**
 
-- `frontend-fast`: Build the frontend (vite).
-- `frontend-dev`: Start the frontend development server (hot-reload).
-- `frontend-lint`: Lint and check formatting of all frontend files (eslint).
-- `frontend-types`: Run the TypeScript type checker on all files (tsc).
-- `frontend-format`: Format all frontend files (eslint).
-- `frontend-tests`: Run all frontend unit tests (vitest).
+- `frontend-fast`: Build the frontend (vite). [~40s]
+- `frontend-dev`: Start the frontend development server (hot-reload). [until stopped]
+- `frontend-lint`: Lint and check formatting of all frontend files (eslint). [~45s]
+- `frontend-types`: Run the TypeScript type checker on all files (tsc). [~15s]
+- `frontend-format`: Format all frontend files (eslint). [~10s]
+- `frontend-tests`: Run all frontend unit tests (vitest). [~5min]
 
 **E2E Testing (Playwright):**
 
-- `run-e2e-test`: Run e2e test, via: `make run-e2e-test st_command_test.py`.
+- `run-e2e-test`: Run e2e test, via: `make run-e2e-test st_command_test.py`. [varies by test]
 
 **Debugging backend & frontend:**
 
-- `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`.
+- `debug`: Start Streamlit backend and Vite dev server together, via: `make debug my_app.py`. [until stopped]
   - Frontend hot-reload: Changes to frontend code (`frontend/`) are applied within seconds.
   - Backend hot-reload: Only changes to the **app script** trigger a rerun. Changes to the Streamlit library itself (`lib/streamlit/`) require restarting `make debug`.
   - Logs are written to a per-session directory under `work-tmp/debug/` (e.g. `work-tmp/debug/<session>/backend.log` and `work-tmp/debug/<session>/frontend.log`).
@@ -87,6 +87,7 @@ Selection of `make` commands for development (run in the repo root):
 
 ## Testing Strategy
 
+- Most new user-facing features should be covered by both unit tests and E2E tests.
 - **Python Unit Tests**: Test internal behavior without frontend. Located at `lib/tests/streamlit/<package>/<module>_test.py` mirroring `lib/streamlit/<package>/<module>.py` (legacy tests may vary).
 - **Frontend Unit Tests**: Test React components, hooks, and related functionality with Vitest and React Testing Library. Co-located as `<Component>.test.tsx` next to `<Component>.tsx`.
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`.

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -58,11 +58,11 @@ Import from `conftest.py`:
 
 ## Best Practices
 
-- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run, not number of tiny test functions.
+- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run—test each aspect only once, prefer aggregated scenario tests over many micro-tests, and add new tests to existing test files when they fit the scope rather than creating new test scripts.
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.
 - As a guiding principle, tests should resemble how users interact with the UI.
 - Use `expect` for auto-wait assertions, not `assert` (reduces flakiness)
-- If `expect` is insufficient, use the `wait_until` utility. Never use `wait_for_timeout`.
+- If `expect` is insufficient, use the `wait_until` utility. Usage of `wait_for_timeout` is discouraged and should only be used when there is a specific purpose.
 - Add at least one “must NOT happen” check per scenario when practical: Alongside the positive UI outcome, assert the absence of a likely regression (e.g., no duplicate element appears, a tooltip is not shown until hover, a widget remains non-interactive when `disabled=True`, no unexpected rerun/state change, etc.).
 - Keep negatives high-signal: E2E is expensive—prefer one targeted negative assertion per scenario over large negative matrices.
 - Prefer label- or key-based locators over index-based access (e.g. `get_by_test_id().nth(0)`). The recommended order of priority is:
@@ -78,7 +78,6 @@ Import from `conftest.py`:
 - Ensure elements screenshotted are under 640px height to avoid clipping by the header.
 - Naming convention for command-related snapshots: `st_command-test_description`
 - Take a look at other tests in `e2e_playwright/` as inspiration.
-- Important: E2E tests are expensive, please test every aspect only one time. Prefer adding new tests to existing e2e test files if they fit the scope, instead of creating new test scripts.
 - Make use of shared `app_utils` methods (import from `e2e_playwright.shared.app_utils`) if applicable.
 - Make sure that the tests mix different ways of interactions (e.g. fill and type for input fields) for increased coverage.
 
@@ -104,6 +103,5 @@ When adding or modifying tests for an element, ensure the following are covered:
 - Single test file: `make run-e2e-test e2e_playwright/name_of_the_test.py`
 - Single test: `make run-e2e-test e2e_playwright/name_of_the_test.py::test_name`
 - Pass any pytest arguments via `PYTEST_ADDOPTS`, e.g. `PYTEST_ADDOPTS='-k test_name -vvv' make run-e2e-test e2e_playwright/name_of_the_test.py`
-- Debug test (needs manual interactions): `make debug-e2e-test e2e_playwright/name_of_the_test.py`
 - If frontend logic was changed, it will require running `make frontend-fast` to update the frontend.
 - You can ignore missing or mismatched snapshot errors. These need to be updated manually.

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -58,6 +58,7 @@ Import from `conftest.py`:
 
 ## Best Practices
 
+- Important: E2E tests are much more expensive than unit tests. Optimize for confidence per browser run, not number of tiny test functions.
 - Imports should be at the top-level of the test file. Only use imports inside test functions when there is a specific reason.
 - As a guiding principle, tests should resemble how users interact with the UI.
 - Use `expect` for auto-wait assertions, not `assert` (reduces flakiness)
@@ -70,6 +71,8 @@ Import from `conftest.py`:
   3. If the element doesn't support key or label, you can wrap it with an `st.container(key="my_key")` to better target it via `get_element_by_key`. E.g. `get_element_by_key("my_key").get_by_test_id("stComponent")`.
 - Prefer stable locators like `get_by_test_id`, `get_by_text` or `get_by_role` over CSS / XPath selectors via `.locator`.
 - Group related tests into single, logical test files (e.g., by widget or feature) for CI efficiency.
+- Prefer a single aggregated scenario test over many micro-tests when they share the same setup and page state. Reuse one app load, cover multiple assertions in sequence, and reduce browser loads.
+- Use `@pytest.mark.parametrize` sparingly in E2E. Avoid parameterizing over expensive flows and prefer iterating variants in one scenario test when setup dominates runtime.
 - Minimize screenshot surface area; screenshot specific elements, not the whole page unless necessary.
 - Use descriptive test names.
 - Ensure elements screenshotted are under 640px height to avoid clipping by the header.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -56,6 +56,16 @@
   - Don't remove focus outlines without replacing them. Prefer `:focus-visible` styles and use `theme.shadows` values for consistent rings.
 - **Keyboard dismissal shouldn’t steal focus**: Popovers/tooltips/dialogs should support Escape to dismiss while keeping focus on the trigger unless there’s a strong reason to move it.
 
+## Logging
+
+- Use `loglevel`'s `getLogger` for logging (e.g. warnings / errors). Create a module-level `LOG` constant with a descriptive name:
+
+```tsx
+import { getLogger } from "loglevel"
+
+const LOG = getLogger("MyComponent")
+```
+
 ## Static Data Structures
 
 - Extract static lookup maps and constants to module-level scope outside functions/components


### PR DESCRIPTION
## Describe your changes

Applies a couple of tweaks to the agent rules to 1) prevent agents to handle e2e test like unit tests 2) add runtime estimates to `make` commands to simulate the intuition we get when using these commands 3) hint about covering new features with e2e and unit tests. 4) hint about logging usage in frontend.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.