### PR TITLE
Fix file uploader JPG/JPEG display redundancy

### DIFF
--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.test.tsx
@@ -143,5 +143,33 @@ describe("FileDropzoneInstructions widget", () => {
     expect(
       screen.getByText(/• image, application\/pdf, JSON/)
     ).toBeInTheDocument()
+  it("deduplicates JPG and JPEG extensions, showing only JPG", () => {
+    const props = getProps({
+      acceptedTypes: [".jpg", ".jpeg", ".png"],
+    })
+    render(<FileDropzoneInstructions {...props} />)
+
+    expect(screen.getByText(/• JPG, PNG/)).toBeInTheDocument()
+    expect(screen.queryByText(/JPEG/)).not.toBeInTheDocument()
+  })
+
+  it("shows JPEG when only JPEG is provided", () => {
+    const props = getProps({
+      acceptedTypes: [".jpeg"],
+    })
+    render(<FileDropzoneInstructions {...props} />)
+
+    expect(screen.getByText(/• JPEG/)).toBeInTheDocument()
+  })
+
+  it("shows JPG when only JPG is provided", () => {
+    const props = getProps({
+      acceptedTypes: [".jpg"],
+    })
+    render(<FileDropzoneInstructions {...props} />)
+
+    expect(screen.getByText(/• JPG/)).toBeInTheDocument()
+  })
+
   })
 })

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzoneInstructions.tsx
@@ -58,7 +58,17 @@ const FileDropzoneInstructions = ({
 
   const getFileTypeInfo = (): string | null => {
     if (acceptedTypes.length) {
-      return ` • ${formatTypesForDisplay(acceptedTypes)}`
+      // Remove duplicate display of JPG/JPEG - show only JPG
+      const formatted = acceptedTypes.map(t => {
+        if (t.endsWith("/*")) return t.slice(0, -2)
+        if (t.includes("/")) return t
+        return t.replace(/^\./, "").toUpperCase()
+      })
+      const deduplicated = formatted.filter((ext, _index, arr) => {
+        if (ext === "JPEG" && arr.includes("JPG")) return false
+        return true
+      })
+      return ` • ${deduplicated.join(", ")}`
     }
     return null
   }


### PR DESCRIPTION
Fixes issue #11991 where st.file_uploader shows both JPG and JPEG extensions redundantly in the UI.

Changes Made:
- Modified FileDropzoneInstructions.tsx to deduplicate JPG/JPEG extensions display
- When both JPG and JPEG are present, only show JPG in the UI
- Added test cases for the deduplication logic

Fixes #11991