### PR TITLE
fix(cache): preserve on_release behavior in TTLCleanupCache.clear()

### DIFF
--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -75,6 +75,16 @@ class TTLCleanupCache(TTLCache[K, V]):
 
         return items
 
+    @override
+    def clear(self) -> None:
+        # cachetools 7.0.2 makes clear() O(1) and bypasses popitem(). We clear
+        # via popitem() to preserve the behavior seen in cachetools <= 7.0.1.
+        while True:
+            try:
+                self.popitem()
+            except KeyError:  # noqa: PERF203
+                break
+
     def safe_del(self, key: K) -> None:
         """Delete that calls _on_release."""
         has_value = key in self


### PR DESCRIPTION
## Describe your changes

cachetools 7.0.2 changed TTLCache.clear() to an O(1) implementation that bypasses `popitem()`/`expire()`. That skipped `TTLCleanupCache` release hooks and broke resource cleanup paths that expect on_release to run for each entry.

Override `TTLCleanupCache.clear()` to evict entries via `popitem()`, preserving release semantics across `cachetools` versions. Update related inline comments in `cache_resource_api` to document the callback/exception behavior and why per-item cleanup is still used.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Covered by existing tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
