### PR TITLE
fix: prevent code text from overlapping copy button in st.code

### DIFF
--- a/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.test.tsx
+++ b/frontend/lib/src/components/elements/CodeBlock/StreamlitSyntaxHighlighter.test.tsx
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { screen } from "@testing-library/react"
+
+import { mockTheme } from "~lib/mocks/mockTheme"
 import { render } from "~lib/test_util"
 
 import StreamlitSyntaxHighlighter, {
@@ -81,5 +84,41 @@ describe("CustomCodeTag Element", () => {
     const props = getStreamlitSyntaxHighlighterProps({ children })
     const { baseElement } = render(<StreamlitSyntaxHighlighter {...props} />)
     expect(baseElement.querySelector("pre code")).toHaveTextContent(expected)
+  })
+
+  it("should render copy button for non-empty code", () => {
+    const props = getStreamlitSyntaxHighlighterProps()
+    render(<StreamlitSyntaxHighlighter {...props} />)
+
+    // Use queryByTestId (returns null instead of throwing) so the
+    // toBeInTheDocument assertion is meaningful, not redundant.
+    const copyButton = screen.queryByTestId("stCodeCopyButton")
+    expect(copyButton).toBeInTheDocument()
+  })
+
+  it("should not render copy button for empty code", () => {
+    const props = getStreamlitSyntaxHighlighterProps({ children: "" })
+    render(<StreamlitSyntaxHighlighter {...props} />)
+
+    const copyButton = screen.queryByTestId("stCodeCopyButton")
+    expect(copyButton).not.toBeInTheDocument()
+  })
+
+  it("should reserve space for the copy button via paddingRight on the code block", () => {
+    const longCode =
+      "x = " +
+      "'a very long string that extends well beyond the viewport width'".repeat(
+        5
+      )
+    const props = getStreamlitSyntaxHighlighterProps({ children: longCode })
+    render(<StreamlitSyntaxHighlighter {...props} />)
+
+    const codeBlock = screen.getByTestId("stCode")
+    // The code block should reserve space for the copy button so it
+    // doesn't overlap scrolled code, and clip overflowing content.
+    expect(codeBlock).toHaveStyle(
+      `padding-right: ${mockTheme.emotion.iconSizes.threeXL}`
+    )
+    expect(codeBlock).toHaveStyle("overflow: hidden")
   })
 })

--- a/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
+++ b/frontend/lib/src/components/elements/CodeBlock/styled-components.ts
@@ -83,8 +83,10 @@ export const StyledCode = styled.code<StyledCodeProps>(
 export const StyledPre = styled.pre<StyledCodeProps>(
   ({ theme, wrapLines }) => ({
     height: "100%",
-    background: theme.colors.codeBackgroundColor,
-    borderRadius: theme.radii.default,
+    // Background and border-radius have moved to the parent StyledCodeBlock
+    // so that the reserved copy-button zone shares the same background.
+    background: "transparent",
+    borderRadius: 0,
     color: theme.colors.bodyText,
     fontSize: theme.fontSizes.twoSm,
     fontFamily: theme.genericFonts.codeFont,
@@ -98,10 +100,10 @@ export const StyledPre = styled.pre<StyledCodeProps>(
     // Don't allow content to break outside
     overflow: "auto",
 
-    // Add padding around the code
+    // Add padding around the code. Right padding for the copy button is
+    // now handled by the parent StyledCodeBlock's paddingRight, so all
+    // four sides use the same value here.
     padding: theme.spacing.lg,
-    // Add padding to the right to account for the copy button
-    paddingRight: theme.iconSizes.threeXL,
 
     code: { ...codeBlockStyle(theme, wrapLines) },
 
@@ -228,6 +230,15 @@ export const StyledCodeBlock = styled.div(({ theme }) => ({
   marginRight: theme.spacing.none,
   marginTop: theme.spacing.none,
   marginBottom: undefined,
+  // Background and border-radius are on the outer container so the code
+  // block background extends behind the copy-button zone.
+  background: theme.colors.codeBackgroundColor,
+  borderRadius: theme.radii.default,
+  overflow: "hidden",
+  // Reserve space on the right for the copy button. Because StyledPre
+  // is a flow child it only fills the *content* area, so code never
+  // scrolls underneath the button.
+  paddingRight: theme.iconSizes.threeXL,
 
   "&:hover": {
     [`${StyledCopyButtonContainer}`]: {


### PR DESCRIPTION
## Describe your changes

Prevent the copy-to-clipboard button from overlapping with long code text in `st.code` blocks.

### The Problem

When `st.code` displays content with long lines, horizontal scrolling causes code text to pass underneath the copy button, making it invisible or hard to click. This happens because:
1. `StyledPre` (the `<pre>` element) has `overflow: auto` and scrolls horizontally
2. The copy button is absolutely positioned on top of `StyledCodeBlock`
3. The previous `paddingRight` on `StyledPre` only added space at the *end* of the scrollable content, not at the viewport's right edge — so during mid-scroll, code text still passed under the button

### The Fix

Moved the `background`, `borderRadius`, and `paddingRight` from `StyledPre` to the parent `StyledCodeBlock`. Since `StyledPre` is a flow child, it only fills the *content area* of `StyledCodeBlock` (i.e., total width minus the right padding). This creates a physically separate zone for the copy button that code text can never reach, regardless of scroll position.

**Key changes in `styled-components.ts`:**
- `StyledCodeBlock`: Added `background`, `borderRadius`, `overflow: hidden`, and `paddingRight` (button reserve zone)
- `StyledPre`: Changed to `background: transparent`, `borderRadius: 0`, removed the `paddingRight` override

This approach differs from previous PRs that used a solid background on the copy button to hide code underneath. Instead, **code text never overlaps the button at all** — the scrollable area and button zone are structurally separate.

## GitHub Issue Link (if applicable)

Fixes #12958

## Testing Plan

- **Unit Tests (JS):** Added 3 new tests to `StreamlitSyntaxHighlighter.test.tsx`:
  - Copy button renders for non-empty code
  - Copy button does not render for empty code
  - Copy button is contained within the code block (verified with long code)
- **Existing tests:** All 19 CodeBlock tests pass (16 existing + 3 new)
- **Lint:** `eslint` and `prettier` pass with no errors
- **Manual testing needed:** Yes — verify visually that:
  1. Long code lines can be scrolled and the copy button does not overlap
  2. The button remains visible and clickable on hover
  3. Both light and dark themes look correct
  4. `st.exception` blocks are unaffected (they use a different copy mechanism)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
