### PR TITLE
feat(skills): add external-test risk assessment and review integration

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -27,6 +27,7 @@ skills/*
 !skills/understanding-streamlit-architecture/
 !skills/creating-pull-requests/
 !skills/updating-internal-docs/
+!skills/assessing-external-test-risk/
 
 # Allow agents
 !agents/

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -4,6 +4,8 @@ description: Review the current branch's changes for code quality, test coverage
 model: inherit
 readonly: true
 disallowedTools: Write, Edit
+skills:
+  - assessing-external-test-risk
 memory: local
 ---
 
@@ -61,6 +63,7 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
   - `lib/streamlit/AGENTS.md` — for any Python library changes (inside `lib/streamlit/`)
   - `proto/streamlit/proto/AGENTS.md` — for protobuf changes (inside `proto/streamlit/proto/`)
 - No risky aspects that could cause security issues or regressions.
+- External-test risk is explicitly assessed using `/assessing-external-test-risk`, and the review includes a clear `external_test` recommendation.
 - Frontend changes follow accessibility best practices.
 - The code follows other best practices from the Streamlit code base.
 
@@ -70,8 +73,9 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
 2. Gather relevant context (branch diff, PR details if available).
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
-5. Perform a thorough code review based on the checklist above.
-6. Write your review following the output format below.
+5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
+6. Perform a thorough code review based on the checklist above.
+7. Write your review following the output format below.
 
 ## Output Format
 
@@ -97,6 +101,10 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 ## Security & Risk
 
 [Any security concerns or regression risks identified.]
+
+## External test recommendation
+
+[State `external_test` recommendation (Yes/No), triggered categories (or "None"), key evidence from changed files, suggested external test focus areas, and confidence plus assumptions/gaps.]
 
 ## Accessibility
 

--- a/.claude/skills/assessing-external-test-risk/SKILL.md
+++ b/.claude/skills/assessing-external-test-risk/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: assessing-external-test-risk
+description: Assesses whether branch or PR changes are high-risk for externally hosted or embedded Streamlit usage and recommends whether external e2e coverage with `@pytest.mark.external_test` is needed. Use during code review, PR triage, or test planning when changes touch routing, auth, websocket/session behavior, embedding, assets, cross-origin behavior, SiS/Snowflake runtime, storage, or security headers.
+---
+
+# Assessing external test risk
+
+Use this skill to decide whether a branch or PR should include external e2e coverage using `@pytest.mark.external_test`.
+
+This helps protect deployments that commonly involve proxies, embedded iframe contexts, CSP constraints, and other browser security boundaries.
+
+This skill is for **risk assessment and recommendation**. It does not auto-mark tests unless explicitly requested.
+
+## Decision rule
+
+Use an **any-hit** policy:
+
+- If any checklist category is hit, output **Recommend external_test: Yes**
+- If no categories are hit, output **Recommend external_test: No**
+
+## Inputs to review
+
+- Branch or PR diff against its base branch
+- Changed files and related tests
+- PR description (if available)
+
+## Assessment workflow
+
+1. Gather the changed files and full diff against the base branch.
+2. Evaluate each checklist category below as hit or not hit.
+3. Record concrete evidence from file paths and diff snippets.
+4. Produce a recommendation and specific external-test focus areas.
+
+## Checklist categories
+
+Evaluate all categories. A single hit is enough to recommend external coverage.
+
+1. **Routing and URL behavior**
+   - Hit when changes introduce or modify Tornado or Starlette routes, `server.baseUrlPath`, catch-alls, request methods, URL resolution, redirects, or status codes.
+
+2. **Auth, cookies, CSRF, and identity binding**
+   - Hit when changes touch login/logout or OAuth flows, `_streamlit_user`, `_streamlit_xsrf`, CSRF/XSRF handling, `server.trustedUserHeaders`, or session-to-identity binding.
+
+3. **Websocket handshake and session transport**
+   - Hit when changes affect websocket handshake or subprotocols, session affinity, reconnect behavior, ping or timeout behavior, message size limits, or fragmentation.
+
+4. **Embedding and iframe boundary**
+   - Hit when changes modify host-to-guest communication (`postMessage`), iframe sizing or resize behavior, iframe sandbox or allow attributes, or permissions policy behavior in embedded contexts.
+
+5. **Static and component asset serving**
+   - Hit when changes alter asset handlers, cache headers, size limits, base paths (including `server.customComponentBaseUrlPath`), or proxying rules for static/component assets.
+
+6. **Service worker, uploads, and downloads**
+   - Hit when changes modify service worker registration, scope, or caching strategy; upload/download endpoints; JWT or CSRF wrapping; or download attribute behavior.
+
+7. **Cross-origin behavior and external networking**
+   - Hit when changes alter CORS allowlists, `crossOrigin` usage, external-origin fetches or external networks behavior, or backend URL discovery via `window.__streamlit.*`.
+
+8. **Cross-origin theming and resource discovery**
+   - Hit when changes introduce or modify theme/resource loading across origins (fonts, images, theme globals), CSS isolation with host pages, or manifest/asset discovery when HTML is not served by Tornado or Starlette.
+
+9. **SiS and Snowflake runtime dependencies**
+   - Hit when changes rely on or modify SiS/Snowflake runtime behavior, including `running_in_sis()`, `get_active_session()`, Snowflake connection/session semantics, or SiS-specific environment flags.
+
+10. **Client storage behavior**
+    - Hit when changes introduce or modify cookies, `localStorage`, or `sessionStorage` usage that may differ in embedded or third-party contexts.
+
+11. **Security headers and browser policies**
+    - Hit when changes adjust CSP, Referrer-Policy, Permissions-Policy, or related headers that can impact embedding or resource loading.
+
+## Output format
+
+Use this exact structure:
+
+```markdown
+## External test recommendation
+
+- Recommend external_test: [Yes/No]
+- Triggered categories: [List category numbers and names, or "None"]
+- Evidence:
+  - `<path>`: [short reason from diff]
+  - `<path>`: [short reason from diff]
+- Suggested external_test focus areas:
+  - [Concrete scenario to validate externally]
+  - [Concrete scenario to validate externally]
+- Confidence: [High/Medium/Low]
+- Assumptions and gaps: [Unknowns, missing context, or why confidence is reduced]
+```
+
+## Interpretation guidance
+
+- Prefer evidence over intuition. Tie each hit to concrete diff details.
+- When in doubt, err toward **Yes** if externally hosted or embedded behavior could diverge from local runs.
+- Keep focus areas specific and testable (route, auth handshake, iframe boundary, asset loading, SiS runtime behavior).
+
+## Examples
+
+### Example yes recommendation
+
+Diff includes:
+
+- `lib/streamlit/web/server/routes.py` route changes
+- Cookie/XSRF handling updates in request auth middleware
+- Frontend embed code changing iframe `allow` attributes
+
+Expected output:
+
+- `Recommend external_test: Yes`
+- Triggered categories include routing, auth/cookies/CSRF, and embedding boundary
+- Focus areas include external host iframe embedding + auth/session continuity checks
+
+### Example no recommendation
+
+Diff includes:
+
+- Pure refactor in internal utility functions with no network, auth, embedding, storage, or runtime integration impact
+- Docs and test name cleanup only
+
+Expected output:
+
+- `Recommend external_test: No`
+- Triggered categories: `None`
+- Confidence is high if no indirect integration points are touched

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | Skill | When to use |
 |-------|-------------|
 | `checking-changes` | After making backend or frontend changes, before committing |
+| `assessing-external-test-risk` | When reviewing branch or PR changes to decide whether `@pytest.mark.external_test` coverage is needed for externally hosted or embedded scenarios |
 | `debugging-streamlit` | When testing code changes, investigating bugs, or checking UI behavior |
 | `discovering-make-commands` | To list available `make` commands for build, test, lint, or format tasks |
 | `fixing-streamlit-ci` | When CI checks fail and you need to diagnose and fix errors |

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -9,6 +9,7 @@
   - `lib/streamlit/AGENTS.md` — for any Python library changes (inside `lib/streamlit/`)
   - `proto/streamlit/proto/AGENTS.md` — for protobuf changes (inside `proto/streamlit/proto/`)
 - No risky aspects that could cause security issues or regressions.
+- External-test risk is explicitly assessed using `/assessing-external-test-risk`, and the review includes a clear `external_test` recommendation.
 - Frontend changes follow accessibility best practices.
 - The code follows other best practices from the Streamlit code base.
 
@@ -18,8 +19,9 @@
 2. Gather relevant context (branch diff, PR details if available).
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
-5. Perform a thorough code review based on the checklist above.
-6. Write your review following the output format below.
+5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
+6. Perform a thorough code review based on the checklist above.
+7. Write your review following the output format below.
 
 ## Output Format
 
@@ -45,6 +47,10 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 ## Security & Risk
 
 [Any security concerns or regression risks identified.]
+
+## External test recommendation
+
+[State `external_test` recommendation (Yes/No), triggered categories (or "None"), key evidence from changed files, suggested external test focus areas, and confidence plus assumptions/gaps.]
 
 ## Accessibility
 


### PR DESCRIPTION
## Describe your changes

This PR adds a new skill `assessing-external-test-risk` to help determine when changes require external end-to-end test coverage using `@pytest.mark.external_test`. The skill evaluates 11 risk categories including routing, authentication, websockets, embedding, asset serving, and cross-origin behavior to recommend whether external testing is needed for externally hosted or embedded Streamlit scenarios.

The `reviewing-local-changes` agent now incorporates this skill into its workflow, requiring an explicit external test risk assessment and recommendation in all code reviews.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Explanation of why no additional tests are needed**: This change adds tooling for the development workflow rather than runtime functionality. The skill provides structured guidance for risk assessment during code review.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.