### PR TITLE
Prevent false directory child file-change notifications on Windows

### DIFF
--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -286,12 +286,14 @@ class WatchedPath:
         *,  # keyword-only arguments:
         glob_pattern: str | None = None,
         allow_nonexistent: bool = False,
+        child_path_states: dict[str, tuple[float, str]] | None = None,
     ) -> None:
         self.md5 = md5
         self.modification_time = modification_time
 
         self.glob_pattern = glob_pattern
         self.allow_nonexistent = allow_nonexistent
+        self.child_path_states = child_path_states or {}
 
         self.on_changed = Signal()
 
@@ -320,6 +322,32 @@ class _FolderEventHandler(events.FileSystemEventHandler):
     def __repr__(self) -> str:
         return repr_(self)
 
+    def _initialize_child_path_states(
+        self,
+        path: str,
+        *,
+        glob_pattern: str | None,
+        allow_nonexistent: bool,
+    ) -> dict[str, tuple[float, str]]:
+        """Initialize file-level state for files inside a watched directory."""
+        if not os.path.isdir(path):
+            return {}
+
+        child_path_states: dict[str, tuple[float, str]] = {}
+        for child_path in util.iter_matching_files(path, glob_pattern or "*"):
+            try:
+                child_path_states[child_path] = (
+                    util.path_modification_time(child_path, allow_nonexistent),
+                    util.calc_md5_with_blocking_retries(
+                        child_path, allow_nonexistent=allow_nonexistent
+                    ),
+                )
+            except StreamlitMaxRetriesError:
+                # Ignore transiently unreadable files during initial watcher setup.
+                continue
+
+        return child_path_states
+
     def add_path_change_listener(
         self,
         path: str,
@@ -341,11 +369,17 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                     modification_time = util.path_modification_time(
                         path, allow_nonexistent
                     )
+                    child_path_states = self._initialize_child_path_states(
+                        path,
+                        glob_pattern=glob_pattern,
+                        allow_nonexistent=allow_nonexistent,
+                    )
                     watched_path = WatchedPath(
                         md5=md5,
                         modification_time=modification_time,
                         glob_pattern=glob_pattern,
                         allow_nonexistent=allow_nonexistent,
+                        child_path_states=child_path_states,
                     )
                     self._watched_paths[path] = watched_path
                 except StreamlitMaxRetriesError as ex:
@@ -417,6 +451,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
         # To prevent a race condition, we hold a lock while accessing
         # _watched_paths.
+        matched_directory_watcher_path: str | None = None
         with self._lock:
             # First check if the exact path is being watched
             changed_path_info = self._watched_paths.get(abs_changed_path, None)
@@ -432,6 +467,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                     try:
                         if os.path.commonpath([path, abs_changed_path]) == path:
                             changed_path_info = info
+                            matched_directory_watcher_path = path
                             break
                     except ValueError as ex:
                         # On Windows, os.path.commonpath raises ValueError when paths
@@ -458,6 +494,37 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             modification_time = util.path_modification_time(
                 abs_changed_path, changed_path_info.allow_nonexistent
             )
+            new_md5 = util.calc_md5_with_blocking_retries(
+                abs_changed_path,
+                glob_pattern=changed_path_info.glob_pattern,
+                allow_nonexistent=changed_path_info.allow_nonexistent,
+            )
+
+            if matched_directory_watcher_path is not None:
+                previous_state = changed_path_info.child_path_states.get(
+                    abs_changed_path
+                )
+                changed_path_info.child_path_states[abs_changed_path] = (
+                    modification_time,
+                    new_md5,
+                )
+
+                if previous_state is not None:
+                    previous_mtime, previous_md5 = previous_state
+                    if modification_time != 0.0 and modification_time == previous_mtime:
+                        _LOGGER.debug(
+                            "Directory child timestamp did not change: %s", abs_changed_path
+                        )
+                        return
+                    if new_md5 == previous_md5:
+                        _LOGGER.debug(
+                            "Directory child MD5 did not change: %s", abs_changed_path
+                        )
+                        return
+
+                _LOGGER.debug("Directory child MD5 changed: %s", abs_changed_path)
+                changed_path_info.on_changed.send(abs_changed_path)
+                return
 
             # We add modification_time != 0.0 check since on some file systems (s3fs/fuse)
             # modification_time is always 0.0 because of file system limitations.
@@ -469,11 +536,6 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 return
 
             changed_path_info.modification_time = modification_time
-            new_md5 = util.calc_md5_with_blocking_retries(
-                abs_changed_path,
-                glob_pattern=changed_path_info.glob_pattern,
-                allow_nonexistent=changed_path_info.allow_nonexistent,
-            )
             if new_md5 == changed_path_info.md5:
                 _LOGGER.debug("File/dir MD5 did not change: %s", abs_changed_path)
                 return

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -184,10 +184,11 @@ def watch_dir(
     including file creation, deletion, and content modifications. The callback
     receives the path of the actual changed file (not the directory path).
 
-    Note: The glob_pattern parameter only affects the initial state detection
+    Note: The glob_pattern parameter only affects initial state tracking
     (which files are counted when determining if the directory changed). It does
-    NOT filter which file events trigger the callback - all file events in the
-    directory will invoke the callback regardless of glob_pattern.
+    NOT filter runtime event eligibility; directory file events are still
+    observed, but unchanged repeated events may be ignored by watcher state
+    checks.
 
     Parameters
     ----------

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -119,11 +119,21 @@ def _get_file_content(file_path: str) -> bytes:
         return f.read()
 
 
-def _dirfiles(dir_path: str, glob_pattern: str) -> str:
+def iter_matching_files(dir_path: str, glob_pattern: str) -> list[str]:
+    """Return sorted, non-hidden file paths matching a glob pattern."""
     p = Path(dir_path)
-    filenames = sorted(
-        [f.name for f in p.glob(glob_pattern) if not f.name.startswith(".")]
+    files = sorted(
+        [
+            os.path.realpath(str(f))
+            for f in p.glob(glob_pattern)
+            if f.is_file() and not f.name.startswith(".")
+        ]
     )
+    return files
+
+
+def _dirfiles(dir_path: str, glob_pattern: str) -> str:
+    filenames = [Path(path).name for path in iter_matching_files(dir_path, glob_pattern)]
     return "+".join(filenames)
 
 

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -42,6 +42,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         )
         self.MockObserverClass = self.observer_class_patcher.start()
         self.mock_util = self.util_patcher.start()
+        self.mock_util.iter_matching_files = lambda *args: []
 
     def tearDown(self):
         # The test suite patches MultiPathWatcher. We need to close
@@ -647,4 +648,79 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         # Callback SHOULD be triggered again (file was modified)
         assert cb.call_count == 2
 
+        ro.close()
+
+    @mock.patch("os.path.isdir")
+    def test_directory_watcher_ignores_unchanged_file_events(self, mock_is_dir):
+        watched_dir = "/this/is/my/dir"
+        watched_file = f"{watched_dir}/config.toml"
+        mock_is_dir.side_effect = lambda path: path == watched_dir
+
+        cb = mock.Mock()
+
+        self.mock_util.iter_matching_files = lambda *args: [watched_file]
+
+        def path_modification_time(path, *args):
+            return 201.0 if path == watched_file else 101.0
+
+        def calc_md5(path, **kwargs):
+            return "file_hash" if path == watched_file else "dir_hash"
+
+        self.mock_util.path_modification_time = path_modification_time
+        self.mock_util.calc_md5_with_blocking_retries = calc_md5
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(
+            watched_dir, cb, glob_pattern="*.toml"
+        )
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        ev = events.FileSystemEvent(watched_file)
+        ev.event_type = events.EVENT_TYPE_MODIFIED
+        folder_handler.on_modified(ev)
+
+        cb.assert_not_called()
+        ro.close()
+
+    @mock.patch("os.path.isdir")
+    def test_directory_watcher_triggers_for_changed_file_events(self, mock_is_dir):
+        watched_dir = "/this/is/my/dir"
+        watched_file = f"{watched_dir}/config.toml"
+        mock_is_dir.side_effect = lambda path: path == watched_dir
+
+        cb = mock.Mock()
+
+        self.mock_util.iter_matching_files = lambda *args: [watched_file]
+
+        def initial_mtime(path, *args):
+            return 201.0 if path == watched_file else 101.0
+
+        def initial_md5(path, **kwargs):
+            return "file_hash" if path == watched_file else "dir_hash"
+
+        self.mock_util.path_modification_time = initial_mtime
+        self.mock_util.calc_md5_with_blocking_retries = initial_md5
+
+        ro = event_based_path_watcher.EventBasedPathWatcher(
+            watched_dir, cb, glob_pattern="*.toml"
+        )
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = fo._observer.schedule.call_args[0][0]
+
+        def changed_mtime(path, *args):
+            return 202.0 if path == watched_file else 101.0
+
+        def changed_md5(path, **kwargs):
+            return "file_hash_changed" if path == watched_file else "dir_hash"
+
+        self.mock_util.path_modification_time = changed_mtime
+        self.mock_util.calc_md5_with_blocking_retries = changed_md5
+
+        ev = events.FileSystemEvent(watched_file)
+        ev.event_type = events.EVENT_TYPE_MODIFIED
+        folder_handler.on_modified(ev)
+
+        cb.assert_called_once_with(watched_file)
         ro.close()

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -14,8 +14,10 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -98,6 +100,7 @@ class DirHelperTests(unittest.TestCase):
         create_file("03", ".py")
         create_file("04", ".rs")
         create_file(".05", ".py")
+        Path(self._test_dir.name, "06_dir").mkdir()
 
     def tearDown(self) -> None:
         self._test_dir.cleanup()
@@ -111,6 +114,13 @@ class DirHelperTests(unittest.TestCase):
         dirfiles = util._dirfiles(self._test_dir.name, "*.py")
         filename_prefixes = [f[:2] for f in dirfiles.split("+")]
         assert filename_prefixes == ["01", "02", "03"]
+
+    def test_iter_matching_files_returns_sorted_absolute_file_paths(self):
+        matching_files = util.iter_matching_files(self._test_dir.name, "*")
+        matching_basenames = [Path(path).name[:2] for path in matching_files]
+
+        assert matching_basenames == ["01", "02", "03", "04"]
+        assert all(os.path.isabs(path) for path in matching_files)
 
     @patch("streamlit.watcher.util._dirfiles", MagicMock(side_effect=["foo", "foo"]))
     def test_stable_dir(self):


### PR DESCRIPTION
**Task inspiration/Seed Task:**

Issue: False "File change" detection on Windows with no actual file modifications

PR: [to be updated]
issue: https://github.com/streamlit/streamlit/issues/13954

**Major differences from seed task (skip if original task):**

Implemented a per-child file state cache for watched directories and updated watcher tests to validate unchanged-event suppression and changed-event propagation.

**Agent analysis:**

- [x] Agreed with the agent result analysis.
- [ ] Disagreed with the agent result analysis. (Provide explanation and evidence below)


**Other checks:**

- [x] I've gone through the [checklist](https://docs.google.com/document/d/19riH_WBy8GFBm6jQx8E4uxCSaQ3MlAN1YlMeYV9mge4/edit?tab=t.0).
- [x] The task idea was originated from me, not an LLM.
- [x] All behavior checked in the test cases is described in the task instruction.
- [x] All behavior described in the task instruction is checked in the unit tests.
- [x] If the agent produces structured data (e.g. it is tasked with building an API) the exact schema is described in the task.yaml or a separate file.

Fixes #13954
