### PR TITLE
Simplify query-params infra for wire format changes

### DIFF
--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1486,15 +1486,14 @@ describe("Trigger JSON payloads (aggregated)", () => {
         expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
       })
 
-      it("registers binding with options for index-based widgets", () => {
+      it("registers binding with urlDefault for select_slider", () => {
         widgetMgr.registerQueryParamBinding(
           "widget1",
           "color",
-          "int_value",
-          0,
+          "string_array_value",
+          ["Red"],
           false,
-          undefined,
-          ["Red", "Green", "Blue"]
+          "repeated"
         )
 
         expect(widgetMgr.hasQueryParamBinding("widget1")).toBe(true)
@@ -1728,671 +1727,558 @@ describe("Trigger JSON payloads (aggregated)", () => {
       })
     })
 
-    describe("URL sync with options (index-based widgets)", () => {
-      it("converts index to option string for int_value", () => {
-        const widget = { id: "radio1", formId: "" }
+    describe("URL sync for array values", () => {
+      it("syncs string array with repeated params", () => {
+        const widget = { id: "multiselect1", formId: "" }
         widgetMgr.registerQueryParamBinding(
-          "radio1",
-          "color",
-          "int_value",
-          0,
-          false,
-          undefined,
-          ["Red", "Green", "Blue"]
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          [],
+          true
         )
 
-        widgetMgr.setIntValue(widget, 1, { fromUi: true }, undefined)
-
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("color=Green")
-      })
-
-      it("falls back to index if option not found", () => {
-        const widget = { id: "radio1", formId: "" }
-        widgetMgr.registerQueryParamBinding(
-          "radio1",
-          "color",
-          "int_value",
-          0,
-          false,
-          undefined,
-          ["Red", "Green", "Blue"]
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["foo", "bar"],
+          { fromUi: true },
+          undefined
         )
 
-        widgetMgr.setIntValue(widget, 99, { fromUi: true }, undefined)
-
-        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("color=99")
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "tags=foo&tags=bar"
+        )
       })
 
-      it("converts indices to option strings for int_array_value", () => {
+      it("syncs string array with comma format", () => {
+        const widget = { id: "multiselect1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          [],
+          true,
+          "comma"
+        )
+
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["foo", "bar"],
+          { fromUi: true },
+          undefined
+        )
+
+        // Comma is URL-encoded by URLSearchParams.toString()
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("tags=foo%2Cbar")
+      })
+
+      it("syncs double array with repeated params", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100],
+          false
+        )
+
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [10, 90],
+          { fromUi: true },
+          undefined
+        )
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "range=10&range=90"
+        )
+      })
+
+      it("filters out invalid double array values", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100],
+          false
+        )
+
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [10, NaN, 90],
+          { fromUi: true },
+          undefined
+        )
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "range=10&range=90"
+        )
+      })
+
+      it("clears URL param when all double array values are invalid (fromUi: true)", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100],
+          false
+        )
+
+        // First set a valid value to put something in the URL
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [10, 90],
+          { fromUi: true },
+          undefined
+        )
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "range=10&range=90"
+        )
+
+        // Now set all invalid values - should clear the URL
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [NaN, NaN],
+          { fromUi: true },
+          undefined
+        )
+
+        // URL should be cleared (empty string means param removed)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+        // State should NOT be updated when all values are invalid (previous value remains)
+        expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([10, 90])
+      })
+
+      it("does not update URL when all double array values are invalid (fromUi: false)", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100],
+          false
+        )
+
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [NaN, NaN],
+          { fromUi: false },
+          undefined
+        )
+
+        // URL should NOT be modified for backend changes
+        expect(window.history.replaceState).not.toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+        // State should NOT be updated when all values are invalid
+        expect(widgetMgr.getDoubleArrayValue(widget)).toBeUndefined()
+      })
+
+      it("updates state but not URL for valid double array values (fromUi: false)", () => {
+        const widget = { id: "slider1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "slider1",
+          "range",
+          "double_array_value",
+          [0, 100],
+          false
+        )
+
+        widgetMgr.setDoubleArrayValue(
+          widget,
+          [25, 75],
+          { fromUi: false },
+          undefined
+        )
+
+        // URL should NOT be modified for backend changes
+        expect(window.history.replaceState).not.toHaveBeenCalled()
+        expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+        // State SHOULD be updated
+        expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([25, 75])
+      })
+
+      it("clears URL when empty array equals default (hide at default)", () => {
+        const widget = { id: "multiselect1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          [], // default is empty array
+          true // clearable
+        )
+
+        // First set a value to put something in the URL
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["tag1", "tag2"],
+          { fromUi: true },
+          undefined
+        )
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "tags=tag1&tags=tag2"
+        )
+
+        // Now clear the array - empty matches default, so clear param
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setStringArrayValue(widget, [], { fromUi: true }, undefined)
+
+        // Empty matches default [], so param is cleared (not ?tags=)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+
+      it("preserves empty array in URL when empty differs from default", () => {
+        const widget = { id: "multiselect2", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect2",
+          "langs",
+          "string_array_value",
+          ["Python"], // default is non-empty
+          true // clearable
+        )
+
+        // Clear to empty - differs from default, so preserve ?langs=
+        widgetMgr.setStringArrayValue(widget, [], { fromUi: true }, undefined)
+
+        // Empty differs from default ["Python"], so we write ?langs=
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("langs=")
+      })
+    })
+
+    describe("empty value handling with clearable parameter", () => {
+      it("preserves empty value in URL when clearable=true (multiselect)", () => {
+        const widget = { id: "multiselect1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "multiselect1",
+          "tags",
+          "string_array_value",
+          ["default"],
+          true // clearable - multiselect always allows clearing
+        )
+
+        // Set empty array - should write ?tags= since clearable=true
+        widgetMgr.setStringArrayValue(widget, [], { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("tags=")
+      })
+
+      it("preserves empty value in URL when clearable=true (pills)", () => {
         const widget = { id: "pills1", formId: "" }
         widgetMgr.registerQueryParamBinding(
           "pills1",
-          "tags",
+          "selected",
           "int_array_value",
-          [],
-          true,
-          undefined,
-          ["Apple", "Banana", "Cherry"]
+          [0],
+          true // clearable - pills allows clearing
         )
 
-        widgetMgr.setIntArrayValue(widget, [0, 2], { fromUi: true }, undefined)
+        // Set empty array - should write ?selected= since clearable=true
+        widgetMgr.setIntArrayValue(widget, [], { fromUi: true }, undefined)
 
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("selected=")
+      })
+
+      it("preserves empty value in URL when clearable=true and empty differs from default (selectbox)", () => {
+        const widget = { id: "selectbox1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "selectbox1",
+          "choice",
+          "string_value",
+          "Red", // Non-null default
+          true // clearable - selectbox with index=None allows clearing
+        )
+
+        // Set null (cleared) - differs from default "Red", so write ?choice=
+        widgetMgr.setStringValue(widget, null, { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("choice=")
+      })
+
+      it("clears URL when null equals null default (hide at default)", () => {
+        const widget = { id: "selectbox2", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "selectbox2",
+          "option",
+          "string_value",
+          null, // Null default
+          true // clearable
+        )
+
+        // First set a non-null value
+        widgetMgr.setStringValue(widget, "Blue", { fromUi: true }, undefined)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("option=Blue")
+
+        // Set back to null - matches default, so clear param
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setStringValue(widget, null, { fromUi: true }, undefined)
+
+        // Null matches default null, so param is cleared (not ?option=)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+
+      it("clears URL param when clearable=false (checkbox)", () => {
+        const widget = { id: "checkbox1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "checkbox1",
+          "enabled",
+          "bool_value",
+          false,
+          false // not clearable - checkbox always has a value
+        )
+
+        // First set to non-default value to populate URL
+        widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("enabled=true")
+
+        // Clear mock and set back to default - should clear the param
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setBoolValue(widget, false, { fromUi: true }, undefined)
+
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+
+      it("clears param when value matches non-null default (clearable=false)", () => {
+        const widget = { id: "text1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "text1",
+          "name",
+          "string_value",
+          "default text", // non-null default
+          false // not clearable
+        )
+
+        // First set to default to establish baseline
+        widgetMgr.setStringValue(
+          widget,
+          "default text",
+          { fromUi: true },
+          undefined
+        )
+        // Default value - no URL param
+        expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+
+        // Set to non-default value
+        widgetMgr.setStringValue(widget, "hello", { fromUi: true }, undefined)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("name=hello")
+
+        // Set back to default - clears param
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setStringValue(
+          widget,
+          "default text",
+          { fromUi: true },
+          undefined
+        )
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+
+      it("clears param when value matches null default (clearable=true)", () => {
+        const widget = { id: "text2", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "text2",
+          "bio",
+          "string_value",
+          null, // null default
+          true // clearable
+        )
+
+        // First set non-empty value
+        widgetMgr.setStringValue(widget, "hello", { fromUi: true }, undefined)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("bio=hello")
+
+        // Set to empty string - matches null default, so clears param
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setStringValue(widget, "", { fromUi: true }, undefined)
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+    })
+
+    describe("Date object default comparison", () => {
+      it("clears URL when string array matches Date[] default (date_input)", () => {
+        const widget = { id: "date1", formId: "" }
+        const dateDefault = [new Date(2025, 0, 15)] // Jan 15, 2025
+        widgetMgr.registerQueryParamBinding(
+          "date1",
+          "birthday",
+          "string_array_value",
+          dateDefault,
+          false
+        )
+
+        // Set to non-default value first
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["2025-06-20"],
+          { fromUi: true },
+          undefined
+        )
         expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-          "tags=Apple&tags=Cherry"
+          "birthday=2025-06-20"
+        )
+
+        // Set back to default — URL string "2025-01-15" should match Date default
+        mockOnQueryParamsChange.mockClear()
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["2025-01-15"],
+          { fromUi: true },
+          undefined
+        )
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
+      })
+
+      it("clears URL when string array matches Date[] range default", () => {
+        const widget = { id: "daterange1", formId: "" }
+        const rangeDefault = [new Date(2025, 2, 1), new Date(2025, 2, 15)]
+        widgetMgr.registerQueryParamBinding(
+          "daterange1",
+          "range",
+          "string_array_value",
+          rangeDefault,
+          false
+        )
+
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["2025-03-01", "2025-03-15"],
+          { fromUi: true },
+          undefined
+        )
+        expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
+      })
+
+      it("does not clear URL when string array differs from Date[] default", () => {
+        const widget = { id: "date2", formId: "" }
+        const dateDefault = [new Date(2025, 0, 15)]
+        widgetMgr.registerQueryParamBinding(
+          "date2",
+          "birthday",
+          "string_array_value",
+          dateDefault,
+          false
+        )
+
+        widgetMgr.setStringArrayValue(
+          widget,
+          ["2025-06-20"],
+          { fromUi: true },
+          undefined
+        )
+        expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
+          "birthday=2025-06-20"
         )
       })
+    })
 
-      describe("URL sync for array values", () => {
-        it("syncs string array with repeated params", () => {
-          const widget = { id: "multiselect1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "multiselect1",
-            "tags",
-            "string_array_value",
-            [],
-            true
-          )
-
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["foo", "bar"],
-            { fromUi: true },
-            undefined
-          )
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "tags=foo&tags=bar"
-          )
+    describe("handler edge cases", () => {
+      it("gracefully handles no handler set", () => {
+        // Create a new widgetMgr without setting a handler
+        const mgr = new WidgetStateManager({
+          sendRerunBackMsg: vi.fn(),
+          formsDataChanged: vi.fn(),
         })
 
-        it("syncs string array with comma format", () => {
-          const widget = { id: "multiselect1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "multiselect1",
-            "tags",
-            "string_array_value",
-            [],
-            true,
-            "comma"
-          )
+        const widget = { id: "checkbox1", formId: "" }
+        mgr.registerQueryParamBinding(
+          "checkbox1",
+          "enabled",
+          "bool_value",
+          false,
+          false
+        )
 
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["foo", "bar"],
-            { fromUi: true },
-            undefined
-          )
+        // Should not throw when no handler is set
+        expect(() => {
+          mgr.setBoolValue(widget, true, { fromUi: true }, undefined)
+        }).not.toThrow()
+      })
+    })
 
-          // Comma is URL-encoded by URLSearchParams.toString()
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "tags=foo%2Cbar"
-          )
-        })
-
-        it("syncs double array with options (select_slider)", () => {
-          const widget = { id: "select_slider1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "select_slider1",
-            "range",
-            "double_array_value",
-            [0, 2],
-            false,
-            undefined,
-            ["Small", "Medium", "Large"]
-          )
-
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [1, 2],
-            { fromUi: true },
-            undefined
-          )
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "range=Medium&range=Large"
-          )
-        })
-
-        it("syncs double array with repeated params", () => {
-          const widget = { id: "slider1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "slider1",
-            "range",
-            "double_array_value",
-            [0, 100],
-            false
-          )
-
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [10, 90],
-            { fromUi: true },
-            undefined
-          )
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "range=10&range=90"
-          )
-        })
-
-        it("filters out invalid double array values", () => {
-          const widget = { id: "slider1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "slider1",
-            "range",
-            "double_array_value",
-            [0, 100],
-            false
-          )
-
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [10, NaN, 90],
-            { fromUi: true },
-            undefined
-          )
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "range=10&range=90"
-          )
-        })
-
-        it("clears URL param when all double array values are invalid (fromUi: true)", () => {
-          const widget = { id: "slider1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "slider1",
-            "range",
-            "double_array_value",
-            [0, 100],
-            false
-          )
-
-          // First set a valid value to put something in the URL
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [10, 90],
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "range=10&range=90"
-          )
-
-          // Now set all invalid values - should clear the URL
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [NaN, NaN],
-            { fromUi: true },
-            undefined
-          )
-
-          // URL should be cleared (empty string means param removed)
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-          // State should NOT be updated when all values are invalid (previous value remains)
-          expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([10, 90])
-        })
-
-        it("does not update URL when all double array values are invalid (fromUi: false)", () => {
-          const widget = { id: "slider1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "slider1",
-            "range",
-            "double_array_value",
-            [0, 100],
-            false
-          )
-
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [NaN, NaN],
-            { fromUi: false },
-            undefined
-          )
-
-          // URL should NOT be modified for backend changes
-          expect(window.history.replaceState).not.toHaveBeenCalled()
-          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
-          // State should NOT be updated when all values are invalid
-          expect(widgetMgr.getDoubleArrayValue(widget)).toBeUndefined()
-        })
-
-        it("updates state but not URL for valid double array values (fromUi: false)", () => {
-          const widget = { id: "slider1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "slider1",
-            "range",
-            "double_array_value",
-            [0, 100],
-            false
-          )
-
-          widgetMgr.setDoubleArrayValue(
-            widget,
-            [25, 75],
-            { fromUi: false },
-            undefined
-          )
-
-          // URL should NOT be modified for backend changes
-          expect(window.history.replaceState).not.toHaveBeenCalled()
-          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
-          // State SHOULD be updated
-          expect(widgetMgr.getDoubleArrayValue(widget)).toEqual([25, 75])
-        })
-
-        it("clears URL when empty array equals default (hide at default)", () => {
-          const widget = { id: "multiselect1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "multiselect1",
-            "tags",
-            "string_array_value",
-            [], // default is empty array
-            true // clearable
-          )
-
-          // First set a value to put something in the URL
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["tag1", "tag2"],
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "tags=tag1&tags=tag2"
-          )
-
-          // Now clear the array - empty matches default, so clear param
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setStringArrayValue(
-            widget,
-            [],
-            { fromUi: true },
-            undefined
-          )
-
-          // Empty matches default [], so param is cleared (not ?tags=)
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-        })
-
-        it("preserves empty array in URL when empty differs from default", () => {
-          const widget = { id: "multiselect2", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "multiselect2",
-            "langs",
-            "string_array_value",
-            ["Python"], // default is non-empty
-            true // clearable
-          )
-
-          // Clear to empty - differs from default, so preserve ?langs=
-          widgetMgr.setStringArrayValue(
-            widget,
-            [],
-            { fromUi: true },
-            undefined
-          )
-
-          // Empty differs from default ["Python"], so we write ?langs=
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("langs=")
-        })
+    describe("filterParamsForPageChange", () => {
+      it("returns only embed params when no widgets are bound", () => {
+        const result = widgetMgr.filterParamsForPageChange("embed=true")
+        expect(result).toBe("embed=true")
       })
 
-      describe("empty value handling with clearable parameter", () => {
-        it("preserves empty value in URL when clearable=true (multiselect)", () => {
-          const widget = { id: "multiselect1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "multiselect1",
-            "tags",
-            "string_array_value",
-            ["default"],
-            true // clearable - multiselect always allows clearing
-          )
-
-          // Set empty array - should write ?tags= since clearable=true
-          widgetMgr.setStringArrayValue(
-            widget,
-            [],
-            { fromUi: true },
-            undefined
-          )
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("tags=")
-        })
-
-        it("preserves empty value in URL when clearable=true (pills)", () => {
-          const widget = { id: "pills1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "pills1",
-            "selected",
-            "int_array_value",
-            [0],
-            true, // clearable - pills allows clearing
-            undefined,
-            ["Red", "Green", "Blue"]
-          )
-
-          // Set empty array - should write ?selected= since clearable=true
-          widgetMgr.setIntArrayValue(widget, [], { fromUi: true }, undefined)
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("selected=")
-        })
-
-        it("preserves empty value in URL when clearable=true and empty differs from default (selectbox)", () => {
-          const widget = { id: "selectbox1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "selectbox1",
-            "choice",
-            "string_value",
-            "Red", // Non-null default
-            true // clearable - selectbox with index=None allows clearing
-          )
-
-          // Set null (cleared) - differs from default "Red", so write ?choice=
-          widgetMgr.setStringValue(widget, null, { fromUi: true }, undefined)
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("choice=")
-        })
-
-        it("clears URL when null equals null default (hide at default)", () => {
-          const widget = { id: "selectbox2", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "selectbox2",
-            "option",
-            "string_value",
-            null, // Null default
-            true // clearable
-          )
-
-          // First set a non-null value
-          widgetMgr.setStringValue(widget, "Blue", { fromUi: true }, undefined)
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("option=Blue")
-
-          // Set back to null - matches default, so clear param
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setStringValue(widget, null, { fromUi: true }, undefined)
-
-          // Null matches default null, so param is cleared (not ?option=)
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-        })
-
-        it("clears URL param when clearable=false (checkbox)", () => {
-          const widget = { id: "checkbox1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "checkbox1",
-            "enabled",
-            "bool_value",
-            false,
-            false // not clearable - checkbox always has a value
-          )
-
-          // First set to non-default value to populate URL
-          widgetMgr.setBoolValue(widget, true, { fromUi: true }, undefined)
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("enabled=true")
-
-          // Clear mock and set back to default - should clear the param
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setBoolValue(widget, false, { fromUi: true }, undefined)
-
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-        })
-
-        it("clears param when value matches non-null default (clearable=false)", () => {
-          const widget = { id: "text1", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "text1",
-            "name",
-            "string_value",
-            "default text", // non-null default
-            false // not clearable
-          )
-
-          // First set to default to establish baseline
-          widgetMgr.setStringValue(
-            widget,
-            "default text",
-            { fromUi: true },
-            undefined
-          )
-          // Default value - no URL param
-          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
-
-          // Set to non-default value
-          widgetMgr.setStringValue(
-            widget,
-            "hello",
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("name=hello")
-
-          // Set back to default - clears param
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setStringValue(
-            widget,
-            "default text",
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-        })
-
-        it("clears param when value matches null default (clearable=true)", () => {
-          const widget = { id: "text2", formId: "" }
-          widgetMgr.registerQueryParamBinding(
-            "text2",
-            "bio",
-            "string_value",
-            null, // null default
-            true // clearable
-          )
-
-          // First set non-empty value
-          widgetMgr.setStringValue(
-            widget,
-            "hello",
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("bio=hello")
-
-          // Set to empty string - matches null default, so clears param
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setStringValue(widget, "", { fromUi: true }, undefined)
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-        })
+      it("returns empty string when no embed params and no bound widgets", () => {
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toBe("")
       })
 
-      describe("Date object default comparison", () => {
-        it("clears URL when string array matches Date[] default (date_input)", () => {
-          const widget = { id: "date1", formId: "" }
-          const dateDefault = [new Date(2025, 0, 15)] // Jan 15, 2025
-          widgetMgr.registerQueryParamBinding(
-            "date1",
-            "birthday",
-            "string_array_value",
-            dateDefault,
-            false
-          )
+      it("preserves bound widget params from current URL", () => {
+        // Register a binding
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "my_key",
+          "string_value",
+          "default",
+          false
+        )
 
-          // Set to non-default value first
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["2025-06-20"],
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "birthday=2025-06-20"
-          )
+        // Set the widget value to update URL
+        const widget = { id: "widget1", formId: "" }
+        widgetMgr.setStringValue(
+          widget,
+          "my_value",
+          { fromUi: true },
+          undefined
+        )
 
-          // Set back to default — URL string "2025-01-15" should match Date default
-          mockOnQueryParamsChange.mockClear()
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["2025-01-15"],
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
-        })
-
-        it("clears URL when string array matches Date[] range default", () => {
-          const widget = { id: "daterange1", formId: "" }
-          const rangeDefault = [new Date(2025, 2, 1), new Date(2025, 2, 15)]
-          widgetMgr.registerQueryParamBinding(
-            "daterange1",
-            "range",
-            "string_array_value",
-            rangeDefault,
-            false
-          )
-
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["2025-03-01", "2025-03-15"],
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).not.toHaveBeenCalled()
-        })
-
-        it("does not clear URL when string array differs from Date[] default", () => {
-          const widget = { id: "date2", formId: "" }
-          const dateDefault = [new Date(2025, 0, 15)]
-          widgetMgr.registerQueryParamBinding(
-            "date2",
-            "birthday",
-            "string_array_value",
-            dateDefault,
-            false
-          )
-
-          widgetMgr.setStringArrayValue(
-            widget,
-            ["2025-06-20"],
-            { fromUi: true },
-            undefined
-          )
-          expect(mockOnQueryParamsChange).toHaveBeenCalledWith(
-            "birthday=2025-06-20"
-          )
-        })
+        // Now filter - should preserve the bound param
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toBe("my_key=my_value")
       })
 
-      describe("handler edge cases", () => {
-        it("gracefully handles no handler set", () => {
-          // Create a new widgetMgr without setting a handler
-          const mgr = new WidgetStateManager({
-            sendRerunBackMsg: vi.fn(),
-            formsDataChanged: vi.fn(),
-          })
+      it("combines embed params with bound widget params", () => {
+        // Register a binding
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "color",
+          "string_value",
+          "red",
+          false
+        )
 
-          const widget = { id: "checkbox1", formId: "" }
-          mgr.registerQueryParamBinding(
-            "checkbox1",
-            "enabled",
-            "bool_value",
-            false,
-            false
-          )
+        // Set the widget value
+        const widget = { id: "widget1", formId: "" }
+        widgetMgr.setStringValue(widget, "blue", { fromUi: true }, undefined)
 
-          // Should not throw when no handler is set
-          expect(() => {
-            mgr.setBoolValue(widget, true, { fromUi: true }, undefined)
-          }).not.toThrow()
-        })
+        // Filter with embed params
+        const result = widgetMgr.filterParamsForPageChange("embed=true")
+        expect(result).toBe("embed=true&color=blue")
       })
 
-      describe("filterParamsForPageChange", () => {
-        it("returns only embed params when no widgets are bound", () => {
-          const result = widgetMgr.filterParamsForPageChange("embed=true")
-          expect(result).toBe("embed=true")
-        })
+      it("preserves multiple bound widget params", () => {
+        // Register multiple bindings
 
-        it("returns empty string when no embed params and no bound widgets", () => {
-          const result = widgetMgr.filterParamsForPageChange("")
-          expect(result).toBe("")
-        })
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "name",
+          "string_value",
+          "",
+          false
+        )
+        widgetMgr.registerQueryParamBinding(
+          "widget2",
+          "count",
+          "int_value",
+          0,
+          false
+        )
 
-        it("preserves bound widget params from current URL", () => {
-          // Register a binding
-          widgetMgr.registerQueryParamBinding(
-            "widget1",
-            "my_key",
-            "string_value",
-            "default",
-            false
-          )
+        // Set widget values
+        const widget1 = { id: "widget1", formId: "" }
 
-          // Set the widget value to update URL
-          const widget = { id: "widget1", formId: "" }
-          widgetMgr.setStringValue(
-            widget,
-            "my_value",
-            { fromUi: true },
-            undefined
-          )
+        const widget2 = { id: "widget2", formId: "" }
+        widgetMgr.setStringValue(widget1, "test", { fromUi: true }, undefined)
+        widgetMgr.setIntValue(widget2, 42, { fromUi: true }, undefined)
 
-          // Now filter - should preserve the bound param
-          const result = widgetMgr.filterParamsForPageChange("")
-          expect(result).toBe("my_key=my_value")
-        })
-
-        it("combines embed params with bound widget params", () => {
-          // Register a binding
-          widgetMgr.registerQueryParamBinding(
-            "widget1",
-            "color",
-            "string_value",
-            "red",
-            false
-          )
-
-          // Set the widget value
-          const widget = { id: "widget1", formId: "" }
-          widgetMgr.setStringValue(widget, "blue", { fromUi: true }, undefined)
-
-          // Filter with embed params
-          const result = widgetMgr.filterParamsForPageChange("embed=true")
-          expect(result).toBe("embed=true&color=blue")
-        })
-
-        it("preserves multiple bound widget params", () => {
-          // Register multiple bindings
-
-          widgetMgr.registerQueryParamBinding(
-            "widget1",
-            "name",
-            "string_value",
-            "",
-            false
-          )
-          widgetMgr.registerQueryParamBinding(
-            "widget2",
-            "count",
-            "int_value",
-            0,
-            false
-          )
-
-          // Set widget values
-          const widget1 = { id: "widget1", formId: "" }
-
-          const widget2 = { id: "widget2", formId: "" }
-          widgetMgr.setStringValue(
-            widget1,
-            "test",
-            { fromUi: true },
-            undefined
-          )
-          widgetMgr.setIntValue(widget2, 42, { fromUi: true }, undefined)
-
-          // Filter - should preserve both bound params
-          const result = widgetMgr.filterParamsForPageChange("")
-          expect(result).toContain("name=test")
-          expect(result).toContain("count=42")
-        })
+        // Filter - should preserve both bound params
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toContain("name=test")
+        expect(result).toContain("count=42")
       })
     })
   })

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -73,9 +73,6 @@ export interface QueryParamBinding {
   // When true, empty values write ?foo= to URL; when false, empty clears the param.
   clearable: boolean
   urlFormat?: "comma" | "repeated" // How to serialize arrays
-  // TODO(query-params): Remove options field after wire format changes from
-  // index-based to string-based values for applicable widgets (selectbox, pills, etc.)
-  options?: string[] // For index-based widgets, the formatted option strings
 }
 
 /**
@@ -1078,8 +1075,6 @@ export class WidgetStateManager {
    * mirrors the backend behavior in QueryParams.bind_widget() which also
    * handles duplicate paramKey cleanup.
    *
-   * @param options - For index-based widgets, the formatted option strings.
-   *   TODO(query-params): Remove options param after wire format changes.
    * @param clearable - Whether the widget allows clearing to empty state.
    *   Required - widget components must explicitly pass this based on their UI behavior.
    */
@@ -1089,8 +1084,7 @@ export class WidgetStateManager {
     valueType: WidgetValueType,
     defaultValue: unknown,
     clearable: boolean,
-    urlFormat?: "comma" | "repeated",
-    options?: string[]
+    urlFormat?: "comma" | "repeated"
   ): void {
     // Clean up old binding if a different widget was bound to this paramKey.
     // This keeps boundWidgets and paramKeyToWidgetId consistent.
@@ -1099,37 +1093,11 @@ export class WidgetStateManager {
       this.boundWidgets.delete(existingWidgetId)
     }
 
-    // TODO(query-params): Remove options normalization after wire format changes
-    // from index-based to string-based values for applicable widgets.
-    // Normalize defaultValue to URL-compatible format for index-based widgets.
-    // This ensures default comparison works correctly (e.g., "Red" === "Red"
-    // instead of "Red" === "0").
-    let normalizedDefault = defaultValue
-    if (options && options.length > 0) {
-      if (
-        typeof defaultValue === "number" &&
-        options[defaultValue] !== undefined
-      ) {
-        // Scalar index -> option string
-        normalizedDefault = options[defaultValue]
-      } else if (Array.isArray(defaultValue)) {
-        // Array of indices -> array of option strings
-        normalizedDefault = defaultValue
-          .map(idx =>
-            typeof idx === "number" && options[idx] !== undefined
-              ? options[idx]
-              : String(idx)
-          )
-          .filter((s): s is string => s !== undefined)
-      }
-    }
-
     this.boundWidgets.set(widgetId, {
       paramKey,
       valueType,
-      defaultValue: normalizedDefault,
+      defaultValue,
       urlFormat,
-      options,
       clearable,
     })
     this.paramKeyToWidgetId.set(paramKey, widgetId)
@@ -1231,11 +1199,8 @@ export class WidgetStateManager {
       case "double_value":
         return String(value as number)
 
-      // TODO(query-params): Remove options lookup after wire format changes.
-      case "int_value": {
-        const num = value as number
-        return binding.options?.[num] ?? String(num)
-      }
+      case "int_value":
+        return String(value as number)
 
       case "string_value":
         return value as string
@@ -1243,25 +1208,11 @@ export class WidgetStateManager {
       case "string_array_value":
         return (value as string[]).filter(v => v !== "")
 
-      // TODO(query-params): Remove options lookup after wire format changes.
-      case "int_array_value": {
-        const arr = value as number[]
-        return binding.options
-          ? arr
-              .map(idx => binding.options?.[idx])
-              .filter((s): s is string => s !== undefined)
-          : arr.map(n => String(n))
-      }
+      case "int_array_value":
+        return (value as number[]).map(n => String(n))
 
-      // TODO(query-params): Remove options lookup after wire format changes.
-      case "double_array_value": {
-        const arr = value as number[]
-        return binding.options && binding.options.length > 0
-          ? arr
-              .map(idx => binding.options?.[idx])
-              .filter((s): s is string => s !== undefined)
-          : arr.map(n => String(n))
-      }
+      case "double_array_value":
+        return (value as number[]).map(n => String(n))
 
       default:
         return assertNever(binding.valueType)

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -555,8 +555,7 @@ describe("ButtonGroup query param binding", () => {
       "string_array_value",
       ["cat"],
       true,
-      "repeated",
-      undefined
+      "repeated"
     )
   })
 
@@ -600,8 +599,7 @@ describe("ButtonGroup query param binding", () => {
       "string_array_value",
       ["cat", "bird"],
       true,
-      "repeated",
-      undefined
+      "repeated"
     )
   })
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -208,7 +208,6 @@ describe("Checkbox query param binding", () => {
       "bool_value",
       props.element.default,
       false,
-      undefined,
       undefined
     )
   })
@@ -257,7 +256,6 @@ describe("Checkbox query param binding", () => {
       "bool_value",
       true,
       false,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
+++ b/frontend/lib/src/components/widgets/ColorPicker/ColorPicker.test.tsx
@@ -189,7 +189,6 @@ describe("ColorPicker query param binding", () => {
       "string_value",
       props.element.default,
       false,
-      undefined,
       undefined
     )
   })
@@ -237,7 +236,6 @@ describe("ColorPicker query param binding", () => {
       "string_value",
       "#750dc5",
       false,
-      undefined,
       undefined
     )
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -684,7 +684,6 @@ describe("DateInput query param binding", () => {
       "string_array_value",
       expect.any(Array),
       false,
-      undefined,
       undefined
     )
   })
@@ -727,7 +726,6 @@ describe("DateInput query param binding", () => {
       "string_array_value",
       expect.any(Array),
       true,
-      undefined,
       undefined
     )
   })
@@ -748,8 +746,7 @@ describe("DateInput query param binding", () => {
       "string_array_value",
       expect.any(Array),
       false,
-      "repeated",
-      undefined
+      "repeated"
     )
   })
 

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -563,7 +563,6 @@ describe("DateTimeInput widget", () => {
         "string_array_value",
         expect.anything(),
         false,
-        undefined,
         undefined
       )
     })
@@ -606,7 +605,6 @@ describe("DateTimeInput widget", () => {
         "string_array_value",
         null,
         true,
-        undefined,
         undefined
       )
     })

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -910,8 +910,7 @@ describe("Multiselect query param binding", () => {
       "string_array_value",
       ["a"],
       true,
-      "repeated",
-      undefined
+      "repeated"
     )
   })
 

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -1465,7 +1465,6 @@ describe("NumberInput query param binding", () => {
       "double_value",
       props.element.default,
       false,
-      undefined,
       undefined
     )
   })
