### PR TITLE
Fix stale query params in page URL during navigation

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics.py
+++ b/e2e_playwright/multipage_apps/mpa_basics.py
@@ -19,6 +19,9 @@ import streamlit as st
 st.header("Main Page")
 st.slider("x")
 
+bound_cb = st.checkbox("Bound checkbox", key="bound_cb", bind="query-params")
+st.write("bound_cb:", bound_cb)
+
 st.write("Query Params:", st.query_params)
 
 if st.button("`pages/02_page2.py`"):

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
@@ -22,6 +24,7 @@ from e2e_playwright.conftest import (
 )
 from e2e_playwright.shared.app_utils import (
     click_button,
+    expect_prefixed_markdown,
     get_button_group,
     get_segment_button,
     goto_app,
@@ -288,6 +291,23 @@ def test_removes_non_embed_query_params_when_swapping_pages(
             query="embed=true&embed_options=show_toolbar&embed_options=show_colored_line",
         )
     )
+
+
+def test_bound_widget_query_param_cleared_on_page_switch(page: Page, app_base_url: str):
+    """Test that widget-bound query params are cleared when switching pages."""
+    # Load main page with a bound query param in the URL
+    goto_app(page, build_app_url(app_base_url, query={"bound_cb": "true"}))
+
+    # Verify the widget reflects the URL value
+    expect_prefixed_markdown(page, "bound_cb:", "True")
+    expect(page).to_have_url(re.compile(r"bound_cb=true"))
+
+    # Switch to another page via sidebar
+    page.get_by_test_id("stSidebarNav").locator("a").nth(1).click()
+    wait_for_app_loaded(page)
+
+    # Bound query param should be cleared from URL
+    expect(page).not_to_have_url(re.compile(r"bound_cb="))
 
 
 def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -306,8 +306,9 @@ def test_bound_widget_query_param_cleared_on_page_switch(page: Page, app_base_ur
     page.get_by_test_id("stSidebarNav").locator("a").nth(1).click()
     wait_for_app_loaded(page)
 
-    # Bound query param should be cleared from URL
-    expect(page).not_to_have_url(re.compile(r"bound_cb="))
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Page 2")
+    # Bound query param clearing may lag behind navigation on webkit
+    expect(page).not_to_have_url(re.compile(r"bound_cb="), timeout=7000)
 
 
 def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):

--- a/e2e_playwright/st_navigation.py
+++ b/e2e_playwright/st_navigation.py
@@ -19,11 +19,32 @@ import streamlit as st
 
 def a():
     st.header("Header A")
+    page_a_num = st.number_input(
+        "Page A number",
+        min_value=0,
+        max_value=100,
+        value=10,
+        key="page_a_num",
+        bind="query-params",
+    )
+    st.write("page_a_num:", page_a_num)
 
 
 def b():
     st.header("Header B")
+    page_b_choice = st.selectbox(
+        "Page B choice",
+        ["alpha", "beta", "gamma"],
+        key="page_b_choice",
+        bind="query-params",
+    )
+    st.write("page_b_choice:", page_b_choice)
 
