### PR TITLE
fix: prevent copy button from being obscured by long code lines in st.code

### DIFF
--- a/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
+++ b/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
@@ -247,6 +247,10 @@ export const StyledCopyButton = styled(CopyButton)(({ theme }) => ({
     buttonSize: theme.iconSizes.threeXL,
     focusRing: theme.shadows.focusRingSubtle,
   }),
+  // Use a solid background so the button is not obscured by long code lines
+  // that scroll underneath it. (Fixes #12958)
+  backgroundColor: theme.colors.codeBackgroundColor,
+  borderRadius: theme.radii.default,
 
   // Reveal the overlay when the code block container is hovered.
   [`${StyledCodeBlock}:hover &`]: {


### PR DESCRIPTION
## Summary

Fixes the copy-to-clipboard button in `st.code` being overlapped and hidden by long lines of code.

## Problem

When `st.code` displays content with long lines, the text extends underneath the copy button, making it invisible or difficult to click. This happens because the copy button had a transparent background, so scrolled content would show through it.

Screenshot from issue report showing the overlap:
![image](https://github.com/streamlit/streamlit/assets/100121698/518cae0b-1080-4952-810d-87b1bf99a291)

## Fix

Added a solid `backgroundColor` (`theme.colors.codeBackgroundColor`) to the `StyledCopyButton` component in the CodeBlock styled-components. This ensures the button always has a visible, opaque background that matches the code block, preventing text from showing through when it scrolls underneath.

## Changes

- `frontend/lib/src/components/elements/CodeBlock/styled-components.ts`: Added `backgroundColor` and `borderRadius` to `StyledCopyButton` to give it a solid background matching the code block.

Fixes #12958