### PR TITLE
Bind widgets to query params - `st.pills` & `st.segmented_control`

### DIFF
--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -239,3 +239,52 @@ else:
         format_func=lambda x: x.capitalize(),
     )
     st.write("Initial pills value:", dyn_val)
+
+# --- Bound pills widgets (query-params) ---
+
+st.header("Pills - bound to query params")
+
+bound_single = st.pills(
+    "Bound single pills",
+    ["cat", "dog", "bird"],
+    key="bound_pills",
+    bind="query-params",
+)
+st.text(f"bound_pills: {bound_single}")
+
+bound_single_default = st.pills(
+    "Bound single pills with default",
+    ["Red", "Green", "Blue"],
+    default="Red",
+    key="bound_pills_default",
+    bind="query-params",
+)
+st.text(f"bound_pills_default: {bound_single_default}")
+
+bound_single_fmt = st.pills(
+    "Bound single pills with format_func",
+    ["cat", "dog", "bird"],
+    format_func=str.upper,
+    key="bound_pills_fmt",
+    bind="query-params",
+)
+st.text(f"bound_pills_fmt: {bound_single_fmt}")
+
+bound_multi = st.pills(
+    "Bound multi pills",
+    ["Red", "Green", "Blue", "Yellow"],
+    selection_mode="multi",
+    key="bound_pills_multi",
+    bind="query-params",
+)
+st.text(f"bound_pills_multi: {bound_multi}")
+
+bound_multi_default = st.pills(
+    "Bound multi pills with default",
+    ["Red", "Green", "Blue", "Yellow"],
+    selection_mode="multi",
+    default=["Red", "Green"],
+    key="bound_pills_multi_default",
+    bind="query-params",
+)
+st.text(f"bound_pills_multi_default: {bound_multi_default}")

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -351,7 +351,7 @@ def test_pills_query_param_seeding_multi(page: Page, app_base_url: str):
 
 
 def test_pills_query_param_updates_url_single(app: Page):
-    """Test that selecting a single pill updates the URL."""
+    """Test that selecting, deselecting, and switching pills updates the URL."""
     bound_group = get_element_by_key(app, "bound_pills")
     get_pill_button(bound_group, "cat").click()
     wait_for_app_run(app)
@@ -359,8 +359,16 @@ def test_pills_query_param_updates_url_single(app: Page):
     expect_text(app, "bound_pills: cat")
     expect(app).to_have_url(re.compile(r"\?bound_pills=cat"))
 
+    # Switch selection: clicking a different pill replaces the URL value
+    get_pill_button(bound_group, "dog").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills: dog")
+    expect(app).to_have_url(re.compile(r"\?bound_pills=dog"))
+    expect(app).not_to_have_url(re.compile(r"bound_pills=cat"))
+
     # Deselect (toggle off) clears URL param
-    get_pill_button(bound_group, "cat").click()
+    get_pill_button(bound_group, "dog").click()
     wait_for_app_run(app)
 
     expect_text(app, "bound_pills: None")
@@ -384,14 +392,21 @@ def test_pills_query_param_updates_url_multi(app: Page):
 
 
 def test_pills_query_param_default_override(page: Page, app_base_url: str):
-    """Test that URL overrides default, and reverting clears URL param."""
+    """Test default override: URL overrides default, invalid reverts, revert clears."""
+    # Invalid URL reverts to default ("Red"), not to None
+    page.goto(build_app_url(app_base_url, query={"bound_pills_default": "Invalid"}))
+    wait_for_app_loaded(page)
+    expect_text(page, "bound_pills_default: Red")
+    expect(page).not_to_have_url(re.compile(r"bound_pills_default="))
+
+    # Valid URL overrides default
     page.goto(build_app_url(app_base_url, query={"bound_pills_default": "Blue"}))
     wait_for_app_loaded(page)
 
     expect_text(page, "bound_pills_default: Blue")
     expect(page).to_have_url(re.compile(r"bound_pills_default=Blue"))
 
-    # Revert to default by selecting "Red"
+    # Revert to default by selecting "Red" clears URL param
     bound_group = get_element_by_key(page, "bound_pills_default")
     get_pill_button(bound_group, "Red").click()
     wait_for_app_run(page)
@@ -400,30 +415,26 @@ def test_pills_query_param_default_override(page: Page, app_base_url: str):
     expect(page).not_to_have_url(re.compile(r"bound_pills_default="))
 
 
-def test_pills_query_param_invalid_value_cleared(page: Page, app_base_url: str):
-    """Test that invalid URL values revert widget to default (None when no default)."""
+def test_pills_query_param_single_edge_cases(page: Page, app_base_url: str):
+    """Test single-select edge cases: invalid, empty, and multiple URL values."""
+    # Invalid URL value reverts to default (None when no default)
     page.goto(build_app_url(app_base_url, query={"bound_pills": "Invalid"}))
     wait_for_app_loaded(page)
-
     expect_text(page, "bound_pills: None")
     expect(page).not_to_have_url(re.compile(r"bound_pills="))
 
-
-def test_pills_query_param_multi_invalid_filtered(page: Page, app_base_url: str):
-    """Test that invalid values in multi-select are filtered out."""
-    page.goto(
-        build_app_url(
-            app_base_url,
-            query={"bound_pills_multi": ["Red", "Invalid", "Blue"]},
-        )
-    )
+    # Empty URL param clears to None (clearable widget)
+    page.goto(build_app_url(app_base_url, query={"bound_pills": ""}))
     wait_for_app_loaded(page)
+    expect_text(page, "bound_pills: None")
+    expect(page).not_to_have_url(re.compile(r"bound_pills="))
 
