### PR TITLE
test(e2e): expand mega tester coverage

### DIFF
--- a/e2e_playwright/mega_tester_app.py
+++ b/e2e_playwright/mega_tester_app.py
@@ -14,168 +14,880 @@
 
 from __future__ import annotations
 
-import random
-import time
+import importlib.util
+import re
+import sys
+from datetime import date, datetime, time
 from pathlib import Path
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
-import altair as alt
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import plotly.express as px
-import pydeck as pdk
 
 import streamlit as st
+import streamlit.components.v1 as components
 
-STATIC_DIR = Path(__file__).parent / "static"
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-np.random.seed(42)
-random.seed(42)
+    from streamlit.elements.widgets.chat import ChatInputValue
+    from streamlit.navigation.page import StreamlitPage
 
-LOREM = (
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor "
-    "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation "
-    "ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit "
-    "in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
-    "non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-)
+_DUMMY_PDF = (
+    "%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n"
+    "2 0 obj\n<<\n/Type /Pages\n/Kids [3 0 R]\n/Count 1\n>>\nendobj\n"
+    "3 0 obj\n<<\n/Type /Page\n/Parent 2 0 R\n/MediaBox [0 0 612 792]\n"
+    "/Contents 4 0 R\n/Resources <<\n/Font <<\n/F1 5 0 R\n>>\n>>\n>>\nendobj\n"
+    "4 0 obj\n<<\n/Length 44\n>>\nstream\nBT\n/F1 12 Tf\n100 700 Td\n"
+    "(Hello PDF World!) Tj\nET\nendstream\nendobj\n"
+    "5 0 obj\n<<\n/Type /Font\n/Subtype /Type1\n/BaseFont /Helvetica\n>>\nendobj\n"
+    "xref\n0 6\n0000000000 65535 f\n0000000009 00000 n\n0000000058 00000 n\n"
+    "0000000115 00000 n\n0000000274 00000 n\n0000000373 00000 n\ntrailer\n"
+    "<<\n/Size 6\n/Root 1 0 R\n>>\nstartxref\n446\n%%EOF"
+).encode("latin-1")
+
+_MAGIC_COW = """\
+ ______________
+< Abracowdabra! >
+ --------------
+        \\   ^__^
+         \\  (oo)\\_______
+            (__)\\       )\\/\\
+                ||----w |
+                ||     ||
+"""
+
+_STATIC_DIR = Path(__file__).resolve().parent / "static"
 
 
-def generate_sparkline_data(
+def _minor_version() -> int:
+    match = re.match(r"^\d+\.(\d+)", st.__version__)
+    if match is None:
+        raise RuntimeError(f"Unable to parse Streamlit version: {st.__version__}")
+    return int(match.group(1))
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def _stream_chunks() -> Generator[str | pd.DataFrame, None, None]:
+    yield "lorem "
+    yield "ipsum "
+    yield pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    yield "dolor sit amet"
+
+
+def _generate_sparkline_data(
     length: int = 15, drift: float = 0.05, volatility: float = 10
 ) -> list[float]:
-    random_changes = np.random.normal(loc=drift, scale=volatility, size=length)
-    initial_value = np.random.normal(loc=50, scale=5)
+    random_changes = np.random.default_rng(31).normal(
+        loc=drift, scale=volatility, size=length
+    )
+    initial_value = np.random.default_rng(32).normal(loc=50, scale=5)
     data = initial_value + np.cumsum(random_changes)
     return cast("list[float]", data.tolist())
 
 
-# Add disable toggle in sidebar
-with st.sidebar:
-    help_text = "Tooltip text" if st.toggle("Show tooltips", True) else None
-    disabled = st.toggle("Disable widgets", False)
-    nav_sections = st.toggle("Page sections", True)
-    many_pages = st.toggle("Many pages", False)
-    top_nav = st.toggle("Top navigation", False)
-    wide_mode = st.toggle("Wide mode", False)
-    st.divider()
+def _render_sidebar_controls() -> tuple[str | None, bool]:
+    with st.sidebar:
+        st.subheader("Mega tester controls")
+        show_tooltips = st.toggle("Show tooltips", True, key="show_tooltips")
+        disabled = st.toggle("Disable widgets", False, key="disable_widgets")
+        st.toggle("Wide mode", True, key="wide_mode")
+        st.toggle("Navigation sections", True, key="nav_sections")
+        st.toggle("Many pages", False, key="many_pages")
+        st.toggle("Show more chart lines", False, key="more_lines")
+        st.toggle("Horizontal bars", False, key="horizontal_bars")
+        st.toggle("Range sliders", False, key="range_sliders")
+        st.toggle("Show chat input at bottom", False, key="chat_input_bottom")
+        st.divider()
+        st.write("Sidebar widgets")
+        st.selectbox(
+            "Sidebar animal",
+            ["cat", "dog", "bird"],
+            key="sidebar_selectbox",
+            disabled=disabled,
+        )
+        st.button("Sidebar button", key="sidebar_button", disabled=disabled)
+        st.checkbox(
+            "Sidebar choice",
+            key="sidebar_checkbox",
+            disabled=disabled,
+        )
+        with st.expander("Sidebar expander"):
+            st.write("Sidebar expander content")
+        st.info("Sidebar info")
 
-STREAMLIT_LOGO_SMALL_PATH = STATIC_DIR / "streamlit-logo-small.png"
-st.logo(
-    STREAMLIT_LOGO_SMALL_PATH
-    if STREAMLIT_LOGO_SMALL_PATH.is_file()
-    else "https://streamlit.io/images/brand/streamlit-mark-color.png",
-    size="small",
+    st.sidebar.write("Sidebar write API")
+    help_text = "Tooltip text" if show_tooltips else None
+    return help_text, disabled
+
+
+def _render_packages_and_magic() -> None:
+    st.header("Packages and magic")
+
+    python_match = re.match(r"^\d+\.\d+\.\d+", sys.version)
+    if python_match is None:
+        raise RuntimeError(f"Unable to parse Python version: {sys.version}")
+
+    st.dataframe(
+        pd.DataFrame(
+            {
+                "package": ["Python", "Streamlit"],
+                "version": [python_match.group(0), st.__version__],
+            }
+        ),
+        width="stretch",
+    )
+
+    optional_deps = [
+        "altair",
+        "graphviz",
+        "matplotlib",
+        "plotly",
+        "pydeck",
+        "seaborn",
+        "snowflake.snowpark",
+        "streamlit_pdf",
+    ]
+    st.dataframe(
+        pd.DataFrame(
+            {
+                "module": optional_deps,
+                "status": [
+                    "available" if _module_available(module_name) else "missing"
+                    for module_name in optional_deps
+                ],
+            }
+        ),
+        width="stretch",
+    )
+    st.code(_MAGIC_COW)
+
+    st.write("Write API call")
+    "Magic bare expression"
+
+
+def _render_map_and_media(minor_version: int) -> None:
+    st.header("Map and media elements")
+
+    rng = np.random.default_rng(7)
+    map_df = pd.DataFrame(rng.standard_normal((1000, 2)) / [50, 50] + [37.76, -122.4])
+    map_df.columns = ["lat", "lon"]
+    st.map(map_df)
+
+    st.image(
+        np.arange(10000, dtype=np.uint8).reshape(100, 100), caption="Generated image"
+    )
+
+    if minor_version >= 35:
+        logo = np.tile(np.array([[0, 255], [255, 0]], dtype=np.uint8), (40, 40))
+        if minor_version >= 39:
+            st.logo(logo, link="https://streamlit.io", size="large")
+        else:
+            st.logo(logo, link="https://streamlit.io")
+
+    t = np.linspace(0.0, 0.25, 2000, endpoint=False)
+    audio = 0.25 * np.sin(2 * np.pi * 440 * t)
+    st.audio(audio, sample_rate=8000)
+    example_video_path = _STATIC_DIR / "sintel-short.mp4"
+    if example_video_path.is_file():
+        st.video(example_video_path)
+
+
+def _render_data_display(
+    minor_version: int, help_text: str | None, disabled: bool
+) -> None:
+    st.header("Data display elements")
+
+    rng = np.random.default_rng(11)
+    chart_data = pd.DataFrame(rng.standard_normal((20, 3)), columns=["a", "b", "c"])
+    st.dataframe(chart_data, width="stretch")
+
+    selection_df = pd.DataFrame(rng.standard_normal((12, 5)), columns=list("abcde"))
+    st.dataframe(
+        selection_df,
+        key="selection_df",
+        on_select="rerun",
+        selection_mode=["multi-row", "multi-column", "multi-cell"],
+        width="stretch",
+    )
+
+    if minor_version >= 52:
+        st.dataframe(
+            pd.DataFrame({"col1": [1, None, 3], "col2": [None, "b", "c"]}),
+            placeholder="N/A",
+            width="stretch",
+        )
+
+    edited_df = st.data_editor(
+        pd.DataFrame(
+            [
+                {"command": "st.selectbox", "rating": 4, "is_widget": True},
+                {"command": "st.balloons", "rating": 5, "is_widget": False},
+                {"command": "st.time_input", "rating": 3, "is_widget": True},
+            ]
+        ),
+        num_rows="dynamic",
+        disabled=disabled,
+        key="data_editor",
+    )
+    st.download_button(
+        "Download data as CSV",
+        edited_df.to_csv(index=False).encode("utf-8"),
+        "df.csv",
+        "text/csv",
+    )
+
+    if hasattr(st, "column_config"):
+        st.subheader("Column config matrix")
+        column_config_df = pd.DataFrame(
+            {
+                "column": ["foo", "bar", "baz"],
+                "text": ["foo", "bar", "baz"],
+                "number": [1, 2, 3],
+                "checkbox": [True, False, True],
+                "selectbox": ["foo", "bar", "foo"],
+                "datetime": pd.to_datetime(
+                    [
+                        "2021-01-01 00:00:00",
+                        "2021-01-02 00:00:00",
+                        "2021-01-03 00:00:00",
+                    ]
+                ),
+                "date": pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-03"]),
+                "time": [time(0, 0), time(1, 0), time(2, 0)],
+                "list": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                "link": [
+                    "https://streamlit.io",
+                    "https://streamlit.io",
+                    "https://streamlit.io",
+                ],
+                "image": [
+                    "./app/static/test-streamlit-logo.png",
+                    "./app/static/test-streamlit-logo.png",
+                    "./app/static/test-streamlit-logo.png",
+                ],
+                "area_chart": [[1, 2, 1], [2, 3, 1], [3, 1, 2]],
+                "line_chart": [[1, 2, 1], [2, 3, 1], [3, 1, 2]],
+                "bar_chart": [[1, 2, 1], [2, 3, 1], [3, 1, 2]],
+                "progress": [0.1, 0.2, 0.3],
+                "json": [
+                    {"foo": "bar"},
+                    {"numbers": [123, 4.56]},
+                    {"level1": {"level2": {"level3": {"a": "b"}}}},
+                ],
+            }
+        )
+        st.data_editor(
+            column_config_df,
+            key="column_config_editor",
+            column_config={
+                "column": st.column_config.Column(
+                    "Column", help="A column tooltip", pinned=True
+                ),
+                "text": st.column_config.TextColumn("TextColumn"),
+                "number": st.column_config.NumberColumn("NumberColumn"),
+                "checkbox": st.column_config.CheckboxColumn("CheckboxColumn"),
+                "selectbox": st.column_config.SelectboxColumn(
+                    "SelectboxColumn", options=["foo", "bar", "baz"]
+                ),
+                "datetime": st.column_config.DatetimeColumn("DatetimeColumn"),
+                "date": st.column_config.DateColumn("DateColumn"),
+                "time": st.column_config.TimeColumn("TimeColumn"),
+                "list": st.column_config.ListColumn("ListColumn"),
+                "link": st.column_config.LinkColumn("LinkColumn"),
+                "image": st.column_config.ImageColumn("ImageColumn"),
+                "area_chart": st.column_config.AreaChartColumn("AreaChartColumn"),
+                "line_chart": st.column_config.LineChartColumn("LineChartColumn"),
+                "bar_chart": st.column_config.BarChartColumn("BarChartColumn"),
+                "progress": st.column_config.ProgressColumn("ProgressColumn"),
+                "json": st.column_config.JsonColumn("JSONColumn"),
+            },
+        )
+
+    st.table(chart_data.head())
+    st.metric("Metric", 42, 2, help=help_text)
+    if minor_version >= 52:
+        st.metric("Metric without arrow", 100, -5, delta_arrow="off")
+
+    pos_col, neg_col, neutral_col = st.columns(3)
+    pos_col.metric("Metric positive", 1234, 123, help=help_text)
+    neg_col.metric("Metric negative", 1234, -123, help=help_text)
+    neutral_col.metric("Metric neutral", 1234, 123, delta_color="off", help=help_text)
+
+    left, middle, right = st.columns(3)
+    left.metric(
+        "Metric sparkline line",
+        1234,
+        123,
+        border=True,
+        chart_data=_generate_sparkline_data(),
+        chart_type="line",
+        help=help_text,
+    )
+    middle.metric(
+        "Metric sparkline area",
+        1234,
+        -123,
+        border=True,
+        chart_data=_generate_sparkline_data(),
+        chart_type="area",
+        help=help_text,
+    )
+    right.metric(
+        "Metric sparkline bar",
+        1234,
+        123,
+        border=True,
+        chart_data=_generate_sparkline_data(),
+        chart_type="bar",
+        delta_color="off",
+        help=help_text,
+    )
+    st.json(chart_data.head().to_dict(), expanded=2)
+
+
+def _render_charts(minor_version: int) -> None:
+    st.header("Chart elements")
+
+    if _module_available("matplotlib"):
+        import matplotlib.pyplot as plt
+
+        arr = np.random.default_rng(17).normal(1, 1, size=100)
+        fig, ax = plt.subplots()
+        ax.hist(arr, bins=20)
+        ax.set_title("Histogram")
+        st.pyplot(fig)
+
+    if _module_available("matplotlib") and _module_available("seaborn"):
+        import matplotlib.pyplot as plt
+        import seaborn as sns  # type: ignore[import-untyped]
+
+        fig, _ = plt.subplots()
+        sns.heatmap(pd.DataFrame([[1, 2], [3, 4]]), cmap="plasma")
+        st.pyplot(fig)
+
+    column_count = 10 if st.session_state.get("more_lines", False) else 3
+    columns = (
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+        if column_count == 10
+        else ["a", "b", "c"]
+    )
+    chart_data = pd.DataFrame(
+        np.random.default_rng(19).standard_normal((20, column_count)),
+        columns=columns,
+    )
+    st.line_chart(chart_data, x_label="x label", y_label="y label")
+    area_stack = cast(
+        "Literal['normalize', 'center'] | bool",
+        st.segmented_control(
+            "Area chart stack",
+            [True, False, "normalize", "center"],
+            key="area_stack",
+        ),
+    )
+    st.area_chart(chart_data, x_label="x label", y_label="y label", stack=area_stack)
+    bar_stack = cast(
+        "Literal['normalize', 'center'] | bool",
+        st.segmented_control(
+            "Bar chart stack",
+            [True, False, "normalize", "center"],
+            key="bar_stack",
+        ),
+    )
+    st.bar_chart(
+        chart_data,
+        x_label="x label",
+        y_label="y label",
+        horizontal=st.session_state.get("horizontal_bars", False),
+        stack=bar_stack,
+    )
+
+    if _module_available("altair"):
+        import altair as alt
+
+        st.altair_chart(
+            alt.Chart(chart_data)
+            .mark_circle()
+            .encode(x="a", y="b", size="c", color="c", tooltip=["a", "b", "c"]),
+            use_container_width=True,
+        )
+
+    if minor_version >= 27:
+        st.scatter_chart(chart_data, x_label="x label", y_label="y label")
+
+    st.vega_lite_chart(
+        chart_data,
+        {
+            "mark": {"type": "circle", "tooltip": True},
+            "encoding": {
+                "x": {"field": "a", "type": "quantitative"},
+                "y": {"field": "b", "type": "quantitative"},
+                "size": {"field": "c", "type": "quantitative"},
+                "color": {"field": "c", "type": "quantitative"},
+            },
+        },
+    )
+
+    if _module_available("plotly"):
+        import plotly.graph_objects as go
+
+        fig = go.Figure()
+        fig.add_scatter(y=[1, 3, 2, 4], mode="lines", name="Demo")
+        st.plotly_chart(fig, use_container_width=True)
+
+    if _module_available("pydeck"):
+        import pydeck as pdk
+
+        points = pd.DataFrame(
+            np.random.default_rng(23).standard_normal((1000, 2)) / [50, 50]
+            + [37.76, -122.4],
+            columns=["lat", "lon"],
+        )
+        st.pydeck_chart(
+            pdk.Deck(
+                map_style=None,
+                initial_view_state=pdk.ViewState(
+                    latitude=37.76,
+                    longitude=-122.4,
+                    zoom=11,
+                ),
+                layers=[
+                    pdk.Layer(
+                        "ScatterplotLayer",
+                        data=points,
+                        get_position="[lon, lat]",
+                        get_radius=200,
+                    )
+                ],
+            )
+        )
+
+    if _module_available("graphviz"):
+        import graphviz
+
+        graph = graphviz.Digraph()
+        graph.edge("run", "kernel")
+        graph.edge("kernel", "sleep")
+        st.graphviz_chart(graph)
+
+    st.graphviz_chart("""
+        digraph {
+            start -> process
+            process -> decision
+            decision -> finish
+        }
+    """)
+
+
+def _render_custom_ui(minor_version: int) -> None:
+    st.header("Custom UI elements")
+
+    components.html("<b style='color: green'>Bold green HTML text</b>", height=50)
+    st.markdown(
+        "<b style='color: green'>Unsafe markdown HTML</b>", unsafe_allow_html=True
+    )
+    components.html("<button>Click me</button>", height=50)
+
+    if (
+        minor_version >= 51
+        and hasattr(st, "components")
+        and hasattr(st.components, "v2")
+        and hasattr(st.components.v2, "component")
+    ):
+        inline_component = st.components.v2.component(
+            "inline_links",
+            js="""
+            export default function(component) {
+              const { setTriggerValue } = component;
+              const links = document.querySelectorAll('a[href="#"]');
+              links.forEach((link) => {
+                link.onclick = () => {
+                  setTriggerValue("clicked", link.innerHTML);
+                };
+              });
+            }
+            """,
+        )
+        click_result = inline_component(on_clicked_change=lambda: None)
+        st.markdown("Click [one](#) or [two](#) inline link.")
+        clicked_link = click_result.get("clicked")
+        if clicked_link:
+            st.write(f"Clicked link: {clicked_link}")
+
+
+@st.dialog(
+    "Test dialog",
+    width=cast(
+        "Literal['small', 'medium', 'large']",
+        st.session_state.get("dialog_width", "small"),
+    ),
+    dismissible=st.session_state.get("dialog_dismissible", True),
 )
-
-st.title("🎈 Mega tester app")
-st.set_page_config("Mega tester app", "🎈", layout="wide" if wide_mode else "centered")
-
-
-def page1():
-    pass
+def _dialog(item: str) -> None:
+    reason = st.text_input("Dialog reason", key="dialog_reason")
+    if st.button("Submit dialog"):
+        st.session_state.vote = {"item": item, "reason": reason}
+        st.rerun()
 
 
-def page2():
-    pass
+def _render_inputs(minor_version: int, help_text: str | None, disabled: bool) -> None:
+    st.header("Input widgets")
+
+    st.text_input(
+        "Textbox",
+        key="textbox",
+        help=help_text,
+        disabled=disabled,
+    )
+    st.number_input(
+        "Number",
+        key="number",
+        help=help_text,
+        disabled=disabled,
+    )
+    range_slider = st.session_state.get("range_sliders", False)
+    st.slider(
+        "Slider",
+        value=(30, 60) if range_slider else 30,
+        key="slider",
+        help=help_text,
+        disabled=disabled,
+    )
+    if minor_version >= 46:
+        st.slider(
+            "Slider narrow",
+            width=200,
+            key="slider_narrow",
+            help=help_text,
+            disabled=disabled,
+        )
+
+    if st.button(
+        "Button",
+        key="button",
+        icon=":material/home:",
+        help=help_text,
+        disabled=disabled,
+    ):
+        st.write("You pressed the default button")
+    if st.button(
+        "Button primary",
+        key="button_primary",
+        type="primary",
+        icon=":material/home:",
+        help=help_text,
+        disabled=disabled,
+    ):
+        st.write("You pressed the primary button")
+    if st.button(
+        "Button tertiary",
+        key="button_tertiary",
+        type="tertiary",
+        icon=":material/home:",
+        help=help_text,
+        disabled=disabled,
+    ):
+        st.write("You pressed the tertiary button")
+    if minor_version >= 52:
+        st.button(
+            "Shortcut button",
+            shortcut="k",
+            key="shortcut_button",
+            disabled=disabled,
+        )
+
+    st.download_button(
+        "Download hello",
+        data="Hello!",
+        icon=":material/home:",
+        help=help_text,
+        disabled=disabled,
+    )
+    st.link_button(
+        "Link button in inputs",
+        "https://streamlit.io",
+        icon=":material/home:",
+        help=help_text,
+        disabled=disabled,
+    )
+    if hasattr(st, "page_link"):
+        st.page_link(
+            "https://streamlit.io",
+            label="Page link",
+            icon=":material/home:",
+            help=help_text,
+            disabled=disabled,
+        )
+
+    st.checkbox("Checkbox", key="checkbox", help=help_text, disabled=disabled)
+    toggle_value = st.toggle("Toggle", key="toggle", help=help_text, disabled=disabled)
+    st.write(f"Toggle state is {toggle_value}")
+    st.radio(
+        "Radio",
+        ["cat", "dog"],
+        key="radio",
+        help=help_text,
+        disabled=disabled,
+    )
+    st.radio(
+        "Horizontal option",
+        ["cat", "dog"],
+        key="radio_horizontal",
+        horizontal=True,
+        help=help_text,
+        disabled=disabled,
+    )
+
+    accept_new_options = st.toggle(
+        "Accept new options",
+        key="accept_new_options",
+    )
+
+    if minor_version >= 45:
+        st.selectbox(
+            "Selectbox",
+            ["cat", "dog"],
+            accept_new_options=accept_new_options,
+            key="selectbox",
+            help=help_text,
+            disabled=disabled,
+        )
+        st.multiselect(
+            "Multiselect",
+            ["cat", "dog"],
+            accept_new_options=accept_new_options,
+            key="multiselect",
+            help=help_text,
+            disabled=disabled,
+        )
+    else:
+        st.selectbox(
+            "Selectbox",
+            ["cat", "dog"],
+            key="selectbox",
+            help=help_text,
+            disabled=disabled,
+        )
+        st.multiselect(
+            "Multiselect",
+            ["cat", "dog"],
+            key="multiselect",
+            help=help_text,
+            disabled=disabled,
+        )
+
+    st.select_slider(
+        "Select slider",
+        ["xsmall", "small", "medium", "large", "xlarge"],
+        value=("small", "large") if range_slider else "small",
+        key="select_slider",
+        help=help_text,
+        disabled=disabled,
+    )
+    st.text_area(
+        "Text area",
+        key="text_area",
+        help=help_text,
+        disabled=disabled,
+    )
+    st.date_input(
+        "Date input",
+        value=date(2024, 1, 1),
+        key="date_input",
+        help=help_text,
+        disabled=disabled,
+    )
+    st.time_input(
+        "Time input",
+        value=time(8, 30),
+        key="time_input",
+        help=help_text,
+        disabled=disabled,
+    )
+    if minor_version >= 52:
+        st.datetime_input(
+            "Datetime input",
+            value=datetime(2024, 1, 1, 8, 30),
+            key="datetime_input",
+            help=help_text,
+            disabled=disabled,
+        )
+    if minor_version >= 49:
+        upload_mode = cast(
+            "Literal['directory'] | bool",
+            st.segmented_control(
+                "File uploader mode",
+                [False, True, "directory"],
+                default=False,
+                key="file_uploader_mode",
+            ),
+        )
+        if upload_mode is False:
+            st.file_uploader("File input", key="file_input", disabled=disabled)
+        else:
+            st.file_uploader(
+                "File input",
+                accept_multiple_files=upload_mode,
+                key="file_input",
+                disabled=disabled,
+            )
+    else:
+        st.file_uploader("File input", key="file_input", disabled=disabled)
+    st.color_picker(
+        "Color picker",
+        key="color_picker",
+        help=help_text,
+        disabled=disabled,
+    )
+
+    with st.form("form"):
+        st.text_input(
+            "Form text",
+            key="form_text",
+            help=help_text,
+            disabled=disabled,
+        )
+        submitted = st.form_submit_button(
+            "Submit form", help=help_text, disabled=disabled
+        )
+    if submitted:
+        st.write("Form submitted")
+
+    if st.button("Trigger rerun", key="rerun"):
+        st.rerun()
+
+    st.segmented_control(
+        "Dialog width",
+        ["small", "medium", "large"],
+        default="small",
+        key="dialog_width",
+    )
+    st.toggle(
+        "Dialog dismissible",
+        True,
+        key="dialog_dismissible",
+    )
+
+    show_chat_input_bottom = st.session_state.get("chat_input_bottom", False)
+    prompt: str | ChatInputValue | None = None
+    if show_chat_input_bottom:
+        if minor_version >= 52:
+            prompt = st.chat_input(
+                "Chat input",
+                key="chat_input",
+                accept_file="multiple",
+                accept_audio=True,
+                disabled=disabled,
+            )
+        elif minor_version >= 43:
+            prompt = st.chat_input(
+                "Chat input",
+                key="chat_input",
+                accept_file="multiple",
+                disabled=disabled,
+            )
+        else:
+            prompt = st.chat_input(
+                "Chat input",
+                key="chat_input",
+                disabled=disabled,
+            )
+    else:
+        chat_input_target = st.container()
+        if minor_version >= 52:
+            prompt = chat_input_target.chat_input(
+                "Chat input",
+                key="chat_input",
+                accept_file="multiple",
+                accept_audio=True,
+                disabled=disabled,
+            )
+        elif minor_version >= 43:
+            prompt = chat_input_target.chat_input(
+                "Chat input",
+                key="chat_input",
+                accept_file="multiple",
+                disabled=disabled,
+            )
+        else:
+            prompt = chat_input_target.chat_input(
+                "Chat input",
+                key="chat_input",
+                disabled=disabled,
+            )
+
+    if prompt:
+        st.chat_message("user").write(getattr(prompt, "text", str(prompt)))
+    st.chat_message("assistant").write("Assistant response")
+
+    if st.button("Write stream", key="write_stream"):
+        st.write_stream(_stream_chunks)
+
+    if "vote" not in st.session_state:
+        if st.button("Open dialog item 1", key="dialog_open"):
+            _dialog("1")
+    else:
+        st.write(
+            f"Dialog result item={st.session_state.vote['item']} "
+            f"reason={st.session_state.vote['reason']}"
+        )
+    if minor_version >= 37:
+        st.feedback("thumbs", key="feedback_thumbs", disabled=disabled)
+        st.feedback("faces", key="feedback_faces", disabled=disabled)
+        st.feedback("stars", key="feedback_stars", disabled=disabled)
+
+    if minor_version >= 40:
+        pills_value = st.pills(
+            "Pills",
+            ["North", "East", "South", "West"],
+            selection_mode="multi",
+            key="pills",
+            disabled=disabled,
+            help=help_text,
+        )
+        st.write(f"Pills value is {pills_value}")
+        segmented_value = st.segmented_control(
+            "Segmented",
+            ["North", "East", "South", "West"],
+            selection_mode="multi",
+            key="segmented",
+            disabled=disabled,
+            help=help_text,
+        )
+        st.write(f"Segmented value is {segmented_value}")
+        audio_value = st.audio_input(
+            "Audio input",
+            key="audio_input",
+            disabled=disabled,
+        )
+        st.write(f"Audio input is {audio_value}")
+
+    if hasattr(st, "camera_input") and st.toggle(
+        "Show camera input", False, key="show_camera_input"
+    ):
+        camera_value = st.camera_input(
+            "Camera input",
+            key="camera_input",
+            disabled=disabled,
+        )
+        st.write(f"Camera input is {camera_value}")
 
 
-def page3():
-    pass
-
-
-def page4():
-    pass
-
-
-def page5():
-    pass
-
-
-def page6():
-    pass
-
-
-def page7():
-    pass
-
-
-def page8():
-    pass
-
-
-def page9():
-    pass
-
-
-def page10():
-    pass
-
-
-def page11():
-    pass
-
-
-def page12():
-    pass
-
-
-def page13():
-    pass
-
-
-if many_pages:
-    pages = {
-        "General": [
-            st.Page(page1, title="Home", icon=":material/home:"),
-            st.Page(page2, title="Data visualizations", icon=":material/monitoring:"),
-            st.Page(page3, title="Analytics", icon=":material/analytics:"),
-        ],
-        "Tools": [
-            st.Page(page4, title="Calculator", icon=":material/calculate:"),
-            st.Page(page5, title="Editor", icon=":material/edit:"),
-            st.Page(page6, title="Viewer", icon=":material/visibility:"),
-            st.Page(page7, title="Converter", icon=":material/swap_horiz:"),
-        ],
-        "Data": [
-            st.Page(page8, title="Import", icon=":material/file_upload:"),
-            st.Page(page9, title="Export", icon=":material/file_download:"),
-            st.Page(page10, title="Transform", icon=":material/transform:"),
-        ],
-        "Admin": [
-            st.Page(page11, title="Settings", icon=":material/settings:"),
-            st.Page(page12, title="Users", icon=":material/people:"),
-            st.Page(page13, title="Logs", icon=":material/history:"),
-        ],
-    }
-else:
-    pages = {
-        "General": [
-            st.Page(page1, title="Home", icon=":material/home:"),
-            st.Page(page2, title="Data visualizations", icon=":material/monitoring:"),
-        ],
-        "Admin": [st.Page(page3, title="Settings", icon=":material/settings:")],
-    }
-
-st.navigation(
-    pages if nav_sections else [page for section in pages.values() for page in section],
-    position="top" if top_nav else "sidebar",
-)
-
-
-"## Write and magic"
-st.write("st.write")
-"magic"
-
-
-"## Text elements"
-st.markdown("st.markdown", help=help_text)
-st.markdown(
-    "Markdown features: **bold** *italic* ~strikethrough~ [link](https://streamlit.io) `code` $a=b$ 🐶 :cat: "
-    ":material/home: :streamlit: <- -> <-> -- >= <= ~= :small[small] $$a = b$$"
-)
-st.markdown("""
+def _render_text_elements(minor_version: int, help_text: str | None) -> None:
+    st.header("Text elements")
+    st.title("Title with tooltip", help=help_text)
+    st.markdown("Markdown", help=help_text)
+    st.markdown(
+        "Markdown features: **bold** *italic* ~strikethrough~ [link](https://streamlit.io) "
+        "`code` $a=b$ 🐶 :cat: :material/home: :streamlit: <- -> <-> -- >= <= ~= :small[small] $$a = b$$"
+    )
+    st.markdown("""
 Text colors:
 
 :blue[blue] :green[green] :orange[orange] :red[red] :violet[violet] :gray[gray] :rainbow[rainbow] :primary[primary]
@@ -186,715 +898,329 @@ Text colors:
 :blue-badge[blue] :green-badge[green] :orange-badge[orange] :red-badge[red] :violet-badge[violet]
 :gray-badge[gray] :primary-badge[primary]
 """)
-st.title("st.title", help=help_text)
-st.header("st.header", help=help_text)
-st.header("st.header with blue divider", divider="blue", help=help_text)
-st.header("st.header with green divider", divider="green", help=help_text)
-st.header("st.header with yellow divider", divider="yellow", help=help_text)
-st.header("st.header with orange divider", divider="orange", help=help_text)
-st.header("st.header with red divider", divider="red", help=help_text)
-st.header("st.header with violet divider", divider="violet", help=help_text)
-st.header("st.header with gray divider", divider="gray", help=help_text)
-st.header("st.header with rainbow divider", divider="rainbow", help=help_text)
-st.subheader("st.subheader", help=help_text)
-st.badge("st.badge", icon=":material/home:", color="green")
-st.caption("st.caption", help=help_text)
-st.code("# st.code\na = 1234")
-st.code("# st.code with line numbers\na = 1234", line_numbers=True)
-st.code(
-    '# st.code with line wrapping\na = "This is a very very very very very very very very very '
-    'very very very long string"',
-    wrap_lines=True,
-)
-with st.echo():
-    st.write("st.echo")
-st.latex(r"\int a x^2 \,dx", help=help_text)
-st.text("st.text", help=help_text)
-st.divider()
-
-
-"## Data elements"
-data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-
-"st.dataframe"
-st.dataframe(data)
-
-"st.dataframe with selections"
-event_data = st.dataframe(
-    data, on_select="rerun", selection_mode=["multi-row", "multi-column", "multi-cell"]
-)
-st.write("Your dataframe selection is", event_data["selection"])
-
-"st.data_editor"
-st.data_editor(data, num_rows="dynamic", disabled=disabled)
-
-"st.column_config"
-data_df = pd.DataFrame(
-    {
-        "column": ["foo", "bar", "baz"],
-        "text": ["foo", "bar", "baz"],
-        "number": [1, 2, 3],
-        "checkbox": [True, False, True],
-        "selectbox": ["foo", "bar", "foo"],
-        "datetime": pd.to_datetime(
-            ["2021-01-01 00:00:00", "2021-01-02 00:00:00", "2021-01-03 00:00:00"]
-        ),
-        "date": pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-03"]),
-        "time": pd.to_datetime(["00:00:00", "01:00:00", "02:00:00"]),
-        "list": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
-        "link": [
-            "https://streamlit.io",
-            "https://streamlit.io",
-            "https://streamlit.io",
-        ],
-        "image": [
-            "https://picsum.photos/200/300",
-            "https://picsum.photos/200/300",
-            "https://picsum.photos/200/300",
-        ],
-        "area_chart": [[1, 2, 1], [2, 3, 1], [3, 1, 2]],
-        "line_chart": [[1, 2, 1], [2, 3, 1], [3, 1, 2]],
-        "bar_chart": [[1, 2, 1], [2, 3, 1], [3, 1, 2]],
-        "progress": [0.1, 0.2, 0.3],
-        "json": [
-            {
-                "foo": "bar",
-            },
-            {
-                "numbers": [123, 4.56],
-            },
-            {
-                "level1": {"level2": {"level3": {"a": "b"}}},
-            },
-        ],
-    }
-)
-
-st.data_editor(
-    data_df,
-    column_config={
-        "column": st.column_config.Column(
-            "Column", help="A column tooltip", pinned=True
-        ),
-        "text": st.column_config.TextColumn("TextColumn"),
-        "number": st.column_config.NumberColumn("NumberColumn"),
-        "checkbox": st.column_config.CheckboxColumn("CheckboxColumn"),
-        "selectbox": st.column_config.SelectboxColumn(
-            "SelectboxColumn", options=["foo", "bar", "baz"]
-        ),
-        "datetime": st.column_config.DatetimeColumn("DatetimeColumn"),
-        "date": st.column_config.DateColumn("DateColumn"),
-        "time": st.column_config.TimeColumn("TimeColumn"),
-        "list": st.column_config.ListColumn("ListColumn"),
-        "link": st.column_config.LinkColumn("LinkColumn"),
-        "image": st.column_config.ImageColumn("ImageColumn"),
-        "area_chart": st.column_config.AreaChartColumn("AreaChartColumn"),
-        "line_chart": st.column_config.LineChartColumn("LineChartColumn"),
-        "bar_chart": st.column_config.BarChartColumn("BarChartColumn"),
-        "progress": st.column_config.ProgressColumn("ProgressColumn"),
-        "json": st.column_config.JsonColumn("JSONColumn"),
-    },
-)
-
-"st.table"
-st.table(data.iloc[0:5])
-
-col1, col2, col3 = st.columns(3)
-col1.metric("st.metric positive", 1234, 123, help=help_text)
-col2.metric("st.metric negative", 1234, -123, help=help_text)
-col3.metric("st.metric neutral", 1234, 123, delta_color="off", help=help_text)
-
-col1, col2, col3 = st.columns(3)
-col1.metric(
-    "st.metric positive",
-    1234,
-    123,
-    border=True,
-    help=help_text,
-    chart_data=generate_sparkline_data(),
-    chart_type="line",
-)
-col2.metric(
-    "st.metric negative",
-    1234,
-    -123,
-    border=True,
-    help=help_text,
-    chart_data=generate_sparkline_data(),
-    chart_type="area",
-)
-col3.metric(
-    "st.metric neutral",
-    1234,
-    123,
-    border=True,
-    help=help_text,
-    chart_data=generate_sparkline_data(),
-    chart_type="bar",
-    delta_color="off",
-)
-
-"st.json"
-st.json(
-    {
-        "foo": "bar",
-        "numbers": [
-            123,
-            4.56,
-        ],
-        "level1": {"level2": {"level3": {"a": "b"}}},
-    },
-    expanded=2,
-)
-
-
-"## Chart elements"
-more_lines = st.toggle("Show more lines", False)
-data = pd.DataFrame(
-    np.random.randn(20, 10 if more_lines else 3),
-    columns=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-    if more_lines
-    else ["a", "b", "c"],
-)
-
-"st.area_chart"
-stack = cast(
-    "Literal['normalize', 'center'] | bool",
-    st.segmented_control(
-        "stack",
-        [True, False, "normalize", "center"],
-        key="area_chart_stack",
-    ),
-)
-st.area_chart(data, x_label="x label", y_label="y label", stack=stack)
-"st.bar_chart"
-horizontal = st.toggle("horizontal", False)
-stack = cast(
-    "Literal['normalize', 'center'] | bool",
-    st.segmented_control(
-        "stack",
-        [True, False, "normalize", "center"],
-        key="bar_chart_stack",
-    ),
-)
-st.bar_chart(
-    data, x_label="x label", y_label="y label", horizontal=horizontal, stack=stack
-)
-"st.line_chart"
-st.line_chart(data, x_label="x label", y_label="y label")
-"st.scatter_chart"
-st.scatter_chart(data, x_label="x label", y_label="y label")
-
-"st.map"
-df = pd.DataFrame(
-    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4], columns=["lat", "lon"]
-)
-st.map(df)
-
-"st.pyplot"
-fig, ax = plt.subplots()
-ax.hist(data, bins=20)
-st.pyplot(fig)
-
-"st.altair_chart"
-st.altair_chart(
-    alt.Chart(data)
-    .mark_circle()
-    .encode(x="a", y="b", size="c", color="c", tooltip=["a", "b", "c"]),
-    width="stretch",
-)
-
-"st.vega_lite_chart"
-st.vega_lite_chart(
-    data,
-    {
-        "mark": {"type": "circle", "tooltip": True},
-        "encoding": {
-            "x": {"field": "a", "type": "quantitative"},
-            "y": {"field": "b", "type": "quantitative"},
-            "size": {"field": "c", "type": "quantitative"},
-            "color": {"field": "c", "type": "quantitative"},
-        },
-    },
-    width="stretch",
-)
-
-"st.plotly_chart"
-df = px.data.gapminder()
-fig = px.scatter(
-    df.query("year==2007"),
-    x="gdpPercap",
-    y="lifeExp",
-    size="pop",
-    color="continent",
-    hover_name="country",
-    log_x=True,
-    size_max=60,
-)
-st.plotly_chart(fig, width="stretch")
-
-"st.pydeck_chart"
-data = pd.DataFrame(
-    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4], columns=["lat", "lon"]
-)
-st.pydeck_chart(
-    pdk.Deck(
-        map_style=None,
-        initial_view_state=pdk.ViewState(
-            latitude=37.76,
-            longitude=-122.4,
-            zoom=11,
-            pitch=50,
-        ),
-        layers=[
-            pdk.Layer(
-                "HexagonLayer",
-                data=data,
-                get_position="[lon, lat]",
-                radius=200,
-                elevation_scale=4,
-                elevation_range=[0, 1000],
-                pickable=True,
-                extruded=True,
-            ),
-            pdk.Layer(
-                "ScatterplotLayer",
-                data=data,
-                get_position="[lon, lat]",
-                get_color="[200, 30, 0, 160]",
-                get_radius=200,
-            ),
-        ],
+    st.header("Header")
+    for color in [
+        "blue",
+        "green",
+        "yellow",
+        "orange",
+        "red",
+        "violet",
+        "gray",
+        "rainbow",
+    ]:
+        st.header(f"Header with {color} divider", divider=color, help=help_text)
+    st.subheader("Subheader")
+    st.caption("Caption", help=help_text)
+    st.code("a = 1234")
+    st.code("a = 1234", line_numbers=True)
+    st.code(
+        'a = "This is a very very very very very very very very very very very very long string"',
+        wrap_lines=True,
     )
-)
-
-"st.graphviz_chart"
-st.graphviz_chart(
-    """
-    digraph {
-        run -> intr
-        intr -> runbl
-        runbl -> run
-        run -> kernel
-        kernel -> zombie
-        kernel -> sleep
-        kernel -> runmem
-        sleep -> swap
-        swap -> runswap
-        runswap -> new
-        runswap -> runmem
-        new -> runmem
-        sleep -> runmem
-    }
-    """
-)
-
-
-"## Input widgets"
-if st.button("st.button", help=help_text, icon=":material/home:", disabled=disabled):
-    st.write("You pressed the button!")
-
-if st.button(
-    "st.button primary",
-    type="primary",
-    help=help_text,
-    icon=":material/home:",
-    disabled=disabled,
-):
-    st.write("You pressed the button!")
-
-if st.button(
-    "st.button tertiary",
-    type="tertiary",
-    help=help_text,
-    icon=":material/home:",
-    disabled=disabled,
-):
-    st.write("You pressed the button!")
-
-st.download_button(
-    "st.download_button",
-    data="Hello!",
-    icon=":material/home:",
-    help=help_text,
-    disabled=disabled,
-)
-
-"st.feedback"
-st.feedback("thumbs", disabled=disabled)
-st.feedback("faces", disabled=disabled)
-st.feedback("stars", disabled=disabled)
-
-st.link_button(
-    "st.link_button",
-    "https://streamlit.io",
-    icon=":material/home:",
-    help=help_text,
-    disabled=disabled,
-)
-
-st.page_link(
-    "https://streamlit.io",
-    label="st.page_link",
-    icon=":material/home:",
-    help=help_text,
-    disabled=disabled,
-)
-
-checkbox_input = st.checkbox("st.checkbox", True, help=help_text, disabled=disabled)
-st.write(f"Your checkbox input is {checkbox_input}!")
-
-toggle_input = st.toggle("st.toggle", True, help=help_text, disabled=disabled)
-st.write(f"Your toggle input is {toggle_input}!")
-
-radio_input = st.radio("st.radio", ["cat", "dog"], help=help_text, disabled=disabled)
-st.write(f"Your radio input is {radio_input}!")
-
-radio_input = st.radio(
-    "st.radio horizontal",
-    ["cat", "dog"],
-    horizontal=True,
-    help=help_text,
-    disabled=disabled,
-)
-st.write(f"Your radio input is {radio_input}!")
-
-accept_new_options = st.toggle("accept new options")
-selectbox_input = st.selectbox(
-    "st.selectbox",
-    ["cat", "dog", "monkey", "snake", "bird"],
-    accept_new_options=accept_new_options,
-    help=help_text,
-    disabled=disabled,
-)
-st.write(f"Your selectbox input is {selectbox_input}!")
-
-multiselect_input = st.multiselect(
-    "st.multiselect",
-    ["cat", "dog", "monkey", "snake", "bird"],
-    default=["cat", "monkey"],
-    accept_new_options=accept_new_options,
-    disabled=disabled,
-    help=help_text,
-)
-st.write(f"Your multiselect input is {multiselect_input}!")
-
-pills_input = st.pills(
-    "st.pills",
-    ["cat", "dog", "monkey", "snake", "bird"],
-    selection_mode="multi",
-    default=["cat", "monkey"],
-    disabled=disabled,
-    help=help_text,
-)
-st.write(f"Your pills input is {pills_input}!")
-
-segmented_control_input = st.segmented_control(
-    "st.segmented_control",
-    ["cat", "dog", "monkey", "snake", "bird"],
-    selection_mode="multi",
-    default=["cat", "monkey"],
-    disabled=disabled,
-    help=help_text,
-)
-st.write(f"Your segmented control input is {segmented_control_input}!")
-
-color_input = st.color_picker("st.color_picker", disabled=disabled, help=help_text)
-st.write(f"Your color input hex is {color_input}!")
-
-number_input = st.number_input("st.number_input", disabled=disabled, help=help_text)
-st.write(f"Your number input is {number_input}!")
-
-range_sliders = st.toggle("Range sliders", False)
-
-slider_input = st.slider(
-    "st.slider",
-    value=[30, 60] if range_sliders else 30,
-    disabled=disabled,
-    help=help_text,
-)
-st.write(f"Your slider input is {slider_input}!")
-
-select_slider_input = st.select_slider(
-    "st.select_slider",
-    options=["xsmall", "small", "medium", "large", "xlarge"],
-    value=["small", "large"] if range_sliders else "small",
-    disabled=disabled,
-    help=help_text,
-)
-st.write(f"Your select_slider input is {select_slider_input}!")
-
-date_input = st.date_input("st.date_input", disabled=disabled, help=help_text)
-st.write(f"Your date input is {date_input}!")
-
-time_input = st.time_input("st.time_input", disabled=disabled, help=help_text)
-st.write(f"Your time input is {time_input}!")
-
-text_input = st.text_input("st.text_input", disabled=disabled, help=help_text)
-st.write(f"Your text input is {text_input}!")
-
-text_area_input = st.text_area("st.text_area", disabled=disabled, help=help_text)
-st.write(f"Your text_area input is {text_area_input}!")
-
-audio_input = st.audio_input("st.audio_input", disabled=disabled, help=help_text)
-st.write(f"Your audio input is {audio_input}!")
+    st.text("Text", help=help_text)
+    if minor_version >= 52:
+        st.markdown("Centered markdown", text_alignment="center")
+        st.caption("Centered caption", text_alignment="center")
+        st.text("Centered text", text_alignment="center", width="stretch")
+    st.latex(r"\int a x^2 \,dx", help=help_text)
+    st.divider()
+    st.warning("Warning")
+    st.warning("Warning with icon", icon=":material/home:")
+    st.error("Error")
+    st.error("Error with icon", icon=":material/home:")
+    st.info("Info")
+    st.info("Info with icon", icon=":material/home:")
+    st.success("Success")
+    st.success("Success with icon", icon=":material/home:")
+    st.exception(RuntimeError("Example exception"))
+    if st.button("Run balloons", key="balloons"):
+        st.balloons()
+    if st.button("Run snow", key="snow"):
+        st.snow()
+    if minor_version >= 27:
+        st.link_button("Link button", "https://streamlit.io")
+    if minor_version >= 44:
+        st.badge("Badge", icon=":material/check:", color="green")
 
 
-accept_multiple_files = st.segmented_control(
-    "accept_multiple_files", [False, True, "directory"], default=False
-)
+def _render_blocks(minor_version: int, help_text: str | None, disabled: bool) -> None:
+    st.header("Block elements")
 
-uploaded_file = st.file_uploader(
-    "st.file_uploader",
-    type=["png", "jpg"],
-    accept_multiple_files=accept_multiple_files,  # type: ignore
-    disabled=disabled,
-    help=help_text,
-)
-st.write(f"Your uploaded file is {uploaded_file}!")
+    left, right = st.columns(2)
+    left.write("Left column")
+    right.write("Right column")
+    bordered_left, bordered_right = st.columns(2, border=True)
+    bordered_left.write("Bordered left column")
+    bordered_right.write("Bordered right column")
 
-if st.toggle("Show camera input (requires camera permission)", False):
-    cam_input = st.camera_input("st.camera_input", disabled=disabled, help=help_text)
-    st.write(f"Your cam input is {cam_input}!")
+    tab_a, tab_b = st.tabs(["Tab A", "Tab B"])
+    tab_a.write("Tab A content")
+    tab_b.write("Tab B content")
+
+    with st.expander("Expander"):
+        st.write("Expander content")
+
+    st.container().write("Container content")
+    st.container(border=True).write("Bordered container content")
+    if minor_version >= 32:
+        with st.popover("Popover", help=help_text, disabled=disabled):
+            st.write("Popover content")
+    st.empty().write("Empty content")
+
+    if minor_version >= 37:
+
+        @st.fragment
+        def _fragment() -> None:
+            st.button("Fragment button", key="fragment_button")
+            st.write("Fragment content")
+
+        _fragment()
+
+    if minor_version >= 48:
+        horizontal = st.container(horizontal=True, horizontal_alignment="right")
+        for idx in range(3):
+            horizontal.button(
+                f"Horizontal button {idx + 1}", key=f"horizontal_button_{idx}"
+            )
+
+    if minor_version >= 51:
+        with st.container(horizontal=True):
+            st.button("Left", key="space_left")
+            st.space("stretch")
+            st.button("Right", key="space_right")
+
+    if minor_version >= 52:
+        with st.container(width="content"):
+            st.write("Content-width container")
 
 
-"## Media elements"
-"st.image"
-EXAMPLE_IMAGE_PATH = STATIC_DIR / "test-streamlit-logo.png"
-st.image(
-    EXAMPLE_IMAGE_PATH
-    if EXAMPLE_IMAGE_PATH.is_file()
-    else "https://picsum.photos/200/300"
-)
+def _render_navigation(minor_version: int) -> None:
+    st.header("Navigation elements")
 
-"st.audio"
-EXAMPLE_AUDIO_PATH = STATIC_DIR / "cat-purr.mp3"
-st.audio(
-    EXAMPLE_AUDIO_PATH
-    if EXAMPLE_AUDIO_PATH.is_file()
-    else "https://file-examples.com/storage/fef6248bef689f7bb9c274f/2017/11/file_example_MP3_700KB.mp3"
-)
+    nav_positions: list[Literal["hidden", "sidebar", "top"]] = ["hidden", "sidebar"]
+    if minor_version >= 46:
+        nav_positions.append("top")
 
-"st.video"
-
-EXAMPLE_VIDEO_PATH = STATIC_DIR / "flower.webm"
-
-st.video(
-    EXAMPLE_VIDEO_PATH
-    if EXAMPLE_VIDEO_PATH.is_file()
-    else "https://file-examples.com/storage/fef6248bef689f7bb9c274f/2017/04/file_example_MP4_480_1_5MG.mp4"
-)
-
-"st.pdf"
-# TODO: st.pdf is not compatible with the current CSP / iframe configuration
-# within our tests:
-show_pdf = st.toggle("Show pdf", False)
-if show_pdf:
-    EXAMPLE_PDF_PATH = STATIC_DIR / "sample.pdf"
-
-    st.pdf(
-        EXAMPLE_PDF_PATH
-        if EXAMPLE_PDF_PATH.is_file()
-        else "https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/web/compressed.tracemonkey-pldi-09.pdf"
+    position = st.selectbox(
+        "Navigation position",
+        nav_positions,
+        index=nav_positions.index("sidebar"),
+        key="navigation_position",
     )
 
+    def _nav_home() -> None:
+        st.write("Home page")
 
-"## Layouts and containers"
+    def _nav_about() -> None:
+        st.write("About page")
 
-"st.columns"
-a, b = st.columns(2)
-a.write("column 1")
-b.write("column 2")
+    def _nav_contact() -> None:
+        st.write("Contact page")
 
-"st.columns with border"
-a, b = st.columns(2, border=True)
-a.write("column 1")
-b.write("column 2")
+    def _nav_logs() -> None:
+        st.write("Logs page")
 
-st.container().write("st.container")
-st.container(border=True).write("st.container with border")
+    def _nav_data_visualizations() -> None:
+        st.write("Data visualizations page")
 
-width = cast(
-    "Literal['small', 'medium', 'large']",
-    st.segmented_control(
-        "st.dialog width", ["small", "medium", "large"], default="small"
-    ),
-)
+    def _nav_analytics() -> None:
+        st.write("Analytics page")
 
-dismissible = st.toggle("st.dialog dismissible", True)
+    def _nav_calculator() -> None:
+        st.write("Calculator page")
+
+    def _nav_editor() -> None:
+        st.write("Editor page")
+
+    def _nav_viewer() -> None:
+        st.write("Viewer page")
+
+    def _nav_converter() -> None:
+        st.write("Converter page")
+
+    def _nav_import() -> None:
+        st.write("Import page")
+
+    def _nav_export() -> None:
+        st.write("Export page")
+
+    def _nav_transform() -> None:
+        st.write("Transform page")
+
+    def _nav_settings() -> None:
+        st.write("Settings page")
+
+    def _nav_users() -> None:
+        st.write("Users page")
+
+    many_pages = st.session_state.get("many_pages", False)
+    nav_sections = st.session_state.get("nav_sections", True)
+
+    pages: dict[str, list[StreamlitPage]]
+    if many_pages:
+        pages = {
+            "General": [
+                st.Page(_nav_home, title="Home", icon=":material/home:"),
+                st.Page(
+                    _nav_data_visualizations,
+                    title="Data visualizations",
+                    icon=":material/monitoring:",
+                ),
+                st.Page(_nav_analytics, title="Analytics", icon=":material/analytics:"),
+            ],
+            "Tools": [
+                st.Page(
+                    _nav_calculator, title="Calculator", icon=":material/calculate:"
+                ),
+                st.Page(_nav_editor, title="Editor", icon=":material/edit:"),
+                st.Page(_nav_viewer, title="Viewer", icon=":material/visibility:"),
+                st.Page(
+                    _nav_converter, title="Converter", icon=":material/swap_horiz:"
+                ),
+            ],
+            "Data": [
+                st.Page(_nav_import, title="Import", icon=":material/file_upload:"),
+                st.Page(_nav_export, title="Export", icon=":material/file_download:"),
+                st.Page(_nav_transform, title="Transform", icon=":material/transform:"),
+            ],
+            "Admin": [
+                st.Page(_nav_settings, title="Settings", icon=":material/settings:"),
+                st.Page(_nav_users, title="Users", icon=":material/people:"),
+                st.Page(_nav_logs, title="Logs", icon=":material/history:"),
+            ],
+        }
+    else:
+        pages = {
+            "General": [
+                st.Page(_nav_home, title="Home", icon=":material/home:"),
+                st.Page(_nav_about, title="About", icon=":material/info:"),
+            ],
+            "Admin": [
+                st.Page(_nav_contact, title="Contact", icon=":material/contact_mail:")
+            ],
+        }
+
+    navigation_pages: list[StreamlitPage] | dict[str, list[StreamlitPage]]
+    if nav_sections:
+        navigation_pages = pages
+    else:
+        navigation_pages = [page for section in pages.values() for page in section]
+
+    nav = st.navigation(navigation_pages, position=position)
+    nav.run()
 
 
-@st.dialog("Test dialog", width=width, dismissible=dismissible)
-def dialog():
-    st.write("Hello there!")
-    st.write(LOREM)
-    if st.button("Close", disabled=disabled):
-        st.rerun()
+def _render_context() -> None:
+    st.header("Streamlit context")
+    context_values: dict[str, str] = {}
+    for attr in dir(st.context):
+        if attr.startswith("_"):
+            continue
+        try:
+            context_values[attr] = str(getattr(st.context, attr))
+        except Exception as ex:
+            context_values[attr] = f"Error: {ex}"
+    st.json(context_values)
 
 
-if st.button("Open st.dialog"):
-    dialog()
+def _render_authentication(minor_version: int) -> None:
+    if minor_version < 42:
+        return
 
-a = st.empty()
-a.write("st.empty")
+    st.header("Authentication")
+    if st.button("Login", key="login_button") and hasattr(st, "login"):
+        try:
+            st.login()
+        except Exception as ex:
+            st.info(f"Login unavailable in this environment: {ex}")
 
-with st.expander("st.expander"):
-    st.write("works!")
 
-with st.popover("st.popover", disabled=disabled, help=help_text):
-    st.write("works!")
+def _render_utilities() -> None:
+    st.header("Utility elements")
+    with st.echo():
+        st.write("Echo")
+    st.help(st.write)
 
-st.sidebar.write("st.sidebar")
-
-with st.sidebar:
-    st.selectbox(
-        "st.selectbox sidebar",
-        ["cat", "dog", "monkey", "snake", "bird"],
-        disabled=disabled,
+    duration = cast(
+        "Literal['short', 'long', 'infinite']",
+        st.segmented_control(
+            "Toast duration",
+            ["short", "long", "infinite"],
+            default="short",
+            key="toast_duration",
+        ),
     )
-    st.button("st.button sidebar", disabled=disabled)
-    st.checkbox("st.checkbox sidebar", True, disabled=disabled)
-    st.info("st.info sidebar")
-    st.expander("st.expander sidebar").write("works!")
+    if st.button("Show toast", key="toast_button"):
+        st.toast("Hello there!", icon="🎈", duration=duration)
+    if st.button("Run status", key="status_button"):
+        with st.status("Working...", expanded=True) as status:
+            st.write("Status step 1")
+            st.write("Status step 2")
+            status.update(label="Done", state="complete")
+    if st.button("Run progress", key="progress_button"):
+        progress_bar = st.progress(0)
+        for percent_complete in range(0, 101, 25):
+            progress_bar.progress(percent_complete)
+    if st.button("Run spinner", key="spinner_button"):
+        with st.spinner("Wait!", show_time=True):
+            st.write("Spinner finished")
+    if st.button("Add query params", key="query_params_button"):
+        st.query_params["test"] = "1"
+        st.query_params["bvt"] = "true"
+    st.write("Query params", dict(st.query_params))
 
-"st.tabs"
-tab_a, tab_b = st.tabs(["tab 1", "tab 2"])
-tab_b.write("tab 1 content")
-tab_a.write("tab 2 content")
-
-
-"## Chat elements"
-
-"st.chat_input"
-if st.toggle("Show chat input at the bottom of the screen", False):
-    st.chat_input(accept_file="multiple", disabled=disabled)
-else:
-    st.container().chat_input(accept_file="multiple", disabled=disabled)
-
-"st.chat_message"
-st.chat_message("assistant").write("Hello there!")
-
-if st.button("Start st.status"):
-    with st.status("Working on it...", expanded=True) as status:
-        time.sleep(1)
-        st.write("Some content...")
-        time.sleep(1)
-        st.write("Some content...")
-        time.sleep(1)
-        st.write("Some content...")
-        status.update(label="Done!", state="complete")
+    st.session_state.setdefault("key", True)
+    st.write(st.session_state["key"])
 
 
-if st.button("Start st.write_stream"):
+def _render_pdf(minor_version: int) -> None:
+    if minor_version < 49 or not hasattr(st, "pdf"):
+        return
 
-    def stream():
-        for i in ["hello", " streaming", " world"]:
-            time.sleep(0.5)
-            yield i
+    show_pdf = st.toggle("Show PDF", False, key="show_pdf")
+    if not show_pdf:
+        return
 
-    st.write_stream(stream)
+    st.header("PDF element")
+    uploaded = st.file_uploader("Upload a PDF", type="pdf", key="pdf_upload")
+    st.pdf(uploaded if uploaded is not None else _DUMMY_PDF, height=240)
 
 
-"## Status elements"
-if st.button("st.progress"):
-    my_bar = st.progress(0)
-    for percent_complete in range(100):
-        my_bar.progress(percent_complete + 1)
-        time.sleep(0.05)
+def _render_stop_section() -> None:
+    st.header("Stop behavior")
+    st.text("Text before stop")
+    if st.button("Run st.stop", key="stop_button"):
+        st.stop()
+    st.text("Text after stop")
 
-if st.button("st.spinner"):
-    with st.spinner("Wait!", show_time=True):
-        time.sleep(3)
-        st.write("spinner works if you saw it!")
 
-duration = st.segmented_control(
-    "duration", ["short", "long", "infinite"], default="short"
+layout_mode: Literal["wide", "centered"] = (
+    "wide" if st.session_state.get("wide_mode", True) else "centered"
 )
-if st.button("st.toast"):
-    st.toast("Hello there!", icon="🎈", duration=duration)  # type: ignore[arg-type]
+st.set_page_config(
+    page_title="Mega tester app",
+    page_icon="🎈",
+    layout=layout_mode,
+    initial_sidebar_state="expanded",
+)
 
-if st.button("st.balloons"):
-    st.balloons()
+st.title("🎈 Mega tester app")
 
-if st.button("st.snow"):
-    st.snow()
+minor = _minor_version()
+help_text, disabled = _render_sidebar_controls()
 
-st.success("st.success")
-st.success("st.success with icon", icon=":material/home:")
-st.info("st.info")
-st.info("st.info with icon", icon=":material/home:")
-st.warning("st.warning")
-st.warning("st.warning with icon", icon=":material/home:")
-st.error("st.error")
-st.error("st.error with icon", icon=":material/home:")
-st.exception(RuntimeError("st.exception"))
-
-
-"## Execution flow"
-
-"st.fragment"
-
-
-@st.fragment
-def my_fragment():
-    if st.button("Wait 1s inside the fragment"):
-        time.sleep(1)
-
-
-my_fragment()
-
-if st.button("st.rerun"):
-    st.rerun()
-
-if st.button("st.stop"):
-    st.stop()
-    st.write("if you see this, st.stop does not work")  # type: ignore[unreachable]
-
-with st.form(key="tester"):
-    "st.form"
-    text_tester = st.text_input("Your text", disabled=disabled, help=help_text)
-    st.form_submit_button("Submit", disabled=disabled, help=help_text)
-st.write("Your text is:", text_tester)
-
-
-st.write("## Utilities")
-
-"st.help"
-st.help(st.write)
-
-st.write("## State Management")
-
-"st.session_state"
-if "foo" not in st.session_state:
-    st.session_state["foo"] = "bar"
-st.write(st.session_state)
-
-if st.button("Add st.query_params"):
-    st.query_params["foo"] = "bar"
-
-"st.context.cookies"
-st.write(st.context.cookies)
-
-"st.context.headers"
-st.write(st.context.headers)
-
-"st.context.ip_address"
-st.write(st.context.ip_address)
-
-"st.context.is_embedded"
-st.write(st.context.is_embedded)
-
-"st.context.locale"
-st.write(st.context.locale)
-
-"st.context.theme.type"
-st.write(st.context.theme.type)
-
-"st.context.timezone"
-st.write(st.context.timezone)
-
-"st.context.timezone_offset"
-st.write(st.context.timezone_offset)
-
-"st.context.url"
-st.write(st.context.url)
+_render_packages_and_magic()
+_render_map_and_media(minor)
+_render_data_display(minor, help_text, disabled)
+_render_charts(minor)
+_render_custom_ui(minor)
+_render_inputs(minor, help_text, disabled)
+_render_text_elements(minor, help_text)
+_render_blocks(minor, help_text, disabled)
+_render_navigation(minor)
+_render_context()
+_render_authentication(minor)
+_render_utilities()
+_render_pdf(minor)
+_render_stop_section()

--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -18,13 +18,25 @@ import re
 from typing import TYPE_CHECKING
 
 import pytest
-from playwright.sync_api import expect
+from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import IframedPage, rerun_app, wait_for_app_run
-from e2e_playwright.shared.app_utils import expect_no_skeletons
+from e2e_playwright.conftest import IframedPage, rerun_app, wait_for_app_run, wait_until
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    click_checkbox,
+    click_toggle,
+    expect_no_skeletons,
+    fill_number_input,
+    get_checkbox,
+    get_number_input,
+    get_text_input,
+    open_popover,
+    select_radio_option,
+    select_selectbox_option,
+)
 
 if TYPE_CHECKING:
-    from playwright.sync_api import ConsoleMessage, FrameLocator, Page
+    from playwright.sync_api import ConsoleMessage, FrameLocator
 
     from e2e_playwright.shared.app_target import AppTarget
 
@@ -32,6 +44,8 @@ if TYPE_CHECKING:
 def is_expected_error(
     msg: ConsoleMessage, browser_name: str, *, uses_csp: bool
 ) -> bool:
+    """Check if a console error is expected and should be ignored."""
+
     # Mapbox error is expected and should be ignored:
     if (
         msg.text == "Failed to load resource: net::ERR_CONNECTION_REFUSED"
@@ -65,12 +79,8 @@ def is_expected_error(
 
 
 @pytest.mark.external_test(upload_test_assets=True)
-def test_no_console_errors(
-    app_target: AppTarget,
-    browser_name: str,
-):
+def test_no_console_errors(app_target: AppTarget, browser_name: str) -> None:
     """Test that the app does not log any console errors."""
-
     console_errors = []
 
     def on_console_message(msg: ConsoleMessage) -> None:
@@ -97,15 +107,14 @@ def test_no_console_errors(
     expect(app_target.get_by_test_id("stException")).to_have_count(1)
 
     # Check that title is visible:
-    expect(app_target.get_by_text("🎈 Mega tester app")).to_be_visible()
+    expect(app_target.get_by_text("🎈 Mega tester app", exact=True)).to_be_visible()
 
     # There should be no unexpected console errors:
     assert not console_errors, "Console errors were logged " + str(console_errors)
 
 
-def test_mega_tester_app_in_iframe(iframed_app: IframedPage, browser_name: str):
+def test_mega_tester_app_in_iframe(iframed_app: IframedPage, browser_name: str) -> None:
     """Test that the mega tester app can be loaded within an iframe with CSP."""
-
     console_errors = []
 
     def on_console_message(msg: ConsoleMessage) -> None:
@@ -135,8 +144,7 @@ def test_mega_tester_app_in_iframe(iframed_app: IframedPage, browser_name: str):
     expect_no_skeletons(frame_locator, timeout=25000)
 
     # Check that title is visible:
-    expect(frame_locator.get_by_text("🎈 Mega tester app")).to_be_visible()
-    # There should be only one exception in the app:
+    expect(frame_locator.get_by_text("🎈 Mega tester app", exact=True)).to_be_visible()
     expect(frame_locator.get_by_test_id("stException")).to_have_count(1)
 
     # Check that there are no dialogs (e.g. with errors) visible:
@@ -148,8 +156,304 @@ def test_mega_tester_app_in_iframe(iframed_app: IframedPage, browser_name: str):
 
 @pytest.mark.performance
 @pytest.mark.repeat(5)  # only repeat 5 times since otherwise it would take too long
-def test_mega_tester_app_rendering_performance(app: Page):
+def test_mega_tester_app_rendering_performance(app: Page) -> None:
     """Test the performance of the mega tester app rendering."""
     # Rerun the app 5 times:
     for _ in range(5):
         rerun_app(app)
+
+
+@pytest.mark.external_test(upload_test_assets=True)
+def test_mega_tester_app_renders_expected_content(app_target: AppTarget) -> None:
+    expect_no_skeletons(app_target.locator_context, timeout=25000)
+
+    expect(app_target.get_by_text("🎈 Mega tester app", exact=True)).to_be_visible()
+    mandatory_headings = [
+        "Packages and magic",
+        "Map and media elements",
+        "Data display elements",
+        "Chart elements",
+        "Custom UI elements",
+        "Input widgets",
+        "Text elements",
+        "Block elements",
+        "Navigation elements",
+        "Streamlit context",
+        "Utility elements",
+        "Stop behavior",
+    ]
+    for heading in mandatory_headings:
+        expect(
+            app_target.get_by_role("heading", name=heading, exact=True)
+        ).to_be_visible()
+
+    authentication_heading = app_target.get_by_role(
+        "heading", name="Authentication", exact=True
+    )
+    wait_until(
+        app_target.page,
+        lambda: authentication_heading.count() in {0, 1},
+        timeout=10000,
+    )
+    if authentication_heading.count() == 1:
+        expect(authentication_heading).to_be_visible()
+
+    # Packages + magic: verify semantic content, not just section presence.
+    expect(app_target.get_by_test_id("stDataFrame").first).to_contain_text("Python")
+    expect(app_target.get_by_test_id("stDataFrame").first).to_contain_text("Streamlit")
+    expect(
+        app_target.get_by_test_id("stCode").filter(has_text="Abracowdabra")
+    ).to_be_visible()
+    expect(app_target.get_by_text("Magic bare expression", exact=True)).to_be_visible()
+
+    # Media and data display.
+    expect(app_target.get_by_text("Generated image", exact=True)).to_be_visible()
+    expect(app_target.get_by_test_id("stImage").first).to_be_visible()
+    expect(app_target.get_by_test_id("stAudio").first).to_be_visible()
+    expect(
+        app_target.get_by_role("button", name="Download data as CSV", exact=True)
+    ).to_be_visible()
+    column_config_heading = app_target.get_by_role(
+        "heading", name="Column config matrix", exact=True
+    )
+    if column_config_heading.count() == 1:
+        expect(column_config_heading).to_be_visible()
+        # Column headers can be virtualized/off-screen; assert presence rather than visibility.
+        expect(app_target.get_by_text("TextColumn", exact=True)).to_have_count(1)
+        expect(app_target.get_by_test_id("stTable")).to_be_visible()
+    metric_cards = app_target.get_by_test_id("stMetric")
+    expect(metric_cards.first).to_contain_text("Metric")
+    expect(metric_cards.first).to_contain_text("42")
+    expect(metric_cards.first).to_contain_text("2")
+    expect(metric_cards.filter(has_text="Metric positive")).to_have_count(1)
+    expect(metric_cards.filter(has_text="Metric negative")).to_have_count(1)
+    expect(metric_cards.filter(has_text="Metric neutral")).to_have_count(1)
+    expect(
+        app_target.get_by_test_id("stJson").filter(has_text="timezone").first
+    ).to_be_visible()
+
+    # Charts: ensure multiple concrete chart outputs rendered.
+    # The mega tester app always renders at least four Vega charts.
+    vega_charts = app_target.get_by_test_id("stVegaLiteChart")
+    expect(vega_charts.nth(3)).to_be_visible()
+    expect(vega_charts.first).to_be_visible()
+    plotly_charts = app_target.get_by_test_id("stPlotlyChart")
+    wait_until(
+        app_target.page,
+        lambda: plotly_charts.count() in {0, 1},
+        timeout=10000,
+    )
+    if plotly_charts.count() == 1:
+        expect(plotly_charts.first).to_be_visible()
+    else:
+        expect(plotly_charts).to_have_count(0)
+    expect(app_target.get_by_test_id("stGraphVizChart").first).to_be_visible()
+
+    # Custom UI: verify HTML component iframe and unsafe markdown output.
+    custom_html_iframe = app_target.locator(
+        "iframe[srcdoc*='Bold green HTML text']"
+    ).first
+    expect(custom_html_iframe).to_be_visible()
+    expect(custom_html_iframe).to_have_attribute(
+        "srcDoc", re.compile(r"Bold green HTML text|Click me")
+    )
+    expect(app_target.get_by_text("Unsafe markdown HTML", exact=True)).to_be_visible()
+
+    # Text elements should render concrete messages.
+    expect(
+        app_target.get_by_role("heading", name="Title with tooltip", exact=True)
+    ).to_be_visible()
+    expect(app_target.get_by_text("Warning", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Warning with icon", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Error", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Error with icon", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Info", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Info with icon", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Success", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Success with icon", exact=True)).to_be_visible()
+    expect(
+        app_target.get_by_role("heading", name="Header with blue divider", exact=True)
+    ).to_be_visible()
+    expect(
+        app_target.get_by_role(
+            "heading", name="Header with rainbow divider", exact=True
+        )
+    ).to_be_visible()
+    expect(app_target.get_by_test_id("stException")).to_contain_text(
+        "Example exception"
+    )
+    expect(
+        app_target.get_by_role("link", name="Link button", exact=True)
+    ).to_be_visible()
+
+    # Inputs + blocks + utility content.
+    expect(app_target.get_by_text("Textbox", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Number", exact=True)).to_be_visible()
+    expect(
+        app_target.get_by_role("button", name=re.compile(r"Button primary"))
+    ).to_be_visible()
+    expect(
+        app_target.get_by_role("button", name=re.compile(r"Button tertiary"))
+    ).to_be_visible()
+    expect(app_target.get_by_text("Accept new options", exact=True)).to_be_visible()
+    file_uploader_mode = app_target.get_by_text("File uploader mode", exact=True)
+    if file_uploader_mode.count() == 1:
+        expect(file_uploader_mode).to_be_visible()
+    expect(app_target.get_by_text("Dialog width", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Dialog dismissible", exact=True)).to_be_visible()
+    show_camera_input = app_target.get_by_text("Show camera input", exact=True)
+    if show_camera_input.count() == 1:
+        expect(show_camera_input).to_be_visible()
+    wide_mode = app_target.get_by_text("Wide mode", exact=True)
+    if wide_mode.count() == 1:
+        expect(wide_mode).to_be_visible()
+    expect(app_target.get_by_text("Sidebar widgets", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Sidebar expander", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Sidebar write API", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Selectbox", exact=True)).to_be_visible()
+    expect(app_target.get_by_role("tab", name="Tab A", exact=True)).to_be_visible()
+    expect(app_target.get_by_role("tab", name="Tab B", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Expander", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Bordered left column", exact=True)).to_be_visible()
+    expect(
+        app_target.get_by_text("Bordered container content", exact=True)
+    ).to_be_visible()
+    expect(app_target.get_by_text("Echo", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Text before stop", exact=True)).to_be_visible()
+    expect(app_target.get_by_text("Text after stop", exact=True)).to_be_visible()
+
+    # Negatives for initial state.
+    expect(app_target.get_by_test_id("stDialog")).to_have_count(0)
+    expect(app_target.get_by_text("Form submitted", exact=True)).to_have_count(0)
+
+    if app_target.get_by_role("heading", name="PDF element", exact=True).count() == 1:
+        pdf_container = app_target.get_by_test_id("pdf-container").first
+        expect(pdf_container).to_be_visible(timeout=30000)
+        expect(pdf_container.get_by_test_id("pdf-loading")).to_be_hidden(timeout=30000)
+        expect(pdf_container.locator('[data-index="0"]').first).to_be_visible(
+            timeout=30000
+        )
+
+
+def test_mega_tester_app_interactions_validate_behavior(app: Page) -> None:
+    textbox = get_text_input(app, "Textbox")
+    textbox.locator("input").first.fill("Ada")
+    textbox.locator("input").first.press("Enter")
+    wait_for_app_run(app)
+    expect(textbox.locator("input").first).to_have_value("Ada")
+
+    fill_number_input(app, "Number", 7)
+    number_input = get_number_input(app, "Number")
+    expect(number_input.locator("input").first).to_have_value(re.compile(r"7"))
+
+    click_checkbox(app, "Checkbox")
+    expect(get_checkbox(app, "Checkbox").locator("input").first).to_be_checked()
+
+    select_radio_option(app, option="dog", label="Radio")
+    expect(
+        app.get_by_test_id("stRadio")
+        .filter(has_text="Radio")
+        .get_by_role("radio", name="dog", exact=True)
+    ).to_be_checked()
+
+    click_toggle(app, "Accept new options")
+    wait_for_app_run(app)
+    select_selectbox_option(app, "Selectbox", "dog")
+    expect(
+        app.get_by_test_id("stSelectbox").filter(has_text="Selectbox")
+    ).to_contain_text("dog")
+
+    form_text = get_text_input(app, "Form text")
+    form_text.locator("input").first.fill("hello")
+    app.get_by_role("button", name="Submit form").first.click()
+    expect(app.get_by_text("Form submitted", exact=True)).to_be_visible()
+
+    click_button(app, "Write stream")
+    expect(app.get_by_text("lorem ipsum", exact=False)).to_be_visible()
+    expect(app.get_by_text("dolor sit amet", exact=False)).to_be_visible()
+
+    app.get_by_role("button", name=re.compile(r"Button primary")).first.click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_text("You pressed the primary button", exact=True)
+    ).to_be_visible()
+    app.get_by_role("button", name=re.compile(r"Button tertiary")).first.click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_text("You pressed the tertiary button", exact=True)
+    ).to_be_visible()
+
+    # Expander should hide content until opened.
+    expect(app.get_by_text("Expander content", exact=True)).to_be_hidden()
+    app.get_by_text("Expander", exact=True).click()
+    expect(app.get_by_text("Expander content", exact=True)).to_be_visible()
+    expect(app.get_by_text("Sidebar expander content", exact=True)).to_be_hidden()
+    app.get_by_text("Sidebar expander", exact=True).click()
+    expect(app.get_by_text("Sidebar expander content", exact=True)).to_be_visible()
+
+    # Popover content should only appear when opened.
+    expect(app.get_by_test_id("stPopoverBody")).to_have_count(0)
+    popover_container = open_popover(app, "Popover")
+    expect(popover_container).to_contain_text("Popover content")
+
+    # Tab content should switch when selecting tabs.
+    expect(app.get_by_text("Tab A content", exact=True)).to_be_visible()
+    app.get_by_role("tab", name="Tab B", exact=True).click()
+    expect(app.get_by_text("Tab B content", exact=True)).to_be_visible()
+
+    click_button(app, "Open dialog item 1")
+    expect(app.get_by_test_id("stDialog")).to_have_count(1)
+    dialog_reason = get_text_input(app, "Dialog reason")
+    dialog_reason.locator("input").first.fill("because")
+    click_button(app, "Submit dialog")
+    expect(
+        app.get_by_text("Dialog result item=1 reason=because", exact=True)
+    ).to_be_visible()
+    expect(app.get_by_test_id("stDialog")).to_have_count(0)
+
+    select_selectbox_option(app, "Navigation position", "hidden")
+    expect(app.get_by_text("Home page", exact=True)).to_be_visible()
+    expect(app.get_by_test_id("stSidebarNav")).not_to_be_visible()
+    expect(app.get_by_test_id("stTopNavLink")).to_have_count(0)
+
+    select_selectbox_option(app, "Navigation position", "sidebar")
+    expect(app.get_by_test_id("stSidebarNav")).to_be_visible()
+    app.get_by_test_id("stSidebarNavLink").filter(has_text="About").first.click()
+    wait_for_app_run(app)
+    expect(app.get_by_text("About page", exact=True)).to_be_visible()
+    app.get_by_test_id("stSidebarNavLink").filter(has_text="Contact").first.click()
+    wait_for_app_run(app)
+    expect(app.get_by_text("Contact page", exact=True)).to_be_visible()
+
+    click_toggle(app, "Many pages")
+    expect(
+        app.get_by_test_id("stSidebarNavLink").filter(has_text="About")
+    ).to_have_count(0)
+    # Flatten sections so Logs is always directly clickable.
+    click_toggle(app, "Navigation sections")
+    app.get_by_test_id("stSidebarNavLink").filter(
+        has_text="Data visualizations"
+    ).first.click()
+    wait_for_app_run(app)
+    expect(app.get_by_text("Data visualizations page", exact=True)).to_be_visible()
+
+    select_selectbox_option(app, "Navigation position", "top")
+    expect(app.get_by_test_id("stSidebarNav")).not_to_be_visible()
+    top_nav_items = app.locator(
+        '[data-testid="stTopNavLink"], [data-testid="stTopNavSection"]'
+    )
+    expect(top_nav_items.first).to_be_visible()
+
+    expect(app.get_by_test_id("stChatInput")).to_have_count(1)
+    click_toggle(app, "Show chat input at bottom")
+    wait_for_app_run(app)
+    expect(app.get_by_test_id("stChatInput")).to_have_count(1)
+
+    expect(app.get_by_text("Text after stop", exact=True)).to_be_visible()
+    click_button(app, "Run st.stop")
+    expect(app.get_by_text("Text before stop", exact=True)).to_be_visible()
+    # Negative: content after st.stop should not be rendered after button click.
+    expect(app.get_by_text("Text after stop", exact=True)).to_have_count(0)
+
+    click_toggle(app, "Disable widgets")
+    expect(get_text_input(app, "Textbox").locator("input").first).to_be_disabled()


### PR DESCRIPTION
## Describe your changes

- Merges a number of the "mega testers" that we've had floating around into 1 isomorphic mega tester.
  - Makes the app resilient to different versions of Streamlit.
  - Runs in our CI and in External Mode so other environments (eg: SiS) can run the Mega Tester.
  - Expands test coverage and writes more meaningful test assertions (eg: is the expected thing _actually_ rendering on screen vs is the `data-testid` in the DOM.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- This is a big E2E test upgrade

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
