### PR TITLE
[chore] Wire up check_widget_policies correctly in dynamic containers

### DIFF
--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -819,13 +819,14 @@ class LayoutsMixin:
         current_tab_label = tabs[default_index]
 
         if is_stateful:
+            is_callback = callable(on_change)
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=on_change if callable(on_change) else None,
+                on_change=cast("WidgetCallback", on_change) if is_callback else None,
                 default_value=None,
                 writes_allowed=True,
-                enable_check_callback_rules=callable(on_change),
+                enable_check_callback_rules=is_callback,
             )
 
             ctx = get_script_run_ctx()
@@ -1070,13 +1071,14 @@ class LayoutsMixin:
         element_id: str | None = None
 
         if is_stateful:
+            is_callback = callable(on_change)
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=on_change if callable(on_change) else None,
+                on_change=cast("WidgetCallback", on_change) if is_callback else None,
                 default_value=None,
                 writes_allowed=True,
-                enable_check_callback_rules=callable(on_change),
+                enable_check_callback_rules=is_callback,
             )
 
             ctx = get_script_run_ctx()
@@ -1370,13 +1372,14 @@ class LayoutsMixin:
         element_id: str | None = None
 
         if is_stateful:
+            is_callback = callable(on_change)
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=on_change if callable(on_change) else None,
+                on_change=cast("WidgetCallback", on_change) if is_callback else None,
                 default_value=None,
                 writes_allowed=True,
-                enable_check_callback_rules=callable(on_change),
+                enable_check_callback_rules=is_callback,
             )
 
             ctx = get_script_run_ctx()

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -584,7 +584,6 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander = st.expander("label", on_change="ignore")
         assert expander.open is None
 
-
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_callable_on_change_inside_form_raises(self) -> None:
         """Test that a callable on_change inside st.form raises StreamlitInvalidFormCallbackError."""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import Literal
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from parameterized import parameterized
@@ -24,6 +24,7 @@ from streamlit.errors import (
     FragmentHandledException,
     StreamlitAPIException,
     StreamlitInvalidColumnGapError,
+    StreamlitInvalidFormCallbackError,
     StreamlitInvalidHorizontalAlignmentError,
     StreamlitInvalidVerticalAlignmentError,
 )
@@ -582,6 +583,20 @@ class ExpanderTest(DeltaGeneratorTestCase):
         """Test that on_change='ignore' still works after callback support."""
         expander = st.expander("label", on_change="ignore")
         assert expander.open is None
+
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_callable_on_change_inside_form_raises(self) -> None:
+        """Test that a callable on_change inside st.form raises StreamlitInvalidFormCallbackError."""
+        with pytest.raises(StreamlitInvalidFormCallbackError):
+            with st.form("form"):
+                st.expander("label", on_change=lambda: None)
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_on_change_rerun_inside_form_does_not_raise(self) -> None:
+        """Test that on_change='rerun' inside st.form does not raise (not a callback)."""
+        with st.form("form"):
+            st.expander("label", on_change="rerun")
 
 
 class ContainerTest(DeltaGeneratorTestCase):
@@ -1148,6 +1163,19 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException):
             st.popover("label", on_change=123)  # type: ignore[arg-type]
 
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_callable_on_change_inside_form_raises(self) -> None:
+        """Test that a callable on_change inside st.form raises StreamlitInvalidFormCallbackError."""
+        with pytest.raises(StreamlitInvalidFormCallbackError):
+            with st.form("form"):
+                st.popover("label", on_change=lambda: None)
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_on_change_rerun_inside_form_does_not_raise(self) -> None:
+        """Test that on_change='rerun' inside st.form does not raise (not a callback)."""
+        with st.form("form"):
+            st.popover("label", on_change="rerun")
+
 
 class StatusContainerTest(DeltaGeneratorTestCase):
     def test_label_required(self):
@@ -1566,6 +1594,19 @@ class TabsTest(DeltaGeneratorTestCase):
         tabs = st.tabs(["A", "B"], on_change=None)
         for tab in tabs:
             assert tab.open is None
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_callable_on_change_inside_form_raises(self) -> None:
+        """Test that a callable on_change inside st.form raises StreamlitInvalidFormCallbackError."""
+        with pytest.raises(StreamlitInvalidFormCallbackError):
+            with st.form("form"):
+                st.tabs(["A", "B"], on_change=lambda: None)
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_on_change_rerun_inside_form_does_not_raise(self) -> None:
+        """Test that on_change='rerun' inside st.form does not raise (not a callback)."""
+        with st.form("form"):
+            st.tabs(["A", "B"], on_change="rerun")
 
 
 class DialogTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

The partial change that landed with callable `on_change` support used `callable(on_change)` inline in the `check_widget_policies` call for all three dynamic containers, but without the `is_callback` intermediate variable or `cast`. This aligns all three with the established pattern from `vega_charts.py`:

- Extracts `is_callback = callable(on_change)` as a named variable for clarity
- Passes `on_change=cast("WidgetCallback", on_change) if is_callback else None` for type correctness
- `enable_check_callback_rules=is_callback` (functionally equivalent, but consistent with the pattern)

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

Surfaced in review of #13910.

## Testing Plan

- [x] Python unit tests — added 6 regression tests to `lib/tests/streamlit/elements/layouts_test.py`, covering all three containers:
  - `test_callable_on_change_inside_form_raises` — verifies a callable `on_change` inside `st.form` raises `StreamlitInvalidFormCallbackError` (expander, tabs, popover)
  - `test_on_change_rerun_inside_form_does_not_raise` — verifies `on_change="rerun"` inside `st.form` is still allowed (expander, tabs, popover)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.