### PR TITLE
[refactor] Log widget state duplication warning to console instead of UI

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -390,7 +390,7 @@ _create_section("global", "Global options that apply across all of Streamlit.")
 _create_option(
     "global.disableWidgetStateDuplicationWarning",
     description="""
-        By default, Streamlit displays a warning when a user sets both a widget
+        By default, Streamlit logs a warning when a user sets both a widget
         default value in the function defining the widget and a widget value via
         the widget's key in `st.session_state`.
 

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -63,13 +63,13 @@ def check_session_state_rules(
     """Ensures that no values are set for widgets with the given key when writing
     is not allowed.
 
-    Additionally, if `global.disableWidgetStateDuplicationWarning` is False a warning is
-    shown when a widget has a default value but its value is also set via session state.
+    Additionally, if `global.disableWidgetStateDuplicationWarning` is False, logs a
+    warning when a widget has a default value but its value is also set via session state.
 
     Raises
     ------
-    StreamlitAPIException:
-        Raised when the described rule is violated.
+    StreamlitValueAssignmentNotAllowedError:
+        Raised when writing is not allowed but session state contains a new value.
     """
     global _shown_default_value_warning  # noqa: PLW0603
 
@@ -88,11 +88,11 @@ def check_session_state_rules(
         and not _shown_default_value_warning
         and not config.get_option("global.disableWidgetStateDuplicationWarning")
     ):
-        from streamlit import warning
-
-        warning(
-            f'The widget with key "{key}" was created with a default value but'
-            " also had its value set via the Session State API."
+        _LOGGER.warning(
+            'The widget with key "%s" was created with a default value but also had '
+            "its value set via the Session State API.",
+            key,
+            stack_info=True,
         )
         _shown_default_value_warning = True
 

--- a/lib/tests/streamlit/elements/element_policies_test.py
+++ b/lib/tests/streamlit/elements/element_policies_test.py
@@ -21,7 +21,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from streamlit import config
-from streamlit.elements.lib import utils
 from streamlit.elements.lib.policies import (
     check_cache_replay_rules,
     check_callback_rules,
@@ -63,17 +62,17 @@ class CheckCallbackRulesTest(ElementPoliciesTest):
 
 
 class CheckSessionStateRules(ElementPoliciesTest):
-    @patch("streamlit.warning")
-    def test_check_session_state_rules_no_key(self, patched_st_warning):
+    @patch("streamlit.elements.lib.policies._LOGGER")
+    def test_check_session_state_rules_no_key(self, patched_logger):
         check_session_state_rules(5, key=None)
 
-        patched_st_warning.assert_not_called()
+        patched_logger.warning.assert_not_called()
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.lib.policies.get_session_state")
-    @patch("streamlit.warning")
+    @patch("streamlit.elements.lib.policies._LOGGER")
     def test_check_session_state_rules_no_val(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_logger, patched_get_session_state
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True
@@ -81,13 +80,13 @@ class CheckSessionStateRules(ElementPoliciesTest):
 
         check_session_state_rules(None, key=_KEY)
 
-        patched_st_warning.assert_not_called()
+        patched_logger.warning.assert_not_called()
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.lib.policies.get_session_state")
-    @patch("streamlit.warning")
+    @patch("streamlit.elements.lib.policies._LOGGER")
     def test_check_session_state_rules_no_state_val(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_logger, patched_get_session_state
     ):
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = False
@@ -95,13 +94,13 @@ class CheckSessionStateRules(ElementPoliciesTest):
 
         check_session_state_rules(5, key=_KEY)
 
-        patched_st_warning.assert_not_called()
+        patched_logger.warning.assert_not_called()
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.lib.policies.get_session_state")
-    @patch("streamlit.warning")
+    @patch("streamlit.elements.lib.policies._LOGGER")
     def test_check_session_state_rules_hide_warning_if_state_duplication_disabled(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_logger, patched_get_session_state
     ):
         config._set_option("global.disableWidgetStateDuplicationWarning", True, "test")
 
@@ -111,7 +110,7 @@ class CheckSessionStateRules(ElementPoliciesTest):
 
         check_session_state_rules(5, key=_KEY)
 
-        patched_st_warning.assert_not_called()
+        patched_logger.warning.assert_not_called()
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.lib.policies.get_session_state")
@@ -156,22 +155,26 @@ class SpecialSessionStatesTest(ElementPoliciesTest):
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.lib.policies.get_session_state")
-    @patch("streamlit.warning")
+    @patch("streamlit.elements.lib.policies._LOGGER")
     def test_check_session_state_rules_prints_warning(
-        self, patched_st_warning, patched_get_session_state
+        self, patched_logger, patched_get_session_state
     ):
+        import streamlit.elements.lib.policies as policies_module
+
         mock_session_state = MagicMock()
         mock_session_state.is_new_state_value.return_value = True
         patched_get_session_state.return_value = mock_session_state
-        # Reset globale flag:
-        utils._shown_default_value_warning = False
+        # Reset global flag:
+        policies_module._shown_default_value_warning = False
 
         check_session_state_rules(5, key=_KEY)
 
-        patched_st_warning.assert_called_once()
-        args, _ = patched_st_warning.call_args
+        patched_logger.warning.assert_called_once()
+        args, kwargs = patched_logger.warning.call_args
         warning_msg = args[0]
-        assert 'The widget with key "the key"' in warning_msg
+        assert 'The widget with key "%s"' in warning_msg
+        assert args[1] == _KEY
+        assert kwargs.get("stack_info") is True
 
 
 class CheckCacheReplayTest(ElementPoliciesTest):


### PR DESCRIPTION
## Describe your changes

Changes widget state duplication warning from `st.warning()` (UI display) to `_LOGGER.warning()` (console output), reducing visual noise while still informing developers.

- Warning now logs to console instead of showing in app UI
- Added `stack_info=True` for better debugging (shows where warning originates)

## Testing Plan

- [x] Unit Tests (Python)
