### PR TITLE
Bind widgets to query params - `st.multiselect`

### DIFF
--- a/e2e_playwright/st_multiselect.py
+++ b/e2e_playwright/st_multiselect.py
@@ -249,3 +249,31 @@ i20 = st.multiselect(
     key="multiselect_custom_objects",
 )
 st.text(f"value 20: {[opt.value for opt in i20]}")
+
+# --- Bound multiselect widgets ---
+
+bound_multi = st.multiselect(
+    "Bound multiselect",
+    ["Red", "Green", "Blue", "Yellow"],
+    key="bound_multi",
+    bind="query-params",
+)
+st.text(f"bound_multi: {bound_multi}")
+
+bound_multi_default = st.multiselect(
+    "Bound multiselect with default",
+    ["Red", "Green", "Blue", "Yellow"],
+    default=["Red", "Green"],
+    key="bound_multi_default",
+    bind="query-params",
+)
+st.text(f"bound_multi_default: {bound_multi_default}")
+
+bound_multi_fmt = st.multiselect(
+    "Bound multiselect with format_func",
+    ["cat", "dog", "bird"],
+    format_func=str.upper,
+    key="bound_multi_fmt",
+    bind="query-params",
+)
+st.text(f"bound_multi_fmt: {bound_multi_fmt}")

--- a/e2e_playwright/st_multiselect.py
+++ b/e2e_playwright/st_multiselect.py
@@ -277,3 +277,21 @@ bound_multi_fmt = st.multiselect(
     bind="query-params",
 )
 st.text(f"bound_multi_fmt: {bound_multi_fmt}")
+
+bound_multi_max = st.multiselect(
+    "Bound multiselect with max_selections",
+    ["Red", "Green", "Blue", "Yellow"],
+    max_selections=2,
+    key="bound_multi_max",
+    bind="query-params",
+)
+st.text(f"bound_multi_max: {bound_multi_max}")
+
+bound_multi_new = st.multiselect(
+    "Bound multiselect with accept_new_options",
+    ["Red", "Green", "Blue"],
+    accept_new_options=True,
+    key="bound_multi_new",
+    bind="query-params",
+)
+st.text(f"bound_multi_new: {bound_multi_new}")

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -659,15 +659,31 @@ def test_multiselect_query_param_format_func(page: Page, app_base_url: str):
     expect(page).to_have_url(re.compile(r"bound_multi_fmt=DOG&bound_multi_fmt=BIRD"))
 
 