@@ -1514,7 +1513,6 @@ describe("NumberInput query param binding", () => {
       "double_value",
       3.14,
       false,
-      undefined,
       undefined
     )
   })
@@ -1534,7 +1532,6 @@ describe("NumberInput query param binding", () => {
       "double_value",
       null,
       true,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -242,7 +242,6 @@ describe("Radio query param binding", () => {
       "string_value",
       "a",
       false,
-      undefined,
       undefined
     )
   })
@@ -287,7 +286,6 @@ describe("Radio query param binding", () => {
       "string_value",
       null,
       true,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -192,7 +192,6 @@ describe("Selectbox query param binding", () => {
       "string_value",
       "a",
       false,
-      undefined,
       undefined
     )
   })
@@ -237,7 +236,6 @@ describe("Selectbox query param binding", () => {
       "string_value",
       null,
       true,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -660,12 +660,11 @@ describe("Slider query param binding", () => {
       "double_array_value",
       props.element.default,
       false,
-      "repeated",
-      undefined
+      "repeated"
     )
   })
 
-  it("registers query param binding for select_slider with string_array_value and optionStrings", () => {
+  it("registers query param binding for select_slider with urlDefault strings", () => {
     const props = getProps({
       queryParamKey: "my_select_slider",
       type: SliderProto.Type.SELECT_SLIDER,
@@ -680,10 +679,30 @@ describe("Slider query param binding", () => {
       props.element.id,
       "my_select_slider",
       "string_array_value",
-      props.element.default,
+      ["red"],
       false,
-      "repeated",
-      ["red", "green", "blue"]
+      "repeated"
+    )
+  })
+
+  it("registers query param binding for range select_slider with urlDefault strings", () => {
+    const props = getProps({
+      queryParamKey: "my_range_slider",
+      type: SliderProto.Type.SELECT_SLIDER,
+      options: ["small", "medium", "large"],
+      default: [0, 2],
+    })
+    vi.spyOn(props.widgetMgr, "registerQueryParamBinding")
+
+    render(<Slider {...props} />)
+
+    expect(props.widgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
+      props.element.id,
+      "my_range_slider",
+      "string_array_value",
+      ["small", "large"],
+      false,
+      "repeated"
     )
   })
 

--- a/frontend/lib/src/components/widgets/Slider/Slider.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.tsx
@@ -156,14 +156,13 @@ function Slider({
         valueType: isSelectSlider(element)
           ? ("string_array_value" as const)
           : ("double_array_value" as const),
-        // Sliders always have a value (no empty/cleared state in the UI)
         clearable: false,
         urlFormat: "repeated" as const,
-        // select_slider proto stores defaults as indices (repeated double), but
-        // URL values are formatted option strings. optionStrings enables the
-        // default normalization in registerQueryParamBinding so that reverting
-        // to default correctly clears the URL param.
-        optionStrings: isSelectSlider(element) ? element.options : undefined,
+        // select_slider stores indices internally but uses formatted option
+        // strings in URLs, so provide the default in URL-compatible format.
+        urlDefault: isSelectSlider(element)
+          ? indicesToStringValues(element.default, element.options)
+          : undefined,
       }
     : undefined
 

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -439,7 +439,6 @@ describe("TextArea query param binding", () => {
       "string_value",
       props.element.default,
       true,
-      undefined,
       undefined
     )
   })
@@ -487,7 +486,6 @@ describe("TextArea query param binding", () => {
       "string_value",
       "initial bio",
       true,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -547,7 +547,6 @@ describe("TextInput query param binding", () => {
       "string_value",
       props.element.default,
       true,
-      undefined,
       undefined
     )
   })
@@ -595,7 +594,6 @@ describe("TextInput query param binding", () => {
       "string_value",
       "initial search",
       true,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -273,7 +273,6 @@ describe("TimeInput query param binding", () => {
       "string_value",
       "12:45",
       false,
-      undefined,
       undefined
     )
   })
@@ -316,7 +315,6 @@ describe("TimeInput query param binding", () => {
       "string_value",
       null,
       true,
-      undefined,
       undefined
     )
   })

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -460,7 +460,6 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         "string_value",
         "default",
         false,
-        undefined,
         undefined
       )
     })
@@ -532,23 +531,22 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       expect(unregisterSpy).toHaveBeenCalledWith("widget-unmount-test")
     })
 
-    it("passes urlFormat and optionStrings correctly", () => {
+    it("passes urlFormat correctly", () => {
       const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
 
       const element: MockProto = {
         formId: "",
         setValue: false,
-        id: "widget-with-options",
-        value: 0,
-        default: 0,
+        id: "widget-with-format",
+        value: "hello",
+        default: "hello",
       }
 
       const queryParamBinding: QueryParamBindingConfig = {
-        paramKey: "color",
-        valueType: "int_value",
+        paramKey: "greeting",
+        valueType: "string_value",
         clearable: false,
         urlFormat: "comma",
-        optionStrings: ["Red", "Green", "Blue"],
       }
 
       renderHook(() =>
@@ -566,13 +564,55 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
       )
 
       expect(registerSpy).toHaveBeenCalledWith(
-        "widget-with-options",
-        "color",
-        "int_value",
-        0,
+        "widget-with-format",
+        "greeting",
+        "string_value",
+        "hello",
         false,
-        "comma",
-        ["Red", "Green", "Blue"]
+        "comma"
+      )
+    })
+
+    it("uses urlDefault when provided instead of getDefaultStateFromProto", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-with-url-default",
+        value: 0,
+        default: 0,
+      }
+
+      const queryParamBinding: QueryParamBindingConfig = {
+        paramKey: "color",
+        valueType: "string_array_value",
+        clearable: false,
+        urlFormat: "repeated",
+        urlDefault: ["Red"],
+      }
+
+      renderHook(() =>
+        useBasicWidgetState({
+          getStateFromWidgetMgr,
+          getCurrStateFromProto,
+          getDefaultStateFromProto,
+          updateWidgetMgrState,
+          element,
+          widgetMgr,
+          fragmentId: undefined,
+          formClearBehavior: "resetValueOnly",
+          queryParamBinding,
+        })
+      )
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        "widget-with-url-default",
+        "color",
+        "string_array_value",
+        ["Red"],
+        false,
+        "repeated"
       )
     })
   })

--- a/frontend/lib/src/hooks/useBasicWidgetState.test.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.test.ts
@@ -615,5 +615,58 @@ describe("useBasicWidgetState - getDefaultState logic", () => {
         "repeated"
       )
     })
