### PR TITLE
[DynamicContainers] Callback support for expanders

### DIFF
--- a/e2e_playwright/st_expander.py
+++ b/e2e_playwright/st_expander.py
@@ -210,3 +210,46 @@ with st.expander("Ignore-mode expander"):
     st.write("This expander uses the default on_change='ignore'")
 
 st.write(f"Expander ignore rerun count: {st.session_state.exp_ignore_rerun_count}")
+
+# Callback support
+# ============================================================================
+
+if "cb_toggle_count" not in st.session_state:
+    st.session_state.cb_toggle_count = 0
+if "cb_last_state" not in st.session_state:
+    st.session_state.cb_last_state = None
+
+
+def expander_callback() -> None:
+    st.session_state.cb_toggle_count += 1
+    st.session_state.cb_last_state = st.session_state.cb_expander
+
+
+with st.expander("Callback expander", key="cb_expander", on_change=expander_callback):
+    st.write("Callback expander content")
+
+st.write(f"Callback count: {st.session_state.cb_toggle_count}")
+st.write(f"Callback last state: {st.session_state.cb_last_state}")
+
+
+# Callback with args/kwargs
+# ============================================================================
+
+if "cb_args_result" not in st.session_state:
+    st.session_state.cb_args_result = ""
+
+
+def expander_callback_with_args(prefix: str, suffix: str = "") -> None:
+    st.session_state.cb_args_result = f"{prefix}-toggled-{suffix}"
+
+
+with st.expander(
+    "Callback args expander",
+    key="cb_args_expander",
+    on_change=expander_callback_with_args,
+    args=("hello",),
+    kwargs={"suffix": "world"},
+):
+    st.write("Callback args expander content")
+
+st.write(f"Callback args result: {st.session_state.cb_args_result}")

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -21,7 +21,7 @@ from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
 
 EXPANDER_HEADER_IDENTIFIER = "summary"
 
