### PR TITLE
Fix st.Page accepting slash-only url_path without error

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -254,7 +254,7 @@ class StreamlitPage:
         self._url_path: str = inferred_name
         if url_path is not None:
             self._url_path = url_path.strip("/")
-            if self._url_path == "" and not default:
+            if self._url_path.strip() == "" and not default:
                 raise StreamlitAPIException(
                     "The URL path cannot be an empty string unless the page is the default page."
                 )

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -253,12 +253,12 @@ class StreamlitPage:
 
         self._url_path: str = inferred_name
         if url_path is not None:
-            if url_path.strip() == "" and not default:
+            self._url_path = url_path.strip("/")
+            if self._url_path == "" and not default:
                 raise StreamlitAPIException(
                     "The URL path cannot be an empty string unless the page is the default page."
                 )
 
-            self._url_path = url_path.strip("/")
             if "/" in self._url_path:
                 raise StreamlitAPIException(
                     "The URL path cannot contain a nested path (e.g. foo/bar)."

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -125,6 +125,27 @@ class StPagesTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.Page(page_9, url_path="")
 
+    def test_non_default_pages_cannot_have_slash_only_url_path(self):
+        """Tests that an error is raised if the url path contains only slashes"""
+
+        def page_9():
+            pass
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page(page_9, url_path="/")
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page(page_9, url_path="///")
+
+    def test_non_default_pages_cannot_have_whitespace_only_url_path(self):
+        """Tests that an error is raised if the url path contains only whitespace"""
+
+        def page_9():
+            pass
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page(page_9, url_path="   ")
+
     def test_non_default_pages_cannot_have_nested_url_path(self):
         """Tests that an error is raised if the url path contains a nested path"""
 


### PR DESCRIPTION
## Summary

- Fixed `st.Page` silently accepting slash-only `url_path` values like `"///"` instead of raising an error
- Moved `strip("/")` before the empty-string validation check

## Details

When `url_path` is a string consisting only of slashes (e.g. `"///"`), `strip("/")` reduces it to `""`. However, the empty-string check was running `url_path.strip()` (whitespace strip) instead of checking the slash-stripped result. This meant:

- `url_path="///"` passed the whitespace strip check (non-empty)
- Then `strip("/")` produced `""` which was silently assigned to `self._url_path`
- The page ended up with an empty URL path without being marked as default

The fix moves the `strip("/")` assignment before the empty check, so slash-only paths correctly raise `StreamlitAPIException`.

Fixes #13952