+
+    it("does not re-register when urlDefault is a new reference with same value", () => {
+      const registerSpy = vi.spyOn(widgetMgr, "registerQueryParamBinding")
+
+      const element: MockProto = {
+        formId: "",
+        setValue: false,
+        id: "widget-stable-default",
+        value: 0,
+        default: 0,
+      }
+
+      const { rerender } = renderHook(
+        ({ binding }) =>
+          useBasicWidgetState({
+            getStateFromWidgetMgr,
+            getCurrStateFromProto,
+            getDefaultStateFromProto,
+            updateWidgetMgrState,
+            element,
+            widgetMgr,
+            fragmentId: undefined,
+            formClearBehavior: "resetValueOnly",
+            queryParamBinding: binding,
+          }),
+        {
+          initialProps: {
+            binding: {
+              paramKey: "color",
+              valueType: "string_array_value" as const,
+              clearable: false,
+              urlFormat: "repeated" as const,
+              urlDefault: ["Red"],
+            },
+          },
+        }
+      )
+
+      expect(registerSpy).toHaveBeenCalledTimes(1)
+
+      // Re-render with a new array reference containing the same value
+      rerender({
+        binding: {
+          paramKey: "color",
+          valueType: "string_array_value" as const,
+          clearable: false,
+          urlFormat: "repeated" as const,
+          urlDefault: ["Red"],
+        },
+      })
+
+      expect(registerSpy).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -301,17 +301,19 @@ export function useBasicWidgetState<
   // When hasQueryParamBinding is false, fallback values are unused (hook early-returns).
   const hasQueryParamBinding = !isNullOrUndefined(queryParamBinding)
 
+  // JSON.stringify provides value-based comparison for urlDefault arrays
+  // (e.g., select_slider's ["green"] is a new reference each render).
+  const urlDefaultKey =
+    queryParamBinding?.urlDefault !== undefined
+      ? JSON.stringify(queryParamBinding.urlDefault)
+      : undefined
   const defaultValueForBinding = useMemo(() => {
     if (!hasQueryParamBinding) return undefined
     return queryParamBinding?.urlDefault !== undefined
       ? queryParamBinding.urlDefault
       : getDefaultStateFromProto(element)
-  }, [
-    hasQueryParamBinding,
-    element,
-    getDefaultStateFromProto,
-    queryParamBinding?.urlDefault,
-  ])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- urlDefaultKey provides value-based comparison
+  }, [hasQueryParamBinding, element, getDefaultStateFromProto, urlDefaultKey])
 
   const queryParamBindingOptions = useMemo(
     () =>

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -198,11 +198,13 @@ export interface QueryParamBindingConfig {
   /** How to serialize arrays in the URL ("comma" or "repeated") */
   urlFormat?: "comma" | "repeated"
   /**
-   * For index-based widgets, the formatted option strings to use in URLs.
-   * TODO(query-params): Remove after wire format changes from index-based
-   * to string-based values for applicable widgets (selectbox, pills, etc.)
+   * The widget's default value expressed in URL-compatible format.
+   * When provided, used instead of getDefaultStateFromProto(element) for
+   * URL binding default comparison. Only needed when the widget's internal
+   * state type differs from its URL representation (e.g., select_slider
+   * stores indices internally but uses formatted option strings in URLs).
    */
-  optionStrings?: string[]
+  urlDefault?: unknown
 }
 
 interface UseBasicWidgetStateBaseArgs<
@@ -296,30 +298,27 @@ export function useBasicWidgetState<
   })
 
   // Memoize values for useQueryParamBinding to prevent unnecessary effect re-runs.
