### PR TITLE
Fix `AppTest` not rendering content for apps using `st.navigation`

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -128,9 +128,10 @@ class AppTest:
 
     .. note::
         ``AppTest`` only supports testing a single page of an app per
-        instance. For multipage apps, each page will need to be tested
-        separately. ``AppTest`` is not yet compatible with multipage apps
-        using ``st.navigation`` and ``st.Page``.
+        instance. For multipage apps using ``st.navigation``, ``AppTest``
+        will render the default page. To test other pages, you can use
+        ``st.switch_page`` within your test or modify query parameters
+        before running.
 
     .. |st.testing.v1.AppTest.from_file| replace:: ``st.testing.v1.AppTest.from_file``
     .. _st.testing.v1.AppTest.from_file: #apptestfrom_file
@@ -339,6 +340,8 @@ class AppTest:
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
         Runtime._instance = mock_runtime
         script_cache = ScriptCache()
+        # Reset to ensure st.navigation works correctly regardless of prior test state.
+        PagesManager.uses_pages_directory = None
         pages_manager = PagesManager(
             self._script_path, script_cache, setup_watcher=False
         )

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -130,7 +130,7 @@ class AppTest:
         ``AppTest`` only supports testing a single page of an app per
         instance. For multipage apps using ``st.navigation``, ``AppTest``
         will render the default page. To test other pages, you can use
-        ``st.switch_page`` within your test or modify query parameters
+        ``AppTest.switch_page()`` within your test or modify query parameters
         before running.
 
     .. |st.testing.v1.AppTest.from_file| replace:: ``st.testing.v1.AppTest.from_file``

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -232,3 +232,66 @@ def test_switch_page_widgets():
     assert not at.slider
     at.switch_page("main.py").run()
     assert at.slider[0].value == 0
+
+
+def test_navigation_with_callable_pages():
+    """Test st.navigation renders callable pages correctly.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/9446
+    """
+
+    def script():
+        import streamlit as st
+
+        def page1():
+            st.title("Page 1 Title")
+            st.write("Content from page 1")
+
+        def page2():
+            st.title("Page 2 Title")
+            st.write("Content from page 2")
+
+        st.write("Header from main app")
+        pg = st.navigation(
+            [
+                st.Page(page1, title="Page 1"),
+                st.Page(page2, title="Page 2"),
+            ]
+        )
+        pg.run()
+
+    at = AppTest.from_function(script).run()
+
+    assert at.title[0].value == "Page 1 Title"
+    assert "Header from main app" in at.markdown.values
+    assert "Content from page 1" in at.markdown.values
+
+
+def test_navigation_resets_pages_manager_state():
+    """Test AppTest resets PagesManager.uses_pages_directory before running.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/9446
+    """
+    from streamlit.runtime.pages_manager import PagesManager
+
+    original_value = PagesManager.uses_pages_directory
+    PagesManager.uses_pages_directory = True
+
+    try:
+
+        def script():
+            import streamlit as st
+
+            def page1():
+                st.title("Navigation Page")
+                st.write("Page content")
+
+            pg = st.navigation([st.Page(page1, title="Page 1")])
+            pg.run()
+
+        at = AppTest.from_function(script).run()
+
+        assert at.title[0].value == "Navigation Page"
+        assert "Page content" in at.markdown.values
+    finally:
+        PagesManager.uses_pages_directory = original_value

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.testing.v1 import AppTest
 
 
@@ -272,7 +273,6 @@ def test_navigation_resets_pages_manager_state():
 
     Regression test for https://github.com/streamlit/streamlit/issues/9446
     """
-    from streamlit.runtime.pages_manager import PagesManager
 
     original_value = PagesManager.uses_pages_directory
     PagesManager.uses_pages_directory = True


### PR DESCRIPTION
## Describe your changes

Fixes #9446.

`AppTest` was not rendering content for pages in apps using `st.navigation` and `st.Page`. The root cause is that `PagesManager.uses_pages_directory` is a class-level attribute that persists across test runs. When set to `True` (from a previous test or because a `pages/` directory exists), the `ScriptRunner` would invoke the legacy MPA v1 path instead of executing the script code directly, causing `st.navigation`-based pages to not render properly.

**Changes:**
- Reset `PagesManager.uses_pages_directory = None` before each `AppTest.run()` to ensure clean state
- Updated `AppTest` docstring to reflect that `st.navigation` is now supported
- Added two regression tests for the fix

## Testing Plan

- [x] Added `test_navigation_with_callable_pages` - tests the user scenario from the issue
- [x] Added `test_navigation_resets_pages_manager_state` - regression test that verifies the fix works even if `PagesManager.uses_pages_directory` was previously set to `True`

**Contributor License Agreement**

- [x] By submitting this pull request I have read and agree to the [Contributor License Agreement](https://github.com/streamlit/streamlit/blob/develop/CONTRIBUTING.md).

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->