### PR TITLE
docs: fix duplicated word in media file manager comment

### DIFF
--- a/lib/streamlit/runtime/media_file_manager.py
+++ b/lib/streamlit/runtime/media_file_manager.py
@@ -89,7 +89,7 @@ class MediaFileManager:
       important so we can remove files from memory when no more sessions need
       them.
     - The exact location in the app where each file is being used (i.e. the
-      file's "coordinates"). This is is important so we can mark a file as "not
+      file's "coordinates"). This is important so we can mark a file as "not
       being used by a certain session" if it gets replaced by another file at
       the same coordinates. For example, when doing an animation where the same
       image is constantly replace with new frames. (This doesn't solve the case


### PR DESCRIPTION
## Describe your changes
- Fix duplicated wording in a code comment in `lib/streamlit/runtime/media_file_manager.py`.
- Changed `This is is important so we can mark a file as "not` to `This is important so we can mark a file as "not`.

## Screenshot or video (only for visual changes)
- N/A (no visual/UI changes)

## GitHub Issue Link (if applicable)
- N/A (trivial comment typo fix)

## Testing Plan
- Explanation of why no additional tests are needed: comment-only wording update; no runtime, API, or UI behavior changed.
- Unit Tests (JS and/or Python): not required.
- E2E Tests: not required.
- Any manual testing needed?: none.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
