### PR TITLE
Improve backend cleanup of stale query param bindings

### DIFF
--- a/e2e_playwright/st_checkbox.py
+++ b/e2e_playwright/st_checkbox.py
@@ -122,3 +122,18 @@ bound_cb_true = st.checkbox(
     bind="query-params",
 )
 st.write("bound checkbox true value:", bound_cb_true)
+
+# Unbind test: checkbox whose bind="query-params" can be removed at runtime
+st.markdown("Unbind test:")
+if st.button("Remove binding"):
+    st.session_state.use_bind = False
+
+use_bind = st.session_state.get("use_bind", True)
+if use_bind:
+    unbind_val = st.checkbox(
+        "Unbindable checkbox", key="unbindable", bind="query-params"
+    )
+else:
+    unbind_val = st.checkbox("Unbindable checkbox", key="unbindable")
+st.write("unbindable value:", unbind_val)
+st.write("bind active:", use_bind)

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -33,7 +33,7 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-CHECKBOX_ELEMENTS = 19
+CHECKBOX_ELEMENTS = 20
 
 
 def test_checkbox_widget_display(
@@ -267,3 +267,23 @@ def test_checkbox_query_param_invalid_value(page: Page, app_base_url: str):
     # Checkbox should use default (False), and invalid param should be cleared
     expect_prefixed_markdown(page, "bound checkbox value:", "False")
     expect(page).not_to_have_url(re.compile(r"bound_checkbox"))
+
+
+def test_checkbox_unbind_clears_url_param(page: Page, app_base_url: str):
+    """Test that removing bind='query-params' clears the URL param."""
+    page.goto(build_app_url(app_base_url, query={"unbindable": "true"}))
+    wait_for_app_loaded(page)
+
+    expect_prefixed_markdown(page, "unbindable value:", "True")
+    expect_prefixed_markdown(page, "bind active:", "True")
+    expect(page).to_have_url(re.compile(r"unbindable=true"))
+
+    # Remove the binding by clicking the button
+    page.get_by_role("button", name="Remove binding").click()
+    wait_for_app_run(page)
+
+    # URL should no longer contain the query param
+    expect(page).not_to_have_url(re.compile(r"unbindable"))
+    # Widget value should still be True (preserved in session state)
+    expect_prefixed_markdown(page, "unbindable value:", "True")
+    expect_prefixed_markdown(page, "bind active:", "False")

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -495,7 +495,7 @@ class QueryParams(MutableMapping[str, str]):
 
         Unlike ``unbind_widget`` which only removes the internal tracking, this
         method also deletes the query parameter value and sends a forward
-        message so the frontend URL is updated.  It is a no-op when no binding
+        message so the frontend URL is updated. It is a no-op when no binding
         exists for *widget_id*.
 
         Parameters

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -490,6 +490,29 @@ class QueryParams(MutableMapping[str, str]):
         if binding:
             self._bindings_by_param.pop(binding.param_key, None)
 
+    def unbind_and_clear_param(self, widget_id: str) -> None:
+        """Remove a widget binding and its associated query param from the URL.
+
+        Unlike ``unbind_widget`` which only removes the internal tracking, this
+        method also deletes the query parameter value and sends a forward
+        message so the frontend URL is updated.  It is a no-op when no binding
+        exists for *widget_id*.
+
+        Parameters
+        ----------
+        widget_id : str
+            The unique widget ID.
+        """
+        binding = self._bindings_by_widget.get(widget_id)
+        if binding is None:
+            return
+
+        param_key = binding.param_key
+        self.unbind_widget(widget_id)
+        if param_key in self._query_params:
+            del self._query_params[param_key]
+            self._send_query_param_msg()
+
     def is_bound(self, param_key: str) -> bool:
         """Check if a query parameter is bound to a widget.
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -973,6 +973,9 @@ class SessionState:
             url_value_seeded = self._handle_query_param_binding(
                 metadata, user_key, widget_id
             )
+        elif metadata.bind is None and user_key is not None:
+            # Widget stopped using bind — clean up any stale binding
+            self.query_params.unbind_and_clear_param(widget_id)
 
         if (
             widget_id not in self

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -981,6 +981,31 @@ class WidgetBindingTest(DeltaGeneratorTestCase):
         # Should not raise
         self.query_params.unbind_widget("nonexistent_widget")
 
+    def test_unbind_and_clear_param_removes_binding_and_url_param(self) -> None:
+        """Test that unbind_and_clear_param removes binding and query param."""
+        self.query_params.bind_widget(
+            param_key="my_key",
+            widget_id="widget_123",
+            value_type="string_value",
+            script_hash="hash_abc",
+        )
+        self.query_params.set_with_no_forward_msg("my_key", "some_value")
+
+        self.query_params.unbind_and_clear_param("widget_123")
+
+        assert not self.query_params.is_bound("my_key")
+        assert "widget_123" not in self.query_params._bindings_by_widget
+        assert "my_key" not in self.query_params._query_params
+
+    def test_unbind_and_clear_param_noop_for_unknown_widget(self) -> None:
+        """Test that unbind_and_clear_param is a no-op for unknown widget IDs."""
+        self.query_params.set_with_no_forward_msg("other_key", "val")
+
+        self.query_params.unbind_and_clear_param("nonexistent_widget")
+
+        # Unrelated param should be untouched
+        assert self.query_params["other_key"] == "val"
+
     def test_is_bound_returns_false_for_unbound_param(self) -> None:
         """Test that is_bound returns False for parameters that aren't bound."""
         assert not self.query_params.is_bound("unbound_key")

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -1009,6 +1009,26 @@ class WidgetBindingTest(DeltaGeneratorTestCase):
         # Unrelated param should be untouched
         assert self.query_params["other_key"] == "val"
 
+    def test_unbind_and_clear_param_skips_msg_when_param_already_cleared(
+        self,
+    ) -> None:
+        """Test that no forward message is sent when binding exists but param was already removed."""
+        self.query_params.bind_widget(
+            param_key="my_key",
+            widget_id="widget_123",
+            value_type="string_value",
+            script_hash="hash_abc",
+        )
+        # Binding exists but no corresponding query param in _query_params
+
+        self.query_params.unbind_and_clear_param("widget_123")
+
+        # Binding should be removed
+        assert not self.query_params.is_bound("my_key")
+        assert "widget_123" not in self.query_params._bindings_by_widget
+        # No forward message should have been enqueued
+        assert self.forward_msg_queue.is_empty()
+
     def test_is_bound_returns_false_for_unbound_param(self) -> None:
         """Test that is_bound returns False for parameters that aren't bound."""
         assert not self.query_params.is_bound("unbound_key")

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -997,6 +997,9 @@ class WidgetBindingTest(DeltaGeneratorTestCase):
         assert "widget_123" not in self.query_params._bindings_by_widget
         assert "my_key" not in self.query_params._query_params
 
+        message = self.get_message_from_queue(0)
+        assert "my_key" not in message.page_info_changed.query_string
+
     def test_unbind_and_clear_param_noop_for_unknown_widget(self) -> None:
         """Test that unbind_and_clear_param is a no-op for unknown widget IDs."""
         self.query_params.set_with_no_forward_msg("other_key", "val")

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1572,6 +1572,67 @@ class HandleQueryParamBindingTest(DeltaGeneratorTestCase):
         assert self.session_state._new_session_state["my_widget"] == "url_value"
 
 
+class RegisterWidgetUnbindTest(DeltaGeneratorTestCase):
+    """Tests for register_widget cleaning up stale bindings when bind is removed."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+        self.query_params = self.session_state.query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_register_widget_unbinds_when_bind_removed(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Test that re-registering a widget without bind clears the stale binding."""
+        widget_id = "$$ID-hash-my_widget"
+
+        # Simulate first run with bind="query-params"
+        bound_metadata = _create_test_widget_metadata(widget_id)
+        self.session_state.register_widget(bound_metadata, user_key="my_widget")
+
+        self.query_params.set_with_no_forward_msg("my_widget", "42")
+        assert self.query_params.is_bound("my_widget")
+
+        # Simulate second run with bind=None (developer removed bind)
+        unbound_metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x if x is not None else "default",
+            serializer=lambda x: x,
+            value_type="string_value",
+            bind=None,
+        )
+        self.session_state.register_widget(unbound_metadata, user_key="my_widget")
+
+        assert not self.query_params.is_bound("my_widget")
+        assert "my_widget" not in self.query_params._query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_register_widget_without_bind_is_noop_when_never_bound(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Test that registering a widget that was never bound does nothing extra."""
+        widget_id = "$$ID-hash-plain"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x if x is not None else "default",
+            serializer=lambda x: x,
+            value_type="string_value",
+            bind=None,
+        )
+
+        self.session_state.register_widget(metadata, user_key="plain")
+
+        assert not self.query_params.is_bound("plain")
+        assert len(self.query_params._bindings_by_widget) == 0
+
+
 class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):
     """Tests for _seed_widget_from_url method."""
 


### PR DESCRIPTION
## Describe your changes
- Add `QueryParams.unbind_and_clear_param()` method that removes a stale widget binding **and** clears the associated query param from the URL (with frontend notification), encapsulating cleanup that previously required reaching into private internals
- Add an `elif` branch in `SessionState.register_widget()` so that when a keyed widget re-registers with `bind=None` (i.e., the developer removed `bind="query-params"`), any stale binding and its URL param are cleaned up immediately
- This fixes a gap where `remove_stale_bindings()` could not catch stale bindings for widgets that are still active but simply dropped their `bind` parameter, because `bind` is not part of the widget ID computation

## Testing Plan
- Python Unit Tests: ✅ 