+
+entry_radio = st.radio(
+    "Entry radio", ["red", "green", "blue"], key="entry_radio", bind="query-params"
+)
+st.write("entry_radio:", entry_radio)
 
 position: Literal["sidebar", "top", "hidden"] = st.radio(
     "Position", ["sidebar", "top", "hidden"]

--- a/e2e_playwright/st_navigation_test.py
+++ b/e2e_playwright/st_navigation_test.py
@@ -18,7 +18,7 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import build_app_url, wait_for_app_run
+from e2e_playwright.conftest import build_app_url, wait_for_app_loaded, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     expect_prefixed_markdown,
     goto_app,
@@ -93,7 +93,7 @@ def test_page_specific_bound_query_param_cleared_on_page_switch(
 
     # Switch to page B via sidebar nav
     page.get_by_test_id("stSidebarNavLink").nth(1).click()
-    wait_for_app_run(page)
+    wait_for_app_loaded(page)
 
     expect(page.get_by_test_id("stHeading").filter(has_text="Header B")).to_be_visible()
     expect(page).not_to_have_url(re.compile(r"page_a_num="))

--- a/e2e_playwright/st_navigation_test.py
+++ b/e2e_playwright/st_navigation_test.py
@@ -14,10 +14,16 @@
 
 from __future__ import annotations
 
+import re
+
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
-from e2e_playwright.shared.app_utils import select_radio_option
+from e2e_playwright.conftest import build_app_url, wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    expect_prefixed_markdown,
+    goto_app,
+    select_radio_option,
+)
 
 
 def test_sidebar_navigation_mode_shows_sidebar_nav_only(app: Page) -> None:
@@ -74,3 +80,48 @@ def test_hidden_navigation_mode_hides_both_navs(app: Page) -> None:
 
     # The app should still show content from the current page.
     expect(app.get_by_test_id("stHeading").filter(has_text="Header A")).to_be_visible()
+
+
+def test_page_specific_bound_query_param_cleared_on_page_switch(
+    page: Page, app_base_url: str
+) -> None:
+    """Page-scoped bound widget params are cleared when navigating to another page."""
+    goto_app(page, build_app_url(app_base_url, query={"page_a_num": "42"}))
+
+    expect_prefixed_markdown(page, "page_a_num:", "42")
+    expect(page).to_have_url(re.compile(r"page_a_num=42"))
+
+    # Switch to page B via sidebar nav
+    page.get_by_test_id("stSidebarNavLink").nth(1).click()
+    wait_for_app_run(page)
+
+    expect(page.get_by_test_id("stHeading").filter(has_text="Header B")).to_be_visible()
+    expect(page).not_to_have_url(re.compile(r"page_a_num="))
+
+
+def test_entry_file_bound_query_param_persists_across_page_switch(
+    page: Page, app_base_url: str
+) -> None:
+    """Entry-file bound widget params persist when navigating between pages."""
+    goto_app(page, build_app_url(app_base_url, query={"entry_radio": "green"}))
+
+    expect_prefixed_markdown(page, "entry_radio:", "green")
+    expect(page).to_have_url(re.compile(r"entry_radio=green"))
+
+    # Switch to page B
+    page.get_by_test_id("stSidebarNavLink").nth(1).click()
+    wait_for_app_run(page)
+
+    expect(page.get_by_test_id("stHeading").filter(has_text="Header B")).to_be_visible()
+
+    # Entry-file param should still be in the URL
+    expect(page).to_have_url(re.compile(r"entry_radio=green"))
+    expect_prefixed_markdown(page, "entry_radio:", "green")
+
+    # Switch back to page A
+    page.get_by_test_id("stSidebarNavLink").nth(0).click()
+    wait_for_app_run(page)
+
+    expect(page.get_by_test_id("stHeading").filter(has_text="Header A")).to_be_visible()
+    expect(page).to_have_url(re.compile(r"entry_radio=green"))
+    expect_prefixed_markdown(page, "entry_radio:", "green")

--- a/e2e_playwright/st_slider.py
+++ b/e2e_playwright/st_slider.py
@@ -355,3 +355,17 @@ bound_datetime_secs = st.slider(
     bind="query-params",
 )
 st.write("Bound datetime secs value:", bound_datetime_secs)
+
+# --- Session state + query param collision slider ---
+
+if "bound_ss" not in st.session_state:
+    st.session_state.bound_ss = 30
+
+bound_ss = st.slider(
+    "Bound session state slider",
+    min_value=0,
+    max_value=100,
+    key="bound_ss",
+    bind="query-params",
+)
+st.write("Bound ss value:", bound_ss)

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -20,6 +20,7 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.conftest import (
     ImageCompareFunction,
     build_app_url,
+    rerun_app,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -37,7 +38,7 @@ from e2e_playwright.shared.app_utils import (
     tab_until_focused,
 )
 
-NUM_SLIDER_WIDGETS = 36
+NUM_SLIDER_WIDGETS = 37
 
 
 def test_slider_rendering(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -611,3 +612,46 @@ def test_slider_query_param_datetime_seconds_iso_seeding(page: Page, app_base_ur
 
     expect_prefixed_markdown(page, "Bound datetime secs value:", "2024-03-20 09:30:30")
     expect(page).to_have_url(re.compile(r"bound_datetime_secs=2024-03-20T09%3A30%3A30"))
+
+
+# --- Session state vs URL value collision tests ---
+
+
+def test_slider_url_value_wins_over_session_state_on_initial_load(
+    page: Page, app_base_url: str
+):
+    """On initial load, URL value takes priority over pre-set session_state."""
+    page.goto(build_app_url(app_base_url, query={"bound_ss": "75"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound ss value:", "75")
+    expect(page).to_have_url(re.compile(r"bound_ss=75"))
+
+
+def test_slider_session_state_wins_when_no_url_value(app: Page):
+    """Without URL value, session_state pre-set (30) wins over widget default (0)."""
+    expect_prefixed_markdown(app, "Bound ss value:", "30")
+    # Session-state pre-set doesn't push to URL without user interaction
+    expect(app).not_to_have_url(re.compile(r"bound_ss="))
+
+
+def test_slider_ui_value_wins_on_rerun_and_syncs_url(page: Page, app_base_url: str):
+    """After initial load, interacting with the widget updates session_state and URL."""
+    page.goto(build_app_url(app_base_url, query={"bound_ss": "75"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "Bound ss value:", "75")
+
+    slider = get_element_by_key(page, "bound_ss")
+    slider.get_by_role("slider").press("ArrowRight")
+    wait_for_app_run(page)
+
+    expect_prefixed_markdown(page, "Bound ss value:", "76")
+    expect(page).to_have_url(re.compile(r"bound_ss=76"))
+
+    # Rerun the app — UI/session_state value should persist, not revert to
+    # the session_state pre-set (30) or the original URL value (75)
+    rerun_app(page)
+
+    expect_prefixed_markdown(page, "Bound ss value:", "76")
+    expect(page).to_have_url(re.compile(r"bound_ss=76"))

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -234,7 +234,10 @@ describe("AppNavigation", () => {
       pageScriptHash: "page_script_hash2",
       expanded: false,
     })
-    appNavigation.handleNavigation(navigation)
+    const maybeState = appNavigation.handleNavigation(navigation)
+    // onUpdatePageUrl is called in the setState callback
+    const callback = maybeState![1]
+    callback()
     expect(onUpdatePageUrl).toHaveBeenCalledWith(
       "streamlit_app",
       "streamlit_app2",

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -146,12 +146,6 @@ export class AppNavigation {
       this.onPageIconChange(currentPage.icon)
     }
 
-    this.onUpdatePageUrl(
-      mainPage.urlPathname ?? "",
-      currentPageName,
-      currentPage.isDefault ?? false
-    )
-
     return [
       {
         appPages,
@@ -162,6 +156,15 @@ export class AppNavigation {
         currentPageScriptHash,
       },
       () => {
+        // Update the page URL in the setState callback so that
+        // this.state.queryParams reflects all batched updates
+        // (e.g. from handlePageInfoChanged) before we read it.
+        this.onUpdatePageUrl(
+          mainPage.urlPathname ?? "",
+          currentPageName,
+          currentPage.isDefault ?? false
+        )
+
         this.hostCommunicationMgr.sendMessageToHost({
           type: "SET_APP_PAGES",
           appPages,


### PR DESCRIPTION
## Describe your changes
**Fix:** Move `onUpdatePageUrl` call in `AppNavigation.handleNavigation` from the synchronous body into the `setState` callback. This fixes a race condition where `maybeUpdatePageUrl` reads stale `this.state.queryParams` when building the new page URL during `st.navigation` page switches.

**Root cause:** React 18 batches `setState` calls within the same synchronous task. When the frontend processes a batch of WebSocket messages, `handlePageInfoChanged` updates `queryParams` via `setState`, but the update hasn't been committed when `maybeUpdatePageUrl` runs moments later in the same batch. By deferring the URL update to the `setState` callback, we guarantee all batched state (including the cleaned query params from the backend) is committed before we read it.

**E2E tests:** Adds coverage for widget binding + page navigation scenarios that were previously untested:

| Scenario | Test file |
|---|---|
| 1. MPA v1 page switch clears params | `mpa_basics_test.py` |
| 2. MPA v2 page-specific params cleared | `st_navigation_test.py` |
| 3. MPA v2 entry file params persist | `st_navigation_test.py` |
| 4. Session state vs URL collision | `st_slider_test.py` |


## Testing Plan
- JS Unit Tests: ✅ Updated
- E2E Tests: ✅ Added