### PR TITLE
Accept integer/pixel size for gap parameter in columns/layouts

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -177,6 +177,8 @@ export const FlexBoxContainer = (
       // the gap size was defaulted to small.
       props.node.deltaBlock.flexContainer?.gapConfig?.gapSize ??
       streamlit.GapSize.SMALL,
+    pixelGap:
+      props.node.deltaBlock.flexContainer?.gapConfig?.pixelGap ?? undefined,
     direction: direction,
     // This is also backwards compatible since previously wrap was not added
     // to the flex container.
@@ -374,6 +376,7 @@ export const BlockNodeRenderer = (
       <StyledColumn
         weight={node.deltaBlock.column.weight ?? 0}
         gap={getColumnGapSize(node.deltaBlock.column)}
+        pixelGap={node.deltaBlock.column.gapConfig?.pixelGap ?? undefined}
         verticalAlignment={
           node.deltaBlock.column.verticalAlignment ?? undefined
         }

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -143,17 +143,23 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
 interface StyledColumnProps {
   weight: number
   gap: streamlit.GapSize | undefined
+  pixelGap?: number | undefined
   showBorder: boolean
   verticalAlignment?: BlockProto.Column.VerticalAlignment
 }
 
 export const StyledColumn = styled.div<StyledColumnProps>(
-  ({ theme, weight, gap, showBorder, verticalAlignment }) => {
+  ({ theme, weight, gap, pixelGap, showBorder, verticalAlignment }) => {
     const { VerticalAlignment } = BlockProto.Column
     const percentage = weight * 100
-    const gapWidth = translateGapWidth(gap, theme)
+    let gapWidth: string
+    if (pixelGap !== undefined && pixelGap > 0) {
+      gapWidth = `${pixelGap}px`
+    } else {
+      gapWidth = translateGapWidth(gap, theme)
+    }
     const width =
-      gapWidth === theme.spacing.none
+      gapWidth === theme.spacing.none || gapWidth === "0px"
         ? `${percentage}%`
         : `calc(${percentage}% - ${gapWidth})`
 
@@ -239,6 +245,7 @@ const getJustifyContent = (
 export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
   gap?: streamlit.GapSize | undefined
+  pixelGap?: number | undefined
   flex?: React.CSSProperties["flex"]
   // This marks the prop as a transient property so it is
   // not passed to the DOM. It overlaps with a valid attribute
@@ -257,6 +264,7 @@ export const StyledFlexContainerBlock =
       theme,
       direction,
       gap,
+      pixelGap,
       flex,
       $wrap,
       height,
@@ -265,8 +273,10 @@ export const StyledFlexContainerBlock =
       justify,
       overflow,
     }) => {
-      let gapWidth
-      if (gap !== undefined) {
+      let gapWidth: string | undefined
+      if (pixelGap !== undefined && pixelGap > 0) {
+        gapWidth = `${pixelGap}px`
+      } else if (gap !== undefined) {
         gapWidth = translateGapWidth(gap, theme)
       }
 

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -25,6 +25,7 @@ from streamlit.elements.lib.layout_utils import (
     VerticalAlignment,
     Width,
     WidthWithoutContent,
+    build_gap_config,
     get_align,
     get_gap_size,
     get_height_config,
@@ -67,7 +68,7 @@ class LayoutsMixin:
         horizontal: bool = False,
         horizontal_alignment: HorizontalAlignment = "left",
         vertical_alignment: VerticalAlignment = "top",
-        gap: Gap | None = "small",
+        gap: Gap | int | None = "small",
     ) -> DeltaGenerator:
         """Insert a multi-element container.
 
@@ -167,7 +168,7 @@ class LayoutsMixin:
               When ``horizontal`` is ``True``, ``"distribute"`` aligns the
               elements the same as ``"top"``.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", int, or None
             The minimum gap size between the elements inside the container.
             This can be one of the following:
 
@@ -178,6 +179,7 @@ class LayoutsMixin:
             - ``"large"``: 4rem gap between the elements.
             - ``"xlarge"``: 6rem gap between the elements.
             - ``"xxlarge"``: 8rem gap between the elements.
+            - An integer: gap in pixels between the elements.
             - ``None``: No gap between the elements.
 
             The rem unit is relative to the ``theme.baseFontSize``
@@ -283,8 +285,8 @@ class LayoutsMixin:
         block_proto = BlockProto()
         block_proto.allow_empty = False
         block_proto.flex_container.border = border or False
-        block_proto.flex_container.gap_config.gap_size = get_gap_size(
-            gap, "st.container"
+        block_proto.flex_container.gap_config.CopyFrom(
+            build_gap_config(gap, "st.container")
         )
 
         validate_horizontal_alignment(horizontal_alignment)
@@ -337,7 +339,7 @@ class LayoutsMixin:
         self,
         spec: SpecType,
         *,
-        gap: Gap | None = "small",
+        gap: Gap | int | None = "small",
         vertical_alignment: Literal["top", "center", "bottom"] = "top",
         border: bool = False,
         width: WidthWithoutContent = "stretch",
@@ -368,7 +370,7 @@ class LayoutsMixin:
               Or ``[1, 2, 3]`` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", int, or None
             The size of the gap between the columns. This can be one of the
             following:
 
@@ -379,6 +381,7 @@ class LayoutsMixin:
             - ``"large"``: 4rem gap between the columns.
             - ``"xlarge"``: 6rem gap between the columns.
             - ``"xxlarge"``: 8rem gap between the columns.
+            - An integer: gap in pixels between the columns.
             - ``None``: No gap between the columns.
 
             The rem unit is relative to the ``theme.baseFontSize``
@@ -532,9 +535,7 @@ class LayoutsMixin:
                 element_type="st.columns",
             )
 
-        gap_size = get_gap_size(gap, "st.columns")
-        gap_config = GapConfig()
-        gap_config.gap_size = gap_size
+        gap_config = build_gap_config(gap, "st.columns")
 
         def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -200,7 +200,7 @@ def get_height_config(height: Height | SpaceSize) -> HeightConfig:
     return height_config
 
 
-def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
+def get_gap_size(gap: str | int | None, element_type: str) -> GapSize.ValueType:
     """Convert a gap string or None to a GapSize proto value."""
     gap_mapping = {
         "xxsmall": GapSize.XXSMALL,
@@ -212,6 +212,10 @@ def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
         "xxlarge": GapSize.XXLARGE,
     }
 
+    if isinstance(gap, int):
+        # Integer values are handled separately via build_gap_config
+        return GapSize.SMALL  # fallback, not used when int path is taken
+
     if isinstance(gap, str):
         gap_size = gap.lower()
         valid_sizes = gap_mapping.keys()
@@ -222,6 +226,24 @@ def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
         return GapSize.NONE
 
     raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+
+
+def build_gap_config(gap: str | int | None, element_type: str) -> "GapConfig":
+    """Build a GapConfig proto from a gap value (string, int, or None).
+
+    If gap is an integer, it is treated as a pixel value.
+    If gap is a string or None, it is mapped to a GapSize enum value.
+    """
+    from streamlit.proto.GapSize_pb2 import GapConfig
+
+    config = GapConfig()
+    if isinstance(gap, int):
+        if gap < 0:
+            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        config.pixel_gap = gap
+    else:
+        config.gap_size = get_gap_size(gap, element_type)
+    return config
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -265,7 +265,6 @@ class ColumnsTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             "invalid",
-            5,
             "5rem",
             "10px",
         ]
@@ -274,6 +273,23 @@ class ColumnsTest(DeltaGeneratorTestCase):
         """Test that it throws an error on invalid gap argument"""
         with pytest.raises(StreamlitInvalidColumnGapError):
             st.columns(3, gap=invalid_gap)
+
+    def test_columns_with_integer_gap(self):
+        """Test that integer gap values are accepted as pixel values"""
+        st.columns(3, gap=16)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        col_block = all_deltas[1]
+        assert (
+            col_block.add_block.column.gap_config.WhichOneof("gap_spec")
+            == "pixel_gap"
+        )
+        assert col_block.add_block.column.gap_config.pixel_gap == 16
+
+    def test_columns_with_negative_integer_gap(self):
+        """Test that negative integer gap values raise an error"""
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            st.columns(3, gap=-5)
 
     def test_columns_with_border(self):
         """Test that it works correctly with border argument"""

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -34,5 +34,6 @@ enum GapSize {
 message GapConfig {
   oneof gap_spec {
     GapSize gap_size = 1;
+    int32 pixel_gap = 2;
   }
 }


### PR DESCRIPTION
## Summary

Add support for integer values in the `gap` parameter of `st.container` and `st.columns`. When an integer is provided, it is treated as a pixel value, giving users fine-grained control over spacing.

## Changes

- **Proto**: Add `GapConfig` message with `oneof` for `gap_size` (enum) or `pixel_gap` (int32) in `GapSize.proto`
- **Python backend**: Add `build_gap_config()` utility to construct `GapConfig` from string, int, or None. Update `st.container` and `st.columns` to use `GapConfig` proto.
- **Frontend**: Update styled-components to handle `pixelGap` values for both horizontal and vertical column layouts
- **Type hints & docs**: Update type annotations and docstrings to document integer support

## Usage

```python
# Existing string values still work
st.columns(3, gap="small")

# New: integer values interpreted as pixels
st.columns(3, gap=8)

# Works with st.container too
with st.container(gap=4):
    st.write("Tight spacing")
```

Closes #13005