### PR TITLE
Update AI PR review workflow to use multiple models

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
         required: false
         type: string
-        default: "opus-4.6-thinking"
+        default: "gpt-5.3-codex-high,opus-4.6-thinking"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'opus-4.6-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,opus-4.6-thinking' }}
 
 jobs:
   # Job 1: Parse model list and check for API key


### PR DESCRIPTION
## Describe your changes

Updated the AI PR review workflow to use multiple models for reviews. The workflow now uses `gpt-5.3-codex-high` as the primary reviewer alongside `opus-4.6-thinking` as the judge for consolidating reviews. This provides improved review quality through multi-model analysis.

## Testing Plan

The workflow configuration changes are for GitHub Actions CI/CD and will be validated through the CI system upon merge.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.