-  // - defaultValueForBinding: getDefaultStateFromProto may return new references
-  // - queryParamBindingOptions: uses JSON.stringify for value-based array comparison
   // When hasQueryParamBinding is false, fallback values are unused (hook early-returns).
   const hasQueryParamBinding = !isNullOrUndefined(queryParamBinding)
 
-  const defaultValueForBinding = useMemo(
-    () =>
-      hasQueryParamBinding ? getDefaultStateFromProto(element) : undefined,
-    [hasQueryParamBinding, element, getDefaultStateFromProto]
-  )
+  const defaultValueForBinding = useMemo(() => {
+    if (!hasQueryParamBinding) return undefined
+    return queryParamBinding?.urlDefault !== undefined
+      ? queryParamBinding.urlDefault
+      : getDefaultStateFromProto(element)
+  }, [
+    hasQueryParamBinding,
+    element,
+    getDefaultStateFromProto,
+    queryParamBinding?.urlDefault,
+  ])
 
-  const optionStringsKey = queryParamBinding?.optionStrings
-    ? JSON.stringify(queryParamBinding.optionStrings)
-    : undefined
   const queryParamBindingOptions = useMemo(
     () =>
       hasQueryParamBinding
-        ? {
-            urlFormat: queryParamBinding?.urlFormat,
-            optionStrings: queryParamBinding?.optionStrings,
-          }
+        ? { urlFormat: queryParamBinding?.urlFormat }
         : undefined,
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- optionStringsKey provides value-based comparison
-    [hasQueryParamBinding, queryParamBinding?.urlFormat, optionStringsKey]
+    [hasQueryParamBinding, queryParamBinding?.urlFormat]
   )
 
   // Query param binding registration (optional, integrated for convenience)

