### PR TITLE
[feat] Add `on_click` rerun support to `st.link_button`

### DIFF
--- a/e2e_playwright/st_link_button.py
+++ b/e2e_playwright/st_link_button.py
@@ -94,3 +94,25 @@ st.link_button(
     icon=":material/bolt:",
     icon_position="right",
 )
+
+
+def on_click_callback() -> None:
+    if "link_button_click_count" not in st.session_state:
+        st.session_state.link_button_click_count = 0
+
+    st.session_state.link_button_click_count += 1
+
+
+st.link_button(
+    "Link Button with on_click callback",
+    "https://streamlit.io",
+    key="on_click_link_button",
+    on_click=on_click_callback,
+)
+callback_was_invoked = "link_button_click_count" in st.session_state
+st.write("Link Button callback invoked:", callback_was_invoked)
+if callback_was_invoked:
+    st.write(
+        "Link Button callback times clicked:",
+        st.session_state.link_button_click_count,
+    )

--- a/e2e_playwright/st_link_button.py
+++ b/e2e_playwright/st_link_button.py
@@ -97,22 +97,28 @@ st.link_button(
 
 
 def on_click_callback() -> None:
-    if "link_button_click_count" not in st.session_state:
-        st.session_state.link_button_click_count = 0
+    st.session_state.link_button_click_count = (
+        st.session_state.get("link_button_click_count", 0) + 1
+    )
 
-    st.session_state.link_button_click_count += 1
 
-
-st.link_button(
+callback_link_clicked = st.link_button(
     "Link Button with on_click callback",
     "https://streamlit.io",
     key="on_click_link_button",
     on_click=on_click_callback,
 )
-callback_was_invoked = "link_button_click_count" in st.session_state
-st.write("Link Button callback invoked:", callback_was_invoked)
-if callback_was_invoked:
+st.write("Link Button with on_click value:", callback_link_clicked)
+if "link_button_click_count" in st.session_state:
     st.write(
         "Link Button callback times clicked:",
         st.session_state.link_button_click_count,
     )
+
+rerun_link_clicked = st.link_button(
+    "Link Button with rerun",
+    "https://streamlit.io",
+    key="rerun_link_button",
+    on_click="rerun",
+)
+st.write("Link Button with rerun value:", rerun_link_clicked)

--- a/e2e_playwright/st_link_button_test.py
+++ b/e2e_playwright/st_link_button_test.py
@@ -18,10 +18,15 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction
-from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    check_top_level_class,
+    expect_prefixed_markdown,
+    get_element_by_key,
+    get_expander,
+)
 
-LINK_BUTTON_ELEMENTS = 17
+LINK_BUTTON_ELEMENTS = 18
 
 
 def test_link_button_display(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -81,6 +86,28 @@ def test_link_button_width_examples(app: Page, assert_snapshot: ImageCompareFunc
     assert_snapshot(link_elements.nth(0), name="st_link_button-width_content")
     assert_snapshot(link_elements.nth(1), name="st_link_button-width_stretch")
     assert_snapshot(link_elements.nth(2), name="st_link_button-width_400px")
+
+
+def test_link_button_click_calls_callback(app: Page):
+    callback_link_button = get_element_by_key(app, "on_click_link_button").locator("a")
+
+    expect_prefixed_markdown(
+        app, "Link Button callback invoked:", "False", exact_match=True
+    )
+
+    with app.expect_popup() as popup_info:
+        callback_link_button.click()
+
+    popup = popup_info.value
+    popup.close()
+
+    wait_for_app_run(app)
+    expect_prefixed_markdown(
+        app, "Link Button callback invoked:", "True", exact_match=True
+    )
+    expect_prefixed_markdown(
+        app, "Link Button callback times clicked:", "1", exact_match=True
+    )
 
 
 @pytest.mark.only_browser(

--- a/e2e_playwright/st_link_button_test.py
+++ b/e2e_playwright/st_link_button_test.py
@@ -16,7 +16,7 @@
 import re
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
@@ -26,7 +26,15 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-LINK_BUTTON_ELEMENTS = 18
+LINK_BUTTON_ELEMENTS = 19
+
+
+def _click_link_and_wait_for_rerun(app: Page, link: Locator) -> None:
+    with app.expect_popup() as popup_info:
+        link.click()
+
+    popup_info.value.close()
+    wait_for_app_run(app)
 
 
 def test_link_button_display(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -77,6 +85,11 @@ def test_check_top_level_class(app: Page):
     check_top_level_class(app, "stLinkButton")
 
 
+def test_custom_css_class_via_key(app: Page):
+    """Test that the element can have a custom css class via the key argument."""
+    expect(get_element_by_key(app, "on_click_link_button")).to_be_visible()
+
+
 def test_link_button_width_examples(app: Page, assert_snapshot: ImageCompareFunction):
     """Test link button width examples via screenshot matching."""
     link_expander = get_expander(app, "Link Button Width Examples")
@@ -89,24 +102,33 @@ def test_link_button_width_examples(app: Page, assert_snapshot: ImageCompareFunc
 
 
 def test_link_button_click_calls_callback(app: Page):
-    callback_link_button = get_element_by_key(app, "on_click_link_button").locator("a")
-
-    expect_prefixed_markdown(
-        app, "Link Button callback invoked:", "False", exact_match=True
+    callback_link_button = get_element_by_key(app, "on_click_link_button").get_by_role(
+        "link"
     )
 
-    with app.expect_popup() as popup_info:
-        callback_link_button.click()
-
-    popup = popup_info.value
-    popup.close()
-
-    wait_for_app_run(app)
     expect_prefixed_markdown(
-        app, "Link Button callback invoked:", "True", exact_match=True
+        app, "Link Button with on_click value:", "False", exact_match=True
+    )
+
+    _click_link_and_wait_for_rerun(app, callback_link_button)
+    expect_prefixed_markdown(
+        app, "Link Button with on_click value:", "True", exact_match=True
     )
     expect_prefixed_markdown(
         app, "Link Button callback times clicked:", "1", exact_match=True
+    )
+
+
+def test_link_button_click_returns_true_for_rerun(app: Page):
+    rerun_link_button = get_element_by_key(app, "rerun_link_button").get_by_role("link")
+
+    expect_prefixed_markdown(
+        app, "Link Button with rerun value:", "False", exact_match=True
+    )
+
+    _click_link_and_wait_for_rerun(app, rerun_link_button)
+    expect_prefixed_markdown(
+        app, "Link Button with rerun value:", "True", exact_match=True
     )
 
 

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -912,7 +912,11 @@ const RawElementNodeRenderer = (
           config={ElementContainerConfig.DEFAULT}
           isStale={isStale}
         >
-          <LinkButton element={linkButtonProto} {...elementProps} />
+          <LinkButton
+            element={linkButtonProto}
+            widgetMgr={props.widgetMgr}
+            fragmentId={node.fragmentId}
+          />
         </ElementContainer>
       )
     }

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -166,6 +166,20 @@ describe("LinkButton widget", () => {
     )
   })
 
+  it("does not trigger rerun when disabled", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      id: "link-id",
+      ignoreRerun: false,
+      disabled: true,
+    })
+    render(<LinkButton {...props} />)
+
+    await user.click(screen.getByRole("link"))
+
+    expect(props.widgetMgr.setTriggerValue).not.toHaveBeenCalled()
+  })
+
   describe("wrapped BaseLinkButton", () => {
     const LINK_BUTTON_TYPES = ["primary", "secondary", "tertiary"]
 

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -22,6 +22,7 @@ import { LinkButton as LinkButtonProto } from "@streamlit/protobuf"
 
 import { useRegisterShortcut } from "~lib/hooks/useRegisterShortcut"
 import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import LinkButton, { Props } from "./LinkButton"
 
@@ -32,6 +33,7 @@ vi.mock("~lib/hooks/useRegisterShortcut", () => ({
       shortcut?.replace(/\+/g, " + ") || undefined
   ),
 }))
+vi.mock("~lib/WidgetStateManager")
 
 const getProps = (
   elementProps: Partial<LinkButtonProto> = {},
@@ -41,6 +43,10 @@ const getProps = (
     label: "Label",
     url: "https://streamlit.io",
     ...elementProps,
+  }),
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
   }),
   ...widgetProps,
 })