-    expect_text(page, "bound_pills_multi: ['Red', 'Blue']")
-    expect(page).to_have_url(
-        re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue")
-    )
-    expect(page).not_to_have_url(re.compile(r"Invalid"))
+    # Multiple URL values truncated to first for single-select
+    page.goto(build_app_url(app_base_url, query={"bound_pills": ["cat", "dog"]}))
+    wait_for_app_loaded(page)
+    expect_text(page, "bound_pills: cat")
+    expect(page).to_have_url(re.compile(r"\?bound_pills=cat"))
+    expect(page).not_to_have_url(re.compile(r"bound_pills=dog"))
 
 
 def test_pills_query_param_format_func(page: Page, app_base_url: str):
@@ -433,25 +444,6 @@ def test_pills_query_param_format_func(page: Page, app_base_url: str):
 
     expect_text(page, "bound_pills_fmt: dog")
     expect(page).to_have_url(re.compile(r"bound_pills_fmt=DOG"))
-
-
-def test_pills_query_param_clearable_empty(page: Page, app_base_url: str):
-    """Test that empty URL param clears to None for single-select."""
-    page.goto(build_app_url(app_base_url, query={"bound_pills": ""}))
-    wait_for_app_loaded(page)
-
-    expect_text(page, "bound_pills: None")
-    expect(page).not_to_have_url(re.compile(r"bound_pills="))
-
-
-def test_pills_query_param_single_truncates_multiple(page: Page, app_base_url: str):
-    """Test that single-select pills truncates multiple URL params to one."""
-    page.goto(build_app_url(app_base_url, query={"bound_pills": ["cat", "dog"]}))
-    wait_for_app_loaded(page)
-
-    expect_text(page, "bound_pills: cat")
-    expect(page).to_have_url(re.compile(r"\?bound_pills=cat"))
-    expect(page).not_to_have_url(re.compile(r"bound_pills=dog"))
 
 
 def test_pills_query_param_multi_default_override(page: Page, app_base_url: str):
@@ -483,8 +475,23 @@ def test_pills_query_param_multi_default_override(page: Page, app_base_url: str)
     expect(page).not_to_have_url(re.compile(r"bound_pills_multi_default="))
 
 
