### PR TITLE
[fix] Normalize URL query encoding in `page_link` and `link_button`

### DIFF
--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -68,7 +68,7 @@ from streamlit.runtime.state import (
 )
 from streamlit.runtime.state.query_params import process_query_params
 from streamlit.string_util import validate_icon_or_emoji
-from streamlit.url_util import is_url
+from streamlit.url_util import is_url, normalize_url_query_encoding
 from streamlit.util import in_sidebar
 
 if TYPE_CHECKING:
@@ -1432,7 +1432,7 @@ class ButtonMixin:
             )
 
         link_button_proto.label = label
-        link_button_proto.url = url
+        link_button_proto.url = normalize_url_query_encoding(url)
         link_button_proto.type = type
         link_button_proto.disabled = disabled
         link_button_proto.ignore_rerun = ignore_rerun
@@ -1528,7 +1528,7 @@ class ButtonMixin:
             if is_url(page):
                 if label is None or label == "":
                     raise StreamlitMissingPageLabelError()
-                page_link_proto.page = page
+                page_link_proto.page = normalize_url_query_encoding(page)
                 page_link_proto.external = True
                 layout_config = LayoutConfig(width=width)
                 return self.dg._enqueue(

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from typing import Final, Literal, TypeAlias
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 UrlSchema: TypeAlias = Literal["http", "https", "mailto", "data"]
 
@@ -161,13 +161,13 @@ def normalize_url_query_encoding(url: str) -> str:
     if not parsed.query:
         return url
 
-    # parse_qs decodes the query string (handles both encoded and unencoded)
+    # parse_qsl decodes the query string and returns a list of (key, value) tuples
+    # which preserves the original parameter order (unlike parse_qs which returns a dict)
     # keep_blank_values=True preserves empty values like "foo="
-    query_params = parse_qs(parsed.query, keep_blank_values=True)
+    query_params = parse_qsl(parsed.query, keep_blank_values=True)
 
     # urlencode re-encodes properly
-    # doseq=True handles lists (multiple values for same key)
-    normalized_query = urlencode(query_params, doseq=True)
+    normalized_query = urlencode(query_params)
 
     # Reconstruct the URL with normalized query parameters
     return urlunparse(

--- a/lib/streamlit/url_util.py
+++ b/lib/streamlit/url_util.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from typing import Final, Literal, TypeAlias
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 UrlSchema: TypeAlias = Literal["http", "https", "mailto", "data"]
 
@@ -118,3 +118,65 @@ def make_url_path(base_url: str, path: str) -> str:
 
     path = path.lstrip("/")
     return f"{base_url}/{path}"
+
+
+def normalize_url_query_encoding(url: str) -> str:
+    """Normalize URL query parameter encoding.
+
+    This ensures query parameters are properly URL-encoded, handling both
+    already-encoded and unencoded URLs safely. This is useful for external
+    URLs provided by users that may contain special characters like spaces,
+    asterisks, or slashes in query values.
+
+    The normalization:
+    - Parses and decodes query parameters (handles both encoded and unencoded)
+    - Re-encodes them using standard URL encoding
+    - Preserves the URL structure (scheme, host, path, fragment)
+
+    Note: Spaces in query values are encoded as '+' (standard for query strings).
+    Both '+' and '%20' are valid and decode to the same value.
+
+    Parameters
+    ----------
+    url : str
+        The URL to normalize.
+
+    Returns
+    -------
+    str
+        The URL with properly encoded query parameters.
+
+    Examples
+    --------
+    >>> normalize_url_query_encoding("http://example.com?foo=/* test */")
+    'http://example.com?foo=%2F%2A+test+%2A%2F'
+
+    >>> normalize_url_query_encoding("http://example.com?foo=%2F%2A+test+%2A%2F")
+    'http://example.com?foo=%2F%2A+test+%2A%2F'
+    """
+
+    parsed = urlparse(url)
+
+    # If no query string, return as-is
+    if not parsed.query:
+        return url
+
+    # parse_qs decodes the query string (handles both encoded and unencoded)
+    # keep_blank_values=True preserves empty values like "foo="
+    query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+    # urlencode re-encodes properly
+    # doseq=True handles lists (multiple values for same key)
+    normalized_query = urlencode(query_params, doseq=True)
+
+    # Reconstruct the URL with normalized query parameters
+    return urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            normalized_query,
+            parsed.fragment,
+        )
+    )

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -184,3 +184,12 @@ class LinkButtonTest(DeltaGeneratorTestCase):
             'The value "invalid" is not a valid emoji. '
             "Shortcodes are not allowed, please use a single character instead."
         )
+
+    def test_url_with_unencoded_query_params(self):
+        """Test that URLs with unencoded query params are properly normalized."""
+        st.link_button(
+            "the label", url="http://example.com?filter=/* Model Errors */worker"
+        )
+
+        c = self.get_delta_from_queue().new_element.link_button
+        assert c.url == "http://example.com?filter=%2F%2A+Model+Errors+%2A%2Fworker"

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -229,3 +229,39 @@ class PageLinkTest(DeltaGeneratorTestCase):
             st.page_link(page="https://example.com", label="Test", icon="   ")
 
         assert 'The value "   " is not a valid emoji' in str(exc_info.value)
