### PR TITLE
[fix] Fix spec-validation workflow: install js-yaml and accept tech-spec.md

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -57,9 +57,7 @@ jobs:
               return;
             }
 
-            // Helper to parse frontmatter (handles both LF and CRLF line endings).
-            // Simple key: value parser — no external dependencies needed for the
-            // two-field frontmatter (author, created) used in specs.
+            // Parses YAML-style frontmatter (handles both LF and CRLF line endings).
             function parseFrontmatter(content) {
               const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
               if (!match) return null;

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -28,6 +28,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
+      - name: Install js-yaml
+        run: npm install js-yaml
+
       - name: Validate spec PR
         uses: actions/github-script@v8
         with:
@@ -87,9 +90,12 @@ jobs:
                 errors.push(`❌ "${specDir}" has invalid date prefix (${dirDate})`);
               }
 
-              const specFile = path.join('specs', specDir, 'product-spec.md');
-              if (!fs.existsSync(specFile)) {
-                errors.push(`❌ Missing: ${specFile}`);
+              const specCandidates = ['product-spec.md', 'tech-spec.md'];
+              const specFile = specCandidates
+                .map(f => path.join('specs', specDir, f))
+                .find(f => fs.existsSync(f));
+              if (!specFile) {
+                errors.push(`❌ Missing: specs/${specDir}/product-spec.md or tech-spec.md`);
                 continue;
               }
 

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -28,16 +28,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Install js-yaml
-        run: npm install js-yaml
-
       - name: Validate spec PR
         uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const yaml = require('js-yaml');
 
             const errors = [];
 
@@ -61,10 +57,18 @@ jobs:
               return;
             }
 
-            // Helper to parse frontmatter (handles both LF and CRLF line endings)
+            // Helper to parse frontmatter (handles both LF and CRLF line endings).
+            // Simple key: value parser — no external dependencies needed for the
+            // two-field frontmatter (author, created) used in specs.
             function parseFrontmatter(content) {
               const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-              return match ? yaml.load(match[1]) : null;
+              if (!match) return null;
+              const result = {};
+              for (const line of match[1].split(/\r?\n/)) {
+                const kv = line.match(/^(\w+):\s*(.+)$/);
+                if (kv) result[kv[1]] = kv[2].trim();
+              }
+              return Object.keys(result).length > 0 ? result : null;
             }
 
             // Helper to validate date format
@@ -95,7 +99,7 @@ jobs:
                 .map(f => path.join('specs', specDir, f))
                 .find(f => fs.existsSync(f));
               if (!specFile) {
-                errors.push(`❌ Missing: specs/${specDir}/product-spec.md or tech-spec.md`);
+                errors.push(`❌ Missing: ${specCandidates.map(f => `specs/${specDir}/${f}`).join(' or ')}`);
                 continue;
               }
 
@@ -109,9 +113,7 @@ jobs:
               if (!fm.author || fm.author === 'github-name') {
                 errors.push(`❌ ${specFile}: author is missing or placeholder`);
               }
-              const createdStr = fm.created instanceof Date
-                ? fm.created.toISOString().split('T')[0]
-                : String(fm.created);
+              const createdStr = fm.created;
               if (!fm.created || createdStr === 'YYYY-MM-DD' || !isValidDate(createdStr)) {
                 errors.push(`❌ ${specFile}: created must be valid YYYY-MM-DD date`);
               }


### PR DESCRIPTION
## Describe your changes

Fixes the validate-spec CI job which was failing with Cannot find module 'js-yaml'. Rather than installing js-yaml at runtime (which has a security risk: a malicious PR could add a repo-level .npmrc to redirect the registry or enable lifecycle scripts), this PR replaces it with an inline key: value frontmatter parser.
The inline parser is sufficient for spec frontmatter, which only ever contains two simple string fields (author and created). As a bonus, js-yaml auto-converts bare dates to Date objects, requiring a runtime instanceof Date workaround — the inline parser returns plain strings, so that dead branch is removed.
Also extends the validator to accept tech-spec.md alongside product-spec.md, and derives the missing-file error message from the candidates list so it stays in sync automatically.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: validated by CI on this PR

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)