### PR TITLE
Add border-radius to st.video and st.map for consistent rounding

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -23,10 +23,12 @@ interface StyledDeckGlChartProps {
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ isStretchHeight }) => ({
+  ({ isStretchHeight, theme }) => ({
     position: "relative",
     height: "100%",
     width: "100%",
+    borderRadius: theme.radii.default,
+    overflow: "hidden",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.
     ...(isStretchHeight && { minHeight: "6.25rem" }),
   })

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -250,7 +250,6 @@ function Video({
   }
 
   return (
-    // eslint-disable-next-line jsx-a11y/media-has-caption
     <StyledVideo
       className="stVideo"
       data-testid="stVideo"

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -37,8 +37,6 @@ export interface Subtitle {
   label: string
   url: string
 }
-
-const VIDEO_STYLE = { width: "100%" }
 
 function Video({
   element,
@@ -253,7 +251,7 @@ function Video({
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -261,7 +259,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -277,7 +274,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -16,6 +16,11 @@
 
 import styled from "@emotion/styled"
 
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: theme.radii.default,
+}))
+
 export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   colorScheme: "normal",
   border: "none",
@@ -23,4 +28,5 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: theme.radii.default,
 }))


### PR DESCRIPTION
## Summary

Adds border-radius rounding to `st.video` and `st.map`/`st.pydeck_chart` elements to match the consistent rounded look used by other Streamlit elements.

## Changes

- **st.video (native)**: Created a `StyledVideo` styled component with `borderRadius: theme.radii.default`, replacing the plain `<video>` element with inline styles.
- **st.video (iframe/YouTube)**: Added `borderRadius: theme.radii.default` to `StyledVideoIframe`.
- **st.map / st.pydeck_chart**: Added `borderRadius: theme.radii.default` and `overflow: hidden` to the `StyledDeckGlChart` container so map content respects the rounded corners.

Using `theme.radii.default` (0.5rem) ensures the rounding is consistent with other elements and small enough not to crop corner controls on video players or maps. The `overflow: hidden` on the map container is necessary to clip the map tiles to the rounded boundary.

Closes #12806