### PR TITLE
[Fix] Fix `st.text_area` `height="content"` not working

### DIFF
--- a/e2e_playwright/st_text_area_test.py
+++ b/e2e_playwright/st_text_area_test.py
@@ -375,6 +375,29 @@ def test_text_area_content_height_expansion(
     assert_snapshot(content_height_form, name="st_text_area-content_height_reduced")
 
 
+def test_text_area_content_height_default_value(app: Page):
+    """Test that st.text_area with height='content' sizes correctly to default value.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/14222
+    The textarea should auto-expand to fit its default value on initial render,
+    not start at minimum height.
+    """
+    # Get the text area with height='content' and default value "Line 1\nLine 2\nLine 3"
+    content_height_form = app.get_by_test_id("stForm").nth(1)
+    textarea = content_height_form.locator("textarea").first
+
+    # Get the computed height of the textarea
+    height = textarea.evaluate("el => el.offsetHeight")
+
+    # The textarea has 3 lines of content. With height='content', it should be
+    # taller than the minimum height (68px). A 3-line textarea should be ~80-120px.
+    # We use a conservative check: height should be > 70px to account for the content.
+    assert height > 70, (
+        f"Textarea with height='content' and default value should auto-expand to fit content. "
+        f"Got height={height}px, expected > 70px"
+    )
+
+
 def test_text_area_query_param_seeding(page: Page, app_port: int):
     """Test that text area value can be seeded from URL query params."""
     page.goto(f"http://localhost:{app_port}/?bound_text_area=seeded_value")

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -165,7 +165,8 @@ const TextArea: FC<Props> = ({
     updateScrollHeight,
   } = useTextInputAutoExpand({
     textareaRef,
-    dependencies: [element.placeholder],
+    // Include uiValue so height recalculates when the value is set from default
+    dependencies: [element.placeholder, uiValue],
   })
 
   const commitWidgetValue = useCallback((): void => {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -165,8 +165,8 @@ const TextArea: FC<Props> = ({
     updateScrollHeight,
   } = useTextInputAutoExpand({
     textareaRef,
-    // Include uiValue so height recalculates when the value is set from default
-    dependencies: [element.placeholder, uiValue],
+    // Recalculate height when placeholder or committed value changes
+    dependencies: [element.placeholder, value],
   })
 
   const commitWidgetValue = useCallback((): void => {


### PR DESCRIPTION
## Describe your changes

Fixes regression in `st.text_area` with `height="content"` introduced in v1.55.0 (#14222).

- Added `uiValue` to `useTextInputAutoExpand` dependencies so height recalculates when default value is set

**Root cause:** PR #13901 removed `element.default` fallback from `getStateFromWidgetMgr`. The textarea starts empty when `useLayoutEffect` calculates auto-expand height; the default value arrives later via `useEffect` but height was never recalculated.

## GitHub Issue

Fixes #14222

## Testing Plan

- [x] Unit Tests (`frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx` — 28 tests pass)
- [x] E2E Tests (`e2e_playwright/st_text_area_test.py::test_text_area_content_height_expansion` — passes)
- [x] E2E Tests (`e2e_playwright/st_text_area_test.py::test_text_area_content_height_default_value` — new regression test)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 2 |

</details>
<!-- agent-metrics-end -->