### PR TITLE
[DynamicContainers] Callback support for popovers

### DIFF
--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -156,3 +156,67 @@ def popover_fragment() -> None:
 
 
 popover_fragment()
+
+# ============================================================================
+# Callback Tests — on_change with callable
+# ============================================================================
+
+if "cb_pop_count" not in st.session_state:
+    st.session_state.cb_pop_count = 0
+
+
+def popover_callback() -> None:
+    st.session_state.cb_pop_count += 1
+
+
+pop_cb = st.popover("Basic callback popover", key="cb_pop", on_change=popover_callback)
+if pop_cb.open:
+    with pop_cb:
+        st.write("Callback popover content")
+
+st.write(f"Callback count: {st.session_state.cb_pop_count}")
+
+
+def popover_args_callback(prefix: str, suffix: str = "") -> None:
+    st.session_state.cb_pop_args_result = f"{prefix}-toggled-{suffix}"
+
+
+pop_args = st.popover(
+    "Callback args popover",
+    key="cb_args_pop",
+    on_change=popover_args_callback,
+    args=("my_prefix",),
+    kwargs={"suffix": "my_suffix"},
+)
+if pop_args.open:
+    with pop_args:
+        st.write("Callback args popover content")
+
+st.write(
+    f"Callback args result: {st.session_state.get('cb_pop_args_result', 'not called')}"
+)
+
+
+# Callback inside a fragment
+if "frag_cb_count" not in st.session_state:
+    st.session_state.frag_cb_count = 0
+
+
+def frag_popover_callback() -> None:
+    st.session_state.frag_cb_count += 1
+
+
+@st.fragment
+def callback_popover_fragment() -> None:
+    pop = st.popover(
+        "Fragment callback popover",
+        key="frag_cb_pop",
+        on_change=frag_popover_callback,
+    )
+    if pop.open:
+        with pop:
+            st.write("Fragment callback popover content")
+    st.write(f"Fragment callback count: {st.session_state.frag_cb_count}")
+
+
+callback_popover_fragment()

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -30,7 +30,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(18)
+    expect(popover_elements).to_have_count(21)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -288,3 +288,67 @@ def test_dynamic_popover_in_fragment(app: Page):
     expect(
         app.get_by_text("Fragment popover content executed 1 times")
     ).not_to_be_visible()
+
+
+def test_popover_callback_fires_on_open_and_close(app: Page):
+    """Test that a callable on_change callback fires when popover is toggled."""
+    # Initially, callback count should be 0
+    expect(app.get_by_text("Callback count: 0", exact=True)).to_be_visible()
+
+    # Open the callback popover
+    open_popover(app, "Basic callback popover")
+    wait_for_app_run(app)
+
+    # Callback should have fired once (popover opened)
+    expect(app.get_by_text("Callback count: 1", exact=True)).to_be_visible()
+
+    # Popover content should be visible
+    expect(app.get_by_text("Callback popover content", exact=True)).to_be_visible()
+
+    # Close the popover by pressing Escape
+    app.keyboard.press("Escape")
+    wait_for_app_run(app)
+
+    # Callback should have fired again (popover closed)
+    expect(app.get_by_text("Callback count: 2", exact=True)).to_be_visible()
+
+    # Popover content should not be visible
+    expect(app.get_by_text("Callback popover content", exact=True)).not_to_be_visible()
+
+
+def test_popover_callback_with_args_kwargs(app: Page):
+    """Test that a callback with args and kwargs receives the correct values."""
+    # Initially, the args result should not be set
+    expect(app.get_by_text("Callback args result: not called")).to_be_visible()
+
+    # Open the args popover
+    open_popover(app, "Callback args popover")
+    wait_for_app_run(app)
+
+    # Callback should have fired with args/kwargs
+    expect(
+        app.get_by_text("Callback args result: my_prefix-toggled-my_suffix")
+    ).to_be_visible()
+
+
+def test_popover_callback_in_fragment(app: Page):
+    """Test that a popover callback works correctly inside a fragment."""
+    # Initially, fragment callback count should be 0
+    expect(app.get_by_text("Fragment callback count: 0")).to_be_visible()
+
+    # Open the fragment callback popover
+    open_popover(app, "Fragment callback popover")
+    wait_for_app_run(app)
+
+    # Callback should have fired once
+    expect(app.get_by_text("Fragment callback count: 1")).to_be_visible()
+
+    # Popover content should be visible
+    expect(app.get_by_text("Fragment callback popover content")).to_be_visible()
+
+    # Close the popover
+    app.keyboard.press("Escape")
+    wait_for_app_run(app)
+
+    # Callback should have fired again
+    expect(app.get_by_text("Fragment callback count: 2")).to_be_visible()

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -1130,7 +1130,9 @@ class LayoutsMixin:
         use_container_width: bool | None = None,
         width: Width = "content",
         key: Key | None = None,
