### PR TITLE
Fix st.Page accepting slash-only url_path without raising exception

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -259,6 +259,10 @@ class StreamlitPage:
                 )
 
             self._url_path = url_path.strip("/")
+            if self._url_path == "" and not default:
+                raise StreamlitAPIException(
+                    "The URL path cannot be an empty string unless the page is the default page."
+                )
             if "/" in self._url_path:
                 raise StreamlitAPIException(
                     "The URL path cannot contain a nested path (e.g. foo/bar)."

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -125,6 +125,15 @@ class StPagesTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.Page(page_9, url_path="")
 
+    def test_non_default_pages_cannot_have_slash_only_url_path(self):
+        """Tests that an error is raised if the url path contains only slashes for a non-default page"""
+
+        def page_9():
+            pass
+
+        with pytest.raises(StreamlitAPIException):
+            st.Page(page_9, url_path="///")
+
     def test_non_default_pages_cannot_have_nested_url_path(self):
         """Tests that an error is raised if the url path contains a nested path"""
 


### PR DESCRIPTION
## Summary

`st.Page` accepted `url_path` values like `"///"` without raising an error. After stripping slashes, these resolved to an empty string, which could cause routing issues for non-default pages.

## Changes

- Added a check after `strip("/")` in `page.py` to raise `StreamlitAPIException` when the resulting `url_path` is empty for non-default pages
- Added test case for slash-only `url_path`

## Root Cause

The existing empty string check at line 256 uses `strip()` (whitespace only), so `"///"` passes. Then `strip("/")` at line 261 reduces it to `""`, resulting in a silently empty `url_path`.

Fixes #13952