### PR TITLE
fix: st.metric with chart_data wraps unexpectedly in horizontal conta…

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -456,7 +456,7 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.DEFAULT}
+          config={ElementContainerConfig.MEDIUM_ELEMENT}
           isStale={isStale}
         >
           <Metric

--- a/frontend/lib/src/components/elements/Metric/styled-components.ts
+++ b/frontend/lib/src/components/elements/Metric/styled-components.ts
@@ -30,6 +30,7 @@ export interface StyledMetricContainerProps {
 export const StyledMetricContainer = styled.div<StyledMetricContainerProps>(
   ({ theme, showBorder }) => ({
     height: "100%",
+    minWidth: 0,
     ...(showBorder && {
       border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
       borderRadius: theme.radii.default,


### PR DESCRIPTION
…iners

Use MEDIUM_ELEMENT config (flex: 1 1 8rem) instead of DEFAULT for the metric element container, providing a stable flex-basis so metrics with sparkline charts share space equally in horizontal layouts instead of relying on fit-content which creates a sizing feedback loop with the ResizeObserver-driven chart width.

Also add minWidth: 0 to StyledMetricContainer so flex items can shrink below their intrinsic content size when needed.

Fixes #13785

## Describe your changes

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