-NUMBER_OF_EXPANDERS: Final = 19
+NUMBER_OF_EXPANDERS: Final = 21
 
 
 def test_expander_displays_correctly(
@@ -329,3 +329,42 @@ def test_expander_ignore_mode_does_not_trigger_rerun(app: Page):
 
     # Still no rerun
     expect(rerun_text).to_have_text(initial_count or "")
+
+
+def test_expander_callback_fires_on_toggle(app: Page):
+    """Test that a callback fires when the expander is toggled."""
+    # Initially callback count is 0
+    expect(app.get_by_text("Callback count: 0")).to_be_visible()
+    expect(app.get_by_text("Callback last state: None")).to_be_visible()
+
+    # Expand the callback expander
+    cb_expander = get_expander(app, "Callback expander")
+    cb_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Callback should have fired, state should be True (expanded)
+    expect(app.get_by_text("Callback count: 1")).to_be_visible()
+    expect(app.get_by_text("Callback last state: True")).to_be_visible()
+
+    # Collapse the callback expander
+    cb_expander = get_expander(app, "Callback expander")
+    cb_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Callback should have fired again, state should be False (collapsed)
+    expect(app.get_by_text("Callback count: 2")).to_be_visible()
+    expect(app.get_by_text("Callback last state: False")).to_be_visible()
+
+
+def test_expander_callback_with_args_kwargs(app: Page):
+    """Test that a callback with args and kwargs receives them correctly."""
+    # Initially no result
+    expect(app.get_by_text("Callback args result:", exact=True)).to_be_visible()
+
+    # Expand the callback args expander
+    cb_args_expander = get_expander(app, "Callback args expander")
+    cb_args_expander.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Callback should have received args and kwargs
+    expect(app.get_by_text("Callback args result: hello-toggled-world")).to_be_visible()

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from streamlit.elements.lib.mutable_popover_container import PopoverContainer
     from streamlit.elements.lib.mutable_status_container import StatusContainer
     from streamlit.elements.lib.mutable_tab_container import TabContainer
-    from streamlit.runtime.state import WidgetCallback
+    from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
 
 SpecType: TypeAlias = int | Sequence[int | float]
 
@@ -881,7 +881,9 @@ class LayoutsMixin:
         key: Key | None = None,
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
-        on_change: Literal["ignore", "rerun"] = "ignore",
+        on_change: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
     ) -> ExpanderContainer:
         r"""Insert a multi-element container that can be expanded/collapsed.
 
@@ -925,8 +927,7 @@ class LayoutsMixin:
 
         key : str or int
             An optional string or integer to use as the unique key for the
-            widget. Only used when ``on_change`` is set to ``"rerun"``.
-            If this is omitted, a key will be generated for the widget
+            widget. If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
             If ``key`` is provided along with ``on_change="rerun"``, it will
@@ -962,10 +963,10 @@ class LayoutsMixin:
               the parent container, the width of the container matches the width
               of the parent container.
 
-        on_change : "ignore" or "rerun"
+        on_change : "ignore", "rerun", or callable
             How the expander should respond to user toggle events. This controls
-            whether the expander tracks state and triggers reruns when toggled.
-            ``on_change`` can be one of the following:
+            whether or not the expander behaves like an input widget with
+            persistent state. ``on_change`` can be one of the following:
 
             - ``"ignore"`` (default): Streamlit will not track the expander's
               state. The ``.open`` attribute will return ``None``. The expander
@@ -976,6 +977,21 @@ class LayoutsMixin:
               the current state (``True`` if expanded, ``False`` if collapsed).
               The expander cannot be used inside ``@st.cache_data`` decorated
               functions.
+
+            - ``callable``: A callback function to execute before rerunning the
+              app when the expander is toggled. Enables state tracking.
+              The callback receives no arguments by default, but you can
+              pass arguments using ``args`` and ``kwargs``. The expander
+              cannot be used inside ``@st.cache_data`` decorated functions
+              when using a callback.
+
+        args : list or tuple or None
+            An optional list or tuple of positional arguments to pass to the
+            ``on_change`` callback function.
+
+        kwargs : dict or None
+            An optional dictionary of keyword arguments to pass to the
+            ``on_change`` callback function.
 
         Examples
         --------
@@ -1019,25 +1035,30 @@ class LayoutsMixin:
         if label is None:
             raise StreamlitAPIException("A label is required for an expander")
 
-        if on_change not in {"ignore", "rerun"}:
-            raise StreamlitValueError("on_change", ["'rerun'", "'ignore'"])
+        if not callable(on_change) and on_change not in {"ignore", "rerun"}:
+            raise StreamlitValueError(
+                "on_change", ["'rerun'", "'ignore'", "a callable"]
+            )
+
+        if not callable(on_change) and (args is not None or kwargs is not None):
+            raise StreamlitAPIException(
+                "`args` and `kwargs` can only be used when `on_change` is a callable."
+            )
 
         key = to_key(key)
-        is_stateful = on_change == "rerun"
+        is_stateful = on_change != "ignore"
 
         current_expanded = expanded
         element_id: str | None = None
 
         if is_stateful:
-            # TODO: Set on_change and enable_check_callback_rules correctly
-            # when user-defined callbacks are supported for expanders.
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=None,
+                on_change=on_change if callable(on_change) else None,
                 default_value=None,
                 writes_allowed=True,
-                enable_check_callback_rules=False,
+                enable_check_callback_rules=callable(on_change),
             )
 
             ctx = get_script_run_ctx()
@@ -1061,6 +1082,9 @@ class LayoutsMixin:
                 serializer=serde.serialize,
                 ctx=ctx,
                 value_type="bool_value",
+                on_change_handler=on_change if callable(on_change) else None,
+                args=args if callable(on_change) else None,
+                kwargs=kwargs if callable(on_change) else None,
             )
 
             current_expanded = expander_state.value

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -29,6 +29,7 @@ from streamlit.errors import (
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.GapSize_pb2 import GapSize
+from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
@@ -481,6 +482,113 @@ class ExpanderTest(DeltaGeneratorTestCase):
         # Widget state should match the initial expanded value
         assert not expander_block.add_block.expandable.expanded
         assert expander.open is False
+
+    def test_on_change_callback_without_key_works(self):
+        """Test that a callback works without an explicit key."""
+        expander = st.expander("label", on_change=lambda: None)
+        assert expander.open is False
+
+    def test_on_change_callback_with_key_sets_open(self):
+        """Test that a callback with key enables state tracking."""
+        expander = st.expander(
+            "label", key="cb_exp", on_change=lambda: None, expanded=True
+        )
+        assert expander.open is True
+        assert st.session_state.cb_exp is True
+
+    def test_on_change_callback_sets_block_id(self):
+        """Test that a callback sets the block id in the proto."""
+        st.expander("label", key="cb_exp2", on_change=lambda: None)
+        expander_block = self.get_delta_from_queue()
+        assert expander_block.add_block.id != ""
+
+    def _get_expander_widget_state(self) -> WidgetState:
+        """Find the expander's WidgetState by matching its element id."""
+        expander_block = self.get_delta_from_queue()
+        element_id = expander_block.add_block.id
+
+        widget_states = self.script_run_ctx.session_state.get_widget_states()
+        for ws in widget_states:
+            if ws.id == element_id:
+                return ws
+        raise AssertionError(f"No widget state found for element id '{element_id}'")
+
+    def test_on_change_callback_fires_on_state_change(self):
+        """Test that the callback fires when the expander state changes."""
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.expander("label", key="cb_fire", on_change=on_change)
+
+        # Simulate a frontend state change (user toggles expander)
+        current_ws = self._get_expander_widget_state()
+        new_widget_state = WidgetState()
+        new_widget_state.CopyFrom(current_ws)
+        new_widget_state.bool_value = True
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_widget_state])
+        )
+
+        assert len(callback_calls) == 1
+
+    def test_on_change_callback_receives_args_kwargs(self):
+        """Test that the callback receives provided args and kwargs."""
+        received_args: list[str] = []
+        received_kwargs: dict[str, str] = {}
+
+        def on_change(*args: str, **kwargs: str) -> None:
+            received_args.extend(args)
+            received_kwargs.update(kwargs)
+
+        st.expander(
+            "label",
+            key="cb_args",
+            on_change=on_change,
+            args=("arg1", "arg2"),
+            kwargs={"key1": "value1"},
+        )
+
+        # Simulate a frontend state change
+        current_ws = self._get_expander_widget_state()
+        new_widget_state = WidgetState()
+        new_widget_state.CopyFrom(current_ws)
+        new_widget_state.bool_value = True
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_widget_state])
+        )
+
+        assert received_args == ["arg1", "arg2"]
+        assert received_kwargs == {"key1": "value1"}
+
+    def test_on_change_callback_no_fire_on_initial_render(self):
+        """Test that the callback does not fire on the initial render."""
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.expander("label", key="cb_no_fire", on_change=on_change)
+        assert len(callback_calls) == 0
+
+    def test_backwards_compat_rerun_still_works(self):
+        """Test that on_change='rerun' still works after callback support."""
+        expander = st.expander("label", on_change="rerun")
+        assert expander.open is False
+
+    def test_backwards_compat_ignore_still_works(self):
+        """Test that on_change='ignore' still works after callback support."""
+        expander = st.expander("label", on_change="ignore")
+        assert expander.open is None
+
+    def test_args_kwargs_without_callable_raises(self):
+        """Test that args/kwargs without a callable on_change raises."""
+        with pytest.raises(StreamlitAPIException, match=r"args.*kwargs.*callable"):
+            st.expander("label", on_change="rerun", args=("x",))
+
+        with pytest.raises(StreamlitAPIException, match=r"args.*kwargs.*callable"):
+            st.expander("label", on_change="rerun", kwargs={"k": "v"})
 
 
 class ContainerTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/typing/expander_container_types.py
