### PR TITLE
[chore] Pin pytest-github-actions-annotate-failures to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,8 @@ test = [
   # pytest-rerunfailures 16.0 is breaking our CI:
   # https://github.com/pytest-dev/pytest-rerunfailures/issues/302
   "pytest-rerunfailures>=15.0,!=16.0",
-  "pytest-github-actions-annotate-failures",
+  # pytest-github-actions-annotate-failures 0.4 has compatibility issues:
+  "pytest-github-actions-annotate-failures==0.3.0",
   "pytest-benchmark>=5.1.0",
   "pytest-repeat>=0.9.3",
   "pytest-timeout>=2.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ test = [
   # https://github.com/pytest-dev/pytest-rerunfailures/issues/302
   "pytest-rerunfailures>=15.0,!=16.0",
   # pytest-github-actions-annotate-failures 0.4 has compatibility issues:
-  "pytest-github-actions-annotate-failures==0.3.0",
+  "pytest-github-actions-annotate-failures>=0.3.0,<0.4.0",
   "pytest-benchmark>=5.1.0",
   "pytest-repeat>=0.9.3",
   "pytest-timeout>=2.3.1",


### PR DESCRIPTION
## Describe your changes

Pin `pytest-github-actions-annotate-failures` to version 0.3.0 because version 0.4 has compatibility issues that break CI.

## Testing Plan

- [x] Existing CI runs will validate the dependency works correctly

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->