### PR TITLE
Add additional VS Code debug profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ e2e_playwright/__snapshots__/*
 !.vscode/extensions.json
 !.vscode/launch.json
 !.vscode/settings.json
+!.vscode/tasks.json
 
 .swc/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
         "--global.developmentMode=true"
       ]
       // allows to set breakpoints in installed packages, such as the Streamlit lib itself or custom component code etc.
-      // "justMyCode": false
+      // "justMyCode": false,
       // allows to use a different installed version of streamlit in another venv folder, e.g.
       // "program": "~/Projects/streamlit/lib/venv/bin/pytest"
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,41 @@
       "type": "debugpy",
       "request": "launch",
       "module": "streamlit",
-      "args": ["run", "${file}"]
+      "args": [
+        "run",
+        "${file}",
+        "--server.headless=true",
+        "--global.developmentMode=true"
+      ]
       // allows to set breakpoints in installed packages, such as the Streamlit lib itself or custom component code etc.
-      // "justMyCode": false,
+      // "justMyCode": false
       // allows to use a different installed version of streamlit in another venv folder, e.g.
       // "program": "~/Projects/streamlit/lib/venv/bin/pytest"
+    },
+    {
+      "name": "Debug React App",
+      "type": "chrome",
+      // allows vs code to launch and manage the debug connection automatically
+      "request": "launch",
+      "url": "http://localhost:3001",
+      "webRoot": "${workspaceFolder}/frontend/app",
+      "sourceMapPathOverrides": {
+        // Vite serves lib files outside the app root using the @fs/ prefix.
+        // Strip it to get the absolute filesystem path.
+        "/@fs/*": "/*",
+        // App source files are served from /src/* and live in frontend/app/src/*.
+        "/src/*": "${workspaceFolder}/frontend/app/src/*"
+      },
+      // Automatically starts the Vite dev server (proxying backend at localhost:8501)
+      // before attaching the Chrome debugger.
+      "preLaunchTask": "Start Frontend Dev Server"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug Streamlit (Full Stack)",
+      "configurations": ["Debug Streamlit App", "Debug React App"],
+      "stopAll": true
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Start Frontend Dev Server",
+      "type": "shell",
+      "command": "cd ${workspaceFolder}/frontend && DEV_SERVER_BACKEND_URL=http://localhost:8501 VITE_PORT=3001 yarn start -- --strictPort",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated"
+      },
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "VITE",
+          "endsPattern": "ready in"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Describe your changes

Adds a debug profile to debug the front end app and create a compound debug profile to debug both the front end and the back end.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/14097

## Testing Plan

- Explanation of why no additional tests are needed

This adds configs to the launch.json. I verified this works by running both profiles in VS Code with breakpoints.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
