### PR TITLE
Add logger.hideWelcomeMessage config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -547,6 +547,23 @@ def _logger_enable_rich() -> bool:
         return False
 
 
+_create_option(
+    "logger.hideWelcomeMessage",
+    description="""
+        If True, hides the welcome message that is normally printed when
+        starting a Streamlit server. This includes the "Welcome to Streamlit"
+        or "You can now view your Streamlit app in your browser" message,
+        along with the Local URL, Network URL, and External URL information.
+
+        This is useful in hosted environments where these messages may be
+        misleading or inactionable.
+    """,
+    visibility="hidden",
+    default_val=False,
+    type_=bool,
+)
+
+
 # Config Section: Client #
 
 _create_section("client", "Settings for scripts that use Streamlit.")

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -640,7 +640,7 @@ class SnowflakeConnection(BaseSnowflakeConnection):
         try:
             if len(st_secrets):
                 _LOGGER.info(
-                    "Connect to Snowflake using the Streamlit secret defined under "
+                    "Connecting to Snowflake using the Streamlit secret defined under "
                     "[connections.snowflake]."
                 )
                 conn_kwargs = {**st_secrets, **kwargs}
@@ -649,7 +649,7 @@ class SnowflakeConnection(BaseSnowflakeConnection):
             # Use the default configuration as defined in https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection
             if self._connection_name == "snowflake":
                 _LOGGER.info(
-                    "Connect to Snowflake using the default configuration as defined "
+                    "Connecting to Snowflake using the default configuration as defined "
                     "in https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection"
                 )
                 return snowflake.connector.connect()

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -233,6 +233,9 @@ def _maybe_print_static_folder_warning(main_script_path: str) -> None:
 
 
 def _print_url(is_running_hello: bool) -> None:
+    if config.get_option("logger.hideWelcomeMessage"):
+        return
+
     if is_running_hello:
         title_message = "Welcome to Streamlit. Check out our demo in your browser."
     else:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -766,6 +766,7 @@ class ConfigTest(unittest.TestCase):
                 "global.suppressDeprecationWarnings",
                 "global.unitTest",
                 "logger.enableRich",
+                "logger.hideWelcomeMessage",
                 "logger.level",
                 "logger.messageFormat",
                 "runner.enforceSerializableSessionState",

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -63,6 +63,14 @@ class BootstrapPrintTest(IsolatedAsyncioTestCase):
         assert "Welcome to Streamlit. Check out our demo in your browser." in out
         assert "URL: http://the-address" in out
 
+    def test_print_url_hidden_when_config_set(self):
+        """Test that _print_url outputs nothing when logger.hideWelcomeMessage is True."""
+        with patch_config_options({"logger.hideWelcomeMessage": True}):
+            bootstrap._print_url(True)
+
+        out = sys.stdout.getvalue()
+        assert out == ""
+
     def test_print_urls_configured(self):
         mock_is_manually_set = testutil.build_mock_config_is_manually_set(
             {"browser.serverAddress": True}


### PR DESCRIPTION
## Describe your changes

Add a new hidden config option that suppresses the welcome message
printed when starting a Streamlit server. This is useful in hosted
environments (like SiS) where the default messages show URLs and
external IP warnings that are misleading or inactionable (for example,
from the container's perspective, it may think that it's serving the app at
`localhost`, but we don't want to display that to the user).

When enabled, the "Welcome to Streamlit" / "You can now view your
Streamlit app" message along with Local URL, Network URL, and
External URL information will not be printed.

We also tweak the grammar in some other logs in
`lib/streamlit/connections/snowflake_connection.py`, which is technically an
orthogonal change but probably not worth creating a second PR for.

## Testing Plan

- Unit Tests (JS and/or Python)
   - Added a unit test
- Any manual testing needed?
   - Ran `streamlit hello` with the new config option set and verified that the
      welcome message doesn't appear.