### PR TITLE
[fix] Allow running streamlit with python optimization

### DIFF
--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -226,11 +226,9 @@ class ConfigOption:
             Returns self, which makes testing easier. See config_test.py.
 
         """
-        if get_val_func.__doc__ is None:
-            raise RuntimeError(
-                "Complex config options require doc strings for their description."
-            )
-        self.description = get_val_func.__doc__
+        # Handle PYTHONOPTIMIZE=2 case where docstrings are stripped.
+        # Fall back to empty string instead of raising an error.
+        self.description = get_val_func.__doc__ or ""
         self._get_val_func = get_val_func
         return self
 

--- a/lib/tests/streamlit/config_option_test.py
+++ b/lib/tests/streamlit/config_option_test.py
@@ -73,18 +73,19 @@ class ConfigOptionTest(unittest.TestCase):
         assert c.description == "Random docstring."
         assert someRandomFunction._get_val_func == c._get_val_func
 
-    def test_call_assert(self):
+    def test_call_with_missing_docstring(self):
+        """Test that missing docstrings default to empty string.
+
+        This supports PYTHONOPTIMIZE=2 where docstrings are stripped.
+        """
         key = "mysection.myName"
         c = ConfigOption(key)
 
-        with pytest.raises(
-            RuntimeError,
-            match=r"Complex config options require doc strings for their description.",
-        ):
+        @c
+        def someRandomFunction():
+            pass
 
-            @c
-            def someRandomFunction():
-                pass
+        assert c.description == ""
 
     def test_value(self):
         my_value = "myValue"

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -231,19 +231,18 @@ class ConfigTest(unittest.TestCase):
         assert config_option.value == 12345
         assert config_option.env_var == "STREAMLIT__TEST_COMPLEX_PARAM"
 
-    def test_complex_config_option_must_have_doc_strings(self):
-        """Test that complex config options use funcs with doc stringsself.
+    def test_complex_config_option_with_missing_docstring(self):
+        """Test that missing docstrings default to empty string.
 
-        This is because the doc string forms the option's description.
+        This supports PYTHONOPTIMIZE=2 where docstrings are stripped.
         """
-        with pytest.raises(
-            RuntimeError,
-            match=r"Complex config options require doc strings for their description.",
-        ):
+        c = ConfigOption("_test.noDocString")
 
-            @ConfigOption("_test.noDocString")
-            def no_doc_string():
-                pass
+        @c
+        def no_doc_string():
+            pass
+
+        assert c.description == ""
 
     def test_invalid_config_name(self):
         """Test setting an invalid config section."""


### PR DESCRIPTION
## Describe your changes

Falls back to empty string for config option descriptions when docstrings are stripped (`PYTHONOPTIMIZE=2`) instead of raising a `RuntimeError`.

Fixes #14155

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/config_option_test.py` — Tests missing docstring fallback
  - `lib/tests/streamlit/config_test.py` — Tests complex config option without docstring