### PR TITLE
Don't accept 0 max selections in `st.multiselect`

### DIFF
--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -339,8 +339,10 @@ class MultiSelectMixin:
         kwargs : dict
             An optional dict of kwargs to pass to the callback.
 
-        max_selections : int
-            The max selections that can be selected at a time.
+        max_selections : int or None
+            The max selections that can be selected at a time. If this is
+            ``None`` (default), there is no limit on the number of selections.
+            If this is an integer, it must be positive.
 
         placeholder : str or  None
             A string to display when no options are selected.

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -53,6 +53,7 @@ from streamlit.elements.lib.utils import (
     to_key,
 )
 from streamlit.errors import (
+    StreamlitInvalidMaxError,
     StreamlitSelectionCountExceedsMaxError,
 )
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
@@ -498,6 +499,11 @@ class MultiSelectMixin:
             default_value=default,
         )
         maybe_raise_label_warnings(label, label_visibility)
+
+        if max_selections is not None and max_selections < 1:
+            raise StreamlitInvalidMaxError(
+                "st.multiselect", "max_selections", max_selections
+            )
 
         indexable_options = convert_to_sequence_and_check_comparable(options)
         formatted_options, formatted_option_to_option_index = create_mappings(

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -504,7 +504,12 @@ class MultiSelectMixin:
 
         if max_selections is not None and max_selections < 1:
             raise StreamlitInvalidMaxError(
-                "st.multiselect", "max_selections", max_selections
+                "st.multiselect",
+                "max_selections",
+                max_selections,
+                corrective_action="To disable `st.multiselect`, use `disabled=True`."
+                if max_selections == 0
+                else None,
             )
 
         indexable_options = convert_to_sequence_and_check_comparable(options)

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -323,10 +323,21 @@ class StreamlitSelectionCountExceedsMaxError(LocalizableStreamlitException):
 class StreamlitInvalidMaxError(LocalizableStreamlitException):
     """Exception raised when an invalid max value is provided (e.g. zero or negative)."""
 
-    def __init__(self, widget_name: str, parameter_name: str, value: int) -> None:
-        super().__init__(
+    def __init__(
+        self,
+        widget_name: str,
+        parameter_name: str,
+        value: int,
+        corrective_action: str | None = None,
+    ) -> None:
+        message = (
             "In `{widget_name}`, `{parameter_name}` was set to {value}. "
-            "`{parameter_name}` must be a positive integer.",
+            "`{parameter_name}` must be a positive integer."
+        )
+        if corrective_action:
+            message += " " + corrective_action
+        super().__init__(
+            message,
             widget_name=widget_name,
             parameter_name=parameter_name,
             value=value,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -320,6 +320,19 @@ class StreamlitSelectionCountExceedsMaxError(LocalizableStreamlitException):
         )
 
 
+class StreamlitInvalidMaxError(LocalizableStreamlitException):
+    """Exception raised when an invalid max value is provided (e.g. zero or negative)."""
+
+    def __init__(self, widget_name: str, parameter_name: str, value: int) -> None:
+        super().__init__(
+            "In `{widget_name}`, `{parameter_name}` was set to {value}. "
+            "`{parameter_name}` must be a positive integer.",
+            widget_name=widget_name,
+            parameter_name=parameter_name,
+            value=value,
+        )
+
+
 # st.number_input
 class StreamlitMixedNumericTypesError(LocalizableStreamlitException):
     """Exception raised mixing floats and ints in st.number_input."""

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -30,6 +30,7 @@ from streamlit.elements.widgets.multiselect import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMaxError,
     StreamlitInvalidWidthError,
     StreamlitSelectionCountExceedsMaxError,
 )
@@ -449,6 +450,22 @@ class Multiselectbox(DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
+            (0,),
+            (-1,),
+            (-100,),
+        ]
+    )
+    def test_max_selections_must_be_positive(self, max_selections: int) -> None:
+        """Raise StreamlitInvalidMaxError when max_selections is zero or negative."""
+        with pytest.raises(
+            StreamlitInvalidMaxError,
+            match=r"In `st\.multiselect`, `max_selections` was set to "
+            + str(max_selections),
+        ):
+            st.multiselect("the label", ["a", "b", "c"], max_selections=max_selections)
+
+    @parameterized.expand(
+        [
             (
                 1,
                 1,
@@ -458,17 +475,6 @@ class Multiselectbox(DeltaGeneratorTestCase):
                     "you manipulated the widget's state through `st.session_state`. "
                     "Note that the latter can happen before the line indicated in the traceback. "
                     "Please select at most 1 option."
-                ),
-            ),
-            (
-                1,
-                0,
-                (
-                    "Multiselect has 1 option selected but `max_selections` is set to 0. "
-                    "This happened because you either gave too many options to `default` or "
-                    "you manipulated the widget's state through `st.session_state`. "
-                    "Note that the latter can happen before the line indicated in the traceback. "
-                    "Please select at most 0 options."
                 ),
             ),
             (

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -30,8 +30,8 @@ from streamlit.elements.widgets.multiselect import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
-    StreamlitInvalidMaxError,
     StreamlitInvalidBindValueError,
+    StreamlitInvalidMaxError,
     StreamlitInvalidWidthError,
     StreamlitSelectionCountExceedsMaxError,
 )

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -448,19 +448,25 @@ class Multiselectbox(DeltaGeneratorTestCase):
                 "the label", ["a", "b", "c", "d"], ["a", "b", "c"], max_selections=2
             )
 
+    def test_max_selections_zero_includes_action(self) -> None:
+        """Raise StreamlitInvalidMaxError with a suggested action when max_selections is 0."""
+        with pytest.raises(
+            StreamlitInvalidMaxError,
+            match=r"To disable `st\.multiselect`, use `disabled=True`",
+        ):
+            st.multiselect("the label", ["a", "b", "c"], max_selections=0)
+
     @parameterized.expand(
         [
-            (0,),
             (-1,),
             (-100,),
         ]
     )
-    def test_max_selections_must_be_positive(self, max_selections: int) -> None:
-        """Raise StreamlitInvalidMaxError when max_selections is zero or negative."""
+    def test_max_selections_negative_no_action(self, max_selections: int) -> None:
+        """Raise StreamlitInvalidMaxError without an action for negative max_selections."""
         with pytest.raises(
             StreamlitInvalidMaxError,
-            match=r"In `st\.multiselect`, `max_selections` was set to "
-            + str(max_selections),
+            match=r"must be a positive integer\.$",
         ):
             st.multiselect("the label", ["a", "b", "c"], max_selections=max_selections)
 


### PR DESCRIPTION
## Describe your changes
The PR validates the `max_selections` parameter in `st.multiselect` to ensure that it is a positive integer.

## GitHub Issue Link (if applicable)
Closes #13965 

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
