### PR TITLE
[feat] Allow specifying number of visible items via `expanded` in `st.navigation`

### DIFF
--- a/e2e_playwright/st_navigation_expanded.py
+++ b/e2e_playwright/st_navigation_expanded.py
@@ -1,0 +1,79 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test app for st.navigation with expanded parameter."""
+
+import streamlit as st
+
+
+# Create 10 page functions
+def page_1():
+    st.header("Page 1")
+
+
+def page_2():
+    st.header("Page 2")
+
+
+def page_3():
+    st.header("Page 3")
+
+
+def page_4():
+    st.header("Page 4")
+
+
+def page_5():
+    st.header("Page 5")
+
+
+def page_6():
+    st.header("Page 6")
+
+
+def page_7():
+    st.header("Page 7")
+
+
+def page_8():
+    st.header("Page 8")
+
+
+def page_9():
+    st.header("Page 9")
+
+
+def page_10():
+    st.header("Page 10")
+
+
+pages = [
+    page_1,
+    page_2,
+    page_3,
+    page_4,
+    page_5,
+    page_6,
+    page_7,
+    page_8,
+    page_9,
+    page_10,
+]
+
+# Use expanded=3 to show only 3 pages initially
+# With 10 pages and expanded=3, the collapse threshold is 5 (3 + 2)
+# Since 10 > 5, this should show "View 7 more" button
+st.sidebar.write("Sidebar content")
+
+st.navigation(pages, expanded=3).run()

--- a/e2e_playwright/st_navigation_expanded_test.py
+++ b/e2e_playwright/st_navigation_expanded_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E tests for st.navigation with expanded parameter."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def test_expanded_int_shows_limited_pages_with_view_more_button(app: Page) -> None:
+    """Test that expanded=N shows N pages with 'View X more' button."""
+    # The app has 10 pages with expanded=3
+    # Should show only 3 pages initially
+    sidebar_nav_links = app.get_by_test_id("stSidebarNavLink")
+    expect(sidebar_nav_links).to_have_count(3)
+
+    # Should show "View 7 more" button (10 total - 3 shown = 7)
+    view_button = app.get_by_test_id("stSidebarNavViewButton")
+    expect(view_button).to_be_visible()
+    expect(view_button).to_contain_text("View 7 more")
+
+
+def test_expanded_int_view_button_expands_to_show_all_pages(app: Page) -> None:
+    """Test that clicking 'View X more' shows all pages."""
+    # Click the view button to expand
+    view_button = app.get_by_test_id("stSidebarNavViewButton")
+    view_button.click()
+
+    # Now all 10 pages should be visible
+    sidebar_nav_links = app.get_by_test_id("stSidebarNavLink")
+    expect(sidebar_nav_links).to_have_count(10)
+
+    # Button should now say "View less"
+    expect(view_button).to_contain_text("View less")
+
+
+def test_expanded_int_view_button_can_collapse_again(app: Page) -> None:
+    """Test that clicking 'View less' collapses back to N pages."""
+    view_button = app.get_by_test_id("stSidebarNavViewButton")
+
+    # Expand
+    view_button.click()
+    expect(app.get_by_test_id("stSidebarNavLink")).to_have_count(10)
+    expect(view_button).to_contain_text("View less")
+
+    # Collapse
+    view_button.click()
+    expect(app.get_by_test_id("stSidebarNavLink")).to_have_count(3)
+    expect(view_button).to_contain_text("View 7 more")

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -193,6 +193,7 @@ interface State {
   hideTopBar: boolean
   hideSidebarNav: boolean
   expandSidebarNav: boolean
+  sidebarNavVisibleItems?: number
   navigationPosition: Navigation.Position
   appPages: IAppPage[]
   navSections: string[]
@@ -2411,6 +2412,7 @@ export class App extends PureComponent<Props, State> {
       hideTopBar,
       hideSidebarNav,
       expandSidebarNav,
+      sidebarNavVisibleItems,
       currentPageScriptHash,
       hostHideSidebarNav,
       pageLinkBaseUrl,
@@ -2469,6 +2471,7 @@ export class App extends PureComponent<Props, State> {
         appLogo={elements.logo}
         sidebarChevronDownshift={sidebarChevronDownshift}
         expandSidebarNav={expandSidebarNav}
+        sidebarNavVisibleItems={sidebarNavVisibleItems}
         hideSidebarNav={
           hideSidebarNav ||
           hostHideSidebarNav ||

--- a/frontend/app/src/components/Navigation/SidebarNav.test.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.test.tsx
@@ -605,6 +605,94 @@ describe("SidebarNav", () => {
     expect(links[1]).toHaveStyle("background-color: rgba(151, 166, 195, 0.25)")
   })
 
+  describe("custom visibleItems via sidebarNavVisibleItems", () => {
+    it("shows custom number of pages when sidebarNavVisibleItems is set", () => {
+      // With 14 pages and sidebarNavVisibleItems=5, should show 5 pages
+      // and "View 9 more" button (collapse threshold = 5 + 2 = 7)
+      renderSidebarNav(
+        { hasSidebarElements: true },
+        {
+          sidebarConfigContext: { sidebarNavVisibleItems: 5 },
+          navigationContext: { appPages: generateAppPages(14) },
+        }
+      )
+
+      const navLinks = screen.getAllByTestId("stSidebarNavLink")
+      expect(navLinks).toHaveLength(5)
+      expect(screen.getByTestId("stSidebarNavViewButton")).toHaveTextContent(
+        "View 9 more"
+      )
+    })
+
+    it("does not show View more button when pages are below custom threshold", () => {
+      // With 6 pages and sidebarNavVisibleItems=5, threshold is 7
+      // So 6 pages should not show "View more" button
+      renderSidebarNav(
+        { hasSidebarElements: true },
+        {
+          sidebarConfigContext: { sidebarNavVisibleItems: 5 },
+          navigationContext: { appPages: generateAppPages(6) },
+        }
+      )
+
+      expect(
+        screen.queryByTestId("stSidebarNavViewButton")
+      ).not.toBeInTheDocument()
+      expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(6)
+    })
+
+    it("shows View more button when pages exceed custom threshold", () => {
+      // With 8 pages and sidebarNavVisibleItems=5, threshold is 7
+      // So 8 pages should show "View 3 more" button
+      renderSidebarNav(
+        { hasSidebarElements: true },
+        {
+          sidebarConfigContext: { sidebarNavVisibleItems: 5 },
+          navigationContext: { appPages: generateAppPages(8) },
+        }
+      )
+
+      expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(5)
+      expect(screen.getByTestId("stSidebarNavViewButton")).toHaveTextContent(
+        "View 3 more"
+      )
+    })
+
+    it("uses default behavior when sidebarNavVisibleItems is undefined", () => {
+      // sidebarNavVisibleItems=undefined should use default behavior (show 10, threshold 12)
+      renderSidebarNav(
+        { hasSidebarElements: true },
+        {
+          sidebarConfigContext: { sidebarNavVisibleItems: undefined },
+          navigationContext: { appPages: generateAppPages(14) },
+        }
+      )
+
+      const navLinks = screen.getAllByTestId("stSidebarNavLink")
+      expect(navLinks).toHaveLength(10)
+      expect(screen.getByTestId("stSidebarNavViewButton")).toHaveTextContent(
+        "View 4 more"
+      )
+    })
+
+    it("works correctly with large visibleItems value", () => {
+      // With 14 pages and sidebarNavVisibleItems=15, threshold is 17
+      // So 14 pages should not show "View more" button
+      renderSidebarNav(
+        { hasSidebarElements: true },
+        {
+          sidebarConfigContext: { sidebarNavVisibleItems: 15 },
+          navigationContext: { appPages: generateAppPages(14) },
+        }
+      )
+
+      expect(
+        screen.queryByTestId("stSidebarNavViewButton")
+      ).not.toBeInTheDocument()
+      expect(screen.getAllByTestId("stSidebarNavLink")).toHaveLength(14)
+    })
+  })
+
   describe("hidden pages", () => {
     it("does not render hidden pages in the navigation", () => {
       const appPages: IAppPage[] = [

--- a/frontend/app/src/components/Navigation/SidebarNav.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.tsx
@@ -34,7 +34,7 @@ import {
   SidebarConfigContext,
 } from "@streamlit/lib"
 import { IAppPage } from "@streamlit/protobuf"
-import { localStorageAvailable } from "@streamlit/utils"
+import { localStorageAvailable, notNullOrUndefined } from "@streamlit/utils"
 
 import NavSection from "./NavSection"
 import SidebarNavLink from "./SidebarNavLink"
@@ -58,9 +58,7 @@ export interface Props {
   widgetsDisabled: boolean
 }
 
-// We make the sidebar nav collapsible when there are more than 12 pages.
-const COLLAPSE_THRESHOLD = 12
-// However, we show the first 10 pages when the sidebar is collapsed.
+// Default number of pages to show when the sidebar is collapsed.
 const NUM_PAGES_TO_SHOW_WHEN_COLLAPSED = 10
 
 const LOG = getLogger("SidebarNav")
@@ -103,7 +101,8 @@ function generateNavSections(
   generateNavLink: (page: IAppPage, index: number) => ReactElement,
   expandedSections: Record<string, boolean>,
   toggleSection: (section: string) => void,
-  currentPageCount: number
+  currentPageCount: number,
+  numPagesToShowWhenCollapsed: number
 ): { sections: ReactNode[]; updatedPageCount: number } {
   const contents: ReactNode[] = []
   let pageCount = currentPageCount
@@ -116,7 +115,7 @@ function generateNavSections(
     const isExpanded = expandedSections[header]
 
     if (needsCollapse) {
-      const availableSlots = NUM_PAGES_TO_SHOW_WHEN_COLLAPSED - pageCount
+      const availableSlots = numPagesToShowWhenCollapsed - pageCount
       if (availableSlots <= 0) {
         viewablePages = []
       } else if (sectionPages.length > availableSlots) {
@@ -154,9 +153,19 @@ const SidebarNav = ({
   widgetsDisabled,
 }: Props): ReactElement | null => {
   const [expanded, setExpanded] = useState(false)
-  const { expandSidebarNav } = useContext(SidebarConfigContext)
+  const { expandSidebarNav, sidebarNavVisibleItems } = useContext(
+    SidebarConfigContext
+  )
   const { pageLinkBaseUrl, appPages, onPageChange, currentPageScriptHash } =
     useContext(NavigationContext)
+
+  // Use the value from context if provided, otherwise use the default
+  const numPagesToShowWhenCollapsed: number =
+    notNullOrUndefined(sidebarNavVisibleItems) && sidebarNavVisibleItems > 0
+      ? sidebarNavVisibleItems
+      : NUM_PAGES_TO_SHOW_WHEN_COLLAPSED
+  // The collapse threshold is numPagesToShowWhenCollapsed + 2
+  const collapseThreshold = numPagesToShowWhenCollapsed + 2
 
   const localStorageKey = `stSidebarSectionsState-${pageLinkBaseUrl}`
   const [expandedSections, setExpandedSections] = useState<Record<
@@ -205,40 +214,28 @@ const SidebarNav = ({
 
   // Loading the state of sections (expanded/collapsed) from localStorage:
   useEffect(() => {
+    let storedState: Record<string, boolean> = {}
     if (localStorageAvailable()) {
-      const storedState = window.localStorage.getItem(localStorageKey)
-      let initialState: Record<string, boolean> = {}
-      if (storedState) {
+      const stored = window.localStorage.getItem(localStorageKey)
+      if (stored) {
         try {
-          initialState = JSON.parse(storedState)
+          storedState = JSON.parse(stored)
         } catch (e) {
-          // The stored state is invalid, so we'll just use the default.
-          initialState = {}
           LOG.warn("Could not parse sidebar nav state from localStorage", e)
         }
       }
-
-      const allSections = Object.keys(navigationStructure.sections).reduce(
-        (acc, sectionName) => {
-          // Default to expanded
-          acc[sectionName] = initialState[sectionName] ?? true
-          return acc
-        },
-        {} as Record<string, boolean>
-      )
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- TODO: Do not set state in effect
-      setExpandedSections(allSections)
-    } else {
-      // If localStorage is not available, default to all expanded.
-      const allSections = Object.keys(navigationStructure.sections).reduce(
-        (acc, sectionName) => {
-          acc[sectionName] = true
-          return acc
-        },
-        {} as Record<string, boolean>
-      )
-      setExpandedSections(allSections)
     }
+
+    const allSections = Object.keys(navigationStructure.sections).reduce(
+      (acc, sectionName) => {
+        // Default to expanded if not in stored state
+        acc[sectionName] = storedState[sectionName] ?? true
+        return acc
+      },
+      {} as Record<string, boolean>
+    )
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- TODO: Do not set state in effect
+    setExpandedSections(allSections)
   }, [navigationStructure.sections, localStorageKey])
 
   // Store the current expanded sections state in localStorage:
@@ -316,7 +313,7 @@ const SidebarNav = ({
   const contents: ReactNode[] = []
   const shouldShowViewButton =
     hasSidebarElements &&
-    numVisiblePages > COLLAPSE_THRESHOLD &&
+    numVisiblePages > collapseThreshold &&
     !expandSidebarNav
   const needsCollapse = shouldShowViewButton && !expanded
 
@@ -326,7 +323,7 @@ const SidebarNav = ({
     const individualPages = needsCollapse
       ? navigationStructure.individualPages.slice(
           0,
-          NUM_PAGES_TO_SHOW_WHEN_COLLAPSED
+          numPagesToShowWhenCollapsed
         )
       : navigationStructure.individualPages
     contents.push(...individualPages.map(generateNavLink))
@@ -341,7 +338,8 @@ const SidebarNav = ({
       generateNavLink,
       expandedSections,
       toggleSection,
-      currentPageCount
+      currentPageCount,
+      numPagesToShowWhenCollapsed
     )
     contents.push(...result.sections)
   }
@@ -358,9 +356,7 @@ const SidebarNav = ({
         >
           {expanded
             ? "View less"
-            : `View ${
-                numVisiblePages - NUM_PAGES_TO_SHOW_WHEN_COLLAPSED
-              } more`}
+            : `View ${numVisiblePages - numPagesToShowWhenCollapsed} more`}
         </StyledViewButton>
       )}
       {hasSidebarElements && (

--- a/frontend/app/src/components/Navigation/SidebarNav.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.tsx
@@ -160,7 +160,7 @@ const SidebarNav = ({
     useContext(NavigationContext)
 
   // Use the value from context if provided, otherwise use the default
-  const numPagesToShowWhenCollapsed: number =
+  const numPagesToShowWhenCollapsed =
     notNullOrUndefined(sidebarNavVisibleItems) && sidebarNavVisibleItems > 0
       ? sidebarNavVisibleItems
       : NUM_PAGES_TO_SHOW_WHEN_COLLAPSED

--- a/frontend/app/src/components/Navigation/SidebarNav.tsx
+++ b/frontend/app/src/components/Navigation/SidebarNav.tsx
@@ -226,14 +226,13 @@ const SidebarNav = ({
       }
     }
 
-    const allSections = Object.keys(navigationStructure.sections).reduce(
-      (acc, sectionName) => {
-        // Default to expanded if not in stored state
-        acc[sectionName] = storedState[sectionName] ?? true
-        return acc
-      },
-      {} as Record<string, boolean>
-    )
+    const allSections = Object.keys(navigationStructure.sections).reduce<
+      Record<string, boolean>
+    >((acc, sectionName) => {
+      // Default to expanded if not in stored state
+      acc[sectionName] = storedState[sectionName] ?? true
+      return acc
+    }, {})
     // eslint-disable-next-line react-hooks/set-state-in-effect -- TODO: Do not set state in effect
     setExpandedSections(allSections)
   }, [navigationStructure.sections, localStorageKey])

--- a/frontend/app/src/components/StreamlitContextProvider.tsx
+++ b/frontend/app/src/components/StreamlitContextProvider.tsx
@@ -73,6 +73,7 @@ type SidebarConfigContextValues = {
   appLogo: Logo | null
   sidebarChevronDownshift: number
   expandSidebarNav: boolean
+  sidebarNavVisibleItems?: number
   hideSidebarNav: boolean
   appRootRef?: RefObject<HTMLDivElement> | null
 }
@@ -134,6 +135,7 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
   appLogo,
   sidebarChevronDownshift,
   expandSidebarNav,
+  sidebarNavVisibleItems,
   hideSidebarNav,
   appRootRef,
   // ThemeContext
@@ -177,6 +179,7 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       appLogo,
       sidebarChevronDownshift,
       expandSidebarNav,
+      sidebarNavVisibleItems,
       hideSidebarNav,
       appRootRef,
     }),
@@ -186,6 +189,7 @@ const StreamlitContextProvider: React.FC<StreamlitContextProviderProps> = ({
       appLogo,
       sidebarChevronDownshift,
       expandSidebarNav,
+      sidebarNavVisibleItems,
       hideSidebarNav,
       appRootRef,
     ]

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -330,6 +330,7 @@ describe("AppNavigation", () => {
       appPages,
       hideSidebarNav: true,
       expandSidebarNav: false,
+      sidebarNavVisibleItems: undefined,
       currentPageScriptHash: "page_script_hash",
       navSections: ["section1", "section2"],
     })
@@ -365,6 +366,7 @@ describe("AppNavigation", () => {
       appPages,
       hideSidebarNav: false,
       expandSidebarNav: true,
+      sidebarNavVisibleItems: undefined,
       currentPageScriptHash: "page_script_hash",
       navSections: ["section1", "section2"],
     })

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -372,6 +372,43 @@ describe("AppNavigation", () => {
     })
   })
 
+  it("sets sidebarNavVisibleItems when visibleItems is provided", () => {
+    const appPages = [
+      new AppPage({
+        pageName: "streamlit_app",
+        pageScriptHash: "page_script_hash",
+        isDefault: true,
+        sectionHeader: "section1",
+      }),
+      new AppPage({
+        pageName: "streamlit_app2",
+        pageScriptHash: "page_script_hash2",
+        isDefault: false,
+        sectionHeader: "section2",
+      }),
+    ]
+    const navigation = new Navigation({
+      sections: ["section1", "section2"],
+      appPages,
+      position: Navigation.Position.SIDEBAR,
+      pageScriptHash: "page_script_hash",
+      expanded: false,
+      visibleItems: 5,
+    })
+    const maybeState = appNavigation.handleNavigation(navigation)
+    expect(maybeState).not.toBeUndefined()
+
+    const [newState] = maybeState!
+    expect(newState).toEqual({
+      appPages,
+      hideSidebarNav: false,
+      expandSidebarNav: false,
+      sidebarNavVisibleItems: 5,
+      currentPageScriptHash: "page_script_hash",
+      navSections: ["section1", "section2"],
+    })
+  })
+
   it("calls host communication on navigation", () => {
     const appPages = [
       new AppPage({

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -24,6 +24,7 @@ import {
 
 interface AppNavigationState {
   expandSidebarNav: boolean
+  sidebarNavVisibleItems?: number
   hideSidebarNav: boolean
   appPages: IAppPage[]
   currentPageScriptHash: string
@@ -157,6 +158,7 @@ export class AppNavigation {
         navSections: sections,
         hideSidebarNav: this.hideSidebarNav,
         expandSidebarNav: navigationMsg.expanded,
+        sidebarNavVisibleItems: navigationMsg.visibleItems ?? undefined,
         currentPageScriptHash,
       },
       () => {

--- a/frontend/lib/src/components/core/SidebarConfigContext.tsx
+++ b/frontend/lib/src/components/core/SidebarConfigContext.tsx
@@ -65,6 +65,16 @@ export interface SidebarConfigContextProps {
   expandSidebarNav: boolean
 
   /**
+   * Maximum number of pages to display when the sidebar nav is collapsed.
+   * When undefined, uses the default (10 pages).
+   * When a positive number, shows that many pages before "View X more".
+   *
+   * Consumed by: SidebarNav
+   * @see SidebarNav
+   */
+  sidebarNavVisibleItems?: number
+
+  /**
    * Whether to hide the sidebar navigation menu entirely.
    * When true, sidebar nav is not rendered even if multiple pages exist.
    *

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -393,17 +393,34 @@ def _navigation(
         else:
             msg.navigation.position = NavigationProto.Position.SIDEBAR
 
-    # Handle expanded parameter: bool or int
-    if expanded is True:
-        msg.navigation.expanded = True
-        # Don't set visible_items - leave it unset to use default
-    elif isinstance(expanded, int) and expanded > 0:
-        msg.navigation.expanded = False
-        msg.navigation.visible_items = expanded
+    # Handle expanded parameter: must be bool or non-negative int
+    if isinstance(expanded, bool):
+        if expanded:
+            msg.navigation.expanded = True
+            # Don't set visible_items - leave it unset to use default
+        else:
+            # expanded is False - use default collapsed behavior
+            msg.navigation.expanded = False
+            # Don't set visible_items - leave it unset to use default
+    elif isinstance(expanded, int):
+        if expanded < 0:
+            raise StreamlitAPIException(
+                f"Invalid value for expanded: {expanded!r}. "
+                "When using an int, expanded must be a non-negative integer."
+            )
+        if expanded == 0:
+            # Documented default behavior: collapsed, default visible_items
+            msg.navigation.expanded = False
+            # Don't set visible_items - leave it unset to use default
+        else:
+            # Positive int: collapsed with a limited number of visible items
+            msg.navigation.expanded = False
+            msg.navigation.visible_items = expanded
     else:
-        # expanded is False or invalid - use defaults
-        msg.navigation.expanded = False
-        # Don't set visible_items - leave it unset to use default
+        raise StreamlitAPIException(
+            f"Invalid type for expanded: {type(expanded).__name__!s}. "
+            "expanded must be a bool or a non-negative integer."
+        )
 
     msg.navigation.sections[:] = nav_sections.keys()
     for section_header in nav_sections:

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -82,7 +82,7 @@ def navigation(
     pages: Sequence[PageType] | Mapping[SectionHeader, Sequence[PageType]],
     *,
     position: Literal["sidebar", "hidden", "top"] = "sidebar",
-    expanded: bool = False,
+    expanded: bool | int = False,
 ) -> StreamlitPage:
     """
     Configure the available pages in a multipage app.
