### PR TITLE
[DynamicContainers] Callback support for tabs

### DIFF
--- a/e2e_playwright/st_tabs.py
+++ b/e2e_playwright/st_tabs.py
@@ -193,3 +193,56 @@ def tabs_fragment() -> None:
 
 
 tabs_fragment()
+
+# ============================================================================
+# Callback Tests (on_change=callable)
+# ============================================================================
+
+if "tabs_callback_log" not in st.session_state:
+    st.session_state.tabs_callback_log = []
+
+
+def tabs_callback() -> None:
+    st.session_state.tabs_callback_log.append("tabs_callback_called")
+
+
+def tabs_callback_with_args(prefix: str, suffix: str = "") -> None:
+    st.session_state.tabs_cb_args_result = f"{prefix}-switched-{suffix}"
+
+
+cb_tabs = st.tabs(
+    ["CbTab1", "CbTab2"],
+    key="callback_tabs",
+    on_change=tabs_callback,
+)
+
+if cb_tabs[0].open:
+    with cb_tabs[0]:
+        st.write("Callback tab 1 content")
+
+if cb_tabs[1].open:
+    with cb_tabs[1]:
+        st.write("Callback tab 2 content")
+
+st.write(f"Tabs callback log: {st.session_state.tabs_callback_log}")
+
+cb_args_tabs = st.tabs(
+    ["ArgsTab1", "ArgsTab2"],
+    key="callback_args_tabs",
+    on_change=tabs_callback_with_args,
+    args=("my_prefix",),
+    kwargs={"suffix": "my_suffix"},
+)
+
+if cb_args_tabs[0].open:
+    with cb_args_tabs[0]:
+        st.write("Args tab 1 content")
+
+if cb_args_tabs[1].open:
+    with cb_args_tabs[1]:
+        st.write("Args tab 2 content")
+
+st.write(
+    f"Tabs callback args result: "
+    f"{st.session_state.get('tabs_cb_args_result', 'Not called')}"
+)

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -25,7 +25,7 @@ from e2e_playwright.shared.app_utils import (
 
 def test_tabs_render_correctly(themed_app: Page, assert_snapshot: ImageCompareFunction):
     st_tabs = themed_app.get_by_test_id("stTabs")
-    expect(st_tabs).to_have_count(11)
+    expect(st_tabs).to_have_count(13)
 
     assert_snapshot(st_tabs.nth(0), name="st_tabs-sidebar")
     assert_snapshot(st_tabs.nth(1), name="st_tabs-text_input")
@@ -249,3 +249,50 @@ def test_dynamic_tabs_in_fragment(app: Page):
 
     # Left should have executed twice, Right still once
     expect(app.get_by_text("Fragment tab execs - Left: 2, Right: 1")).to_be_visible()
+
+
+def test_tabs_callback_fires_on_tab_switch(app: Page):
+    """Test that the on_change callback fires when tabs are switched."""
+    expect(app.get_by_text("Tabs callback log: []")).to_be_visible()
+
+    # Locate the callback tabs container
+    cb_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="CbTab2"))
+        .first
+    )
+
+    # Switch to CbTab2
+    cb_tabs.get_by_role("tab", name="CbTab2").click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_text("Tabs callback log: ['tabs_callback_called']")
+    ).to_be_visible()
+
+    # Switch back to CbTab1 — callback fires again
+    cb_tabs.get_by_role("tab", name="CbTab1").click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_text(
+            "Tabs callback log: ['tabs_callback_called', 'tabs_callback_called']"
+        )
+    ).to_be_visible()
+
+
+def test_tabs_callback_with_args_kwargs(app: Page):
+    """Test that the on_change callback receives args and kwargs correctly."""
+    expect(app.get_by_text("Tabs callback args result: Not called")).to_be_visible()
+
+    # Locate the args callback tabs container
+    args_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="ArgsTab2"))
+        .first
+    )
+
+    # Switch to ArgsTab2
+    args_tabs.get_by_role("tab", name="ArgsTab2").click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_text("Tabs callback args result: my_prefix-switched-my_suffix")
+    ).to_be_visible()

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -616,7 +616,9 @@ class LayoutsMixin:
         width: WidthWithoutContent = "stretch",
         default: str | None = None,
         key: Key | None = None,
