### PR TITLE
Add border around dropdowns in dark mode

### DIFF
--- a/frontend/lib/src/components/shared/Base/styled-components.ts
+++ b/frontend/lib/src/components/shared/Base/styled-components.ts
@@ -47,7 +47,7 @@ export const Box = styled.div<{
  */
 export const getDropdownPopoverBodyStyles = (
   theme: EmotionTheme
-): Record<string, string> => {
+): CSSProperties => {
   const lightBackground = hasLightBackgroundColor(theme)
   const borderWidth = lightBackground ? "0" : theme.sizes.borderWidth
   const borderStyle = lightBackground ? "none" : "solid"

--- a/frontend/lib/src/components/shared/Base/styled-components.ts
+++ b/frontend/lib/src/components/shared/Base/styled-components.ts
@@ -18,6 +18,7 @@ import { CSSProperties } from "react"
 
 import styled from "@emotion/styled"
 
+import { EmotionTheme, hasLightBackgroundColor } from "~lib/theme"
 import { EmotionThemeColors } from "~lib/theme/types"
 
 export const Box = styled.div<{
@@ -39,6 +40,40 @@ export const Box = styled.div<{
  * Note: NumberInput exhibits same styling but doesn't directly use this function -
  * border color is handled in StyledInputContainer instead of the baseweb overrides.
  */
+/**
+ * Returns styles for a dropdown popover body that show a border in dark mode
+ * (where shadows don't provide enough contrast) and rely on box-shadow in
+ * light mode.
+ */
+export const getDropdownPopoverBodyStyles = (
+  theme: EmotionTheme
+): Record<string, string> => {
+  const lightBackground = hasLightBackgroundColor(theme)
+  const borderWidth = lightBackground ? "0" : theme.sizes.borderWidth
+  const borderStyle = lightBackground ? "none" : "solid"
+  const borderColor = lightBackground ? "transparent" : theme.colors.borderColor
+  return {
+    borderLeftWidth: borderWidth,
+    borderRightWidth: borderWidth,
+    borderTopWidth: borderWidth,
+    borderBottomWidth: borderWidth,
+
+    borderLeftStyle: borderStyle,
+    borderRightStyle: borderStyle,
+    borderTopStyle: borderStyle,
+    borderBottomStyle: borderStyle,
+
+    borderLeftColor: borderColor,
+    borderRightColor: borderColor,
+    borderTopColor: borderColor,
+    borderBottomColor: borderColor,
+
+    boxShadow: lightBackground
+      ? "0px 4px 16px rgba(0, 0, 0, 0.16)"
+      : "0px 4px 16px rgba(0, 0, 0, 0.7)",
+  }
+}
+
 export const getBorderColor = (
   colors: EmotionThemeColors,
   $isFocused: boolean

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -28,7 +28,10 @@ import { ChevronDown } from "baseui/icon"
 import { type OnChangeParams, Select as UISelect } from "baseui/select"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { getBorderColor } from "~lib/components/shared/Base/styled-components"
+import {
+  getBorderColor,
+  getDropdownPopoverBodyStyles,
+} from "~lib/components/shared/Base/styled-components"
 import VirtualDropdown from "~lib/components/shared/Dropdown/VirtualDropdown"
 import {
   WidgetLabel,
@@ -37,7 +40,6 @@ import {
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
 import { useSelectCommon } from "~lib/hooks/useSelectCommon"
-import { hasLightBackgroundColor } from "~lib/theme"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
 export interface Props {
@@ -242,61 +244,25 @@ const Selectbox: FC<Props> = ({
               ignoreBoundary: isInSidebar,
               overrides: {
                 Body: {
-                  style: () => {
-                    const lightBackground = hasLightBackgroundColor(theme)
-                    return {
-                      marginTop: theme.spacing.twoXS,
-                      marginRight: theme.spacing.none,
-                      marginBottom: theme.spacing.none,
+                  style: () => ({
+                    marginTop: theme.spacing.twoXS,
+                    marginRight: theme.spacing.none,
+                    marginBottom: theme.spacing.none,
 
-                      paddingTop: theme.spacing.sm,
-                      paddingBottom: theme.spacing.sm,
+                    paddingTop: theme.spacing.sm,
+                    paddingBottom: theme.spacing.sm,
 
-                      maxHeight: "70vh",
-                      overflow: "auto",
-                      boxSizing: "border-box",
+                    maxHeight: "70vh",
+                    overflow: "auto",
+                    boxSizing: "border-box",
 
-                      borderTopLeftRadius: theme.radii.default,
-                      borderTopRightRadius: theme.radii.default,
-                      borderBottomRightRadius: theme.radii.default,
-                      borderBottomLeftRadius: theme.radii.default,
+                    borderTopLeftRadius: theme.radii.default,
+                    borderTopRightRadius: theme.radii.default,
+                    borderBottomRightRadius: theme.radii.default,
+                    borderBottomLeftRadius: theme.radii.default,
 
-                      borderLeftWidth: lightBackground
-                        ? "0"
-                        : theme.sizes.borderWidth,
-                      borderRightWidth: lightBackground
-                        ? "0"
-                        : theme.sizes.borderWidth,
-                      borderTopWidth: lightBackground
-                        ? "0"
-                        : theme.sizes.borderWidth,
-                      borderBottomWidth: lightBackground
-                        ? "0"
-                        : theme.sizes.borderWidth,
-
-                      borderLeftStyle: lightBackground ? "none" : "solid",
-                      borderRightStyle: lightBackground ? "none" : "solid",
-                      borderTopStyle: lightBackground ? "none" : "solid",
-                      borderBottomStyle: lightBackground ? "none" : "solid",
-
-                      borderLeftColor: lightBackground
-                        ? "transparent"
-                        : theme.colors.borderColor,
-                      borderRightColor: lightBackground
-                        ? "transparent"
-                        : theme.colors.borderColor,
-                      borderTopColor: lightBackground
-                        ? "transparent"
-                        : theme.colors.borderColor,
-                      borderBottomColor: lightBackground
-                        ? "transparent"
-                        : theme.colors.borderColor,
-
-                      boxShadow: lightBackground
-                        ? "0px 4px 16px rgba(0, 0, 0, 0.16)"
-                        : "0px 4px 16px rgba(0, 0, 0, 0.7)",
-                    }
-                  },
+                    ...getDropdownPopoverBodyStyles(theme),
+                  }),
                 },
               },
             },

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -33,7 +33,10 @@ import { DateInput as DateInputProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import { LibConfigContext } from "~lib/components/core/LibConfigContext"
-import { getBorderColor } from "~lib/components/shared/Base/styled-components"
+import {
+  getBorderColor,
+  getDropdownPopoverBodyStyles,
+} from "~lib/components/shared/Base/styled-components"
 import Icon from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
@@ -279,6 +282,7 @@ function DateInput({
                 Body: {
                   style: {
                     marginTop: spacing.px,
+                    ...getDropdownPopoverBodyStyles(theme),
                   },
                 },
               },

--- a/frontend/lib/src/components/widgets/DateTimeInput/createDateTimePickerOverrides.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/createDateTimePickerOverrides.tsx
@@ -19,7 +19,10 @@ import type { DatepickerProps } from "baseui/datepicker"
 import { ChevronDown } from "baseui/icon"
 import { PLACEMENT } from "baseui/popover"
 
-import { getBorderColor } from "~lib/components/shared/Base/styled-components"
+import {
+  getBorderColor,
+  getDropdownPopoverBodyStyles,
+} from "~lib/components/shared/Base/styled-components"
 import Icon from "~lib/components/shared/Icon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown"
 import Tooltip, { Placement } from "~lib/components/shared/Tooltip"
@@ -57,6 +60,7 @@ export const createDateTimePickerOverrides = ({
         Body: {
           style: {
             marginTop: theme.spacing.px,
+            ...getDropdownPopoverBodyStyles(theme),
           },
         },
       },
@@ -308,6 +312,7 @@ export const createDateTimePickerOverrides = ({
                     Body: {
                       style: () => ({
                         marginTop: theme.spacing.px,
+                        ...getDropdownPopoverBodyStyles(theme),
                       }),
                     },
                   },

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -38,7 +38,10 @@ import { without } from "lodash-es"
 import { MultiSelect as MultiSelectProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { getBorderColor } from "~lib/components/shared/Base/styled-components"
+import {
+  getBorderColor,
+  getDropdownPopoverBodyStyles,
+} from "~lib/components/shared/Base/styled-components"
 import { VirtualDropdown } from "~lib/components/shared/Dropdown"
 import {
   WidgetLabel,
@@ -297,6 +300,7 @@ const Multiselect: FC<Props> = props => {
                   Body: {
                     style: () => ({
                       marginTop: theme.spacing.px,
+                      ...getDropdownPopoverBodyStyles(theme),
                     }),
                   },
                 },

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -23,7 +23,10 @@ import { TimePicker as UITimePicker } from "baseui/timepicker"
 import { TimeInput as TimeInputProto } from "@streamlit/protobuf"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { getBorderColor } from "~lib/components/shared/Base/styled-components"
+import {
+  getBorderColor,
+  getDropdownPopoverBodyStyles,
+} from "~lib/components/shared/Base/styled-components"
 import {
   WidgetLabel,
   WidgetLabelHelpIcon,
@@ -148,6 +151,7 @@ function TimeInput({
                 Body: {
                   style: () => ({
                     marginTop: theme.spacing.px,
+                    ...getDropdownPopoverBodyStyles(theme),
                   }),
                 },
               },


### PR DESCRIPTION
## Summary

In dark mode, dropdown popover menus lack visual distinction from the background since box-shadows don't provide enough contrast. This adds a subtle border to dropdown popovers in dark mode while keeping the shadow-only approach for light mode.

## Changes

Extracted a shared `getDropdownPopoverBodyStyles()` helper in `Base/styled-components.ts` to avoid duplicating the border/shadow logic across multiple components. The helper conditionally applies:
- **Light mode**: No border, subtle box-shadow (`rgba(0, 0, 0, 0.16)`)
- **Dark mode**: Solid border using `theme.colors.borderColor`, stronger box-shadow (`rgba(0, 0, 0, 0.7)`)

### Components updated:
- **Selectbox** (shared Dropdown) — refactored existing inline border logic to use the new helper
- **Multiselect** — added dark mode border to popover
- **TimeInput** — added dark mode border to popover
- **DateInput** — added dark mode border to calendar popover
- **DateTimeInput** — added dark mode border to both calendar and time popovers

The Selectbox already had this border pattern implemented inline. This PR extracts it into a reusable helper and applies it consistently to all dropdown-style components.

Fixes #12954