### PR TITLE
[fix] Normalize all `date_input` session state values to date

### DIFF
--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -487,6 +487,17 @@ class TimeInputSerde:
         return time.strftime(v, "%H:%M")
 
 
+def _to_date(v: date) -> date:
+    """Convert datetime to date for comparison.
+
+    st.date_input can receive datetime values from session_state. Since datetime
+    is a subclass of date, isinstance(v, date) returns True, but datetime and date
+    objects cannot be directly compared with < or >. This helper normalizes the
+    value for safe comparison with date bounds.
+    """
+    return v.date() if isinstance(v, datetime) else v
+
+
 def _validate_date_value(
     current_value: DateWidgetReturn,
     parsed_values: _DateInputValues,
@@ -532,11 +543,17 @@ def _validate_date_value(
         non_empty_value = cast("tuple[date, ...]", current_value)
         start_date = non_empty_value[0]
         end_date = non_empty_value[-1] if len(non_empty_value) > 1 else start_date
-        if start_date < parsed_values.min or end_date > parsed_values.max:
+        if (
+            _to_date(start_date) < parsed_values.min
+            or _to_date(end_date) > parsed_values.max
+        ):
             value_needs_reset = True
     elif not parsed_values.is_range and isinstance(current_value, date):
-        # For single date mode
-        if current_value < parsed_values.min or current_value > parsed_values.max:
+        # For single date mode. Use _to_date to handle datetime values from session_state.
+        if (
+            _to_date(current_value) < parsed_values.min
+            or _to_date(current_value) > parsed_values.max
+        ):
             value_needs_reset = True
     else:
         # Type mismatch: widget mode doesn't match current value type (e.g., range mode

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -1033,3 +1033,37 @@ class TestDateInputSerdeISO:
             "2025-03-15",
         ]
         assert serde.serialize(None) == []
+
+
+def test_datetime_session_state_value_with_date_bounds():
+    """Test that datetime values in session_state can be compared with date bounds.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/14109
+    When a datetime.datetime value is stored in session_state and compared against
+    datetime.date min/max bounds, the validation should not raise TypeError.
+    """
+    from datetime import datetime as dt
+
+    def script():
+        import datetime
+
+        import streamlit as st
+
+        # Initialize session_state with a datetime value
+        if "date" not in st.session_state:
+            st.session_state["date"] = datetime.datetime(2025, 6, 15, 12, 30, 0)
+
+        # Use date_input with date bounds - this should not raise TypeError
+        result = st.date_input(
+            "Select date",
+            key="date",
+            min_value=datetime.date(2025, 1, 1),
+            max_value=datetime.date(2025, 12, 31),
+        )
+        st.write(f"result: {result}")
+
+    at = AppTest.from_function(script).run()
+    # This should not raise TypeError (the bug being fixed)
+    assert not at.exception
+    # The widget preserves the datetime type from session_state
+    assert at.date_input[0].value == dt(2025, 6, 15, 12, 30, 0)


### PR DESCRIPTION
## Describe your changes

Fixes TypeError when a `datetime` value from `session_state` is compared with `date`-type `min_value`/`max_value` bounds in `st.date_input`.

- Added `_to_date()` helper to normalize datetime to date for safe comparison
- Updated `_validate_date_value()` to handle datetime values from session_state

## GitHub Issue Link

Fixes https://github.com/streamlit/streamlit/issues/14109

## Testing Plan

- [x] Unit Tests (Python) - Added regression test in `lib/tests/streamlit/elements/date_input_test.py`