### PR TITLE
refactor(widgets): require explicit form-clear and fragment contracts

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -153,7 +153,7 @@ function updateWidgetMgrState(
   element: DeckGlJsonChartProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<DeckGlElementState>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   if (!element.id) {
     return

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -188,7 +188,7 @@ function syncWithWidgetManager(
   element: ButtonGroupProto,
   widgetMgr: WidgetStateManager,
   valueWithSource: ValueWithSource<ButtonGroupValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   // Store content strings directly (no index suffix needed)
   widgetMgr.setStringArrayValue(
@@ -333,6 +333,7 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -71,6 +71,7 @@ function Checkbox({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 
@@ -256,7 +257,7 @@ function updateWidgetMgrState(
   element: CheckboxProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<boolean>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   widgetMgr.setBoolValue(
     element,

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.tsx
@@ -66,7 +66,7 @@ const updateWidgetMgrState = (
   element: ColorPickerProto,
   widgetMgr: WidgetStateManager,
   valueWithSource: ValueWithSource<ColorPickerValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void => {
   widgetMgr.setStringValue(
     element,
@@ -102,6 +102,7 @@ const ColorPicker: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -132,6 +132,7 @@ function DateInput({
     widgetMgr,
     fragmentId,
     queryParamBinding,
+    formClearBehavior: "resetValueAndRunCallback",
     onFormCleared: handleFormCleared,
   })
 
@@ -569,7 +570,7 @@ function updateWidgetMgrState(
   element: DateInputProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<Date[]>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   const minDate = moment(element.min, DATE_FORMAT).toDate()
   const maxDate = getMaxDate(element)

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.tsx
@@ -107,6 +107,7 @@ function DateTimeInput({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueAndRunCallback",
     onFormCleared: useCallback(() => {
       setPendingDate(stringToDate(getDefaultStateFromProto(element)))
     }, [element]),

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -119,7 +119,7 @@ describe("updateWidgetMgrState", () => {
       fromUi: true,
     }
 
-    updateWidgetMgrState(element, widgetMgr, vws)
+    updateWidgetMgrState(element, widgetMgr, vws, undefined)
 
     expect(widgetMgr.setStringArrayValue).not.toHaveBeenCalled()
   })
@@ -131,7 +131,7 @@ describe("updateWidgetMgrState", () => {
       fromUi: false,
     }
 
-    updateWidgetMgrState(element, widgetMgr, vws)
+    updateWidgetMgrState(element, widgetMgr, vws, undefined)
 
     expect(widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       element,

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
@@ -92,7 +92,7 @@ export const updateWidgetMgrState = (
   element: DateTimeInputProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<string | null>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void => {
   const minDateTime = stringToDate(element.min)
   const maxDateTime = stringToDate(element.max)

--- a/frontend/lib/src/components/widgets/Feedback/Feedback.tsx
+++ b/frontend/lib/src/components/widgets/Feedback/Feedback.tsx
@@ -186,7 +186,7 @@ function updateWidgetMgrState(
   element: FeedbackProto,
   widgetMgr: WidgetStateManager,
   valueWithSource: ValueWithSource<FeedbackValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   const stringValue =
     valueWithSource.value === null ? "" : String(valueWithSource.value)
@@ -213,6 +213,7 @@ function Feedback(props: Readonly<Props>): ReactElement {
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
   })
 
   // Use element.value (from session_state) as the source of truth when set.

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -94,7 +94,7 @@ const updateWidgetMgrState = (
   element: MultiSelectProto,
   widgetMgr: WidgetStateManager,
   valueWithSource: ValueWithSource<MultiselectValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void => {
   widgetMgr.setStringArrayValue(
     element,
@@ -134,6 +134,7 @@ const Multiselect: FC<Props> = props => {
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -146,6 +146,7 @@ const NumberInput: React.FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueAndRunCallback",
     onFormCleared: useCallback(() => {
       // Reset dirty state and formatted value when form is cleared
       const newValue = elementDefault ?? null

--- a/frontend/lib/src/components/widgets/NumberInput/utils.ts
+++ b/frontend/lib/src/components/widgets/NumberInput/utils.ts
@@ -224,7 +224,7 @@ export function updateWidgetMgrState(
   element: NumberInputProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<number | null>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   switch (element.dataType) {
     case NumberInputProto.DataType.INT:

--- a/frontend/lib/src/components/widgets/Radio/Radio.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.tsx
@@ -68,6 +68,7 @@ function Radio({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 
@@ -130,7 +131,7 @@ function updateWidgetMgrState(
   element: RadioProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<RadioValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   widgetMgr.setStringValue(
     element,

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -64,7 +64,7 @@ const updateWidgetMgrState = (
   element: SelectboxProto,
   widgetMgr: WidgetStateManager,
   valueWithSource: ValueWithSource<SelectboxValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void => {
   widgetMgr.setStringValue(
     element,
@@ -108,6 +108,7 @@ const Selectbox: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -178,6 +178,7 @@ function Slider({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
     queryParamBinding,
   })
 
@@ -490,7 +491,7 @@ function updateWidgetMgrState(
   element: SliderProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<number[]>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   if (isSelectSlider(element)) {
     // For select_slider, convert indices to string values

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -74,7 +74,7 @@ const updateWidgetMgrState = (
   element: TextAreaProto,
   widgetMgr: WidgetStateManager,
   valueWithSource: ValueWithSource<TextAreaValue>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void => {
   widgetMgr.setStringValue(
     element,
@@ -150,6 +150,7 @@ const TextArea: FC<Props> = ({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueAndRunCallback",
     onFormCleared,
     queryParamBinding,
   })

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -96,6 +96,7 @@ function TextInput({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueAndRunCallback",
     onFormCleared,
     queryParamBinding,
   })
@@ -280,7 +281,7 @@ function updateWidgetMgrState(
   element: TextInputProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<string | null>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   widgetMgr.setStringValue(
     element,

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.tsx
@@ -79,6 +79,7 @@ function TimeInput({
     element,
     widgetMgr,
     fragmentId,
+    formClearBehavior: "resetValueOnly",
   })
   const isInSidebar = useContext(IsSidebarContext)
   const theme = useEmotionTheme()
@@ -316,7 +317,7 @@ function updateWidgetMgrState(
   element: TimeInputProto,
   widgetMgr: WidgetStateManager,
   vws: ValueWithSource<string | null>,
-  fragmentId?: string
+  fragmentId: string | undefined
 ): void {
   widgetMgr.setStringValue(
     element,

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -48,7 +48,7 @@ const updateWidgetMgrState = vi.fn(
     _el: MockProto,
     _wm: WidgetStateManager,
     _vws: ValueWithSource<string | number | string[] | number[]>,
-    _fragmentId?: string
+    _fragmentId: string | undefined
   ) => {}
 )
 
@@ -81,6 +81,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -105,6 +107,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -132,6 +136,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -162,6 +168,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -191,6 +199,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -217,6 +227,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -240,6 +252,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -265,6 +279,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
@@ -288,10 +304,121 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
         })
       )
 
       expect(result.current[0]).toBe(0)
+    })
+  })
+
+  describe("form clear behavior", () => {
+    it("runs callback when resetValueAndRunCallback is configured", () => {
+      const onFormCleared = vi.fn()
+
+      const element: MockProto = {
+        formId: "form-1",
+        setValue: false,
+        id: "widget-10",
+        value: "curr-value",
+        default: "default-value",
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueAndRunCallback",
+          onFormCleared,
+        })
+      )
+
+      act(() => {
+        widgetMgr.setFormSubmitBehaviors("form-1", true)
+        widgetMgr.submitForm("form-1", undefined)
+      })
+
+      expect(onFormCleared).toHaveBeenCalledTimes(1)
+    })
+
+    it("resets value to default with resetValueOnly", () => {
+      const element: MockProto = {
+        formId: "form-2",
+        setValue: false,
+        id: "widget-11",
+        value: "curr-value",
+        default: "default-value",
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
+        })
+      )
+
+      updateWidgetMgrState.mockClear()
+
+      act(() => {
+        widgetMgr.setFormSubmitBehaviors("form-2", true)
+        widgetMgr.submitForm("form-2", undefined)
+      })
+
+      expect(updateWidgetMgrState).toHaveBeenCalledWith(
+        element,
+        widgetMgr,
+        { value: "default-value", fromUi: true },
+        undefined
+      )
+    })
+
+    it("forwards non-undefined fragmentId to WidgetStateManager updates", () => {
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-12",
+        value: "curr-value",
+        default: "default-value",
+      }
+
+      const fragmentId = "fragment-123"
+      const { result } = renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          fragmentId,
+          formClearBehavior: "resetValueOnly",
+        })
+      )
+
+      updateWidgetMgrState.mockClear()
+
+      act(() => {
+        result.current[1]({ value: "new-value", fromUi: true })
+      })
+
+      expect(updateWidgetMgrState).toHaveBeenCalledWith(
+        element,
+        widgetMgr,
+        { value: "new-value", fromUi: true },
+        fragmentId
+      )
     })
   })
 
@@ -321,6 +448,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
           queryParamBinding,
         })
       )
@@ -355,6 +484,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
           // No queryParamBinding
         })
       )
@@ -387,6 +518,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
           queryParamBinding,
         })
       )
@@ -426,6 +559,8 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
           updateWidgetMgrState,
           element,
           widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
           queryParamBinding,
         })
       )

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -42,7 +42,7 @@ interface ValueElementProtoInterface {
   formId: string
 }
 
-interface BaseArgs<
+interface SharedArgs<
   T, // Type of the value stored in WidgetStateManager.
   P extends ValueElementProtoInterface, // Proto for this widget.
 > {
@@ -53,21 +53,27 @@ interface BaseArgs<
     el: P,
     wm: WidgetStateManager,
     vws: ValueWithSource<T>,
-    fragmentId?: string
+    fragmentId: string | undefined
   ) => void
   element: P
   widgetMgr: WidgetStateManager
-  fragmentId?: string
-  onFormCleared?: () => void
+  /**
+   * Fragment context for reruns triggered by this widget interaction.
+   *
+   * This key is intentionally required (even when value is `undefined`) so
+   * callsites must consciously thread fragment context through widget hooks.
+   */
+  fragmentId: string | undefined
 }
 
 export interface UseBasicWidgetClientStateArgs<
   T, // Type of the value stored in WidgetStateManager.
   P extends ValueElementProtoInterface, // Proto for this widget.
-> extends BaseArgs<T, P> {
+> extends SharedArgs<T, P> {
   // Important: these callback functions need to have stable references! So
   // either declare them at the module level or wrap in useCallback.
   getDefaultState: (wm: WidgetStateManager, el: P) => T
+  onFormCleared?: () => void
 }
 
 /**
@@ -158,6 +164,23 @@ interface ValueElementProtoInterfaceWithSetValue extends ValueElementProtoInterf
 }
 
 /**
+ * Explicit form-clear behavior contract for standard widget hooks.
+ *
+ * This is intentionally a discriminated union so each callsite must choose one
+ * behavior and cannot "forget" to make the decision.
+ */
+type FormClearBehaviorArgs =
+  | {
+      // Widget only needs the standard default-value reset on form clear.
+      formClearBehavior: "resetValueOnly"
+    }
+  | {
+      // Widget needs additional local UI cleanup when the form is cleared.
+      formClearBehavior: "resetValueAndRunCallback"
+      onFormCleared: () => void
+    }
+
+/**
  * Configuration for query parameter binding integration.
  * When provided to useBasicWidgetState, the hook will automatically
  * register/unregister the widget's URL query parameter binding.
@@ -182,10 +205,10 @@ export interface QueryParamBindingConfig {
   optionStrings?: string[]
 }
 
-export interface UseBasicWidgetStateArgs<
+interface UseBasicWidgetStateBaseArgs<
   T, // Type of the value stored in WidgetStateManager.
   P extends ValueElementProtoInterfaceWithSetValue, // Proto for this widget.
-> extends BaseArgs<T, P> {
+> extends SharedArgs<T, P> {
   // Important: these callback functions need to have stable references! So
   // either declare them at the module level or wrap in useCallback.
   getDefaultStateFromProto: (el: P) => T
@@ -198,6 +221,11 @@ export interface UseBasicWidgetStateArgs<
   queryParamBinding?: QueryParamBindingConfig
 }
 
+export type UseBasicWidgetStateArgs<
+  T, // Type of the value stored in WidgetStateManager.
+  P extends ValueElementProtoInterfaceWithSetValue, // Proto for this widget.
+> = UseBasicWidgetStateBaseArgs<T, P> & FormClearBehaviorArgs
+
 /**
  * A React hook that makes the simplest kinds of widgets very easy to implement.
  *
@@ -206,25 +234,42 @@ export interface UseBasicWidgetStateArgs<
  * - Responding to setValue updates from session_state
  * - Handling form clearing for clear_on_submit forms
  *
+ * Critical API contract:
+ * - Every widget callsite must explicitly declare form-clear intent via
+ *   `formClearBehavior`.
+ * - Every widget callsite must also explicitly pass `fragmentId` as a key,
+ *   using either a fragment string or `undefined`.
+ * - Use `resetValueOnly` for widgets that only need value reset.
+ * - Use `resetValueAndRunCallback` when local ephemeral UI state must also be
+ *   cleared (for example, validation errors, dirty flags, or in-progress input
+ *   state that is not derived from the widget value).
+ *
  * Examples: TextInput, NumberInput, Checkbox, Slider, etc.
  */
 export function useBasicWidgetState<
   T, // Type of the value stored in WidgetStateManager.
   P extends ValueElementProtoInterfaceWithSetValue, // Proto for this widget.
->({
-  getStateFromWidgetMgr,
-  getDefaultStateFromProto,
-  getCurrStateFromProto,
-  updateWidgetMgrState,
-  element,
-  widgetMgr,
-  fragmentId,
-  onFormCleared,
-  queryParamBinding,
-}: UseBasicWidgetStateArgs<T, P>): [
-  T,
-  Dispatch<SetStateAction<ValueWithSource<T> | null>>,
-] {
+>(
+  args: UseBasicWidgetStateArgs<T, P>
+): [T, Dispatch<SetStateAction<ValueWithSource<T> | null>>] {
+  const {
+    getStateFromWidgetMgr,
+    getDefaultStateFromProto,
+    getCurrStateFromProto,
+    updateWidgetMgrState,
+    element,
+    widgetMgr,
+    fragmentId,
+    queryParamBinding,
+  } = args
+
+  // Convert the explicit behavior declaration into the optional callback shape
+  // expected by useBasicWidgetClientState.
+  const formClearCallback =
+    args.formClearBehavior === "resetValueAndRunCallback"
+      ? args.onFormCleared
+      : undefined
+
   const getDefaultState = useCallback<(wm: WidgetStateManager, el: P) => T>(
     (_wm, el) => {
       // Backend explicitly set a value (e.g., from URL params or session_state).
@@ -247,7 +292,7 @@ export function useBasicWidgetState<
     element,
     widgetMgr,
     fragmentId,
-    onFormCleared,
+    onFormCleared: formClearCallback,
   })
 
   // Memoize values for useQueryParamBinding to prevent unnecessary effect re-runs.


### PR DESCRIPTION
## Describe your changes

This PR standardizes form clear behavior across all widget components by introducing an explicit `formClearBehavior` parameter to the `useBasicWidgetState` hook. The changes include:

- Added a discriminated union type `FormClearBehaviorArgs` that requires widgets to explicitly declare their form clear behavior as either `"resetValueOnly"` or `"resetValueAndRunCallback"`
- Made the `fragmentId` parameter explicitly required (even when `undefined`) to ensure fragment context is consciously threaded through widget hooks
- Updated all widget components to specify their appropriate form clear behavior:
  - Input widgets (TextInput, NumberInput, DateInput, DateTimeInput, TextArea) use `"resetValueAndRunCallback"` to handle local UI state cleanup
  - Selection widgets (ButtonGroup, Checkbox, ColorPicker, Radio, Selectbox, Multiselect, Slider, TimeInput, Feedback) use `"resetValueOnly"` for simple value reset
- Standardized the `fragmentId` parameter type from optional (`fragmentId?: string`) to explicit (`fragmentId: string | undefined`) across all `updateWidgetMgrState` functions
- Updated tests to include the new required parameters

## Testing Plan

- **Unit Tests (JS)**: Updated existing tests in `useBasicWidgetState.test.ts` and `dateTimeInputUtils.test.ts` to include the new required parameters and added comprehensive test coverage for both form clear behaviors

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.