### PR TITLE
[feat] Add st.breadcrumbs widget for navigation paths

### DIFF
--- a/e2e_playwright/st_breadcrumbs.py
+++ b/e2e_playwright/st_breadcrumbs.py
@@ -63,3 +63,18 @@ if clicked_objects:
     st.write(f"Navigate to: {clicked_objects['path']}")
 else:
     st.write("Objects clicked: None")
+
+st.header("Custom Text Separator")
+clicked_text_sep = st.breadcrumbs(
+    ["Home", "Section", "Page"],
+    separator=" > ",
+    key="text_separator",
+)
+st.write(f"Text separator clicked: {clicked_text_sep}")
+
+st.header("Material Icon Separator")
+clicked_icon_sep = st.breadcrumbs(
+    ["Home", "Section", "Page"],
+    separator=":material/chevron_right:",
+    key="icon_separator",
+)

--- a/e2e_playwright/st_breadcrumbs.py
+++ b/e2e_playwright/st_breadcrumbs.py
@@ -1,0 +1,65 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+
+import streamlit as st
+
+st.header("Basic Breadcrumbs")
+clicked_basic = st.breadcrumbs(
+    ["Home", "Electronics", "Phones", "iPhone 15"], key="basic"
+)
+st.write(f"Basic clicked: {clicked_basic}")
+
+st.header("With Icons")
+clicked_icons = st.breadcrumbs(
+    ["home", "folder", "settings"],
+    format_func=lambda x: f":material/{x}: {x.title()}",
+    key="icons",
+)
+st.write(f"Icons clicked: {clicked_icons}")
+
+st.header("Disabled")
+clicked_disabled = st.breadcrumbs(
+    ["Home", "Products", "Details"],
+    disabled=True,
+    key="disabled",
+)
+st.write(f"Disabled clicked: {clicked_disabled}")
+
+st.header("Single Item")
+clicked_single = st.breadcrumbs(["Home"], key="single")
+st.write(f"Single clicked: {clicked_single}")
+
+st.header("With Help")
+clicked_help = st.breadcrumbs(
+    ["Home", "Settings", "Profile"],
+    help="Click on a breadcrumb to navigate back",
+    key="help",
+)
+st.write(f"Help clicked: {clicked_help}")
+
+st.header("Custom Objects")
+pages = [
+    {"id": "home", "title": "Home", "path": "home.py"},
+    {"id": "users", "title": "Users", "path": "users.py"},
+    {"id": "detail", "title": "User Detail", "path": "detail.py"},
+]
+clicked_objects = st.breadcrumbs(
+    pages, format_func=operator.itemgetter("title"), key="objects"
+)
+if clicked_objects:
+    st.write(f"Navigate to: {clicked_objects['path']}")
+else:
+    st.write("Objects clicked: None")

--- a/e2e_playwright/st_breadcrumbs.py
+++ b/e2e_playwright/st_breadcrumbs.py
@@ -79,3 +79,31 @@ clicked_icon_sep = st.breadcrumbs(
     key="icon_separator",
 )
 st.write(f"Icon separator clicked: {clicked_icon_sep}")
+
+st.header("Auto-truncate on Selection")
+# Initialize breadcrumb path in session state
+if "breadcrumb_path" not in st.session_state:
+    st.session_state.breadcrumb_path = ["Home", "Electronics", "Phones", "iPhone 15"]
+
+
+def on_breadcrumb_click():
+    """Truncate path to selected item when clicked."""
+    clicked = st.session_state.truncate_breadcrumbs
+    if clicked is not None:
+        # Find index of clicked item and truncate
+        try:
+            idx = st.session_state.breadcrumb_path.index(clicked)
+            st.session_state.breadcrumb_path = st.session_state.breadcrumb_path[
+                : idx + 1
+            ]
+        except ValueError:
+            pass
+
+
+clicked_truncate = st.breadcrumbs(
+    st.session_state.breadcrumb_path,
+    key="truncate_breadcrumbs",
+    on_click=on_breadcrumb_click,
+)
+st.write(f"Truncate path: {st.session_state.breadcrumb_path}")
+st.write(f"Truncate clicked: {clicked_truncate}")

--- a/e2e_playwright/st_breadcrumbs.py
+++ b/e2e_playwright/st_breadcrumbs.py
@@ -17,38 +17,38 @@ import operator
 import streamlit as st
 
 st.header("Basic Breadcrumbs")
-clicked_basic = st.breadcrumbs(
+selected_basic = st.breadcrumbs(
     ["Home", "Electronics", "Phones", "iPhone 15"], key="basic"
 )
-st.write(f"Basic clicked: {clicked_basic}")
+st.write(f"Basic selected: {selected_basic}")
 
 st.header("With Icons")
-clicked_icons = st.breadcrumbs(
+selected_icons = st.breadcrumbs(
     ["home", "folder", "settings"],
     format_func=lambda x: f":material/{x}: {x.title()}",
     key="icons",
 )
-st.write(f"Icons clicked: {clicked_icons}")
+st.write(f"Icons selected: {selected_icons}")
 
 st.header("Disabled")
-clicked_disabled = st.breadcrumbs(
+selected_disabled = st.breadcrumbs(
     ["Home", "Products", "Details"],
     disabled=True,
     key="disabled",
 )
-st.write(f"Disabled clicked: {clicked_disabled}")
+st.write(f"Disabled selected: {selected_disabled}")
 
 st.header("Single Item")
-clicked_single = st.breadcrumbs(["Home"], key="single")
-st.write(f"Single clicked: {clicked_single}")
+selected_single = st.breadcrumbs(["Home"], key="single")
+st.write(f"Single selected: {selected_single}")
 
 st.header("With Help")
-clicked_help = st.breadcrumbs(
+selected_help = st.breadcrumbs(
     ["Home", "Settings", "Profile"],
     help="Click on a breadcrumb to navigate back",
     key="help",
 )
-st.write(f"Help clicked: {clicked_help}")
+st.write(f"Help selected: {selected_help}")
 
 st.header("Custom Objects")
 pages = [
@@ -56,29 +56,44 @@ pages = [
     {"id": "users", "title": "Users", "path": "users.py"},
     {"id": "detail", "title": "User Detail", "path": "detail.py"},
 ]
-clicked_objects = st.breadcrumbs(
+selected_objects = st.breadcrumbs(
     pages, format_func=operator.itemgetter("title"), key="objects"
 )
-if clicked_objects:
-    st.write(f"Navigate to: {clicked_objects['path']}")
-else:
-    st.write("Objects clicked: None")
+# For custom objects, show the currently selected item's path
+st.write(f"Navigate to: {selected_objects['path']}")
 
 st.header("Custom Text Separator")
-clicked_text_sep = st.breadcrumbs(
+selected_text_sep = st.breadcrumbs(
     ["Home", "Section", "Page"],
     separator=" > ",
     key="text_separator",
 )
-st.write(f"Text separator clicked: {clicked_text_sep}")
+st.write(f"Text separator selected: {selected_text_sep}")
 
 st.header("Material Icon Separator")
-clicked_icon_sep = st.breadcrumbs(
+selected_icon_sep = st.breadcrumbs(
     ["Home", "Section", "Page"],
     separator=":material/chevron_right:",
     key="icon_separator",
 )
-st.write(f"Icon separator clicked: {clicked_icon_sep}")
+st.write(f"Icon separator selected: {selected_icon_sep}")
+
+st.header("Selection Parameter")
+# Test explicit selection by value
+selected_by_value = st.breadcrumbs(
+    ["Home", "Electronics", "Phones", "iPhone 15"],
+    selection="Electronics",
+    key="selection_by_value",
+)
+st.write(f"Selection by value: {selected_by_value}")
+
+# Test explicit selection by index
+selected_by_index = st.breadcrumbs(
+    ["Home", "Electronics", "Phones", "iPhone 15"],
+    selection=0,
+    key="selection_by_index",
+)
+st.write(f"Selection by index: {selected_by_index}")
 
 st.header("Auto-truncate on Selection")
 # Initialize breadcrumb path in session state
@@ -86,13 +101,13 @@ if "breadcrumb_path" not in st.session_state:
     st.session_state.breadcrumb_path = ["Home", "Electronics", "Phones", "iPhone 15"]
 
 
-def on_breadcrumb_click():
-    """Truncate path to selected item when clicked."""
-    clicked = st.session_state.truncate_breadcrumbs
-    if clicked is not None:
-        # Find index of clicked item and truncate
+def on_breadcrumb_change():
+    """Truncate path to selected item when changed."""
+    selected = st.session_state.truncate_breadcrumbs
+    if selected is not None:
+        # Find index of selected item and truncate
         try:
-            idx = st.session_state.breadcrumb_path.index(clicked)
+            idx = st.session_state.breadcrumb_path.index(selected)
             st.session_state.breadcrumb_path = st.session_state.breadcrumb_path[
                 : idx + 1
             ]
@@ -100,10 +115,10 @@ def on_breadcrumb_click():
             pass
 
 
-clicked_truncate = st.breadcrumbs(
+selected_truncate = st.breadcrumbs(
     st.session_state.breadcrumb_path,
     key="truncate_breadcrumbs",
-    on_click=on_breadcrumb_click,
+    on_change=on_breadcrumb_change,
 )
 st.write(f"Truncate path: {st.session_state.breadcrumb_path}")
-st.write(f"Truncate clicked: {clicked_truncate}")
+st.write(f"Truncate selected: {selected_truncate}")

--- a/e2e_playwright/st_breadcrumbs.py
+++ b/e2e_playwright/st_breadcrumbs.py
@@ -78,3 +78,4 @@ clicked_icon_sep = st.breadcrumbs(
     separator=":material/chevron_right:",
     key="icon_separator",
 )
+st.write(f"Icon separator clicked: {clicked_icon_sep}")

--- a/e2e_playwright/st_breadcrumbs_test.py
+++ b/e2e_playwright/st_breadcrumbs_test.py
@@ -18,8 +18,8 @@ from e2e_playwright.conftest import wait_for_app_run
 from e2e_playwright.shared.app_utils import expect_markdown, get_element_by_key
 
 
-def test_basic_breadcrumbs_display_and_click(app: Page) -> None:
-    """Test breadcrumbs display, initial state, and click interactions."""
+def test_basic_breadcrumbs_display_and_selection(app: Page) -> None:
+    """Test breadcrumbs display, initial state (last item selected), and selection interactions."""
     breadcrumbs = get_element_by_key(app, "basic")
 
     # Verify all items are visible
@@ -28,8 +28,8 @@ def test_basic_breadcrumbs_display_and_click(app: Page) -> None:
     expect(breadcrumbs.get_by_text("Phones")).to_be_visible()
     expect(breadcrumbs.get_by_text("iPhone 15")).to_be_visible()
 
-    # Verify initial state is None
-    expect_markdown(app, "Basic clicked: None")
+    # Verify initial state is last item selected (stateful widget)
+    expect_markdown(app, "Basic selected: iPhone 15")
 
     # Verify last item is not clickable (only 3 buttons for 4 items)
     buttons = breadcrumbs.get_by_role("button")
@@ -38,14 +38,14 @@ def test_basic_breadcrumbs_display_and_click(app: Page) -> None:
     # Click middle item
     breadcrumbs.get_by_role("button", name="Electronics").click()
     wait_for_app_run(app)
-    expect_markdown(app, "Basic clicked: Electronics")
+    expect_markdown(app, "Basic selected: Electronics")
 
 
 def test_selected_item_becomes_non_clickable(app: Page) -> None:
-    """Test that clicking a breadcrumb makes it selected and non-clickable."""
+    """Test that selecting a breadcrumb makes it non-clickable, others become clickable."""
     breadcrumbs = get_element_by_key(app, "basic")
 
-    # Initially: 3 buttons (Home, Electronics, Phones) - last item not clickable
+    # Initially: 3 buttons (Home, Electronics, Phones) - last item is selected
     buttons = breadcrumbs.get_by_role("button")
     expect(buttons).to_have_count(3)
 
@@ -69,7 +69,7 @@ def test_selected_item_becomes_non_clickable(app: Page) -> None:
     # Click "Phones" (now a clickable item after selection changed)
     breadcrumbs.get_by_role("button", name="Phones").click()
     wait_for_app_run(app)
-    expect_markdown(app, "Basic clicked: Phones")
+    expect_markdown(app, "Basic selected: Phones")
 
     # Now "Phones" is selected - Home and Electronics should be clickable
     expect(breadcrumbs.get_by_role("button", name="Home")).to_be_visible()
@@ -86,8 +86,8 @@ def test_disabled_breadcrumbs(app: Page) -> None:
     buttons = breadcrumbs.get_by_role("button")
     expect(buttons).to_have_count(0)
 
-    # The displayed selection text must remain unchanged
-    expect_markdown(app, "Disabled clicked: None")
+    # Even disabled, initial selection should be last item (stateful)
+    expect_markdown(app, "Disabled selected: Details")
 
 
 def test_single_item_breadcrumbs(app: Page) -> None:
@@ -112,6 +112,9 @@ def test_breadcrumbs_with_icons(app: Page) -> None:
 def test_custom_objects(app: Page) -> None:
     """Test breadcrumbs with custom objects and format_func returns object values."""
     breadcrumbs = get_element_by_key(app, "objects")
+
+    # Initially last item is selected
+    expect_markdown(app, "Navigate to: detail.py")
 
     breadcrumbs.get_by_role("button", name="Users").click()
     wait_for_app_run(app)
@@ -182,3 +185,35 @@ def test_auto_truncate_on_selection(app: Page) -> None:
     # Only Home should be visible
     expect(breadcrumbs.get_by_text("Home")).to_be_visible()
     expect(breadcrumbs.get_by_text("Electronics")).to_have_count(0)
+
+
+def test_selection_parameter_by_value(app: Page) -> None:
+    """Test breadcrumbs with selection parameter set by item value."""
+    breadcrumbs = get_element_by_key(app, "selection_by_value")
+
+    # Verify "Electronics" is selected (not clickable)
+    expect(breadcrumbs.get_by_role("button", name="Electronics")).to_have_count(0)
+
+    # Verify other items are clickable
+    expect(breadcrumbs.get_by_role("button", name="Home")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="Phones")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="iPhone 15")).to_be_visible()
+
+    # Verify selection value
+    expect_markdown(app, "Selection by value: Electronics")
+
+
+def test_selection_parameter_by_index(app: Page) -> None:
+    """Test breadcrumbs with selection parameter set by index."""
+    breadcrumbs = get_element_by_key(app, "selection_by_index")
+
+    # Verify "Home" (index 0) is selected (not clickable)
+    expect(breadcrumbs.get_by_role("button", name="Home")).to_have_count(0)
+
+    # Verify other items are clickable
+    expect(breadcrumbs.get_by_role("button", name="Electronics")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="Phones")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="iPhone 15")).to_be_visible()
+
+    # Verify selection value
+    expect_markdown(app, "Selection by index: Home")

--- a/e2e_playwright/st_breadcrumbs_test.py
+++ b/e2e_playwright/st_breadcrumbs_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import expect_markdown, get_element_by_key
+
+
+def test_basic_breadcrumbs_display_and_click(app: Page) -> None:
+    """Test breadcrumbs display, initial state, and click interactions."""
+    breadcrumbs = get_element_by_key(app, "basic")
+
+    # Verify all items are visible
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Electronics")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Phones")).to_be_visible()
+    expect(breadcrumbs.get_by_text("iPhone 15")).to_be_visible()
+
+    # Verify initial state is None
+    expect_markdown(app, "Basic clicked: None")
+
+    # Verify last item is not clickable (only 3 buttons for 4 items)
+    buttons = breadcrumbs.get_by_role("button")
+    expect(buttons).to_have_count(3)
+
+    # Click first item
+    breadcrumbs.get_by_role("button", name="Home").click()
+    wait_for_app_run(app)
+    expect_markdown(app, "Basic clicked: Home")
+
+    # Click middle item
+    breadcrumbs.get_by_role("button", name="Electronics").click()
+    wait_for_app_run(app)
+    expect_markdown(app, "Basic clicked: Electronics")
+
+
+def test_disabled_breadcrumbs(app: Page) -> None:
+    """Test that disabled breadcrumbs do not respond to clicks."""
+    breadcrumbs = get_element_by_key(app, "disabled")
+
+    home_button = breadcrumbs.get_by_role("button", name="Home")
+    home_button.click(force=True)
+    wait_for_app_run(app)
+
+    expect_markdown(app, "Disabled clicked: None")
+
+
+def test_single_item_breadcrumbs(app: Page) -> None:
+    """Test breadcrumbs with a single item has no clickable buttons."""
+    breadcrumbs = get_element_by_key(app, "single")
+
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+
+    buttons = breadcrumbs.get_by_role("button")
+    expect(buttons).to_have_count(0)
+
+
+def test_breadcrumbs_with_icons(app: Page) -> None:
+    """Test breadcrumbs with material icons display correctly."""
+    breadcrumbs = get_element_by_key(app, "icons")
+
+    expect(breadcrumbs.locator("span").filter(has_text="Home").last).to_be_visible()
+    expect(breadcrumbs.locator("span").filter(has_text="Folder").last).to_be_visible()
+    expect(breadcrumbs.locator("span").filter(has_text="Settings").last).to_be_visible()
+
+
+def test_custom_objects(app: Page) -> None:
+    """Test breadcrumbs with custom objects and format_func returns object values."""
+    breadcrumbs = get_element_by_key(app, "objects")
+
+    breadcrumbs.get_by_role("button", name="Users").click()
+    wait_for_app_run(app)
+
+    expect_markdown(app, "Navigate to: users.py")

--- a/e2e_playwright/st_breadcrumbs_test.py
+++ b/e2e_playwright/st_breadcrumbs_test.py
@@ -84,3 +84,29 @@ def test_custom_objects(app: Page) -> None:
     wait_for_app_run(app)
 
     expect_markdown(app, "Navigate to: users.py")
+
+
+def test_custom_text_separator(app: Page) -> None:
+    """Test breadcrumbs with custom text separator."""
+    breadcrumbs = get_element_by_key(app, "text_separator")
+
+    # Verify items are visible
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Section")).to_be_visible()
+
+    # Verify custom separator " > " is displayed
+    expect(breadcrumbs.get_by_text(" > ").first).to_be_visible()
+
+
+def test_material_icon_separator(app: Page) -> None:
+    """Test breadcrumbs with material icon separator."""
+    breadcrumbs = get_element_by_key(app, "icon_separator")
+
+    # Verify items are visible
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Section")).to_be_visible()
+
+    # Verify material icon separator is rendered (chevron_right icon)
+    # The icon should be in the separator element
+    separators = breadcrumbs.locator('[aria-hidden="true"]')
+    expect(separators.first).to_be_visible()

--- a/e2e_playwright/st_breadcrumbs_test.py
+++ b/e2e_playwright/st_breadcrumbs_test.py
@@ -79,13 +79,14 @@ def test_selected_item_becomes_non_clickable(app: Page) -> None:
 
 
 def test_disabled_breadcrumbs(app: Page) -> None:
-    """Test that disabled breadcrumbs do not respond to clicks."""
+    """Test that disabled breadcrumbs render as plain text and are non-interactive."""
     breadcrumbs = get_element_by_key(app, "disabled")
 
-    home_button = breadcrumbs.get_by_role("button", name="Home")
-    home_button.click(force=True)
-    wait_for_app_run(app)
+    # Disabled breadcrumbs should not render any clickable buttons
+    buttons = breadcrumbs.get_by_role("button")
+    expect(buttons).to_have_count(0)
 
+    # The displayed selection text must remain unchanged
     expect_markdown(app, "Disabled clicked: None")
 
 

--- a/e2e_playwright/st_breadcrumbs_test.py
+++ b/e2e_playwright/st_breadcrumbs_test.py
@@ -35,15 +35,47 @@ def test_basic_breadcrumbs_display_and_click(app: Page) -> None:
     buttons = breadcrumbs.get_by_role("button")
     expect(buttons).to_have_count(3)
 
-    # Click first item
-    breadcrumbs.get_by_role("button", name="Home").click()
-    wait_for_app_run(app)
-    expect_markdown(app, "Basic clicked: Home")
-
     # Click middle item
     breadcrumbs.get_by_role("button", name="Electronics").click()
     wait_for_app_run(app)
     expect_markdown(app, "Basic clicked: Electronics")
+
+
+def test_selected_item_becomes_non_clickable(app: Page) -> None:
+    """Test that clicking a breadcrumb makes it selected and non-clickable."""
+    breadcrumbs = get_element_by_key(app, "basic")
+
+    # Initially: 3 buttons (Home, Electronics, Phones) - last item not clickable
+    buttons = breadcrumbs.get_by_role("button")
+    expect(buttons).to_have_count(3)
+
+    # Click "Home" (first item)
+    breadcrumbs.get_by_role("button", name="Home").click()
+    wait_for_app_run(app)
+
+    # Now "Home" is selected and non-clickable
+    # Items after it (Electronics, Phones, iPhone 15) should be clickable
+    buttons = breadcrumbs.get_by_role("button")
+    expect(buttons).to_have_count(3)
+
+    # Verify "Home" is no longer a button
+    expect(breadcrumbs.get_by_role("button", name="Home")).to_have_count(0)
+
+    # Verify items after "Home" are now clickable
+    expect(breadcrumbs.get_by_role("button", name="Electronics")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="Phones")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="iPhone 15")).to_be_visible()
+
+    # Click "Phones" (now a clickable item after selection changed)
+    breadcrumbs.get_by_role("button", name="Phones").click()
+    wait_for_app_run(app)
+    expect_markdown(app, "Basic clicked: Phones")
+
+    # Now "Phones" is selected - Home and Electronics should be clickable
+    expect(breadcrumbs.get_by_role("button", name="Home")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="Electronics")).to_be_visible()
+    expect(breadcrumbs.get_by_role("button", name="Phones")).to_have_count(0)
+    expect(breadcrumbs.get_by_role("button", name="iPhone 15")).to_be_visible()
 
 
 def test_disabled_breadcrumbs(app: Page) -> None:
