### PR TITLE
[docs] Remove unsupported thousand separators from `number_input` docstring

### DIFF
--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -313,8 +313,7 @@ class NumberInputMixin:
             <https://github.com/alexei/sprintf.js?tab=readme-ov-file#format-specification>`_.
 
             For example, ``format="%0.1f"`` adjusts the displayed decimal
-            precision to only show one digit after the decimal. Use ``,`` for
-            thousand separators (e.g. ``"%,d"`` yields ``"1,234"``).
+            precision to only show one digit after the decimal.
 
         key : str, int, or None
             An optional string or integer to use as the unique key for


### PR DESCRIPTION

## Describe your changes

Removes the thousand separators documentation from `st.number_input`'s `format` parameter since this feature is not actually supported by the widget.

## GitHub Issue Link (if applicable)

## Testing Plan

- Documentation-only change; no functional code affected
