### PR TITLE
fix(vega-lite): render vconcat charts with faceted/repeated children

### DIFF
--- a/e2e_playwright/st_altair_chart.py
+++ b/e2e_playwright/st_altair_chart.py
@@ -212,3 +212,48 @@ text_regression = base_regression.mark_text(dy=-10).encode(
 regression_chart = (base_regression + text_regression) & base_regression
 regression_chart = regression_chart.properties(autosize="fit-x")
 st.altair_chart(regression_chart, width="stretch")
+
+# Regression scenario for https://github.com/streamlit/streamlit/issues/14050:
+# vconcat of layered + faceted children with width=stretch should render.
+st.write("Regression: vconcat of layered faceted charts with width=stretch")
+df_issue_14050 = pd.DataFrame(
+    {
+        "group": ["x", "x", "x", "y", "y", "y", "z", "z", "z"],
+        "bin": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+        "xval": [10, 20, 30, 12, 22, 32, 14, 24, 34],
+        "y1": [4, 6, 8, 5, 7, 9, 6, 8, 10],
+        "y2": [2, 3, 5, 2.5, 3.5, 5.5, 3, 4, 6],
+        "selected": [False, True, False, False, True, False, False, True, False],
+    }
+)
+
+
+def _faceted_layer(metric: str, title: str) -> alt.FacetChart:
+    base_layer = (
+        alt.Chart(df_issue_14050)
+        .mark_line(point=True)
+        .encode(
+            x=alt.X("xval:Q", axis=alt.Axis(title="xval")),
+            y=alt.Y(f"{metric}:Q", axis=alt.Axis(title=title)),
+            color=alt.Color("group:N", legend=alt.Legend(title="Group")),
+            tooltip=["group", "bin", "xval", metric],
+        )
+    )
+    selected_layer = (
+        alt.Chart(df_issue_14050)
+        .mark_point(shape="diamond", color="purple", filled=True, size=90)
+        .encode(x=alt.X("xval:Q"), y=alt.Y(f"{metric}:Q"))
+        .transform_filter(alt.datum.selected)
+    )
+    return alt.layer(base_layer, selected_layer).facet(column=alt.Column("bin:O"))
+
+
+issue_14050_chart = (
+    alt.vconcat(
+        _faceted_layer("y1", "y1"),
+        _faceted_layer("y2", "y2"),
+    )
+    .resolve_scale(x="independent", y="independent")
+    .properties(title="Issue #14050 regression chart")
+)
+st.altair_chart(issue_14050_chart, width="stretch")

--- a/e2e_playwright/st_altair_chart_test.py
+++ b/e2e_playwright/st_altair_chart_test.py
@@ -21,7 +21,8 @@ from e2e_playwright.shared.react18_utils import wait_for_react_stability
 
 BASELINE_CHARTS = 9
 REGRESSION_CHART_INDEX = 9
-NUM_CHARTS = 10
+ISSUE_14050_CHART_INDEX = 10
+NUM_CHARTS = 11
 
 
 def test_altair_chart_displays_correctly(
@@ -73,6 +74,19 @@ def test_layered_vconcat_fit_x_regression_renders(app: Page):
     # Issue #13974 regression signal: hidden SVG with width=0.
     rendered_chart = regression_chart.locator("canvas, svg").first
     expect(rendered_chart).to_be_visible()
+
+
+def test_vconcat_layered_facet_regression_renders(app: Page):
+    """Guard against regression from https://github.com/streamlit/streamlit/issues/14050."""
+    charts = app.get_by_test_id("stVegaLiteChart")
+    expect(charts).to_have_count(NUM_CHARTS)
+
+    regression_chart = charts.nth(ISSUE_14050_CHART_INDEX)
+    expect(regression_chart).to_be_visible()
+
+    # This issue rendered an empty chart with repeated "Infinite extent" console errors.
+    # Assert at least one rendered graphics document exists.
+    expect(regression_chart.locator("[role='graphics-document']").first).to_be_visible()
 
 
 def test_check_top_level_class(app: Page):

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -251,6 +251,32 @@ describe("hasNestedComposition", () => {
       expected: true,
     },
     {
+      name: "vconcat containing facet",
+      spec: {
+        vconcat: [
+          {
+            facet: { column: { field: "group" } },
+            spec: { mark: "line", encoding: { x: { field: "a" } } },
+          },
+          { mark: "bar" },
+        ],
+      },
+      expected: true,
+    },
+    {
+      name: "vconcat containing repeat",
+      spec: {
+        vconcat: [
+          {
+            repeat: { row: ["a", "b"] },
+            spec: { mark: "line", encoding: { x: { field: "a" } } },
+          },
+          { mark: "bar" },
+        ],
+      },
+      expected: true,
+    },
+    {
       name: "simple vconcat without nested compositions",
       spec: {
         vconcat: [

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -66,12 +66,13 @@ export function isFacetChart(spec: string | object): boolean {
 /**
  * Check if a vconcat spec contains nested composition operators.
  *
- * In valid Vega-Lite specs, composition operators (hconcat, vconcat, concat, layer)
- * are always top-level keys of a view specification. They cannot be buried inside
- * encoding, mark, or other nested properties.
+ * In valid Vega-Lite specs, composition operators
+ * (hconcat, vconcat, concat, layer, facet, repeat) are always top-level keys
+ * of a view specification. They cannot be buried inside encoding, mark, or
+ * other nested properties.
  *
  * Nested compositions don't work well with fit-x autosize type and forced width
- * settings, as they can cause "infinite extent" errors (issue #13410).
+ * settings, as they can cause "infinite extent" errors (issues #13410, #14050).
  */
 // Exported for testing
 export function hasNestedComposition(spec: string | object): boolean {
@@ -90,7 +91,9 @@ export function hasNestedComposition(spec: string | object): boolean {
         ("hconcat" in child ||
           "vconcat" in child ||
           "concat" in child ||
-          "layer" in child)
+          "layer" in child ||
+          "facet" in child ||
+          "repeat" in child)
     )
   } catch {
     return false

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.test.ts
@@ -522,6 +522,32 @@ describe("useVegaElementPreprocessor", () => {
         },
         expectedWidths: [undefined, 400],
       },
+      {
+        name: "facet",
+        spec: {
+          vconcat: [
+            {
+              facet: { column: { field: "group" } },
+              spec: { mark: "line", encoding: { x: { field: "a" } } },
+            },
+            { mark: "bar" },
+          ],
+        },
+        expectedWidths: [undefined, 400],
+      },
+      {
+        name: "repeat",
+        spec: {
+          vconcat: [
+            {
+              repeat: { row: ["a", "b"] },
+              spec: { mark: "line", encoding: { x: { field: "a" } } },
+            },
+            { mark: "bar" },
+          ],
+        },
+        expectedWidths: [undefined, 400],
+      },
     ])(
       "skips width on vconcat children that contain $name",
       ({ spec: inputSpec, expectedWidths }) => {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
@@ -155,12 +155,19 @@ const generateSpec = (
         if (child === null || typeof child !== "object") {
           return
         }
-        // Skip setting width on children that are nested concatenations
-        // (hconcat, vconcat, concat) as it causes "infinite extent" errors.
+        // Skip setting width on children that are nested compositions
+        // (hconcat, vconcat, concat, facet, repeat) as it causes
+        // "infinite extent" errors.
         // Layer children should still receive width so layered + vconcat charts
         // can stretch consistently.
         // In valid Vega-Lite specs, composition operators are always top-level keys.
-        if ("hconcat" in child || "vconcat" in child || "concat" in child) {
+        if (
+          "hconcat" in child ||
+          "vconcat" in child ||
+          "concat" in child ||
+          "facet" in child ||
+          "repeat" in child
+        ) {
           return
         }
         child.width = containerWidth

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -280,16 +280,18 @@ def _patch_null_legend_titles(spec: VegaLiteSpec) -> None:
 
 
 def _has_nested_composition(spec: VegaLiteSpec) -> bool:
-    """Check if a vconcat spec contains nested composition operators.
+    """Check if a vconcat spec contains nested multi-view compositions.
 
     This function checks if a vconcat chart contains nested hconcat, vconcat,
-    concat, or layer operators. Such nested compositions don't work well with
-    the fit-x autosize type and can cause infinite extent errors.
+    concat, layer, facet, or repeat operators. Such nested compositions don't
+    work well with fit-x autosize and forced child widths, and can cause
+    infinite extent errors.
 
-    In valid Vega-Lite specs, composition operators (hconcat, vconcat, concat, layer)
-    are always top-level keys of a view specification. They cannot be buried inside
-    encoding, mark, or other nested properties. This allows us to check only the
-    immediate children of vconcat for nested composition operators.
+    In valid Vega-Lite specs, composition operators
+    (hconcat, vconcat, concat, layer, facet, repeat) are always top-level keys
+    of a view specification. They cannot be buried inside encoding, mark, or
+    other nested properties. This allows us to check only the immediate children
+    of vconcat for nested composition operators.
 
     Parameters
     ----------
@@ -308,7 +310,8 @@ def _has_nested_composition(spec: VegaLiteSpec) -> bool:
         for item in spec["vconcat"]:
             # Check if this item is a dict containing any composition operator
             if isinstance(item, dict) and any(
-                k in item for k in ["hconcat", "vconcat", "concat", "layer"]
+                k in item
+                for k in ["hconcat", "vconcat", "concat", "layer", "facet", "repeat"]
             ):
                 return True
     return False

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -3602,10 +3602,11 @@ class VegaUtilitiesTest(unittest.TestCase):
 class NestedCompositionTest(unittest.TestCase):
     """Test nested composition detection and autosize behavior.
 
-    In valid Vega-Lite specs, composition operators (hconcat, vconcat, concat, layer)
-    are always top-level keys of a view specification. They cannot be buried inside
-    encoding, mark, or other nested properties. This allows the detection function
-    to check only immediate children for nested composition operators.
+    In valid Vega-Lite specs, composition operators (hconcat, vconcat, concat, layer,
+    facet, repeat) are always top-level keys of a view specification. They cannot be
+    buried inside encoding, mark, or other nested properties. This allows the
+    detection function to check only immediate children for nested composition
+    operators.
     """
 
     def test_has_nested_composition_simple_vconcat(self):
@@ -3667,6 +3668,57 @@ class NestedCompositionTest(unittest.TestCase):
                         },
                     ]
                 }
+            ]
+        }
+        assert _has_nested_composition(spec) is True
+
+    def test_has_nested_composition_vconcat_with_facet(self):
+        """Test that vconcat containing facet returns True."""
+        from streamlit.elements.vega_charts import _has_nested_composition
+
+        spec = {
+            "vconcat": [
+                {
+                    "facet": {"column": {"field": "group", "type": "nominal"}},
+                    "spec": {
+                        "mark": "line",
+                        "encoding": {
+                            "x": {"field": "a", "type": "quantitative"},
+                            "y": {"field": "b", "type": "quantitative"},
+                        },
+                    },
+                },
+                {
+                    "mark": "bar",
+                    "encoding": {"x": {"field": "a"}, "y": {"field": "b"}},
+                },
+            ]
+        }
+        assert _has_nested_composition(spec) is True
+
+    def test_has_nested_composition_vconcat_with_repeat(self):
+        """Test that vconcat containing repeat returns True."""
+        from streamlit.elements.vega_charts import _has_nested_composition
+
+        spec = {
+            "vconcat": [
+                {
+                    "repeat": {"column": ["a", "b"]},
+                    "spec": {
+                        "mark": "line",
+                        "encoding": {
+                            "x": {"field": "a", "type": "quantitative"},
+                            "y": {
+                                "field": {"repeat": "column"},
+                                "type": "quantitative",
+                            },
+                        },
+                    },
+                },
+                {
+                    "mark": "bar",
+                    "encoding": {"x": {"field": "a"}, "y": {"field": "b"}},
+                },
             ]
         }
         assert _has_nested_composition(spec) is True
@@ -3813,6 +3865,43 @@ class VegaLiteAutosizeTest(DeltaGeneratorTestCase):
         }
 
         st.vega_lite_chart(df, spec, use_container_width=False)
+
+        proto = self.get_delta_from_queue().new_element.vega_lite_chart
+        parsed_spec = json.loads(proto.spec)
+        assert parsed_spec["autosize"]["type"] == "pad"
+        assert parsed_spec["autosize"]["contains"] == "padding"
+
+    def test_vconcat_with_faceted_children_with_use_container_width_true_gets_pad(self):
+        """Test that vconcat with faceted children gets pad autosize."""
+        df = pd.DataFrame(
+            {"a": [1, 2, 3, 4], "b": [4, 5, 6, 7], "group": ["x", "x", "y", "y"]}
+        )
+        spec = {
+            "vconcat": [
+                {
+                    "facet": {"column": {"field": "group", "type": "nominal"}},
+                    "spec": {
+                        "mark": "line",
+                        "encoding": {
+                            "x": {"field": "a", "type": "quantitative"},
+                            "y": {"field": "b", "type": "quantitative"},
+                        },
+                    },
+                },
+                {
+                    "facet": {"column": {"field": "group", "type": "nominal"}},
+                    "spec": {
+                        "mark": "point",
+                        "encoding": {
+                            "x": {"field": "a", "type": "quantitative"},
+                            "y": {"field": "b", "type": "quantitative"},
+                        },
+                    },
+                },
+            ]
+        }
+
+        st.vega_lite_chart(df, spec, use_container_width=True)
 
         proto = self.get_delta_from_queue().new_element.vega_lite_chart
         parsed_spec = json.loads(proto.spec)


### PR DESCRIPTION
## Describe your changes

Fixed a regression where Vega-Lite charts with `vconcat` containing faceted or repeated children would fail to render with "infinite extent" errors when using `width="stretch"`. The issue occurred because the width preprocessing logic only checked for composition operators (`hconcat`, `vconcat`, `concat`, `layer`) but not for multi-view compositions (`facet`, `repeat`).

Updated the nested composition detection logic in both frontend and backend to include `facet` and `repeat` operators, ensuring these chart types use `pad` autosize instead of `fit-x` to prevent rendering errors.

## GitHub Issue Link (if applicable)

Fixes #14050

## Testing Plan

- **Unit Tests (JS and/or Python)**: Added test cases for `facet` and `repeat` detection in both frontend (`ArrowVegaLiteChart.test.tsx`, `useVegaElementPreprocessor.test.ts`) and backend (`vega_charts_test.py`) 
- **E2E Tests**: Added regression test `test_vconcat_layered_facet_regression_renders` that verifies the chart renders correctly and contains visible graphics elements

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.