+
+    def test_external_page_with_unencoded_query_params(self):
+        """Test that external URLs with unencoded query params are properly normalized."""
+        # URL with special characters that should be encoded
+        st.page_link(
+            page="http://example.com?filter=/* Model Errors */worker",
+            label="Test",
+        )
+
+        c = self.get_delta_from_queue().new_element.page_link
+        assert c.label == "Test"
+        # URL should be normalized with proper encoding
+        assert c.page == "http://example.com?filter=%2F%2A+Model+Errors+%2A%2Fworker"
+        assert c.external
+
+    def test_external_page_with_already_encoded_query_params(self):
+        """Test that already encoded URLs remain properly encoded."""
+        # URL that is already properly encoded
+        st.page_link(
+            page="http://example.com?filter=%2F%2A+Model+Errors+%2A%2F",
+            label="Test",
+        )
+
+        c = self.get_delta_from_queue().new_element.page_link
+        assert c.label == "Test"
+        # URL should remain unchanged (already properly encoded)
+        assert c.page == "http://example.com?filter=%2F%2A+Model+Errors+%2A%2F"
+        assert c.external
+
+    def test_external_page_without_query_params_unchanged(self):
+        """Test that external URLs without query params are unchanged."""
+        st.page_link(page="http://example.com/path", label="Test")
+
+        c = self.get_delta_from_queue().new_element.page_link
+        assert c.page == "http://example.com/path"
+        assert c.external

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import unittest
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from parameterized import parameterized
 
@@ -200,7 +201,6 @@ class NormalizeUrlQueryEncodingTest(unittest.TestCase):
         """Test that encoding/decoding cycle preserves meaning."""
         # %20 and + both represent spaces - normalization may change one to the other
         # but the decoded value should be the same
-        from urllib.parse import parse_qs, urlparse
 
         input_url = "http://localhost:8501?name=John%20Doe"
         normalized = url_util.normalize_url_query_encoding(input_url)

--- a/lib/tests/streamlit/url_util_test.py
+++ b/lib/tests/streamlit/url_util_test.py
@@ -135,3 +135,78 @@ class UrlUtilTest(unittest.TestCase):
             assert url_util.is_url(url) == expected_value
         else:
             assert url_util.is_url(url, allowed_schemas) == expected_value
+
+
+class NormalizeUrlQueryEncodingTest(unittest.TestCase):
+    """Tests for normalize_url_query_encoding function."""
+
+    @parameterized.expand(
+        [
+            # Unencoded URLs should be properly encoded
+            (
+                "http://localhost:8501?foo=/* Model Errors */worker",
+                "http://localhost:8501?foo=%2F%2A+Model+Errors+%2A%2Fworker",
+            ),
+            (
+                "http://localhost:8501?name=John Doe&filter=test value",
+                "http://localhost:8501?name=John+Doe&filter=test+value",
+            ),
+            # Already encoded URLs should remain unchanged (or normalized)
+            (
+                "http://localhost:8501?foo=%2F%2A+Model+Errors+%2A%2Fworker",
+                "http://localhost:8501?foo=%2F%2A+Model+Errors+%2A%2Fworker",
+            ),
+            # URLs without query strings should be unchanged
+            ("http://localhost:8501", "http://localhost:8501"),
+            ("http://localhost:8501/page", "http://localhost:8501/page"),
+            ("http://localhost:8501#section", "http://localhost:8501#section"),
+            # URLs with fragments should preserve the fragment
+            (
+                "http://localhost:8501?foo=bar value#section",
+                "http://localhost:8501?foo=bar+value#section",
+            ),
+            # Empty values should be preserved
+            (
+                "http://localhost:8501?empty=&foo=bar",
+                "http://localhost:8501?empty=&foo=bar",
+            ),
+            # Multiple values for same key should be preserved
+            (
+                "http://localhost:8501?arr=1&arr=2",
+                "http://localhost:8501?arr=1&arr=2",
+            ),
+            # Special characters in query values
+            (
+                "http://example.com?q=hello world!",
+                "http://example.com?q=hello+world%21",
+            ),
+            # URLs with paths
+            (
+                "http://example.com/path/to/page?key=value with spaces",
+                "http://example.com/path/to/page?key=value+with+spaces",
+            ),
+            # Query parameter value containing '=' should be handled
+            (
+                "http://example.com?formula=a=b",
+                "http://example.com?formula=a%3Db",
+            ),
+        ]
+    )
+    def test_normalize_url_query_encoding(self, input_url: str, expected_url: str):
+        """Test that URLs are properly normalized."""
+        assert url_util.normalize_url_query_encoding(input_url) == expected_url
+
+    def test_normalize_preserves_semantics_for_encoded_urls(self):
+        """Test that encoding/decoding cycle preserves meaning."""
+        # %20 and + both represent spaces - normalization may change one to the other
+        # but the decoded value should be the same
+        from urllib.parse import parse_qs, urlparse
+
+        input_url = "http://localhost:8501?name=John%20Doe"
+        normalized = url_util.normalize_url_query_encoding(input_url)
+
+        # Parse both and verify the query param values are equivalent
+        input_params = parse_qs(urlparse(input_url).query)
+        normalized_params = parse_qs(urlparse(normalized).query)
+
+        assert input_params == normalized_params


### PR DESCRIPTION
## Describe your changes

Normalizes URL query parameters in external links for `st.page_link` and `st.link_button` to ensure consistent browser behavior.

- Adds `normalize_url_query_encoding()` function to properly encode query parameters in user-provided URLs
- Handles both already-encoded and unencoded URLs safely (idempotent)
- Fixes inconsistent behavior across browsers when clicking vs copying links with special characters

**Why:** Users providing URLs with unencoded special characters (like `/* Model Errors */`) experienced different behavior when clicking vs copying the link, varying by browser. This normalization ensures URLs are properly encoded before being rendered in the DOM.

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/url_util_test.py` — Tests for `normalize_url_query_encoding()` function
  - `lib/tests/streamlit/elements/page_link_test.py` — Tests URL normalization in external page links
  - `lib/tests/streamlit/elements/link_button_test.py` — Tests URL normalization in link buttons

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->