-def test_pills_query_param_multi_all_invalid_cleared(page: Page, app_base_url: str):
-    """Test that all-invalid URL values clear to empty list and remove the URL param."""
+def test_pills_query_param_multi_edge_cases(page: Page, app_base_url: str):
+    """Test multi-select edge cases: invalid filtering, empty, and duplicates."""
+    # Partial invalid values are filtered out, keeping valid ones
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_pills_multi": ["Red", "Invalid", "Blue"]},
+        )
+    )
+    wait_for_app_loaded(page)
+    expect_text(page, "bound_pills_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(
+        re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue")
+    )
+    expect(page).not_to_have_url(re.compile(r"Invalid"))
+
+    # All-invalid URL values clear to empty list and remove param
     page.goto(
         build_app_url(
             app_base_url,
@@ -492,35 +499,16 @@ def test_pills_query_param_multi_all_invalid_cleared(page: Page, app_base_url: s
         )
     )
     wait_for_app_loaded(page)
-
     expect_text(page, "bound_pills_multi: []")
     expect(page).not_to_have_url(re.compile(r"bound_pills_multi="))
 
-
-def test_pills_query_param_multi_empty_clears_when_no_default(
-    page: Page, app_base_url: str
-):
-    """Test that empty URL param on multi-select with no default clears the URL."""
+    # Empty URL param on multi-select with no default clears the URL
     page.goto(build_app_url(app_base_url, query={"bound_pills_multi": ""}))
     wait_for_app_loaded(page)
-
     expect_text(page, "bound_pills_multi: []")
     expect(page).not_to_have_url(re.compile(r"bound_pills_multi="))
 
-
-def test_pills_query_param_multi_empty_overrides_nonempty_default(
-    page: Page, app_base_url: str
-):
-    """Test that empty URL param overrides a non-empty default to [] and persists."""
-    page.goto(build_app_url(app_base_url, query={"bound_pills_multi_default": ""}))
-    wait_for_app_loaded(page)
-
-    expect_text(page, "bound_pills_multi_default: []")
-    expect(page).to_have_url(re.compile(r"bound_pills_multi_default="))
-
-
-def test_pills_query_param_multi_duplicates_deduplicated(page: Page, app_base_url: str):
-    """Test that duplicate URL values are deduplicated."""
+    # Duplicate URL values are deduplicated
     page.goto(
         build_app_url(
             app_base_url,
@@ -528,7 +516,6 @@ def test_pills_query_param_multi_duplicates_deduplicated(page: Page, app_base_ur
         )
     )
     wait_for_app_loaded(page)
-
     expect_text(page, "bound_pills_multi: ['Red', 'Blue']")
     expect(page).to_have_url(
         re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue")
@@ -540,55 +527,12 @@ def test_pills_query_param_multi_duplicates_deduplicated(page: Page, app_base_ur
     )
 
 
-def test_pills_query_param_multi_deselect_all_clears_url(app: Page):
-    """Test that deselecting all multi-select pills clears the URL param."""
-    bound_group = get_element_by_key(app, "bound_pills_multi")
-
-    get_pill_button(bound_group, "Red").click()
-    wait_for_app_run(app)
-    get_pill_button(bound_group, "Blue").click()
-    wait_for_app_run(app)
-
-    expect_text(app, "bound_pills_multi: ['Red', 'Blue']")
-    expect(app).to_have_url(re.compile(r"bound_pills_multi="))
-
-    get_pill_button(bound_group, "Red").click()
-    wait_for_app_run(app)
-    get_pill_button(bound_group, "Blue").click()
-    wait_for_app_run(app)
-
-    expect_text(app, "bound_pills_multi: []")
-    expect(app).not_to_have_url(re.compile(r"bound_pills_multi="))
-
-
-def test_pills_query_param_single_invalid_with_default_reverts_to_default(
+def test_pills_query_param_multi_empty_overrides_nonempty_default(
     page: Page, app_base_url: str
 ):
-    """Test that invalid URL on widget with default reverts to the default value.
-
-    Invalid URL values are not an intentional clear — they are bad data.
-    The widget should revert to its default ("Red"), not clear to None.
-    This matches the behavior of st.radio and st.selectbox.
-    """
-    page.goto(build_app_url(app_base_url, query={"bound_pills_default": "Invalid"}))
+    """Test that empty URL param overrides a non-empty default to [] and persists."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills_multi_default": ""}))
     wait_for_app_loaded(page)
 
-    expect_text(page, "bound_pills_default: Red")
-    expect(page).not_to_have_url(re.compile(r"bound_pills_default="))
-
-
-def test_pills_query_param_single_switch_selection_updates_url(app: Page):
-    """Test that switching from one pill to another updates the URL correctly."""
-    bound_group = get_element_by_key(app, "bound_pills")
-    get_pill_button(bound_group, "cat").click()
-    wait_for_app_run(app)
-
-    expect_text(app, "bound_pills: cat")
-    expect(app).to_have_url(re.compile(r"\?bound_pills=cat"))
-
-    get_pill_button(bound_group, "dog").click()
-    wait_for_app_run(app)
-
-    expect_text(app, "bound_pills: dog")
-    expect(app).to_have_url(re.compile(r"\?bound_pills=dog"))
-    expect(app).not_to_have_url(re.compile(r"bound_pills=cat"))
+    expect_text(page, "bound_pills_multi_default: []")
+    expect(page).to_have_url(re.compile(r"bound_pills_multi_default="))

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -16,7 +16,12 @@ import re
 
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
@@ -26,6 +31,7 @@ from e2e_playwright.shared.app_utils import (
     expect_help_tooltip,
     expect_markdown,
     expect_prefixed_markdown,
+    expect_text,
     get_button_group,
     get_element_by_key,
 )
@@ -317,3 +323,161 @@ def test_dynamic_pills_props(app: Page, assert_snapshot: ImageCompareFunction):
     # Selection should be PRESERVED since "mango" is in both option sets
     # If this was reset, it would show "apple" (initial default), not "mango"
     expect_prefixed_markdown(app, "Initial pills value:", "mango")
+
+
+# --- Query parameter binding tests ---
+
+
+def test_pills_query_param_seeding_single(page: Page, app_base_url: str):
+    """Test that single-select pills value can be seeded from URL query params."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills": "dog"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills: dog")
+    expect(page).to_have_url(re.compile(r"\?bound_pills=dog"))
+    expect(page).not_to_have_url(re.compile(r"bound_pills_default="))
+    expect(page).not_to_have_url(re.compile(r"bound_pills_fmt="))
+
+
+def test_pills_query_param_seeding_multi(page: Page, app_base_url: str):
+    """Test that multi-select pills values can be seeded from URL query params."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills_multi": ["Red", "Blue"]}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(
+        re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue")
+    )
+
+
+def test_pills_query_param_updates_url_single(app: Page):
+    """Test that selecting a single pill updates the URL."""
+    bound_group = get_element_by_key(app, "bound_pills")
+    get_pill_button(bound_group, "cat").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills: cat")
+    expect(app).to_have_url(re.compile(r"\?bound_pills=cat"))
+
+    # Deselect (toggle off) clears URL param
+    get_pill_button(bound_group, "cat").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills: None")
+    expect(app).not_to_have_url(re.compile(r"bound_pills="))
+
+
+def test_pills_query_param_updates_url_multi(app: Page):
+    """Test that selecting multiple pills updates the URL."""
+    bound_group = get_element_by_key(app, "bound_pills_multi")
+    get_pill_button(bound_group, "Red").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills_multi: ['Red']")
+    expect(app).to_have_url(re.compile(r"\?bound_pills_multi=Red"))
+
+    get_pill_button(bound_group, "Blue").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills_multi: ['Red', 'Blue']")
+    expect(app).to_have_url(re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue"))
+
+
+def test_pills_query_param_default_override(page: Page, app_base_url: str):
+    """Test that URL overrides default, and reverting clears URL param."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills_default": "Blue"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_default: Blue")
+    expect(page).to_have_url(re.compile(r"bound_pills_default=Blue"))
+
+    # Revert to default by selecting "Red"
+    bound_group = get_element_by_key(page, "bound_pills_default")
+    get_pill_button(bound_group, "Red").click()
+    wait_for_app_run(page)
+
+    expect_text(page, "bound_pills_default: Red")
+    expect(page).not_to_have_url(re.compile(r"bound_pills_default="))
+
+
+def test_pills_query_param_invalid_value_cleared(page: Page, app_base_url: str):
+    """Test that invalid URL values are cleared."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills": "Invalid"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills: None")
+    expect(page).not_to_have_url(re.compile(r"bound_pills="))
+
+
+def test_pills_query_param_multi_invalid_filtered(page: Page, app_base_url: str):
+    """Test that invalid values in multi-select are filtered out."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_pills_multi": ["Red", "Invalid", "Blue"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(
+        re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue")
+    )
+    expect(page).not_to_have_url(re.compile(r"Invalid"))
+
+
+def test_pills_query_param_format_func(page: Page, app_base_url: str):
+    """Test that formatted option strings work in URL."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills_fmt": "DOG"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_fmt: dog")
+    expect(page).to_have_url(re.compile(r"bound_pills_fmt=DOG"))
+
+
+def test_pills_query_param_clearable_empty(page: Page, app_base_url: str):
+    """Test that empty URL param clears to None for single-select."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills": ""}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills: None")
+    expect(page).not_to_have_url(re.compile(r"bound_pills="))
+
+
+def test_pills_query_param_single_truncates_multiple(page: Page, app_base_url: str):
+    """Test that single-select pills truncates multiple URL params to one."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills": ["cat", "dog"]}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills: cat")
+    expect(page).to_have_url(re.compile(r"\?bound_pills=cat"))
+    expect(page).not_to_have_url(re.compile(r"bound_pills=dog"))
+
+
+def test_pills_query_param_multi_default_override(page: Page, app_base_url: str):
+    """Test multiselect pills: URL overrides default, reverting clears param."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_pills_multi_default": ["Yellow", "Blue"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi_default: ['Yellow', 'Blue']")
+    expect(page).to_have_url(re.compile(r"bound_pills_multi_default="))
+
+    # Revert to default ["Red", "Green"] by deselecting Yellow, Blue
+    # then selecting Red, Green
+    bound_group = get_element_by_key(page, "bound_pills_multi_default")
+    get_pill_button(bound_group, "Yellow").click()
+    wait_for_app_run(page)
+    get_pill_button(bound_group, "Blue").click()
+    wait_for_app_run(page)
+    get_pill_button(bound_group, "Red").click()
+    wait_for_app_run(page)
+    get_pill_button(bound_group, "Green").click()
+    wait_for_app_run(page)
+
+    expect_text(page, "bound_pills_multi_default: ['Red', 'Green']")
+    expect(page).not_to_have_url(re.compile(r"bound_pills_multi_default="))

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -401,7 +401,7 @@ def test_pills_query_param_default_override(page: Page, app_base_url: str):
 
 
 def test_pills_query_param_invalid_value_cleared(page: Page, app_base_url: str):
-    """Test that invalid URL values are cleared."""
+    """Test that invalid URL values revert widget to default (None when no default)."""
     page.goto(build_app_url(app_base_url, query={"bound_pills": "Invalid"}))
     wait_for_app_loaded(page)
 
@@ -481,3 +481,114 @@ def test_pills_query_param_multi_default_override(page: Page, app_base_url: str)
 
     expect_text(page, "bound_pills_multi_default: ['Red', 'Green']")
     expect(page).not_to_have_url(re.compile(r"bound_pills_multi_default="))
+
+
+def test_pills_query_param_multi_all_invalid_cleared(page: Page, app_base_url: str):
+    """Test that all-invalid URL values clear to empty list and remove the URL param."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_pills_multi": ["Invalid1", "Invalid2"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi: []")
+    expect(page).not_to_have_url(re.compile(r"bound_pills_multi="))
+
+
+def test_pills_query_param_multi_empty_clears_when_no_default(
+    page: Page, app_base_url: str
+):
+    """Test that empty URL param on multi-select with no default clears the URL."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills_multi": ""}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi: []")
+    expect(page).not_to_have_url(re.compile(r"bound_pills_multi="))
+
+
+def test_pills_query_param_multi_empty_overrides_nonempty_default(
+    page: Page, app_base_url: str
+):
+    """Test that empty URL param overrides a non-empty default to [] and persists."""
+    page.goto(build_app_url(app_base_url, query={"bound_pills_multi_default": ""}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi_default: []")
+    expect(page).to_have_url(re.compile(r"bound_pills_multi_default="))
+
+
+def test_pills_query_param_multi_duplicates_deduplicated(page: Page, app_base_url: str):
+    """Test that duplicate URL values are deduplicated."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_pills_multi": ["Red", "Blue", "Red"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(
+        re.compile(r"bound_pills_multi=Red&bound_pills_multi=Blue")
+    )
+    expect(page).not_to_have_url(
+        re.compile(
+            r"bound_pills_multi=Red&bound_pills_multi=Blue&bound_pills_multi=Red"
+        )
+    )
+
+
+def test_pills_query_param_multi_deselect_all_clears_url(app: Page):
+    """Test that deselecting all multi-select pills clears the URL param."""
+    bound_group = get_element_by_key(app, "bound_pills_multi")
+
+    get_pill_button(bound_group, "Red").click()
+    wait_for_app_run(app)
+    get_pill_button(bound_group, "Blue").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills_multi: ['Red', 'Blue']")
+    expect(app).to_have_url(re.compile(r"bound_pills_multi="))
+
+    get_pill_button(bound_group, "Red").click()
+    wait_for_app_run(app)
+    get_pill_button(bound_group, "Blue").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills_multi: []")
+    expect(app).not_to_have_url(re.compile(r"bound_pills_multi="))
+
+
+def test_pills_query_param_single_invalid_with_default_reverts_to_default(
+    page: Page, app_base_url: str
+):
+    """Test that invalid URL on widget with default reverts to the default value.
+
+    Invalid URL values are not an intentional clear — they are bad data.
+    The widget should revert to its default ("Red"), not clear to None.
+    This matches the behavior of st.radio and st.selectbox.
+    """
+    page.goto(build_app_url(app_base_url, query={"bound_pills_default": "Invalid"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_pills_default: Red")
+    expect(page).not_to_have_url(re.compile(r"bound_pills_default="))
+
+
+def test_pills_query_param_single_switch_selection_updates_url(app: Page):
+    """Test that switching from one pill to another updates the URL correctly."""
+    bound_group = get_element_by_key(app, "bound_pills")
+    get_pill_button(bound_group, "cat").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills: cat")
+    expect(app).to_have_url(re.compile(r"\?bound_pills=cat"))
+
+    get_pill_button(bound_group, "dog").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_pills: dog")
+    expect(app).to_have_url(re.compile(r"\?bound_pills=dog"))
+    expect(app).not_to_have_url(re.compile(r"bound_pills=cat"))

--- a/e2e_playwright/st_segmented_control.py
+++ b/e2e_playwright/st_segmented_control.py
@@ -263,3 +263,24 @@ else:
         format_func=lambda text: text.capitalize(),
     )
     st.write("Initial segmented control value:", dyn_val)
+
+# --- Bound segmented control widgets (query-params) ---
+
+st.header("Segmented control - bound to query params")
+
+bound_sc_single = st.segmented_control(
+    "Bound single segmented control",
+    ["cat", "dog", "bird"],
+    key="bound_sc",
+    bind="query-params",
+)
+st.text(f"bound_sc: {bound_sc_single}")
+
+bound_sc_multi = st.segmented_control(
+    "Bound multi segmented control",
+    ["Red", "Green", "Blue", "Yellow"],
+    selection_mode="multi",
+    key="bound_sc_multi",
+    bind="query-params",
+)
+st.text(f"bound_sc_multi: {bound_sc_multi}")

--- a/e2e_playwright/st_segmented_control.py
+++ b/e2e_playwright/st_segmented_control.py
@@ -276,6 +276,15 @@ bound_sc_single = st.segmented_control(
 )
 st.text(f"bound_sc: {bound_sc_single}")
 
+bound_sc_default = st.segmented_control(
+    "Bound single segmented control with default",
+    ["Red", "Green", "Blue"],
+    default="Red",
+    key="bound_sc_default",
+    bind="query-params",
+)
+st.text(f"bound_sc_default: {bound_sc_default}")
+
 bound_sc_multi = st.segmented_control(
     "Bound multi segmented control",
     ["Red", "Green", "Blue", "Yellow"],

--- a/e2e_playwright/st_segmented_control_test.py
+++ b/e2e_playwright/st_segmented_control_test.py
@@ -345,44 +345,15 @@ def test_segmented_control_query_param_updates_url(app: Page):
     expect(app).not_to_have_url(re.compile(r"bound_sc="))
 
 
-def test_segmented_control_query_param_seeding_multi(page: Page, app_base_url: str):
-    """Test that multi-select segmented control can be seeded from URL."""
-    page.goto(build_app_url(app_base_url, query={"bound_sc_multi": ["Red", "Blue"]}))
-    wait_for_app_loaded(page)
-
-    expect_text(page, "bound_sc_multi: ['Red', 'Blue']")
-    expect(page).to_have_url(re.compile(r"bound_sc_multi=Red&bound_sc_multi=Blue"))
-
-
-def test_segmented_control_query_param_invalid_cleared(page: Page, app_base_url: str):
-    """Test that invalid URL values revert widget to default (None when no default)."""
+def test_segmented_control_query_param_edge_cases(page: Page, app_base_url: str):
+    """Smoke test: invalid value handling for single and multi-select."""
+    # Single-select: invalid URL reverts to default (None when no default)
     page.goto(build_app_url(app_base_url, query={"bound_sc": "Invalid"}))
     wait_for_app_loaded(page)
-
     expect_text(page, "bound_sc: None")
     expect(page).not_to_have_url(re.compile(r"bound_sc="))
 
-
-def test_segmented_control_query_param_multi_all_invalid_cleared(
-    page: Page, app_base_url: str
-):
-    """Test that all-invalid multi-select URL values clear to empty list."""
-    page.goto(
-        build_app_url(
-            app_base_url,
-            query={"bound_sc_multi": ["Invalid1", "Invalid2"]},
-        )
-    )
-    wait_for_app_loaded(page)
-
-    expect_text(page, "bound_sc_multi: []")
-    expect(page).not_to_have_url(re.compile(r"bound_sc_multi="))
-
-
-def test_segmented_control_query_param_multi_partial_invalid_filtered(
-    page: Page, app_base_url: str
-):
-    """Test that invalid values in multi-select are filtered, keeping valid ones."""
+    # Multi-select: partial invalid values filtered, valid ones kept
     page.goto(
         build_app_url(
             app_base_url,
@@ -390,10 +361,20 @@ def test_segmented_control_query_param_multi_partial_invalid_filtered(
         )
     )
     wait_for_app_loaded(page)
-
     expect_text(page, "bound_sc_multi: ['Red', 'Blue']")
     expect(page).to_have_url(re.compile(r"bound_sc_multi=Red&bound_sc_multi=Blue"))
     expect(page).not_to_have_url(re.compile(r"Invalid"))
+
+    # Multi-select: all-invalid clears to empty list
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_sc_multi": ["Invalid1", "Invalid2"]},
+        )
+    )
+    wait_for_app_loaded(page)
+    expect_text(page, "bound_sc_multi: []")
+    expect(page).not_to_have_url(re.compile(r"bound_sc_multi="))
 
 
 def test_segmented_control_query_param_default_override(page: Page, app_base_url: str):

--- a/e2e_playwright/st_segmented_control_test.py
+++ b/e2e_playwright/st_segmented_control_test.py
@@ -355,9 +355,58 @@ def test_segmented_control_query_param_seeding_multi(page: Page, app_base_url: s
 
 
 def test_segmented_control_query_param_invalid_cleared(page: Page, app_base_url: str):
-    """Test that invalid URL values are cleared."""
+    """Test that invalid URL values revert widget to default (None when no default)."""
     page.goto(build_app_url(app_base_url, query={"bound_sc": "Invalid"}))
     wait_for_app_loaded(page)
 
     expect_text(page, "bound_sc: None")
     expect(page).not_to_have_url(re.compile(r"bound_sc="))
+
+
+def test_segmented_control_query_param_multi_all_invalid_cleared(
+    page: Page, app_base_url: str
+):
+    """Test that all-invalid multi-select URL values clear to empty list."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_sc_multi": ["Invalid1", "Invalid2"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_sc_multi: []")
+    expect(page).not_to_have_url(re.compile(r"bound_sc_multi="))
+
+
+def test_segmented_control_query_param_multi_partial_invalid_filtered(
+    page: Page, app_base_url: str
+):
+    """Test that invalid values in multi-select are filtered, keeping valid ones."""
+    page.goto(
+        build_app_url(
+            app_base_url,
+            query={"bound_sc_multi": ["Red", "Invalid", "Blue"]},
+        )
+    )
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_sc_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(re.compile(r"bound_sc_multi=Red&bound_sc_multi=Blue"))
+    expect(page).not_to_have_url(re.compile(r"Invalid"))
+
+
+def test_segmented_control_query_param_default_override(page: Page, app_base_url: str):
+    """Test that URL overrides default, and reverting to default clears URL param."""
+    page.goto(build_app_url(app_base_url, query={"bound_sc_default": "Blue"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_sc_default: Blue")
+    expect(page).to_have_url(re.compile(r"bound_sc_default=Blue"))
+
+    bound_group = get_element_by_key(page, "bound_sc_default")
+    get_segment_button(bound_group, "Red").click()
+    wait_for_app_run(page)
+
+    expect_text(page, "bound_sc_default: Red")
+    expect(page).not_to_have_url(re.compile(r"bound_sc_default="))

--- a/e2e_playwright/st_segmented_control_test.py
+++ b/e2e_playwright/st_segmented_control_test.py
@@ -16,7 +16,12 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    wait_for_app_loaded,
+    wait_for_app_run,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
@@ -26,6 +31,7 @@ from e2e_playwright.shared.app_utils import (
     expect_help_tooltip,
     expect_markdown,
     expect_prefixed_markdown,
+    expect_text,
     get_button_group,
     get_element_by_key,
     get_markdown,
@@ -308,3 +314,50 @@ def test_dynamic_segmented_control_props(
     # Selection should be PRESERVED since "mango" is in both option sets
     # If this was reset, it would show "apple" (initial default), not "mango"
     expect_prefixed_markdown(app, "Initial segmented control value:", "mango")
+
+
+# --- Query parameter binding tests ---
+
+
+def test_segmented_control_query_param_seeding_single(page: Page, app_base_url: str):
+    """Test that single-select segmented control can be seeded from URL."""
+    page.goto(build_app_url(app_base_url, query={"bound_sc": "dog"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_sc: dog")
+    expect(page).to_have_url(re.compile(r"\?bound_sc=dog"))
+
+
+def test_segmented_control_query_param_updates_url(app: Page):
+    """Test that selecting a segment updates the URL."""
+    bound_group = get_element_by_key(app, "bound_sc")
+    get_segment_button(bound_group, "cat").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_sc: cat")
+    expect(app).to_have_url(re.compile(r"\?bound_sc=cat"))
+
+    # Deselect (toggle off) clears URL param
+    get_segment_button(bound_group, "cat").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "bound_sc: None")
+    expect(app).not_to_have_url(re.compile(r"bound_sc="))
+
+
+def test_segmented_control_query_param_seeding_multi(page: Page, app_base_url: str):
+    """Test that multi-select segmented control can be seeded from URL."""
+    page.goto(build_app_url(app_base_url, query={"bound_sc_multi": ["Red", "Blue"]}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_sc_multi: ['Red', 'Blue']")
+    expect(page).to_have_url(re.compile(r"bound_sc_multi=Red&bound_sc_multi=Blue"))
+
+
+def test_segmented_control_query_param_invalid_cleared(page: Page, app_base_url: str):
+    """Test that invalid URL values are cleared."""
+    page.goto(build_app_url(app_base_url, query={"bound_sc": "Invalid"}))
+    wait_for_app_loaded(page)
+
+    expect_text(page, "bound_sc: None")
+    expect(page).not_to_have_url(re.compile(r"bound_sc="))

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -582,6 +582,29 @@ describe("ButtonGroup query param binding", () => {
     )
   })
 
+  it("registers query param binding for multi-select with same config", () => {
+    const props = getProps({
+      queryParamKey: "my_multi_pills",
+      options: simpleOptions,
+      default: [0, 2],
+      clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
+      style: ButtonGroupProto.Style.PILLS,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ButtonGroup {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_multi_pills",
+      "string_array_value",
+      ["cat", "bird"],
+      true,
+      "repeated",
+      undefined
+    )
+  })
+
   it("does not register query param binding when queryParamKey is not set", () => {
     const props = getProps({ options: simpleOptions, default: [0] })
     vi.spyOn(props.widgetMgr, "registerQueryParamBinding")

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -530,3 +530,64 @@ describe("ButtonGroup getContentElement", () => {
     expect(size).toBe(BaseButtonSize.MEDIUM)
   })
 })
+
+describe("ButtonGroup query param binding", () => {
+  const simpleOptions = [
+    ButtonGroupProto.Option.create({ content: "cat" }),
+    ButtonGroupProto.Option.create({ content: "dog" }),
+    ButtonGroupProto.Option.create({ content: "bird" }),
+  ]
+
+  it("registers query param binding when queryParamKey is set", () => {
+    const props = getProps({
+      queryParamKey: "my_pills",
+      options: simpleOptions,
+      default: [0],
+      style: ButtonGroupProto.Style.PILLS,
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ButtonGroup {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_pills",
+      "string_array_value",
+      ["cat"],
+      true,
+      "repeated",
+      undefined
+    )
+  })
+
+  it("unregisters query param binding on unmount", () => {
+    const props = getProps({
+      queryParamKey: "my_pills",
+      options: simpleOptions,
+      default: [0],
+    })
+    const unregisterSpy = vi.spyOn(
+      props.widgetMgr,
+      "unregisterQueryParamBinding"
+    )
+
+    const { unmount } = render(<ButtonGroup {...props} />)
+
+    unregisterSpy.mockClear()
+
+    unmount()
+
+    expect(props.widgetMgr.unregisterQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id
+    )
+  })
+
+  it("does not register query param binding when queryParamKey is not set", () => {
+    const props = getProps({ options: simpleOptions, default: [0] })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<ButtonGroup {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -312,6 +312,15 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
   const { clickMode, options, style, label, labelVisibility, help } = element
   const theme = useEmotionTheme()
 
+  const queryParamBinding = element.queryParamKey
+    ? {
+        paramKey: element.queryParamKey,
+        valueType: "string_array_value" as const,
+        clearable: true,
+        urlFormat: "repeated" as const,
+      }
+    : undefined
+
   // State stores base content strings (e.g., ["Apple", "Banana"])
   const [value, setValueWithSource] = useBasicWidgetState<
     ButtonGroupValue,
@@ -324,6 +333,7 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
     element,
     widgetMgr,
     fragmentId,
+    queryParamBinding,
   })
 
   // Derive indices from content strings + current options (like Radio)

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -57,7 +57,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ButtonGroup_pb2 import ButtonGroup as ButtonGroupProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
-from streamlit.runtime.state import register_widget
+from streamlit.runtime.state import BindOption, register_widget
 from streamlit.string_util import is_emoji, validate_material_icon
 
 if TYPE_CHECKING:
@@ -288,6 +288,7 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> V | None: ...
     @overload
     def pills(
@@ -306,6 +307,7 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> list[V]: ...
     @gather_metrics("pills")
     def pills(
@@ -324,6 +326,7 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> list[V] | V | None:
         r"""Display a pills widget.
 
@@ -429,6 +432,16 @@ class ButtonGroupMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            Enables two-way binding between the widget value and the URL
+            query string. When set to ``"query-params"``, the widget's
+            ``key`` is used as the URL parameter name. Requires ``key``
+            to be set. For ``selection_mode="multi"``, multiple
+            selections use repeated parameters (e.g.,
+            ``?tags=Red&tags=Blue``). Invalid URL values (not in
+            ``options``) are silently filtered out and the URL is
+            auto-corrected. The default is ``None``.
+
         Returns
         -------
         list of V, V, or None
@@ -497,6 +510,7 @@ class ButtonGroupMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             width=width,
+            bind=bind,
         )
 
     @overload
@@ -516,6 +530,7 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> V | None: ...
     @overload
     def segmented_control(
@@ -534,6 +549,7 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> list[V]: ...
 
     @gather_metrics("segmented_control")
@@ -553,6 +569,7 @@ class ButtonGroupMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        bind: BindOption = None,
     ) -> list[V] | V | None:
         r"""Display a segmented control widget.
 
@@ -658,6 +675,16 @@ class ButtonGroupMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        bind : "query-params" or None
+            Enables two-way binding between the widget value and the URL
+            query string. When set to ``"query-params"``, the widget's
+            ``key`` is used as the URL parameter name. Requires ``key``
+            to be set. For ``selection_mode="multi"``, multiple
+            selections use repeated parameters (e.g.,
+            ``?tags=Red&tags=Blue``). Invalid URL values (not in
+            ``options``) are silently filtered out and the URL is
+            auto-corrected. The default is ``None``.
+
         Returns
         -------
         list of V, V, or None
@@ -729,6 +756,7 @@ class ButtonGroupMixin:
             disabled=disabled,
             label_visibility=label_visibility,
             width=width,
+            bind=bind,
         )
 
     @gather_metrics("_internal_button_group")
@@ -749,6 +777,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         help: str | None = None,
         width: Width = "content",
+        bind: BindOption = None,
     ) -> list[V] | V | None:
         maybe_raise_label_warnings(label, label_visibility)
 
@@ -838,6 +867,8 @@ class ButtonGroupMixin:
             label_visibility=label_visibility,
             width=width,
             options_format_func=actual_format_func,
+            bind=bind,
+            string_formatted_options=formatted_options,
         )
 
         # Handle return type based on selection mode
@@ -872,6 +903,8 @@ class ButtonGroupMixin:
         help: str | None = None,
         width: Width = "content",
         options_format_func: Callable[[Any], str] | None = None,
+        bind: BindOption = None,
+        string_formatted_options: list[str] | None = None,
     ) -> RegisterWidgetResult[T]:
         _maybe_raise_selection_mode_warning(selection_mode)
 
@@ -950,6 +983,9 @@ class ButtonGroupMixin:
             help=help,
         )
 
+        if bind == "query-params" and key is not None:
+            proto.query_param_key = str(key)
+
         widget_state = register_widget(
             proto.id,
             on_change_handler=on_change,
@@ -959,6 +995,10 @@ class ButtonGroupMixin:
             serializer=serializer,
             ctx=ctx,
             value_type="string_array_value",
+            bind=bind,
+            clearable=True,
+            formatted_options=string_formatted_options,
+            max_array_length=1 if selection_mode == "single" else None,
         )
 
         # Validate and sync value with options for pills/segmented_control

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -436,11 +436,13 @@ class ButtonGroupMixin:
             Enables two-way binding between the widget value and the URL
             query string. When set to ``"query-params"``, the widget's
             ``key`` is used as the URL parameter name. Requires ``key``
-            to be set. For ``selection_mode="multi"``, multiple
-            selections use repeated parameters (e.g.,
-            ``?tags=Red&tags=Blue``). Invalid URL values (not in
-            ``options``) are silently filtered out and the URL is
-            auto-corrected. The default is ``None``.
+            to be set. The URL displays the formatted option string
+            (e.g., ``?color=Red``). For ``selection_mode="multi"``,
+            multiple selections use repeated parameters (e.g.,
+            ``?tags=Red&tags=Blue``) and duplicate URL values are
+            deduplicated. Invalid URL values (not in ``options``) are
+            reset to the ``default`` and removed from the URL. The
+            default is ``None``.
 
         Returns
         -------
@@ -679,11 +681,13 @@ class ButtonGroupMixin:
             Enables two-way binding between the widget value and the URL
             query string. When set to ``"query-params"``, the widget's
             ``key`` is used as the URL parameter name. Requires ``key``
-            to be set. For ``selection_mode="multi"``, multiple
-            selections use repeated parameters (e.g.,
-            ``?tags=Red&tags=Blue``). Invalid URL values (not in
-            ``options``) are silently filtered out and the URL is
-            auto-corrected. The default is ``None``.
+            to be set. The URL displays the formatted option string
+            (e.g., ``?color=Red``). For ``selection_mode="multi"``,
+            multiple selections use repeated parameters (e.g.,
+            ``?tags=Red&tags=Blue``) and duplicate URL values are
+            deduplicated. Invalid URL values (not in ``options``) are
+            reset to the ``default`` and removed from the URL. The
+            default is ``None``.
 
         Returns
         -------

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -30,7 +30,7 @@ from streamlit.elements.widgets.button_group import (
     _MultiSelectButtonGroupSerde,
     _SingleSelectButtonGroupSerde,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.ButtonGroup_pb2 import ButtonGroup as ButtonGroupProto
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.runtime.state.session_state import get_script_run_ctx
@@ -1195,3 +1195,95 @@ class TestButtonGroupAppTest:
         at.button_group("sc").select("y").run()
         assert at.button_group("sc").value == "y"
         assert not at.exception
+
+
+class PillsBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for st.pills bind='query-params' functionality."""
+
+    def test_bind_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.pills("label", ["a", "b", "c"], key="my_key", bind="query-params")
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == "my_key"
+
+    def test_bind_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.pills("label", ["a", "b", "c"], bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind, query_param_key is not set."""
+        st.pills("label", ["a", "b", "c"], key="my_key")
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == ""
+
+    def test_invalid_bind_value_raises_exception(self):
+        """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
+        with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
+            st.pills("label", ["a", "b"], key="my_key", bind="invalid-value")
+
+    def test_bind_with_format_func(self):
+        """Test that bind works with format_func."""
+        st.pills(
+            "label",
+            ["cat", "dog"],
+            format_func=str.upper,
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == "my_key"
+
+    def test_bind_multi_mode(self):
+        """Test that bind works with selection_mode='multi'."""
+        st.pills(
+            "label",
+            ["a", "b", "c"],
+            selection_mode="multi",
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == "my_key"
+
+
+class SegmentedControlBindQueryParamsTest(DeltaGeneratorTestCase):
+    """Tests for st.segmented_control bind='query-params' functionality."""
+
+    def test_bind_sets_query_param_key(self):
+        """Test that bind='query-params' with a key sets query_param_key in proto."""
+        st.segmented_control(
+            "label", ["a", "b", "c"], key="my_key", bind="query-params"
+        )
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == "my_key"
+
+    def test_bind_without_key_raises_exception(self):
+        """Test that bind='query-params' without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.segmented_control("label", ["a", "b", "c"], bind="query-params")
+
+    def test_no_bind_does_not_set_query_param_key(self):
+        """Test that without bind, query_param_key is not set."""
+        st.segmented_control("label", ["a", "b", "c"], key="my_key")
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == ""
+
+    def test_bind_multi_mode(self):
+        """Test that bind works with selection_mode='multi'."""
+        st.segmented_control(
+            "label",
+            ["a", "b", "c"],
+            selection_mode="multi",
+            key="my_key",
+            bind="query-params",
+        )
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.query_param_key == "my_key"

--- a/lib/tests/streamlit/typing/pills_types.py
+++ b/lib/tests/streamlit/typing/pills_types.py
@@ -53,3 +53,15 @@ if TYPE_CHECKING:
         pills("foo", options, selection_mode="multi", default=[1]),
         list[int],
     )
+
+    # Check bind parameter
+    assert_type(pills("foo", options, bind="query-params"), int | None)
+    assert_type(pills("foo", options, bind=None), int | None)
+    assert_type(
+        pills("foo", options, selection_mode="single", bind="query-params"),
+        int | None,
+    )
+    assert_type(
+        pills("foo", options, selection_mode="multi", bind="query-params"),
+        list[int],
+    )

--- a/lib/tests/streamlit/typing/segmented_control_types.py
+++ b/lib/tests/streamlit/typing/segmented_control_types.py
@@ -53,3 +53,15 @@ if TYPE_CHECKING:
         segmented_control("foo", options, selection_mode="multi", default=[1]),
         list[int],
     )
+
+    # Check bind parameter
+    assert_type(segmented_control("foo", options, bind="query-params"), int | None)
+    assert_type(segmented_control("foo", options, bind=None), int | None)
+    assert_type(
+        segmented_control("foo", options, selection_mode="single", bind="query-params"),
+        int | None,
+    )
+    assert_type(
+        segmented_control("foo", options, selection_mode="multi", bind="query-params"),
+        list[int],
+    )

--- a/proto/streamlit/proto/ButtonGroup.proto
+++ b/proto/streamlit/proto/ButtonGroup.proto
@@ -57,6 +57,9 @@ message ButtonGroup {
   // For single-select mode, this contains at most one selected option string.
   repeated string raw_values = 14;
 
+  // If set, widget value is bound to this query parameter key
+  optional string query_param_key = 15;
+
   reserved 7, 9;
-  // next id: 15
+  // next id: 16
 }


### PR DESCRIPTION
## Describe your changes
Adds bind="query-params" to `st.pills` and `st.segmented_control` for two-way sync between widget values and URL query parameters.

**Key changes:**
- Uses string_array_value with repeated URL params, consistent with `st.multiselect`. Single-select: `?color=Red`. Multi-select: ?`tags=Red&tags=Blue`.
- Clearability is unconditionally True: Both widgets allow deselecting all options via the UI, so empty URL params (`?key=`) are accepted as an intentional clear to None/[].
- Invalid URL values revert to default, not to cleared state: If no valid values remain after filtering, the widget falls back to its default — matching `st.radio` and `st.selectbox`. This distinction (invalid ≠ cleared) is verified by dedicated tests.
- Single-select truncation: Multiple URL values on a single-select widget (e.g., `?color=Red&color=Blue`) are truncated to the first via max_array_length=1.
- Duplicate URL values are deduplicated for multi-select mode, consistent with st.multiselect.
- format_func handled naturally: URL contains formatted option strings; validation checks the same list.

## Testing Plan
- JS & Python Unit Tests: ✅ Added
- E2E Tests: ✅ Added
- Manual Testing: ✅
