### PR TITLE
Preserve non-fragment widget state during run_every fragment auto-reruns

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -408,6 +408,19 @@ class AppSession:
                 )
                 return
 
+            # For ``run_every`` auto-reruns, the frontend may fire a rerun
+            # request even when the user has navigated to a different page.
+            # The ScriptRunner handles this correctly — the fragment runs in
+            # isolation and _is_stale_widget preserves non-fragment widget
+            # state — but we log a debug message here to aid diagnosability.
+            if fragment_id and client_state.is_auto_rerun:
+                _LOGGER.debug(
+                    "Fragment auto-rerun received for fragment %s (page hash: %s). "
+                    "Non-fragment widget state will be preserved.",
+                    fragment_id,
+                    client_state.page_script_hash,
+                )
+
             if client_state.HasField("context_info"):
                 self._client_state.context_info.CopyFrom(client_state.context_info)
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -544,7 +544,12 @@ class ScriptRunner:
                     # widgets on the new page if keys collide.
                     qp.set_initial_query_params_from_current()
 
-                # Now safe to do normal cleanup - filtering already done
+                # Now safe to do normal cleanup - filtering already done.
+                # Important: ctx.fragment_ids_this_run still reflects the
+                # *previous* run at this point (ctx.reset hasn't been called
+                # yet).  _remove_stale_widgets reads ctx.fragment_ids_this_run
+                # internally, so widgets that were protected during a preceding
+                # fragment-only auto-rerun are correctly preserved here as well.
                 self._session_state.on_script_finished(widget_ids)
 
             fragment_ids_this_run: list[str] | None = (

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -42,6 +42,25 @@ if TYPE_CHECKING:
 GENERATED_ELEMENT_ID_PREFIX: Final = "$$ID"
 TESTING_KEY = "$$STREAMLIT_INTERNAL_KEY_TESTING"
 
+# When a fragment-only (``run_every``) auto-rerun is in progress, ``fragment_ids_this_run``
+# is populated with the IDs of the executing fragments.  The widget-cleanup pass in
+# ``SessionState._remove_stale_widgets`` uses this to distinguish between:
+#
+#   * A widget that genuinely no longer exists (should be removed).
+#   * A widget from a non-fragment part of the script that was not re-executed in this
+#     partial run (should be *preserved* until the next full-page run).
+#
+# In particular, widgets protected by the "interrupt-cleanup" pattern
+# (``st.session_state[key] = st.session_state.get(key, default)`` before a widget
+# declaration) must survive fragment auto-reruns, otherwise cross-page widget state
+# is silently dropped while ``run_every`` fragments are active.
+#
+# See: https://github.com/streamlit/streamlit/issues/10805
+FRAGMENT_AUTO_RERUN_WIDGET_PRESERVATION_NOTE: Final = (
+    "fragment_ids_this_run being set signals a partial (fragment-only) run; "
+    "widgets absent from _new_widget_state.widget_metadata must be preserved."
+)
+
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1165,6 +1165,20 @@ def _is_stale_widget(
     fragment_ids_this_run: list[str] | None,
 ) -> bool:
     if not metadata:
+        # During a fragment-only auto-rerun the widget metadata in
+        # ``_new_widget_state`` is limited to the widgets that were
+        # re-registered by the running fragment(s).  Widgets from non-fragment
+        # portions of the script (including those protected by the
+        # "interrupt-cleanup" pattern — ``st.session_state[key] = …`` before
+        # the widget declaration) are absent from metadata but are NOT gone;
+        # they simply weren't part of this partial execution.  Preserving them
+        # here avoids spurious session-state loss when ``run_every`` fragments
+        # run while the user is on a different page.
+        #
+        # Full-page reruns: metadata is absent only for truly deleted widgets,
+        # so the original True is correct and unchanged.
+        if fragment_ids_this_run:
+            return False
         return True
 
     # If we're running 1 or more fragments, but this widget is unrelated to any of the


### PR DESCRIPTION
## Summary

Fixes widget state being silently dropped when a `run_every` fragment fires its periodic timer while the user has navigated to a different page, particularly when widgets are protected by the "interrupt-cleanup" pattern (`st.session_state[key] = st.session_state.get(key, default)`).

**Root cause:** During a fragment-only auto-rerun, `_compact_state()` clears `_new_widget_state` at the start of the run. Non-fragment widgets are never re-registered (they're on a different page), so their metadata is absent from `_new_widget_state.widget_metadata`. `_is_stale_widget` returned `True` for `metadata=None`, unconditionally evicting those widgets from both `_new_widget_state.states` and `_old_state` — discarding the interrupt-cleanup state.

**Reproduce:**
```python
key = "test_radio"
options = ["option 1", "option 2"]
st.session_state[key] = st.session_state.get(key, options[0])
st.radio("Test radio", options=options, key=key)

@st.fragment(run_every=2)
def test_fragment():
    pass

test_fragment()
```
1. Choose "option 2" and wait 2 seconds (fragment fires)
2. Navigate to another page → "option 1" is shown (state lost)

**Changes:**

- `lib/streamlit/runtime/state/session_state.py` — in `_is_stale_widget`, when `fragment_ids_this_run` is set (fragment-only run), treat `metadata=None` as "preserve" rather than "stale". The widget was absent from metadata because it lives outside the fragment, not because it was deleted. Full-page runs evict metadata-less widgets as before.
- `lib/streamlit/runtime/state/common.py` — add `FRAGMENT_AUTO_RERUN_WIDGET_PRESERVATION_NOTE` constant documenting the widget-cleanup invariant for fragment auto-reruns.
- `lib/streamlit/runtime/scriptrunner/script_runner.py` — add a comment at the page-change pre-cleanup call site explaining why the previous run's `fragment_ids_this_run` is still valid.
- `lib/streamlit/runtime/app_session.py` — add a debug-level log when a `run_every` auto-rerun request arrives to aid diagnosability.

Closes https://github.com/streamlit/streamlit/issues/10805
