### PR TITLE
[docs] Make PR agent labeling more reliable 

### DIFF
--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -68,7 +68,7 @@ All PRs require these labels:
 | Impact | `impact:users` (affects user behavior) OR `impact:internal` (no user behavior change) |
 | Change type | `change:feature`, `change:bugfix`, `change:chore`, `change:refactor`, `change:docs`, `change:spec`, `change:other` |
 
-Note: `security-assessment-completed` is added by the reviewer after security assessment, not by the PR author.
+Note: `security-assessment-completed` is added by the reviewer after security assessment, not by the PR author. PRs labeled `change:spec` (for spec/design documents only) are exempt from Impact and security label requirements.
 
 ### 3.2 Generate PR title
 

--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -66,7 +66,7 @@ All PRs require these labels:
 | Category | Options |
 |----------|---------|
 | Impact | `impact:users` (affects user behavior) OR `impact:internal` (no user behavior change) |
-| Change type | `change:feature`, `change:bugfix`, `change:chore`, `change:refactor`, `change:docs`, `change:other` |
+| Change type | `change:feature`, `change:bugfix`, `change:chore`, `change:refactor`, `change:docs`, `change:spec`, `change:other` |
 
 Note: `security-assessment-completed` is added by the reviewer after security assessment, not by the PR author.
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -66,7 +66,14 @@ Check if a PR exists for the current branch:
 gh pr view --json number,title,url
 ```
 
-**If no PR exists**, create one following the guidelines in `wiki/pull-requests.md`. Add appropriate labels (`impact:*` and `change:*`) and fill in the body based on `.github/pull_request_template.md` (skip the video/screenshot section):
+**If no PR exists**, create one following the guidelines in `wiki/pull-requests.md` (please read!). Add appropriate labels and fill in the body based on `.github/pull_request_template.md` (skip the video/screenshot section):
+
+**Required labels:**
+
+| Category | Options |
+|----------|---------|
+| Impact | `impact:users` (affects user behavior) OR `impact:internal` (no user behavior change) |
+| Change type | `change:feature`, `change:bugfix`, `change:chore`, `change:refactor`, `change:docs`, `change:spec`, `change:other` |
 
 ```bash
 # Push branch to origin first (required for gh pr create in non-interactive mode)

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -75,6 +75,8 @@ gh pr view --json number,title,url
 | Impact | `impact:users` (affects user behavior) OR `impact:internal` (no user behavior change) |
 | Change type | `change:feature`, `change:bugfix`, `change:chore`, `change:refactor`, `change:docs`, `change:spec`, `change:other` |
 
+Note: `security-assessment-completed` is added by the reviewer after security assessment, not by the PR author. PRs labeled `change:spec` (for spec/design documents only) are exempt from Impact and security label requirements.
+
 ```bash
 # Push branch to origin first (required for gh pr create in non-interactive mode)
 git push -u origin HEAD

--- a/wiki/pull-requests.md
+++ b/wiki/pull-requests.md
@@ -94,7 +94,7 @@ All PRs require three labels:
 | Category | Options |
 |----------|---------|
 | Impact | `impact:users` (affects user behavior) **or** `impact:internal` |
-| Change type | `change:feature` · `change:bugfix` · `change:chore` · `change:refactor` · `change:docs` · `change:other` |
+| Change type | `change:feature` · `change:bugfix` · `change:chore` · `change:refactor` · `change:docs` · `change:spec` · `change:other` |
 
 `security-assessment-completed` is added by the reviewer after security assessment, not by the PR author.
 

--- a/wiki/pull-requests.md
+++ b/wiki/pull-requests.md
@@ -98,6 +98,8 @@ All PRs require three labels:
 
 `security-assessment-completed` is added by the reviewer after security assessment, not by the PR author.
 
+**Note:** PRs labeled `change:spec` (for spec/design documents only) are exempt from the `impact:*` and `security-assessment-completed` requirements. Do not use `change:spec` for PRs with code changes.
+
 ## Testing plan
 
 **Where tests live:**


### PR DESCRIPTION
## Describe your changes

Attempt to make the PR labeling by agents more reliable.

## Testing Plan

- Documentation-only changes, no behavior modifications

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->