### PR TITLE
Add deprecation warning to SnowparkConnection

### DIFF
--- a/lib/streamlit/connections/snowpark_connection.py
+++ b/lib/streamlit/connections/snowpark_connection.py
@@ -31,6 +31,7 @@ from streamlit.connections.util import (
     load_from_snowsql_config_file,
     running_in_sis,
 )
+from streamlit.deprecation_util import show_deprecation_warning
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching import cache_data
 
@@ -55,6 +56,12 @@ class SnowparkConnection(BaseConnection["Session"]):
     SnowparkConnections should always be created using ``st.connection()``, **not**
     initialized directly.
 
+    .. warning::
+        ``SnowparkConnection`` is deprecated and will be removed in a future release.
+        Please use ``st.connection("<name>", type="snowflake")`` with
+        :class:`~streamlit.connections.SnowflakeConnection` instead, which provides
+        the same functionality with better support and additional features.
+
     .. note::
         We don't expect this iteration of SnowparkConnection to be able to scale
         well in apps with many concurrent users due to the lock contention that will occur
@@ -62,6 +69,12 @@ class SnowparkConnection(BaseConnection["Session"]):
     """
 
     def __init__(self, connection_name: str, **kwargs: Any) -> None:
+        show_deprecation_warning(
+            "`SnowparkConnection` is deprecated and will be removed in a future release. "
+            'Please use `st.connection("<name>", type="snowflake")` with '
+            "`SnowflakeConnection` instead.",
+            show_once=True,
+        )
         self._lock = threading.RLock()
         super().__init__(connection_name, **kwargs)
 

--- a/lib/tests/streamlit/connections/snowpark_connection_test.py
+++ b/lib/tests/streamlit/connections/snowpark_connection_test.py
@@ -26,6 +26,25 @@ from streamlit.runtime.secrets import AttrDict
 from tests.testutil import create_mock_script_run_ctx
 
 
+class SnowparkConnectionDeprecationTest(unittest.TestCase):
+    """Test deprecation warning for SnowparkConnection."""
+
+    @patch(
+        "streamlit.connections.snowpark_connection.SnowparkConnection._connect",
+        MagicMock(),
+    )
+    @patch("streamlit.connections.snowpark_connection.show_deprecation_warning")
+    def test_shows_deprecation_warning_on_init(self, mock_warning: MagicMock):
+        """Test that a deprecation warning is shown when SnowparkConnection is initialized."""
+        SnowparkConnection("my_snowpark_connection")
+
+        mock_warning.assert_called_once()
+        call_args = mock_warning.call_args
+        assert "deprecated" in call_args[0][0].lower()
+        assert "SnowflakeConnection" in call_args[0][0]
+        assert call_args[1].get("show_once") is True
+
+
 @pytest.mark.require_integration
 class SnowparkConnectionTest(unittest.TestCase):
     def tearDown(self) -> None:


### PR DESCRIPTION
## Describe your changes

Deprecates `SnowparkConnection` in favor of `SnowflakeConnection`:

- Adds `show_deprecation_warning` call in `__init__` with `show_once=True`
- Adds `.. warning::` directive to the class docstring pointing users to `SnowflakeConnection`
- Adds unit test to verify the deprecation warning is shown

Context: https://github.com/streamlit/streamlit/pull/14094#issuecomment-3955429890

## Testing Plan

- [x] Unit test (`SnowparkConnectionDeprecationTest`)