### PR TITLE
[chore] Fix or ignore deprecation warnings in Python unit tests

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -181,9 +181,24 @@ markers = [
 ]
 filterwarnings = [
   # PyTest filter syntax: action:message:category:module:line
+
+  # External library warnings - wait for upstream fixes
   "ignore::UserWarning:altair.*:",
   "ignore::DeprecationWarning:flatbuffers.*:",
   "ignore::DeprecationWarning:keras_preprocessing.*:",
+  # Plotly uses deprecated Matplotlib converter API (Matplotlib 3.10+)
+  "ignore:The converter attribute was deprecated:matplotlib.MatplotlibDeprecationWarning:plotly.*:",
+  # Altair selection deduplication warning - informational, not actionable
+  "ignore:Automatically deduplicated selection parameter:UserWarning:",
+
+  # Pytest plugin compatibility
+  # asyncio_default_fixture_loop_scope is required for pytest-asyncio but may
+  # trigger unknown config warning in some pytest versions
+  "ignore:Unknown config option. asyncio_default_fixture_loop_scope:_pytest.config.PytestConfigWarning:",
+
+  # Informational warnings from Streamlit code - expected behavior
+  # DataFrame.attrs serialization fails for non-JSON-serializable objects
+  "ignore:Could not serialize pd.DataFrame.attrs:UserWarning:",
 ]
 addopts = "--cov=streamlit --cov-report=html --cov-config=lib/pyproject.toml"
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -120,7 +120,7 @@ class DataframeUtilTest(unittest.TestCase):
             original_df, ensure_copy=True
         )
         # Apply a change
-        converted_df["integer"] = [4, 5, 6]
+        converted_df.loc[:, "integer"] = [4, 5, 6]
         # Ensure that the original dataframe is not changed
         assert original_df["integer"].to_list() == [1, 2, 3]
 
@@ -128,7 +128,7 @@ class DataframeUtilTest(unittest.TestCase):
             original_df, ensure_copy=False
         )
         # Apply a change
-        converted_df["integer"] = [4, 5, 6]
+        converted_df.loc[:, "integer"] = [4, 5, 6]
         # The original dataframe should be changed here since ensure_copy is False
         assert original_df["integer"].to_list() == [4, 5, 6]
 

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import pytest
 from google.protobuf.descriptor import FieldDescriptor
 from parameterized import parameterized
 
@@ -35,6 +36,12 @@ from streamlit.proto.ParentMessage_pb2 import ParentMessage
 from streamlit.proto.SessionStatus_pb2 import SessionStatus
 
 FD = FieldDescriptor
+
+# Suppress protobuf label() deprecation warning. This test validates proto schema
+# stability by accessing field label/type constants, which triggers the warning.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:label\\(\\) is deprecated:DeprecationWarning"
+)
 
 
 @parameterized.expand(

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -561,6 +561,12 @@ def get_test_tuples(
 
 
 class FragmentCannotWriteToOutsidePathTest(DeltaGeneratorTestCase):
+    # Suppress unawaited coroutine warning from MagicMock(spec=Runtime). This occurs
+    # when rich's exception formatter accesses auto-created AsyncMock attributes.
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:coroutine.*was never awaited:RuntimeWarning"
+    )
+
     @parameterized.expand(
         get_test_tuples(outside_container_writing_apps, WIDGET_ELEMENTS)
     )

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from starlette.applications import Starlette
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import PlainTextResponse, RedirectResponse
+from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from streamlit.web.server.starlette import starlette_app_utils, starlette_auth_routes
@@ -42,12 +43,10 @@ if TYPE_CHECKING:
 
 
 def _build_app() -> Starlette:
-    app = Starlette(routes=create_auth_routes(""))
-
-    @app.route("/", methods=["GET"])  # type: ignore[arg-type]
     async def root(_: Any) -> PlainTextResponse:
         return PlainTextResponse("ok")
 
+    app = Starlette(routes=[*create_auth_routes(""), Route("/", root, methods=["GET"])])
     app.add_middleware(SessionMiddleware, secret_key="test-secret")
     return app
 
@@ -354,11 +353,16 @@ class TestAuthCookieFlags:
     @patch_config_options({"server.baseUrlPath": "myapp"})
     def test_logout_clears_cookie_with_correct_path(self) -> None:
         """Test that logout clears the cookie with the same path it was set with."""
-        app = Starlette(routes=create_auth_routes("/myapp"))
 
-        @app.route("/myapp/", methods=["GET"])  # type: ignore[arg-type]
         async def root(_: Any) -> PlainTextResponse:
             return PlainTextResponse("ok")
+
+        app = Starlette(
+            routes=[
+                *create_auth_routes("/myapp"),
+                Route("/myapp/", root, methods=["GET"]),
+            ]
+        )
 
         with TestClient(app) as client:
             client.cookies.set("_streamlit_user", "value", path="/myapp")


### PR DESCRIPTION
## Describe your changes

- Reduced warnings from 126 to 10. 

- Replace deprecated Starlette `@app.route()` decorator with `Route` class in auth route tests
- Add pytest warning suppression for protobuf `label()` deprecation (100 warnings)
- Add pytest warning suppression for AsyncMock unawaited coroutine in fragment tests
- Fix pandas ChainedAssignmentError by using `.loc[]` accessor in dataframe test
- Add global pytest warning filters for external library warnings:
  - Matplotlib converter deprecation (from Plotly)
  - Altair selection deduplication warning
  - pytest asyncio config warning
  - DataFrame.attrs serialization warning

## Testing Plan

- [x] Existing unit tests pass
- [x] `make check` passes with reduced warnings

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.