### PR TITLE
Bind widgets to query params - `st.slider` & `st.select_slider`

### DIFF
--- a/e2e_playwright/st_select_slider.py
+++ b/e2e_playwright/st_select_slider.py
@@ -236,3 +236,38 @@ markdown_select_slider_value = st.select_slider(
     key="markdown_options_select_slider",
 )
 st.write("Markdown option selection:", markdown_select_slider_value)
+
+# --- Query Param Binding Select Sliders ---
+
+COLORS = ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+
+# Select Slider 17 - Single value with bind
+bound_color = st.select_slider(
+    "Bound color",
+    options=COLORS,
+    value="green",
+    key="bound_color",
+    bind="query-params",
+)
+st.write("Bound color:", bound_color)
+
+# Select Slider 18 - Range with bind
+bound_color_range = st.select_slider(
+    "Bound color range",
+    options=COLORS,
+    value=("orange", "indigo"),
+    key="bound_color_range",
+    bind="query-params",
+)
+st.write("Bound color range:", bound_color_range)
+
+# Select Slider 19 - With format_func and bind
+bound_formatted = st.select_slider(
+    "Bound formatted",
+    options=["sm", "md", "lg", "xl"],
+    value="md",
+    format_func=str.upper,
+    key="bound_formatted",
+    bind="query-params",
+)
+st.write("Bound formatted:", bound_formatted)

--- a/e2e_playwright/st_select_slider_test.py
+++ b/e2e_playwright/st_select_slider_test.py
@@ -358,6 +358,24 @@ def test_select_slider_query_param_updates_url(app: Page):
     expect(app).to_have_url(re.compile(r"[?&]bound_color=blue"))
 
 
