### PR TITLE
ci(workflows): schedule stale-prs nightly and simplify stale run output

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -113,7 +113,7 @@ steps:
 | `autofix.yml` | `autofix` label on PR | Runs formatters/linters and creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |
-| `stale-prs.yml` | Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
+| `stale-prs.yml` | Daily schedule (6:30 UTC), Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
 
 ### AI-Assisted Workflows
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -111,7 +111,7 @@ steps:
 | `autofix.yml` | `autofix` label on PR | Runs formatters/linters and creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |
-| `stale-prs.yml` | Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
+| `stale-prs.yml` | Daily schedule (6:30 UTC), Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
 
 ### AI-Assisted Workflows
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -107,7 +107,7 @@ steps:
 | `autofix.yml` | `autofix` label on PR | Runs formatters/linters and creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |
-| `stale-prs.yml` | Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
+| `stale-prs.yml` | Daily schedule (6:30 UTC), Manual (`workflow_dispatch`) | Stale PR processing for inactivity policy |
 
 ### AI-Assisted Workflows
 

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,16 +1,22 @@
 name: Stale PRs
 
 on:
+  schedule:
+    # Run job at 10.30pm PST or 11.30pm PDT
+    - cron: "30 6 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
         description: Run in dry-run mode (no labels/comments/closures)
         required: true
-        default: true
+        default: false
         type: boolean
 
+# Avoid overlapping stale processing runs globally in this repository.
+concurrency:
+  group: stale-prs-global
+
 permissions:
-  actions: write
   contents: read
   issues: write
   pull-requests: write
@@ -70,19 +76,3 @@ jobs:
             echo "Marked stale: ${STALED_COUNT}"
             echo "Closed: ${CLOSED_COUNT}"
           fi
-
-      - name: Write stale audit files
-        env:
-          STALED_JSON: ${{ steps.stale.outputs['staled-issues-prs'] || '[]' }}
-          CLOSED_JSON: ${{ steps.stale.outputs['closed-issues-prs'] || '[]' }}
-        run: |
-          mkdir -p stale-prs-audit
-          jq '.' <<<"$STALED_JSON" > stale-prs-audit/staled-issues-prs.json
-          jq '.' <<<"$CLOSED_JSON" > stale-prs-audit/closed-issues-prs.json
-
-      - name: Upload stale audit artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: stale-prs-output
-          path: stale-prs-audit
-          retention-days: 14


### PR DESCRIPTION
## Describe your changes

- This pull request enables automated scheduling for the stale PR workflow and adjusts its configuration. The workflow now runs daily at 10:30 PM PST/11:30 PM PDT via cron schedule (matches `nightly.yml`).
- The default dry-run mode has been changed from `true` to `false` for manual workflow dispatches, and dry-run logic now only applies when the workflow is manually triggered with the dry-run option enabled.
- The audit file generation and artifact upload steps have been removed from the workflow.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: This change modifies GitHub Actions workflow configuration which will be validated by GitHub's workflow parser when merged. The cron schedule and conditional logic can be verified through workflow execution logs.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.