-        on_change: Literal["ignore", "rerun"] | None = None,
+        on_change: Literal["ignore", "rerun"] | WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
     ) -> Sequence[TabContainer]:
         r"""Insert containers separated into tabs.
 
@@ -630,10 +632,11 @@ class LayoutsMixin:
 
         .. note::
             By default, all tab content is computed and sent to the frontend
-            regardless of which tab is selected. Use ``on_change="rerun"`` to
-            enable lazy execution, where only the active tab's content runs.
-            Each tab's ``.open`` property indicates whether it is the currently
-            active tab, letting you conditionally render expensive content.
+            regardless of which tab is selected. Use ``on_change="rerun"`` or
+            pass a callable to ``on_change`` to enable lazy execution, where
+            only the active tab's content runs. Each tab's ``.open`` property
+            indicates whether it is the currently active tab, letting you
+            conditionally render expensive content.
 
         Parameters
         ----------
@@ -677,10 +680,10 @@ class LayoutsMixin:
             widget. If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-            When ``on_change`` is set to ``"rerun"``, the active tab label is
-            also accessible via ``st.session_state[key]``.
+            When ``on_change`` is set to ``"rerun"`` or a callable, the active
+            tab label is also accessible via ``st.session_state[key]``.
 
-        on_change : "ignore", "rerun", or None
+        on_change : "ignore", "rerun", callable, or None
             How the tabs should respond to user tab changes. This controls
             whether tabs track state and trigger reruns when switched.
             ``on_change`` can be one of the following:
@@ -693,6 +696,18 @@ class LayoutsMixin:
               tabs. The ``.open`` attribute will return ``True`` for the active
               tab and ``False`` for inactive tabs. Allows lazy execution of
               tab content.
+            - A callable: A callback function to execute before rerunning the
+              app when tabs are switched. Enables state tracking (equivalent to
+              ``"rerun"`` plus the callback). The callback receives no arguments
+              by default, but you can pass arguments using ``args`` and
+              ``kwargs``.
+
+        args : list or tuple or None
+            An optional list or tuple of args to pass to the ``on_change``
+            callback.
+
+        kwargs : dict or None
+            An optional dict of kwargs to pass to the ``on_change`` callback.
 
         Returns
         -------
@@ -786,8 +801,15 @@ class LayoutsMixin:
                 "The tabs input list to st.tabs is only allowed to contain strings."
             )
 
-        if on_change is not None and on_change not in {"ignore", "rerun"}:
-            raise StreamlitValueError("on_change", ["'rerun'", "'ignore'", "None"])
+        if (
+            on_change is not None
+            and not callable(on_change)
+            and on_change not in {"ignore", "rerun"}
+        ):
+            raise StreamlitValueError(
+                "on_change",
+                ["'rerun'", "'ignore'", "None", "a callback function"],
+            )
 
         key = to_key(key)
         default_index = tabs.index(default) if default else 0
@@ -797,15 +819,13 @@ class LayoutsMixin:
         current_tab_label = tabs[default_index]
 
         if is_stateful:
-            # TODO: Set on_change and enable_check_callback_rules correctly
-            # when user-defined callbacks are supported for tabs.
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=None,
+                on_change=on_change if callable(on_change) else None,
                 default_value=None,
                 writes_allowed=True,
-                enable_check_callback_rules=False,
+                enable_check_callback_rules=callable(on_change),
             )
 
             ctx = get_script_run_ctx()
@@ -828,6 +848,9 @@ class LayoutsMixin:
                 serializer=serde.serialize,
                 ctx=ctx,
                 value_type="string_value",
+                on_change_handler=on_change if callable(on_change) else None,
+                args=args if callable(on_change) else None,
+                kwargs=kwargs if callable(on_change) else None,
             )
 
             current_tab_label = tabs_state.value
@@ -1038,11 +1061,6 @@ class LayoutsMixin:
         if not callable(on_change) and on_change not in {"ignore", "rerun"}:
             raise StreamlitValueError(
                 "on_change", ["'rerun'", "'ignore'", "a callable"]
-            )
-
-        if not callable(on_change) and (args is not None or kwargs is not None):
-            raise StreamlitAPIException(
-                "`args` and `kwargs` can only be used when `on_change` is a callable."
             )
 
         key = to_key(key)

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -582,14 +582,6 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander = st.expander("label", on_change="ignore")
         assert expander.open is None
 
-    def test_args_kwargs_without_callable_raises(self):
-        """Test that args/kwargs without a callable on_change raises."""
-        with pytest.raises(StreamlitAPIException, match=r"args.*kwargs.*callable"):
-            st.expander("label", on_change="rerun", args=("x",))
-
-        with pytest.raises(StreamlitAPIException, match=r"args.*kwargs.*callable"):
-            st.expander("label", on_change="rerun", kwargs={"k": "v"})
-
 
 class ContainerTest(DeltaGeneratorTestCase):
     def test_border_parameter(self):
@@ -1297,6 +1289,131 @@ class TabsTest(DeltaGeneratorTestCase):
         for tab in tabs:
             assert tab.open is None
         assert "my_tabs" not in st.session_state
+
+    def test_on_change_callback_sets_id(self) -> None:
+        """Test that a callable on_change sets id on the tab container proto."""
+
+        def on_change() -> None:
+            pass
+
+        st.tabs(["A", "B"], key="cb_tabs", on_change=on_change)
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.tab_container.id != ""
+
+    def test_on_change_callback_sets_open_on_tabs(self) -> None:
+        """Test that a callable on_change sets .open correctly on each tab."""
+
+        def on_change() -> None:
+            pass
+
+        tabs = st.tabs(["A", "B", "C"], key="cb_tabs", on_change=on_change)
+        assert tabs[0].open is True
+        assert tabs[1].open is False
+        assert tabs[2].open is False
+
+    def test_on_change_callback_with_default_tab(self) -> None:
+        """Test that a callable on_change with default sets correct tab open."""
+
+        def on_change() -> None:
+            pass
+
+        tabs = st.tabs(["A", "B", "C"], key="cb_tabs", default="B", on_change=on_change)
+        assert tabs[0].open is False
+        assert tabs[1].open is True
+        assert tabs[2].open is False
+
+    def _get_tabs_widget_state(self) -> WidgetState:
+        """Get the single tabs WidgetState from session state."""
+        widget_states = self.script_run_ctx.session_state.get_widget_states()
+        assert len(widget_states) == 1, (
+            f"Expected exactly 1 widget state, got {len(widget_states)}"
+        )
+        return widget_states[0]
+
+    def test_on_change_callback_fires_on_state_change(self) -> None:
+        """Test that callback function is invoked when active tab switches."""
+        callback_calls: list[str] = []
+
+        def on_tab_change() -> None:
+            callback_calls.append("called")
+
+        st.tabs(["A", "B"], key="cb_tabs", on_change=on_tab_change)
+
+        # Simulate tab switch from frontend
+        current_ws = self._get_tabs_widget_state()
+        new_ws = WidgetState()
+        new_ws.CopyFrom(current_ws)
+        new_ws.string_value = "B"
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_ws])
+        )
+        assert len(callback_calls) == 1
+
+    def test_on_change_callback_no_fire_on_initial_render(self) -> None:
+        """Test that callback does not fire on initial render."""
+        callback_calls: list[str] = []
+
+        def on_tab_change() -> None:
+            callback_calls.append("called")
+
+        st.tabs(["A", "B"], key="cb_tabs", on_change=on_tab_change)
+        assert len(callback_calls) == 0
+
+    def test_on_change_callback_receives_args_kwargs(self) -> None:
+        """Test that callback receives provided args and kwargs."""
+        received_args: list[object] = []
+        received_kwargs: dict[str, object] = {}
+
+        def on_change(*args: object, **kwargs: object) -> None:
+            received_args.extend(args)
+            received_kwargs.update(kwargs)
+
+        st.tabs(
+            ["A", "B"],
+            key="cb_tabs",
+            on_change=on_change,
+            args=("arg1", "arg2"),
+            kwargs={"key1": "value1"},
+        )
+
+        current_ws = self._get_tabs_widget_state()
+        new_ws = WidgetState()
+        new_ws.CopyFrom(current_ws)
+        new_ws.string_value = "B"
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_ws])
+        )
+
+        assert received_args == ["arg1", "arg2"]
+        assert received_kwargs == {"key1": "value1"}
+
+    def test_on_change_callback_accessible_via_session_state(self) -> None:
+        """Test that active tab label is accessible via session_state with callback."""
+
+        def on_change() -> None:
+            pass
+
+        st.tabs(["A", "B", "C"], key="cb_tabs", on_change=on_change)
+        assert "cb_tabs" in st.session_state
+        assert st.session_state.cb_tabs == "A"
+
+    def test_invalid_on_change_with_callback_type_still_raises(self) -> None:
+        """Test that non-string, non-callable on_change raises an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.tabs(["A", "B"], on_change=123)  # type: ignore[arg-type]
+
+    def test_backwards_compat_rerun_still_works(self) -> None:
+        """Test that on_change='rerun' still works after callback support."""
+        tabs = st.tabs(["A", "B"], on_change="rerun")
+        assert tabs[0].open is True
+        assert tabs[1].open is False
+
+    def test_backwards_compat_none_still_works(self) -> None:
+        """Test that on_change=None still works after callback support."""
+        tabs = st.tabs(["A", "B"], on_change=None)
+        for tab in tabs:
+            assert tab.open is None
 
 
 class DialogTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/typing/tab_container_types.py
