### PR TITLE
feat: add st.set_theme() API for runtime theme updates

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -997,6 +997,8 @@ export class App extends PureComponent<Props, State> {
           }
         },
         heartbeatAck: () => this.handleHeartbeatAck(),
+        themeChanged: (themeConfig: CustomThemeConfig) =>
+          this.handleThemeChanged(themeConfig),
       })
     } catch (e) {
       const err = ensureError(e)
@@ -1015,6 +1017,10 @@ export class App extends PureComponent<Props, State> {
         }),
       }
     })
+  }
+
+  handleThemeChanged = (themeConfig: CustomThemeConfig): void => {
+    this.processThemeInput(themeConfig)
   }
 
   handlePageConfigChanged = (pageConfig: PageConfig): void => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1020,7 +1020,23 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleThemeChanged = (themeConfig: CustomThemeConfig): void => {
-    this.processThemeInput(themeConfig)
+    // Filter out proto3-default scalar values (empty strings, null, undefined)
+    // so that partial CustomThemeConfig updates don't overwrite existing theme
+    // overrides with default values.
+    const filteredConfig: Partial<ICustomThemeConfig> = {}
+
+    Object.entries(themeConfig as unknown as Record<string, unknown>).forEach(
+      ([key, value]) => {
+        if (value === "" || value === null || value === undefined) {
+          // Treat proto3-default string / unset values as "not provided".
+          return
+        }
+
+        ;(filteredConfig as Record<string, unknown>)[key] = value
+      }
+    )
+
+    this.processThemeInput(filteredConfig as ICustomThemeConfig)
   }
 
   handlePageConfigChanged = (pageConfig: PageConfig): void => {

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -141,6 +141,7 @@ from streamlit.commands.navigation import navigation as navigation
 from streamlit.navigation.page import Page as Page
 
 from streamlit.commands.page_config import set_page_config as set_page_config
+from streamlit.commands.theme import set_theme as set_theme
 from streamlit.commands.execution_control import (
     stop as stop,
     rerun as rerun,

--- a/lib/streamlit/commands/theme.py
+++ b/lib/streamlit/commands/theme.py
@@ -1,0 +1,103 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto.ForwardMsg_pb2 import ForwardMsg as ForwardProto
+from streamlit.proto.NewSession_pb2 import CustomThemeConfig
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+
+
+@gather_metrics("set_theme")
+def set_theme(
+    *,
+    base: str | None = None,
+    primary_color: str | None = None,
+    background_color: str | None = None,
+    secondary_background_color: str | None = None,
+    text_color: str | None = None,
+) -> None:
+    """
+    Update the app's theme at runtime for the current user session.
+
+    This allows dynamic, per-session theming without restarting the app.
+    Only specified parameters will be updated; unspecified parameters retain
+    their current values.
+
+    Parameters
+    ----------
+    base : "light", "dark", or None
+        The base theme to use. If ``None`` (default), the base theme is not
+        changed.
+
+    primary_color : str or None
+        The accent color used for interactive elements like buttons, sliders,
+        and links. Should be a valid CSS color string (e.g., ``"#FF4B4B"``).
+
+    background_color : str or None
+        The main background color of the app. Should be a valid CSS color
+        string.
+
+    secondary_background_color : str or None
+        The background color used for secondary content areas like the
+        sidebar and some containers. Should be a valid CSS color string.
+
+    text_color : str or None
+        The default text color. Should be a valid CSS color string.
+
+    Example
+    -------
+    >>> import streamlit as st
+    >>>
+    >>> st.set_theme(
+    ...     base="light",
+    ...     primary_color="#FF4B4B",
+    ...     background_color="#FFFFFF",
+    ...     secondary_background_color="#F0F2F6",
+    ...     text_color="#31333F",
+    ... )
+    """
+    msg = ForwardProto()
+    theme_msg = msg.theme_changed
+
+    if base is not None:
+        base_map = {
+            "light": CustomThemeConfig.BaseTheme.LIGHT,
+            "dark": CustomThemeConfig.BaseTheme.DARK,
+        }
+        if base not in base_map:
+            raise StreamlitAPIException(
+                f'"{base}" is an invalid value for base. '
+                f"Allowed values are {list(base_map.keys())}."
+            )
+        theme_msg.base = base_map[base]
+
+    if primary_color is not None:
+        theme_msg.primary_color = primary_color
+
+    if background_color is not None:
+        theme_msg.background_color = background_color
+
+    if secondary_background_color is not None:
+        theme_msg.secondary_background_color = secondary_background_color
+
+    if text_color is not None:
+        theme_msg.text_color = text_color
+
+    ctx = get_script_run_ctx()
+    if ctx is None:
+        return
+    ctx.enqueue(msg)

--- a/lib/streamlit/commands/theme.py
+++ b/lib/streamlit/commands/theme.py
@@ -34,8 +34,9 @@ def set_theme(
     Update the app's theme at runtime for the current user session.
 
     This allows dynamic, per-session theming without restarting the app.
-    Only specified parameters will be updated; unspecified parameters retain
-    their current values.
+    Only parameters explicitly provided in a call are sent to the frontend;
+    unspecified parameters are completed from the base theme defaults, which
+    may reset any previous overrides for those fields.
 
     Parameters
     ----------
@@ -70,19 +71,30 @@ def set_theme(
     ...     text_color="#31333F",
     ... )
     """
+    # Validate base early, before checking if we have any params to send.
+    base_map = {
+        "light": CustomThemeConfig.BaseTheme.LIGHT,
+        "dark": CustomThemeConfig.BaseTheme.DARK,
+    }
+    if base is not None and base not in base_map:
+        raise StreamlitAPIException(
+            f'"{base}" is an invalid value for base. '
+            f"Allowed values are {list(base_map.keys())}."
+        )
+
+    # Return early if no params are provided to avoid enqueuing an empty
+    # ForwardMsg with no type set, which would break the frontend dispatcher.
+    if all(
+        p is None
+        for p in [base, primary_color, background_color,
+                  secondary_background_color, text_color]
+    ):
+        return
+
     msg = ForwardProto()
     theme_msg = msg.theme_changed
 
     if base is not None:
-        base_map = {
-            "light": CustomThemeConfig.BaseTheme.LIGHT,
-            "dark": CustomThemeConfig.BaseTheme.DARK,
-        }
-        if base not in base_map:
-            raise StreamlitAPIException(
-                f'"{base}" is an invalid value for base. '
-                f"Allowed values are {list(base_map.keys())}."
-            )
         theme_msg.base = base_map[base]
 
     if primary_color is not None:

--- a/lib/tests/streamlit/commands/theme_test.py
+++ b/lib/tests/streamlit/commands/theme_test.py
@@ -1,0 +1,76 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto.NewSession_pb2 import CustomThemeConfig
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+class SetThemeTest(DeltaGeneratorTestCase):
+    def test_set_theme_primary_color(self):
+        st.set_theme(primary_color="#FF4B4B")
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.primary_color == "#FF4B4B"
+
+    def test_set_theme_background_color(self):
+        st.set_theme(background_color="#FFFFFF")
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.background_color == "#FFFFFF"
+
+    def test_set_theme_secondary_background_color(self):
+        st.set_theme(secondary_background_color="#F0F2F6")
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.secondary_background_color == "#F0F2F6"
+
+    def test_set_theme_text_color(self):
+        st.set_theme(text_color="#31333F")
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.text_color == "#31333F"
+
+    def test_set_theme_base_light(self):
+        st.set_theme(base="light")
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.base == CustomThemeConfig.BaseTheme.LIGHT
+
+    def test_set_theme_base_dark(self):
+        st.set_theme(base="dark")
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.base == CustomThemeConfig.BaseTheme.DARK
+
+    def test_set_theme_base_invalid(self):
+        with pytest.raises(StreamlitAPIException):
+            st.set_theme(base="invalid")
+
+    def test_set_theme_multiple_params(self):
+        st.set_theme(
+            base="dark",
+            primary_color="#c08a5b",
+            background_color="#f5efe6",
+            secondary_background_color="#e8dfd4",
+            text_color="#3a312b",
+        )
+        msg = self.get_message_from_queue()
+        assert msg.theme_changed.base == CustomThemeConfig.BaseTheme.DARK
+        assert msg.theme_changed.primary_color == "#c08a5b"
+        assert msg.theme_changed.background_color == "#f5efe6"
+        assert msg.theme_changed.secondary_background_color == "#e8dfd4"
+        assert msg.theme_changed.text_color == "#3a312b"
+
+    def test_set_theme_no_params(self):
+        """Calling set_theme with no params should not raise an error."""
+        # Just verify it doesn't raise - no params means no theme fields set
+        st.set_theme()

--- a/lib/tests/streamlit/commands/theme_test.py
+++ b/lib/tests/streamlit/commands/theme_test.py
@@ -71,6 +71,24 @@ class SetThemeTest(DeltaGeneratorTestCase):
         assert msg.theme_changed.text_color == "#3a312b"
 
     def test_set_theme_no_params(self):
-        """Calling set_theme with no params should not raise an error."""
-        # Just verify it doesn't raise - no params means no theme fields set
+        """Calling set_theme with no params should not enqueue a message."""
         st.set_theme()
+        assert len(self.forward_msg_queue._queue) == 0
+
+    def test_set_theme_successive_calls_enqueue_separate_messages(self):
+        """Each set_theme call should enqueue its own message with only
+        the specified fields."""
+        st.set_theme(primary_color="#FF0000")
+        st.set_theme(background_color="#00FF00")
+
+        assert len(self.forward_msg_queue._queue) == 2
+
+        msg1 = self.forward_msg_queue._queue[0]
+        assert msg1.theme_changed.primary_color == "#FF0000"
+        # background_color should be empty (proto default) in the first message
+        assert msg1.theme_changed.background_color == ""
+
+        msg2 = self.forward_msg_queue._queue[1]
+        assert msg2.theme_changed.background_color == "#00FF00"
+        # primary_color should be empty (proto default) in the second message
+        assert msg2.theme_changed.primary_color == ""

--- a/lib/tests/streamlit/streamlit_test.py
+++ b/lib/tests/streamlit/streamlit_test.py
@@ -72,6 +72,7 @@ NON_ELEMENT_COMMANDS: set[str] = {
     "session_state",
     "set_option",
     "set_page_config",
+    "set_theme",
     "sidebar",
     "stop",
     "switch_page",

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -98,6 +98,9 @@ message ForwardMsg {
     // responds with this ack so the frontend can verify the connection is
     // healthy.
     bool heartbeat_ack = 26;
+
+    // Runtime theme update from st.set_theme()
+    CustomThemeConfig theme_changed = 27;
   }
 
   // The ID of the last BackMsg that we received before sending this
@@ -106,7 +109,7 @@ message ForwardMsg {
   string debug_last_backmsg_id = 17;
 
   reserved 7, 8, 16;
-  // Next: 27
+  // Next: 28
 }
 
 message DeferredFileResponse {


### PR DESCRIPTION
## Description

Implements `st.set_theme()` — a new public API that enables dynamic, per-session theme updates at runtime without requiring an app restart.

Closes #14172

## Changes

### Backend
- **[proto/streamlit/proto/ForwardMsg.proto](cci:7://file:///Users/bvpranay/streamlit/proto/streamlit/proto/ForwardMsg.proto:0:0-0:0)** — Added `theme_changed` field (tag 27) to `ForwardMsg.oneof type`, reusing the existing [CustomThemeConfig](cci:2://file:///Users/bvpranay/streamlit/proto/streamlit/proto/NewSession.proto:133:0-208:1) message
- **[lib/streamlit/commands/theme.py](cci:7://file:///Users/bvpranay/streamlit/lib/streamlit/commands/theme.py:0:0-0:0)** *(new)* — [set_theme()](cci:1://file:///Users/bvpranay/streamlit/lib/streamlit/commands/theme.py:23:0-102:20) function accepting [base](cci:1://file:///Users/bvpranay/streamlit/lib/tests/streamlit/commands/theme_test.py:48:4-51:73), [primary_color](cci:1://file:///Users/bvpranay/streamlit/lib/tests/streamlit/commands/theme_test.py:23:4-26:59), [background_color](cci:1://file:///Users/bvpranay/streamlit/lib/tests/streamlit/commands/theme_test.py:28:4-31:62), [secondary_background_color](cci:1://file:///Users/bvpranay/streamlit/lib/tests/streamlit/commands/theme_test.py:33:4-36:72), and [text_color](cci:1://file:///Users/bvpranay/streamlit/lib/tests/streamlit/commands/theme_test.py:38:4-41:56) parameters. Follows the `st.set_page_config` pattern.
- **[lib/streamlit/__init__.py](cci:7://file:///Users/bvpranay/streamlit/lib/streamlit/__init__.py:0:0-0:0)** — Exported `st.set_theme`

### Frontend
- **[frontend/app/src/App.tsx](cci:7://file:///Users/bvpranay/streamlit/frontend/app/src/App.tsx:0:0-0:0)** — Added [themeChanged](cci:1://file:///Users/bvpranay/streamlit/frontend/app/src/App.tsx:999:8-1000:46) handler to message dispatcher, delegating to existing [processThemeInput](cci:1://file:///Users/bvpranay/streamlit/frontend/app/src/App.tsx:1491:2-1556:3)

### Tests
- **[lib/tests/streamlit/commands/theme_test.py](cci:7://file:///Users/bvpranay/streamlit/lib/tests/streamlit/commands/theme_test.py:0:0-0:0)** *(new)* — 9 unit tests covering all parameters, combinations, edge cases, and error handling

## Usage

```python
import streamlit as st

if st.button("Dark Mode"):
    st.set_theme(
        base="dark",
        primary_color="#FF4B4B",
        background_color="#0E1117",
        secondary_background_color="#262730",
        text_color="#FAFAFA",
    )


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
