### PR TITLE
feat: add border radius rounding to st.video and st.map

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -40,6 +40,7 @@ import { assertNever } from "~lib/util/assertNever"
 import { MapBoxCss } from "./MapBoxCss"
 import {
   StyledDeckGlChart,
+  StyledDeckGlMapContent,
   StyledNavigationControlContainer,
 } from "./styled-components"
 import type { DeckGlElementState, DeckGLProps } from "./types"
@@ -216,7 +217,6 @@ export const DeckGlJsonChart: FC<DeckGLProps> = props => {
       data-testid="stDeckGlJsonChart"
       isStretchHeight={isStretchHeight}
     >
-      {usesMapbox ? <MapBoxCss /> : null}
       <Toolbar
         isFullScreen={isFullScreen}
         disableFullscreenMode={disableFullscreenMode}
@@ -233,38 +233,41 @@ export const DeckGlJsonChart: FC<DeckGLProps> = props => {
           />
         )}
       </Toolbar>
-      {/* Only render the DeckGL component if the viewState is not null,
-      or else we'll get a runtime assertion error from deck.gl and the map will not render. */}
-      {viewState && (
-        <DeckGL
-          viewState={viewState}
-          onViewStateChange={onViewStateChange}
-          layers={isInitialized ? deck.layers : EMPTY_LAYERS}
-          getTooltip={createTooltip}
-          // @ts-expect-error There is a type mismatch due to our versions of the libraries
-          ContextProvider={MapContext.Provider}
-          controller
-          onClick={
-            isSelectionModeActivated && !disabled ? handleClick : undefined
-          }
-        >
-          <StaticMap
-            mapStyle={
-              deck.mapStyle &&
-              (typeof deck.mapStyle === "string"
-                ? deck.mapStyle
-                : deck.mapStyle[0])
+      <StyledDeckGlMapContent>
+        {usesMapbox ? <MapBoxCss /> : null}
+        {/* Only render the DeckGL component if the viewState is not null,
+        or else we'll get a runtime assertion error from deck.gl and the map will not render. */}
+        {viewState && (
+          <DeckGL
+            viewState={viewState}
+            onViewStateChange={onViewStateChange}
+            layers={isInitialized ? deck.layers : EMPTY_LAYERS}
+            getTooltip={createTooltip}
+            // @ts-expect-error There is a type mismatch due to our versions of the libraries
+            ContextProvider={MapContext.Provider}
+            controller
+            onClick={
+              isSelectionModeActivated && !disabled ? handleClick : undefined
             }
-            mapboxApiAccessToken={mapboxToken}
-          />
-          <StyledNavigationControlContainer>
-            <NavigationControl
-              data-testid="stDeckGlJsonChartZoomButton"
-              showCompass={false}
+          >
+            <StaticMap
+              mapStyle={
+                deck.mapStyle &&
+                (typeof deck.mapStyle === "string"
+                  ? deck.mapStyle
+                  : deck.mapStyle[0])
+              }
+              mapboxApiAccessToken={mapboxToken}
             />
-          </StyledNavigationControlContainer>
-        </DeckGL>
-      )}
+            <StyledNavigationControlContainer>
+              <NavigationControl
+                data-testid="stDeckGlJsonChartZoomButton"
+                showCompass={false}
+              />
+            </StyledNavigationControlContainer>
+          </DeckGL>
+        )}
+      </StyledDeckGlMapContent>
     </StyledDeckGlChart>
   )
 }

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -32,6 +32,13 @@ export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
   })
 )
 
+export const StyledDeckGlMapContent = styled.div(({ theme }) => ({
+  width: "100%",
+  height: "100%",
+  borderRadius: theme.radii.default,
+  overflow: "hidden",
+}))
+
 export const StyledNavigationControlContainer = styled.div(({ theme }) => ({
   position: "absolute",
   right: "2.625rem",

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -33,7 +33,6 @@ export interface VideoProps {
   elementMgr: ElementStateManager
 }
 
-const VIDEO_STYLE = { width: "100%" }
 
 function Video({
   element,
@@ -247,8 +246,7 @@ function Video({
   }
 
   return (
-    // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -256,7 +254,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -272,7 +269,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -23,4 +23,10 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: theme.radii.default,
+}))
+
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: theme.radii.default,
 }))


### PR DESCRIPTION
## Description

Add `theme.radii.default` rounding to the Video and DeckGlJsonChart (`st.map`/`st.pydeck_chart`) components for a more consistent look with the rest of Streamlit's UI elements.

### Changes

- **Video**: Created a new `StyledVideo` styled component with `borderRadius: theme.radii.default`, replacing the inline `style={{ width: '100%' }}` on the `<video>` element. Also added `borderRadius` to `StyledVideoIframe` for YouTube embeds.
- **DeckGlJsonChart**: Added `borderRadius: theme.radii.default` and `overflow: 'hidden'` to the `StyledDeckGlChart` wrapper to round the map container.

The `overflow: hidden` on the map ensures map tiles don't render outside the rounded corners. Since the navigation controls are positioned with `position: absolute` inside the container, they remain accessible and unaffected by the rounding.

**Applicable Streamlit issue:** Fixes #12806

**Contribution type:** improvement to an existing Streamlit feature