+++ b/lib/tests/streamlit/typing/expander_container_types.py
@@ -42,3 +42,26 @@ if TYPE_CHECKING:
 
     # .open property returns bool | None
     assert_type(expander("Test").open, bool | None)
+
+    # on_change accepts string literals
+    assert_type(expander("Test", on_change="rerun"), ExpanderContainer)
+    assert_type(expander("Test", on_change="ignore"), ExpanderContainer)
+
+    # on_change accepts callable with key
+    def _noop() -> None: ...
+
+    assert_type(expander("Test", key="k", on_change=_noop), ExpanderContainer)
+
+    # on_change callable with args and kwargs
+    def _callback(x: int, y: str) -> None: ...
+
+    assert_type(
+        expander(
+            "Test",
+            key="k2",
+            on_change=_callback,
+            args=(1,),
+            kwargs={"y": "hello"},
+        ),
+        ExpanderContainer,
+    )


### PR DESCRIPTION
## Describe your changes

Adds callable `on_change` callback support to `st.expander`, extending the existing `"ignore"` / `"rerun"` string literals.

- `on_change` now accepts a callable in addition to the existing string options
- Optional `args` and `kwargs` parameters pass through to the callback
- Requires a `key` when using a callable (consistent with existing expander behavior where `key` is required for `"rerun"`)
- The callback fires on any state change (both expand and collapse). Users can check `st.session_state[key]` inside the callback to distinguish between expand (`True`) and collapse (`False`) events.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (Python) — `lib/tests/streamlit/elements/layouts_test.py`
- [x] E2E Tests — `e2e_playwright/st_expander_test.py`
- [x] Any manual testing needed?
    - Manually verified as well.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
