### PR TITLE
[chore] Enable work-stealing for pytest-xdist in Playwright CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,10 +55,11 @@ jobs:
             echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
           fi
       - name: Run playwright tests
-        # With psutil installed, pytest-xdist's `-n auto` uses physical cores (32 on 64-core runner)
+        # pytest-xdist `-n auto` creates 32 worker processes on 64-core runner.
+        # `--dist worksteal` enables work-stealing to balance uneven test runtimes.
         run: |
           cd e2e_playwright && rm -rf ./test-results
-          uv run pytest --ignore ./custom_components --browser webkit --browser chromium --browser firefox -n auto --reruns 1 -m "not performance"
+          uv run pytest --ignore ./custom_components --browser webkit --browser chromium --browser firefox -n auto --dist worksteal --reruns 1 -m "not performance"
       - name: Upload test statistics
         uses: actions/upload-artifact@v6
         if: always()


### PR DESCRIPTION
## Describe your changes

- Add `--dist worksteal` flag to pytest-xdist configuration in Playwright CI workflow
- Enables work-stealing distribution mode to balance uneven test runtimes across 32 parallel workers

## Testing Plan

- [x] No additional tests needed—this is a CI workflow optimization
- [x] Existing Playwright E2E test suite validates the change across `webkit`, `chromium`, and `firefox`
- [x] Monitoring first few CI runs to confirm timeout resolution without regressions

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.