### PR TITLE
Fix SVGs rendering at 0x0 in st.image when no explicit width is set

### DIFF
--- a/e2e_playwright/st_image.py
+++ b/e2e_playwright/st_image.py
@@ -260,3 +260,13 @@ st.image(img800, width="content", caption="Large image with width='content'")
 # Stretch width - full container width
 st.image(img, width="stretch", caption="Small image with width='stretch'")
 st.image(img800, width="stretch", caption="Large image with width='stretch'")
+
+st.header("SVG dimension handling")
+
+# Dimensionless SVG (only viewBox, no width/height) should render at full width
+dimensionless_svg = '<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg"><rect fill="blue" width="200" height="100"/></svg>'
+st.image(dimensionless_svg, caption="Dimensionless SVG (viewBox only)")
+
+# SVG with explicit width/height should render at its intrinsic size
+sized_svg = '<svg width="150" height="75" xmlns="http://www.w3.org/2000/svg"><rect fill="green" width="150" height="75"/></svg>'
+st.image(sized_svg, caption="Sized SVG (width=150, height=75)")

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -334,3 +334,24 @@ def test_image_source_error(app: Page, app_base_url: str):
         ),
         timeout=10000,
     )
+
+
+def test_dimensionless_svg_renders_with_nonzero_size(app: Page):
+    """Dimensionless SVGs (no width/height attrs) should render visibly, not at 0x0."""
+    dimensionless_header = app.get_by_text("SVG dimension handling")
+    dimensionless_header.scroll_into_view_if_needed()
+
+    # The first image after the header is the dimensionless SVG
+    dimensionless_img = app.locator(
+        'img[alt="0"]'
+    ).last  # last matching, since caption text is "Dimensionless SVG"
+
+    # Get the images in the SVG dimension handling section
+    svg_section_images = app.get_by_test_id("stImage").last
+    first_img = svg_section_images.locator("img").first
+
+    # The dimensionless SVG should have a non-zero rendered size
+    bounding_box = first_img.bounding_box()
+    assert bounding_box is not None, "Dimensionless SVG image should be visible"
+    assert bounding_box["width"] > 0, "Dimensionless SVG width should be > 0"
+    assert bounding_box["height"] > 0, "Dimensionless SVG height should be > 0"

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -280,6 +280,20 @@ describe("ImageList Element", () => {
       expect(containers[0]).toHaveStyle("width: auto")
     })
 
