### PR TITLE
[chore] Add tech-spec template and support tech-spec.md in spec validation

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -34,7 +34,6 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const yaml = require('js-yaml');
 
             const errors = [];
 
@@ -59,9 +58,16 @@ jobs:
             }
 
             // Helper to parse frontmatter (handles both LF and CRLF line endings)
+            // Simple key: value parser — no external dependencies needed
             function parseFrontmatter(content) {
               const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-              return match ? yaml.load(match[1]) : null;
+              if (!match) return null;
+              const result = {};
+              for (const line of match[1].split(/\r?\n/)) {
+                const kv = line.match(/^(\w+):\s*(.+)$/);
+                if (kv) result[kv[1]] = kv[2].trim();
+              }
+              return Object.keys(result).length > 0 ? result : null;
             }
 
             // Helper to validate date format
@@ -87,9 +93,12 @@ jobs:
                 errors.push(`❌ "${specDir}" has invalid date prefix (${dirDate})`);
               }
 
-              const specFile = path.join('specs', specDir, 'product-spec.md');
-              if (!fs.existsSync(specFile)) {
-                errors.push(`❌ Missing: ${specFile}`);
+              const specCandidates = ['product-spec.md', 'tech-spec.md'];
+              const specFile = specCandidates
+                .map(f => path.join('specs', specDir, f))
+                .find(f => fs.existsSync(f));
+              if (!specFile) {
+                errors.push(`❌ Missing: specs/${specDir}/product-spec.md or tech-spec.md`);
                 continue;
               }
 

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -34,6 +34,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const yaml = require('js-yaml');
 
             const errors = [];
 
@@ -58,16 +59,9 @@ jobs:
             }
 
             // Helper to parse frontmatter (handles both LF and CRLF line endings)
-            // Simple key: value parser — no external dependencies needed
             function parseFrontmatter(content) {
               const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-              if (!match) return null;
-              const result = {};
-              for (const line of match[1].split(/\r?\n/)) {
-                const kv = line.match(/^(\w+):\s*(.+)$/);
-                if (kv) result[kv[1]] = kv[2].trim();
-              }
-              return Object.keys(result).length > 0 ? result : null;
+              return match ? yaml.load(match[1]) : null;
             }
 
             // Helper to validate date format
@@ -93,12 +87,9 @@ jobs:
                 errors.push(`❌ "${specDir}" has invalid date prefix (${dirDate})`);
               }
 
-              const specCandidates = ['product-spec.md', 'tech-spec.md'];
-              const specFile = specCandidates
-                .map(f => path.join('specs', specDir, f))
-                .find(f => fs.existsSync(f));
-              if (!specFile) {
-                errors.push(`❌ Missing: specs/${specDir}/product-spec.md or tech-spec.md`);
+              const specFile = path.join('specs', specDir, 'product-spec.md');
+              if (!fs.existsSync(specFile)) {
+                errors.push(`❌ Missing: ${specFile}`);
                 continue;
               }
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -7,16 +7,41 @@ far!
 
 Not every change requires a spec. Things that don't require a spec:
 
-- Non‑user‑facing features
 - Bug fixes
 - DevOps‑related improvements
 - Small, non‑controversial user‑facing enhancements
+
+Write a **product spec** when:
+
+- Proposing a new user‑facing feature or significant API change
+- The _what_ and _why_ need alignment before implementation begins
+- Design mockups or UX decisions need sign‑off
+
+Write a **tech spec** when:
+
+- The feature is non‑user‑facing but architecturally significant
+- The _how_ needs alignment before implementation begins (e.g. proto design, state
+  management approach, frontend/backend split)
+- Multiple implementation paths exist with meaningful trade‑offs to document
+
+A single spec directory can contain both a `product-spec.md` and a `tech-spec.md` if the
+feature warrants both.
+
+## Product spec vs. tech spec
+
+- **`product-spec.md`** — focuses on _what_ and _why_: user-facing problem, proposed API,
+  design mockups, and behaviour.
+- **`tech-spec.md`** — focuses on _how_: internal architecture, proto changes, frontend/backend
+  design, state management, and alternatives considered.
+
+Both formats share the same directory naming convention and PR process.
 
 ## How to create a spec?
 
 1. Copy `specs/YYYY-MM-DD-template/` to a new folder named `specs/YYYY-MM-DD-my-feature-name/`
    (use the current date), e.g., `specs/2026-02-05-datetime-widget/`.
-2. Fill in the [`product-spec.md`](./YYYY-MM-DD-template/product-spec.md) inside it.
+2. Fill in either [`product-spec.md`](./YYYY-MM-DD-template/product-spec.md) or
+   [`tech-spec.md`](./YYYY-MM-DD-template/tech-spec.md) inside it.
 3. Create a PR with the following details:
    - PR title: `[spec] My feature name`, e.g., `[spec] Datetime widget`
    - Keep the PR in Draft until it’s ready for discussion

--- a/specs/YYYY-MM-DD-template/tech-spec.md
+++ b/specs/YYYY-MM-DD-template/tech-spec.md
@@ -1,0 +1,31 @@
+---
+author: github-name
+created: YYYY-MM-DD
+---
+
+# Feature name
+
+## Summary
+
+<!--
+A clear and concise description of what this tech spec covers (2-3 sentences).
+-->
+
+## Problem
+
+<!--
+Describe the technical problem or limitation being addressed. Link relevant
+GitHub issues and prior art.
+-->
+
+## Proposal
+
+<!--
+Describe the proposed technical solution.
+-->
+
+## Alternatives Considered
+
+<!--
+Other approaches evaluated and why they were rejected.
+-->


### PR DESCRIPTION
## Describe your changes

- Adds `specs/YYYY-MM-DD-template/tech-spec.md` for specs that focus on implementation decisions rather than user-facing product design
- Updates `specs/README.md` to explain when to use a product spec vs. a tech spec

## GitHub Issue Link (if applicable)

N/A

## Testing Plan


---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)