### PR TITLE
[fix] Remove erroneous expander block ID and align on_change defaults

### DIFF
--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -616,7 +616,7 @@ class LayoutsMixin:
         width: WidthWithoutContent = "stretch",
         default: str | None = None,
         key: Key | None = None,
-        on_change: Literal["ignore", "rerun"] | WidgetCallback | None = None,
+        on_change: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
     ) -> Sequence[TabContainer]:
@@ -683,15 +683,15 @@ class LayoutsMixin:
             When ``on_change`` is set to ``"rerun"`` or a callable, the active
             tab label is also accessible via ``st.session_state[key]``.
 
-        on_change : "ignore", "rerun", callable, or None
+        on_change : "ignore", "rerun", or callable
             How the tabs should respond to user tab changes. This controls
             whether tabs track state and trigger reruns when switched.
             ``on_change`` can be one of the following:
 
-            - ``None`` (default): Current behavior — always execute all tabs,
-              no state tracking. The ``.open`` attribute will return ``None``
-              for all tabs.
-            - ``"ignore"``: Equivalent to ``None`` — no state tracking.
+            - ``"ignore"`` (default): Streamlit will not track the tabs'
+              state. The ``.open`` attribute will return ``None`` for all
+              tabs. The tabs can be used inside ``@st.cache_data`` decorated
+              functions.
             - ``"rerun"``: Streamlit will rerun the app when the user switches
               tabs. The ``.open`` attribute will return ``True`` for the active
               tab and ``False`` for inactive tabs. Allows lazy execution of
@@ -801,19 +801,15 @@ class LayoutsMixin:
                 "The tabs input list to st.tabs is only allowed to contain strings."
             )
 
-        if (
-            on_change is not None
-            and not callable(on_change)
-            and on_change not in {"ignore", "rerun"}
-        ):
+        if not callable(on_change) and on_change not in {"ignore", "rerun"}:
             raise StreamlitValueError(
                 "on_change",
-                ["'rerun'", "'ignore'", "None", "a callback function"],
+                ["'rerun'", "'ignore'", "a callback function"],
             )
 
         key = to_key(key)
         default_index = tabs.index(default) if default else 0
-        is_stateful = on_change is not None and on_change != "ignore"
+        is_stateful = on_change != "ignore"
 
         element_id: str | None = None
         current_tab_label = tabs[default_index]
@@ -1002,7 +998,7 @@ class LayoutsMixin:
               The expander cannot be used inside ``@st.cache_data`` decorated
               functions.
 
-            - ``callable``: A callback function to execute before rerunning the
+            - A callable: A callback function to execute before rerunning the
               app when the expander is toggled. Enables state tracking.
               The callback receives no arguments by default, but you can
               pass arguments using ``args`` and ``kwargs``. The expander
@@ -1119,8 +1115,6 @@ class LayoutsMixin:
 
         block_proto = BlockProto()
         block_proto.allow_empty = True
-        if element_id is not None:
-            block_proto.id = element_id
         block_proto.expandable.CopyFrom(expandable_proto)
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -1588,7 +1588,7 @@ class TabsTest(DeltaGeneratorTestCase):
         assert tabs[1].open is False
 
     def test_on_change_none_raises(self) -> None:
-        """Test that on_change=None raises StreamlitValueError."""
+        """Test that on_change=None raises an error."""
         with pytest.raises(StreamlitAPIException):
             st.tabs(["A", "B"], on_change=None)
 

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -435,18 +435,17 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander = st.expander("label", expanded=True, on_change="rerun")
         assert expander.open is True
 
-    def test_on_change_rerun_sets_block_id(self):
-        """Test that on_change='rerun' sets the block id in the proto."""
+    def test_on_change_rerun_does_not_set_block_id(self):
+        """Test that on_change='rerun' does not set the block-level id."""
         st.expander("label", on_change="rerun")
         expander_block = self.get_delta_from_queue()
-        assert expander_block.add_block.id != ""
+        assert expander_block.add_block.id == ""
 
     def test_on_change_rerun_sets_id(self):
         """Test that on_change='rerun' sets id in the expandable proto."""
         st.expander("label", on_change="rerun")
         expander_block = self.get_delta_from_queue()
         assert expander_block.add_block.expandable.id != ""
-        assert expander_block.add_block.expandable.id == expander_block.add_block.id
 
     def test_on_change_ignore_does_not_set_block_id(self):
         """Test that on_change='ignore' does not set the block id."""
@@ -498,16 +497,16 @@ class ExpanderTest(DeltaGeneratorTestCase):
         assert expander.open is True
         assert st.session_state.cb_exp is True
 
-    def test_on_change_callback_sets_block_id(self):
-        """Test that a callback sets the block id in the proto."""
+    def test_on_change_callback_does_not_set_block_id(self):
+        """Test that a callback does not set the block-level id."""
         st.expander("label", key="cb_exp2", on_change=lambda: None)
         expander_block = self.get_delta_from_queue()
-        assert expander_block.add_block.id != ""
+        assert expander_block.add_block.id == ""
 
     def _get_expander_widget_state(self) -> WidgetState:
         """Find the expander's WidgetState by matching its element id."""
         expander_block = self.get_delta_from_queue()
-        element_id = expander_block.add_block.id
+        element_id = expander_block.add_block.expandable.id
 
         widget_states = self.script_run_ctx.session_state.get_widget_states()
         for ws in widget_states:
@@ -1588,11 +1587,10 @@ class TabsTest(DeltaGeneratorTestCase):
         assert tabs[0].open is True
         assert tabs[1].open is False
 
-    def test_backwards_compat_none_still_works(self) -> None:
-        """Test that on_change=None still works after callback support."""
-        tabs = st.tabs(["A", "B"], on_change=None)
-        for tab in tabs:
-            assert tab.open is None
+    def test_on_change_none_raises(self) -> None:
+        """Test that on_change=None raises StreamlitValueError."""
+        with pytest.raises(StreamlitAPIException):
+            st.tabs(["A", "B"], on_change=None)
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     def test_callable_on_change_inside_form_raises(self) -> None:


### PR DESCRIPTION

## Describe your changes

Fixes two issues in layout container state persistence:

- Removes erroneous `block_proto.id = element_id` assignment in `st.expander` — the ID should only live on `expandable_proto.id`, matching the pattern used by `st.tabs` and `st.popover`
- Aligns `on_change` default to `"ignore"` across all three stateful layout containers. `st.tabs` previously used `None` as its default and accepted `None` as a value; now it uses `"ignore"` consistent with `st.expander`, `st.popover`, and the [product spec](../specs/2026-01-14-dynamic-tabs-expander/product-spec.md#new-parameter-on_change)

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
- Updated existing tests to match corrected behavior (block-level ID not set on expander, `on_change=None` now raises on tabs).


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
