### PR TITLE
[fix] Restore layered vconcat width propagation and add #13974 regression tests

### DIFF
--- a/e2e_playwright/st_altair_chart.py
+++ b/e2e_playwright/st_altair_chart.py
@@ -193,3 +193,22 @@ right_hist = (
 
 marginal_hist_chart = top_hist & (points | right_hist)
 st.altair_chart(marginal_hist_chart, theme="streamlit")
+
+# Regression scenario for https://github.com/streamlit/streamlit/issues/13974:
+# layered child inside vconcat with explicit autosize=fit-x and width=stretch.
+st.write("Regression: Layered vconcat chart with autosize=fit-x and width=stretch")
+df_regression = pd.DataFrame(
+    np.random.default_rng(0).standard_normal((60, 2)), columns=["a", "b"]
+)
+base_regression = (
+    alt.Chart(df_regression)
+    .mark_circle()
+    .encode(x="a", y="b")
+    .properties(width=400, height=200)
+)
+text_regression = base_regression.mark_text(dy=-10).encode(
+    text=alt.Text("b:Q", format=".1f")
+)
+regression_chart = (base_regression + text_regression) & base_regression
+regression_chart = regression_chart.properties(autosize="fit-x")
+st.altair_chart(regression_chart, width="stretch")

--- a/e2e_playwright/st_altair_chart_test.py
+++ b/e2e_playwright/st_altair_chart_test.py
@@ -19,7 +19,9 @@ from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class
 from e2e_playwright.shared.react18_utils import wait_for_react_stability
 
-NUM_CHARTS = 9
+BASELINE_CHARTS = 9
+REGRESSION_CHART_INDEX = 9
+NUM_CHARTS = 10
 
 
 def test_altair_chart_displays_correctly(
@@ -28,13 +30,14 @@ def test_altair_chart_displays_correctly(
     charts = themed_app.get_by_test_id("stVegaLiteChart")
     expect(charts).to_have_count(NUM_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(charts.locator("[role='graphics-document']")).to_have_count(NUM_CHARTS)
-
-    # Ensure all charts are visible before taking snapshots
-    for idx in range(NUM_CHARTS):
+    # Compound charts (e.g. layered charts within concatenations) may render
+    # multiple graphics documents by design. Verify each baseline chart still
+    # renders exactly one visible graphics document before snapshotting.
+    for idx in range(BASELINE_CHARTS):
         chart = charts.nth(idx)
-        vega_display = chart.locator("[role='graphics-document']").nth(0)
+        chart_displays = chart.locator("[role='graphics-document']")
+        expect(chart_displays).to_have_count(1)
+        vega_display = chart_displays.first
         expect(vega_display).to_be_visible()
 
     assert_snapshot(charts.nth(0), name="st_altair_chart-pie_chart_large_legend_items")
@@ -56,6 +59,20 @@ def test_altair_chart_displays_correctly(
         charts.nth(7), name="st_altair_chart-altair_chart_cut_off_legend_title_none"
     )
     assert_snapshot(charts.nth(8), name="st_altair_chart-marginal_histogram")
+
+
+def test_layered_vconcat_fit_x_regression_renders(app: Page):
+    """Guard against regression from https://github.com/streamlit/streamlit/issues/13974."""
+    charts = app.get_by_test_id("stVegaLiteChart")
+    expect(charts).to_have_count(NUM_CHARTS)
+
+    regression_chart = charts.nth(REGRESSION_CHART_INDEX)
+    expect(regression_chart).to_be_visible()
+    expect(regression_chart.locator("[role='graphics-document']")).to_have_count(1)
+
+    # Issue #13974 regression signal: hidden SVG with width=0.
+    rendered_chart = regression_chart.locator("canvas, svg").first
+    expect(rendered_chart).to_be_visible()
 
 
 def test_check_top_level_class(app: Page):

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.test.ts
@@ -513,16 +513,6 @@ describe("useVegaElementPreprocessor", () => {
         expectedWidths: [undefined, 400],
       },
       {
-        name: "layer",
-        spec: {
-          vconcat: [
-            { layer: [{ mark: "line" }, { mark: "point" }] },
-            { mark: "bar" },
-          ],
-        },
-        expectedWidths: [undefined, 400],
-      },
-      {
         name: "concat",
         spec: {
           vconcat: [
@@ -552,6 +542,31 @@ describe("useVegaElementPreprocessor", () => {
         expect(spec.vconcat[1].width).toBe(expectedWidths[1])
       }
     )
+
+    it("sets width on vconcat children that contain layer", () => {
+      const layerVconcatSpec = {
+        vconcat: [
+          { layer: [{ mark: "line" }, { mark: "point" }] },
+          { mark: "bar" },
+        ],
+      }
+
+      const { result } = renderHook(
+        (element: VegaLiteChartElement) =>
+          useVegaElementPreprocessor(element, 400, 300, true, false),
+        {
+          initialProps: getElement({
+            spec: JSON.stringify(layerVconcatSpec),
+          }),
+        }
+      )
+
+      const spec = result.current.spec as unknown as {
+        vconcat: { width?: number }[]
+      }
+      expect(spec.vconcat[0].width).toBe(400)
+      expect(spec.vconcat[1].width).toBe(400)
+    })
   })
 
   describe("builtin color name resolution", () => {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
@@ -155,15 +155,12 @@ const generateSpec = (
         if (child === null || typeof child !== "object") {
           return
         }
-        // Skip setting width on children that are nested compositions
-        // (hconcat, vconcat, concat, layer) as it causes "infinite extent" errors.
+        // Skip setting width on children that are nested concatenations
+        // (hconcat, vconcat, concat) as it causes "infinite extent" errors.
+        // Layer children should still receive width so layered + vconcat charts
+        // can stretch consistently.
         // In valid Vega-Lite specs, composition operators are always top-level keys.
-        if (
-          "hconcat" in child ||
-          "vconcat" in child ||
-          "concat" in child ||
-          "layer" in child
-        ) {
+        if ("hconcat" in child || "vconcat" in child || "concat" in child) {
           return
         }
         child.width = containerWidth


### PR DESCRIPTION
## Describe your changes

Fixed a bug where layered Altair charts inside vconcat compositions with `autosize="fit-x"` and `width="stretch"` weren't rendering properly. The issue was in the `useVegaElementPreprocessor` where we were skipping setting width on layer children, causing "infinite extent" errors. This change ensures that layer children still receive width so layered + vconcat charts can stretch consistently.

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/13974

## Testing Plan

- Added a regression test case in the e2e_playwright/st_altair_chart.py file that demonstrates the issue
- Added a new test in st_altair_chart_test.py to verify the fix works properly
- Updated the unit test in useVegaElementPreprocessor.test.ts to better test the layer + vconcat case

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.