### PR TITLE
[chore] Organize work-tmp with per-feature subdirectories for agent output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "plansDirectory": "./work-tmp",
+  "plansDirectory": "./work-tmp/plans",
   "permissions": {
     "allow": [
       "Bash(make *)",

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -87,7 +87,11 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
-- You can use the `work-tmp` directory to store temporary files, specs, and scripts.
+- **Feature working files**: Use `work-tmp/features/<feature-name>/` for per-feature working files (implementation plans, notes, test apps, scratch scripts). Organize each feature directory with:
+  - `implementation-plan.md` — detailed approach for complex features (architecture, specific files to change, edge cases)
+  - `notes.md` — running observations, decisions, and context gathered during development
+  - `test-apps/` — small Streamlit apps for manual testing and debugging
+- For other temporary files (one-off scripts, throwaway experiments), use `work-tmp/` directly.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
 - Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app URL will be printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if you have other sessions running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 - Run `make check` after completing changes to run formatting, linting, type checking, and unit tests on all uncommitted files.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,7 +81,11 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
-- You can use the `work-tmp` directory to store temporary files, specs, and scripts.
+- **Feature working files**: Use `work-tmp/features/<feature-name>/` for per-feature working files (implementation plans, notes, test apps, scratch scripts). Organize each feature directory with:
+  - `implementation-plan.md` — detailed approach for complex features (architecture, specific files to change, edge cases)
+  - `notes.md` — running observations, decisions, and context gathered during development
+  - `test-apps/` — small Streamlit apps for manual testing and debugging
+- For other temporary files (one-off scripts, throwaway experiments), use `work-tmp/` directly.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
 - Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app URL will be printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if you have other sessions running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 - Run `make check` after completing changes to run formatting, linting, type checking, and unit tests on all uncommitted files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,11 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
-- You can use the `work-tmp` directory to store temporary files, specs, and scripts.
+- **Feature working files**: Use `work-tmp/features/<feature-name>/` for per-feature working files (implementation plans, notes, test apps, scratch scripts). Organize each feature directory with:
+  - `implementation-plan.md` — detailed approach for complex features (architecture, specific files to change, edge cases)
+  - `notes.md` — running observations, decisions, and context gathered during development
+  - `test-apps/` — small Streamlit apps for manual testing and debugging
+- For other temporary files (one-off scripts, throwaway experiments), use `work-tmp/` directly.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.
 - Use `make debug <script.py>` to start both backend and frontend with hot-reload for debugging. The app URL will be printed on startup (default `http://localhost:3001`; `3000` is reserved for manual `make frontend-dev`; it may use `3002+` if you have other sessions running). Avoid pinning `VITE_PORT` unless you have a specific hard requirement (last resort).
 - Run `make check` after completing changes to run formatting, linting, type checking, and unit tests on all uncommitted files.


### PR DESCRIPTION
## Describe your changes

Introduces a `work-tmp/features/<feature-name>/` convention for organizing per-feature working files instead of dumping everything flat into `work-tmp/`.

Right now `work-tmp/` is a flat bucket mixing debug logs, implementation plans, test scripts, and throwaway scratch files. This gives feature work its own organized space with a suggested internal structure.

- Per-feature subdirectories: `work-tmp/features/<feature-name>/` with `implementation-plan.md`, `notes.md`, `test-apps/`
- Claude Code `plansDirectory` moved to `work-tmp/plans/` to separate auto-generated session plans from feature working files
- One-off throwaway files can still go directly in `work-tmp/`

Working files accumulated during feature development often have a longer lifespan than truly temporary files — they're useful as context while the feature is in progress and could feed into implementation plans, tech specs, or other longer-lived documentation. This is a first step toward giving `work-tmp/` more structure; further organization (e.g. separating scratch files from feature work) could follow.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: documentation/configuration-only change, no behavior modifications.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.