@@ -128,6 +134,36 @@ describe("LinkButton widget", () => {
     expect(clickSpy).toHaveBeenCalled()
 
     clickSpy.mockRestore()
+  })
+
+  it("does not trigger rerun by default", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ id: "link-id", ignoreRerun: true })
+    render(<LinkButton {...props} />)
+
+    await user.click(screen.getByRole("link"))
+
+    expect(props.widgetMgr.setTriggerValue).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["without fragmentId", undefined],
+    ["with fragmentId", "myFragmentId"],
+  ])("triggers rerun %s", async (_, fragmentId) => {
+    const user = userEvent.setup()
+    const props = getProps(
+      { id: "link-id", ignoreRerun: false },
+      fragmentId ? { fragmentId } : {}
+    )
+    render(<LinkButton {...props} />)
+
+    await user.click(screen.getByRole("link"))
+
+    expect(props.widgetMgr.setTriggerValue).toHaveBeenCalledWith(
+      props.element,
+      { fromUi: true },
+      fragmentId
+    )
   })
 
   describe("wrapped BaseLinkButton", () => {

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -33,23 +33,27 @@ vi.mock("~lib/hooks/useRegisterShortcut", () => ({
       shortcut?.replace(/\+/g, " + ") || undefined
   ),
 }))
-vi.mock("~lib/WidgetStateManager")
 
 const getProps = (
   elementProps: Partial<LinkButtonProto> = {},
   widgetProps: Partial<Props> = {}
-): Props => ({
-  element: LinkButtonProto.create({
-    label: "Label",
-    url: "https://streamlit.io",
-    ...elementProps,
-  }),
-  widgetMgr: new WidgetStateManager({
+): Props => {
+  const widgetMgr = new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
     formsDataChanged: vi.fn(),
-  }),
-  ...widgetProps,
-})
+  })
+  vi.spyOn(widgetMgr, "setTriggerValue")
+
+  return {
+    element: LinkButtonProto.create({
+      label: "Label",
+      url: "https://streamlit.io",
+      ...elementProps,
+    }),
+    widgetMgr,
+    ...widgetProps,
+  }
+}
 
 describe("LinkButton widget", () => {
   beforeEach(() => {

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -153,7 +153,7 @@ describe("LinkButton widget", () => {
     const user = userEvent.setup()
     const props = getProps(
       { id: "link-id", ignoreRerun: false },
-      fragmentId ? { fragmentId } : {}
+      { fragmentId }
     )
     render(<LinkButton {...props} />)
 

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -27,15 +27,18 @@ import {
 } from "~lib/components/shared/BaseButton"
 import { mapProtoIconPosition } from "~lib/components/shared/BaseButton/iconPosition"
 import { useRegisterShortcut } from "~lib/hooks/useRegisterShortcut"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import BaseLinkButton from "./BaseLinkButton"
 
 export interface Props {
   element: LinkButtonProto
+  widgetMgr: WidgetStateManager
+  fragmentId?: string
 }
 
 function LinkButton(props: Readonly<Props>): ReactElement {
-  const { element } = props
+  const { element, widgetMgr, fragmentId } = props
   const shortcut = element.shortcut ? element.shortcut : undefined
 
   let kind = BaseButtonKind.SECONDARY
@@ -60,9 +63,14 @@ function LinkButton(props: Readonly<Props>): ReactElement {
       if (element.disabled) {
         // Prevent the link from being followed if the button is disabled.
         event.preventDefault()
+        return
+      }
+
+      if (!element.ignoreRerun && element.id) {
+        void widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
       }
     },
-    [element.disabled]
+    [element, fragmentId, widgetMgr]
   )
 
   useRegisterShortcut({

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -39,7 +39,7 @@ export interface Props {
 
 function LinkButton(props: Readonly<Props>): ReactElement {
   const { element, widgetMgr, fragmentId } = props
-  const shortcut = element.shortcut ? element.shortcut : undefined
+  const shortcut = element.shortcut || undefined
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -830,10 +830,14 @@ class ButtonMixin:
               The callable is called before the rest of the app.
 
         args : list or tuple
-            An optional list or tuple of args to pass to the callback.
+            An optional list or tuple of args to pass to the callback when
+            ``on_click`` is a callable. Ignored when ``on_click`` is
+            ``"rerun"`` or ``"ignore"``.
 
         kwargs : dict
-            An optional dict of kwargs to pass to the callback.
+            An optional dict of kwargs to pass to the callback when
+            ``on_click`` is a callable. Ignored when ``on_click`` is
+            ``"rerun"`` or ``"ignore"``.
 
         help : str or None
             A tooltip that gets displayed when the button is hovered over. If

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -28,6 +28,7 @@ from typing import (
     TextIO,
     TypeAlias,
     cast,
+    overload,
 )
 
 from streamlit import runtime
@@ -765,6 +766,66 @@ class ButtonMixin:
             shortcut=shortcut,
         )
 
+    @overload
+    def link_button(
+        self,
+        label: str,
+        url: str,
+        *,
+        key: Key | None = None,
+        on_click: Literal["ignore"] = "ignore",
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        help: str | None = None,
+        type: Literal["primary", "secondary", "tertiary"] = "secondary",
+        icon: str | None = None,
+        icon_position: IconPosition = "left",
+        disabled: bool = False,
+        use_container_width: bool | None = None,
+        width: Width = "content",
+        shortcut: str | None = None,
+    ) -> DeltaGenerator: ...
+
+    @overload
+    def link_button(
+        self,
+        label: str,
+        url: str,
+        *,
+        key: Key | None = None,
+        on_click: Literal["rerun"],
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        help: str | None = None,
+        type: Literal["primary", "secondary", "tertiary"] = "secondary",
+        icon: str | None = None,
+        icon_position: IconPosition = "left",
+        disabled: bool = False,
+        use_container_width: bool | None = None,
+        width: Width = "content",
+        shortcut: str | None = None,
+    ) -> bool: ...
+
+    @overload
+    def link_button(
+        self,
+        label: str,
+        url: str,
+        *,
+        key: Key | None = None,
+        on_click: WidgetCallback,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        help: str | None = None,
+        type: Literal["primary", "secondary", "tertiary"] = "secondary",
+        icon: str | None = None,
+        icon_position: IconPosition = "left",
+        disabled: bool = False,
+        use_container_width: bool | None = None,
+        width: Width = "content",
+        shortcut: str | None = None,
+    ) -> bool: ...
+
     @gather_metrics("link_button")
     def link_button(
         self,
@@ -783,7 +844,7 @@ class ButtonMixin:
         use_container_width: bool | None = None,
         width: Width = "content",
         shortcut: str | None = None,
-    ) -> DeltaGenerator:
+    ) -> bool | DeltaGenerator:
         r"""Display a link button element.
 
         When clicked, a new tab will be opened to the specified URL. This will
@@ -934,6 +995,14 @@ class ButtonMixin:
             .. |st.button| replace:: ``st.button``
             .. _st.button: https://docs.streamlit.io/develop/api-reference/widgets/st.button
 
+        Returns
+        -------
+        bool or DeltaGenerator
+            If ``on_click`` is ``"rerun"`` or a callable, this returns ``True``
+            when the button was clicked on the last run of the app, and
+            ``False`` otherwise. If ``on_click`` is ``"ignore"``, this returns a
+            ``DeltaGenerator``.
+
         Example
         -------
         >>> import streamlit as st
@@ -945,7 +1014,6 @@ class ButtonMixin:
            height: 200px
 
         """
-        # Checks whether the entered button type is one of the allowed options - either "primary" or "secondary"
         if type not in {"primary", "secondary", "tertiary"}:
             raise StreamlitAPIException(
                 'The type argument to st.link_button must be "primary", "secondary", or "tertiary". '
@@ -1297,9 +1365,10 @@ class ButtonMixin:
         width: Width = "content",
         shortcut: str | None = None,
         ctx: ScriptRunContext | None = None,
-    ) -> DeltaGenerator:
+    ) -> bool | DeltaGenerator:
         key = to_key(key)
         ignore_rerun = on_click == "ignore"
+        is_rerun_mode = not ignore_rerun
         on_click_callback: WidgetCallback | None = (
             None
             if on_click in {"ignore", "rerun"}
@@ -1311,10 +1380,11 @@ class ButtonMixin:
             normalize_shortcut(shortcut) if shortcut is not None else None
         )
 
+        should_check_widget_policies = is_rerun_mode or key is not None
         should_register_element_id = (
-            not ignore_rerun or normalized_shortcut is not None or key is not None
+            should_check_widget_policies or normalized_shortcut is not None
         )
-        if not ignore_rerun or key is not None:
+        if should_check_widget_policies:
             check_widget_policies(
                 self.dg,
                 key,
@@ -1327,7 +1397,7 @@ class ButtonMixin:
             link_button_proto.id = compute_and_register_element_id(
                 "link_button",
                 user_key=key,
-                key_as_main_identity=not ignore_rerun or key is not None,
+                key_as_main_identity=should_check_widget_policies,
                 dg=self.dg,
                 label=label,
                 icon=icon,
@@ -1355,9 +1425,10 @@ class ButtonMixin:
         if normalized_shortcut is not None:
             link_button_proto.shortcut = normalized_shortcut
 
-        if not ignore_rerun:
+        button_state = None
+        if is_rerun_mode:
             serde = ButtonSerde()
-            register_widget(
+            button_state = register_widget(
                 link_button_proto.id,
                 on_change_handler=on_click_callback,
                 args=args,
@@ -1370,9 +1441,13 @@ class ButtonMixin:
 
         validate_width(width, allow_content=True)
         layout_config = LayoutConfig(width=width)
-        return self.dg._enqueue(
+        link_button_dg = self.dg._enqueue(
             "link_button", link_button_proto, layout_config=layout_config
         )
+
+        if button_state is not None:
+            return button_state.value
+        return link_button_dg
 
     def _page_link(
         self,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1295,6 +1295,7 @@ class ButtonMixin:
         ctx: ScriptRunContext | None = None,
     ) -> DeltaGenerator:
         key = to_key(key)
+        ignore_rerun = on_click == "ignore"
         on_click_callback: WidgetCallback | None = (
             None
             if on_click in {"ignore", "rerun"}
@@ -1306,11 +1307,10 @@ class ButtonMixin:
             normalize_shortcut(shortcut) if shortcut is not None else None
         )
 
-        element_id: str | None = None
         should_register_element_id = (
-            on_click != "ignore" or normalized_shortcut is not None or key is not None
+            not ignore_rerun or normalized_shortcut is not None or key is not None
         )
-        if on_click != "ignore":
+        if not ignore_rerun or key is not None:
             check_widget_policies(
                 self.dg,
                 key,
@@ -1320,10 +1320,10 @@ class ButtonMixin:
             )
 
         if should_register_element_id:
-            element_id = compute_and_register_element_id(
+            link_button_proto.id = compute_and_register_element_id(
                 "link_button",
                 user_key=key,
-                key_as_main_identity=on_click != "ignore" or key is not None,
+                key_as_main_identity=not ignore_rerun or key is not None,
                 dg=self.dg,
                 label=label,
                 icon=icon,
@@ -1335,14 +1335,11 @@ class ButtonMixin:
                 shortcut=normalized_shortcut,
             )
 
-        if element_id is not None:
-            link_button_proto.id = element_id
-
         link_button_proto.label = label
         link_button_proto.url = url
         link_button_proto.type = type
         link_button_proto.disabled = disabled
-        link_button_proto.ignore_rerun = on_click == "ignore"
+        link_button_proto.ignore_rerun = ignore_rerun
 
         if help is not None:
             link_button_proto.help = dedent(help)
@@ -1354,7 +1351,7 @@ class ButtonMixin:
         if normalized_shortcut is not None:
             link_button_proto.shortcut = normalized_shortcut
 
-        if on_click != "ignore":
+        if not ignore_rerun:
             serde = ButtonSerde()
             register_widget(
                 link_button_proto.id,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -771,6 +771,10 @@ class ButtonMixin:
         label: str,
         url: str,
         *,
+        key: Key | None = None,
+        on_click: WidgetCallback | Literal["rerun", "ignore"] = "ignore",
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
         help: str | None = None,
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
@@ -807,6 +811,29 @@ class ButtonMixin:
 
         url : str
             The url to be opened on user click
+
+        key : str or int
+            An optional string or integer to use as the unique key for the widget.
+            If this is omitted, a key will be generated for the widget
+            based on its content. No two widgets may have the same key.
+
+        on_click : callable, "rerun", or "ignore"
+            How the button should respond to user interaction. This controls
+            whether or not the button triggers a rerun and if a callback
+            function is called. This can be one of the following values:
+
+            - ``"ignore"`` (default): The link opens in a new tab and the app
+              doesn't rerun. No callback function is called.
+            - ``"rerun"``: The link opens in a new tab and the app reruns.
+              No callback function is called.
+            - A ``callable``: The link opens in a new tab and the app reruns.
+              The callable is called before the rest of the app.
+
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
+
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
 
         help : str or None
             A tooltip that gets displayed when the button is hovered over. If
@@ -921,6 +948,7 @@ class ButtonMixin:
                 f'\nThe argument passed was "{type}".'
             )
 
+        ctx = get_script_run_ctx()
         normalized_icon_position = _normalize_icon_position(
             icon_position, "st.link_button"
         )
@@ -931,6 +959,10 @@ class ButtonMixin:
         return self._link_button(
             label=label,
             url=url,
+            key=key,
+            on_click=on_click,
+            args=args,
+            kwargs=kwargs,
             help=help,
             disabled=disabled,
             type=type,
@@ -938,6 +970,7 @@ class ButtonMixin:
             icon_position=normalized_icon_position,
             width=width,
             shortcut=shortcut,
+            ctx=ctx,
         )
 
     @gather_metrics("page_link")
@@ -1247,7 +1280,11 @@ class ButtonMixin:
         self,
         label: str,
         url: str,
-        help: str | None,
+        key: Key | None = None,
+        on_click: WidgetCallback | Literal["rerun", "ignore"] = "ignore",
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        help: str | None = None,
         *,  # keyword-only arguments:
         type: Literal["primary", "secondary", "tertiary"] = "secondary",
         icon: str | None = None,
@@ -1255,20 +1292,38 @@ class ButtonMixin:
         disabled: bool = False,
         width: Width = "content",
         shortcut: str | None = None,
+        ctx: ScriptRunContext | None = None,
     ) -> DeltaGenerator:
-        link_button_proto = LinkButtonProto()
-        normalized_shortcut: str | None = None
-        if shortcut is not None:
-            normalized_shortcut = normalize_shortcut(shortcut)
+        key = to_key(key)
+        on_click_callback: WidgetCallback | None = (
+            None
+            if on_click in {"ignore", "rerun"}
+            else cast("WidgetCallback", on_click)
+        )
 
-        if normalized_shortcut is not None:
-            # We only register the element ID if a shortcut is provide.
-            # The ID is required to correctly register and handle the shortcut
-            # on the client side.
-            link_button_proto.id = compute_and_register_element_id(
+        link_button_proto = LinkButtonProto()
+        normalized_shortcut = (
+            normalize_shortcut(shortcut) if shortcut is not None else None
+        )
+
+        element_id: str | None = None
+        should_register_element_id = (
+            on_click != "ignore" or normalized_shortcut is not None or key is not None
+        )
+        if on_click != "ignore":
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=on_click_callback,
+                default_value=None,
+                writes_allowed=False,
+            )
+
+        if should_register_element_id:
+            element_id = compute_and_register_element_id(
                 "link_button",
-                user_key=None,
-                key_as_main_identity=False,
+                user_key=key,
+                key_as_main_identity=on_click != "ignore" or key is not None,
                 dg=self.dg,
                 label=label,
                 icon=icon,
@@ -1276,12 +1331,18 @@ class ButtonMixin:
                 help=help,
                 type=type,
                 width=width,
+                icon_position=icon_position,
                 shortcut=normalized_shortcut,
             )
+
+        if element_id is not None:
+            link_button_proto.id = element_id
+
         link_button_proto.label = label
         link_button_proto.url = url
         link_button_proto.type = type
         link_button_proto.disabled = disabled
+        link_button_proto.ignore_rerun = on_click == "ignore"
 
         if help is not None:
             link_button_proto.help = dedent(help)
@@ -1292,6 +1353,19 @@ class ButtonMixin:
 
         if normalized_shortcut is not None:
             link_button_proto.shortcut = normalized_shortcut
+
+        if on_click != "ignore":
+            serde = ButtonSerde()
+            register_widget(
+                link_button_proto.id,
+                on_change_handler=on_click_callback,
+                args=args,
+                kwargs=kwargs,
+                deserializer=serde.deserialize,
+                serializer=serde.serialize,
+                ctx=ctx,
+                value_type="trigger_value",
+            )
 
         validate_width(width, allow_content=True)
         layout_config = LayoutConfig(width=width)

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -331,12 +331,33 @@ class ButtonTest(DeltaGeneratorTestCase):
             id2 = c2.id
             assert id1 == id2
 
-    def test_stable_id_link_button_with_key(self):
-        """Test that the link button ID is stable when a key is provided."""
+    @parameterized.expand(
+        [
+            ("rerun_and_callback", "rerun", lambda: st.write("Link clicked"), True),
+            ("ignore_mode", "ignore", "ignore", False),
+        ]
+    )
+    def test_stable_id_link_button_with_key(
+        self, _, first_on_click, second_on_click, include_callback_args
+    ):
+        """Test that key-based identity is stable for rerun and ignore modes."""
         with patch(
             "streamlit.elements.lib.utils._register_element_id",
             return_value=MagicMock(),
         ):
+            first_link_button_kwargs = {"on_click": first_on_click}
+            second_link_button_kwargs = {"on_click": second_on_click}
+
+            if include_callback_args:
+                first_link_button_kwargs |= {
+                    "args": ("arg1", "arg2"),
+                    "kwargs": {"kwarg1": "kwarg1"},
+                }
+                second_link_button_kwargs |= {
+                    "args": ("arg_1", "arg_2"),
+                    "kwargs": {"kwarg_1": "kwarg_1"},
+                }
+
             st.link_button(
                 label="Label 1",
                 url="https://streamlit.io/1",
@@ -345,9 +366,7 @@ class ButtonTest(DeltaGeneratorTestCase):
                 type="secondary",
                 disabled=False,
                 width="content",
-                on_click="rerun",
-                args=("arg1", "arg2"),
-                kwargs={"kwarg1": "kwarg1"},
+                **first_link_button_kwargs,
             )
             c1 = self.get_delta_from_queue().new_element.link_button
             id1 = c1.id
@@ -360,42 +379,7 @@ class ButtonTest(DeltaGeneratorTestCase):
                 type="primary",
                 disabled=True,
                 width="stretch",
-                on_click=lambda: st.write("Link clicked"),
-                args=("arg_1", "arg_2"),
-                kwargs={"kwarg_1": "kwarg_1"},
-            )
-            c2 = self.get_delta_from_queue().new_element.link_button
-            id2 = c2.id
-            assert id1 == id2
-
-    def test_stable_id_link_button_with_key_ignore_mode(self):
-        """Test that key-based identity also works in ignore mode."""
-        with patch(
-            "streamlit.elements.lib.utils._register_element_id",
-            return_value=MagicMock(),
-        ):
-            st.link_button(
-                label="Label 1",
-                url="https://streamlit.io/1",
-                key="link_button_key",
-                help="Help 1",
-                type="secondary",
-                disabled=False,
-                width="content",
-                on_click="ignore",
-            )
-            c1 = self.get_delta_from_queue().new_element.link_button
-            id1 = c1.id
-
-            st.link_button(
-                label="Label 2",
-                url="https://streamlit.io/2",
-                key="link_button_key",
-                help="Help 2",
-                type="primary",
-                disabled=True,
-                width="stretch",
-                on_click="ignore",
+                **second_link_button_kwargs,
             )
             c2 = self.get_delta_from_queue().new_element.link_button
             id2 = c2.id

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -331,6 +331,76 @@ class ButtonTest(DeltaGeneratorTestCase):
             id2 = c2.id
             assert id1 == id2
 
+    def test_stable_id_link_button_with_key(self):
+        """Test that the link button ID is stable when a key is provided."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.link_button(
+                label="Label 1",
+                url="https://streamlit.io/1",
+                key="link_button_key",
+                help="Help 1",
+                type="secondary",
+                disabled=False,
+                width="content",
+                on_click="rerun",
+                args=("arg1", "arg2"),
+                kwargs={"kwarg1": "kwarg1"},
+            )
+            c1 = self.get_delta_from_queue().new_element.link_button
+            id1 = c1.id
+
+            st.link_button(
+                label="Label 2",
+                url="https://streamlit.io/2",
+                key="link_button_key",
+                help="Help 2",
+                type="primary",
+                disabled=True,
+                width="stretch",
+                on_click=lambda: st.write("Link clicked"),
+                args=("arg_1", "arg_2"),
+                kwargs={"kwarg_1": "kwarg_1"},
+            )
+            c2 = self.get_delta_from_queue().new_element.link_button
+            id2 = c2.id
+            assert id1 == id2
+
+    def test_stable_id_link_button_with_key_ignore_mode(self):
+        """Test that key-based identity also works in ignore mode."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.link_button(
+                label="Label 1",
+                url="https://streamlit.io/1",
+                key="link_button_key",
+                help="Help 1",
+                type="secondary",
+                disabled=False,
+                width="content",
+                on_click="ignore",
+            )
+            c1 = self.get_delta_from_queue().new_element.link_button
+            id1 = c1.id
+
+            st.link_button(
+                label="Label 2",
+                url="https://streamlit.io/2",
+                key="link_button_key",
+                help="Help 2",
+                type="primary",
+                disabled=True,
+                width="stretch",
+                on_click="ignore",
+            )
+            c2 = self.get_delta_from_queue().new_element.link_button
+            id2 = c2.id
+            assert id1 == id2
+
     def test_use_container_width_true(self):
         """Test use_container_width=True is mapped to width='stretch'."""
         for button_type, button_func, width in get_button_command_matrix(

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -91,6 +91,19 @@ class LinkButtonTest(DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
+            ("empty", "", r"`key` argument must be non-empty"),
+            ("reserved", "$$ID-reserved", r"Keys beginning with \$\$ID are reserved"),
+        ]
+    )
+    def test_invalid_key_raises_in_ignore_mode(
+        self, _name: str, key: str, match: str
+    ) -> None:
+        """Test that invalid keys are rejected in default ignore mode."""
+        with pytest.raises(StreamlitAPIException, match=match):
+            st.link_button("the label", url="https://streamlit.io", key=key)
+
+    @parameterized.expand(
+        [
             ("rerun", "rerun"),
             ("callback", lambda: None),
         ]

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -36,6 +36,7 @@ class LinkButtonTest(DeltaGeneratorTestCase):
         assert c.label == "the label"
         assert c.type == "secondary"
         assert not c.disabled
+        assert c.ignore_rerun
 
     def test_just_disabled(self):
         """Test that it can be called with disabled param."""
@@ -79,6 +80,28 @@ class LinkButtonTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.link_button
         assert c.icon_position == ProtoButtonLikeIconPosition.RIGHT
+
+    def test_key_sets_id_in_ignore_mode(self):
+        """Test that key is applied even when on_click is ignored."""
+        st.link_button("the label", url="https://streamlit.io", key="my_link_key")
+
+        c = self.get_delta_from_queue().new_element.link_button
+        assert c.id != ""
+        assert c.ignore_rerun
+
+    @parameterized.expand(
+        [
+            ("rerun", "rerun"),
+            ("callback", lambda: None),
+        ]
+    )
+    def test_on_click_enables_rerun(self, _, on_click):
+        """Test that rerun and callback modes enable click-triggered reruns."""
+        st.link_button("the label", url="https://streamlit.io", on_click=on_click)
+
+        c = self.get_delta_from_queue().new_element.link_button
+        assert not c.ignore_rerun
+        assert c.id != ""
 
     def test_invalid_icon(self):
         """Test that an error is raised if an invalid icon is provided."""

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -14,15 +14,23 @@
 
 """link_button unit tests."""
 
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
 import pytest
 from parameterized import parameterized
 
 import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ButtonLikeIconPosition_pb2 import (
     ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
 )
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+def _test_callback() -> None:
+    pass
 
 
 class LinkButtonTest(DeltaGeneratorTestCase):
@@ -105,16 +113,68 @@ class LinkButtonTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             ("rerun", "rerun"),
-            ("callback", lambda: None),
+            ("callback", _test_callback),
         ]
     )
-    def test_on_click_enables_rerun(self, _, on_click):
+    def test_on_click_enables_rerun(
+        self, _name: str, on_click: str | Callable[[], None]
+    ) -> None:
         """Test that rerun and callback modes enable click-triggered reruns."""
         st.link_button("the label", url="https://streamlit.io", on_click=on_click)
 
         c = self.get_delta_from_queue().new_element.link_button
         assert not c.ignore_rerun
         assert c.id != ""
+
+    def test_on_click_ignore_returns_delta_generator(self) -> None:
+        """Test that ignore mode keeps returning a DeltaGenerator."""
+        result = st.link_button(
+            "the label",
+            url="https://streamlit.io",
+            key="ignore_return_value_link",
+            on_click="ignore",
+        )
+        assert isinstance(result, DeltaGenerator)
+
+    @parameterized.expand(
+        [
+            ("rerun", "rerun", None, "rerun_return_value_link"),
+            ("callback", _test_callback, _test_callback, "callback_return_value_link"),
+        ]
+    )
+    def test_on_click_non_ignore_returns_bool(
+        self,
+        _name: str,
+        on_click: str | Callable[[], None],
+        expected_handler: Callable[[], None] | None,
+        key: str,
+    ) -> None:
+        """Test that non-ignore on_click modes return bool and register callbacks."""
+        first_value = st.link_button(
+            "the label",
+            url="https://streamlit.io",
+            key=key,
+            on_click=on_click,
+        )
+        assert first_value is False
+
+        self.script_run_ctx.reset()
+
+        with patch(
+            "streamlit.elements.widgets.button.register_widget",
+            return_value=MagicMock(value=True),
+        ) as mock_register_widget:
+            second_value = st.link_button(
+                "the label",
+                url="https://streamlit.io",
+                key=key,
+                on_click=on_click,
+            )
+            assert (
+                mock_register_widget.call_args.kwargs["on_change_handler"]
+                is expected_handler
+            )
+        assert second_value is True
 
     def test_invalid_icon(self):
         """Test that an error is raised if an invalid icon is provided."""

--- a/lib/tests/streamlit/typing/button_types.py
+++ b/lib/tests/streamlit/typing/button_types.py
@@ -255,12 +255,8 @@ if TYPE_CHECKING:
     assert_type(
         link_button("Link", "https://example.com", on_click="ignore"), DeltaGenerator
     )
-    assert_type(
-        link_button("Link", "https://example.com", on_click="rerun"), DeltaGenerator
-    )
-    assert_type(
-        link_button("Link", "https://example.com", on_click=my_callback), DeltaGenerator
-    )
+    assert_type(link_button("Link", "https://example.com", on_click="rerun"), bool)
+    assert_type(link_button("Link", "https://example.com", on_click=my_callback), bool)
     assert_type(
         link_button(
             "Link",
@@ -268,7 +264,7 @@ if TYPE_CHECKING:
             on_click=callback_with_args,
             args=(1, "a"),
         ),
-        DeltaGenerator,
+        bool,
     )
     assert_type(
         link_button(
@@ -277,7 +273,7 @@ if TYPE_CHECKING:
             on_click=callback_with_args,
             kwargs={"x": 1, "y": "a"},
         ),
-        DeltaGenerator,
+        bool,
     )
 
     # Link button with all parameters combined
@@ -296,7 +292,7 @@ if TYPE_CHECKING:
             width="stretch",
             shortcut="Ctrl+Shift+S",
         ),
-        DeltaGenerator,
+        bool,
     )
 
     # =====================================================================

--- a/lib/tests/streamlit/typing/button_types.py
+++ b/lib/tests/streamlit/typing/button_types.py
@@ -192,6 +192,10 @@ if TYPE_CHECKING:
 
     # Basic link button - returns DeltaGenerator
     assert_type(link_button("Google", "https://google.com"), DeltaGenerator)
+    assert_type(
+        link_button("Google", "https://google.com", key="link_key"), DeltaGenerator
+    )
+    assert_type(link_button("Google", "https://google.com", key=789), DeltaGenerator)
 
     # Link button with type parameter
     assert_type(
@@ -247,11 +251,44 @@ if TYPE_CHECKING:
         link_button("Link", "https://example.com", shortcut=None), DeltaGenerator
     )
 
+    # Link button with on_click parameter - supports "rerun", "ignore", or callable
+    assert_type(
+        link_button("Link", "https://example.com", on_click="ignore"), DeltaGenerator
+    )
+    assert_type(
+        link_button("Link", "https://example.com", on_click="rerun"), DeltaGenerator
+    )
+    assert_type(
+        link_button("Link", "https://example.com", on_click=my_callback), DeltaGenerator
+    )
+    assert_type(
+        link_button(
+            "Link",
+            "https://example.com",
+            on_click=callback_with_args,
+            args=(1, "a"),
+        ),
+        DeltaGenerator,
+    )
+    assert_type(
+        link_button(
+            "Link",
+            "https://example.com",
+            on_click=callback_with_args,
+            kwargs={"x": 1, "y": "a"},
+        ),
+        DeltaGenerator,
+    )
+
     # Link button with all parameters combined
     assert_type(
         link_button(
             "Full link",
             "https://streamlit.io",
+            key="full_link",
+            on_click=my_callback,
+            args=None,
+            kwargs=None,
             help="Visit Streamlit",
             type="primary",
             icon="🚀",

--- a/proto/streamlit/proto/LinkButton.proto
+++ b/proto/streamlit/proto/LinkButton.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 import "streamlit/proto/ButtonLikeIconPosition.proto";
 
 message LinkButton {
-  // The ID is only needed if a shortcut is provided.
+  // The ID is needed for shortcuts, keys, and click-triggered reruns.
   string id = 1;
   string label = 2;
   string help = 4;
@@ -30,4 +30,5 @@ message LinkButton {
   string icon = 10;
   string shortcut = 11;
   streamlit.ButtonLikeIconPosition icon_position = 12;
+  bool ignore_rerun = 13;
 }


### PR DESCRIPTION
## Describe your changes

- Update `st.link_button` so `on_click=\"rerun\"` and callable `on_click` return a `bool` (`False` by default, `True` after click), matching `st.button` trigger semantics.
- Keep `on_click=\"ignore\"` returning `DeltaGenerator`, and add API overloads + doc updates to make return types explicit.
- Add/expand unit, typing, and e2e coverage for callback/rerun return values and keyed CSS class behavior.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/7453

## Testing Plan

- [x] `make check`
- [x] `uv run pytest lib/tests/streamlit/elements/button_test.py -k link_button`
- [x] `make run-e2e-test e2e_playwright/st_link_button_test.py::test_link_button_click_calls_callback`
- [x] `make run-e2e-test e2e_playwright/st_link_button_test.py::test_link_button_click_returns_true_for_rerun`
- [x] `make run-e2e-test e2e_playwright/st_link_button_test.py::test_custom_css_class_via_key`