### PR TITLE
Improve version copy accessibility

### DIFF
--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -24,13 +24,13 @@ def test_main_menu_images(themed_app: Page, assert_snapshot: ImageCompareFunctio
     themed_app.get_by_test_id("stMainMenu").click()
 
     # Replace version with placeholder so snapshots don't change across versions.
-    menu = themed_app.get_by_role("menu", name="Main menu")
-    menu.get_by_text(re.compile(r"^Made with Streamlit v")).evaluate(
+    # The version footer lives outside role="menu" (inside the popover wrapper).
+    popover = themed_app.get_by_test_id("stMainMenuPopover")
+    popover.get_by_text(re.compile(r"^Made with Streamlit v")).evaluate(
         "el => (el.textContent = 'Made with Streamlit vX.XX.X')"
     )
 
-    element = themed_app.get_by_test_id("stMainMenuPopover")
-    assert_snapshot(element, name="main_menu")
+    assert_snapshot(popover, name="main_menu")
 
 
 def test_main_menu_closes_on_escape(app: Page):
@@ -172,10 +172,11 @@ def test_focus_returns_to_menu_button_after_close(app: Page):
 
 
 def test_tab_closes_menu(app: Page):
-    """Test that pressing Tab inside the menu closes it without returning focus to trigger.
+    """Test that pressing Tab from the menu eventually closes the popover.
 
-    Per WAI-ARIA menu-button pattern, Tab/Shift+Tab should close the menu and
-    allow focus to advance rather than snapping back to the trigger button.
+    The first Tab moves focus from the menu items to the version CopyButton
+    (which lives outside role="menu" but inside the popover's focus-lock).
+    The second Tab closes the popover and advances focus.
     """
     menu_button = app.get_by_test_id("stMainMenuButton")
     menu_button.focus()
@@ -184,6 +185,11 @@ def test_tab_closes_menu(app: Page):
     popover = app.get_by_test_id("stMainMenuPopover")
     expect(popover).to_be_visible()
 
+    # First Tab: focus moves from the menu to the CopyButton in the footer.
+    app.keyboard.press("Tab")
+    expect(popover).to_be_visible()
+
+    # Second Tab: closes the popover (forward Tab from the CopyButton).
     app.keyboard.press("Tab")
     expect(popover).not_to_be_visible()
 
@@ -326,15 +332,16 @@ def test_rerun_visible_in_dev_mode(app: Page):
 
 
 def test_main_menu_version_footer_visible(app: Page):
-    """Test that the Made with Streamlit version footer is visible in the menu."""
+    """Test that the Made with Streamlit version footer is visible in the popover."""
     app.get_by_test_id("stMainMenu").click()
-    menu = app.get_by_role("menu", name="Main menu")
-    expect(menu).to_be_visible()
+    popover = app.get_by_test_id("stMainMenuPopover")
+    expect(popover).to_be_visible()
 
-    version_text = menu.get_by_text(re.compile(r"^Made with Streamlit v"))
+    # The version footer lives outside role="menu" but inside the popover.
+    version_text = popover.get_by_text(re.compile(r"^Made with Streamlit v"))
     expect(version_text).to_be_visible()
 
-    copy_button = menu.get_by_role("button", name="Copy version to clipboard")
+    copy_button = popover.get_by_role("button", name="Copy version to clipboard")
     expect(copy_button).to_have_css("pointer-events", "none")
     expect(copy_button).to_have_attribute("data-copy-state", "idle")
 
@@ -343,11 +350,12 @@ def test_main_menu_version_footer_visible(app: Page):
 def test_main_menu_version_footer_copies_version(app: Page):
     """Test that the copy button in the menu footer copies the version string."""
     app.get_by_test_id("stMainMenu").click()
-    menu = app.get_by_role("menu", name="Main menu")
-    expect(menu).to_be_visible()
+    popover = app.get_by_test_id("stMainMenuPopover")
+    expect(popover).to_be_visible()
 
-    version_text = menu.get_by_text(re.compile(r"^Made with Streamlit v"))
-    copy_button = menu.get_by_role("button", name="Copy version to clipboard")
+    # The version footer lives outside role="menu" but inside the popover.
+    version_text = popover.get_by_text(re.compile(r"^Made with Streamlit v"))
+    copy_button = popover.get_by_role("button", name="Copy version to clipboard")
 
     # The copy button starts hidden (opacity: 0, pointer-events: none) until hover.
     expect(copy_button).to_have_css("pointer-events", "none")

--- a/e2e_playwright/theming/custom_theme_fonts_test.py
+++ b/e2e_playwright/theming/custom_theme_fonts_test.py
@@ -77,10 +77,10 @@ def test_custom_theme_main_menu(app: Page, assert_snapshot: ImageCompareFunction
     app.get_by_test_id("stMainMenu").click()
 
     # Replace version with placeholder so snapshots don't change across versions.
-    menu = app.get_by_role("menu", name="Main menu")
-    menu.get_by_text(re.compile(r"^Made with Streamlit v")).evaluate(
+    # The version footer lives outside role="menu" (inside the popover wrapper).
+    popover = app.get_by_test_id("stMainMenuPopover")
+    popover.get_by_text(re.compile(r"^Made with Streamlit v")).evaluate(
         "el => (el.textContent = 'Made with Streamlit vX.XX.X')"
     )
 
-    element = app.get_by_test_id("stMainMenuPopover")
-    assert_snapshot(element, name="custom_fonts_main_menu")
+    assert_snapshot(popover, name="custom_fonts_main_menu")

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -1564,6 +1564,97 @@ describe("MainMenu", () => {
         screen.getByText("Made with Streamlit v1.46.1")
       ).toBeInTheDocument()
     })
+
+    it("renders the CopyButton outside role=menu", async () => {
+      const props = getProps({ streamlitVersion: "1.46.1" })
+      render(<MainMenu {...props} />)
+      await openMenu()
+
+      const menu = screen.getByRole("menu", { name: "Main menu" })
+      const copyButton = screen.getByRole("button", {
+        name: "Copy version to clipboard",
+      })
+
+      expect(menu).not.toContainElement(copyButton)
+    })
+
+    it("does not close the menu on Tab from a menu item when footer exists", async () => {
+      const props = getProps({ streamlitVersion: "1.46.1" })
+      render(<MainMenu {...props} />)
+      await openMenu()
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      await user.keyboard("{Tab}")
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(screen.getByTestId("stMainMenuPopover")).toBeInTheDocument()
+    })
+
+    it("closes the menu on forward Tab from the CopyButton", async () => {
+      const props = getProps({ streamlitVersion: "1.46.1" })
+      render(<MainMenu {...props} />)
+      await openMenu()
+
+      const copyButton = screen.getByRole("button", {
+        name: "Copy version to clipboard",
+      })
+      act(() => {
+        copyButton.focus()
+      })
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      await user.keyboard("{Tab}")
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+    })
+
+    it("does not close the menu on Shift+Tab from the CopyButton", async () => {
+      const props = getProps({ streamlitVersion: "1.46.1" })
+      render(<MainMenu {...props} />)
+      await openMenu()
+
+      const copyButton = screen.getByRole("button", {
+        name: "Copy version to clipboard",
+      })
+      act(() => {
+        copyButton.focus()
+      })
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      await user.keyboard("{Shift>}{Tab}{/Shift}")
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(screen.getByTestId("stMainMenuPopover")).toBeInTheDocument()
+    })
+
+    it("closes the menu on Escape from the CopyButton", async () => {
+      const props = getProps({ streamlitVersion: "1.46.1" })
+      render(<MainMenu {...props} />)
+      await openMenu()
+
+      const copyButton = screen.getByRole("button", {
+        name: "Copy version to clipboard",
+      })
+      act(() => {
+        copyButton.focus()
+      })
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      await user.keyboard("{Escape}")
+      act(() => {
+        vi.runAllTimers()
+      })
+
+      expect(screen.queryByTestId("stMainMenuPopover")).not.toBeInTheDocument()
+    })
   })
 })
 

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -55,6 +55,7 @@ import {
   StyledMenuItemLabel,
   StyledMenuItemRow,
   StyledMenuItemShortcut,
+  StyledMenuPopoverContent,
   StyledMenuVersionFooter,
   StyledMenuVersionRow,
   StyledMenuVersionText,
@@ -703,13 +704,37 @@ function MenuContent({
         break
       }
       case "Tab": {
-        // Per WAI-ARIA, Tab/Shift+Tab close the menu and move focus to
-        // the next/previous tabbable element.  preventDefault is needed
-        // to stop react-focus-lock from cycling focus within the popover.
-        // The returnFocus callback uses focusNextElement/focusPrevElement
-        // to advance focus from the menu button after the popover unmounts.
+        if (streamlitVersion) {
+          // A CopyButton exists in the version footer outside role="menu"
+          // but inside the popover's focus-lock.  Let focus-lock move
+          // focus there instead of closing the menu immediately.
+          break
+        }
+        // No footer — close the menu and advance focus per WAI-ARIA.
         event.preventDefault()
         closeMenu(event.shiftKey ? "shift-tab" : "tab")
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  const handleFooterKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    switch (event.key) {
+      case "Tab": {
+        if (!event.shiftKey) {
+          // Forward Tab from the footer: close menu and advance focus
+          // past the trigger, same as Tab from a bare menu.
+          event.preventDefault()
+          closeMenu("tab")
+        }
+        // Shift+Tab: focus-lock moves focus back into the menu.
+        break
+      }
+      case "Escape": {
+        event.preventDefault()
+        closeMenu("escape")
         break
       }
       default:
@@ -799,17 +824,19 @@ function MenuContent({
   }
 
   return (
-    <StyledMenuContainer
-      ref={menuListRef}
-      data-testid="stMainMenuList"
-      aria-label="Main menu"
-      role="menu"
-      onFocus={handleMenuFocus}
-      onKeyDown={handleKeyDown}
-    >
-      {elements}
+    <StyledMenuPopoverContent>
+      <StyledMenuContainer
+        ref={menuListRef}
+        data-testid="stMainMenuList"
+        aria-label="Main menu"
+        role="menu"
+        onFocus={handleMenuFocus}
+        onKeyDown={handleKeyDown}
+      >
+        {elements}
+      </StyledMenuContainer>
       {streamlitVersion && (
-        <StyledMenuVersionFooter>
+        <StyledMenuVersionFooter onKeyDown={handleFooterKeyDown}>
           <StyledMenuVersionRow>
             <StyledMenuVersionText>
               Made with Streamlit v{formatDisplayVersion(streamlitVersion)}
@@ -825,7 +852,7 @@ function MenuContent({
           </StyledMenuVersionRow>
         </StyledMenuVersionFooter>
       )}
-    </StyledMenuContainer>
+    </StyledMenuPopoverContent>
   )
 }
 

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -50,8 +50,9 @@ export const StyledMenuDivider = styled.div(({ theme }) => ({
 
 /**
  * Outermost wrapper for the popover body (menu + optional footer).
- * Owns all outer padding so neither StyledMenuContainer nor
- * StyledMenuVersionFooter need to duplicate it.
+ * Owns outer padding; the footer adds its own horizontal padding
+ * so its content width contributes to the popover's intrinsic width
+ * (matching the develop-branch layout where it was inside the container).
  */
 export const StyledMenuPopoverContent = styled.div(({ theme }) => ({
   padding: theme.spacing.sm,
@@ -323,7 +324,10 @@ export const StyledToggleKnob = styled.div<StyledToggleProps>(
  * Keyboard users reach the CopyButton via Tab; focus-lock keeps
  * focus within the popover.
  */
-export const StyledMenuVersionFooter = styled.div({})
+export const StyledMenuVersionFooter = styled.div(({ theme }) => ({
+  paddingLeft: theme.spacing.sm,
+  paddingRight: theme.spacing.sm,
+}))
 
 /**
  * Flex row for version text + copy button.
@@ -358,5 +362,4 @@ export const StyledMenuVersionText = styled.span(({ theme }) => ({
   lineHeight: theme.lineHeights.menuItem,
   color: theme.colors.bodyText,
   whiteSpace: "nowrap",
-  paddingLeft: theme.spacing.sm,
 }))

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -342,15 +342,13 @@ export const StyledMenuVersionRow = styled.div(({ theme }) => ({
   ".stMenuVersionCopyButton": {
     opacity: 0,
     pointerEvents: "none",
-    transform: "scale(0.9)",
-    transition: "opacity 120ms ease, transform 120ms ease",
+    transition: "opacity 120ms ease",
   },
 
   "&:hover .stMenuVersionCopyButton, &:focus-within .stMenuVersionCopyButton":
     {
       opacity: 1,
       pointerEvents: "auto",
-      transform: "scale(1)",
     },
 }))
 

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -55,6 +55,7 @@ export const StyledMenuDivider = styled.div(({ theme }) => ({
  */
 export const StyledMenuPopoverContent = styled.div(({ theme }) => ({
   padding: theme.spacing.sm,
+  minWidth: theme.sizes.appMainMenu,
 
   "@media print": {
     display: "none",
@@ -66,7 +67,6 @@ export const StyledMenuContainer = styled.div(({ theme }) => ({
   flexDirection: "column",
   alignItems: "stretch",
   gap: theme.spacing.xs,
-  minWidth: theme.sizes.appMainMenu,
 }))
 
 export const StyledMainMenuContainer = styled.span({
@@ -333,7 +333,7 @@ export const StyledMenuVersionRow = styled.div(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   gap: theme.spacing.sm,
-  marginTop: theme.spacing.twoXS,
+  marginTop: theme.spacing.xs,
 
   ".stMenuVersionCopyButton": {
     opacity: 0,

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -48,17 +48,25 @@ export const StyledMenuDivider = styled.div(({ theme }) => ({
   width: "100%",
 }))
 
+/**
+ * Outermost wrapper for the popover body (menu + optional footer).
+ * Owns all outer padding so neither StyledMenuContainer nor
+ * StyledMenuVersionFooter need to duplicate it.
+ */
+export const StyledMenuPopoverContent = styled.div(({ theme }) => ({
+  padding: theme.spacing.sm,
+
+  "@media print": {
+    display: "none",
+  },
+}))
+
 export const StyledMenuContainer = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   alignItems: "stretch",
   gap: theme.spacing.xs,
   minWidth: theme.sizes.appMainMenu,
-  padding: theme.spacing.sm,
-
-  "@media print": {
-    display: "none",
-  },
 }))
 
 export const StyledMainMenuContainer = styled.span({
@@ -309,14 +317,13 @@ export const StyledToggleKnob = styled.div<StyledToggleProps>(
 )
 
 /**
- * Footer container for the version string inside the menu.
- * A plain wrapper with no semantic role — screen readers will
- * naturally discover the focusable CopyButton within it.
+ * Footer container for the version string.
+ * Lives outside the role="menu" container (as a sibling within the
+ * popover) so the CopyButton is not an invalid child of role="menu".
+ * Keyboard users reach the CopyButton via Tab; focus-lock keeps
+ * focus within the popover.
  */
-export const StyledMenuVersionFooter = styled.div(({ theme }) => ({
-  paddingLeft: theme.spacing.sm,
-  paddingRight: theme.spacing.sm,
-}))
+export const StyledMenuVersionFooter = styled.div({})
 
 /**
  * Flex row for version text + copy button.
@@ -326,6 +333,7 @@ export const StyledMenuVersionRow = styled.div(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   gap: theme.spacing.sm,
+  marginTop: theme.spacing.twoXS,
 
   ".stMenuVersionCopyButton": {
     opacity: 0,
@@ -342,9 +350,6 @@ export const StyledMenuVersionRow = styled.div(({ theme }) => ({
     },
 }))
 
-/**
- * Muted version text that matches the Settings dialog style.
- */
 export const StyledMenuVersionText = styled.span(({ theme }) => ({
   display: "inline-flex",
   alignItems: "center",
@@ -353,4 +358,5 @@ export const StyledMenuVersionText = styled.span(({ theme }) => ({
   lineHeight: theme.lineHeights.menuItem,
   color: theme.colors.bodyText,
   whiteSpace: "nowrap",
+  paddingLeft: theme.spacing.sm,
 }))


### PR DESCRIPTION
## Describe your changes
Improves accessibility and layout of the version copy button in the `MainMenu` footer.

- **Move version footer outside `role="menu"`**: The `StyledMenuVersionFooter` (containing the `CopyButton`) is now a sibling of `StyledMenuContainer` rather than a child. This fixes a WAI-ARIA violation where an interactive button was nested inside `role="menu"` without being a `menuitem`. A new `StyledMenuPopoverContent` wrapper owns the outer padding and `minWidth` for both the menu and footer.
- **Keyboard navigation for the footer CopyButton**: Tab from the last menu item moves focus to the `CopyButton` (via focus-lock), then a second Tab closes the popover. Escape from the `CopyButton` also closes the popover. Shift+Tab returns focus to the menu.
- **Remove hover jitter on copy button**: Removed the `transform: scale(0.9)` → `scale(1)` transition that caused visual jitter on hover. The button now fades in with a clean opacity transition only.

## Testing Plan
- JS Unit Tests: ✅ Added 
- E2E Tests: ✅ Updated
- Manual Testing: ✅ 