### PR TITLE
[chore] Fix nightly workflow permission validation error

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,9 +87,14 @@ jobs:
       pull-requests: write
 
   run-playwright-tests:
+    needs: create-nightly-tag
     uses: ./.github/workflows/playwright.yml
     with:
       ref: ${{needs.create-nightly-tag.outputs.tag}}
+    permissions:
+      # Required by check-e2e-test-count job (only runs on PRs, not nightly)
+      actions: read
+      pull-requests: write
 
   test-status-notification:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
     uses: ./.github/workflows/playwright.yml
     with:
       ref: ${{ github.ref_name }}
+    permissions:
+      # Required by check-e2e-test-count job (only runs on PRs, not releases)
+      actions: read
+      pull-requests: write
 
   build-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Describe your changes

Fixes the nightly workflow failure caused by permission validation error when calling `playwright.yml` via `workflow_call`:

> The nested job 'check-e2e-test-count' is requesting 'actions: read, pull-requests: write', but is only allowed 'actions: none, pull-requests: none'.

Adds `permissions` block to `run-playwright-tests` job in both `nightly.yml` and `release.yml`, matching the pattern already used for `run-python-tests` and `run-javascript-tests`.

The `check-e2e-test-count` job only runs on PRs (due to its `if: github.event_name == 'pull_request'` condition), but GitHub validates permissions at parse time regardless of runtime conditions.

## GitHub Issue

N/A (CI infrastructure fix)

## Testing Plan

- [x] Workflow YAML validated via `make check`
- [ ] Manual verification when nightly workflow runs

**Why no unit/E2E tests:** This is a CI workflow change, not a code change.