### PR TITLE
Fix stale query params after same-page popstate navigation

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1764,6 +1764,47 @@ describe("App", () => {
         connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
       ).toBe("mykey=myvalue")
     })
+
+    it("uses current URL query params when browser history stays on the same page", async () => {
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", {
+        ...CURRENT_NEW_SESSION_JSON,
+        pageScriptHash: "top_hash",
+      })
+      sendForwardMessage("navigation", {
+        ...THIS_NAVIGATION_JSON,
+        pageScriptHash: "top_hash",
+      })
+
+      // Simulate stale query params stored from an earlier server update.
+      sendForwardMessage("pageInfoChanged", {
+        queryString: "stale=oldvalue",
+      })
+
+      const connectionManager = getMockConnectionManager()
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
+      // Simulate browser back/forward changing URL query params on same page.
+      window.history.pushState({}, "", "/?fresh=newvalue")
+      act(() => {
+        window.dispatchEvent(new PopStateEvent("popstate"))
+      })
+
+      await waitFor(() => {
+        expect(connectionManager.sendMessage).toBeCalledTimes(1)
+      })
+
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.queryString
+      ).toBe("fresh=newvalue")
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.pageScriptHash
+      ).toBe("top_hash")
+    })
   })
 
   describe("App.handlePageConfigChanged", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -95,6 +95,7 @@ import {
   isKeyboardEventFromEditableTarget,
   isPaddingDisplayed,
   isPresetTheme,
+  normalizeQueryString,
   isScrollingHidden,
   isToolbarDisplayed,
   IToolbarItem,
@@ -1429,7 +1430,11 @@ export class App extends PureComponent<Props, State> {
     // navigating via browser history (back/forward buttons). This ensures that
     // query params present in the URL after history navigation are sent to the
     // server on the first script run.
-    this.onPageChange(targetAppPage.pageScriptHash as string, undefined, true)
+    this.onPageChange(
+      targetAppPage.pageScriptHash as string,
+      normalizeQueryString(document.location.search),
+      true
+    )
   }
 
   /**
@@ -2177,7 +2182,7 @@ export class App extends PureComponent<Props, State> {
         ? queryParams
         : document.location.search
 
-    return queryString.startsWith("?") ? queryString.substring(1) : queryString
+    return normalizeQueryString(queryString)
   }
 
   getThemeColorScheme = (): string => {

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -187,6 +187,7 @@ export {
   isScrollingHidden,
   isToolbarDisplayed,
   makeElementWithInfoText,
+  normalizeQueryString,
   notUndefined,
   preserveEmbedQueryParams,
   setCookie,

--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -42,6 +42,7 @@ import {
   isToolbarDisplayed,
   keysToSnakeCase,
   LoadingScreenType,
+  normalizeQueryString,
   preserveEmbedQueryParams,
   setCookie,
 } from "./utils"
@@ -831,6 +832,13 @@ describe("getQueryString", () => {
       expected: "embed=true&embed_options=dark&page=1&sort=asc",
       description: "handles complex query strings",
     },
+    {
+      queryStringOverride: "?foo=bar",
+      preservedQueryParams: "embed=true",
+      expected: "embed=true&foo=bar",
+      description:
+        "normalizes queryStringOverride values with a leading question mark",
+    },
   ])(
     "$description",
     ({ queryStringOverride, preservedQueryParams, expected }) => {
@@ -839,4 +847,14 @@ describe("getQueryString", () => {
       )
     }
   )
+})
+
+describe("normalizeQueryString", () => {
+  it("strips a leading question mark", () => {
+    expect(normalizeQueryString("?foo=bar")).toBe("foo=bar")
+  })
+
+  it("returns an unchanged query string when there is no leading question mark", () => {
+    expect(normalizeQueryString("foo=bar")).toBe("foo=bar")
+  })
 })

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -135,6 +135,13 @@ export function preserveEmbedQueryParams(): string {
 }
 
 /**
+ * Normalizes a query string by removing a leading "?" if present.
+ */
+export function normalizeQueryString(queryString: string): string {
+  return queryString.startsWith("?") ? queryString.substring(1) : queryString
+}
+
+/**
  * Builds a query string by combining an optional override with preserved embed params.
  * Used during page navigation to merge user query params with embed options.
  */
@@ -143,12 +150,14 @@ export function getQueryString(
   preservedQueryParams: string
 ): string {
   if (queryStringOverride !== undefined) {
+    const normalizedQueryStringOverride =
+      normalizeQueryString(queryStringOverride)
     if (preservedQueryParams) {
-      return queryStringOverride
-        ? `${preservedQueryParams}&${queryStringOverride}`
+      return normalizedQueryStringOverride
+        ? `${preservedQueryParams}&${normalizedQueryStringOverride}`
         : preservedQueryParams
     }
-    return queryStringOverride
+    return normalizedQueryStringOverride
   }
   return preservedQueryParams
 }


### PR DESCRIPTION
## Describe your changes

- Fix `App.onHistoryChange` to pass query params from the browser URL during popstate navigation, so same-page back/forward reruns use current URL params instead of stale internal state.
- Add a shared query-string normalizer and apply it consistently in rerun query handling paths.
- Add regression tests for same-page popstate query-param sync and query normalization.

## Screenshot or video (only for visual changes)

- N/A

## GitHub Issue Link (if applicable)

- Fixes #13963

## Testing Plan

- Explanation of why no additional tests are needed
  - The change is covered by frontend unit tests and does not alter backend protocol semantics.
- Unit Tests (JS and/or Python)
  - Added/updated tests in `frontend/app/src/App.test.tsx` and `frontend/lib/src/util/utils.test.ts`.
  - Could not run locally because `yarn` is unavailable in this environment.
- E2E Tests
  - Not run.
- Any manual testing needed?
  - Optional: verify back/forward query param sync in a multipage app with `st.query_params`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