+def test_select_slider_query_param_default_override(page: Page, app_base_url: str):
+    """Test that URL overrides default, and reverting to default clears the URL param."""
+    # bound_color has default "green"; seed with "blue" (one step right)
+    page.goto(build_app_url(app_base_url, query={"bound_color": "blue"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound color:", "blue")
+    expect(page).to_have_url(re.compile(r"bound_color=blue"))
+
+    # Click center of 7-option slider to snap to middle option ("green" = default)
+    slider = get_element_by_key(page, "bound_color")
+    slider.click()
+    wait_for_app_run(page)
+
+    expect_prefixed_markdown(page, "Bound color:", "green")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_color="))
+
+
 def test_select_slider_query_param_zero_width_range(page: Page, app_base_url: str):
     """Test that zero-width range (duplicate values) works correctly."""
     page.goto(

--- a/e2e_playwright/st_select_slider_test.py
+++ b/e2e_playwright/st_select_slider_test.py
@@ -17,7 +17,12 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
@@ -30,7 +35,7 @@ from e2e_playwright.shared.app_utils import (
     reset_hovering,
 )
 
-NUM_SELECT_SLIDERS = 17
+NUM_SELECT_SLIDERS = 20
 
 
 def test_select_slider_rendering(
@@ -279,3 +284,101 @@ def test_select_slider_range_dynamic_options_resets_on_invalid(app: Page):
         has_text=re.compile(r"Dynamic range selection:")
     )
     expect(markdown_element).not_to_contain_text("'alpha'")
+
+
+# --- Query Param Binding Tests ---
+
+
+def test_select_slider_query_param_seeding(page: Page, app_base_url: str):
+    """Test that select_slider value can be seeded from URL query params."""
+    page.goto(build_app_url(app_base_url, query={"bound_color": "blue"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound color:", "blue")
+    expect(page).to_have_url(re.compile(r"bound_color=blue"))
+
+
+def test_select_slider_query_param_seeding_range(page: Page, app_base_url: str):
+    """Test that select_slider range can be seeded via repeated URL params."""
+    page.goto(
+        build_app_url(app_base_url, query={"bound_color_range": ["red", "violet"]})
+    )
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound color range:", "('red', 'violet')")
+    expect(page).to_have_url(
+        re.compile(r"bound_color_range=red&bound_color_range=violet")
+    )
+
+
+def test_select_slider_query_param_invalid_value_resets(page: Page, app_base_url: str):
+    """Test that invalid URL option reverts to default."""
+    # bound_color has default "green"
+    page.goto(build_app_url(app_base_url, query={"bound_color": "invalid"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound color:", "green")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_color="))
+
+
+def test_select_slider_query_param_range_partial_invalid(page: Page, app_base_url: str):
+    """Test range with one invalid value auto-corrects to fallback."""
+    # bound_color_range has default ("orange", "indigo")
+    # "red" is valid, "invalid" falls back to the default for that position
+    page.goto(
+        build_app_url(app_base_url, query={"bound_color_range": ["red", "invalid"]})
+    )
+    wait_for_app_loaded(page)
+
+    # The invalid position falls back to its default index (position 1 → "indigo")
+    expect_prefixed_markdown(page, "Bound color range:", "('red', 'indigo')")
+
+
+def test_select_slider_query_param_format_func(page: Page, app_base_url: str):
+    """Test that format_func options work in URL."""
+    # bound_formatted uses format_func=str.upper, so URL options are uppercase
+    page.goto(build_app_url(app_base_url, query={"bound_formatted": "LG"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound formatted:", "lg")
+    expect(page).to_have_url(re.compile(r"bound_formatted=LG"))
+
+
+def test_select_slider_query_param_updates_url(app: Page):
+    """Test that interacting with a bound select_slider updates the URL."""
+    slider = get_element_by_key(app, "bound_color")
+    slider.hover()
+    app.mouse.down()
+
+    # Move slider to the right to change from default ("green")
+    app.keyboard.press("ArrowRight")
+    wait_for_app_run(app)
+
+    expect_prefixed_markdown(app, "Bound color:", "blue")
+    expect(app).to_have_url(re.compile(r"[?&]bound_color=blue"))
+
+
+def test_select_slider_query_param_both_invalid_range(page: Page, app_base_url: str):
+    """Test that range with both values invalid resets to default."""
+    # bound_color_range default is ("orange", "indigo")
+    page.goto(
+        build_app_url(
+            app_base_url, query={"bound_color_range": ["invalid1", "invalid2"]}
+        )
+    )
+    wait_for_app_loaded(page)
+
+    # Both values invalid -> falls back to default for both positions
+    expect_prefixed_markdown(page, "Bound color range:", "('orange', 'indigo')")
+    # Default value should not remain in URL
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_color_range="))
+
+
+def test_select_slider_query_param_empty_value_rejected(page: Page, app_base_url: str):
+    """Test that empty URL param is rejected for non-clearable select_slider."""
+    page.goto(build_app_url(app_base_url, query={"bound_color": ""}))
+    wait_for_app_loaded(page)
+
+    # Should use default ("green")
+    expect_prefixed_markdown(page, "Bound color:", "green")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_color="))

--- a/e2e_playwright/st_select_slider_test.py
+++ b/e2e_playwright/st_select_slider_test.py
@@ -371,6 +371,18 @@ def test_select_slider_query_param_zero_width_range(page: Page, app_base_url: st
     )
 
 
+def test_select_slider_query_param_single_value_on_range_resets(
+    page: Page, app_base_url: str
+):
+    """Test that a single URL value for a range select_slider resets to default."""
+    # bound_color_range is a range slider with default=("orange", "indigo")
+    page.goto(build_app_url(app_base_url, query={"bound_color_range": "blue"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound color range:", "('orange', 'indigo')")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_color_range="))
+
+
 def test_select_slider_query_param_both_invalid_range(page: Page, app_base_url: str):
     """Test that range with both values invalid resets to default."""
     # bound_color_range default is ("orange", "indigo")

--- a/e2e_playwright/st_select_slider_test.py
+++ b/e2e_playwright/st_select_slider_test.py
@@ -358,6 +358,19 @@ def test_select_slider_query_param_updates_url(app: Page):
     expect(app).to_have_url(re.compile(r"[?&]bound_color=blue"))
 
 
+def test_select_slider_query_param_zero_width_range(page: Page, app_base_url: str):
+    """Test that zero-width range (duplicate values) works correctly."""
+    page.goto(
+        build_app_url(app_base_url, query={"bound_color_range": ["blue", "blue"]})
+    )
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound color range:", "('blue', 'blue')")
+    expect(page).to_have_url(
+        re.compile(r"bound_color_range=blue&bound_color_range=blue")
+    )
+
+
 def test_select_slider_query_param_both_invalid_range(page: Page, app_base_url: str):
     """Test that range with both values invalid resets to default."""
     # bound_color_range default is ("orange", "indigo")

--- a/e2e_playwright/st_slider.py
+++ b/e2e_playwright/st_slider.py
@@ -251,3 +251,39 @@ else:
         step=1,
     )
     st.write("Initial slider value:", dyn_value)
+
+# --- Query Param Binding Sliders ---
+
+# Slider 27 - Integer slider with bind
+bound_int = st.slider(
+    "Bound int slider",
+    min_value=0,
+    max_value=100,
+    value=50,
+    key="bound_int",
+    bind="query-params",
+)
+st.write("Bound int value:", bound_int)
+
+# Slider 28 - Float slider with bind
+bound_float = st.slider(
+    "Bound float slider",
+    min_value=0.0,
+    max_value=1.0,
+    value=0.5,
+    step=0.1,
+    key="bound_float",
+    bind="query-params",
+)
+st.write("Bound float value:", bound_float)
+
+# Slider 29 - Range slider with bind
+bound_range = st.slider(
+    "Bound range slider",
+    min_value=0,
+    max_value=100,
+    value=(25, 75),
+    key="bound_range",
+    bind="query-params",
+)
+st.write("Bound range value:", bound_range)

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -19,6 +19,8 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
     wait_for_app_run,
 )
 from e2e_playwright.shared.app_utils import (
@@ -35,7 +37,7 @@ from e2e_playwright.shared.app_utils import (
     tab_until_focused,
 )
 
-NUM_SLIDER_WIDGETS = 27
+NUM_SLIDER_WIDGETS = 30
 
 
 def test_slider_rendering(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -362,3 +364,96 @@ def test_dynamic_slider_props(app: Page, assert_snapshot: ImageCompareFunction):
     wait_for_app_run(app)
 
     expect_prefixed_markdown(app, "Updated slider value:", "51")
+
+
+# --- Query Param Binding Tests ---
+
+
+def test_slider_query_param_seeding_int(page: Page, app_base_url: str):
+    """Test that slider integer value can be seeded from URL query params."""
+    page.goto(build_app_url(app_base_url, query={"bound_int": "75"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound int value:", "75")
+    expect(page).to_have_url(re.compile(r"bound_int=75"))
+
+
+def test_slider_query_param_seeding_float(page: Page, app_base_url: str):
+    """Test that slider float value can be seeded from URL query params."""
+    page.goto(build_app_url(app_base_url, query={"bound_float": "0.3"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound float value:", "0.3")
+    expect(page).to_have_url(re.compile(r"bound_float=0.3"))
+
+
+def test_slider_query_param_seeding_range(page: Page, app_base_url: str):
+    """Test that range slider can be seeded via repeated URL params."""
+    page.goto(build_app_url(app_base_url, query={"bound_range": ["10", "90"]}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound range value:", "(10, 90)")
+    expect(page).to_have_url(re.compile(r"bound_range=10&bound_range=90"))
+
+
+def test_slider_query_param_out_of_range_resets_to_default(
+    page: Page, app_base_url: str
+):
+    """Test that out-of-range URL value resets slider to default."""
+    # bound_int has min=0, max=100, default=50
+    page.goto(build_app_url(app_base_url, query={"bound_int": "999"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound int value:", "50")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))
+
+    # Below min
+    page.goto(build_app_url(app_base_url, query={"bound_int": "-50"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound int value:", "50")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))
+
+
+def test_slider_query_param_updates_url(app: Page):
+    """Test that interacting with a bound slider updates the URL."""
+    slider = get_element_by_key(app, "bound_int")
+    slider.hover()
+    app.mouse.down()
+
+    # Move slider to the right to change the value from the default (50)
+    app.keyboard.press("ArrowRight")
+    wait_for_app_run(app)
+
+    expect_prefixed_markdown(app, "Bound int value:", "51")
+    expect(app).to_have_url(re.compile(r"[?&]bound_int=51"))
+
+
+def test_slider_query_param_default_override(page: Page, app_base_url: str):
+    """Test that seeding a non-default value works and reverting clears param."""
+    # Seed bound_int (default=50) with a non-default value
+    page.goto(build_app_url(app_base_url, query={"bound_int": "75"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound int value:", "75")
+    expect(page).to_have_url(re.compile(r"bound_int=75"))
+
+
+def test_slider_query_param_invalid_non_numeric(page: Page, app_base_url: str):
+    """Test that non-numeric URL value is rejected and slider uses default."""
+    page.goto(build_app_url(app_base_url, query={"bound_int": "notanumber"}))
+    wait_for_app_loaded(page)
+
+    # Slider should use default (50), invalid param should be cleared
+    expect_prefixed_markdown(page, "Bound int value:", "50")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))
+
+
+def test_slider_query_param_empty_value_rejected(page: Page, app_base_url: str):
+    """Test that empty URL param is rejected for non-clearable slider."""
+    page.goto(build_app_url(app_base_url, query={"bound_int": ""}))
+    wait_for_app_loaded(page)
+
+    # Slider should use default (50), empty param should be cleared
+    expect_prefixed_markdown(page, "Bound int value:", "50")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -415,6 +415,17 @@ def test_slider_query_param_out_of_range_resets_to_default(
     expect(page).not_to_have_url(re.compile(r"[?&]bound_int="))
 
 
+def test_slider_query_param_range_partial_out_of_bounds(page: Page, app_base_url: str):
+    """Test that range with one out-of-bounds value resets entire range to default."""
+    # bound_range has min=0, max=100, default=(25, 75)
+    # First value valid, second out of bounds
+    page.goto(build_app_url(app_base_url, query={"bound_range": ["30", "150"]}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound range value:", "(25, 75)")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_range="))
+
+
 def test_slider_query_param_updates_url(app: Page):
     """Test that interacting with a bound slider updates the URL."""
     slider = get_element_by_key(app, "bound_int")

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -426,6 +426,16 @@ def test_slider_query_param_range_partial_out_of_bounds(page: Page, app_base_url
     expect(page).not_to_have_url(re.compile(r"[?&]bound_range="))
 
 
+def test_slider_query_param_single_value_on_range_resets(page: Page, app_base_url: str):
+    """Test that a single URL value for a range slider resets to default."""
+    # bound_range is a range slider with default=(25, 75)
+    page.goto(build_app_url(app_base_url, query={"bound_range": "50"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound range value:", "(25, 75)")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_range="))
+
+
 def test_slider_query_param_updates_url(app: Page):
     """Test that interacting with a bound slider updates the URL."""
     slider = get_element_by_key(app, "bound_int")

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -431,12 +431,21 @@ def test_slider_query_param_updates_url(app: Page):
 
 def test_slider_query_param_default_override(page: Page, app_base_url: str):
     """Test that seeding a non-default value works and reverting clears param."""
-    # Seed bound_int (default=50) with a non-default value
-    page.goto(build_app_url(app_base_url, query={"bound_int": "75"}))
+    # Seed bound_float (default=0.5) with a non-default value
+    page.goto(build_app_url(app_base_url, query={"bound_float": "0.3"}))
     wait_for_app_loaded(page)
 
-    expect_prefixed_markdown(page, "Bound int value:", "75")
-    expect(page).to_have_url(re.compile(r"bound_int=75"))
+    expect_prefixed_markdown(page, "Bound float value:", "0.3")
+    expect(page).to_have_url(re.compile(r"bound_float=0.3"))
+
+    # Interact to set it back to the default (0.5 is at the midpoint)
+    slider = get_element_by_key(page, "bound_float")
+    slider.click()
+    wait_for_app_run(page)
+
+    # Default value should not remain in URL
+    expect_prefixed_markdown(page, "Bound float value:", "0.5")
+    expect(page).not_to_have_url(re.compile(r"[?&]bound_float="))
 
 
 def test_slider_query_param_invalid_non_numeric(page: Page, app_base_url: str):

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -643,3 +643,76 @@ describe("Slider widget", () => {
     })
   })
 })
+
+describe("Slider query param binding", () => {
+  it("registers query param binding for numeric slider when queryParamKey is set", () => {
+    const props = getProps({
+      queryParamKey: "my_slider",
+      type: SliderProto.Type.SLIDER,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Slider {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_slider",
+      "double_array_value",
+      props.element.default,
+      false,
+      "repeated",
+      undefined
+    )
+  })
+
+  it("registers query param binding for select_slider with string_array_value", () => {
+    const props = getProps({
+      queryParamKey: "my_select_slider",
+      type: SliderProto.Type.SELECT_SLIDER,
+      options: ["red", "green", "blue"],
+      default: [0],
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Slider {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_select_slider",
+      "string_array_value",
+      props.element.default,
+      false,
+      "repeated",
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({
+      queryParamKey: "my_slider",
+    })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<Slider {...props} />)
+
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Slider {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -665,7 +665,7 @@ describe("Slider query param binding", () => {
     )
   })
 
-  it("registers query param binding for select_slider with string_array_value", () => {
+  it("registers query param binding for select_slider with string_array_value and optionStrings", () => {
     const props = getProps({
       queryParamKey: "my_select_slider",
       type: SliderProto.Type.SELECT_SLIDER,
@@ -683,7 +683,7 @@ describe("Slider query param binding", () => {
       props.element.default,
       false,
       "repeated",
-      undefined
+      ["red", "green", "blue"]
     )
   })
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -147,6 +147,18 @@ function Slider({
   widgetMgr,
   fragmentId,
 }: Props): ReactElement {
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: isSelectSlider(element)
+          ? ("string_array_value" as const)
+          : ("double_array_value" as const),
+        // Sliders always have a value (no empty/cleared state in the UI)
+        clearable: false,
+        urlFormat: "repeated" as const,
+      }
+    : undefined
+
   const [value, setValueWithSource] = useBasicWidgetState<
     number[],
     SliderProto
@@ -158,6 +170,7 @@ function Slider({
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding,
   })
 
   // We tie the UI to `uiValue` rather than `value` because `value` only

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -159,6 +159,11 @@ function Slider({
         // Sliders always have a value (no empty/cleared state in the UI)
         clearable: false,
         urlFormat: "repeated" as const,
+        // select_slider proto stores defaults as indices (repeated double), but
+        // URL values are formatted option strings. optionStrings enables the
+        // default normalization in registerQueryParamBinding so that reverting
+        // to default correctly clears the URL param.
+        optionStrings: isSelectSlider(element) ? element.options : undefined,
       }
     : undefined
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -150,6 +150,9 @@ function Slider({
   const queryParamBinding = element.queryParamKey
     ? {
         paramKey: element.queryParamKey,
+        // TODO(query-params): Date/time/datetime sliders produce microsecond
+        // timestamps in URLs (e.g., ?date=1718409600000000) because they use
+        // double_array_value. Consider formatting as ISO strings for readability.
         valueType: isSelectSlider(element)
           ? ("string_array_value" as const)
           : ("double_array_value" as const),

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -53,6 +53,7 @@ from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -166,6 +167,7 @@ class SelectSliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> tuple[T, T]: ...
 
     @overload
@@ -184,6 +186,7 @@ class SelectSliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T: ...
 
     @gather_metrics("select_slider")
@@ -202,6 +205,7 @@ class SelectSliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | tuple[T, T]:
         r"""
         Display a slider widget to select items from a list.
@@ -304,6 +308,16 @@ class SelectSliderMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Invalid URL options are auto-corrected to
+            the closest valid state. Range select sliders use repeated
+            parameters (e.g., ``?key=red&key=blue``). Requires a ``key`` to
+            be set, which will be used as the query parameter name. The
+            default is ``None``.
+
         Returns
         -------
         any value or tuple of any value
@@ -369,6 +383,7 @@ class SelectSliderMixin:
             label_visibility=label_visibility,
             ctx=ctx,
             width=width,
+            bind=bind,
         )
 
     def _select_slider(
@@ -386,6 +401,7 @@ class SelectSliderMixin:
         label_visibility: LabelVisibility = "visible",
         ctx: ScriptRunContext | None = None,
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> T | tuple[T, T]:
         key = to_key(key)
 
@@ -458,6 +474,9 @@ class SelectSliderMixin:
         if help is not None:
             slider_proto.help = dedent(help)
 
+        if bind and key:
+            slider_proto.query_param_key = str(key)
+
         validate_width(width)
         layout_config = LayoutConfig(width=width)
 
@@ -477,6 +496,13 @@ class SelectSliderMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="string_array_value",
+            bind=bind,
+            # Select sliders always have a value (no empty/cleared state in
+            # the UI), so disallow empty URL params (e.g., ?key=).
+            clearable=False if bind else None,
+            # Skip URL dedup: ?color=red&color=red is a valid zero-width
+            # range. Single-mode duplicates are handled by validation.
+            allow_url_duplicates=True,
         )
         if isinstance(widget_state.value, tuple):
             widget_state = maybe_coerce_enum_sequence(

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -123,10 +123,16 @@ class SelectSliderSerde(Generic[T]):
 
     def deserialize(self, ui_value: list[str] | None) -> T | tuple[T, T]:
         """Convert formatted string list back to option value(s)."""
-        is_range = ui_value is not None and len(ui_value) >= 2
+        is_range = len(self.default_indices) >= 2
 
         if not ui_value:
-            return self._get_default(is_range=len(self.default_indices) >= 2)
+            return self._get_default(is_range=is_range)
+
+        expected_len = 2 if is_range else 1
+        if len(ui_value) != expected_len:
+            # Wrong number of values (e.g. single URL param for a range
+            # select_slider); fall back to default so the URL param is cleared.
+            return self._get_default(is_range=is_range)
 
         # Look up each string value
         results: list[tuple[int, T]] = []
@@ -141,7 +147,7 @@ class SelectSliderSerde(Generic[T]):
                 ]
                 results.append((default_idx, self.options[default_idx]))
 
-        if is_range and len(results) >= 2:
+        if is_range:
             # Ensure start <= end by returning deserialized range value in ascending order
             if results[0][0] > results[1][0]:
                 return (results[1][1], results[0][1])

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -499,7 +499,7 @@ class SelectSliderMixin:
             bind=bind,
             # Select sliders always have a value (no empty/cleared state in
             # the UI), so disallow empty URL params (e.g., ?key=).
-            clearable=False if bind else None,
+            clearable=False,
             # Skip URL dedup: ?color=red&color=red is a valid zero-width
             # range. Single-mode duplicates are handled by validation.
             allow_url_duplicates=True,

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -1025,8 +1025,10 @@ class SliderMixin:
             data_type,
             single_value,
             orig_tz,
-            min_value=slider_proto.min,
-            max_value=slider_proto.max,
+            # Proto min/max are always serialized as doubles (dates/times
+            # become microsecond floats), so the cast is safe here.
+            min_value=cast("float", slider_proto.min),  # type: ignore[redundant-cast]
+            max_value=cast("float", slider_proto.max),  # type: ignore[redundant-cast]
         )
 
         widget_state = register_widget(

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -1041,7 +1041,7 @@ class SliderMixin:
             bind=bind,
             # Sliders always have a value (no empty/cleared state in the UI),
             # so disallow empty URL params (e.g., ?key=).
-            clearable=False if bind else None,
+            clearable=False,
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -193,15 +193,19 @@ class SliderSerde:
     def deserialize(self, ui_value: list[float] | None) -> Any:
         if ui_value is not None:
             val = ui_value
-            # Reset to default if any value is outside [min_value, max_value].
-            # This rejects out-of-range values seeded from URL query params;
-            # a no-op for frontend values since the UI enforces bounds.
-            # Returning the default triggers _seed_widget_from_url's
-            # "deserialized == default" check, which clears the URL param.
-            for v in val:
-                if v < self.min_value or v > self.max_value:
-                    val = self.value
-                    break
+            expected_len = 1 if self.single_value else 2
+            if len(val) != expected_len:
+                # Wrong number of values (e.g. single URL param for a range
+                # slider); fall back to default so the URL param is cleared.
+                val = self.value
+            else:
+                # Reset to default if any value is outside [min_value, max_value].
+                # This rejects out-of-range values seeded from URL query params;
+                # a no-op for frontend values since the UI enforces bounds.
+                for v in val:
+                    if v < self.min_value or v > self.max_value:
+                        val = self.value
+                        break
         else:
             # Widget has not been used; fallback to the original value,
             val = self.value

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -202,6 +202,10 @@ class SliderSerde:
                 # Reset to default if any value is outside [min_value, max_value].
                 # This rejects out-of-range values seeded from URL query params;
                 # a no-op for frontend values since the UI enforces bounds.
+                # TODO(query-params): URL values that pass bounds checking but
+                # don't align to the step (e.g., ?val=0.15 with step=0.1) are
+                # accepted as-is. Consider snapping to the nearest valid step
+                # for consistency with the UI.
                 for v in val:
                     if v < self.min_value or v > self.max_value:
                         val = self.value

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -53,6 +53,7 @@ from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
+    BindOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -171,6 +172,8 @@ class SliderSerde:
     data_type: int
     single_value: bool
     orig_tz: tzinfo | None
+    min_value: float
+    max_value: float
 
     def deserialize_single_value(self, value: float) -> SliderScalar:
         if self.data_type == SliderProto.INT:
@@ -190,6 +193,15 @@ class SliderSerde:
     def deserialize(self, ui_value: list[float] | None) -> Any:
         if ui_value is not None:
             val = ui_value
+            # Reset to default if any value is outside [min_value, max_value].
+            # This rejects out-of-range values seeded from URL query params;
+            # a no-op for frontend values since the UI enforces bounds.
+            # Returning the default triggers _seed_widget_from_url's
+            # "deserialized == default" check, which clears the URL param.
+            for v in val:
+                if v < self.min_value or v > self.max_value:
+                    val = self.value
+                    break
         else:
             # Widget has not been used; fallback to the original value,
             val = self.value
@@ -240,6 +252,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> int: ...
 
     # If min-value or max_value is provided and a numeric type, and value (if provided)
@@ -262,6 +275,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> SliderNumericT: ...
 
     # If value is provided and a sequence of numeric type,
@@ -284,6 +298,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> tuple[SliderNumericT, SliderNumericT]: ...
 
     # If value is provided positionally and a sequence of numeric type,
@@ -306,6 +321,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> tuple[SliderNumericT, SliderNumericT]: ...
 
     # If min-value is provided and a datelike type, and value (if provided)
@@ -328,6 +344,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> SliderDatelikeT: ...
 
     # If max-value is provided and a datelike type, and value (if provided)
@@ -350,6 +367,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> SliderDatelikeT: ...
 
     # If value is provided and a datelike type, return the same datelike type.
@@ -371,6 +389,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> SliderDatelikeT: ...
 
     # If value is provided and a sequence of datelike type,
@@ -395,6 +414,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> tuple[SliderDatelikeT, SliderDatelikeT]: ...
 
     # If value is provided positionally and a sequence of datelike type,
@@ -418,6 +438,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> tuple[SliderDatelikeT, SliderDatelikeT]: ...
 
     # https://github.com/python/mypy/issues/17614
@@ -439,6 +460,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
     ) -> Any:
         r"""Display a slider widget.
 
@@ -604,6 +626,16 @@ class SliderMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            If set to ``"query-params"``, the widget's value will be synced
+            with a URL query parameter. When the widget value changes, the URL
+            is updated; when the page loads with a query parameter, the widget
+            is initialized from it. Out-of-range URL values (outside
+            ``min_value``/``max_value``) are ignored, reverting the widget to
+            its default value. Range sliders use repeated parameters
+            (e.g., ``?key=10&key=90``). Requires a ``key`` to be set, which
+            will be used as the query parameter name. The default is ``None``.
+
         Returns
         -------
         int/float/date/time/datetime or tuple of int/float/date/time/datetime
@@ -667,6 +699,7 @@ class SliderMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             width=width,
+            bind=bind,
             ctx=ctx,
         )
 
@@ -687,6 +720,7 @@ class SliderMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
+        bind: BindOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> SliderReturn:
         key = to_key(key)
@@ -983,11 +1017,16 @@ class SliderMixin:
         if help is not None:
             slider_proto.help = dedent(help)
 
+        if bind and key:
+            slider_proto.query_param_key = str(key)
+
         serde = SliderSerde(
             prepared_value,
             data_type,
             single_value,
             orig_tz,
+            min_value=slider_proto.min,
+            max_value=slider_proto.max,
         )
 
         widget_state = register_widget(
@@ -999,6 +1038,10 @@ class SliderMixin:
             serializer=serde.serialize,
             ctx=ctx,
             value_type="double_array_value",
+            bind=bind,
+            # Sliders always have a value (no empty/cleared state in the UI),
+            # so disallow empty URL params (e.g., ?key=).
+            clearable=False if bind else None,
         )
 
         if widget_state.value_changed:

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -176,6 +176,14 @@ class WidgetMetadata(Generic[T]):
     # params from triggering selection-count errors.
     max_array_length: int | None = None
 
+    # Whether duplicate values in URL array params are semantically valid for this
+    # widget. When False (default), _sanitize_url_array deduplicates URL values
+    # (e.g., ?tags=Red&tags=Red → ["Red"]) because the UI prevents duplicate
+    # selections (multiselect). When True, duplicates are preserved because the UI
+    # allows them (e.g., select_slider range mode: ?color=red&color=red is a valid
+    # zero-width range).
+    allow_url_duplicates: bool = False
+
     def __repr__(self) -> str:
         return util.repr_(self)
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -75,9 +75,10 @@ def _sanitize_url_array(
     *,
     valid_options: list[str] | None,
     max_length: int | None,
+    allow_duplicates: bool = False,
 ) -> list[str] | None:
     """Sanitize a URL-parsed string array by filtering invalid values,
-    removing duplicates, and enforcing a maximum length.
+    optionally removing duplicates, and enforcing a maximum length.
 
     Returns the sanitized list if any changes were made, or None if the
     input required no sanitization.
@@ -88,16 +89,18 @@ def _sanitize_url_array(
     if valid_options is not None:
         result = [v for v in result if v in valid_options]
 
-    # Deduplicate while preserving order (the UI prevents duplicate
-    # selections, so duplicates in the URL are user error).
-    seen: set[str] = set()
-    deduped: list[str] = []
-    for v in result:
-        if v not in seen:
-            seen.add(v)
-            deduped.append(v)
-    if len(deduped) < len(result):
-        result = deduped
+    # Deduplicate while preserving order. Skipped when allow_duplicates is
+    # True (e.g., select_slider range mode where ?color=red&color=red is a
+    # valid zero-width range).
+    if not allow_duplicates:
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for v in result:
+            if v not in seen:
+                seen.add(v)
+                deduped.append(v)
+        if len(deduped) < len(result):
+            result = deduped
 
     # Truncate to max_length (e.g. multiselect max_selections).
     if max_length is not None and max_length > 0 and len(result) > max_length:
@@ -1098,8 +1101,9 @@ class SessionState:
                 self._clear_url_param(user_key)
                 return False
 
-            # For string_array_value widgets (e.g. multiselect), sanitize the
-            # parsed URL values: filter invalid options and enforce max length.
+            # For string_array_value widgets (e.g. multiselect, select_slider),
+            # sanitize the parsed URL values: filter invalid options, optionally
+            # deduplicate, and enforce max length.
             if metadata.value_type == "string_array_value" and isinstance(
                 parsed_value, list
             ):
@@ -1107,6 +1111,7 @@ class SessionState:
                     parsed_value,
                     valid_options=metadata.formatted_options,
                     max_length=metadata.max_array_length,
+                    allow_duplicates=metadata.allow_url_duplicates,
                 )
                 if sanitized is not None:
                     if not sanitized:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -54,6 +54,7 @@ def register_widget(
     formatted_options: list[str] | None = None,
     clearable: bool | None = None,
     max_array_length: int | None = None,
+    allow_url_duplicates: bool = False,
 ) -> RegisterWidgetResult[T]:
     """Register a widget with Streamlit, and return its current value.
     NOTE: This function should be called after the proto has been filled.
@@ -168,6 +169,7 @@ def register_widget(
         formatted_options=formatted_options,
         clearable=clearable if clearable is not None else False,
         max_array_length=max_array_length,
+        allow_url_duplicates=allow_url_duplicates,
     )
     return register_widget_from_metadata(metadata, ctx)
 

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -1270,7 +1270,7 @@ class Slider(Widget, Generic[SliderValueT]):
     @property
     def _widget_state(self) -> WidgetState:
         data_type = self.proto.data_type
-        serde = SliderSerde([], data_type, True, None)
+        serde = SliderSerde([], data_type, True, None, self.proto.min, self.proto.max)
         v = serde.serialize(self.value)
 
         ws = WidgetState()

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -24,7 +24,11 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidWidthError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidBindValueError,
+    StreamlitInvalidWidthError,
+)
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.testing.v1.app_test import AppTest
 from streamlit.testing.v1.util import patch_config_options
@@ -706,3 +710,69 @@ def test_select_slider_format_func_multiple_runs():
     at = at.run()
     assert at.select_slider[0].value == 0.20
     assert at.select_slider[1].value == (0.00, 0.40)
+
+
+class SelectSliderBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for select_slider bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.select_slider(
+            "the label",
+            options=["a", "b", "c"],
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.select_slider("the label", options=["a", "b", "c"], bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.select_slider("the label", options=["a", "b", "c"], key="my_key")
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.select_slider(
+                "the label",
+                options=["a", "b"],
+                key="my_key",
+                bind="invalid-value",
+            )
+
+    def test_bind_with_format_func(self):
+        """Test that bind works with format_func."""
+        st.select_slider(
+            "the label",
+            options=["cat", "dog", "bird"],
+            format_func=str.upper,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+        assert list(c.options) == ["CAT", "DOG", "BIRD"]
+
+    def test_bind_with_range_value(self):
+        """Test that bind works with range values."""
+        st.select_slider(
+            "the label",
+            options=["a", "b", "c", "d", "e"],
+            value=("b", "d"),
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+        assert list(c.default) == [1, 3]

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -25,6 +25,7 @@ import streamlit as st
 from streamlit.elements.lib.js_number import JSNumber
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidBindValueError,
     StreamlitInvalidWidthError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
@@ -557,3 +558,76 @@ class SliderStableIdTest(DeltaGeneratorTestCase):
             c2 = self.get_delta_from_queue().new_element.slider
             id2 = c2.id
             assert id1 != id2
+
+
+class SliderBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for slider bind='query-params' functionality."""
+
+    def test_bind_query_params_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.slider("the label", key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+
+    def test_bind_query_params_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.slider("the label", bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind parameter, query_param_key is not set."""
+        st.slider("the label", key="my_key")
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.slider("the label", key="my_key", bind="invalid-value")
+
+    def test_bind_with_int_slider(self):
+        """Test that bind works with integer slider."""
+        st.slider(
+            "the label",
+            min_value=0,
+            max_value=100,
+            value=50,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+        assert c.data_type == 0  # INT
+
+    def test_bind_with_float_slider(self):
+        """Test that bind works with float slider."""
+        st.slider(
+            "the label",
+            min_value=0.0,
+            max_value=1.0,
+            value=0.5,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+        assert c.data_type == 1  # FLOAT
+
+    def test_bind_with_range_slider(self):
+        """Test that bind works with range slider."""
+        st.slider(
+            "the label",
+            min_value=0,
+            max_value=100,
+            value=(25, 75),
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.query_param_key == "my_key"
+        assert list(c.default) == [25, 75]

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2171,3 +2171,87 @@ class AutoCorrectUrlTest(DeltaGeneratorTestCase):
         )
 
         assert self.query_params._query_params["tags"] == ["Apple"]
+
+
+class SanitizeUrlArrayTest(unittest.TestCase):
+    """Tests for the _sanitize_url_array helper function."""
+
+    def test_deduplicates_by_default(self):
+        """By default, duplicate values are removed."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Red", "Blue", "Red"],
+            valid_options=None,
+            max_length=None,
+        )
+        assert result == ["Red", "Blue"]
+
+    def test_allows_duplicates_when_enabled(self):
+        """When allow_duplicates=True, duplicate values are preserved."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Red", "Red"],
+            valid_options=None,
+            max_length=None,
+            allow_duplicates=True,
+        )
+        # No changes needed, so returns None
+        assert result is None
+
+    def test_allows_duplicates_preserves_order(self):
+        """When allow_duplicates=True, order and duplicates are preserved."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Blue", "Red", "Blue"],
+            valid_options=None,
+            max_length=None,
+            allow_duplicates=True,
+        )
+        assert result is None
+
+    def test_filters_invalid_options(self):
+        """Invalid options are filtered out."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Red", "Invalid", "Blue"],
+            valid_options=["Red", "Blue", "Green"],
+            max_length=None,
+        )
+        assert result == ["Red", "Blue"]
+
+    def test_truncates_to_max_length(self):
+        """Arrays exceeding max_length are truncated."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Red", "Blue", "Green"],
+            valid_options=None,
+            max_length=2,
+        )
+        assert result == ["Red", "Blue"]
+
+    def test_returns_none_when_no_changes(self):
+        """Returns None when no sanitization is needed."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Red", "Blue"],
+            valid_options=["Red", "Blue", "Green"],
+            max_length=None,
+        )
+        assert result is None
+
+    def test_combined_filter_dedup_truncate(self):
+        """All sanitization steps work together."""
+        from streamlit.runtime.state.session_state import _sanitize_url_array
+
+        result = _sanitize_url_array(
+            ["Red", "Invalid", "Blue", "Red", "Green"],
+            valid_options=["Red", "Blue", "Green"],
+            max_length=2,
+        )
+        assert result == ["Red", "Blue"]

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -46,6 +46,7 @@ from streamlit.runtime.state.session_state import (
     Value,
     WStates,
     _is_stale_widget,
+    _sanitize_url_array,
 )
 from streamlit.runtime.stats import CACHE_MEMORY_FAMILY
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
@@ -2178,7 +2179,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_deduplicates_by_default(self):
         """By default, duplicate values are removed."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Red", "Blue", "Red"],
@@ -2189,7 +2189,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_allows_duplicates_when_enabled(self):
         """When allow_duplicates=True, duplicate values are preserved."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Red", "Red"],
@@ -2202,7 +2201,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_allows_duplicates_preserves_order(self):
         """When allow_duplicates=True, order and duplicates are preserved."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Blue", "Red", "Blue"],
@@ -2214,7 +2212,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_filters_invalid_options(self):
         """Invalid options are filtered out."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Red", "Invalid", "Blue"],
@@ -2225,7 +2222,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_truncates_to_max_length(self):
         """Arrays exceeding max_length are truncated."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Red", "Blue", "Green"],
@@ -2236,7 +2232,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_returns_none_when_no_changes(self):
         """Returns None when no sanitization is needed."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Red", "Blue"],
@@ -2247,7 +2242,6 @@ class SanitizeUrlArrayTest(unittest.TestCase):
 
     def test_combined_filter_dedup_truncate(self):
         """All sanitization steps work together."""
-        from streamlit.runtime.state.session_state import _sanitize_url_array
 
         result = _sanitize_url_array(
             ["Red", "Invalid", "Blue", "Red", "Green"],

--- a/lib/tests/streamlit/typing/select_slider_types.py
+++ b/lib/tests/streamlit/typing/select_slider_types.py
@@ -59,3 +59,12 @@ if TYPE_CHECKING:
     # tuple[object, object] since value: Sequence[int] is a subtype of object.
     # Technically this return type isn't wrong (tuple[object, object] is a subtype
     # of object), it's just not as specific as we'd like.
+
+    # Check bind parameter
+    assert_type(select_slider("foo", [1, 2, 3], bind="query-params"), int)
+    assert_type(select_slider("foo", ["a", "b", "c"], bind="query-params"), str)
+    assert_type(select_slider("foo", [1, 2, 3], bind=None), int)
+    assert_type(
+        select_slider("foo", [1, 2, 3], value=(1, 3), bind="query-params"),
+        tuple[int, int],
+    )

--- a/lib/tests/streamlit/typing/slider_types.py
+++ b/lib/tests/streamlit/typing/slider_types.py
@@ -371,3 +371,9 @@ if TYPE_CHECKING:
     assert_type(slider("foo", value=_2020_01_01_09_30, format="iso8601"), datetime)
     assert_type(slider("foo", value=_2024_5_1, format="localized"), date)
     assert_type(slider("foo", value=_0800, format="localized"), time)
+
+    # Check bind parameter
+    assert_type(slider("foo", bind="query-params"), int)
+    assert_type(slider("foo", value=5.0, bind="query-params"), float)
+    assert_type(slider("foo", bind=None), int)
+    assert_type(slider("foo", value=(1, 10), bind="query-params"), tuple[int, int])

--- a/proto/streamlit/proto/Slider.proto
+++ b/proto/streamlit/proto/Slider.proto
@@ -58,4 +58,8 @@ message Slider {
   // String-based value for select_slider to support dynamic option changes.
   // Stores formatted option strings instead of indices.
   repeated string raw_value = 18;
+
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 19;
+  // Next: 20
 }


### PR DESCRIPTION
## Describe your changes
Adds the bind parameter to `st.slider` and `st.select_slider` to enable two-way sync between widget values and URL query parameters.

**Key changes:**
- Range values use repeated URL parameters (e.g., `?key=10&key=90` or `?key=red&key=blue`).
- **Out-of-range handling for `st.slider`:** Bounds checking is performed in `SliderSerde.deserialize` -- if any URL value falls outside `[min_value, max_value]`, the widget silently reverts to its default and the invalid param is cleared from the URL. This mirrors `st.number_input`'s deserializer behavior.
- **Invalid option handling for `st.select_slider`:** Invalid URL options are auto-corrected to the closest valid state by leveraging the existing deserializer and post-registration `validate_and_sync` functions. If all values are invalid, the widget reverts to its default.
- **Clearability is unconditionally `False`:** Both `st.slider` and `st.select_slider` always have a value (no empty/cleared state in the UI), so empty URL params (e.g., `?key=`) are rejected.
- **Added `allow_url_duplicates` to `WidgetMetadata`:** A new boolean field that controls whether `_sanitize_url_array` deduplicates URL array values. `st.select_slider` sets this to `True` because `?color=red&color=red` is a valid zero-width range. Other widgets like `st.multiselect` retain the default deduplication behavior since duplicate selections aren't possible in the UI.
- **`format_func` is handled naturally** for `st.select_slider`: the URL contains formatted option strings (what the user sees), and validation checks against the same formatted list.

## Testing Plan
- JS & Python Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