--- a/frontend/lib/src/hooks/useBasicWidgetState.ts
+++ b/frontend/lib/src/hooks/useBasicWidgetState.ts
@@ -204,7 +204,7 @@ export interface QueryParamBindingConfig {
    * state type differs from its URL representation (e.g., select_slider
    * stores indices internally but uses formatted option strings in URLs).
    */
-  urlDefault?: unknown
+  urlDefault?: string | number | boolean | string[] | number[] | null
 }
 
 interface UseBasicWidgetStateBaseArgs<

--- a/frontend/lib/src/hooks/useQueryParamBinding.test.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.test.ts
@@ -52,7 +52,6 @@ describe("useQueryParamBinding", () => {
       "string_value",
       "default",
       false,
-      undefined,
       undefined
     )
   })
@@ -129,32 +128,7 @@ describe("useQueryParamBinding", () => {
       "string_array_value",
       [],
       true,
-      "comma",
-      undefined
-    )
-  })
-
-  it("passes optionStrings option correctly", () => {
-    renderHook(() =>
-      useQueryParamBinding(
-        mockWidgetMgr as unknown as WidgetStateManager,
-        "widget-123",
-        "color",
-        "int_value",
-        0,
-        false,
-        { optionStrings: ["Red", "Green", "Blue"] }
-      )
-    )
-
-    expect(mockWidgetMgr.registerQueryParamBinding).toHaveBeenCalledWith(
-      "widget-123",
-      "color",
-      "int_value",
-      0,
-      false,
-      undefined,
-      ["Red", "Green", "Blue"]
+      "comma"
     )
   })
 