@@ -138,12 +138,19 @@ def navigation(
         If there is only one page in ``pages``, the navigation will be hidden
         for any value of ``position``.
 
-    expanded : bool
-        Whether the navigation menu should be expanded. If this is ``False``
-        (default), the navigation menu will be collapsed and will include a
-        button to view more options when there are too many pages to display.
-        If this is ``True``, the navigation menu will always be expanded; no
-        button to collapse the menu will be displayed.
+    expanded : bool or int
+        Controls whether the navigation menu is expanded and how many items
+        are visible when collapsed.
+
+        If this is ``False`` (default), the navigation menu will be collapsed
+        when there are more than 12 pages, showing only the first 10 pages
+        with a "View X more" button. If this is ``True``, the navigation menu
+        will always be fully expanded; no collapse button will be displayed.
+
+        If this is a positive integer, it specifies the maximum number of
+        pages to display when collapsed. For example, ``expanded=5`` shows
+        only the first 5 pages with a "View X more" button when there are
+        more than 7 pages.
 
         If ``st.navigation`` changes from ``expanded=True`` to
         ``expanded=False`` on a rerun, the menu will stay expanded and a
@@ -308,7 +315,7 @@ def _navigation(
     pages: Sequence[PageType] | Mapping[SectionHeader, Sequence[PageType]],
     *,
     position: Literal["sidebar", "hidden", "top"],
-    expanded: bool,
+    expanded: bool | int,
 ) -> StreamlitPage:
     if isinstance(pages, Sequence):
         converted_pages = [convert_to_streamlit_page(p) for p in pages]
@@ -386,7 +393,18 @@ def _navigation(
         else:
             msg.navigation.position = NavigationProto.Position.SIDEBAR
 
-    msg.navigation.expanded = expanded
+    # Handle expanded parameter: bool or int
+    if expanded is True:
+        msg.navigation.expanded = True
+        # Don't set visible_items - leave it unset to use default
+    elif isinstance(expanded, int) and expanded > 0:
+        msg.navigation.expanded = False
+        msg.navigation.visible_items = expanded
+    else:
+        # expanded is False or invalid - use defaults
+        msg.navigation.expanded = False
+        # Don't set visible_items - leave it unset to use default
+
     msg.navigation.sections[:] = nav_sections.keys()
     for section_header in nav_sections:
         for page in nav_sections[section_header]:

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -213,6 +213,24 @@ class NavigationTest(DeltaGeneratorTestCase):
         assert not c.HasField("visible_items")
         assert c.sections == [""]
 
+    def test_navigation_message_with_expanded_negative_raises(self):
+        """Test that negative expanded values raise an error."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.navigation(
+                [st.Page("page1.py"), st.Page("page2.py")],
+                expanded=-1,
+            )
+        assert "must be a non-negative integer" in str(exc.value)
+
+    def test_navigation_message_with_expanded_invalid_type_raises(self):
+        """Test that invalid expanded type raises an error."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.navigation(
+                [st.Page("page1.py"), st.Page("page2.py")],
+                expanded="invalid",  # type: ignore[arg-type]
+            )
+        assert "must be a bool or a non-negative integer" in str(exc.value)
+
     def test_convert_to_streamlit_page_with_string(self):
         """Test converting string path to StreamlitPage"""
         page = convert_to_streamlit_page("page1.py")

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -184,6 +184,33 @@ class NavigationTest(DeltaGeneratorTestCase):
         assert not c.app_pages[2].is_default
         assert c.position == NavigationProto.Position.SIDEBAR
         assert c.expanded
+        assert not c.HasField("visible_items")
+        assert c.sections == [""]
+
+    def test_navigation_message_with_expanded_int(self):
+        """Test that expanded with an integer sets visible_items correctly"""
+        st.navigation(
+            [st.Page("page1.py"), st.Page("page2.py"), st.Page("page3.py")],
+            expanded=5,
+        )
+        c = self.get_message_from_queue().navigation
+        assert len(c.app_pages) == 3
+        assert c.position == NavigationProto.Position.SIDEBAR
+        assert not c.expanded
+        assert c.visible_items == 5
+        assert c.sections == [""]
+
+    def test_navigation_message_with_expanded_zero(self):
+        """Test that expanded=0 behaves like expanded=False (use defaults)"""
+        st.navigation(
+            [st.Page("page1.py"), st.Page("page2.py"), st.Page("page3.py")],
+            expanded=0,
+        )
+        c = self.get_message_from_queue().navigation
+        assert len(c.app_pages) == 3
+        assert c.position == NavigationProto.Position.SIDEBAR
+        assert not c.expanded
+        assert not c.HasField("visible_items")
         assert c.sections == [""]
 
     def test_convert_to_streamlit_page_with_string(self):

--- a/lib/tests/streamlit/typing/navigation_types.py
+++ b/lib/tests/streamlit/typing/navigation_types.py
@@ -72,6 +72,9 @@ if TYPE_CHECKING:
     assert_type(
         navigation(["page1.py"], position="hidden", expanded=False), StreamlitPage
     )
+    # Test expanded with integer values
+    assert_type(navigation(["page1.py"], expanded=5), StreamlitPage)
+    assert_type(navigation(["page1.py"], expanded=0), StreamlitPage)
 
     # Test Page with visibility parameter
     visible_page = Page("page.py", visibility="visible")

--- a/proto/streamlit/proto/Navigation.proto
+++ b/proto/streamlit/proto/Navigation.proto
@@ -28,6 +28,11 @@ message Navigation {
 
   bool expanded = 5;
 
+  // Maximum number of pages to display when the navigation is collapsed.
+  // When not set, uses the default (10 pages).
+  // When set to a positive value, shows that many pages before "View X more".
+  optional uint32 visible_items = 6;
+
   // Position of the Navigation
   enum Position {
     // do not display the navigation


### PR DESCRIPTION
## Describe your changes

- Add support for passing a positive integer to the expanded parameter in st.navigation() to specify exactly how many navigation items should be visible when the sidebar is collapsed
- expanded=True shows all pages, expanded=False/expanded=0 uses the default collapse threshold, and expanded=N (positive int) shows exactly N items
- Add visible_items field to Navigation protobuf and sidebarNavVisibleItems to frontend context

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/9646

## Testing Plan

- [x] Unit Tests (JS and/or Python)