@@ -110,3 +142,42 @@ def test_material_icon_separator(app: Page) -> None:
     # The icon should be in the separator element
     separators = breadcrumbs.locator('[aria-hidden="true"]')
     expect(separators.first).to_be_visible()
+
+
+def test_auto_truncate_on_selection(app: Page) -> None:
+    """Test breadcrumbs that auto-truncate path when an item is clicked."""
+    breadcrumbs = get_element_by_key(app, "truncate_breadcrumbs")
+
+    # Initially all 4 items visible
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Electronics")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Phones")).to_be_visible()
+    expect(breadcrumbs.get_by_text("iPhone 15")).to_be_visible()
+
+    # Verify initial path
+    expect_markdown(
+        app, "Truncate path: ['Home', 'Electronics', 'Phones', 'iPhone 15']"
+    )
+
+    # Click "Electronics" - should truncate to ["Home", "Electronics"]
+    breadcrumbs.get_by_role("button", name="Electronics").click()
+    wait_for_app_run(app)
+
+    # Path should be truncated
+    expect_markdown(app, "Truncate path: ['Home', 'Electronics']")
+
+    # Only Home and Electronics should be visible now
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Electronics")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Phones")).to_have_count(0)
+    expect(breadcrumbs.get_by_text("iPhone 15")).to_have_count(0)
+
+    # Click "Home" - should truncate to ["Home"]
+    breadcrumbs.get_by_role("button", name="Home").click()
+    wait_for_app_run(app)
+
+    expect_markdown(app, "Truncate path: ['Home']")
+
+    # Only Home should be visible
+    expect(breadcrumbs.get_by_text("Home")).to_be_visible()
+    expect(breadcrumbs.get_by_text("Electronics")).to_have_count(0)

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -21,6 +21,7 @@ import {
   AudioInput as AudioInputProto,
   Audio as AudioProto,
   BidiComponent as BidiComponentProto,
+  Breadcrumbs as BreadcrumbsProto,
   ButtonGroup as ButtonGroupProto,
   Button as ButtonProto,
   CameraInput as CameraInputProto,
@@ -128,6 +129,7 @@ const Video = lazy(() => import("~lib/components/elements/Video"))
 const AudioInput = lazy(() => import("~lib/components/widgets/AudioInput"))
 const ArrowDataFrame = lazy(() => import("~lib/components/widgets/DataFrame"))
 const Button = lazy(() => import("~lib/components/widgets/Button"))
+const Breadcrumbs = lazy(() => import("~lib/components/widgets/Breadcrumbs"))
 const ButtonGroup = lazy(() => import("~lib/components/widgets/ButtonGroup"))
 const ComponentInstance = lazy(() =>
   import("~lib/components/widgets/CustomComponent").then(module => ({
@@ -714,6 +716,25 @@ const RawElementNodeRenderer = (
           ) : (
             <Button element={buttonProto} {...widgetProps} />
           )}
+        </ElementContainer>
+      )
+    }
+
+    case "breadcrumbs": {
+      const breadcrumbsProto = node.element.breadcrumbs as BreadcrumbsProto
+      widgetProps.disabled = widgetProps.disabled || breadcrumbsProto.disabled
+
+      return (
+        <ElementContainer
+          node={node}
+          config={ElementContainerConfig.DEFAULT}
+          isStale={isStale}
+        >
+          <Breadcrumbs
+            key={breadcrumbsProto.id}
+            element={breadcrumbsProto}
+            {...widgetProps}
+          />
         </ElementContainer>
       )
     }

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
@@ -99,10 +99,7 @@ describe("Breadcrumbs widget", () => {
   })
 
   it("does not render last item as a button", () => {
-    const props = getProps()
-    vi.spyOn(props.widgetMgr, "setStringValue")
-
-    render(<Breadcrumbs {...props} />)
+    render(<Breadcrumbs {...getProps()} />)
 
     expect(
       screen.queryByRole("button", { name: "Phones" })

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
@@ -79,10 +79,10 @@ describe("Breadcrumbs widget", () => {
     expect(separators).toHaveLength(2)
   })
 
-  it("calls setTriggerValue when clicking a non-last item", async () => {
+  it("calls setIntValue when clicking a non-selected item", async () => {
     const user = userEvent.setup()
     const props = getProps()
-    vi.spyOn(props.widgetMgr, "setTriggerValue")
+    vi.spyOn(props.widgetMgr, "setIntValue")
 
     render(<Breadcrumbs {...props} />)
 
@@ -91,11 +91,11 @@ describe("Breadcrumbs widget", () => {
     })
     await user.click(electronicsButton)
 
-    expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
       props.element,
+      1,
       { fromUi: true },
-      props.fragmentId,
-      { index: 1 }
+      props.fragmentId
     )
   })
 

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { Breadcrumbs as BreadcrumbsProto } from "@streamlit/protobuf"
+
+import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import Breadcrumbs from "./Breadcrumbs"
+
+const getProps = (
+  elementProps: Partial<BreadcrumbsProto> = {}
+): {
+  element: BreadcrumbsProto
+  disabled: boolean
+  widgetMgr: WidgetStateManager
+  fragmentId: string
+} => ({
+  element: BreadcrumbsProto.create({
+    id: "test_breadcrumbs",
+    items: [
+      { content: "Home" },
+      { content: "Electronics" },
+      { content: "Phones" },
+    ],
+    disabled: false,
+    ...elementProps,
+  }),
+  disabled: false,
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  }),
+  fragmentId: "test_fragment",
+})
+
+describe("Breadcrumbs widget", () => {
+  it("renders breadcrumbs items", () => {
+    render(<Breadcrumbs {...getProps()} />)
+
+    expect(screen.getByText("Home")).toBeVisible()
+    expect(screen.getByText("Electronics")).toBeVisible()
+    expect(screen.getByText("Phones")).toBeVisible()
+  })
+
+  it("renders with correct accessibility attributes", () => {
+    render(<Breadcrumbs {...getProps()} />)
+
+    const nav = screen.getByRole("navigation")
+    expect(nav).toHaveAttribute("aria-label", "Breadcrumb")
+
+    const phonesText = screen.getByText("Phones")
+    expect(phonesText.parentElement).toHaveAttribute("aria-current", "page")
+  })
+
+  it("renders separators between items", () => {
+    render(<Breadcrumbs {...getProps()} />)
+
+    const separators = screen.getAllByText("/")
+    expect(separators).toHaveLength(2)
+  })
+
+  it("calls setStringValue when clicking a non-last item", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Breadcrumbs {...props} />)
+
+    const electronicsButton = screen.getByRole("button", {
+      name: "Electronics",
+    })
+    await user.click(electronicsButton)
+
+    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+      props.element,
+      "1",
+      { fromUi: true },
+      props.fragmentId
+    )
+  })
+
+  it("does not render last item as a button", () => {
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Breadcrumbs {...props} />)
+
+    expect(
+      screen.queryByRole("button", { name: "Phones" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders icons when provided", () => {
+    const props = getProps({
+      items: [
+        { content: "Home", contentIcon: ":material/home:" },
+        { content: "Current" },
+      ],
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    expect(screen.getByText("Home")).toBeVisible()
+    expect(screen.getByText("Current")).toBeVisible()
+  })
+
+  it("does not trigger click handler when disabled", async () => {
+    const user = userEvent.setup()
+    const props = {
+      ...getProps(),
+      disabled: true,
+    }
+    vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Breadcrumbs {...props} />)
+
+    const homeButton = screen.getByRole("button", { name: "Home" })
+    await user.click(homeButton)
+
+    expect(props.widgetMgr.setStringValue).not.toHaveBeenCalled()
+  })
+
+  it("renders single item without separators", () => {
+    const props = getProps({
+      items: [{ content: "Home" }],
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    expect(screen.getByText("Home")).toBeVisible()
+    expect(screen.queryByText("/")).not.toBeInTheDocument()
+  })
+
+  it("renders help tooltip when provided", () => {
+    const props = getProps({
+      help: "Navigation help text",
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    expect(screen.getByTestId("stTooltipIcon")).toBeVisible()
+  })
+})

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
@@ -79,10 +79,10 @@ describe("Breadcrumbs widget", () => {
     expect(separators).toHaveLength(2)
   })
 
-  it("calls setStringValue when clicking a non-last item", async () => {
+  it("calls setTriggerValue when clicking a non-last item", async () => {
     const user = userEvent.setup()
     const props = getProps()
-    vi.spyOn(props.widgetMgr, "setStringValue")
+    vi.spyOn(props.widgetMgr, "setTriggerValue")
 
     render(<Breadcrumbs {...props} />)
 
@@ -91,11 +91,11 @@ describe("Breadcrumbs widget", () => {
     })
     await user.click(electronicsButton)
 
-    expect(props.widgetMgr.setStringValue).toHaveBeenCalledWith(
+    expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
       props.element,
-      "1",
       { fromUi: true },
-      props.fragmentId
+      props.fragmentId,
+      { index: 1 }
     )
   })
 
@@ -151,20 +151,21 @@ describe("Breadcrumbs widget", () => {
     expect(screen.getByText("Current")).toBeVisible()
   })
 
-  it("does not trigger click handler when disabled", async () => {
-    const user = userEvent.setup()
+  it("renders all items as plain text when disabled (no clickable buttons)", () => {
     const props = {
       ...getProps(),
       disabled: true,
     }
-    vi.spyOn(props.widgetMgr, "setStringValue")
 
     render(<Breadcrumbs {...props} />)
 
-    const homeButton = screen.getByRole("button", { name: "Home" })
-    await user.click(homeButton)
+    // All items should be visible as text
+    expect(screen.getByText("Home")).toBeVisible()
+    expect(screen.getByText("Electronics")).toBeVisible()
+    expect(screen.getByText("Phones")).toBeVisible()
 
-    expect(props.widgetMgr.setStringValue).not.toHaveBeenCalled()
+    // No buttons should be rendered when disabled
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
   })
 
   it("renders single item without separators", () => {

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
@@ -41,6 +41,7 @@ const getProps = (
       { content: "Phones" },
     ],
     disabled: false,
+    separator: "/",
     ...elementProps,
   }),
   disabled: false,
@@ -157,5 +158,37 @@ describe("Breadcrumbs widget", () => {
     render(<Breadcrumbs {...props} />)
 
     expect(screen.getByTestId("stTooltipIcon")).toBeVisible()
+  })
+
+  it("renders custom text separator", () => {
+    const props = getProps({
+      separator: " > ",
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    // Custom separator should not render as default "/"
+    expect(screen.queryByText("/")).not.toBeInTheDocument()
+    // The separator elements should exist (with aria-hidden)
+    const nav = screen.getByRole("navigation")
+    const separators = nav.querySelectorAll('[aria-hidden="true"]')
+    expect(separators).toHaveLength(2)
+    // Check the separator content contains the custom separator
+    expect(separators[0]).toHaveTextContent(">")
+  })
+
+  it("renders material icon separator", () => {
+    const props = getProps({
+      separator: ":material/chevron_right:",
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    // Material icon separator should not render as text "/"
+    expect(screen.queryByText("/")).not.toBeInTheDocument()
+    // The separator elements should still exist (with aria-hidden)
+    const nav = screen.getByRole("navigation")
+    const separators = nav.querySelectorAll('[aria-hidden="true"]')
+    expect(separators).toHaveLength(2)
   })
 })

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.test.tsx
@@ -61,12 +61,13 @@ describe("Breadcrumbs widget", () => {
     expect(screen.getByText("Phones")).toBeVisible()
   })
 
-  it("renders with correct accessibility attributes", () => {
+  it("renders with correct accessibility attributes (defaults to last item)", () => {
     render(<Breadcrumbs {...getProps()} />)
 
     const nav = screen.getByRole("navigation")
     expect(nav).toHaveAttribute("aria-label", "Breadcrumb")
 
+    // When no value is set, the last item is selected by default
     const phonesText = screen.getByText("Phones")
     expect(phonesText.parentElement).toHaveAttribute("aria-current", "page")
   })
@@ -98,12 +99,42 @@ describe("Breadcrumbs widget", () => {
     )
   })
 
-  it("does not render last item as a button", () => {
+  it("does not render last item as a button when no value set", () => {
     render(<Breadcrumbs {...getProps()} />)
 
     expect(
       screen.queryByRole("button", { name: "Phones" })
     ).not.toBeInTheDocument()
+  })
+
+  it("renders selected item (from value) as non-clickable", () => {
+    const props = getProps({
+      value: "1", // "Electronics" is selected
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    // "Electronics" (index 1) should not be a button
+    expect(
+      screen.queryByRole("button", { name: "Electronics" })
+    ).not.toBeInTheDocument()
+
+    // "Home" (index 0) should still be a button
+    expect(screen.getByRole("button", { name: "Home" })).toBeVisible()
+
+    // "Phones" (index 2) should now be a button since it's no longer the selected item
+    expect(screen.getByRole("button", { name: "Phones" })).toBeVisible()
+  })
+
+  it("marks selected item with aria-current page", () => {
+    const props = getProps({
+      value: "0", // "Home" is selected
+    })
+
+    render(<Breadcrumbs {...props} />)
+
+    const homeText = screen.getByText("Home")
+    expect(homeText.parentElement).toHaveAttribute("aria-current", "page")
   })
 
   it("renders icons when provided", () => {

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -68,9 +68,7 @@ function Breadcrumbs({
       if (disabled) {
         return
       }
-      void widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId, {
-        index,
-      })
+      widgetMgr.setIntValue(element, index, { fromUi: true }, fragmentId)
     },
     [disabled, element, widgetMgr, fragmentId]
   )
@@ -93,10 +91,9 @@ function Breadcrumbs({
     >
       <ol>
         {items.map((item, index) => {
-          const isLast = index === items.length - 1
           const isSelected = index === selectedIndex
-          const icon = item.contentIcon || null
-          const content = item.content || ""
+          const icon = item.contentIcon ?? null
+          const content = item.content ?? ""
 
           // When disabled, all items render as plain text (non-interactive)
           // Otherwise, only the selected item renders as plain text
@@ -123,7 +120,7 @@ function Breadcrumbs({
                   <span>{content}</span>
                 </StyledBreadcrumbLink>
               )}
-              {!isLast && renderSeparator()}
+              {index < items.length - 1 && renderSeparator()}
             </StyledBreadcrumbItem>
           )
         })}

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { memo, ReactElement, useCallback } from "react"
+
+import { Breadcrumbs as BreadcrumbsProto } from "@streamlit/protobuf"
+
+import { DynamicIcon } from "~lib/components/shared/Icon"
+import { Placement } from "~lib/components/shared/Tooltip"
+import { WidgetLabelHelpIconInline } from "~lib/components/widgets/BaseWidget"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import {
+  StyledBreadcrumbCurrent,
+  StyledBreadcrumbIcon,
+  StyledBreadcrumbItem,
+  StyledBreadcrumbLink,
+  StyledBreadcrumbs,
+  StyledBreadcrumbSeparator,
+} from "./styled-components"
+
+export interface Props {
+  disabled: boolean
+  element: BreadcrumbsProto
+  widgetMgr: WidgetStateManager
+  fragmentId?: string
+}
+
+const renderIcon = (
+  iconName: string | null | undefined
+): ReactElement | null => {
+  if (!iconName) {
+    return null
+  }
+  return (
+    <StyledBreadcrumbIcon>
+      <DynamicIcon size="base" iconValue={iconName} color="inherit" />
+    </StyledBreadcrumbIcon>
+  )
+}
+
+function Breadcrumbs({
+  element,
+  disabled,
+  widgetMgr,
+  fragmentId,
+}: Readonly<Props>): ReactElement {
+  const { items, help } = element
+
+  const handleClick = useCallback(
+    (index: number): void => {
+      if (disabled) {
+        return
+      }
+      widgetMgr.setStringValue(
+        element,
+        String(index),
+        { fromUi: true },
+        fragmentId
+      )
+    },
+    [disabled, element, widgetMgr, fragmentId]
+  )
+
+  return (
+    <StyledBreadcrumbs
+      className="stBreadcrumbs"
+      data-testid="stBreadcrumbs"
+      aria-label="Breadcrumb"
+    >
+      <ol>
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1
+          const icon = item.contentIcon || null
+          const content = item.content || ""
+
+          return (
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- Items don't have unique IDs and content can be duplicated
+            <StyledBreadcrumbItem key={`${content}-${index}`}>
+              {isLast ? (
+                <StyledBreadcrumbCurrent
+                  aria-current="page"
+                  $disabled={disabled}
+                >
+                  {renderIcon(icon)}
+                  <span>{content}</span>
+                </StyledBreadcrumbCurrent>
+              ) : (
+                <StyledBreadcrumbLink
+                  onClick={() => handleClick(index)}
+                  $disabled={disabled}
+                  type="button"
+                  aria-label={content}
+                  aria-disabled={disabled || undefined}
+                >
+                  {renderIcon(icon)}
+                  <span>{content}</span>
+                </StyledBreadcrumbLink>
+              )}
+              {!isLast && (
+                <StyledBreadcrumbSeparator aria-hidden="true">
+                  /
+                </StyledBreadcrumbSeparator>
+              )}
+            </StyledBreadcrumbItem>
+          )
+        })}
+      </ol>
+      {help && (
+        <WidgetLabelHelpIconInline content={help} placement={Placement.TOP} />
+      )}
+    </StyledBreadcrumbs>
+  )
+}
+
+export default memo(Breadcrumbs)

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -75,23 +75,15 @@ function Breadcrumbs({
     [disabled, element, widgetMgr, fragmentId]
   )
 
-  // Check if separator is a material icon
-  const isMaterialIcon = separator.startsWith(":material/")
-
-  const renderSeparator = (): ReactElement => {
-    if (isMaterialIcon) {
-      return (
-        <StyledBreadcrumbSeparator aria-hidden="true">
-          <DynamicIcon size="base" iconValue={separator} color="inherit" />
-        </StyledBreadcrumbSeparator>
-      )
-    }
-    return (
-      <StyledBreadcrumbSeparator aria-hidden="true">
-        {separator}
-      </StyledBreadcrumbSeparator>
-    )
-  }
+  const renderSeparator = (): ReactElement => (
+    <StyledBreadcrumbSeparator aria-hidden="true">
+      {separator.startsWith(":material/") ? (
+        <DynamicIcon size="base" iconValue={separator} color="inherit" />
+      ) : (
+        separator
+      )}
+    </StyledBreadcrumbSeparator>
+  )
 
   return (
     <StyledBreadcrumbs
@@ -121,7 +113,6 @@ function Breadcrumbs({
                   onClick={() => handleClick(index)}
                   $disabled={disabled}
                   type="button"
-                  aria-label={content}
                   aria-disabled={disabled || undefined}
                 >
                   {renderIcon(icon)}

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -58,7 +58,7 @@ function Breadcrumbs({
   widgetMgr,
   fragmentId,
 }: Readonly<Props>): ReactElement {
-  const { items, help } = element
+  const { items, help, separator } = element
 
   const handleClick = useCallback(
     (index: number): void => {
@@ -74,6 +74,24 @@ function Breadcrumbs({
     },
     [disabled, element, widgetMgr, fragmentId]
   )
+
+  // Check if separator is a material icon
+  const isMaterialIcon = separator.startsWith(":material/")
+
+  const renderSeparator = (): ReactElement => {
+    if (isMaterialIcon) {
+      return (
+        <StyledBreadcrumbSeparator aria-hidden="true">
+          <DynamicIcon size="base" iconValue={separator} color="inherit" />
+        </StyledBreadcrumbSeparator>
+      )
+    }
+    return (
+      <StyledBreadcrumbSeparator aria-hidden="true">
+        {separator}
+      </StyledBreadcrumbSeparator>
+    )
+  }
 
   return (
     <StyledBreadcrumbs
@@ -110,11 +128,7 @@ function Breadcrumbs({
                   <span>{content}</span>
                 </StyledBreadcrumbLink>
               )}
-              {!isLast && (
-                <StyledBreadcrumbSeparator aria-hidden="true">
-                  /
-                </StyledBreadcrumbSeparator>
-              )}
+              {!isLast && renderSeparator()}
             </StyledBreadcrumbItem>
           )
         })}

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -68,12 +68,9 @@ function Breadcrumbs({
       if (disabled) {
         return
       }
-      widgetMgr.setStringValue(
-        element,
-        String(index),
-        { fromUi: true },
-        fragmentId
-      )
+      void widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId, {
+        index,
+      })
     },
     [disabled, element, widgetMgr, fragmentId]
   )
@@ -101,12 +98,16 @@ function Breadcrumbs({
           const icon = item.contentIcon || null
           const content = item.content || ""
 
+          // When disabled, all items render as plain text (non-interactive)
+          // Otherwise, only the selected item renders as plain text
+          const renderAsPlainText = disabled || isSelected
+
           return (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- Items don't have unique IDs and content can be duplicated
             <StyledBreadcrumbItem key={`${content}-${index}`}>
-              {isSelected ? (
+              {renderAsPlainText ? (
                 <StyledBreadcrumbCurrent
-                  aria-current="page"
+                  aria-current={isSelected ? "page" : undefined}
                   $disabled={disabled}
                 >
                   {renderIcon(icon)}
@@ -117,7 +118,6 @@ function Breadcrumbs({
                   onClick={() => handleClick(index)}
                   $disabled={disabled}
                   type="button"
-                  aria-disabled={disabled || undefined}
                 >
                   {renderIcon(icon)}
                   <span>{content}</span>

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -47,7 +47,7 @@ const renderIcon = (
   }
   return (
     <StyledBreadcrumbIcon>
-      <DynamicIcon size="base" iconValue={iconName} color="inherit" />
+      <DynamicIcon size="md" iconValue={iconName} color="inherit" />
     </StyledBreadcrumbIcon>
   )
 }
@@ -76,7 +76,7 @@ function Breadcrumbs({
   const renderSeparator = (): ReactElement => (
     <StyledBreadcrumbSeparator aria-hidden="true">
       {separator.startsWith(":material/") ? (
-        <DynamicIcon size="base" iconValue={separator} color="inherit" />
+        <DynamicIcon size="md" iconValue={separator} color="inherit" />
       ) : (
         separator
       )}

--- a/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/Breadcrumbs.tsx
@@ -58,7 +58,10 @@ function Breadcrumbs({
   widgetMgr,
   fragmentId,
 }: Readonly<Props>): ReactElement {
-  const { items, help, separator } = element
+  const { items, help, separator, value } = element
+
+  // Determine the selected index: use the value if set, otherwise default to last item
+  const selectedIndex = value ? parseInt(value, 10) : items.length - 1
 
   const handleClick = useCallback(
     (index: number): void => {
@@ -94,13 +97,14 @@ function Breadcrumbs({
       <ol>
         {items.map((item, index) => {
           const isLast = index === items.length - 1
+          const isSelected = index === selectedIndex
           const icon = item.contentIcon || null
           const content = item.content || ""
 
           return (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- Items don't have unique IDs and content can be duplicated
             <StyledBreadcrumbItem key={`${content}-${index}`}>
-              {isLast ? (
+              {isSelected ? (
                 <StyledBreadcrumbCurrent
                   aria-current="page"
                   $disabled={disabled}

--- a/frontend/lib/src/components/widgets/Breadcrumbs/index.ts
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from "./Breadcrumbs"
+export type { Props } from "./Breadcrumbs"

--- a/frontend/lib/src/components/widgets/Breadcrumbs/styled-components.ts
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/styled-components.ts
@@ -50,17 +50,17 @@ export const StyledBreadcrumbLink = styled.button<{ $disabled: boolean }>(
     margin: 0,
     borderRadius: theme.radii.sm,
     cursor: $disabled ? "default" : "pointer",
-    color: $disabled ? theme.colors.fadedText40 : theme.colors.link,
+    color: $disabled ? theme.colors.fadedText40 : theme.colors.fadedText60,
     textDecoration: "none",
     fontSize: "inherit",
     fontFamily: "inherit",
-    transition: "background-color 0.2s ease",
+    transition: "background-color 0.2s ease, color 0.2s ease",
 
     "&:hover": $disabled
       ? {}
       : {
           backgroundColor: theme.colors.darkenedBgMix15,
-          textDecoration: "underline",
+          color: theme.colors.bodyText,
         },
 
     "&:focus-visible": {

--- a/frontend/lib/src/components/widgets/Breadcrumbs/styled-components.ts
+++ b/frontend/lib/src/components/widgets/Breadcrumbs/styled-components.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+export const StyledBreadcrumbs = styled.nav(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: theme.spacing.sm,
+
+  "& > ol": {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    gap: theme.spacing.none,
+  },
+}))
+
+export const StyledBreadcrumbItem = styled.li(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  fontSize: theme.fontSizes.sm,
+  lineHeight: theme.lineHeights.base,
+}))
+
+export const StyledBreadcrumbLink = styled.button<{ $disabled: boolean }>(
+  ({ theme, $disabled }) => ({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: theme.spacing.twoXS,
+    background: "none",
+    border: "none",
+    padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
+    margin: 0,
+    borderRadius: theme.radii.sm,
+    cursor: $disabled ? "default" : "pointer",
+    color: $disabled ? theme.colors.fadedText40 : theme.colors.link,
+    textDecoration: "none",
+    fontSize: "inherit",
+    fontFamily: "inherit",
+    transition: "background-color 0.2s ease",
+
+    "&:hover": $disabled
+      ? {}
+      : {
+          backgroundColor: theme.colors.darkenedBgMix15,
+          textDecoration: "underline",
+        },
+
+    "&:focus-visible": {
+      outline: `2px solid ${theme.colors.primary}`,
+      outlineOffset: "1px",
+    },
+  })
+)
+
+export const StyledBreadcrumbCurrent = styled.span<{ $disabled: boolean }>(
+  ({ theme, $disabled }) => ({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: theme.spacing.twoXS,
+    padding: `${theme.spacing.twoXS} ${theme.spacing.xs}`,
+    color: $disabled ? theme.colors.fadedText40 : theme.colors.bodyText,
+    fontWeight: theme.fontWeights.normal,
+  })
+)
+
+export const StyledBreadcrumbSeparator = styled.span(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  color: theme.colors.fadedText60,
+  padding: `0 ${theme.spacing.twoXS}`,
+  userSelect: "none",
+}))
+
+export const StyledBreadcrumbIcon = styled.span(() => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+}))

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -170,6 +170,7 @@ balloons = _main.balloons
 bar_chart = _main.bar_chart
 _bidi_component = _main._bidi_component
 bokeh_chart = _main.bokeh_chart
+breadcrumbs = _main.breadcrumbs
 button = _main.button
 caption = _main.caption
 camera_input = _main.camera_input

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -85,6 +85,7 @@ from streamlit.elements.text import TextMixin
 from streamlit.elements.toast import ToastMixin
 from streamlit.elements.vega_charts import VegaChartsMixin
 from streamlit.elements.widgets.audio_input import AudioInputMixin
+from streamlit.elements.widgets.breadcrumbs import BreadcrumbsMixin
 from streamlit.elements.widgets.button import ButtonMixin
 from streamlit.elements.widgets.button_group import ButtonGroupMixin
 from streamlit.elements.widgets.camera_input import CameraInputMixin
@@ -182,6 +183,7 @@ class DeltaGenerator(
     AudioInputMixin,
     BalloonsMixin,
     BokehMixin,
+    BreadcrumbsMixin,
     ButtonMixin,
     ButtonGroupMixin,
     CameraInputMixin,

--- a/lib/streamlit/elements/widgets/breadcrumbs.py
+++ b/lib/streamlit/elements/widgets/breadcrumbs.py
@@ -1,0 +1,363 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Generic,
+    TypeVar,
+    cast,
+)
+
+from streamlit.elements.lib.form_utils import current_form_id
+from streamlit.elements.lib.policies import check_widget_policies
+from streamlit.elements.lib.utils import (
+    Key,
+    compute_and_register_element_id,
+    save_for_app_testing,
+    to_key,
+)
+from streamlit.errors import StreamlitAPIException
+from streamlit.navigation.page import StreamlitPage
+from streamlit.proto.Breadcrumbs_pb2 import Breadcrumbs as BreadcrumbsProto
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.runtime.state import register_widget
+from streamlit.string_util import is_emoji, validate_material_icon
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.runtime.state import (
+        WidgetArgs,
+        WidgetCallback,
+        WidgetKwargs,
+    )
+
+T = TypeVar("T")
+
+
+class _BreadcrumbsSerde(Generic[T]):
+    """Serde for breadcrumbs widget with trigger-based behavior.
+
+    Serializes the clicked item index and deserializes back to the item value.
+    Returns None when no item has been clicked (initial state or after reset).
+    """
+
+    options: Sequence[T]
+
+    def __init__(self, options: Sequence[T]) -> None:
+        self.options = options
+
+    def serialize(self, v: T | None) -> str:
+        """Serialize clicked item to index string."""
+        if v is None:
+            return ""
+        index = next(
+            (i for i, opt in enumerate(self.options) if opt == v),
+            None,
+        )
+        return str(index) if index is not None else ""
+
+    def deserialize(self, ui_value: str | None, _widget_id: str = "") -> T | None:
+        """Deserialize index string to item value."""
+        if ui_value is None or ui_value == "":
+            return None
+
+        try:
+            index = int(ui_value)
+            if 0 <= index < len(self.options):
+                return self.options[index]
+        except (ValueError, IndexError):
+            pass
+
+        return None
+
+
+def _default_format_func_for_page(page: StreamlitPage) -> str:
+    """Default format function for StreamlitPage objects.
+
+    Returns the page title with icon if available.
+    """
+    if page.icon:
+        return f"{page.icon} {page.title}"
+    return page.title
+
+
+class BreadcrumbsMixin:
+    @gather_metrics("breadcrumbs")
+    def breadcrumbs(
+        self,
+        items: Sequence[T],
+        *,
+        key: Key | None = None,
+        help: str | None = None,
+        on_click: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        disabled: bool = False,
+        format_func: Callable[[T], str] | None = None,
+    ) -> T | None:
+        r"""Display a breadcrumbs navigation widget.
+
+        A breadcrumbs widget displays a horizontal navigation path (e.g.,
+        Home > Section > Page), helping users understand their location in
+        multi-page or nested app flows and quickly jump to higher-level views.
+
+        Clicking an item triggers a rerun and returns the clicked item.
+        The last item represents the current page and is not clickable.
+
+        Parameters
+        ----------
+        items : Sequence[T]
+            Items to display in the breadcrumb path, ordered from root to
+            current. The last item represents the current page and is not
+            clickable. Must contain at least one item.
+
+            Each item can be any type, including strings, dictionaries, or
+            ``st.Page`` objects. When using ``st.Page`` objects, the title
+            and icon are automatically extracted.
+
+        key : str or int
+            An optional string or integer to use as the unique key for the
+            widget. If this is omitted, a key will be generated for the widget
+            based on its content. Multiple widgets of the same type may not
+            share the same key.
+
+        help : str or None
+            A tooltip that gets displayed when hovering over the widget.
+            If this is ``None`` (default), no tooltip is displayed.
+
+            The tooltip can optionally contain GitHub-flavored Markdown,
+            including the Markdown directives described in the ``body``
+            parameter of ``st.markdown``.
+
+        on_click : callable
+            An optional callback invoked when an item is clicked.
+
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
+
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
+
+        disabled : bool
+            An optional boolean that disables the widget if set to ``True``.
+            When disabled, all items appear as plain text and are not
+            clickable. The default is ``False``.
+
+        format_func : function
+            Function to modify the display of the items. It receives
+            the raw item as an argument and should output the label to be
+            shown for that item. This has no impact on the return value of
+            the command.
+
+            The output can optionally contain GitHub-flavored Markdown,
+            including Material icons (e.g., ``:material/home:``). If the
+            formatted string starts with a Material icon or emoji, it will
+            be extracted and displayed as an icon.
+
+            For ``st.Page`` objects, the default format function uses the
+            page's title and icon.
+
+        Returns
+        -------
+        T or None
+            The clicked item when a breadcrumb is clicked, or ``None`` if no
+            item was clicked. The last item (current page) is not clickable
+            and cannot be returned.
+
+        Examples
+        --------
+        **Basic usage:**
+
+        >>> import streamlit as st
+        >>>
+        >>> clicked = st.breadcrumbs(["Home", "Electronics", "Phones", "iPhone 15"])
+        >>>
+        >>> if clicked == "Home":
+        ...     st.switch_page("home.py")
+        >>> elif clicked == "Electronics":
+        ...     st.switch_page("electronics.py")
+        >>> elif clicked == "Phones":
+        ...     st.switch_page("phones.py")
+        >>> # "iPhone 15" is current page, not clickable
+
+        **With icons:**
+
+        >>> import streamlit as st
+        >>>
+        >>> clicked = st.breadcrumbs(
+        ...     ["home", "folder", "file"],
+        ...     format_func=lambda x: f":material/{x}: {x.title()}",
+        ... )
+
+        **With custom objects:**
+
+        >>> import streamlit as st
+        >>>
+        >>> pages = [
+        ...     {"id": "home", "title": "Home", "path": "home.py"},
+        ...     {"id": "users", "title": "Users", "path": "users.py"},
+        ...     {"id": "detail", "title": "User Detail", "path": "detail.py"},
+        ... ]
+        >>>
+        >>> clicked = st.breadcrumbs(
+        ...     pages,
+        ...     format_func=lambda p: p["title"],
+        ... )
+        >>>
+        >>> if clicked:
+        ...     st.switch_page(clicked["path"])
+
+        **With st.Page objects:**
+
+        >>> import streamlit as st
+        >>>
+        >>> home = st.Page("home.py", title="Home", icon=":material/home:")
+        >>> section = st.Page("section.py", title="Section")
+        >>> current = st.Page("current.py", title="Current Page")
+        >>>
+        >>> clicked = st.breadcrumbs([home, section, current])
+        >>>
+        >>> if clicked:
+        ...     st.switch_page(clicked)  # st.Page works with st.switch_page
+
+        """
+        return self._breadcrumbs(
+            items=items,
+            key=key,
+            help=help,
+            on_click=on_click,
+            args=args,
+            kwargs=kwargs,
+            disabled=disabled,
+            format_func=format_func,
+        )
+
+    def _breadcrumbs(
+        self,
+        items: Sequence[T],
+        *,
+        key: Key | None = None,
+        help: str | None = None,
+        on_click: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        disabled: bool = False,
+        format_func: Callable[[T], str] | None = None,
+    ) -> T | None:
+        if len(items) == 0:
+            raise StreamlitAPIException(
+                "The `items` argument to `st.breadcrumbs` must contain at least one item."
+            )
+
+        items_list: list[T] = list(items)
+
+        def resolve_format_func(item: T) -> str:
+            """Apply user-provided format_func or fall back to defaults."""
+            if format_func is not None:
+                return format_func(item)
+            if isinstance(item, StreamlitPage):
+                return _default_format_func_for_page(item)
+            return str(item)
+
+        def _transform_item_to_proto(
+            item: T,
+        ) -> BreadcrumbsProto.BreadcrumbItem:
+            """Convert item to proto, extracting icon from formatted string if present."""
+            transformed = resolve_format_func(item)
+            transformed_parts = transformed.split(" ")
+            icon: str | None = None
+
+            if len(transformed_parts) > 0:
+                maybe_icon = transformed_parts[0].strip()
+                try:
+                    if maybe_icon.startswith(":material"):
+                        icon = validate_material_icon(maybe_icon)
+                    elif is_emoji(maybe_icon):
+                        icon = maybe_icon
+
+                    if icon:
+                        # Reassemble the string without the icon
+                        transformed = " ".join(transformed_parts[1:])
+                except StreamlitAPIException:
+                    # Not a valid icon, keep as-is
+                    pass
+
+            return BreadcrumbsProto.BreadcrumbItem(
+                content=transformed,
+                content_icon=icon,
+            )
+
+        key = to_key(key)
+
+        check_widget_policies(
+            self.dg,
+            key,
+            on_click,
+            default_value=None,
+            writes_allowed=False,
+        )
+
+        ctx = get_script_run_ctx()
+        form_id = current_form_id(self.dg)
+
+        formatted_items = [_transform_item_to_proto(item) for item in items_list]
+
+        element_id = compute_and_register_element_id(
+            "breadcrumbs",
+            user_key=key,
+            key_as_main_identity=True,
+            dg=self.dg,
+            items=formatted_items,
+            help=help,
+        )
+
+        proto = BreadcrumbsProto()
+        proto.id = element_id
+        proto.disabled = disabled
+        proto.form_id = form_id
+
+        if help is not None:
+            proto.help = help
+
+        proto.items.extend(formatted_items)
+
+        serde = _BreadcrumbsSerde[T](items_list)
+
+        widget_state = register_widget(
+            proto.id,
+            on_change_handler=on_click,
+            args=args,
+            kwargs=kwargs,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
+            ctx=ctx,
+            value_type="string_value",
+        )
+
+        if ctx:
+            save_for_app_testing(ctx, element_id, widget_state.value)
+
+        self.dg._enqueue("breadcrumbs", proto)
+
+        return widget_state.value
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/widgets/breadcrumbs.py
+++ b/lib/streamlit/elements/widgets/breadcrumbs.py
@@ -51,56 +51,41 @@ T = TypeVar("T")
 
 
 class _BreadcrumbsSerde(Generic[T]):
-    """Serde for breadcrumbs widget with trigger-based behavior.
+    """Serde for breadcrumbs widget with stateful selection behavior.
 
-    Serializes the clicked item index and deserializes back to the item value.
-    Returns None when no item has been clicked (initial state or after reset).
-    The frontend sends a JSON array of trigger payloads via json_trigger_value.
+    Serializes the selected item index and deserializes back to the item value.
+    Always returns a valid selection (defaults to last item if none specified).
     """
 
     options: Sequence[T]
+    default_index: int
 
-    def __init__(self, options: Sequence[T]) -> None:
+    def __init__(self, options: Sequence[T], default_index: int) -> None:
         self.options = options
+        self.default_index = default_index
 
-    def serialize(self, v: T | None) -> dict[str, int | None]:
-        """Serialize clicked item to index dict for JSON trigger value."""
+    def serialize(self, v: T | None) -> int:
+        """Serialize selected item to index for int_value."""
         if v is None:
-            return {"index": None}
-        index = next(
+            return self.default_index
+        return next(
             (i for i, opt in enumerate(self.options) if opt == v),
-            None,
+            self.default_index,
         )
-        return {"index": index}
 
-    def deserialize(self, ui_value: str | None, _widget_id: str = "") -> T | None:
-        """Deserialize JSON trigger value to item value.
+    def deserialize(self, ui_value: int | None, _widget_id: str = "") -> T:
+        """Deserialize int_value to selected item.
 
-        The frontend sends a JSON-stringified array like '[{"index": 1}]'.
-        We parse it, extract the last payload's index, and return the item.
+        Returns the item at the given index, or the default item if invalid.
         """
-        import json
+        if ui_value is None:
+            return self.options[self.default_index]
 
-        if ui_value is None or ui_value == "":
-            return None
+        if 0 <= ui_value < len(self.options):
+            return self.options[ui_value]
 
-        try:
-            parsed = json.loads(ui_value)
-            # Handle array of payloads (take the last one)
-            if isinstance(parsed, list) and len(parsed) > 0:
-                payload = parsed[-1]
-            else:
-                payload = parsed
-
-            if isinstance(payload, dict):
-                index = payload.get("index")
-                if index is not None and 0 <= index < len(self.options):
-                    return self.options[index]
-        except (json.JSONDecodeError, TypeError, AttributeError):
-            # If parsing fails, return None (no selection)
-            pass
-
-        return None
+        # Fall back to default if index is out of range
+        return self.options[self.default_index]
 
 
 def _default_format_func_for_page(page: StreamlitPage) -> str:
@@ -139,34 +124,41 @@ class BreadcrumbsMixin:
         self,
         items: Sequence[T],
         *,
+        selection: T | int | None = None,
         separator: str = "/",
         key: Key | None = None,
         help: str | None = None,
-        on_click: WidgetCallback | None = None,
+        on_change: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         disabled: bool = False,
         format_func: Callable[[T], str] | None = None,
-    ) -> T | None:
+    ) -> T:
         r"""Display a breadcrumbs navigation widget.
 
         A breadcrumbs widget displays a horizontal navigation path (e.g.,
         Home > Section > Page), helping users understand their location in
         multi-page or nested app flows and quickly jump to higher-level views.
 
-        Clicking an item triggers a rerun and returns the clicked item.
-        The last item represents the current page and is not clickable.
+        The widget maintains a stateful selection. Clicking an item updates
+        the selection, triggers a rerun, and returns the newly selected item.
+        The selected item is visually highlighted and displayed as
+        non-clickable text.
 
         Parameters
         ----------
         items : Sequence[T]
             Items to display in the breadcrumb path, ordered from root to
-            current. The last item represents the current page and is not
-            clickable. Must contain at least one item.
+            current. Must contain at least one item.
 
             Each item can be any type, including strings, dictionaries, or
             ``st.Page`` objects. When using ``st.Page`` objects, the title
             and icon are automatically extracted.
+
+        selection : T, int, or None
+            The item to select initially. Can be specified as an item value
+            from ``items`` or as an integer index. If ``None`` (default),
+            the last item is selected (representing the current page).
 
         separator : str
             Separator displayed between items. Defaults to ``"/"``.
@@ -187,8 +179,8 @@ class BreadcrumbsMixin:
             including the Markdown directives described in the ``body``
             parameter of ``st.markdown``.
 
-        on_click : callable
-            An optional callback invoked when an item is clicked.
+        on_change : callable
+            An optional callback invoked when the selection changes.
 
         args : list or tuple
             An optional list or tuple of args to pass to the callback.
@@ -218,10 +210,10 @@ class BreadcrumbsMixin:
 
         Returns
         -------
-        T or None
-            The clicked item when a breadcrumb is clicked, or ``None`` if no
-            item was clicked. The last item (current page) is not clickable
-            and cannot be returned.
+        T
+            The currently selected item. Initially this is the item specified
+            by ``selection`` (or the last item by default). After clicking
+            a breadcrumb item, this returns that item.
 
         Examples
         --------
@@ -229,21 +221,21 @@ class BreadcrumbsMixin:
 
         >>> import streamlit as st
         >>>
-        >>> clicked = st.breadcrumbs(["Home", "Electronics", "Phones", "iPhone 15"])
+        >>> selected = st.breadcrumbs(["Home", "Electronics", "Phones", "iPhone 15"])
         >>>
-        >>> if clicked == "Home":
+        >>> if selected == "Home":
         ...     st.switch_page("home.py")
-        >>> elif clicked == "Electronics":
+        >>> elif selected == "Electronics":
         ...     st.switch_page("electronics.py")
-        >>> elif clicked == "Phones":
+        >>> elif selected == "Phones":
         ...     st.switch_page("phones.py")
-        >>> # "iPhone 15" is current page, not clickable
+        >>> # "iPhone 15" is selected by default (last item)
 
         **With icons:**
 
         >>> import streamlit as st
         >>>
-        >>> clicked = st.breadcrumbs(
+        >>> selected = st.breadcrumbs(
         ...     ["home", "folder", "file"],
         ...     format_func=lambda x: f":material/{x}: {x.title()}",
         ... )
@@ -253,10 +245,10 @@ class BreadcrumbsMixin:
         >>> import streamlit as st
         >>>
         >>> # Using a text separator
-        >>> clicked = st.breadcrumbs(["Home", "Section", "Page"], separator=" > ")
+        >>> selected = st.breadcrumbs(["Home", "Section", "Page"], separator=" > ")
         >>>
         >>> # Using a material icon as separator
-        >>> clicked = st.breadcrumbs(
+        >>> selected = st.breadcrumbs(
         ...     ["Home", "Section", "Page"],
         ...     separator=":material/chevron_right:",
         ... )
@@ -271,13 +263,13 @@ class BreadcrumbsMixin:
         ...     {"id": "detail", "title": "User Detail", "path": "detail.py"},
         ... ]
         >>>
-        >>> clicked = st.breadcrumbs(
+        >>> selected = st.breadcrumbs(
         ...     pages,
         ...     format_func=lambda p: p["title"],
         ... )
         >>>
-        >>> if clicked:
-        ...     st.switch_page(clicked["path"])
+        >>> if selected != pages[-1]:  # Not on the last page
+        ...     st.switch_page(selected["path"])
 
         **With st.Page objects:**
 
@@ -287,18 +279,19 @@ class BreadcrumbsMixin:
         >>> section = st.Page("section.py", title="Section")
         >>> current = st.Page("current.py", title="Current Page")
         >>>
-        >>> clicked = st.breadcrumbs([home, section, current])
+        >>> selected = st.breadcrumbs([home, section, current])
         >>>
-        >>> if clicked:
-        ...     st.switch_page(clicked)  # st.Page works with st.switch_page
+        >>> if selected != current:
+        ...     st.switch_page(selected)  # st.Page works with st.switch_page
 
         """
         return self._breadcrumbs(
             items=items,
+            selection=selection,
             separator=separator,
             key=key,
             help=help,
-            on_click=on_click,
+            on_change=on_change,
             args=args,
             kwargs=kwargs,
             disabled=disabled,
@@ -309,21 +302,44 @@ class BreadcrumbsMixin:
         self,
         items: Sequence[T],
         *,
+        selection: T | int | None = None,
         separator: str = "/",
         key: Key | None = None,
         help: str | None = None,
-        on_click: WidgetCallback | None = None,
+        on_change: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         disabled: bool = False,
         format_func: Callable[[T], str] | None = None,
-    ) -> T | None:
+    ) -> T:
         if not items:
             raise StreamlitAPIException(
                 "The `items` argument to `st.breadcrumbs` must contain at least one item."
             )
 
         items_list = list(items)
+
+        # Determine the default selection index
+        if selection is None:
+            # Default to last item (current page)
+            default_index = len(items_list) - 1
+        elif isinstance(selection, int):
+            # Selection is an index
+            if not (0 <= selection < len(items_list)):
+                raise StreamlitAPIException(
+                    f"The `selection` index {selection} is out of range. "
+                    f"Valid indices are 0 to {len(items_list) - 1}."
+                )
+            default_index = selection
+        else:
+            # Selection is an item value - find its index
+            try:
+                default_index = items_list.index(selection)
+            except ValueError:
+                raise StreamlitAPIException(
+                    f"The `selection` value {selection!r} is not in `items`. "
+                    "Please provide a valid item from the `items` sequence."
+                )
 
         def _format_item(item: T) -> str:
             """Apply format_func or use default formatting."""
@@ -355,7 +371,7 @@ class BreadcrumbsMixin:
         check_widget_policies(
             self.dg,
             key,
-            on_click,
+            on_change,
             default_value=None,
             writes_allowed=False,
         )
@@ -388,27 +404,21 @@ class BreadcrumbsMixin:
 
         proto.items.extend(formatted_items)
 
-        serde = _BreadcrumbsSerde[T](items_list)
+        serde = _BreadcrumbsSerde[T](items_list, default_index)
 
         widget_state = register_widget(
             proto.id,
-            on_change_handler=on_click,
+            on_change_handler=on_change,
             args=args,
             kwargs=kwargs,
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-            value_type="json_trigger_value",
+            value_type="int_value",
         )
 
         # Send current selection index to frontend for styling
-        if widget_state.value is not None:
-            index = next(
-                (i for i, opt in enumerate(items_list) if opt == widget_state.value),
-                None,
-            )
-            if index is not None:
-                proto.value = str(index)
+        proto.value = str(serde.serialize(widget_state.value))
 
         if ctx:
             save_for_app_testing(ctx, element_id, widget_state.value)

--- a/lib/streamlit/elements/widgets/breadcrumbs.py
+++ b/lib/streamlit/elements/widgets/breadcrumbs.py
@@ -88,13 +88,32 @@ class _BreadcrumbsSerde(Generic[T]):
 
 
 def _default_format_func_for_page(page: StreamlitPage) -> str:
-    """Default format function for StreamlitPage objects.
-
-    Returns the page title with icon if available.
-    """
+    """Return the page title with icon if available."""
     if page.icon:
         return f"{page.icon} {page.title}"
     return page.title
+
+
+def _extract_icon_from_text(text: str) -> tuple[str, str | None]:
+    """Extract leading icon (material or emoji) from text.
+
+    Returns a tuple of (remaining_text, icon_or_none).
+    """
+    parts = text.split(" ")
+    if not parts:
+        return text, None
+
+    maybe_icon = parts[0].strip()
+    try:
+        if maybe_icon.startswith(":material"):
+            icon = validate_material_icon(maybe_icon)
+            return " ".join(parts[1:]), icon
+        if is_emoji(maybe_icon):
+            return " ".join(parts[1:]), maybe_icon
+    except StreamlitAPIException:
+        pass
+
+    return text, None
 
 
 class BreadcrumbsMixin:
@@ -281,46 +300,27 @@ class BreadcrumbsMixin:
         disabled: bool = False,
         format_func: Callable[[T], str] | None = None,
     ) -> T | None:
-        if len(items) == 0:
+        if not items:
             raise StreamlitAPIException(
                 "The `items` argument to `st.breadcrumbs` must contain at least one item."
             )
 
-        items_list: list[T] = list(items)
+        items_list = list(items)
 
-        def resolve_format_func(item: T) -> str:
-            """Apply user-provided format_func or fall back to defaults."""
+        def _format_item(item: T) -> str:
+            """Apply format_func or use default formatting."""
             if format_func is not None:
                 return format_func(item)
             if isinstance(item, StreamlitPage):
                 return _default_format_func_for_page(item)
             return str(item)
 
-        def _transform_item_to_proto(
-            item: T,
-        ) -> BreadcrumbsProto.BreadcrumbItem:
-            """Convert item to proto, extracting icon from formatted string if present."""
-            transformed = resolve_format_func(item)
-            transformed_parts = transformed.split(" ")
-            icon: str | None = None
-
-            if len(transformed_parts) > 0:
-                maybe_icon = transformed_parts[0].strip()
-                try:
-                    if maybe_icon.startswith(":material"):
-                        icon = validate_material_icon(maybe_icon)
-                    elif is_emoji(maybe_icon):
-                        icon = maybe_icon
-
-                    if icon:
-                        # Reassemble the string without the icon
-                        transformed = " ".join(transformed_parts[1:])
-                except StreamlitAPIException:
-                    # Not a valid icon, keep as-is
-                    pass
-
+        def _item_to_proto(item: T) -> BreadcrumbsProto.BreadcrumbItem:
+            """Convert item to proto, extracting icon if present."""
+            formatted = _format_item(item)
+            content, icon = _extract_icon_from_text(formatted)
             return BreadcrumbsProto.BreadcrumbItem(
-                content=transformed,
+                content=content,
                 content_icon=icon,
             )
 
@@ -337,7 +337,7 @@ class BreadcrumbsMixin:
         ctx = get_script_run_ctx()
         form_id = current_form_id(self.dg)
 
-        formatted_items = [_transform_item_to_proto(item) for item in items_list]
+        formatted_items = [_item_to_proto(item) for item in items_list]
 
         element_id = compute_and_register_element_id(
             "breadcrumbs",

--- a/lib/streamlit/elements/widgets/breadcrumbs.py
+++ b/lib/streamlit/elements/widgets/breadcrumbs.py
@@ -55,6 +55,7 @@ class _BreadcrumbsSerde(Generic[T]):
 
     Serializes the clicked item index and deserializes back to the item value.
     Returns None when no item has been clicked (initial state or after reset).
+    The frontend sends a JSON array of trigger payloads via json_trigger_value.
     """
 
     options: Sequence[T]
@@ -62,26 +63,41 @@ class _BreadcrumbsSerde(Generic[T]):
     def __init__(self, options: Sequence[T]) -> None:
         self.options = options
 
-    def serialize(self, v: T | None) -> str:
-        """Serialize clicked item to index string."""
+    def serialize(self, v: T | None) -> dict[str, int | None]:
+        """Serialize clicked item to index dict for JSON trigger value."""
         if v is None:
-            return ""
+            return {"index": None}
         index = next(
             (i for i, opt in enumerate(self.options) if opt == v),
             None,
         )
-        return str(index) if index is not None else ""
+        return {"index": index}
 
     def deserialize(self, ui_value: str | None, _widget_id: str = "") -> T | None:
-        """Deserialize index string to item value."""
+        """Deserialize JSON trigger value to item value.
+
+        The frontend sends a JSON-stringified array like '[{"index": 1}]'.
+        We parse it, extract the last payload's index, and return the item.
+        """
+        import json
+
         if ui_value is None or ui_value == "":
             return None
 
         try:
-            index = int(ui_value)
-            if 0 <= index < len(self.options):
-                return self.options[index]
-        except (ValueError, IndexError):
+            parsed = json.loads(ui_value)
+            # Handle array of payloads (take the last one)
+            if isinstance(parsed, list) and len(parsed) > 0:
+                payload = parsed[-1]
+            else:
+                payload = parsed
+
+            if isinstance(payload, dict):
+                index = payload.get("index")
+                if index is not None and 0 <= index < len(self.options):
+                    return self.options[index]
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            # If parsing fails, return None (no selection)
             pass
 
         return None
@@ -111,6 +127,7 @@ def _extract_icon_from_text(text: str) -> tuple[str, str | None]:
         if is_emoji(maybe_icon):
             return " ".join(parts[1:]), maybe_icon
     except StreamlitAPIException:
+        # Invalid icon format - treat as regular text without icon extraction
         pass
 
     return text, None
@@ -190,10 +207,11 @@ class BreadcrumbsMixin:
             shown for that item. This has no impact on the return value of
             the command.
 
-            The output can optionally contain GitHub-flavored Markdown,
-            including Material icons (e.g., ``:material/home:``). If the
-            formatted string starts with a Material icon or emoji, it will
-            be extracted and displayed as an icon.
+            The output is treated as plain text. If the formatted string
+            starts with a Material icon shortcode (e.g., ``:material/home:``)
+            or an emoji, that leading icon will be extracted and displayed as
+            the breadcrumb icon. Any remaining text is rendered without
+            Markdown formatting.
 
             For ``st.Page`` objects, the default format function uses the
             page's title and icon.
@@ -315,12 +333,20 @@ class BreadcrumbsMixin:
                 return _default_format_func_for_page(item)
             return str(item)
 
-        def _item_to_proto(item: T) -> BreadcrumbsProto.BreadcrumbItem:
+        def _item_to_proto(item: T, index: int) -> BreadcrumbsProto.BreadcrumbItem:
             """Convert item to proto, extracting icon if present."""
             formatted = _format_item(item)
             content, icon = _extract_icon_from_text(formatted)
+            # Validate that content is non-empty after icon extraction
+            stripped_content = content.strip()
+            if not stripped_content:
+                raise StreamlitAPIException(
+                    f"Item at index {index} in `st.breadcrumbs` must contain text in "
+                    "addition to any leading icon. Icon-only labels are not supported "
+                    "because they would create inaccessible buttons without visible text."
+                )
             return BreadcrumbsProto.BreadcrumbItem(
-                content=content,
+                content=stripped_content,
                 content_icon=icon,
             )
 
@@ -337,7 +363,9 @@ class BreadcrumbsMixin:
         ctx = get_script_run_ctx()
         form_id = current_form_id(self.dg)
 
-        formatted_items = [_item_to_proto(item) for item in items_list]
+        formatted_items = [
+            _item_to_proto(item, index) for index, item in enumerate(items_list)
+        ]
 
         element_id = compute_and_register_element_id(
             "breadcrumbs",
@@ -346,6 +374,7 @@ class BreadcrumbsMixin:
             dg=self.dg,
             items=formatted_items,
             help=help,
+            separator=separator,
         )
 
         proto = BreadcrumbsProto()
@@ -369,11 +398,17 @@ class BreadcrumbsMixin:
             deserializer=serde.deserialize,
             serializer=serde.serialize,
             ctx=ctx,
-            value_type="string_value",
+            value_type="json_trigger_value",
         )
 
-        # Send current selection to frontend for styling
-        proto.value = serde.serialize(widget_state.value)
+        # Send current selection index to frontend for styling
+        if widget_state.value is not None:
+            index = next(
+                (i for i, opt in enumerate(items_list) if opt == widget_state.value),
+                None,
+            )
+            if index is not None:
+                proto.value = str(index)
 
         if ctx:
             save_for_app_testing(ctx, element_id, widget_state.value)

--- a/lib/streamlit/elements/widgets/breadcrumbs.py
+++ b/lib/streamlit/elements/widgets/breadcrumbs.py
@@ -372,6 +372,9 @@ class BreadcrumbsMixin:
             value_type="string_value",
         )
 
+        # Send current selection to frontend for styling
+        proto.value = serde.serialize(widget_state.value)
+
         if ctx:
             save_for_app_testing(ctx, element_id, widget_state.value)
 

--- a/lib/streamlit/elements/widgets/breadcrumbs.py
+++ b/lib/streamlit/elements/widgets/breadcrumbs.py
@@ -103,6 +103,7 @@ class BreadcrumbsMixin:
         self,
         items: Sequence[T],
         *,
+        separator: str = "/",
         key: Key | None = None,
         help: str | None = None,
         on_click: WidgetCallback | None = None,
@@ -130,6 +131,11 @@ class BreadcrumbsMixin:
             Each item can be any type, including strings, dictionaries, or
             ``st.Page`` objects. When using ``st.Page`` objects, the title
             and icon are automatically extracted.
+
+        separator : str
+            Separator displayed between items. Defaults to ``"/"``.
+            Supports plain text or Material icons (e.g.,
+            ``:material/chevron_right:``).
 
         key : str or int
             An optional string or integer to use as the unique key for the
@@ -205,6 +211,19 @@ class BreadcrumbsMixin:
         ...     format_func=lambda x: f":material/{x}: {x.title()}",
         ... )
 
+        **With custom separator:**
+
+        >>> import streamlit as st
+        >>>
+        >>> # Using a text separator
+        >>> clicked = st.breadcrumbs(["Home", "Section", "Page"], separator=" > ")
+        >>>
+        >>> # Using a material icon as separator
+        >>> clicked = st.breadcrumbs(
+        ...     ["Home", "Section", "Page"],
+        ...     separator=":material/chevron_right:",
+        ... )
+
         **With custom objects:**
 
         >>> import streamlit as st
@@ -239,6 +258,7 @@ class BreadcrumbsMixin:
         """
         return self._breadcrumbs(
             items=items,
+            separator=separator,
             key=key,
             help=help,
             on_click=on_click,
@@ -252,6 +272,7 @@ class BreadcrumbsMixin:
         self,
         items: Sequence[T],
         *,
+        separator: str = "/",
         key: Key | None = None,
         help: str | None = None,
         on_click: WidgetCallback | None = None,
@@ -331,6 +352,7 @@ class BreadcrumbsMixin:
         proto.id = element_id
         proto.disabled = disabled
         proto.form_id = form_id
+        proto.separator = separator
 
         if help is not None:
             proto.help = help

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -56,6 +56,7 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     # checkboxes
     ("checkbox", lambda: st.checkbox("Check me")),
     ("pills", lambda: st.pills("Some pills", ["a", "b", "c"])),
+    ("breadcrumbs", lambda: st.breadcrumbs(["Home", "Section", "Page"])),
     (
         "segmented_control",
         lambda: st.segmented_control("Some segments", ["a", "b", "c"]),

--- a/lib/tests/streamlit/elements/breadcrumbs_test.py
+++ b/lib/tests/streamlit/elements/breadcrumbs_test.py
@@ -35,29 +35,32 @@ class TestBreadcrumbsSerde:
     @pytest.mark.parametrize(
         ("value", "expected"),
         [
-            ("Home", "0"),
-            ("Electronics", "1"),
-            ("Phones", "2"),
-            (None, ""),
-            ("Unknown", ""),
+            ("Home", {"index": 0}),
+            ("Electronics", {"index": 1}),
+            ("Phones", {"index": 2}),
+            (None, {"index": None}),
+            ("Unknown", {"index": None}),
         ],
         ids=["first", "middle", "last", "none", "unknown"],
     )
-    def test_serialize(self, value: str | None, expected: str) -> None:
-        """Test serialization of various values to index strings."""
+    def test_serialize(
+        self, value: str | None, expected: dict[str, int | None]
+    ) -> None:
+        """Test serialization of values to index dicts for JSON trigger value."""
         serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
         assert serde.serialize(value) == expected
 
     @pytest.mark.parametrize(
         ("ui_value", "expected"),
         [
-            ("0", "Home"),
-            ("1", "Electronics"),
-            ("2", "Phones"),
+            ('[{"index": 0}]', "Home"),
+            ('[{"index": 1}]', "Electronics"),
+            ('[{"index": 2}]', "Phones"),
             (None, None),
             ("", None),
-            ("999", None),
-            ("invalid", None),
+            ('[{"index": 999}]', None),
+            ("invalid_json", None),
+            ('[{"index": null}]', None),
         ],
         ids=[
             "first",
@@ -66,13 +69,21 @@ class TestBreadcrumbsSerde:
             "none",
             "empty",
             "out_of_bounds",
-            "non_numeric",
+            "invalid_json",
+            "null_index",
         ],
     )
     def test_deserialize(self, ui_value: str | None, expected: str | None) -> None:
-        """Test deserialization of various index strings to option values."""
+        """Test deserialization of JSON trigger value to option values."""
         serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
         assert serde.deserialize(ui_value) == expected
+
+    def test_deserialize_takes_last_payload(self) -> None:
+        """Test that when multiple payloads are batched, the last one is used."""
+        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
+        # Simulates batched payloads - should take the last one
+        ui_value = '[{"index": 0}, {"index": 2}]'
+        assert serde.deserialize(ui_value) == "Phones"
 
     def test_custom_objects(self) -> None:
         """Test serde roundtrip with custom dictionary objects."""
@@ -82,8 +93,8 @@ class TestBreadcrumbsSerde:
         ]
         serde = _BreadcrumbsSerde(pages)
 
-        assert serde.serialize(pages[1]) == "1"
-        assert serde.deserialize("1") == pages[1]
+        assert serde.serialize(pages[1]) == {"index": 1}
+        assert serde.deserialize('[{"index": 1}]') == pages[1]
 
 
 class TestBreadcrumbs(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/breadcrumbs_test.py
+++ b/lib/tests/streamlit/elements/breadcrumbs_test.py
@@ -35,55 +35,34 @@ class TestBreadcrumbsSerde:
     @pytest.mark.parametrize(
         ("value", "expected"),
         [
-            ("Home", {"index": 0}),
-            ("Electronics", {"index": 1}),
-            ("Phones", {"index": 2}),
-            (None, {"index": None}),
-            ("Unknown", {"index": None}),
+            ("Home", 0),
+            ("Electronics", 1),
+            ("Phones", 2),
+            (None, 2),  # None uses default_index (last item)
+            ("Unknown", 2),  # Unknown uses default_index (last item)
         ],
         ids=["first", "middle", "last", "none", "unknown"],
     )
-    def test_serialize(
-        self, value: str | None, expected: dict[str, int | None]
-    ) -> None:
-        """Test serialization of values to index dicts for JSON trigger value."""
-        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
+    def test_serialize(self, value: str | None, expected: int) -> None:
+        """Test serialization of values to index for int_value."""
+        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS, default_index=2)
         assert serde.serialize(value) == expected
 
     @pytest.mark.parametrize(
         ("ui_value", "expected"),
         [
-            ('[{"index": 0}]', "Home"),
-            ('[{"index": 1}]', "Electronics"),
-            ('[{"index": 2}]', "Phones"),
-            (None, None),
-            ("", None),
-            ('[{"index": 999}]', None),
-            ("invalid_json", None),
-            ('[{"index": null}]', None),
+            (0, "Home"),
+            (1, "Electronics"),
+            (2, "Phones"),
+            (None, "Phones"),  # None returns default (last item)
+            (999, "Phones"),  # Out of bounds returns default
         ],
-        ids=[
-            "first",
-            "middle",
-            "last",
-            "none",
-            "empty",
-            "out_of_bounds",
-            "invalid_json",
-            "null_index",
-        ],
+        ids=["first", "middle", "last", "none", "out_of_bounds"],
     )
-    def test_deserialize(self, ui_value: str | None, expected: str | None) -> None:
-        """Test deserialization of JSON trigger value to option values."""
-        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
+    def test_deserialize(self, ui_value: int | None, expected: str) -> None:
+        """Test deserialization of int_value to option values."""
+        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS, default_index=2)
         assert serde.deserialize(ui_value) == expected
-
-    def test_deserialize_takes_last_payload(self) -> None:
-        """Test that when multiple payloads are batched, the last one is used."""
-        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
-        # Simulates batched payloads - should take the last one
-        ui_value = '[{"index": 0}, {"index": 2}]'
-        assert serde.deserialize(ui_value) == "Phones"
 
     def test_custom_objects(self) -> None:
         """Test serde roundtrip with custom dictionary objects."""
@@ -91,10 +70,21 @@ class TestBreadcrumbsSerde:
             {"id": "home", "title": "Home"},
             {"id": "users", "title": "Users"},
         ]
-        serde = _BreadcrumbsSerde(pages)
+        serde = _BreadcrumbsSerde(pages, default_index=1)
 
-        assert serde.serialize(pages[1]) == {"index": 1}
-        assert serde.deserialize('[{"index": 1}]') == pages[1]
+        assert serde.serialize(pages[0]) == 0
+        assert serde.serialize(pages[1]) == 1
+        assert serde.deserialize(0) == pages[0]
+        assert serde.deserialize(1) == pages[1]
+
+    def test_different_default_index(self) -> None:
+        """Test serde with non-last default index."""
+        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS, default_index=0)
+
+        # None and unknown should return first item
+        assert serde.deserialize(None) == "Home"
+        assert serde.serialize(None) == 0
+        assert serde.serialize("Unknown") == 0
 
 
 class TestBreadcrumbs(DeltaGeneratorTestCase):
@@ -207,25 +197,75 @@ class TestBreadcrumbs(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.breadcrumbs
         assert proto.separator == ":material/chevron_right:"
 
-    def test_breadcrumbs_value_initially_empty(self) -> None:
-        """Test that value is empty string initially (no selection)."""
+    def test_breadcrumbs_value_default_is_last_item(self) -> None:
+        """Test that value is set to last item index by default."""
         st.breadcrumbs(["Home", "Page"])
 
         proto = self.get_delta_from_queue().new_element.breadcrumbs
-        assert proto.value == ""
+        assert proto.value == "1"  # Index of last item
+
+    def test_breadcrumbs_selection_by_value(self) -> None:
+        """Test that selection parameter works with item value."""
+        st.breadcrumbs(["Home", "Section", "Page"], selection="Section")
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.value == "1"  # Index of "Section"
+
+    def test_breadcrumbs_selection_by_index(self) -> None:
+        """Test that selection parameter works with index."""
+        st.breadcrumbs(["Home", "Section", "Page"], selection=0)
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.value == "0"
+
+    def test_breadcrumbs_selection_invalid_value_raises_error(self) -> None:
+        """Test that invalid selection value raises StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="not in `items`"):
+            st.breadcrumbs(["Home", "Page"], selection="Invalid")
+
+    def test_breadcrumbs_selection_invalid_index_raises_error(self) -> None:
+        """Test that invalid selection index raises StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="out of range"):
+            st.breadcrumbs(["Home", "Page"], selection=5)
 
 
 class TestBreadcrumbsWithAppTest:
     """Test breadcrumbs with AppTest."""
 
-    def test_initial_value_is_none(self) -> None:
-        """Test that the initial return value is None before any click."""
+    def test_initial_value_is_last_item(self) -> None:
+        """Test that the initial return value is the last item (default selection)."""
 
         def script() -> None:
             import streamlit as st
 
-            clicked = st.breadcrumbs(["Home", "Electronics", "Phones"])
-            st.write(f"Clicked: {clicked}")
+            selected = st.breadcrumbs(["Home", "Electronics", "Phones"])
+            st.write(f"Selected: {selected}")
 
         at = AppTest.from_function(script).run()
-        assert at.markdown[0].value == "Clicked: None"
+        assert at.markdown[0].value == "Selected: Phones"
+
+    def test_selection_parameter_by_value(self) -> None:
+        """Test that selection parameter sets initial value by item value."""
+
+        def script() -> None:
+            import streamlit as st
+
+            selected = st.breadcrumbs(
+                ["Home", "Electronics", "Phones"], selection="Electronics"
+            )
+            st.write(f"Selected: {selected}")
+
+        at = AppTest.from_function(script).run()
+        assert at.markdown[0].value == "Selected: Electronics"
+
+    def test_selection_parameter_by_index(self) -> None:
+        """Test that selection parameter sets initial value by index."""
+
+        def script() -> None:
+            import streamlit as st
+
+            selected = st.breadcrumbs(["Home", "Electronics", "Phones"], selection=0)
+            st.write(f"Selected: {selected}")
+
+        at = AppTest.from_function(script).run()
+        assert at.markdown[0].value == "Selected: Home"

--- a/lib/tests/streamlit/elements/breadcrumbs_test.py
+++ b/lib/tests/streamlit/elements/breadcrumbs_test.py
@@ -1,0 +1,192 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Breadcrumbs unit tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import streamlit as st
+from streamlit.elements.widgets.breadcrumbs import _BreadcrumbsSerde
+from streamlit.errors import StreamlitAPIException
+from streamlit.testing.v1.app_test import AppTest
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+_SAMPLE_OPTIONS = ["Home", "Electronics", "Phones"]
+
+
+class TestBreadcrumbsSerde:
+    """Tests for the _BreadcrumbsSerde class."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("Home", "0"),
+            ("Electronics", "1"),
+            ("Phones", "2"),
+            (None, ""),
+            ("Unknown", ""),
+        ],
+        ids=["first", "middle", "last", "none", "unknown"],
+    )
+    def test_serialize(self, value: str | None, expected: str) -> None:
+        """Test serialization of various values to index strings."""
+        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
+        assert serde.serialize(value) == expected
+
+    @pytest.mark.parametrize(
+        ("ui_value", "expected"),
+        [
+            ("0", "Home"),
+            ("1", "Electronics"),
+            ("2", "Phones"),
+            (None, None),
+            ("", None),
+            ("999", None),
+            ("invalid", None),
+        ],
+        ids=[
+            "first",
+            "middle",
+            "last",
+            "none",
+            "empty",
+            "out_of_bounds",
+            "non_numeric",
+        ],
+    )
+    def test_deserialize(self, ui_value: str | None, expected: str | None) -> None:
+        """Test deserialization of various index strings to option values."""
+        serde = _BreadcrumbsSerde[str](_SAMPLE_OPTIONS)
+        assert serde.deserialize(ui_value) == expected
+
+    def test_custom_objects(self) -> None:
+        """Test serde roundtrip with custom dictionary objects."""
+        pages: list[dict[str, Any]] = [
+            {"id": "home", "title": "Home"},
+            {"id": "users", "title": "Users"},
+        ]
+        serde = _BreadcrumbsSerde(pages)
+
+        assert serde.serialize(pages[1]) == "1"
+        assert serde.deserialize("1") == pages[1]
+
+
+class TestBreadcrumbs(DeltaGeneratorTestCase):
+    """Tests for the st.breadcrumbs widget."""
+
+    def test_basic_breadcrumbs(self) -> None:
+        """Test basic breadcrumbs rendering with multiple items."""
+        st.breadcrumbs(["Home", "Section", "Page"])
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.id
+        assert len(proto.items) == 3
+        assert proto.items[0].content == "Home"
+        assert proto.items[1].content == "Section"
+        assert proto.items[2].content == "Page"
+        assert not proto.disabled
+
+    def test_breadcrumbs_with_icons(self) -> None:
+        """Test that material icons are extracted from formatted strings."""
+        st.breadcrumbs(
+            ["home", "folder"],
+            format_func=lambda x: f":material/{x}: {x.title()}",
+        )
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.items[0].content == "Home"
+        assert proto.items[0].content_icon == ":material/home:"
+        assert proto.items[1].content == "Folder"
+        assert proto.items[1].content_icon == ":material/folder:"
+
+    def test_breadcrumbs_with_emoji_icons(self) -> None:
+        """Test that emoji icons are extracted from formatted strings."""
+        st.breadcrumbs(
+            ["home", "docs"],
+            format_func=lambda x: (
+                f"🏠 {x.title()}" if x == "home" else f"📄 {x.title()}"
+            ),
+        )
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.items[0].content == "Home"
+        assert proto.items[0].content_icon == "🏠"
+        assert proto.items[1].content == "Docs"
+        assert proto.items[1].content_icon == "📄"
+
+    def test_breadcrumbs_disabled(self) -> None:
+        """Test that disabled flag is set correctly."""
+        st.breadcrumbs(["Home", "Page"], disabled=True)
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.disabled
+
+    def test_breadcrumbs_with_help(self) -> None:
+        """Test that help tooltip text is set correctly."""
+        st.breadcrumbs(["Home", "Page"], help="Navigate to parent pages")
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.help == "Navigate to parent pages"
+
+    def test_breadcrumbs_with_format_func(self) -> None:
+        """Test that format_func transforms item display text."""
+        pages = [
+            {"id": "home", "title": "Home Page"},
+            {"id": "detail", "title": "Detail Page"},
+        ]
+        st.breadcrumbs(pages, format_func=lambda p: p["title"])
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.items[0].content == "Home Page"
+        assert proto.items[1].content == "Detail Page"
+
+    def test_breadcrumbs_empty_raises_error(self) -> None:
+        """Test that empty items sequence raises StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException):
+            st.breadcrumbs([])
+
+    def test_breadcrumbs_single_item(self) -> None:
+        """Test that single item breadcrumbs render correctly."""
+        st.breadcrumbs(["Home"])
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert len(proto.items) == 1
+        assert proto.items[0].content == "Home"
+
+    def test_breadcrumbs_with_key(self) -> None:
+        """Test that breadcrumbs with custom key generates valid ID."""
+        st.breadcrumbs(["Home", "Page"], key="my_breadcrumbs")
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.id
+
+
+class TestBreadcrumbsWithAppTest:
+    """Test breadcrumbs with AppTest."""
+
+    def test_initial_value_is_none(self) -> None:
+        """Test that the initial return value is None before any click."""
+
+        def script() -> None:
+            import streamlit as st
+
+            clicked = st.breadcrumbs(["Home", "Electronics", "Phones"])
+            st.write(f"Clicked: {clicked}")
+
+        at = AppTest.from_function(script).run()
+        assert at.markdown[0].value == "Clicked: None"

--- a/lib/tests/streamlit/elements/breadcrumbs_test.py
+++ b/lib/tests/streamlit/elements/breadcrumbs_test.py
@@ -183,7 +183,7 @@ class TestBreadcrumbs(DeltaGeneratorTestCase):
         assert proto.separator == "/"
 
     def test_breadcrumbs_custom_separator(self) -> None:
-        """Test that custom separator is set correctly."""
+        """Test that custom text separator is set correctly."""
         st.breadcrumbs(["Home", "Page"], separator=" > ")
 
         proto = self.get_delta_from_queue().new_element.breadcrumbs

--- a/lib/tests/streamlit/elements/breadcrumbs_test.py
+++ b/lib/tests/streamlit/elements/breadcrumbs_test.py
@@ -175,6 +175,27 @@ class TestBreadcrumbs(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.breadcrumbs
         assert proto.id
 
+    def test_breadcrumbs_default_separator(self) -> None:
+        """Test that default separator is set correctly."""
+        st.breadcrumbs(["Home", "Page"])
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.separator == "/"
+
+    def test_breadcrumbs_custom_separator(self) -> None:
+        """Test that custom separator is set correctly."""
+        st.breadcrumbs(["Home", "Page"], separator=" > ")
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.separator == " > "
+
+    def test_breadcrumbs_material_icon_separator(self) -> None:
+        """Test that material icon separator is set correctly."""
+        st.breadcrumbs(["Home", "Page"], separator=":material/chevron_right:")
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.separator == ":material/chevron_right:"
+
 
 class TestBreadcrumbsWithAppTest:
     """Test breadcrumbs with AppTest."""

--- a/lib/tests/streamlit/elements/breadcrumbs_test.py
+++ b/lib/tests/streamlit/elements/breadcrumbs_test.py
@@ -196,6 +196,13 @@ class TestBreadcrumbs(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.breadcrumbs
         assert proto.separator == ":material/chevron_right:"
 
+    def test_breadcrumbs_value_initially_empty(self) -> None:
+        """Test that value is empty string initially (no selection)."""
+        st.breadcrumbs(["Home", "Page"])
+
+        proto = self.get_delta_from_queue().new_element.breadcrumbs
+        assert proto.value == ""
+
 
 class TestBreadcrumbsWithAppTest:
     """Test breadcrumbs with AppTest."""

--- a/lib/tests/streamlit/typing/breadcrumbs_types.py
+++ b/lib/tests/streamlit/typing/breadcrumbs_types.py
@@ -24,43 +24,46 @@ if TYPE_CHECKING:
 
     breadcrumbs = BreadcrumbsMixin().breadcrumbs
 
-    # Test basic return type - T | None
-    assert_type(breadcrumbs(["Home", "Section", "Page"]), str | None)
-    assert_type(breadcrumbs([1, 2, 3]), int | None)
-    assert_type(breadcrumbs([1.0, 2.0, 3.0]), float | None)
+    # Test basic return type - T (stateful, always returns selected item)
+    assert_type(breadcrumbs(["Home", "Section", "Page"]), str)
+    assert_type(breadcrumbs([1, 2, 3]), int)
+    assert_type(breadcrumbs([1.0, 2.0, 3.0]), float)
 
-    # Test with custom objects - returns dict | None
+    # Test with custom objects - returns dict
     items = [{"id": "home"}, {"id": "section"}]
-    assert_type(breadcrumbs(items), dict[str, str] | None)
+    assert_type(breadcrumbs(items), dict[str, str])
 
     # Test key parameter
-    assert_type(breadcrumbs(["a", "b"], key="my_key"), str | None)
-    assert_type(breadcrumbs(["a", "b"], key=123), str | None)
+    assert_type(breadcrumbs(["a", "b"], key="my_key"), str)
+    assert_type(breadcrumbs(["a", "b"], key=123), str)
 
     # Test help parameter
-    assert_type(breadcrumbs(["a", "b"], help="tooltip text"), str | None)
-    assert_type(breadcrumbs(["a", "b"], help=None), str | None)
+    assert_type(breadcrumbs(["a", "b"], help="tooltip text"), str)
+    assert_type(breadcrumbs(["a", "b"], help=None), str)
 
     # Test disabled parameter
-    assert_type(breadcrumbs(["a", "b"], disabled=True), str | None)
-    assert_type(breadcrumbs(["a", "b"], disabled=False), str | None)
+    assert_type(breadcrumbs(["a", "b"], disabled=True), str)
+    assert_type(breadcrumbs(["a", "b"], disabled=False), str)
 
     # Test separator parameter
-    assert_type(breadcrumbs(["a", "b"], separator=" > "), str | None)
-    assert_type(
-        breadcrumbs(["a", "b"], separator=":material/chevron_right:"), str | None
-    )
+    assert_type(breadcrumbs(["a", "b"], separator=" > "), str)
+    assert_type(breadcrumbs(["a", "b"], separator=":material/chevron_right:"), str)
 
-    # Test on_click parameter
+    # Test on_change parameter
     def my_callback() -> None:
         pass
 
-    assert_type(breadcrumbs(["a", "b"], on_click=my_callback), str | None)
-    assert_type(breadcrumbs(["a", "b"], on_click=None), str | None)
+    assert_type(breadcrumbs(["a", "b"], on_change=my_callback), str)
+    assert_type(breadcrumbs(["a", "b"], on_change=None), str)
 
     # Test format_func parameter
     def format_item(item: str) -> str:
         return f":material/home: {item}"
 
-    assert_type(breadcrumbs(["a", "b"], format_func=format_item), str | None)
-    assert_type(breadcrumbs(["a", "b"], format_func=None), str | None)
+    assert_type(breadcrumbs(["a", "b"], format_func=format_item), str)
+    assert_type(breadcrumbs(["a", "b"], format_func=None), str)
+
+    # Test selection parameter
+    assert_type(breadcrumbs(["a", "b", "c"], selection="a"), str)
+    assert_type(breadcrumbs(["a", "b", "c"], selection=1), str)
+    assert_type(breadcrumbs(["a", "b", "c"], selection=None), str)

--- a/lib/tests/streamlit/typing/breadcrumbs_types.py
+++ b/lib/tests/streamlit/typing/breadcrumbs_types.py
@@ -1,0 +1,66 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform some "type checking testing"; mypy should flag any assignments that are incorrect.
+if TYPE_CHECKING:
+    from streamlit.elements.widgets.breadcrumbs import BreadcrumbsMixin
+
+    breadcrumbs = BreadcrumbsMixin().breadcrumbs
+
+    # Test basic return type - T | None
+    assert_type(breadcrumbs(["Home", "Section", "Page"]), str | None)
+    assert_type(breadcrumbs([1, 2, 3]), int | None)
+    assert_type(breadcrumbs([1.0, 2.0, 3.0]), float | None)
+
+    # Test with custom objects - returns dict | None
+    items = [{"id": "home"}, {"id": "section"}]
+    assert_type(breadcrumbs(items), dict[str, str] | None)
+
+    # Test key parameter
+    assert_type(breadcrumbs(["a", "b"], key="my_key"), str | None)
+    assert_type(breadcrumbs(["a", "b"], key=123), str | None)
+
+    # Test help parameter
+    assert_type(breadcrumbs(["a", "b"], help="tooltip text"), str | None)
+    assert_type(breadcrumbs(["a", "b"], help=None), str | None)
+
+    # Test disabled parameter
+    assert_type(breadcrumbs(["a", "b"], disabled=True), str | None)
+    assert_type(breadcrumbs(["a", "b"], disabled=False), str | None)
+
+    # Test separator parameter
+    assert_type(breadcrumbs(["a", "b"], separator=" > "), str | None)
+    assert_type(
+        breadcrumbs(["a", "b"], separator=":material/chevron_right:"), str | None
+    )
+
+    # Test on_click parameter
+    def my_callback() -> None:
+        pass
+
+    assert_type(breadcrumbs(["a", "b"], on_click=my_callback), str | None)
+    assert_type(breadcrumbs(["a", "b"], on_click=None), str | None)
+
+    # Test format_func parameter
+    def format_item(item: str) -> str:
+        return f":material/home: {item}"
+
+    assert_type(breadcrumbs(["a", "b"], format_func=format_item), str | None)
+    assert_type(breadcrumbs(["a", "b"], format_func=None), str | None)

--- a/proto/streamlit/proto/Breadcrumbs.proto
+++ b/proto/streamlit/proto/Breadcrumbs.proto
@@ -40,5 +40,7 @@ message Breadcrumbs {
   // The currently clicked value (index as string), used for trigger behavior.
   // When set, contains the index of the clicked item.
   optional string value = 6;
-  // next id: 7
+  // Separator displayed between items. Supports text or material icon syntax.
+  string separator = 7;
+  // next id: 8
 }

--- a/proto/streamlit/proto/Breadcrumbs.proto
+++ b/proto/streamlit/proto/Breadcrumbs.proto
@@ -1,0 +1,44 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+// Breadcrumbs widget displaying a navigation path.
+// Clicking an item (except the last) triggers a rerun and returns the clicked item.
+message Breadcrumbs {
+  // A single item in the breadcrumb path.
+  message BreadcrumbItem {
+    // Display text for this breadcrumb item.
+    string content = 1;
+    // Optional icon (material icon or emoji) displayed before the content.
+    optional string content_icon = 2;
+  }
+
+  // Unique widget identifier.
+  string id = 1;
+  // Ordered list of breadcrumb items from root to current page.
+  repeated BreadcrumbItem items = 2;
+  // Whether the widget is disabled (no items clickable).
+  bool disabled = 3;
+  // Form ID if this widget is inside a form.
+  string form_id = 4;
+  // Tooltip text shown on hover.
+  optional string help = 5;
+  // The currently clicked value (index as string), used for trigger behavior.
+  // When set, contains the index of the clicked item.
+  optional string value = 6;
+  // next id: 7
+}

--- a/proto/streamlit/proto/Breadcrumbs.proto
+++ b/proto/streamlit/proto/Breadcrumbs.proto
@@ -17,7 +17,8 @@
 syntax = "proto3";
 
 // Breadcrumbs widget displaying a navigation path.
-// Clicking an item (except the last) triggers a rerun and returns the clicked item.
+// Maintains a stateful selection. Clicking an item updates the selection
+// and triggers a rerun, returning the newly selected item.
 message Breadcrumbs {
   // A single item in the breadcrumb path.
   message BreadcrumbItem {
@@ -37,8 +38,8 @@ message Breadcrumbs {
   string form_id = 4;
   // Tooltip text shown on hover.
   optional string help = 5;
-  // The currently clicked value (index as string), used for trigger behavior.
-  // When set, contains the index of the clicked item.
+  // The currently selected item index (as string for consistency).
+  // Always set to the index of the selected item.
   optional string value = 6;
   // Separator displayed between items. Supports text or material icon syntax.
   string separator = 7;

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -21,6 +21,7 @@ import "streamlit/proto/Audio.proto";
 import "streamlit/proto/AudioInput.proto";
 import "streamlit/proto/Balloons.proto";
 import "streamlit/proto/BidiComponent.proto";
+import "streamlit/proto/Breadcrumbs.proto";
 import "streamlit/proto/Button.proto";
 import "streamlit/proto/ButtonGroup.proto";
 import "streamlit/proto/CameraInput.proto";
@@ -135,7 +136,8 @@ message Element {
     Video video = 14;
     Heading heading = 47;
     Code code = 48;
-    // Next ID: 64
+    Breadcrumbs breadcrumbs = 64;
+    // Next ID: 65
   }
 
   reserved 3, 9, 10, 11, 17;

--- a/specs/2026-02-21-breadcrumbs/product-spec.md
+++ b/specs/2026-02-21-breadcrumbs/product-spec.md
@@ -1,0 +1,280 @@
+---
+author: lukasmasuch
+created: 2026-02-21
+---
+
+# Breadcrumbs widget
+
+## Summary
+
+Add a new `st.breadcrumbs` widget that displays a horizontal navigation path (e.g.,
+Home > Section > Page), helping users understand their location in multi-page or nested
+app flows and quickly jump to higher-level views. Clicking an item triggers a rerun and
+returns the clicked item.
+
+## Problem
+
+Users building multi-page apps or nested navigation flows need a way to show the current
+location hierarchy and allow navigation to parent pages. Breadcrumbs are a common UI
+pattern for this use case, but Streamlit doesn't provide a built-in solution.
+
+**Requests:**
+
+- [#13147](https://github.com/streamlit/streamlit/issues/13147) — Add a breadcrumbs widget
+- [#5889](https://github.com/streamlit/streamlit/issues/5889) — Hierarchical multipage
+  navigation (14+ comments, related use case)
+
+**Use cases:**
+
+- Documentation sites with nested sections (Home > Guide > Installation)
+- E-commerce apps with category hierarchies (Home > Electronics > Phones)
+- Admin dashboards with nested views (Dashboard > Users > User Detail)
+- File browsers showing directory paths (Root > Documents > Reports)
+- Multi-step wizards showing progress (Step 1 > Step 2 > Step 3)
+
+**Current workarounds:**
+
+Users combine `st.columns` with multiple `st.button` or use custom HTML, but this lacks
+proper accessibility semantics and consistent styling.
+
+```python
+# Current workaround (verbose, no accessibility)
+cols = st.columns([1, 1, 1, 3])
+with cols[0]:
+    if st.button("Home", type="tertiary"):
+        st.switch_page("home.py")
+with cols[1]:
+    st.write(">")
+with cols[2]:
+    if st.button("Section", type="tertiary"):
+        st.switch_page("section.py")
+```
+
+## Proposal
+
+### API
+
+```python
+st.breadcrumbs(
+    items: Sequence[T],
+    *,
+    separator: str = "/",
+    key: Key | None = None,
+    help: str | None = None,
+    on_click: WidgetCallback | None = None,
+    args: WidgetArgs | None = None,
+    kwargs: WidgetKwargs | None = None,
+    disabled: bool = False,
+    format_func: Callable[[T], str] = str,
+) -> T | None
+```
+
+### Parameters
+
+| Parameter     | Type                         | Default  | Description                                                                                                                        |
+| ------------- | ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `items`       | `Sequence[T]`                | required | Items to display in the breadcrumb path, ordered from root to current. The last item represents the current page.                  |
+| `separator`   | `str`                        | `"/"`    | Separator displayed between items. Supports markdown including icons (e.g., `:material/chevron_right:`).                           |
+| `key`         | `str \| int \| None`         | `None`   | Unique key for the widget.                                                                                                         |
+| `help`        | `str \| None`                | `None`   | Tooltip text shown on hover over the widget.                                                                                       |
+| `on_click`    | `Callable \| None`           | `None`   | Callback function executed when an item is clicked.                                                                                |
+| `args`        | `list \| tuple \| None`      | `None`   | Arguments to pass to the callback.                                                                                                 |
+| `kwargs`      | `dict \| None`               | `None`   | Keyword arguments to pass to the callback.                                                                                         |
+| `disabled`    | `bool`                       | `False`  | Whether the breadcrumb navigation is disabled.                                                                                     |
+| `format_func` | `Callable[[T], str]`         | `str`    | Function to convert items to display strings. Supports markdown including icons (`:material/home:`). Same behavior as `st.pills`. |
+
+### Return Value
+
+| Condition    | Return Value                                                                |
+| ------------ | --------------------------------------------------------------------------- |
+| Item clicked | `T` — the clicked item value (not the last item, which is non-clickable).   |
+| No click     | `None`                                                                      |
+
+### Behavior
+
+- Items are displayed horizontally with the `separator` string between them (default `/`)
+- The separator supports markdown including material icons (e.g., `:material/chevron_right:`)
+- All items except the last are clickable links; the last item (current page) is displayed
+  as plain text
+- Clicking an item triggers a rerun and returns the clicked item value
+- The widget uses proper accessibility semantics (`<nav>` with `aria-label`, ordered list,
+  `aria-current="page"` on the last item)
+- When `disabled=True`, all items appear as plain text (none are clickable)
+- Long paths that overflow wrap to the next line or can be truncated (design TBD)
+
+### Examples
+
+**Basic usage:**
+
+```python
+import streamlit as st
+
+clicked = st.breadcrumbs(["Home", "Electronics", "Phones", "iPhone 15"])
+
+if clicked == "Home":
+    st.switch_page("home.py")
+elif clicked == "Electronics":
+    st.switch_page("electronics.py")
+elif clicked == "Phones":
+    st.switch_page("phones.py")
+# "iPhone 15" is current page, not clickable
+```
+
+**With icons:**
+
+```python
+import streamlit as st
+
+clicked = st.breadcrumbs(
+    ["home", "folder", "file"],
+    format_func=lambda x: f":material/{x}: {x.title()}",
+)
+```
+
+**With custom separator:**
+
+```python
+import streamlit as st
+
+# Using a text separator
+clicked = st.breadcrumbs(["Home", "Section", "Page"], separator=" > ")
+
+# Using a material icon as separator
+clicked = st.breadcrumbs(
+    ["Home", "Section", "Page"],
+    separator=":material/chevron_right:",
+)
+```
+
+**With custom objects:**
+
+```python
+import streamlit as st
+
+pages = [
+    {"id": "home", "title": "Home", "path": "home.py"},
+    {"id": "users", "title": "Users", "path": "users.py"},
+    {"id": "detail", "title": "User Detail", "path": "detail.py"},
+]
+
+clicked = st.breadcrumbs(
+    pages,
+    format_func=lambda p: p["title"],
+)
+
+if clicked:
+    st.switch_page(clicked["path"])
+```
+
+**With `st.Page` objects (future integration):**
+
+```python
+import streamlit as st
+
+# When combined with st.navigation, st.Page objects can be used directly
+home = st.Page("home.py", title="Home", icon=":material/home:")
+section = st.Page("section.py", title="Section")
+current = st.Page("current.py", title="Current Page")
+
+clicked = st.breadcrumbs([home, section, current])
+
+if clicked:
+    st.switch_page(clicked)  # st.Page has url_path for navigation
+```
+
+### Edge Cases
+
+- **Empty items**: Raises `StreamlitAPIException`
+- **Single item**: Displays the item as non-clickable text (current page only)
+- **Duplicate items**: Allowed; returns the exact item value clicked
+- **Long item labels**: Truncated with ellipsis; full text shown on hover
+- **Click on current (last) item**: Not clickable, returns `None`
+
+---
+
+## Design Options
+
+### Option 1: Trigger-based widget (like `st.button`) ✅ PREFERRED
+
+The proposal above follows this approach. The widget acts as a trigger: clicking an item
+returns it once, then returns `None` on subsequent reruns until clicked again.
+
+**Pros:**
+- Consistent with `st.button` and `st.menu_button` patterns
+- Simple mental model: click returns value
+- Works naturally with `st.switch_page` for navigation
+
+**Cons:**
+- No persistent state (but breadcrumbs typically don't need it)
+
+### Option 2: Selection-based widget (like `st.selectbox`)
+
+The widget would maintain state and always return the currently selected/last item.
+
+```python
+current = st.breadcrumbs(["Home", "Section", "Page"], default="Page")
+# Returns "Page" until user clicks another item
+```
+
+**Pros:**
+- More like traditional widgets with persistent selection
+
+**Cons:**
+- Doesn't match typical breadcrumb UX (navigate away, don't select)
+- Confusing: what does "selecting" a breadcrumb mean?
+- Would need `default` parameter logic
+
+### Option 3: Automatic page navigation
+
+The widget would automatically call `st.switch_page` when an item with a `url_path` is
+clicked (like when using `st.Page` objects).
+
+```python
+st.breadcrumbs([home_page, section_page, current_page])
+# Automatically navigates when clicked, no return value needed
+```
+
+**Pros:**
+- More convenient for multipage apps
+- Tighter integration with `st.navigation`
+
+**Cons:**
+- Magic behavior that's harder to customize
+- What if user wants to do something before/instead of navigation?
+- Inconsistent with other widgets that return values
+
+---
+
+## Out of Scope (Future Work)
+
+- **Automatic breadcrumb generation**: Automatically derive breadcrumbs from
+  `st.navigation` page hierarchy. Requires changes to how `st.Page` tracks parent/child
+  relationships. See [#5889](https://github.com/streamlit/streamlit/issues/5889).
+- **Collapsible breadcrumbs**: For very long paths, collapse middle items into a dropdown
+  (e.g., Home > ... > Current). Can add based on user feedback.
+- **Structured data / SEO**: Output JSON-LD structured data for search engines. Not
+  applicable for Streamlit apps.
+
+---
+
+## Checklist
+
+| Item                       | ✅ or comment                                                  |
+| -------------------------- | -------------------------------------------------------------- |
+| Works on SiS, Cloud, etc?  | ✅                                                             |
+| No breaking API changes    | ✅                                                             |
+| No new dependencies        | ✅                                                             |
+| Metrics collected          | ✅                                                             |
+| Any security/legal impact? | ✅ None                                                        |
+| Any docs changes needed?   | ✅ Document new widget, add to navigation category in API docs |
+
+---
+
+## References
+
+- **GitHub Issues:**
+  - [#13147](https://github.com/streamlit/streamlit/issues/13147) — Add a breadcrumbs widget
+  - [#5889](https://github.com/streamlit/streamlit/issues/5889) — Hierarchical multipage navigation
+- **Design resources:**
+  - [Component Gallery: Breadcrumbs](https://component.gallery/components/breadcrumbs/)
+  - [WAI-ARIA Breadcrumb Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)

--- a/specs/2026-02-21-breadcrumbs/product-spec.md
+++ b/specs/2026-02-21-breadcrumbs/product-spec.md
@@ -9,8 +9,8 @@ created: 2026-02-21
 
 Add a new `st.breadcrumbs` widget that displays a horizontal navigation path (e.g.,
 Home > Section > Page), helping users understand their location in multi-page or nested
-app flows and quickly jump to higher-level views. Clicking an item triggers a rerun and
-returns the clicked item.
+app flows and quickly jump to higher-level views. The widget maintains a stateful
+selection that persists across reruns.
 
 ## Problem
 
@@ -58,26 +58,28 @@ with cols[2]:
 st.breadcrumbs(
     items: Sequence[T],
     *,
+    selection: T | int | None = None,
     separator: str = "/",
     key: Key | None = None,
     help: str | None = None,
-    on_click: WidgetCallback | None = None,
+    on_change: WidgetCallback | None = None,
     args: WidgetArgs | None = None,
     kwargs: WidgetKwargs | None = None,
     disabled: bool = False,
     format_func: Callable[[T], str] = str,
-) -> T | None
+) -> T
 ```
 
 ### Parameters
 
 | Parameter     | Type                         | Default  | Description                                                                                                                        |
 | ------------- | ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `items`       | `Sequence[T]`                | required | Items to display in the breadcrumb path, ordered from root to current. The last item represents the current page.                  |
+| `items`       | `Sequence[T]`                | required | Items to display in the breadcrumb path, ordered from root to current.                                                             |
+| `selection`   | `T \| int \| None`           | `None`   | The initially selected item. Can be an item value or index. Defaults to the last item (current page).                              |
 | `separator`   | `str`                        | `"/"`    | Separator displayed between items. Supports markdown including icons (e.g., `:material/chevron_right:`).                           |
 | `key`         | `str \| int \| None`         | `None`   | Unique key for the widget.                                                                                                         |
 | `help`        | `str \| None`                | `None`   | Tooltip text shown on hover over the widget.                                                                                       |
-| `on_click`    | `Callable \| None`           | `None`   | Callback function executed when an item is clicked.                                                                                |
+| `on_change`   | `Callable \| None`           | `None`   | Callback function executed when the selection changes.                                                                             |
 | `args`        | `list \| tuple \| None`      | `None`   | Arguments to pass to the callback.                                                                                                 |
 | `kwargs`      | `dict \| None`               | `None`   | Keyword arguments to pass to the callback.                                                                                         |
 | `disabled`    | `bool`                       | `False`  | Whether the breadcrumb navigation is disabled.                                                                                     |
@@ -85,20 +87,20 @@ st.breadcrumbs(
 
 ### Return Value
 
-| Condition    | Return Value                                                                |
-| ------------ | --------------------------------------------------------------------------- |
-| Item clicked | `T` — the clicked item value (not the last item, which is non-clickable).   |
-| No click     | `None`                                                                      |
+| Condition         | Return Value                                                                |
+| ----------------- | --------------------------------------------------------------------------- |
+| Initial render    | `T` — the item specified by `selection` (or the last item by default).      |
+| Selection changed | `T` — the newly selected item.                                              |
 
 ### Behavior
 
 - Items are displayed horizontally with the `separator` string between them (default `/`)
 - The separator supports markdown including material icons (e.g., `:material/chevron_right:`)
-- All items except the last are clickable links; the last item (current page) is displayed
-  as plain text
-- Clicking an item triggers a rerun and returns the clicked item value
+- The selected item is displayed as non-clickable text; all other items are clickable links
+- Clicking an item updates the selection, triggers a rerun, and returns the newly selected item
+- Selection state persists across reruns (stateful widget)
 - The widget uses proper accessibility semantics (`<nav>` with `aria-label`, ordered list,
-  `aria-current="page"` on the last item)
+  `aria-current="page"` on the selected item)
 - When `disabled=True`, all items appear as plain text (none are clickable)
 - Long paths that overflow wrap to the next line or can be truncated (design TBD)
 
@@ -109,15 +111,15 @@ st.breadcrumbs(
 ```python
 import streamlit as st
 
-clicked = st.breadcrumbs(["Home", "Electronics", "Phones", "iPhone 15"])
+selected = st.breadcrumbs(["Home", "Electronics", "Phones", "iPhone 15"])
 
-if clicked == "Home":
+if selected == "Home":
     st.switch_page("home.py")
-elif clicked == "Electronics":
+elif selected == "Electronics":
     st.switch_page("electronics.py")
-elif clicked == "Phones":
+elif selected == "Phones":
     st.switch_page("phones.py")
-# "iPhone 15" is current page, not clickable
+# "iPhone 15" is selected by default (last item)
 ```
 
 **With icons:**
@@ -125,7 +127,7 @@ elif clicked == "Phones":
 ```python
 import streamlit as st
 
-clicked = st.breadcrumbs(
+selected = st.breadcrumbs(
     ["home", "folder", "file"],
     format_func=lambda x: f":material/{x}: {x.title()}",
 )
@@ -137,10 +139,10 @@ clicked = st.breadcrumbs(
 import streamlit as st
 
 # Using a text separator
-clicked = st.breadcrumbs(["Home", "Section", "Page"], separator=" > ")
+selected = st.breadcrumbs(["Home", "Section", "Page"], separator=" > ")
 
 # Using a material icon as separator
-clicked = st.breadcrumbs(
+selected = st.breadcrumbs(
     ["Home", "Section", "Page"],
     separator=":material/chevron_right:",
 )
@@ -157,13 +159,13 @@ pages = [
     {"id": "detail", "title": "User Detail", "path": "detail.py"},
 ]
 
-clicked = st.breadcrumbs(
+selected = st.breadcrumbs(
     pages,
     format_func=lambda p: p["title"],
 )
 
-if clicked:
-    st.switch_page(clicked["path"])
+if selected != pages[-1]:  # Not on the last page
+    st.switch_page(selected["path"])
 ```
 
 **With `st.Page` objects (future integration):**
@@ -176,53 +178,73 @@ home = st.Page("home.py", title="Home", icon=":material/home:")
 section = st.Page("section.py", title="Section")
 current = st.Page("current.py", title="Current Page")
 
-clicked = st.breadcrumbs([home, section, current])
+selected = st.breadcrumbs([home, section, current])
 
-if clicked:
-    st.switch_page(clicked)  # st.Page has url_path for navigation
+if selected != current:
+    st.switch_page(selected)  # st.Page has url_path for navigation
+```
+
+**With explicit selection:**
+
+```python
+import streamlit as st
+
+# Select a specific item by value
+selected = st.breadcrumbs(
+    ["Home", "Section", "Subsection", "Page"],
+    selection="Section",  # Start with "Section" selected
+)
+
+# Or select by index
+selected = st.breadcrumbs(
+    ["Home", "Section", "Subsection", "Page"],
+    selection=1,  # Select "Section" (index 1)
+)
 ```
 
 ### Edge Cases
 
 - **Empty items**: Raises `StreamlitAPIException`
-- **Single item**: Displays the item as non-clickable text (current page only)
-- **Duplicate items**: Allowed; returns the exact item value clicked
+- **Single item**: Displays the item as non-clickable text (always selected)
+- **Duplicate items**: Allowed; returns the exact item value selected
 - **Long item labels**: Truncated with ellipsis; full text shown on hover
-- **Click on current (last) item**: Not clickable, returns `None`
+- **Invalid selection value**: Raises `StreamlitAPIException`
+- **Invalid selection index**: Raises `StreamlitAPIException`
 
 ---
 
 ## Design Options
 
-### Option 1: Trigger-based widget (like `st.button`) ✅ PREFERRED
+### Option 1: Trigger-based widget (like `st.button`)
 
-The proposal above follows this approach. The widget acts as a trigger: clicking an item
-returns it once, then returns `None` on subsequent reruns until clicked again.
+The widget acts as a trigger: clicking an item returns it once, then returns `None` on
+subsequent reruns until clicked again.
 
 **Pros:**
 - Consistent with `st.button` and `st.menu_button` patterns
-- Simple mental model: click returns value
-- Works naturally with `st.switch_page` for navigation
+- Simple mental model: click returns value once
 
 **Cons:**
-- No persistent state (but breadcrumbs typically don't need it)
+- No persistent state (breadcrumbs often need to track current position)
+- Awkward for navigation use cases where you want to know current selection
 
-### Option 2: Selection-based widget (like `st.selectbox`)
+### Option 2: Selection-based widget (like `st.pills`) ✅ CHOSEN
 
-The widget would maintain state and always return the currently selected/last item.
+The widget maintains state and always returns the currently selected item.
 
 ```python
-current = st.breadcrumbs(["Home", "Section", "Page"], default="Page")
+selected = st.breadcrumbs(["Home", "Section", "Page"], selection="Page")
 # Returns "Page" until user clicks another item
 ```
 
 **Pros:**
 - More like traditional widgets with persistent selection
+- Natural for navigation: always know "where you are"
+- Better matches breadcrumb semantics: showing current location in hierarchy
 
 **Cons:**
-- Doesn't match typical breadcrumb UX (navigate away, don't select)
-- Confusing: what does "selecting" a breadcrumb mean?
-- Would need `default` parameter logic
+- Slightly more complex than trigger widgets
+- Needs `selection` parameter for initial value
 
 ### Option 3: Automatic page navigation
 


### PR DESCRIPTION
## Describe your changes

- Add new `st.breadcrumbs` widget that displays a horizontal navigation path (e.g., Home > Section > Page)
- Enables users to understand their location in multi-page or nested app flows and navigate to higher-level views
- Follows trigger-based widget pattern (like `st.button`) - clicking an item returns that item and triggers a rerun
- Supports material icons and emoji icons via `format_func`
- Includes customizable `separator` parameter (text or material icon)
- Follows WAI-ARIA breadcrumb accessibility guidelines

## Testing Plan

- [x] Unit Tests (Python): 26 tests covering serialization, rendering, icons, disabled state, format_func, separators
- [x] Unit Tests (TypeScript): 11 tests covering rendering, accessibility, click handling, separators, icons
- [x] E2E Tests: 7 tests covering display, click interactions, disabled state, icons, custom objects, separators

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.