### PR TITLE
Cache SqlConnection.query results per-instance.

### DIFF
--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Literal, TypeVar, cast
 
@@ -73,6 +74,9 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         """
         self._connection_name = connection_name
         self._kwargs = kwargs
+        # A per-instance unique ID. Guaranteed unique for the lifetime of a process,
+        # unlike Python's id() builtin.
+        self._connection_instance_id = uuid.uuid4()
 
         self._config_section_hash = calc_md5(json.dumps(self._secrets.to_dict()))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -33,6 +33,7 @@ _LOGGER: Final = logger.get_logger(__name__)
 
 if TYPE_CHECKING:
     from datetime import timedelta
+    from uuid import UUID
 
     from pandas import DataFrame
     from snowflake.connector.cursor import SnowflakeCursor  # type:ignore[import]
@@ -141,7 +142,7 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         # `@st.cache_data` includes it in the cache key.
         def _query(
             # Dummy parameter to retain per-instance caching.
-            instance_id: int,  # noqa: ARG001
+            instance_id: UUID,  # noqa: ARG001
             sql: str,
             params: Any = None,
         ) -> DataFrame:

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -139,7 +139,12 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         )
         # `params` must be an explicit parameter (not captured from closure) so that
         # `@st.cache_data` includes it in the cache key.
-        def _query(sql: str, params: Any = None) -> DataFrame:
+        def _query(
+            # Dummy parameter to retain per-instance caching.
+            instance_id: int,  # noqa: ARG001
+            sql: str,
+            params: Any = None,
+        ) -> DataFrame:
             cur = self._instance.cursor()
             cur.execute(sql, params=params, **kwargs)
             return cur.fetch_pandas_all()  # type: ignore
@@ -157,7 +162,7 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ttl=ttl,
         )(_query)
 
-        return _query(sql, params)
+        return _query(self._connection_instance_id, sql, params)
 
     def write_pandas(
         self,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -312,7 +312,7 @@ class SQLConnection(BaseConnection["Engine"]):
         )
         def _query(
             # Dummy parameter to retain per-instance caching.
-            cache_id: int,  # noqa: ARG001
+            instance_id: int,  # noqa: ARG001
             sql: str,
             index_col: str | list[str] | None = None,
             chunksize: int | None = None,
@@ -348,7 +348,7 @@ class SQLConnection(BaseConnection["Engine"]):
         )(_query)
 
         return _query(
-            id(self),
+            self._connection_instance_id,
             sql,
             index_col=index_col,
             chunksize=chunksize,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -30,6 +30,7 @@ from streamlit.runtime.caching import cache_data
 
 if TYPE_CHECKING:
     from datetime import timedelta
+    from uuid import UUID
 
     from pandas import DataFrame
     from sqlalchemy.engine import Connection as SQLAlchemyConnection
@@ -312,7 +313,7 @@ class SQLConnection(BaseConnection["Engine"]):
         )
         def _query(
             # Dummy parameter to retain per-instance caching.
-            instance_id: int,  # noqa: ARG001
+            instance_id: UUID,  # noqa: ARG001
             sql: str,
             index_col: str | list[str] | None = None,
             chunksize: int | None = None,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -311,6 +311,8 @@ class SQLConnection(BaseConnection["Engine"]):
             wait=wait_fixed(1),
         )
         def _query(
+            # Dummy parameter to retain per-instance caching.
+            cache_id: int,  # noqa: ARG001
             sql: str,
             index_col: str | list[str] | None = None,
             chunksize: int | None = None,
@@ -346,6 +348,7 @@ class SQLConnection(BaseConnection["Engine"]):
         )(_query)
 
         return _query(
+            id(self),
             sql,
             index_col=index_col,
             chunksize=chunksize,

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -161,19 +161,26 @@ class SnowflakeConnectionTest(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_cursor.fetch_pandas_all = MagicMock(return_value="i am a dataframe")
 
-        conn1 = SnowflakeConnection("my_snowflake_connection1")
+        conn1 = SnowflakeConnection("my_snowflake_connection1", host="host1")
+        conn2 = SnowflakeConnection("my_snowflake_connection1", host="another_host")
+        conn3 = SnowflakeConnection("my_snowflake_connection2")
+
         conn1._instance.cursor.return_value = mock_cursor
-        conn2 = SnowflakeConnection("my_snowflake_connection2")
-        conn2._instance.cursor.return_value = mock_cursor
-
-        conn1.query("SELECT 1;")
-        conn1.query("SELECT 1;")
-        conn2.query("SELECT 1;")
-        conn2.query("SELECT 1;")
-
         assert conn1._instance.cursor is conn2._instance.cursor
-        assert conn1._instance.cursor.call_count == 2
+        assert conn2._instance.cursor is conn3._instance.cursor
+
+        conn1.query("SELECT 1;")
+        assert mock_cursor.execute.call_count == 1
+        conn1.query("SELECT 1;")
+        assert mock_cursor.execute.call_count == 1
+        conn2.query("SELECT 1;")
         assert mock_cursor.execute.call_count == 2
+        conn2.query("SELECT 1;")
+        assert mock_cursor.execute.call_count == 2
+        conn3.query("SELECT 1;")
+        assert mock_cursor.execute.call_count == 3
+        conn3.query("SELECT 1;")
+        assert mock_cursor.execute.call_count == 3
 
     @patch(
         "streamlit.connections.snowflake_connection.SnowflakeConnection._connect",

--- a/lib/tests/streamlit/connections/sql_connection_test.py
+++ b/lib/tests/streamlit/connections/sql_connection_test.py
@@ -164,20 +164,27 @@ class SQLConnectionTest(unittest.TestCase):
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")
-    def test_scopes_caches_by_connection_name(self, patched_read_sql):
+    def test_scopes_caches_by_connection_instance(self, patched_read_sql):
         # Caching functions rely on an active script run ctx
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
         patched_read_sql.return_value = "i am a dataframe"
 
-        conn1 = SQLConnection("my_sql_connection1")
-        conn2 = SQLConnection("my_sql_connection2")
+        conn1 = SQLConnection("my_sql_connection1", host="host1")
+        conn2 = SQLConnection("my_sql_connection1", host="another_host")
+        conn3 = SQLConnection("my_sql_connection2")
 
         conn1.query("SELECT 1;")
+        assert patched_read_sql.call_count == 1
         conn1.query("SELECT 1;")
+        assert patched_read_sql.call_count == 1
         conn2.query("SELECT 1;")
-        conn2.query("SELECT 1;")
-
         assert patched_read_sql.call_count == 2
+        conn2.query("SELECT 1;")
+        assert patched_read_sql.call_count == 2
+        conn3.query("SELECT 1;")
+        assert patched_read_sql.call_count == 3
+        conn3.query("SELECT 1;")
+        assert patched_read_sql.call_count == 3
 
     @patch("streamlit.connections.sql_connection.SQLConnection._connect", MagicMock())
     @patch("pandas.read_sql")


### PR DESCRIPTION
## Describe your changes

Include an instance ID parameter in the cache key for SqlConnection.query's internal cache. This prevents cache leakage between two different database connections running the same query.

This may result in some new cache misses. Note however that since `connection_factory` / `st.connection` cache resources globally, this will only result in extra cache misses in cases where users are constructing SqlConnections manually and not through `st.connection`.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/14077

## Testing Plan

See PR.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
