### PR TITLE
fix(widgets): clear stale date validation UI on form clear

### DIFF
--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -408,6 +408,36 @@ describe("DateInput widget", () => {
     )
   })
 
+  it("clears validation error state when form is cleared", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      formId: "form",
+      default: ["2026/01/15"],
+      min: "2026/01/01",
+      max: "2026/12/31",
+    })
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
+
+    render(<DateInput {...props} />)
+    const dateInput = screen.getByTestId("stDateInputField")
+
+    await user.clear(dateInput)
+    await user.type(dateInput, "2025/12/01")
+
+    expect(screen.getByTestId("stTooltipErrorHoverTarget")).toBeVisible()
+
+    act(() => {
+      props.widgetMgr.submitForm("form", undefined)
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stTooltipErrorHoverTarget")
+      ).not.toBeInTheDocument()
+    })
+    expect(dateInput).toHaveValue("2026/01/15")
+  })
+
   describe("localization", () => {
     const getCalendarHeader = async (): Promise<HTMLElement> => {
       const calendar = await screen.findByLabelText("Calendar.")

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -95,6 +95,18 @@ function DateInput({
 }: Props): ReactElement {
   const theme = useEmotionTheme()
   const isInSidebar = useContext(IsSidebarContext)
+  const [isEmpty, setIsEmpty] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const resetError = useCallback(() => {
+    setError(null)
+  }, [])
+
+  const handleFormCleared = useCallback(() => {
+    resetError()
+    setIsEmpty(false)
+  }, [resetError])
+
   /**
    * An array with start and end date specified by the user via the UI. If the user
    * didn't touch this widget's UI, the default value is used. End date is optional.
@@ -110,10 +122,8 @@ function DateInput({
     element,
     widgetMgr,
     fragmentId,
+    onFormCleared: handleFormCleared,
   })
-
-  const [isEmpty, setIsEmpty] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   const {
     colors,
@@ -205,8 +215,7 @@ function DateInput({
     }: {
       date: Date | (Date | null | undefined)[] | null | undefined
     }): void => {
-      // Reset our error state
-      setError(null)
+      resetError()
 
       if (isNullOrUndefined(date)) {
         setValueWithSource({ value: [], fromUi: true })
@@ -241,7 +250,14 @@ function DateInput({
       setValueWithSource({ value: newDates, fromUi: true })
       setIsEmpty(!newDates)
     },
-    [setValueWithSource, createErrorMessage, setError, minDate, maxDate]
+    [
+      createErrorMessage,
+      maxDate,
+      minDate,
+      resetError,
+      setError,
+      setValueWithSource,
+    ]
   )
 
   const handleClose = useCallback((): void => {

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -218,6 +218,36 @@ describe("DateTimeInput widget", () => {
     })
   })
 
+  it("clears validation error state when form is cleared", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      formId: "form",
+      default: ["2026/01/15, 12:00"],
+      min: "2026/01/01, 00:00",
+      max: "2026/12/31, 23:59",
+    })
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
+
+    render(<DateTimeInput {...props} />)
+    const inputField = screen.getByTestId("stDateTimeInputField")
+
+    await user.clear(inputField)
+    await user.type(inputField, "2025/12/01, 12:00")
+
+    expect(screen.getByTestId("stTooltipErrorHoverTarget")).toBeVisible()
+
+    act(() => {
+      props.widgetMgr.submitForm("form", undefined)
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stTooltipErrorHoverTarget")
+      ).not.toBeInTheDocument()
+    })
+    expect(inputField).toHaveValue("2026/01/15, 12:00")
+  })
+
   describe("Validation and error handling", () => {
     it("displays error when date is below minimum", async () => {
       const user = userEvent.setup()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.tsx
@@ -76,6 +76,26 @@ function DateTimeInput({
   const { innerHeight: windowHeight } = useWindowDimensionsContext()
   const datepickerRef = useRef<DatepickerClass<Date> | null>(null)
 
+  const getInitialCommittedDate = (): Date | null => {
+    // Keep this in sync with useBasicWidgetState initialization.
+    const initialValue =
+      getStateFromWidgetMgr(widgetMgr, element) ??
+      (element.setValue
+        ? getCurrStateFromProto(element)
+        : getDefaultStateFromProto(element))
+    return stringToDate(initialValue)
+  }
+
+  // pendingDate is the temporary value while the user is selecting
+  const [pendingDate, setPendingDate] = useState<Date | null>(
+    getInitialCommittedDate
+  )
+
+  // Store the previous committedDate to detect changes from the widget manager
+  const [prevCommittedDate, setPrevCommittedDate] = useState<Date | null>(
+    getInitialCommittedDate
+  )
+
   const [value, setValueWithSource] = useBasicWidgetState<
     string | null,
     DateTimeInputProto
@@ -87,6 +107,9 @@ function DateTimeInput({
     element,
     widgetMgr,
     fragmentId,
+    onFormCleared: useCallback(() => {
+      setPendingDate(stringToDate(getDefaultStateFromProto(element)))
+    }, [element]),
   })
 
   const { locale } = useContext(LibConfigContext)
@@ -99,14 +122,6 @@ function DateTimeInput({
 
   // committedDate is the value from the widget manager
   const committedDate = useMemo(() => stringToDate(value), [value])
-
-  // pendingDate is the temporary value while the user is selecting
-  const [pendingDate, setPendingDate] = useState<Date | null>(committedDate)
-
-  // Store the previous committedDate to detect changes from the widget manager
-  const [prevCommittedDate, setPrevCommittedDate] = useState<Date | null>(
-    committedDate
-  )
 
   // Sync pendingDate when committedDate changes (e.g., from external widget state updates)
   if (committedDate !== prevCommittedDate) {


### PR DESCRIPTION
## Describe your changes

Fixed validation error state persistence in DateInput and DateTimeInput widgets when forms are cleared. Previously, validation errors would remain visible even after form submission/clearing, creating a confusing user experience. Now both widgets properly reset their error states when the form is cleared through the `onFormCleared` callback.

For DateTimeInput, also refactored the initialization logic to ensure `pendingDate` is properly initialized with the correct initial value instead of relying on the committed date state.

## GitHub Issue Link (if applicable)

Fixes #14052

## Testing Plan

- Unit Tests (JS and/or Python)
  - Added test cases for both DateInput and DateTimeInput widgets that verify validation errors are cleared when forms are submitted

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.