-def test_multiselect_query_param_empty_value(page: Page, app_base_url: str):
-    """Test that empty URL param clears multiselect to []."""
+def test_multiselect_query_param_empty_value_clears_when_default_is_empty(
+    page: Page, app_base_url: str
+):
+    """Test that empty URL param on a widget with no default clears the URL."""
+    # bound_multi has no default, so default is []. Empty URL → [] == default → clear.
+    page.goto(build_app_url(app_base_url, query={"bound_multi": ""}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_multi: []")
+    # URL param should be cleared because [] matches the default
+    expect(page).not_to_have_url(re.compile(r"bound_multi="))
+
+
+def test_multiselect_query_param_empty_value_overrides_nonempty_default(
+    page: Page, app_base_url: str
+):
+    """Test that empty URL param overrides a non-empty default to []."""
+    # bound_multi_default has default=["Red", "Green"]. Empty URL → [] != default → keep.
     page.goto(build_app_url(app_base_url, query={"bound_multi_default": ""}))
     wait_for_app_loaded(page)
 
-    # Empty param should clear to [] (multiselect is always clearable)
+    # Widget should show [] (empty overrides the default)
     expect_text(page, "bound_multi_default: []")
-    # URL param should be cleared (empty == default for empty list)
-    expect(page).not_to_have_url(re.compile(r"bound_multi_default="))
+    # URL param should persist because [] is not the default for this widget
+    expect(page).to_have_url(re.compile(r"bound_multi_default="))
 
 
 def test_multiselect_query_param_max_selections_truncates(

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -35,7 +35,7 @@ from e2e_playwright.shared.app_utils import (
     get_multiselect,
 )
 
-MULTISELECT_COUNT = 24
+MULTISELECT_COUNT = 26
 
 
 def _get_multiselect_input(locator: Locator | Page, label: str) -> Locator:
@@ -668,3 +668,56 @@ def test_multiselect_query_param_empty_value(page: Page, app_base_url: str):
     expect_text(page, "bound_multi_default: []")
     # URL param should be cleared (empty == default for empty list)
     expect(page).not_to_have_url(re.compile(r"bound_multi_default="))
+
+
+def test_multiselect_query_param_max_selections_truncates(
+    page: Page, app_base_url: str
+):
+    """Test that URL values exceeding max_selections are truncated."""
+    # max_selections=2, but we seed 3 values
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_multi_max": ["Red", "Green", "Blue"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    # Only the first 2 should be kept
+    expect_text(page, "bound_multi_max: ['Red', 'Green']")
+    # URL should be auto-corrected to only contain the truncated values
+    expect(page).to_have_url(re.compile(r"bound_multi_max=Red&bound_multi_max=Green"))
+    expect(page).not_to_have_url(re.compile(r"bound_multi_max=Blue"))
+
+
+def test_multiselect_query_param_max_selections_within_limit(
+    page: Page, app_base_url: str
+):
+    """Test that URL values within max_selections pass through unchanged."""
+    # max_selections=2, seed exactly 2 values
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_multi_max": ["Red", "Blue"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_multi_max: ['Red', 'Blue']")
+    expect(page).to_have_url(re.compile(r"bound_multi_max=Red&bound_multi_max=Blue"))
+
+
+def test_multiselect_query_param_accept_new_options(page: Page, app_base_url: str):
+    """Test that novel URL values are accepted when accept_new_options is True."""
+    # "Purple" is not in the original options list
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_multi_new": ["Red", "Purple"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    # Both values should be accepted (no filtering)
+    expect_text(page, "bound_multi_new: ['Red', 'Purple']")
+    expect(page).to_have_url(re.compile(r"bound_multi_new=Red&bound_multi_new=Purple"))

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -721,3 +721,24 @@ def test_multiselect_query_param_accept_new_options(page: Page, app_base_url: st
     # Both values should be accepted (no filtering)
     expect_text(page, "bound_multi_new: ['Red', 'Purple']")
     expect(page).to_have_url(re.compile(r"bound_multi_new=Red&bound_multi_new=Purple"))
+
+
+def test_multiselect_query_param_duplicate_values_deduplicated(
+    page: Page, app_base_url: str
+):
+    """Test that duplicate URL values are deduplicated."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_multi": ["Red", "Blue", "Red"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    # Duplicate "Red" should be removed, keeping first occurrence
+    expect_text(page, "bound_multi: ['Red', 'Blue']")
+    # URL should be auto-corrected to remove the duplicate
+    expect(page).to_have_url(re.compile(r"bound_multi=Red&bound_multi=Blue"))
+    expect(page).not_to_have_url(
+        re.compile(r"bound_multi=Red&bound_multi=Blue&bound_multi=Red")
+    )

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -18,7 +18,12 @@ import re
 
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_checkbox,
@@ -30,7 +35,7 @@ from e2e_playwright.shared.app_utils import (
     get_multiselect,
 )
 
-MULTISELECT_COUNT = 21
+MULTISELECT_COUNT = 24
 
 
 def _get_multiselect_input(locator: Locator | Page, label: str) -> Locator:
@@ -554,3 +559,112 @@ def test_multiselect_custom_objects_without_eq(app: Page):
 
     # Verify both selections are visible
     expect(multiselect_elem.locator('[data-baseweb="tag"]')).to_have_count(2)
+
+
+# --- Query parameter binding tests ---
+
+
+def test_multiselect_query_param_seeding(page: Page, app_base_url: str):
+    """Test that multiselect value can be seeded from URL query params."""
+    page.goto(build_app_url(app_base_url, query={"bound_multi": "Red"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_multi: ['Red']")
+    expect(page).to_have_url(re.compile(r"\?bound_multi=Red"))
+    # Negative assertion: other bound widgets should not be affected
+    expect(page).not_to_have_url(re.compile(r"bound_multi_default="))
+    expect(page).not_to_have_url(re.compile(r"bound_multi_fmt="))
+
+
+def test_multiselect_query_param_seeding_multiple(page: Page, app_base_url: str):
+    """Test that multiple values can be seeded via repeated params."""
+    page.goto(build_app_url(app_base_url, query={"bound_multi": ["Red", "Blue"]}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(re.compile(r"bound_multi=Red&bound_multi=Blue"))
+
+
+def test_multiselect_query_param_updates_url(app: Page):
+    """Test that changing a bound multiselect updates the URL."""
+    select_for_multiselect(app, "Bound multiselect", "Red", True)
+    expect(app).to_have_url(re.compile(r"\?bound_multi=Red"))
+    expect_text(app, "bound_multi: ['Red']")
+
+    # Add a second selection
+    select_for_multiselect(app, "Bound multiselect", "Blue", True)
+    expect(app).to_have_url(re.compile(r"bound_multi=Red&bound_multi=Blue"))
+    expect_text(app, "bound_multi: ['Red', 'Blue']")
+
+
+def test_multiselect_query_param_default_override(page: Page, app_base_url: str):
+    """Test multiselect with query param: seed then revert to default clears param."""
+    page.goto(
+        build_app_url(app_base_url, query={"bound_multi_default": ["Yellow", "Blue"]})
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_multi_default: ['Yellow', 'Blue']")
+    expect(page).to_have_url(re.compile(r"bound_multi_default="))
+
+    # Clear and set back to default ["Red", "Green"]
+    get_multiselect(page, "Bound multiselect with default").locator(
+        '[role="button"][aria-label="Clear all"]'
+    ).first.click()
+    wait_for_app_run(page)
+    select_for_multiselect(page, "Bound multiselect with default", "Red", True)
+    select_for_multiselect(page, "Bound multiselect with default", "Green", True)
+
+    # Default values should not appear in URL
+    expect(page).not_to_have_url(re.compile(r"bound_multi_default="))
+    expect_text(page, "bound_multi_default: ['Red', 'Green']")
+
+
+def test_multiselect_query_param_invalid_values_filtered(page: Page, app_base_url: str):
+    """Test that invalid URL values are filtered out, keeping only valid ones."""
+    page.goto(
+        build_app_url(app_base_url, query={"bound_multi": ["Red", "Invalid", "Blue"]})
+    )
+    wait_for_app_loaded(page)
+
+    # Only valid options should be seeded
+    expect_text(page, "bound_multi: ['Red', 'Blue']")
+    # URL should be auto-corrected to remove invalid value
+    expect(page).to_have_url(re.compile(r"bound_multi=Red&bound_multi=Blue"))
+    expect(page).not_to_have_url(re.compile(r"Invalid"))
+    # Negative assertion: other bound widgets should not be affected
+    expect(page).not_to_have_url(re.compile(r"bound_multi_default="))
+
+
+def test_multiselect_query_param_all_invalid_cleared(page: Page, app_base_url: str):
+    """Test that all-invalid URL values clear the URL param entirely."""
+    page.goto(
+        build_app_url(app_base_url, query={"bound_multi": ["Invalid1", "Invalid2"]})
+    )
+    wait_for_app_loaded(page)
+
+    # Widget should show default (empty)
+    expect_text(page, "bound_multi: []")
+    # URL param should be cleared
+    expect(page).not_to_have_url(re.compile(r"bound_multi="))
+
+
+def test_multiselect_query_param_format_func(page: Page, app_base_url: str):
+    """Test that formatted option strings work in URL."""
+    # The format_func is str.upper, so options in URL are "CAT", "DOG", "BIRD"
+    page.goto(build_app_url(app_base_url, query={"bound_multi_fmt": ["DOG", "BIRD"]}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_multi_fmt: ['dog', 'bird']")
+    expect(page).to_have_url(re.compile(r"bound_multi_fmt=DOG&bound_multi_fmt=BIRD"))
+
+
+def test_multiselect_query_param_empty_value(page: Page, app_base_url: str):
+    """Test that empty URL param clears multiselect to []."""
+    page.goto(build_app_url(app_base_url, query={"bound_multi_default": ""}))
+    wait_for_app_loaded(page)
+
+    # Empty param should clear to [] (multiselect is always clearable)
+    expect_text(page, "bound_multi_default: []")
+    # URL param should be cleared (empty == default for empty list)
+    expect(page).not_to_have_url(re.compile(r"bound_multi_default="))

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -582,3 +582,50 @@ describe("Multiselect widget", () => {
     })
   })
 })
+
+describe("Multiselect query param binding", () => {
+  it("registers query param binding on mount when queryParamKey is set", () => {
+    const props = getProps({ queryParamKey: "my_multi" })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Multiselect {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_multi",
+      "string_array_value",
+      ["a"],
+      true,
+      "repeated",
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({ queryParamKey: "my_multi" })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<Multiselect {...props} />)
+
+    // Clear any calls from React Strict Mode's initial mount/unmount/remount cycle
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Multiselect {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -103,6 +103,16 @@ const Multiselect: FC<Props> = props => {
   const isInSidebar = useContext(IsSidebarContext)
   const valueContainerRef = useRef<HTMLDivElement>(null)
   const scrollTopRef = useRef(0)
+
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "string_array_value" as const,
+        clearable: true,
+        urlFormat: "repeated" as const,
+      }
+    : undefined
+
   const [value, setValueWithSource] = useBasicWidgetState<
     MultiselectValue,
     MultiSelectProto
@@ -114,6 +124,7 @@ const Multiselect: FC<Props> = props => {
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding,
   })
 
   const overMaxSelections =

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -58,7 +58,7 @@ from streamlit.errors import (
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
-from streamlit.runtime.state import register_widget
+from streamlit.runtime.state import BindOption, register_widget
 from streamlit.type_util import (
     is_iterable,
 )
@@ -209,6 +209,7 @@ class MultiSelectMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[False] = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> list[T]: ...
 
     @overload
@@ -230,6 +231,7 @@ class MultiSelectMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: Literal[True] = True,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> list[T | str]: ...
 
     @overload
@@ -251,6 +253,7 @@ class MultiSelectMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: bool = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> list[T] | list[T | str]: ...
 
     @gather_metrics("multiselect")
@@ -272,6 +275,7 @@ class MultiSelectMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: bool = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> list[T] | list[T | str]:
         r"""Display a multiselect widget.
         The multiselect widget starts as empty.
@@ -390,6 +394,14 @@ class MultiSelectMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Invalid URL values (not in ``options``)
+            are filtered out. Requires a ``key`` to be set, which will be used
+            as the query parameter name. The default is ``None``.
+
         Returns
         -------
         list
@@ -465,6 +477,7 @@ class MultiSelectMixin:
             label_visibility=label_visibility,
             accept_new_options=accept_new_options,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -486,6 +499,7 @@ class MultiSelectMixin:
         label_visibility: LabelVisibility = "visible",
         accept_new_options: bool = False,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> list[T] | list[T | str]:
         key = to_key(key)
@@ -548,6 +562,10 @@ class MultiSelectMixin:
             proto.help = dedent(help)
         proto.accept_new_options = accept_new_options
 
+        # Set query param key if bound
+        if bind == "query-params" and key is not None:
+            proto.query_param_key = str(key)
+
         serde = MultiSelectSerde(
             indexable_options,
             formatted_options=formatted_options,
@@ -565,6 +583,14 @@ class MultiSelectMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_array_value",
+            bind=bind,
+            # Multiselect is always clearable: users can always remove all
+            # selections, so ?key= (empty URL param) should clear to [].
+            clearable=True,
+            # Pass formatted_options so _seed_widget_from_url can filter out
+            # invalid option strings from URLs. Not passed when
+            # accept_new_options=True since any string is valid.
+            formatted_options=None if accept_new_options else formatted_options,
         )
 
         _check_max_selections(widget_state.value, max_selections)

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -591,6 +591,9 @@ class MultiSelectMixin:
             # invalid option strings from URLs. Not passed when
             # accept_new_options=True since any string is valid.
             formatted_options=None if accept_new_options else formatted_options,
+            # Pass max_selections so _seed_widget_from_url can truncate
+            # URL-seeded arrays that exceed the limit, instead of crashing.
+            max_array_length=max_selections,
         )
 
         _check_max_selections(widget_state.value, max_selections)

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -395,12 +395,16 @@ class MultiSelectMixin:
               of the parent container.
 
         bind : "query-params" or None
-            If set to ``"query-params"``, the widget's value will be synced
-            with a URL query parameter. When the widget value changes, the URL
-            is updated; when the page loads with a query parameter, the widget
-            is initialized from it. Invalid URL values (not in ``options``)
-            are filtered out. Requires a ``key`` to be set, which will be used
-            as the query parameter name. The default is ``None``.
+            Enables two-way binding between the widget value and the URL
+            query string. When set to ``"query-params"``, the widget's
+            ``key`` is used as the URL parameter name. Requires ``key``
+            to be set. Multiple selections use repeated parameters
+            (e.g., ``?tags=Red&tags=Blue``). Invalid URL values (not in
+            ``options``) are silently filtered out and the URL is
+            auto-corrected. Duplicate URL values are deduplicated. If
+            ``max_selections`` is set, excess URL values are truncated to
+            the limit. When ``accept_new_options`` is ``True``, any URL
+            value is accepted. The default is ``None``.
 
         Returns
         -------

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -170,6 +170,12 @@ class WidgetMetadata(Generic[T]):
     #   - selectbox: clearable only if index=None (allows "no selection" state)
     clearable: bool = False
 
+    # Maximum number of elements allowed in array-valued widgets (e.g. multiselect
+    # max_selections). When set, _seed_widget_from_url truncates URL-seeded arrays
+    # that exceed this limit to the first max_array_length values, preventing URL
+    # params from triggering selection-count errors.
+    max_array_length: int | None = None
+
     def __repr__(self) -> str:
         return util.repr_(self)
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1062,6 +1062,31 @@ class SessionState:
                 self._clear_url_param(user_key)
                 return False
 
+            # For string_array_value selection widgets (multiselect), filter
+            # out invalid URL values individually (partial filtering). Unlike
+            # string_value which rejects the entire value, array widgets keep
+            # valid entries and remove only invalid ones.
+            if (
+                metadata.formatted_options is not None
+                and metadata.value_type == "string_array_value"
+                and isinstance(parsed_value, list)
+            ):
+                valid_parsed = [
+                    v for v in parsed_value if v in metadata.formatted_options
+                ]
+                if len(valid_parsed) < len(parsed_value):
+                    if not valid_parsed:
+                        # All values were invalid — clear URL entirely
+                        self._clear_url_param(user_key)
+                        return False
+                    # Re-deserialize with only valid values; keep original
+                    # parsed_value so _auto_correct_url_if_needed detects
+                    # the mismatch and corrects the URL.
+                    deserialized_value = metadata.deserializer(valid_parsed)
+                    if deserialized_value == default_value:
+                        self._clear_url_param(user_key)
+                        return False
+
             # Store the value in widget and session state
             self._new_widget_state.set_from_value(widget_id, deserialized_value)
             self._new_session_state[user_key] = deserialized_value

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -70,6 +70,31 @@ SCRIPT_RUN_WITHOUT_ERRORS_KEY: Final = (
 )
 
 
+def _sanitize_url_array(
+    parsed: list[str],
+    *,
+    valid_options: list[str] | None,
+    max_length: int | None,
+) -> list[str] | None:
+    """Sanitize a URL-parsed string array by filtering invalid values and
+    enforcing a maximum length.
+
+    Returns the sanitized list if any changes were made, or None if the
+    input required no sanitization.
+    """
+    result = parsed
+
+    # Remove values not in the valid options list.
+    if valid_options is not None:
+        result = [v for v in result if v in valid_options]
+
+    # Truncate to max_length (e.g. multiselect max_selections).
+    if max_length is not None and max_length > 0 and len(result) > max_length:
+        result = result[:max_length]
+
+    return result if result != parsed else None
+
+
 @dataclass(frozen=True)
 class Serialized:
     """A widget value that's serialized to a protobuf. Immutable."""
@@ -1062,27 +1087,21 @@ class SessionState:
                 self._clear_url_param(user_key)
                 return False
 
-            # For string_array_value selection widgets (multiselect), filter
-            # out invalid URL values individually (partial filtering). Unlike
-            # string_value which rejects the entire value, array widgets keep
-            # valid entries and remove only invalid ones.
-            if (
-                metadata.formatted_options is not None
-                and metadata.value_type == "string_array_value"
-                and isinstance(parsed_value, list)
+            # For string_array_value widgets (e.g. multiselect), sanitize the
+            # parsed URL values: filter invalid options and enforce max length.
+            if metadata.value_type == "string_array_value" and isinstance(
+                parsed_value, list
             ):
-                valid_parsed = [
-                    v for v in parsed_value if v in metadata.formatted_options
-                ]
-                if len(valid_parsed) < len(parsed_value):
-                    if not valid_parsed:
-                        # All values were invalid — clear URL entirely
+                sanitized = _sanitize_url_array(
+                    parsed_value,
+                    valid_options=metadata.formatted_options,
+                    max_length=metadata.max_array_length,
+                )
+                if sanitized is not None:
+                    if not sanitized:
                         self._clear_url_param(user_key)
                         return False
-                    # Re-deserialize with only valid values; keep original
-                    # parsed_value so _auto_correct_url_if_needed detects
-                    # the mismatch and corrects the URL.
-                    deserialized_value = metadata.deserializer(valid_parsed)
+                    deserialized_value = metadata.deserializer(sanitized)
                     if deserialized_value == default_value:
                         self._clear_url_param(user_key)
                         return False

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -76,8 +76,8 @@ def _sanitize_url_array(
     valid_options: list[str] | None,
     max_length: int | None,
 ) -> list[str] | None:
-    """Sanitize a URL-parsed string array by filtering invalid values and
-    enforcing a maximum length.
+    """Sanitize a URL-parsed string array by filtering invalid values,
+    removing duplicates, and enforcing a maximum length.
 
     Returns the sanitized list if any changes were made, or None if the
     input required no sanitization.
@@ -87,6 +87,17 @@ def _sanitize_url_array(
     # Remove values not in the valid options list.
     if valid_options is not None:
         result = [v for v in result if v in valid_options]
+
+    # Deduplicate while preserving order (the UI prevents duplicate
+    # selections, so duplicates in the URL are user error).
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for v in result:
+        if v not in seen:
+            seen.add(v)
+            deduped.append(v)
+    if len(deduped) < len(result):
+        result = deduped
 
     # Truncate to max_length (e.g. multiselect max_selections).
     if max_length is not None and max_length > 0 and len(result) > max_length:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -53,6 +53,7 @@ def register_widget(
     # string-based wire formats (string_value/string_array_value).
     formatted_options: list[str] | None = None,
     clearable: bool | None = None,
+    max_array_length: int | None = None,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
@@ -166,6 +167,7 @@ def register_widget(
         bind=bind,
         formatted_options=formatted_options,
         clearable=clearable if clearable is not None else False,
+        max_array_length=max_array_length,
     )
     return register_widget_from_metadata(metadata, ctx)
 

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -30,6 +30,7 @@ from streamlit.elements.widgets.multiselect import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidBindValueError,
     StreamlitInvalidWidthError,
     StreamlitSelectionCountExceedsMaxError,
 )
@@ -856,3 +857,59 @@ def test_multiselect_session_state_updated_when_key_provided():
     assert at.multiselect[0].value == ["a"]
     assert at.text[0].value == "widget_value=['a']"
     assert at.text[1].value == "session_state_value=['a']"
+
+
+class MultiSelectBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for multiselect bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.multiselect("the label", ["a", "b", "c"], key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.multiselect
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.multiselect("the label", ["a", "b", "c"], bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.multiselect("the label", ["a", "b", "c"], key="my_key")
+
+        c = self.get_delta_from_queue().new_element.multiselect
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.multiselect("the label", ["a", "b"], key="my_key", bind="invalid-value")
+
+    def test_bind_with_format_func(self):
+        """Test that bind works with format_func."""
+        st.multiselect(
+            "the label",
+            ["cat", "dog"],
+            format_func=str.upper,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.multiselect
+        assert c.query_param_key == "my_key"
+        assert list(c.options) == ["CAT", "DOG"]
+
+    def test_bind_with_accept_new_options(self):
+        """Test that bind works with accept_new_options."""
+        st.multiselect(
+            "the label",
+            ["a", "b"],
+            key="my_key",
+            bind="query-params",
+            accept_new_options=True,
+        )
+
+        c = self.get_delta_from_queue().new_element.multiselect
+        assert c.query_param_key == "my_key"
+        assert c.accept_new_options is True

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2057,24 +2057,6 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         # Duplicate "Red" should be removed, keeping first occurrence
         assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
 
-    def test_duplicate_array_values_no_dedup_when_unique(self) -> None:
-        """Test that unique array values pass through without modification."""
-        metadata = _create_test_widget_metadata(
-            "widget_1",
-            value_type="string_array_value",
-            formatted_options=["Red", "Green", "Blue"],
-            deserializer=lambda x: x if x is not None else [],
-            serializer=lambda x: x,
-        )
-        self.query_params._query_params["colors"] = ["Red", "Blue"]
-
-        seeded = self.session_state._seed_widget_from_url(
-            metadata, "colors", "widget_1", ["Red", "Blue"]
-        )
-
-        assert seeded is True
-        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
-
     def test_duplicate_array_values_with_filtering_and_truncation(self) -> None:
         """Test that dedup composes with filtering and truncation."""
         metadata = _create_test_widget_metadata(

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1850,6 +1850,63 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is True
         assert self.session_state._new_widget_state["widget_1"] == "anything"
 
+    def test_formatted_options_filters_invalid_array_values(self) -> None:
+        """Test that invalid values are filtered from string_array_value URL params."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            # Deserializer returns the list as-is (valid values pass through)
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Invalid", "Blue"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Invalid", "Blue"]
+        )
+
+        assert seeded is True
+        # Only valid values should be stored
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
+
+    def test_formatted_options_clears_all_invalid_array_values(self) -> None:
+        """Test that all-invalid array URL values clear the URL param."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["colors"] = ["Invalid1", "Invalid2"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Invalid1", "Invalid2"]
+        )
+
+        assert seeded is False
+        assert "widget_1" not in self.session_state._new_widget_state
+        assert "colors" not in self.query_params._query_params
+
+    def test_formatted_options_accepts_all_valid_array_values(self) -> None:
+        """Test that all-valid array URL values pass through without filtering."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Blue"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Blue"]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
+
 
 class AutoCorrectUrlTest(DeltaGeneratorTestCase):
     """Tests for _auto_correct_url_if_needed method."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1852,6 +1852,47 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is True
         assert self.session_state._new_widget_state["widget_1"] == "anything"
 
+    def test_no_formatted_options_accepts_novel_array_values(self) -> None:
+        """Test that novel values pass through for string_array_value when
+        formatted_options is None (e.g. multiselect with accept_new_options)."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=None,
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["tags"] = ["Red", "NewTag", "AnotherNew"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "tags", "widget_1", ["Red", "NewTag", "AnotherNew"]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == [
+            "Red",
+            "NewTag",
+            "AnotherNew",
+        ]
+
+    def test_no_formatted_options_still_deduplicates_array_values(self) -> None:
+        """Test that deduplication applies even when formatted_options is None."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=None,
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["tags"] = ["NewTag", "Red", "NewTag"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "tags", "widget_1", ["NewTag", "Red", "NewTag"]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == ["NewTag", "Red"]
+
     def test_formatted_options_filters_invalid_array_values(self) -> None:
         """Test that invalid values are filtered from string_array_value URL params."""
         metadata = _create_test_widget_metadata(
@@ -1996,6 +2037,92 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
         assert seeded is False
         assert "widget_1" not in self.session_state._new_widget_state
         assert "colors" not in self.query_params._query_params
+
+    def test_duplicate_array_values_deduplicated(self) -> None:
+        """Test that duplicate URL values are deduplicated, preserving order."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Blue", "Red"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Blue", "Red"]
+        )
+
+        assert seeded is True
+        # Duplicate "Red" should be removed, keeping first occurrence
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
+
+    def test_duplicate_array_values_no_dedup_when_unique(self) -> None:
+        """Test that unique array values pass through without modification."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Blue"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Blue"]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
+
+    def test_duplicate_array_values_with_filtering_and_truncation(self) -> None:
+        """Test that dedup composes with filtering and truncation."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+            max_array_length=2,
+        )
+        # After filter: ["Red", "Green", "Red", "Blue"] (Invalid removed)
+        # After dedup: ["Red", "Green", "Blue"]
+        # After truncate: ["Red", "Green"]
+        self.query_params._query_params["colors"] = [
+            "Red",
+            "Invalid",
+            "Green",
+            "Red",
+            "Blue",
+        ]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata,
+            "colors",
+            "widget_1",
+            ["Red", "Invalid", "Green", "Red", "Blue"],
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Green"]
+
+    def test_all_duplicate_values_collapse_to_single(self) -> None:
+        """Test that all-duplicate URL values collapse to a single value."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Red", "Red"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Red", "Red"]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == ["Red"]
 
 
 class AutoCorrectUrlTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -72,6 +72,7 @@ def _create_test_widget_metadata(
     serializer=None,
     formatted_options: list[str] | None = None,
     clearable: bool = False,
+    max_array_length: int | None = None,
 ) -> WidgetMetadata:
     """Helper to create widget metadata for query param binding tests."""
     return WidgetMetadata(
@@ -82,6 +83,7 @@ def _create_test_widget_metadata(
         bind="query-params",
         formatted_options=formatted_options,
         clearable=clearable,
+        max_array_length=max_array_length,
     )
 
 
@@ -1906,6 +1908,94 @@ class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
 
         assert seeded is True
         assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
+
+    def test_max_array_length_truncates_excess_values(self) -> None:
+        """Test that arrays exceeding max_array_length are truncated."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+            max_array_length=2,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Green", "Blue", "Yellow"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Green", "Blue", "Yellow"]
+        )
+
+        assert seeded is True
+        # Only the first 2 values should be kept
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Green"]
+
+    def test_max_array_length_no_truncation_when_within_limit(self) -> None:
+        """Test that arrays within max_array_length are not truncated."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+            max_array_length=3,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Blue"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Blue"]
+        )
+
+        assert seeded is True
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Blue"]
+
+    def test_max_array_length_with_filtering_and_truncation(self) -> None:
+        """Test that filtering and truncation compose: filter first, then truncate."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            formatted_options=["Red", "Green", "Blue", "Yellow"],
+            deserializer=lambda x: x if x is not None else [],
+            serializer=lambda x: x,
+            max_array_length=2,
+        )
+        # 5 URL values: 2 invalid + 3 valid = after filtering 3, truncate to 2
+        self.query_params._query_params["colors"] = [
+            "Red",
+            "Invalid1",
+            "Green",
+            "Invalid2",
+            "Blue",
+        ]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata,
+            "colors",
+            "widget_1",
+            ["Red", "Invalid1", "Green", "Invalid2", "Blue"],
+        )
+
+        assert seeded is True
+        # After filtering: ["Red", "Green", "Blue"], then truncated to 2
+        assert self.session_state._new_widget_state["widget_1"] == ["Red", "Green"]
+
+    def test_max_array_length_truncation_clears_when_equals_default(self) -> None:
+        """Test that truncated value matching default clears the URL param."""
+        metadata = _create_test_widget_metadata(
+            "widget_1",
+            value_type="string_array_value",
+            # Default is ["Red"] — truncation to 1 should match default
+            deserializer=lambda x: x if x is not None else ["Red"],
+            serializer=lambda x: x,
+            max_array_length=1,
+        )
+        self.query_params._query_params["colors"] = ["Red", "Blue"]
+
+        seeded = self.session_state._seed_widget_from_url(
+            metadata, "colors", "widget_1", ["Red", "Blue"]
+        )
+
+        # Truncated to ["Red"] which equals default — should clear
+        assert seeded is False
+        assert "widget_1" not in self.session_state._new_widget_state
+        assert "colors" not in self.query_params._query_params
 
 
 class AutoCorrectUrlTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/typing/multiselect_types.py
+++ b/lib/tests/streamlit/typing/multiselect_types.py
@@ -95,3 +95,12 @@ if TYPE_CHECKING:
         multiselect("foo", Alfred, default=Alfred.HITCHCOCK, accept_new_options=True),
         list[Alfred | str],
     )
+
+    # Check bind parameter
+    assert_type(multiselect("foo", ["a", "b"], bind="query-params"), list[str])
+    assert_type(multiselect("foo", [1, 2, 3], bind="query-params"), list[int])
+    assert_type(multiselect("foo", ["a", "b"], bind=None), list[str])
+    assert_type(
+        multiselect("foo", ["a", "b"], bind="query-params", accept_new_options=True),
+        list[str],
+    )

--- a/proto/streamlit/proto/MultiSelect.proto
+++ b/proto/streamlit/proto/MultiSelect.proto
@@ -36,6 +36,10 @@ message MultiSelect {
   int32 max_selections = 11;
   string placeholder = 12;
   optional bool accept_new_options = 13;
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 15;
+
+  // Next: 16
 
   reserved 7;
 }


### PR DESCRIPTION
## Describe your changes
Adds the bind parameter to `st.multiselect` to enable two-way sync between widget values and URL query parameters.

**Key changes:**
- Added `bind="query-params"` support to `st.multiselect` using repeated params (`?tags=Red&tags=Blue`)
- Implement robust URL sanitization for array-valued widgets: invalid option filtering, duplicate deduplication, and max_selections truncation — all with automatic URL correction
- When `accept_new_options=True`, any URL string accepted (no filtering)
- Multiselect is always clearable (with `?foo=`)

## Testing Plan
- JS & Python Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅ 