### PR TITLE
Tweak agent rules to push towards styled-components

### DIFF
--- a/.claude/agents/simplifying-local-changes.md
+++ b/.claude/agents/simplifying-local-changes.md
@@ -107,6 +107,7 @@ Guidelines:
 
 - Omit trivially inferred types (e.g., `const count = 0` not `const count: number = 0`)
 - Prefer optional chaining (`?.`) over `&&` chains for property access
+- **Avoid inline `style` props**: Prefer `@emotion/styled` components over inline `style` attributes. Move styled components to `styled-components.ts` when possible.
 - Naming conventions:
   - Refs must end with `Ref` suffix (e.g., `inputRef`)
   - Event handlers prefixed with `handle` (e.g., `handleClick`)

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -36,7 +36,7 @@ alwaysApply: false
   - ❌ `const input = useRef<HTMLInputElement>(null)`
 - **Updater functions must be pure**: `setState(prev => newState)` updaters must not mutate `prev` or have side effects—return a new object. See [useState](https://react.dev/reference/react/useState#setstate-parameters).
 - Prefix event handlers with "handle" (e.g., handleClick, handleSubmit).
-- Favor leveraging @emotion/styled instead of inline styles.
+- **Avoid inline `style` props**: Prefer `@emotion/styled` components over inline `style` attributes. Move styled components to `styled-components.ts` when possible.
 - Leverage object style notation in Emotion.
 - All styled components begin with the word `Styled` to indicate it's a styled component.
 - Utilize props in styled components to display elements that may have some interactivity.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -34,7 +34,7 @@ applyTo: "**/*.ts, **/*.tsx"
   - ❌ `const input = useRef<HTMLInputElement>(null)`
 - **Updater functions must be pure**: `setState(prev => newState)` updaters must not mutate `prev` or have side effects—return a new object. See [useState](https://react.dev/reference/react/useState#setstate-parameters).
 - Prefix event handlers with "handle" (e.g., handleClick, handleSubmit).
-- Favor leveraging @emotion/styled instead of inline styles.
+- **Avoid inline `style` props**: Prefer `@emotion/styled` components over inline `style` attributes. Move styled components to `styled-components.ts` when possible.
 - Leverage object style notation in Emotion.
 - All styled components begin with the word `Styled` to indicate it's a styled component.
 - Utilize props in styled components to display elements that may have some interactivity.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -30,7 +30,7 @@
   - ❌ `const input = useRef<HTMLInputElement>(null)`
 - **Updater functions must be pure**: `setState(prev => newState)` updaters must not mutate `prev` or have side effects—return a new object. See [useState](https://react.dev/reference/react/useState#setstate-parameters).
 - Prefix event handlers with "handle" (e.g., handleClick, handleSubmit).
-- Favor leveraging @emotion/styled instead of inline styles.
+- **Avoid inline `style` props**: Prefer `@emotion/styled` components over inline `style` attributes. Move styled components to `styled-components.ts` when possible.
 - Leverage object style notation in Emotion.
 - All styled components begin with the word `Styled` to indicate it's a styled component.
 - Utilize props in styled components to display elements that may have some interactivity.


### PR DESCRIPTION
## Describe your changes

- Clarify TypeScript/React styling guidelines to explicitly discourage inline `style` props
- Recommend using `@emotion/styled` components instead
- Guidance to move styled components to `styled-components.ts` when possible
- Updates applied consistently across frontend documentation, code review rules, and IDE instructions

## Testing Plan

- [x] Documentation changes only—no code or tests required
- [x] Consistency verified across all documentation files
- [x] All pre-commit checks passed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.