### PR TITLE
[refactor] remove loading skeleton for dynamic popover

### DIFF
--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { screen, waitFor } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { Mocked } from "vitest"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
-import { ScriptRunState } from "~lib/ScriptRunState"
-import { render, renderWithContexts } from "~lib/test_util"
+import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Popover, { PopoverProps } from "./Popover"
@@ -271,65 +270,5 @@ describe("Dynamic popover (widget mode)", () => {
     // The sync effect should only update local UI state, not send a value
     // back to the backend (which would cause a feedback loop).
     expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
-  })
-
-  it("does not show skeleton during unrelated script runs after loading completes", async () => {
-    const user = userEvent.setup()
-    const widgetMgr = createMockWidgetMgr()
-
-    const widgetId = "popover-widget-id"
-    const props = getProps({ id: widgetId }, { widgetMgr, empty: true })
-
-    // Start with NOT_RUNNING, scriptRunId = "run-1"
-    const { rerenderWithContexts } = renderWithContexts(
-      <Popover {...props}>
-        <div>content</div>
-      </Popover>,
-      {
-        scriptRunContext: {
-          scriptRunState: ScriptRunState.NOT_RUNNING,
-          scriptRunId: "run-1",
-        },
-      }
-    )
-
-    // User opens the empty widget popover → skeleton should show
-    await user.click(screen.getByText("label"))
-    expect(screen.queryByTestId("stPopoverSkeleton")).toBeVisible()
-
-    // Triggered run completes: new scriptRunId, back to NOT_RUNNING
-    rerenderWithContexts(
-      <Popover {...props}>
-        <div>content</div>
-      </Popover>,
-      {
-        scriptRunContext: {
-          scriptRunState: ScriptRunState.NOT_RUNNING,
-          scriptRunId: "run-2",
-        },
-      }
-    )
-
-    // Skeleton should be gone (run completed, content still empty)
-    expect(screen.queryByTestId("stPopoverSkeleton")).not.toBeInTheDocument()
-
-    // An unrelated script run starts (e.g. user interacted with another widget)
-    rerenderWithContexts(
-      <Popover {...props}>
-        <div>content</div>
-      </Popover>,
-      {
-        scriptRunContext: {
-          scriptRunState: ScriptRunState.RUNNING,
-          scriptRunId: "run-3",
-        },
-      }
-    )
-
-    // Skeleton must NOT reappear — this is an unrelated run.
-    // Use waitFor to ensure all async Popover state updates from Popper.js complete.
-    await waitFor(() => {
-      expect(screen.queryByTestId("stPopoverSkeleton")).not.toBeInTheDocument()
-    })
   })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -22,8 +22,6 @@ import { Block as BlockProto } from "@streamlit/protobuf"
 import { notNullOrUndefined } from "@streamlit/utils"
 
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { ScriptRunContext } from "~lib/components/core/ScriptRunContext"
-import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components"
 import {
   Box,
   getPopoverContainerStyle,
@@ -38,7 +36,6 @@ import { DynamicIcon } from "~lib/components/shared/Icon"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
-import { ScriptRunState } from "~lib/ScriptRunState"
 import { convertRemToPx } from "~lib/theme"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -66,7 +63,6 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   fragmentId,
 }): ReactElement => {
   const isInSidebar = useContext(IsSidebarContext)
-  const { scriptRunState, scriptRunId } = useContext(ScriptRunContext)
 
   const theme = useEmotionTheme()
 
@@ -78,14 +74,6 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // Initialize from backend state.
   const [open, setOpen] = useState(element.open ?? false)
 
-  // Tracks the scriptRunId at the time the user opened an empty widget
-  // popover. Used to derive isLoadingContent: we show the skeleton until
-  // a *different* script run completes (meaning our triggered run finished)
-  // or content arrives.
-  const [loadingStartScriptRunId, setLoadingStartScriptRunId] = useState<
-    string | null
-  >(null)
-
   // Sync backend state changes (for programmatic control via session_state).
   // Uses render-time comparison instead of useEffect — no DOM side effects needed.
   useExecuteWhenChanged(() => {
@@ -93,33 +81,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       return
     }
     setOpen(element.open)
-    setLoadingStartScriptRunId(null)
   }, [widgetId, element.open])
-
-  // Clear loadingStartScriptRunId once the triggered run completes,
-  // so unrelated script runs don't re-activate the skeleton.
-  useExecuteWhenChanged(() => {
-    if (
-      loadingStartScriptRunId !== null &&
-      scriptRunState === ScriptRunState.NOT_RUNNING &&
-      scriptRunId !== loadingStartScriptRunId
-    ) {
-      setLoadingStartScriptRunId(null)
-    }
-  }, [scriptRunState, scriptRunId])
-
-  // Loading is active when: widget mode, popover is open, content is empty, loading
-  // was initiated by the user, and the script run that would populate
-  // content hasn't completed yet.
-  const isLoadingContent =
-    Boolean(widgetId) &&
-    open &&
-    empty &&
-    loadingStartScriptRunId !== null &&
-    !(
-      scriptRunState === ScriptRunState.NOT_RUNNING &&
-      scriptRunId !== loadingStartScriptRunId
-    )
 
   // It would be nice to remove this since it uses a resize observer
   // and therefore has a performance overhead. However, this is needed
@@ -135,10 +97,6 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     setOpen(newOpen)
 
     if (widgetId) {
-      // Track loading start when opening an empty widget popover.
-      // isLoadingContent is derived from this + other state.
-      setLoadingStartScriptRunId(newOpen && empty ? scriptRunId : null)
-
       // Send state update to backend
       widgetMgr?.setBoolValue(
         { id: widgetId },
@@ -147,13 +105,12 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         fragmentId
       )
     }
-  }, [open, empty, scriptRunId, widgetMgr, widgetId, fragmentId])
+  }, [open, widgetMgr, widgetId, fragmentId])
 
   const handleClose = useCallback((): void => {
     setOpen(false)
 
     if (widgetId) {
-      setLoadingStartScriptRunId(null)
       widgetMgr?.setBoolValue(
         { id: widgetId },
         false,
@@ -175,13 +132,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       <UIPopover
         triggerType={TRIGGER_TYPE.click}
         placement={PLACEMENT.bottomLeft}
-        content={() =>
-          isLoadingContent ? (
-            <SquareSkeleton data-testid="stPopoverSkeleton" />
-          ) : (
-            children
-          )
-        }
+        content={() => children}
         isOpen={open}
         onClickOutside={handleClose}
         // We need to handle the click here as well to allow closing the


### PR DESCRIPTION
## Describe your changes

Removes the loading skeleton from the dynamic popover widget. The skeleton was shown while waiting for content to arrive after a user-triggered rerun, but PM decided it's not needed.

- Removes `isLoadingContent` derivation, `loadingStartScriptRunId` tracking, and `SquareSkeleton` render from `Popover.tsx`
- Simplifies `handleToggle`/`handleClose` by removing loading state management

## Testing Plan

- [x] Unit Tests (JS) — removed skeleton-specific test that is no longer applicable

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