+    it("uses explicit pixelWidth for SVGs instead of full-width stretch", () => {
+      const dimensionlessSvg =
+        '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle r="50"/></svg>'
+      const dataUri = "data:image/svg+xml;base64," + btoa(dimensionlessSvg)
+      const props = getProps(
+        { imgs: [{ caption: "svg", url: dataUri }] },
+        { pixelWidth: 200 }
+      )
+      render(<ImageList {...props} />)
+
+      const images = screen.getAllByRole("img")
+      expect(images[0]).toHaveStyle("width: 200px")
+    })
+
     it("does NOT apply full-width stretch for non-SVG images", () => {
       const props = getProps(
         { imgs: [{ caption: "png", url: "/media/image.png" }] },

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -206,6 +206,16 @@ describe("ImageList Element", () => {
       expect(isSvgImage("/media/IMAGE.Svg?v=2")).toBe(true)
     })
 
+    it("detects .svg with fragment", () => {
+      expect(isSvgImage("/media/icon.svg#section")).toBe(true)
+    })
+
+    it("does not false-positive when .svg appears mid-path", () => {
+      expect(isSvgImage("https://example.com/some.svg.bak/image.png")).toBe(
+        false
+      )
+    })
+
     it("returns false for non-SVG URLs", () => {
       expect(isSvgImage("/media/image.png")).toBe(false)
       expect(isSvgImage("/media/image.jpeg")).toBe(false)

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -22,7 +22,11 @@ import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import { render, renderWithContexts } from "~lib/test_util"
 
-import ImageList, { ImageListProps } from "./ImageList"
+import ImageList, {
+  ImageListProps,
+  isSvgImage,
+  svgHasIntrinsicSize,
+} from "./ImageList"
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
 vi.mock("@streamlit/utils", async () => {
@@ -181,6 +185,101 @@ describe("ImageList Element", () => {
       "onerror triggered",
       "https://mock.media.url/"
     )
+  })
+
+  describe("isSvgImage", () => {
+    it("detects .svg extension", () => {
+      expect(isSvgImage("/media/image.svg")).toBe(true)
+    })
+
+    it("detects .svg with query params", () => {
+      expect(isSvgImage("/media/image.svg?v=1")).toBe(true)
+    })
+
+    it("detects data:image/svg+xml URIs", () => {
+      expect(isSvgImage("data:image/svg+xml;base64,PHN2Zz4=")).toBe(true)
+    })
+
+    it("is case-insensitive", () => {
+      expect(isSvgImage("/media/image.SVG")).toBe(true)
+      expect(isSvgImage("data:image/SVG+XML;base64,PHN2Zz4=")).toBe(true)
+      expect(isSvgImage("/media/IMAGE.Svg?v=2")).toBe(true)
+    })
+
+    it("returns false for non-SVG URLs", () => {
+      expect(isSvgImage("/media/image.png")).toBe(false)
+      expect(isSvgImage("/media/image.jpeg")).toBe(false)
+      expect(isSvgImage("data:image/png;base64,abc")).toBe(false)
+    })
+  })
+
+  describe("svgHasIntrinsicSize", () => {
+    it("returns false for base64 SVG without width/height", () => {
+      const svg = '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle r="50"/></svg>'
+      const dataUri = "data:image/svg+xml;base64," + btoa(svg)
+      expect(svgHasIntrinsicSize(dataUri)).toBe(false)
+    })
+
+    it("returns true for base64 SVG with width and height", () => {
+      const svg = '<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg"><circle r="50"/></svg>'
+      const dataUri = "data:image/svg+xml;base64," + btoa(svg)
+      expect(svgHasIntrinsicSize(dataUri)).toBe(true)
+    })
+
+    it("returns false for SVG with only width but no height", () => {
+      const svg = '<svg width="100" viewBox="0 0 100 100"><circle r="50"/></svg>'
+      const dataUri = "data:image/svg+xml;base64," + btoa(svg)
+      expect(svgHasIntrinsicSize(dataUri)).toBe(false)
+    })
+
+    it("returns true for remote SVG URLs (assumes dimensions)", () => {
+      expect(svgHasIntrinsicSize("https://example.com/image.svg")).toBe(true)
+    })
+
+    it("handles URL-encoded data URIs", () => {
+      const svg = '<svg viewBox="0 0 100 100"><rect/></svg>'
+      const dataUri = "data:image/svg+xml," + encodeURIComponent(svg)
+      expect(svgHasIntrinsicSize(dataUri)).toBe(false)
+    })
+  })
+
+  describe("SVG full-width stretch behavior", () => {
+    it("applies full-width stretch for dimensionless SVG data URIs", () => {
+      const dimensionlessSvg = '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle r="50"/></svg>'
+      const dataUri = "data:image/svg+xml;base64," + btoa(dimensionlessSvg)
+      const props = getProps(
+        { imgs: [{ caption: "svg", url: dataUri }] },
+        { useContent: true }
+      )
+      render(<ImageList {...props} />)
+
+      const containers = screen.getAllByTestId("stImageContainer")
+      expect(containers[0]).toHaveStyle("width: 100%")
+    })
+
+    it("does NOT apply full-width stretch for SVGs with intrinsic dimensions", () => {
+      const sizedSvg = '<svg width="50" height="50" xmlns="http://www.w3.org/2000/svg"><circle r="25"/></svg>'
+      const dataUri = "data:image/svg+xml;base64," + btoa(sizedSvg)
+      const props = getProps(
+        { imgs: [{ caption: "svg", url: dataUri }] },
+        { useContent: true }
+      )
+      render(<ImageList {...props} />)
+
+      const containers = screen.getAllByTestId("stImageContainer")
+      expect(containers[0]).toHaveStyle("width: auto")
+    })
+
+    it("does NOT apply full-width stretch for non-SVG images", () => {
+      const props = getProps(
+        { imgs: [{ caption: "png", url: "/media/image.png" }] },
+        { useContent: true }
+      )
+      render(<ImageList {...props} />)
+
+      const containers = screen.getAllByTestId("stImageContainer")
+      expect(containers[0]).toHaveStyle("width: auto")
+    })
   })
 
   describe("crossOrigin attribute", () => {

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -42,6 +42,17 @@ import {
 
 const LOG = getLogger("ImageList")
 
+/**
+ * Check if a URL points to an SVG image.
+ */
+function isSvgImage(url: string): boolean {
+  return (
+    url.endsWith(".svg") ||
+    url.includes("data:image/svg+xml") ||
+    url.includes(".svg?")
+  )
+}
+
 export interface ImageListProps {
   endpoints: StreamlitEndpoints
   element: ImageListProto
@@ -146,6 +157,14 @@ function ImageList({
 
   const shouldStretch = widthConfig?.useStretch ?? false
 
+  // @see issue https://github.com/streamlit/streamlit/issues/9098
+  // When the image is an SVG and no explicit width is set (useContent mode),
+  // SVGs without intrinsic dimensions would render at 0x0 because the
+  // container collapses. Detect if any image is SVG so we can expand the
+  // container to full width in that case.
+  const hasAnySvg = element.imgs.some((img) => isSvgImage(img.url))
+  const svgNeedsFullWidth = hasAnySvg && imageWidth === undefined
+
   const imgStyle: CSSProperties = {}
 
   if (fullScreenHeight && isFullScreen) {
@@ -194,7 +213,7 @@ function ImageList({
       <StyledImageList
         className="stImage"
         data-testid="stImage"
-        shouldStretch={shouldStretch}
+        shouldStretch={shouldStretch || svgNeedsFullWidth}
       >
         {element.imgs.map(
           (iimage, idx): ReactElement => (
@@ -207,7 +226,10 @@ function ImageList({
               imgStyle={imgStyle}
               buildMediaURL={(url: string) => endpoints.buildMediaURL(url)}
               handleImageError={handleImageError}
-              shouldStretch={shouldStretch}
+              shouldStretch={
+                shouldStretch ||
+                (svgNeedsFullWidth && isSvgImage((iimage as ImageProto).url))
+              }
             />
           )
         )}

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -45,12 +45,56 @@ const LOG = getLogger("ImageList")
 /**
  * Check if a URL points to an SVG image.
  */
-function isSvgImage(url: string): boolean {
+export function isSvgImage(url: string): boolean {
+  const lower = url.toLowerCase()
   return (
-    url.endsWith(".svg") ||
-    url.includes("data:image/svg+xml") ||
-    url.includes(".svg?")
+    lower.endsWith(".svg") ||
+    lower.includes("data:image/svg+xml") ||
+    lower.includes(".svg?")
   )
+}
+
+/**
+ * Check whether an SVG data URI encodes an SVG that lacks intrinsic
+ * width/height attributes (i.e. it is "dimensionless"). Only data URIs
+ * can be inspected on the frontend; for remote URLs we conservatively
+ * return true (assume dimensionless) so the full-width fallback applies.
+ */
+export function svgHasIntrinsicSize(url: string): boolean {
+  const lower = url.toLowerCase()
+  if (!lower.includes("data:image/svg+xml")) {
+    // Remote URL - we cannot inspect it, assume it has dimensions
+    // (most SVG files served over HTTP have width/height).
+    return true
+  }
+
+  let svgText: string
+  try {
+    if (lower.includes(";base64,")) {
+      const base64 = url.split(";base64,")[1]
+      svgText = atob(base64)
+    } else {
+      // URL-encoded data URI
+      const dataContent = url.split(",").slice(1).join(",")
+      svgText = decodeURIComponent(dataContent)
+    }
+  } catch {
+    // If decoding fails, assume it has dimensions to avoid breaking layout
+    return true
+  }
+
+  // Extract the opening <svg ...> tag and check for width/height attributes
+  const svgTagMatch = svgText.match(/<svg[^>]*>/i)
+  if (!svgTagMatch) {
+    return true
+  }
+
+  const svgTag = svgTagMatch[0]
+  // Check for width="..." or height="..." attributes (not viewBox)
+  const hasWidth = /\bwidth\s*=/i.test(svgTag)
+  const hasHeight = /\bheight\s*=/i.test(svgTag)
+
+  return hasWidth && hasHeight
 }
 
 export interface ImageListProps {
@@ -162,8 +206,12 @@ function ImageList({
   // SVGs without intrinsic dimensions would render at 0x0 because the
   // container collapses. Detect if any image is SVG so we can expand the
   // container to full width in that case.
-  const hasAnySvg = element.imgs.some(img => isSvgImage(img.url ?? ""))
-  const svgNeedsFullWidth = hasAnySvg && imageWidth === undefined
+  // Only apply full-width to SVGs that actually lack intrinsic dimensions.
+  const hasDimensionlessSvg = element.imgs.some(img => {
+    const url = img.url ?? ""
+    return isSvgImage(url) && !svgHasIntrinsicSize(url)
+  })
+  const svgNeedsFullWidth = hasDimensionlessSvg && imageWidth === undefined
 
   const imgStyle: CSSProperties = {}
 
@@ -229,7 +277,8 @@ function ImageList({
               shouldStretch={
                 shouldStretch ||
                 (svgNeedsFullWidth &&
-                  isSvgImage((iimage as ImageProto).url ?? ""))
+                  isSvgImage((iimage as ImageProto).url ?? "") &&
+                  !svgHasIntrinsicSize((iimage as ImageProto).url ?? ""))
               }
             />
           )

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -228,7 +228,8 @@ function ImageList({
               handleImageError={handleImageError}
               shouldStretch={
                 shouldStretch ||
-                (svgNeedsFullWidth && isSvgImage((iimage as ImageProto).url ?? ""))
+                (svgNeedsFullWidth &&
+                  isSvgImage((iimage as ImageProto).url ?? ""))
               }
             />
           )

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -47,11 +47,14 @@ const LOG = getLogger("ImageList")
  */
 export function isSvgImage(url: string): boolean {
   const lower = url.toLowerCase()
-  return (
-    lower.endsWith(".svg") ||
-    lower.includes("data:image/svg+xml") ||
-    lower.includes(".svg?")
-  )
+  if (lower.includes("data:image/svg+xml")) {
+    return true
+  }
+  // Strip query string and fragment before checking the extension so that
+  // patterns like ".svg?token=abc" or ".svg#icon" are handled correctly
+  // without false-positiving on URLs where ".svg?" appears mid-path.
+  const pathOnly = lower.split("?")[0].split("#")[0]
+  return pathOnly.endsWith(".svg")
 }
 
 /**
@@ -202,11 +205,15 @@ function ImageList({
   const shouldStretch = widthConfig?.useStretch ?? false
 
   // @see issue https://github.com/streamlit/streamlit/issues/9098
-  // When the image is an SVG and no explicit width is set (useContent mode),
-  // SVGs without intrinsic dimensions would render at 0x0 because the
-  // container collapses. Detect if any image is SVG so we can expand the
-  // container to full width in that case.
-  // Only apply full-width to SVGs that actually lack intrinsic dimensions.
+  // SVGs without intrinsic width/height attributes render at 0x0 in
+  // useContent mode because the container collapses to zero.
+  // To fix this, we detect dimensionless SVGs (those whose data URI lacks
+  // explicit width and height on the <svg> tag) and expand the outer list
+  // container to full width so the SVG has a rendering context.
+  // In mixed lists (SVG + non-SVG), the list container stretches to full
+  // width, but only the individual dimensionless-SVG containers get
+  // shouldStretch -- non-SVG images and SVGs with intrinsic sizes keep
+  // their natural width.
   const hasDimensionlessSvg = element.imgs.some(img => {
     const url = img.url ?? ""
     return isSvgImage(url) && !svgHasIntrinsicSize(url)

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -162,7 +162,7 @@ function ImageList({
   // SVGs without intrinsic dimensions would render at 0x0 because the
   // container collapses. Detect if any image is SVG so we can expand the
   // container to full width in that case.
-  const hasAnySvg = element.imgs.some((img) => isSvgImage(img.url))
+  const hasAnySvg = element.imgs.some(img => isSvgImage(img.url ?? ""))
   const svgNeedsFullWidth = hasAnySvg && imageWidth === undefined
 
   const imgStyle: CSSProperties = {}
@@ -228,7 +228,7 @@ function ImageList({
               handleImageError={handleImageError}
               shouldStretch={
                 shouldStretch ||
-                (svgNeedsFullWidth && isSvgImage((iimage as ImageProto).url))
+                (svgNeedsFullWidth && isSvgImage((iimage as ImageProto).url ?? ""))
               }
             />
           )

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -105,8 +105,9 @@ class ImageMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-            When using an SVG image without a default width, use ``"stretch"``
-            or an integer.
+            When using an SVG image without intrinsic dimensions,
+            ``"content"`` automatically uses the full container width to
+            prevent the image from rendering at 0x0.
         use_column_width : "auto", "always", "never", or bool
             If "auto", set the image's width to its natural size,
             but do not exceed the width of the column.


### PR DESCRIPTION
## Summary

Fixes #9098.

When an SVG without intrinsic `width`/`height` attributes is passed to `st.image()` without an explicit `width` parameter, it renders at 0x0 because the parent containers collapse (they use `fit-content`/`auto` sizing and SVGs provide no intrinsic dimensions to size from).

## Changes

**Frontend (`ImageList.tsx`):**
- Added `isSvgImage()` helper to detect SVG URLs (by extension or data URI)
- When the image is an SVG and no explicit width is set (`useContent` mode), the list and image containers expand to full width so the SVG renders properly
- Non-SVG images are completely unaffected by this change

**Python (`image.py`):**
- Updated the `width` parameter docstring to reflect the new SVG behavior instead of telling users to manually set `"stretch"` or an integer

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| SVG without intrinsic size, no width set | Renders at 0x0 | Takes full container width |
| SVG with intrinsic size, no width set | Works (unchanged) | Works (unchanged) |
| Non-SVG image, no width set | Uses natural size (unchanged) | Uses natural size (unchanged) |
| Any image with explicit width | Uses specified width (unchanged) | Uses specified width (unchanged) |

This matches the approach suggested by maintainers in #9098: make SVGs take full container width when `width` is not explicitly set.