--- a/frontend/lib/src/hooks/useQueryParamBinding.ts
+++ b/frontend/lib/src/hooks/useQueryParamBinding.ts
@@ -21,8 +21,6 @@ import { WidgetStateManager, WidgetValueType } from "~lib/WidgetStateManager"
 export interface QueryParamBindingOptions {
   /** How to serialize arrays in the URL ("comma" for comma-separated, "repeated" for ?key=a&key=b) */
   urlFormat?: "comma" | "repeated"
-  /** For index-based widgets, the formatted option strings to use in URLs */
-  optionStrings?: string[]
 }
 
 /**
@@ -40,7 +38,7 @@ export interface QueryParamBindingOptions {
  * @param defaultValue - The widget's default value (for clearing URL when value equals default)
  * @param clearable - Whether the widget allows clearing to empty state.
  *   Widget components must explicitly pass this based on their UI behavior.
- * @param options - Optional configuration for URL format and option strings.
+ * @param options - Optional configuration for URL format.
  *   Note: This object is included in the useEffect dependency array. Callers should
  *   memoize the options object (e.g., via useMemo) to avoid unnecessary effect re-runs.
  */
@@ -65,8 +63,7 @@ export function useQueryParamBinding(
       valueType,
       defaultValue,
       clearable,
-      options?.urlFormat,
-      options?.optionStrings
+      options?.urlFormat
     )
 
     return () => {

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1152,56 +1152,13 @@ class SessionState:
         parsed_value: Any,
         deserialized_value: Any,
     ) -> None:
