### PR TITLE
[fix] st.metric with chart_data wrapping in horizontal containers

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -19,6 +19,7 @@ import { screen, waitFor } from "@testing-library/react"
 import {
   Balloons as BalloonsProto,
   ForwardMsgMetadata,
+  Metric as MetricProto,
   Snow as SnowProto,
 } from "@streamlit/protobuf"
 
@@ -30,9 +31,22 @@ import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
+import { ElementContainer } from "./ElementContainer"
+import {
+  ElementContainerConfig,
+  MinStretchWidth,
+} from "./ElementContainerConfig"
 import ElementNodeRenderer, {
   ElementNodeRendererProps,
 } from "./ElementNodeRenderer"
+
+vi.mock("./ElementContainer", async importOriginal => {
+  const mod = await importOriginal<typeof import("./ElementContainer")>()
+  return {
+    ...mod,
+    ElementContainer: vi.fn((props: any) => mod.ElementContainer(props)),
+  }
+})
 
 const FAKE_SCRIPT_HASH = "fake_script_hash"
 
@@ -62,6 +76,24 @@ function createSnowNode(scriptRunId: string): ElementNode {
   return node
 }
 
+function createMetricNode(
+  scriptRunId: string,
+  metricProps: Partial<MetricProto> = {}
+): ElementNode {
+  const metric = MetricProto.create({
+    body: "100",
+    label: "Test Metric",
+    ...metricProps,
+  })
+  const element = { type: "metric", metric } as any
+  return new ElementNode(
+    element,
+    ForwardMsgMetadata.create({}),
+    scriptRunId,
+    FAKE_SCRIPT_HASH
+  )
+}
+
 function getProps(
   props: Partial<ElementNodeRendererProps> &
     Pick<ElementNodeRendererProps, "node">
@@ -87,6 +119,12 @@ function getProps(
 }
 
 describe("ElementNodeRenderer Block Component", () => {
+  const mockElementContainer = vi.mocked(ElementContainer)
+
+  beforeEach(() => {
+    mockElementContainer.mockClear()
+  })
+
   describe("render Balloons", () => {
     it("should NOT render a stale component", async () => {
       const scriptRunId = "SCRIPT_RUN_ID"
@@ -168,6 +206,71 @@ describe("ElementNodeRenderer Block Component", () => {
       const elementRendererChildren = elementNodeRenderer.children
       expect(elementRendererChildren).toHaveLength(1)
       expect(elementRendererChildren[0]).toHaveClass("stSnow")
+    })
+  })
+
+  describe("render Metric", () => {
+    it("should use LARGE_ELEMENT config when chartData is present", async () => {
+      const scriptRunId = "SCRIPT_RUN_ID"
+      const node = createMetricNode(scriptRunId, {
+        chartData: [1, 2, 3, 4, 5],
+        chartType: MetricProto.ChartType.LINE,
+      })
+      const props = getProps({ node })
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: { scriptRunId },
+      })
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("stSkeleton")).toBeNull()
+      )
+      expect(screen.getByTestId("stElementContainer")).toBeInTheDocument()
+
+      const lastCall = mockElementContainer.mock.calls.at(-1)
+      expect(lastCall).toBeDefined()
+      const config = lastCall![0].config
+      expect(config).toBe(ElementContainerConfig.LARGE_ELEMENT)
+      expect(config.minStretchWidth).toBe(MinStretchWidth.LARGE)
+    })
+
+    it("should use DEFAULT config when chartData is empty", async () => {
+      const scriptRunId = "SCRIPT_RUN_ID"
+      const node = createMetricNode(scriptRunId, { chartData: [] })
+      const props = getProps({ node })
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: { scriptRunId },
+      })
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("stSkeleton")).toBeNull()
+      )
+      expect(screen.getByTestId("stElementContainer")).toBeInTheDocument()
+
+      const lastCall = mockElementContainer.mock.calls.at(-1)
+      expect(lastCall).toBeDefined()
+      const config = lastCall![0].config
+      expect(config).toBe(ElementContainerConfig.DEFAULT)
+      expect(config.minStretchWidth).toBe(MinStretchWidth.NONE)
+    })
+
+    it("should use DEFAULT config when chartData is not provided", async () => {
+      const scriptRunId = "SCRIPT_RUN_ID"
+      const node = createMetricNode(scriptRunId)
+      const props = getProps({ node })
+      renderWithContexts(<ElementNodeRenderer {...props} />, {
+        scriptRunContext: { scriptRunId },
+      })
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("stSkeleton")).toBeNull()
+      )
+      expect(screen.getByTestId("stElementContainer")).toBeInTheDocument()
+
+      const lastCall = mockElementContainer.mock.calls.at(-1)
+      expect(lastCall).toBeDefined()
+      const config = lastCall![0].config
+      expect(config).toBe(ElementContainerConfig.DEFAULT)
+      expect(config.minStretchWidth).toBe(MinStretchWidth.NONE)
     })
   })
 })

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -18,6 +18,7 @@ import { screen, waitFor } from "@testing-library/react"
 
 import {
   Balloons as BalloonsProto,
+  Element,
   ForwardMsgMetadata,
   Metric as MetricProto,
   Snow as SnowProto,
@@ -31,7 +32,7 @@ import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
-import { ElementContainer } from "./ElementContainer"
+import { ElementContainer, ElementContainerProps } from "./ElementContainer"
 import {
   ElementContainerConfig,
   MinStretchWidth,
@@ -44,7 +45,9 @@ vi.mock("./ElementContainer", async importOriginal => {
   const mod = await importOriginal<typeof import("./ElementContainer")>()
   return {
     ...mod,
-    ElementContainer: vi.fn((props: any) => mod.ElementContainer(props)),
+    ElementContainer: vi.fn((props: ElementContainerProps) =>
+      mod.ElementContainer(props)
+    ),
   }
 })
 
@@ -85,7 +88,7 @@ function createMetricNode(
     label: "Test Metric",
     ...metricProps,
   })
-  const element = { type: "metric", metric } as any
+  const element = { type: "metric", metric } as unknown as Element
   return new ElementNode(
     element,
     ForwardMsgMetadata.create({}),
@@ -227,8 +230,8 @@ describe("ElementNodeRenderer Block Component", () => {
       expect(screen.getByTestId("stElementContainer")).toBeInTheDocument()
 
       const lastCall = mockElementContainer.mock.calls.at(-1)
-      expect(lastCall).toBeDefined()
-      const config = lastCall![0].config
+      if (!lastCall) throw new Error("Expected ElementContainer to be called")
+      const config = lastCall[0].config
       expect(config).toBe(ElementContainerConfig.LARGE_ELEMENT)
       expect(config.minStretchWidth).toBe(MinStretchWidth.LARGE)
     })
@@ -247,8 +250,8 @@ describe("ElementNodeRenderer Block Component", () => {
       expect(screen.getByTestId("stElementContainer")).toBeInTheDocument()
 
       const lastCall = mockElementContainer.mock.calls.at(-1)
-      expect(lastCall).toBeDefined()
-      const config = lastCall![0].config
+      if (!lastCall) throw new Error("Expected ElementContainer to be called")
+      const config = lastCall[0].config
       expect(config).toBe(ElementContainerConfig.DEFAULT)
       expect(config.minStretchWidth).toBe(MinStretchWidth.NONE)
     })
@@ -267,8 +270,8 @@ describe("ElementNodeRenderer Block Component", () => {
       expect(screen.getByTestId("stElementContainer")).toBeInTheDocument()
 
       const lastCall = mockElementContainer.mock.calls.at(-1)
-      expect(lastCall).toBeDefined()
-      const config = lastCall![0].config
+      if (!lastCall) throw new Error("Expected ElementContainer to be called")
+      const config = lastCall[0].config
       expect(config).toBe(ElementContainerConfig.DEFAULT)
       expect(config.minStretchWidth).toBe(MinStretchWidth.NONE)
     })

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -452,19 +452,24 @@ const RawElementNodeRenderer = (
       )
     }
 
-    case "metric":
+    case "metric": {
+      const metricProto = node.element.metric as MetricProto
+      const hasChart =
+        metricProto.chartData && metricProto.chartData.length > 0
       return (
         <ElementContainer
           node={node}
-          config={ElementContainerConfig.DEFAULT}
+          config={
+            hasChart
+              ? ElementContainerConfig.LARGE_ELEMENT
+              : ElementContainerConfig.DEFAULT
+          }
           isStale={isStale}
         >
-          <Metric
-            element={node.element.metric as MetricProto}
-            {...elementProps}
-          />
+          <Metric element={metricProto} {...elementProps} />
         </ElementContainer>
       )
+    }
 
     case "html":
       return (


### PR DESCRIPTION
## Summary

Fixes #13785.

[Test App](https://5y4mkpadelke7z37rdmd2e.streamlit.app/). 

`st.metric` elements with `chart_data` (sparkline charts) placed inside `st.container(horizontal=True)` could non-deterministically wrap to multiple rows. This was caused by a sizing race condition: the Vega-Lite chart renders asynchronously via `useEffect` + `ResizeObserver`, which changes the element's intrinsic size *after* the initial flex layout, causing a positive feedback loop of reflows and widening.

The fix conditionally applies `LARGE_ELEMENT` config (`14rem` min-width, matching other chart elements) when the metric has `chart_data`. Metrics without charts retain `DEFAULT` config — zero behavior change for the common case.

**Behavior matrix:**
| Scenario | Before | After |
|---|---|---|
| Metric **with** chart in horizontal container | `DEFAULT` (no min-width → race condition) | `LARGE_ELEMENT` (14rem min-width → stable) |
| Metric **without** chart in horizontal container | `DEFAULT` | `DEFAULT` (unchanged) |
| Metric in vertical layout | No flex applied | No flex applied (unchanged) |
| Metric in `st.columns` | Column sizing | Column sizing (unchanged) |

## Test plan

- [x] Existing `ElementNodeRenderer` unit tests pass (4/4)
- [x] Existing `Metric` component unit tests pass (58/58)
- [x] E2E `st_metric` tests (metrics with charts in columns — unchanged behavior)
- [x] E2E `st_layouts_container_various_elements` (metrics without charts in horizontal — unchanged behavior)
- [x] Visual verification with reproduction app
