### PR TITLE
[docs] add exact matching and element count guidance to E2E docs

### DIFF
--- a/.cursor/rules/e2e_playwright.mdc
+++ b/.cursor/rules/e2e_playwright.mdc
@@ -85,6 +85,7 @@ See `st_video.py` and `st_image.py` for examples.
   2. elements that don't support `label` but support `key`: get elements by a unique key (`get_element_by_key`).
   3. If the element doesn't support key or label, you can wrap it with an `st.container(key="my_key")` to better target it via `get_element_by_key`. E.g. `get_element_by_key("my_key").get_by_test_id("stComponent")`.
 - Prefer stable locators like `get_by_test_id`, `get_by_text` or `get_by_role` over CSS / XPath selectors via `.locator`.
+- Use `exact=True` with `get_by_text()` and `filter(has_text=...)` when the target text is a prefix/substring of other text on the page. For example, `get_by_text("Count:", exact=True)` avoids accidentally matching "Count: 5". Without `exact=True`, Playwright uses substring matching, which causes strict mode violations when multiple elements match.
 - Group related tests into single, logical test files (e.g., by widget or feature) for CI efficiency.
 - Prefer a single aggregated scenario test over many micro-tests when they share the same setup and page state. Reuse one app load, cover multiple assertions in sequence, and reduce browser loads.
 - Use `@pytest.mark.parametrize` sparingly in E2E. Avoid parameterizing over expensive flows and prefer iterating variants in one scenario test when setup dominates runtime.
@@ -112,6 +113,7 @@ When adding or modifying tests for an element, ensure the following are covered:
   - If the element uses the `key` parameter, verify a corresponding CSS class or attribute is set.
   - If the element is a widget, make sure to test that the identity is kept stable when `key` is provided.
 - **Custom Config:** Use module-scoped fixtures with `@pytest.mark.early` for tests requiring specific Streamlit configuration options.
+- **Existing test compatibility:** When adding new elements to an existing app script, check whether existing tests assert element counts (e.g., `to_have_count(18)`) and update them to reflect the new total.
 
 ## Running tests
 

--- a/.github/instructions/e2e_playwright.instructions.md
+++ b/.github/instructions/e2e_playwright.instructions.md
@@ -83,6 +83,7 @@ See `st_video.py` and `st_image.py` for examples.
   2. elements that don't support `label` but support `key`: get elements by a unique key (`get_element_by_key`).
   3. If the element doesn't support key or label, you can wrap it with an `st.container(key="my_key")` to better target it via `get_element_by_key`. E.g. `get_element_by_key("my_key").get_by_test_id("stComponent")`.
 - Prefer stable locators like `get_by_test_id`, `get_by_text` or `get_by_role` over CSS / XPath selectors via `.locator`.
+- Use `exact=True` with `get_by_text()` and `filter(has_text=...)` when the target text is a prefix/substring of other text on the page. For example, `get_by_text("Count:", exact=True)` avoids accidentally matching "Count: 5". Without `exact=True`, Playwright uses substring matching, which causes strict mode violations when multiple elements match.
 - Group related tests into single, logical test files (e.g., by widget or feature) for CI efficiency.
 - Prefer a single aggregated scenario test over many micro-tests when they share the same setup and page state. Reuse one app load, cover multiple assertions in sequence, and reduce browser loads.
 - Use `@pytest.mark.parametrize` sparingly in E2E. Avoid parameterizing over expensive flows and prefer iterating variants in one scenario test when setup dominates runtime.
@@ -110,6 +111,7 @@ When adding or modifying tests for an element, ensure the following are covered:
   - If the element uses the `key` parameter, verify a corresponding CSS class or attribute is set.
   - If the element is a widget, make sure to test that the identity is kept stable when `key` is provided.
 - **Custom Config:** Use module-scoped fixtures with `@pytest.mark.early` for tests requiring specific Streamlit configuration options.
+- **Existing test compatibility:** When adding new elements to an existing app script, check whether existing tests assert element counts (e.g., `to_have_count(18)`) and update them to reflect the new total.
 
 ## Running tests
 

--- a/e2e_playwright/AGENTS.md
+++ b/e2e_playwright/AGENTS.md
@@ -79,6 +79,7 @@ See `st_video.py` and `st_image.py` for examples.
   2. elements that don't support `label` but support `key`: get elements by a unique key (`get_element_by_key`).
   3. If the element doesn't support key or label, you can wrap it with an `st.container(key="my_key")` to better target it via `get_element_by_key`. E.g. `get_element_by_key("my_key").get_by_test_id("stComponent")`.
 - Prefer stable locators like `get_by_test_id`, `get_by_text` or `get_by_role` over CSS / XPath selectors via `.locator`.
+- Use `exact=True` with `get_by_text()` and `filter(has_text=...)` when the target text is a prefix/substring of other text on the page. For example, `get_by_text("Count:", exact=True)` avoids accidentally matching "Count: 5". Without `exact=True`, Playwright uses substring matching, which causes strict mode violations when multiple elements match.
 - Group related tests into single, logical test files (e.g., by widget or feature) for CI efficiency.
 - Prefer a single aggregated scenario test over many micro-tests when they share the same setup and page state. Reuse one app load, cover multiple assertions in sequence, and reduce browser loads.
 - Use `@pytest.mark.parametrize` sparingly in E2E. Avoid parameterizing over expensive flows and prefer iterating variants in one scenario test when setup dominates runtime.
@@ -106,6 +107,7 @@ When adding or modifying tests for an element, ensure the following are covered:
   - If the element uses the `key` parameter, verify a corresponding CSS class or attribute is set.
   - If the element is a widget, make sure to test that the identity is kept stable when `key` is provided.
 - **Custom Config:** Use module-scoped fixtures with `@pytest.mark.early` for tests requiring specific Streamlit configuration options.
+- **Existing test compatibility:** When adding new elements to an existing app script, check whether existing tests assert element counts (e.g., `to_have_count(18)`) and update them to reflect the new total.
 
 ## Running tests
 


### PR DESCRIPTION

## Describe your changes

Adds two best practices to the E2E Playwright testing docs (`AGENTS.md` and mirrors):

- Use `exact=True` with `get_by_text()` and `filter(has_text=...)` to prevent substring matching from causing strict mode violations when the target text is a prefix of other text on the page.
- Check and update existing element count assertions (e.g., `to_have_count(N)`) when adding new elements to an existing app script.

Both patterns caused recurring CI failures across the dynamic containers callback PRs.

## Testing Plan

- Explanation of why no additional tests are needed: Documentation-only changes, no behavior modifications.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