-        on_change: Literal["ignore", "rerun"] = "ignore",
+        on_change: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
     ) -> PopoverContainer:
         r"""Insert a popover container.
 
@@ -1255,10 +1257,11 @@ class LayoutsMixin:
             widget. If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
 
-            When ``on_change`` is set to ``"rerun"``, the open/closed state
-            is also accessible via ``st.session_state[key]``.
+            When ``on_change`` is set to ``"rerun"`` or a callable, the
+            open/closed state is also accessible via
+            ``st.session_state[key]``.
 
-        on_change : "ignore" or "rerun"
+        on_change : "ignore", "rerun", or callable
             How the popover should respond to user open/close events. This
             controls whether the popover tracks state and triggers reruns.
             ``on_change`` can be one of the following:
@@ -1272,6 +1275,23 @@ class LayoutsMixin:
               current state (``True`` if open, ``False`` if closed). The
               popover cannot be used inside ``@st.cache_data`` decorated
               functions.
+
+            - A callable: A callback function that is invoked when the
+              popover's state changes (opened or closed). Enables state
+              tracking (equivalent to ``"rerun"`` plus the callback). The
+              callback receives no arguments by default, but you can pass
+              arguments using ``args`` and ``kwargs``. Use
+              ``st.session_state[key]`` inside the callback to determine
+              whether the popover was opened (``True``) or closed (``False``).
+              The popover cannot be used inside ``@st.cache_data`` decorated
+              functions when using a callback.
+
+        args : list or tuple or None
+            An optional list or tuple of args to pass to the ``on_change``
+            callback.
+
+        kwargs : dict or None
+            An optional dict of kwargs to pass to the ``on_change`` callback.
 
         Examples
         --------
@@ -1320,25 +1340,25 @@ class LayoutsMixin:
                 f'\nThe argument passed was "{type}".'
             )
 
-        if on_change not in {"ignore", "rerun"}:
-            raise StreamlitValueError("on_change", ["'rerun'", "'ignore'"])
+        if not callable(on_change) and on_change not in {"ignore", "rerun"}:
+            raise StreamlitValueError(
+                "on_change", ["'rerun'", "'ignore'", "a callback function"]
+            )
 
         key = to_key(key)
-        is_stateful = on_change == "rerun"
+        is_stateful = on_change != "ignore"
 
         current_open = False
         element_id: str | None = None
 
         if is_stateful:
-            # TODO: Set on_change and enable_check_callback_rules correctly
-            # when user-defined callbacks are supported for popovers.
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=None,
+                on_change=on_change if callable(on_change) else None,
                 default_value=None,
                 writes_allowed=True,
-                enable_check_callback_rules=False,
+                enable_check_callback_rules=callable(on_change),
             )
 
             ctx = get_script_run_ctx()
@@ -1364,6 +1384,9 @@ class LayoutsMixin:
                 serializer=serde.serialize,
                 ctx=ctx,
                 value_type="bool_value",
+                on_change_handler=on_change if callable(on_change) else None,
+                args=args if callable(on_change) else None,
+                kwargs=kwargs if callable(on_change) else None,
             )
 
             current_open = popover_state.value

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -30,6 +30,7 @@ from streamlit.errors import (
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.GapSize_pb2 import GapSize
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
+from streamlit.runtime.state.session_state import get_script_run_ctx
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
@@ -1003,6 +1004,157 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         assert "my_pop" not in st.session_state
         popover_block = self.get_delta_from_queue()
         assert popover_block.add_block.id == ""
+
+    def test_callback_enables_state_tracking(self):
+        """Test that passing a callable on_change enables state tracking."""
+        popover = st.popover("label", on_change=lambda: None)
+        # Callback implies stateful: .open should be a bool, not None
+        assert popover.open is False
+
+    def test_callback_sets_proto_id(self):
+        """Test that callable on_change sets the popover proto id."""
+        st.popover("label", on_change=lambda: None)
+        popover_block = self.get_delta_from_queue()
+        assert popover_block.add_block.popover.id != ""
+
+    def test_callback_registered_in_widget_metadata(self):
+        """Test that the callback is stored in widget metadata."""
+
+        st.popover("label", on_change=lambda: None)
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        session_state = ctx.session_state._state
+        widget_id = session_state.get_widget_states()[0].id
+        metadata = session_state._new_widget_state.widget_metadata.get(widget_id)
+        assert metadata is not None
+        assert metadata.callback is not None
+
+    def test_callback_fires_on_state_change(self):
+        """Test that callback fires when popover state changes."""
+
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.popover("label", key="cb_pop", on_change=on_change)
+
+        # Simulate opening the popover (False -> True)
+        current_states = self.script_run_ctx.session_state.get_widget_states()
+        new_state = WidgetState()
+        new_state.CopyFrom(current_states[0])
+        new_state.bool_value = True
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_state])
+        )
+
+        assert len(callback_calls) == 1
+
+    def test_callback_fires_on_open_and_close(self):
+        """Test that callback fires on both open and close transitions."""
+
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.popover("label", key="cb_pop_both", on_change=on_change)
+
+        # Open the popover (False -> True) — callback fires
+        current_states = self.script_run_ctx.session_state.get_widget_states()
+        open_state = WidgetState()
+        open_state.CopyFrom(current_states[0])
+        open_state.bool_value = True
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[open_state])
+        )
+        assert len(callback_calls) == 1
+
+        # Close the popover (True -> False) — callback fires again
+        close_state = WidgetState()
+        close_state.CopyFrom(open_state)
+        close_state.bool_value = False
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[close_state])
+        )
+        assert len(callback_calls) == 2
+
+    def test_callback_does_not_fire_on_initial_render(self):
+        """Test that callback does not fire during the initial render."""
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.popover("label", on_change=on_change)
+        assert len(callback_calls) == 0
+
+    def test_callback_receives_args(self):
+        """Test that callback receives positional args."""
+
+        received_args: list[str] = []
+
+        def on_change(arg1: str, arg2: str) -> None:
+            received_args.extend([arg1, arg2])
+
+        st.popover("label", key="args_pop", on_change=on_change, args=("a", "b"))
+
+        current_states = self.script_run_ctx.session_state.get_widget_states()
+        new_state = WidgetState()
+        new_state.CopyFrom(current_states[0])
+        new_state.bool_value = True
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_state])
+        )
+
+        assert received_args == ["a", "b"]
+
+    def test_callback_receives_kwargs(self):
+        """Test that callback receives keyword args."""
+
+        received_kwargs: dict[str, str] = {}
+
+        def on_change(prefix: str = "") -> None:
+            received_kwargs["prefix"] = prefix
+
+        st.popover(
+            "label",
+            key="kwargs_pop",
+            on_change=on_change,
+            kwargs={"prefix": "hello"},
+        )
+
+        current_states = self.script_run_ctx.session_state.get_widget_states()
+        new_state = WidgetState()
+        new_state.CopyFrom(current_states[0])
+        new_state.bool_value = True
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_state])
+        )
+
+        assert received_kwargs == {"prefix": "hello"}
+
+    def test_callback_with_key_accessible_via_session_state(self):
+        """Test that callback with key makes state accessible."""
+        st.popover("label", key="my_cb_pop", on_change=lambda: None)
+        assert "my_cb_pop" in st.session_state
+        assert st.session_state.my_cb_pop is False
+
+    def test_callback_without_key_works(self):
+        """Test that callback works even without a user-provided key."""
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        popover = st.popover("label", on_change=on_change)
+        # Should still be stateful (widget registered with element_id)
+        assert popover.open is False
+
+    def test_invalid_on_change_with_callback_type_raises(self):
+        """Test that non-string, non-callable on_change raises."""
+        with pytest.raises(StreamlitAPIException):
+            st.popover("label", on_change=123)  # type: ignore[arg-type]
 
 
 class StatusContainerTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/typing/popover_container_types.py
+++ b/lib/tests/streamlit/typing/popover_container_types.py
@@ -42,3 +42,19 @@ if TYPE_CHECKING:
 
     # .open property returns bool | None
     assert_type(popover("Test").open, bool | None)
+
+    # on_change accepts "ignore", "rerun", or a callable
+    popover("Test", on_change="ignore")
+    popover("Test", on_change="rerun")
+    popover("Test", on_change=lambda: None)
+
+    # Callback with args and kwargs
+    def my_callback(prefix: str, suffix: str = "") -> None: ...
+
+    popover("Test", on_change=my_callback, args=("hello",), kwargs={"suffix": "world"})
+
+    # Callback without key is valid
+    popover("Test", on_change=lambda: None)
+
+    # Callback with key is also valid
+    popover("Test", key="my_pop", on_change=lambda: None)


### PR DESCRIPTION
## Describe your changes

Adds `on_change` callback support to `st.popover`, consistent with the existing callback pattern in other widgets (`st.checkbox`, `st.toggle`, etc.).

- `on_change` accepts a callable in addition to the existing `"ignore"` / `"rerun"` string literals
- Optional `args` and `kwargs` parameters pass through to the callback
- The callback fires on any state change (both open and close). Users can check `st.session_state[key]` inside the callback to distinguish between open (`True`) and close (`False`) events.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (Python) — `lib/tests/streamlit/elements/layouts_test.py`
- [x] E2E Tests — `e2e_playwright/st_popover_test.py`
- [x] Any manual testing needed?
     - Did some manual testing of using the callbacks and targeting to open/close.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
