### PR TITLE
feat(ci): Add stale-prs workflow

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -113,6 +113,7 @@ steps:
 | `autofix.yml` | `autofix` label on PR | Runs formatters/linters and creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |
+| `stale-prs.yml` | Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
 
 ### AI-Assisted Workflows
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       - "change:chore"
       - "impact:internal"
       - "autofix"
+      - "never-stale"
 
     ignore:
       - dependency-name: "baseui"
@@ -107,6 +108,7 @@ updates:
       - "change:chore"
       - "impact:internal"
       - "autofix"
+      - "never-stale"
 
   # Keep python dependencies up to date (via uv)
   # Root pyproject.toml contains dev/test dependency groups
@@ -127,6 +129,7 @@ updates:
       - "change:chore"
       - "impact:internal"
       - "autofix"
+      - "never-stale"
 
     ignore:
       - dependency-name: "langchain"
@@ -151,6 +154,7 @@ updates:
       - "change:chore"
       - "impact:users"
       - "autofix"
+      - "never-stale"
 
   # Maintain dependencies in GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -162,3 +166,4 @@ updates:
       - "change:chore"
       - "impact:internal"
       - "autofix"
+      - "never-stale"

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -111,6 +111,7 @@ steps:
 | `autofix.yml` | `autofix` label on PR | Runs formatters/linters and creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |
+| `stale-prs.yml` | Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
 
 ### AI-Assisted Workflows
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -107,6 +107,7 @@ steps:
 | `autofix.yml` | `autofix` label on PR | Runs formatters/linters and creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |
+| `stale-prs.yml` | Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
 
 ### AI-Assisted Workflows
 

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,88 @@
+name: Stale PRs
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run in dry-run mode (no labels/comments/closures)
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-prs:
+    if: github.repository == 'streamlit/streamlit'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process stale pull requests
+        id: stale
+        # v10.2.0 - https://github.com/actions/stale/tree/v10.2.0
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # We only want this to apply to PRs. Issues are not to be marked as stale.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+
+          # Exemptions from stale processing.
+          exempt-draft-pr: true
+          exempt-pr-labels: never-stale,change:spec
+
+          # Mark PRs as stale after inactivity and remove the stale label on updates.
+          stale-pr-label: stale
+          remove-pr-stale-when-updated: true
+
+          stale-pr-message: >
+            This pull request has had no activity for 14 days, so it has been marked as stale.
+            If you still want to continue this work, please leave a comment or push a commit
+            within 7 days. A maintainer can also apply the `never-stale` label to opt out.
+          close-pr-message: >
+            This pull request was closed after being marked stale for 7 days with no further
+            activity. If you want to continue, comment here and a maintainer can help reopen.
+
+          # Toggle dry-run behavior when dispatching this workflow.
+          debug-only: ${{ inputs.dry_run }}
+
+          # Tune this above current open PR count to evaluate broad candidate set.
+          operations-per-run: 200
+
+      - name: Print results
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          STALED_JSON: ${{ steps.stale.outputs['staled-issues-prs'] || '[]' }}
+          CLOSED_JSON: ${{ steps.stale.outputs['closed-issues-prs'] || '[]' }}
+        run: |
+          STALED_COUNT="$(jq 'length' <<<"$STALED_JSON")"
+          CLOSED_COUNT="$(jq 'length' <<<"$CLOSED_JSON")"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run: would mark stale: ${STALED_COUNT}"
+            echo "Dry run: would close: ${CLOSED_COUNT}"
+          else
+            echo "Marked stale: ${STALED_COUNT}"
+            echo "Closed: ${CLOSED_COUNT}"
+          fi
+
+      - name: Write stale audit files
+        env:
+          STALED_JSON: ${{ steps.stale.outputs['staled-issues-prs'] || '[]' }}
+          CLOSED_JSON: ${{ steps.stale.outputs['closed-issues-prs'] || '[]' }}
+        run: |
+          mkdir -p stale-prs-audit
+          jq '.' <<<"$STALED_JSON" > stale-prs-audit/staled-issues-prs.json
+          jq '.' <<<"$CLOSED_JSON" > stale-prs-audit/closed-issues-prs.json
+
+      - name: Upload stale audit artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: stale-prs-output
+          path: stale-prs-audit
+          retention-days: 14


### PR DESCRIPTION
## Describe your changes

Added a new `stale-prs.yml` workflow to process pull requests that have been inactive for an extended period. This workflow:

- Marks PRs as stale after 14 days of inactivity
- Closes stale PRs after an additional 7 days without activity
- Exempts draft PRs and those with the `never-stale` label
- Runs in dry-run mode by default (no actual labels/comments/closures)
- Can be manually triggered via `workflow_dispatch`
- Generates audit artifacts showing which PRs would be affected
- Only processes PRs (not issues) and includes appropriate messaging for contributors

## Testing Plan

- Manually trigger the workflow with dry-run mode enabled to verify it correctly identifies stale PRs without taking action
- Review the generated audit artifacts to ensure the correct PRs are being targeted

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.