### PR TITLE
[refactor] Move metric font config to theme typography primitives

### DIFF
--- a/frontend/component-v2-lib/src/theme.ts
+++ b/frontend/component-v2-lib/src/theme.ts
@@ -110,8 +110,8 @@ export interface StreamlitTheme {
   grayTextColor: string
 
   // Metric value styling
-  metricValueFontSize: string | null
-  metricValueFontWeight: number | null
+  metricValueFontSize: string
+  metricValueFontWeight: number
 }
 
 /**

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -198,13 +198,13 @@ describe("Metric element", () => {
 
   // Metric value font styling tests
   describe("Metric value font styling", () => {
-    it("does not set font-weight when theme does not specify metricValueFontWeight", () => {
+    it("applies default font-weight when theme does not specify metricValueFontWeight", () => {
       const props = getProps({ body: "123" })
       render(<Metric {...props} />)
 
-      // fontWeight should inherit from parent when not configured
-      expect(screen.getByTestId("stMetricValue")).not.toHaveStyle(
-        "font-weight: 600"
+      // Default fontWeight should be 400 (normal) from theme fontWeights
+      expect(screen.getByTestId("stMetricValue")).toHaveStyle(
+        "font-weight: 400"
       )
     })
 
@@ -212,7 +212,7 @@ describe("Metric element", () => {
       const props = getProps({ body: "123" })
       render(<Metric {...props} />)
 
-      // Default font-size should be threeXL (2.25rem) when theme doesn't specify metricValueFontSize
+      // Default font-size should be metricValueFontSize (2.25rem) from theme fontSizes
       expect(screen.getByTestId("stMetricValue")).toHaveStyle(
         "font-size: 2.25rem"
       )

--- a/frontend/lib/src/components/elements/Metric/styled-components.ts
+++ b/frontend/lib/src/components/elements/Metric/styled-components.ts
@@ -69,11 +69,9 @@ export const StyledMetricLabelText = styled(
 }))
 
 export const StyledMetricValueText = styled.div(({ theme }) => ({
-  fontSize: theme.metricValueFontSize ?? theme.fontSizes.threeXL,
+  fontSize: theme.fontSizes.metricValueFontSize,
   lineHeight: "normal",
-  ...(theme.metricValueFontWeight !== undefined && {
-    fontWeight: theme.metricValueFontWeight,
-  }),
+  fontWeight: theme.fontWeights.metricValueFontWeight,
   color: theme.colors.bodyText,
   paddingBottom: theme.spacing.twoXS,
 }))

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/theme.test.ts
@@ -103,8 +103,8 @@ describe("BidiComponent/utils/theme", () => {
       violetTextColor: "#aa00ff",
       grayTextColor: "#888888",
 
-      metricValueFontSize: null,
-      metricValueFontWeight: null,
+      metricValueFontSize: "2.25rem",
+      metricValueFontWeight: 400,
       ...overrides,
     })
 

--- a/frontend/lib/src/components/widgets/BidiComponent/utils/theme.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/utils/theme.ts
@@ -177,7 +177,7 @@ export const extractComponentsV2Theme = (
     violetTextColor: theme.colors.violetTextColor,
     grayTextColor: theme.colors.grayTextColor,
 
-    metricValueFontSize: theme.metricValueFontSize ?? null,
-    metricValueFontWeight: theme.metricValueFontWeight ?? null,
+    metricValueFontSize: theme.fontSizes.metricValueFontSize,
+    metricValueFontWeight: theme.fontWeights.metricValueFontWeight,
   }
 }

--- a/frontend/lib/src/theme/primitives/typography.ts
+++ b/frontend/lib/src/theme/primitives/typography.ts
@@ -53,6 +53,8 @@ export const fontSizes = {
   h4FontSize: "1.5rem",
   h5FontSize: "1.25rem",
   h6FontSize: "1rem",
+
+  metricValueFontSize: "2.25rem",
 }
 
 export const fontWeights = {
@@ -72,6 +74,7 @@ export const fontWeights = {
   h4FontWeight: 600,
   h5FontWeight: 600,
   h6FontWeight: 600,
+  metricValueFontWeight: 400,
 }
 
 export const lineHeights = {

--- a/frontend/lib/src/theme/types.ts
+++ b/frontend/lib/src/theme/types.ts
@@ -104,8 +104,6 @@ export interface EmotionTheme extends Omit<
 > {
   colors: EmotionThemeColors
   shadows: ThemeShadows
-  metricValueFontSize?: string
-  metricValueFontWeight?: number
 }
 
 export type ThemeConfig = {

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -3282,24 +3282,18 @@ describe("createEmotionTheme", () => {
 
       const theme = createEmotionTheme(themeInput)
 
-      expect(theme.metricValueFontSize).toBe(expectedFontSize)
+      expect(theme.fontSizes.metricValueFontSize).toBe(expectedFontSize)
     }
   )
 
-  it("does not set metricValueFontSize if not configured", () => {
+  it("uses default metricValueFontSize if not configured", () => {
     const theme = createEmotionTheme({})
 
-    expect(theme.metricValueFontSize).toBeUndefined()
+    expect(theme.fontSizes.metricValueFontSize).toBe("2.25rem")
   })
 
-  it.each([
-    // Invalid format values
-    "invalid",
-    "rem",
-    "px",
-    " ",
-  ])(
-    "logs a warning and does not set metricValueFontSize for invalid value '%s'",
+  it.each(["invalid", "rem", "px", " ", "0px", "0rem"])(
+    "logs a warning and uses default metricValueFontSize for invalid value '%s'",
     metricValueFontSize => {
       const logWarningSpy = vi.spyOn(LOG, "warn")
       const themeInput: Partial<CustomThemeConfig> = {
@@ -3311,39 +3305,12 @@ describe("createEmotionTheme", () => {
       expect(logWarningSpy).toHaveBeenCalledWith(
         `Invalid size passed for metricValueFontSize in theme: ${metricValueFontSize}. Falling back to default metricValueFontSize.`
       )
-      expect(theme.metricValueFontSize).toBeUndefined()
+      expect(theme.fontSizes.metricValueFontSize).toBe("2.25rem")
     }
   )
 
-  it.each([
-    // Zero with unit (caught by parseFontSize due to falsy 0)
-    "0px",
-    "0rem",
-  ])(
-    "logs a warning and does not set metricValueFontSize for zero value '%s'",
-    metricValueFontSize => {
-      const logWarningSpy = vi.spyOn(LOG, "warn")
-      const themeInput: Partial<CustomThemeConfig> = {
-        metricValueFontSize,
-      }
-
-      const theme = createEmotionTheme(themeInput)
-
-      expect(logWarningSpy).toHaveBeenCalledWith(
-        `Invalid size passed for metricValueFontSize in theme: ${metricValueFontSize}. Falling back to default metricValueFontSize.`
-      )
-      expect(theme.metricValueFontSize).toBeUndefined()
-    }
-  )
-
-  it.each([
-    // Zero without unit, negative values (caught by additional validation)
-    "0",
-    "-10",
-    "-10px",
-    "-10rem",
-  ])(
-    "logs a warning and does not set metricValueFontSize for zero/negative value '%s'",
+  it.each(["0", "-10", "-10px", "-10rem"])(
+    "logs a warning and uses default metricValueFontSize for zero/negative value '%s'",
     metricValueFontSize => {
       const logWarningSpy = vi.spyOn(LOG, "warn")
       const themeInput: Partial<CustomThemeConfig> = {
@@ -3355,7 +3322,7 @@ describe("createEmotionTheme", () => {
       expect(logWarningSpy).toHaveBeenCalledWith(
         `Invalid metricValueFontSize: ${metricValueFontSize} in theme. The metricValueFontSize must be greater than 0. Falling back to default metricValueFontSize.`
       )
-      expect(theme.metricValueFontSize).toBeUndefined()
+      expect(theme.fontSizes.metricValueFontSize).toBe("2.25rem")
     }
   )
 
@@ -3366,17 +3333,17 @@ describe("createEmotionTheme", () => {
 
     const theme = createEmotionTheme(themeInput)
 
-    expect(theme.metricValueFontWeight).toBe(600)
+    expect(theme.fontWeights.metricValueFontWeight).toBe(600)
   })
 
-  it("does not set metricValueFontWeight if not configured", () => {
+  it("uses default metricValueFontWeight if not configured", () => {
     const theme = createEmotionTheme({})
 
-    expect(theme.metricValueFontWeight).toBeUndefined()
+    expect(theme.fontWeights.metricValueFontWeight).toBe(400)
   })
 
   it.each([50, 950, -100])(
-    "logs a warning and does not set metricValueFontWeight if value is out of range: %s",
+    "logs a warning and uses default metricValueFontWeight if value is out of range: %s",
     metricValueFontWeight => {
       const logWarningSpy = vi.spyOn(LOG, "warn")
       const themeInput: Partial<CustomThemeConfig> = {
@@ -3388,7 +3355,7 @@ describe("createEmotionTheme", () => {
       expect(logWarningSpy).toHaveBeenCalledWith(
         `Invalid metricValueFontWeight: ${metricValueFontWeight}. Must be between 100 and 900.`
       )
-      expect(theme.metricValueFontWeight).toBeUndefined()
+      expect(theme.fontWeights.metricValueFontWeight).toBe(400)
     }
   )
 
@@ -3605,6 +3572,7 @@ describe("Font weight configuration coverage", () => {
       "h4FontWeight",
       "h5FontWeight",
       "h6FontWeight",
+      "metricValueFontWeight",
     ]
 
     // List of font weights that SHOULD be calculated based on baseFontWeight

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -979,6 +979,27 @@ export const createEmotionTheme = (
     headingFontSizes
   )
 
+  // Conditional Overrides - Metric Value Font Size
+  if (metricValueFontSize) {
+    // Use parseFontSize for format validation
+    const parsedSize = parseFontSize(
+      "metricValueFontSize",
+      metricValueFontSize,
+      inSidebar
+    )
+    if (parsedSize) {
+      // Additional validation: must be greater than 0
+      const numericValue = parseFloat(parsedSize)
+      if (numericValue <= 0) {
+        LOG.warn(
+          `Invalid metricValueFontSize: ${metricValueFontSize} in theme. The metricValueFontSize must be greater than 0. Falling back to default metricValueFontSize.`
+        )
+      } else {
+        conditionalOverrides.fontSizes.metricValueFontSize = parsedSize
+      }
+    }
+  }
+
   // Conditional Overrides - Font Weights
 
   // Set the font weights based on the font weight configs provided
@@ -989,6 +1010,18 @@ export const createEmotionTheme = (
     codeFontWeight,
     headingFontWeights
   )
+
+  // Conditional Overrides - Metric Value Font Weight
+  if (metricValueFontWeight) {
+    if (metricValueFontWeight >= 100 && metricValueFontWeight <= 900) {
+      conditionalOverrides.fontWeights.metricValueFontWeight =
+        metricValueFontWeight
+    } else {
+      LOG.warn(
+        `Invalid metricValueFontWeight: ${metricValueFontWeight}. Must be between 100 and 900.`
+      )
+    }
+  }
 
   // Font Overrides
 
@@ -1029,36 +1062,6 @@ export const createEmotionTheme = (
     genericFonts: fontsOverride,
     ...conditionalOverrides,
     shadows,
-    ...(() => {
-      if (!metricValueFontSize) return {}
-
-      // Use parseFontSize for format validation
-      const parsedSize = parseFontSize(
-        "metricValueFontSize",
-        metricValueFontSize,
-        inSidebar
-      )
-      if (!parsedSize) return {}
-
-      // Additional validation: must be greater than 0
-      const numericValue = parseFloat(parsedSize)
-      if (numericValue <= 0) {
-        LOG.warn(
-          `Invalid metricValueFontSize: ${metricValueFontSize} in theme. The metricValueFontSize must be greater than 0. Falling back to default metricValueFontSize.`
-        )
-        return {}
-      }
-
-      return { metricValueFontSize: parsedSize }
-    })(),
-    ...(metricValueFontWeight
-      ? metricValueFontWeight >= 100 && metricValueFontWeight <= 900
-        ? { metricValueFontWeight }
-        : (LOG.warn(
-            `Invalid metricValueFontWeight: ${metricValueFontWeight}. Must be between 100 and 900.`
-          ),
-          {})
-      : {}),
   }
 }
 


### PR DESCRIPTION
## Describe your changes

Refactors `metricValueFontSize` and `metricValueFontWeight` from top-level `EmotionTheme` properties to their proper locations within the theme typography primitives:

- **`theme.fontSizes.metricValueFontSize`** (default: `2.25rem`)
- **`theme.fontWeights.metricValueFontWeight`** (default: `400`)

### Changes

- Added `metricValueFontSize` and `metricValueFontWeight` to typography primitives
- Removed optional top-level properties from `EmotionTheme` interface
- Updated `createEmotionTheme` to use conditional overrides pattern (consistent with other font configs)
- Updated `StyledMetricValueText` to read from new locations
- Updated Components V2 theme extraction to use new paths
- Simplified `StreamlitTheme` interface by making these properties non-nullable

### Benefits

- Aligns metric font configuration with existing typography structure
- Simplifies Components V2 API (non-nullable properties with sensible defaults)
- Cleaner code organization using established conditional overrides pattern

## Testing Plan

- [x] Unit Tests (JS) - Updated tests for new property locations and default values

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 4 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->