### PR TITLE
fix: preserve active tab selection after spinner reruns

### DIFF
--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -97,3 +97,18 @@ if st.button("Run spinner with delayed container write"):
         container = st.container()
         time.sleep(2)  # Container exists but is empty when spinner renders
         container.write("Hello World")
+
+# Regression test for issue #14018: tabs should preserve selection across reruns
+# when they are rendered after a spinner context.
+if st.button("Enable spinner before tabs scenario"):
+    st.session_state["show_spinner_before_tabs"] = True
+
+if st.session_state.get("show_spinner_before_tabs"):
+    with st.spinner("Starting up..."):
+        time.sleep(1)
+
+    tab_one, tab_two = st.tabs(["tab_one", "tab_two"])
+    with tab_one:
+        st.write("Tab one content")
+    with tab_two:
+        st.number_input("number in tab", key="number_in_tab_after_spinner")

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -233,3 +233,37 @@ def test_spinner_with_delayed_container_write(app: Page):
     # After the spinner completes, the container content should be visible
     expect(app.get_by_test_id("stSpinner")).to_have_count(0)
     expect(app.get_by_text("Hello World")).to_be_visible()
+
+
+def test_spinner_before_tabs_preserves_active_tab_and_increments_number_input(
+    app: Page,
+):
+    """Test that tab selection and number input interaction survive reruns.
+
+    Regression test for issue #14018: widgets in tabs should not reset tab
+    selection when rendered after a spinner context.
+    """
+    get_button(app, "Enable spinner before tabs scenario").click()
+
+    # Spinner appears while the scenario is initializing.
+    expect(app.get_by_test_id("stSpinner")).to_be_visible()
+    wait_for_app_run(app)
+
+    tab_one = app.get_by_role("tab", name="tab_one")
+    tab_two = app.get_by_role("tab", name="tab_two")
+    number_input = app.get_by_role("spinbutton", name="number in tab")
+
+    tab_two.click()
+    expect(tab_two).to_have_attribute("aria-selected", "true")
+    expect(tab_one).to_have_attribute("aria-selected", "false")
+
+    initial_value = float(number_input.input_value())
+    number_input.click()
+    number_input.press("ArrowUp")
+    wait_for_app_run(app)
+
+    # Tab selection should not jump back to the first tab after rerun.
+    expect(tab_two).to_have_attribute("aria-selected", "true")
+    expect(tab_one).to_have_attribute("aria-selected", "false")
+    updated_value = float(number_input.input_value())
+    assert updated_value > initial_value

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -428,6 +428,81 @@ describe("AppRoot", () => {
       expect(replacedBlock.children.length).toBe(1)
     })
 
+    it("inherits children when replacing a block wrapped in a transient node", () => {
+      const tabContainerProto = makeProto(DeltaProto, {
+        addBlock: { tabContainer: {}, allowEmpty: false },
+      })
+      const tab1 = makeProto(DeltaProto, {
+        addBlock: { tab: { label: "tab1" }, allowEmpty: true },
+      })
+      const tab2 = makeProto(DeltaProto, {
+        addBlock: { tab: { label: "tab2" }, allowEmpty: true },
+      })
+      const clearTransientDelta = makeProto(DeltaProto, {
+        newTransient: { elements: [] },
+      })
+
+      const rootWithTabs = ROOT.applyDelta(
+        "old_script_run_id",
+        tabContainerProto,
+        forwardMsgMetadata([0, 1, 1])
+      )
+        .applyDelta(
+          "old_script_run_id",
+          tab1,
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+        .applyDelta(
+          "old_script_run_id",
+          tab2,
+          forwardMsgMetadata([0, 1, 1, 1])
+        )
+
+      const rootWithTransientWrapper = rootWithTabs.applyDelta(
+        "old_script_run_id",
+        clearTransientDelta,
+        forwardMsgMetadata([0, 1, 1])
+      )
+
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(
+          rootWithTransientWrapper.main,
+          [1, 1]
+        )
+      ).toBeInstanceOf(TransientNode)
+
+      const replacedRoot = rootWithTransientWrapper.applyDelta(
+        "new_script_run_id",
+        tabContainerProto,
+        forwardMsgMetadata([0, 1, 1])
+      )
+
+      const replacedBlock = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        replacedRoot.main,
+        [1, 1]
+      ) as BlockNode
+      expect(replacedBlock).toBeDefined()
+      expect(replacedBlock.deltaBlock.type).toBe("tabContainer")
+      expect(replacedBlock.children.length).toBe(2)
+
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(
+            replacedRoot.main,
+            [1, 1, 0]
+          ) as BlockNode
+        ).deltaBlock.tab?.label
+      ).toBe("tab1")
+      expect(
+        (
+          GetNodeByDeltaPathVisitor.getNodeAtPath(
+            replacedRoot.main,
+            [1, 1, 1]
+          ) as BlockNode
+        ).deltaBlock.tab?.label
+      ).toBe("tab2")
+    })
+
     it("removes a dialog block's children when replacing with a different dialog identity", () => {
       // Create a dialog with some children. The id field represents the dialog's
       // identity computed from its attributes.

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -423,10 +423,16 @@ export class AppRoot {
     fragmentId?: string,
     deltaMsgReceivedAt?: number
   ): AppRoot {
-    const existingNode = GetNodeByDeltaPathVisitor.getNodeAtPath(
+    const existingNodeAtPath = GetNodeByDeltaPathVisitor.getNodeAtPath(
       this.root,
       deltaPath
     )
+    // Transient nodes are transport wrappers. For child inheritance, operate on
+    // the underlying anchor node when available.
+    const existingNode =
+      existingNodeAtPath instanceof TransientNode
+        ? (existingNodeAtPath.anchor ?? existingNodeAtPath)
+        : existingNodeAtPath
 
     // If we're replacing an existing Block of the same type, this new Block
     // inherits the existing Block's children. This preserves two things:


### PR DESCRIPTION
## Describe your changes

Fixed a bug where tabs would lose their selection state when rendered after a spinner context. The issue occurred because transient nodes (like spinners) weren't properly handling child inheritance during reruns.

The fix modifies the AppRoot class to check if a node is a TransientNode and use its anchor node for child inheritance when replacing blocks. This ensures that tab selection state is preserved across reruns when tabs are rendered after a spinner.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/14018

## Testing Plan

- Unit Tests (JS and/or Python)
  - Added a unit test in AppRoot.test.ts to verify that children are properly inherited when replacing a block wrapped in a transient node

- E2E Tests
  - Added a regression test scenario in st_spinner.py that reproduces the issue with tabs after a spinner
  - Added a corresponding test in st_spinner_test.py that verifies tab selection is preserved after widget interaction

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.