-        """Auto-correct URL if the value was clamped or filtered.
-
-        For selection widgets using human-readable strings in URLs, we preserve
-        the original strings unless values were actually filtered out.
-        """
+        """Auto-correct URL if the value was clamped or filtered."""
         serialized_value = metadata.serializer(deserialized_value)
         if serialized_value == parsed_value:
             return  # No correction needed
 
-        # TODO(query-params): Remove this formatted_options handling once all selection
-        # widgets use string-based wire formats (string_value/string_array_value).
-        # For index-based widgets, don't auto-correct valid strings to indices -
-        # only correct if values were actually filtered.
-        string_option_types = ("int_value", "int_array_value", "double_array_value")
-        use_formatted_options = False
-
-        if metadata.value_type in string_option_types:
-            # Check if parsed value contained strings
-            if isinstance(parsed_value, list):
-                parsed_has_strings = any(isinstance(v, str) for v in parsed_value)
-                parsed_len = len(parsed_value)
-            else:
-                parsed_has_strings = isinstance(parsed_value, str)
-                parsed_len = 1
-
-            if parsed_has_strings:
-                serialized_len = (
-                    len(serialized_value) if isinstance(serialized_value, list) else 1
-                )
-                if serialized_len == parsed_len:
-                    return  # No filtering, keep original strings in URL
-                use_formatted_options = bool(metadata.formatted_options)
-
-        # Build corrected value, converting indices to formatted strings if needed
-        corrected_value = serialized_value
-        if use_formatted_options and metadata.formatted_options:
-            fmt_opts = metadata.formatted_options
-            if isinstance(serialized_value, list):
-                corrected_value = [
-                    fmt_opts[idx]
-                    for idx in serialized_value
-                    if isinstance(idx, int) and 0 <= idx < len(fmt_opts)
-                ]
-            elif isinstance(serialized_value, int) and 0 <= serialized_value < len(
-                fmt_opts
-            ):
-                corrected_value = fmt_opts[serialized_value]
-
         self.query_params._set_corrected_value(
-            user_key, corrected_value, metadata.value_type
+            user_key, serialized_value, metadata.value_type
         )
 
     def __contains__(self, key: str) -> bool:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -49,8 +49,8 @@ def register_widget(
     value_type: ValueFieldName,
     presenter: WidgetValuePresenter | None = None,
     bind: BindOption = None,
-    # TODO(query-params): Remove formatted_options once all selection widgets use
-    # string-based wire formats (string_value/string_array_value).
+    # For selection widgets with bind="query-params": the valid option strings
+    # used to validate and filter URL values during seeding.
     formatted_options: list[str] | None = None,
     clearable: bool | None = None,
     max_array_length: int | None = None,

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2145,34 +2145,6 @@ class AutoCorrectUrlTest(DeltaGeneratorTestCase):
 
         assert self.query_params._query_params["my_slider"] == "50"
 
-    def test_preserve_strings_when_no_filtering_for_selection_widgets(self) -> None:
-        """Test that human-readable strings are preserved when valid."""
-        metadata = _create_test_widget_metadata(
-            "widget_1",
-            value_type="int_value",
-            serializer=lambda x: 0,
-            formatted_options=["Red", "Green", "Blue"],
-        )
-
-        self.session_state._auto_correct_url_if_needed(metadata, "color", "Red", "Red")
-
-        assert "color" not in self.query_params._query_params
-
-    def test_use_formatted_options_when_filtering(self) -> None:
-        """Test that formatted_options are used when values are filtered."""
-        metadata = _create_test_widget_metadata(
-            "widget_1",
-            value_type="int_array_value",
-            serializer=lambda x: [0],
-            formatted_options=["Apple", "Banana", "Cherry"],
-        )
-
-        self.session_state._auto_correct_url_if_needed(
-            metadata, "tags", ["Apple", "Invalid"], ["Apple"]
-        )
-
-        assert self.query_params._query_params["tags"] == ["Apple"]
-
 
 class SanitizeUrlArrayTest(unittest.TestCase):
     """Tests for the _sanitize_url_array helper function."""


### PR DESCRIPTION
## Describe your changes
Replace the `optionStrings` infrastructure used for query parameter binding with a simpler `urlDefault` field. Instead of threading option strings through three interfaces (`QueryParamBindingConfig` → `QueryParamBindingOptions` → `QueryParamBinding`) and normalizing index-based defaults inside `WidgetStateManager.registerQueryParamBinding`, the conversion now happens once at the call site in `Slider.tsx` using the existing `indicesToStringValues` helper.

Also removes dead code paths in `WidgetStateManager.convertToUrlValue` and `session_state.py._auto_correct_url_if_needed` that handled index-to-string conversion via `options`/`formatted_options` but were no longer exercised by any bound widget.

## Changes

**Frontend:**
- `useBasicWidgetState.ts`: Replace `optionStrings?: string[]` with `urlDefault?: unknown` on `QueryParamBindingConfig`; simplify `defaultValueForBinding` memo to use `urlDefault` when provided
- `useQueryParamBinding.ts`: Remove `optionStrings` from `QueryParamBindingOptions`
- `WidgetStateManager.ts`: Remove `options` from `QueryParamBinding` interface and `registerQueryParamBinding`; remove normalization block and options-based branches in `convertToUrlValue`
- `Slider.tsx`: Compute `urlDefault` directly via `indicesToStringValues(element.default, element.options)` for select_slider

**Backend:**
- `session_state.py`: Remove dead `formatted_options` index-to-string conversion block in `_auto_correct_url_if_needed`
- `widgets.py`: Update `formatted_options` comment to reflect current usage


## Testing Plan
- Unit Tests (JS and/or Python): ✅ Updated