+++ b/lib/tests/streamlit/typing/tab_container_types.py
@@ -50,3 +50,38 @@ if TYPE_CHECKING:
 
     # .open property returns bool | None
     assert_type(tabs(["A", "B"])[0].open, bool | None)
+
+    # --- Callback support ---
+
+    def valid_callback() -> None:
+        pass
+
+    def callback_with_args(arg1: str, arg2: int) -> None:
+        pass
+
+    # Valid usages — should type check
+    assert_type(tabs(["A", "B"], on_change="rerun"), Sequence[TabContainer])
+    assert_type(
+        tabs(["A", "B"], on_change=valid_callback, key="t1"), Sequence[TabContainer]
+    )
+    assert_type(
+        tabs(
+            ["A", "B"],
+            on_change=callback_with_args,
+            args=("test", 1),
+            key="t2",
+        ),
+        Sequence[TabContainer],
+    )
+    assert_type(
+        tabs(
+            ["A", "B"],
+            on_change=callback_with_args,
+            kwargs={"arg1": "test", "arg2": 1},
+            key="t3",
+        ),
+        Sequence[TabContainer],
+    )
+
+    # Invalid usages — should NOT type check
+    tabs(["A", "B"], on_change=123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Describe your changes

Adds callable `on_change` callback support to `st.tabs`, extending the existing `"ignore"` / `"rerun"` / `None` string literals.

- `on_change` now accepts a callable in addition to the existing string options
- Optional `args` and `kwargs` parameters pass through to the callback
- The callback fires when the user switches to a different tab. `st.session_state[key]` contains the label of the newly active tab, so the callback can branch on which tab was selected.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (Python) — `lib/tests/streamlit/elements/layouts_test.py`
- [x] E2E Tests — `e2e_playwright/st_tabs_test.py`
- [x] Any manual testing needed?
    - Manually verified as well. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.