### PR TITLE
fix: improve dropdown border visibility in dark mode

### DIFF
--- a/frontend/lib/src/components/shared/Base/styled-components.ts
+++ b/frontend/lib/src/components/shared/Base/styled-components.ts
@@ -59,18 +59,18 @@ export const getPopoverContainerStyle = (
     borderBottomRightRadius: theme.radii.default,
     borderBottomLeftRadius: theme.radii.default,
 
-    // Always use same border width - in light mode, match background
+    // Always use same border width - on light backgrounds, match background
     // so we don't need to adjust for pixel shifts
     borderWidth: theme.sizes.borderWidth,
     borderStyle: "solid",
-    // In light mode, hide border by matching background color.
-    // In dark mode, use a more visible border (fadedText20) since shadows
+    // On light backgrounds, hide border by matching background color.
+    // On dark backgrounds, use a more visible border (fadedText20) since shadows
     // don't provide enough contrast against dark backgrounds.
     borderColor: lightBackground
       ? theme.colors.bgColor
       : theme.colors.fadedText20,
 
-    // Only show shadow in light mode
+    // Only show shadow on light backgrounds
     boxShadow: lightBackground ? theme.shadows.popover : theme.shadows.none,
   }
 }

--- a/frontend/lib/src/components/shared/Base/styled-components.ts
+++ b/frontend/lib/src/components/shared/Base/styled-components.ts
@@ -63,9 +63,12 @@ export const getPopoverContainerStyle = (
     // so we don't need to adjust for pixel shifts
     borderWidth: theme.sizes.borderWidth,
     borderStyle: "solid",
+    // In light mode, hide border by matching background color.
+    // In dark mode, use a more visible border (fadedText20) since shadows
+    // don't provide enough contrast against dark backgrounds.
     borderColor: lightBackground
       ? theme.colors.bgColor
-      : theme.colors.borderColor,
+      : theme.colors.fadedText20,
 
     // Only show shadow in light mode
     boxShadow: lightBackground ? theme.shadows.popover : theme.shadows.none,


### PR DESCRIPTION
## Summary
Improves the visibility of dropdown borders in dark mode by using a more visible border color.

## Problem
In dark mode, dropdowns (selectbox, multiselect, date picker, etc.) have borders that are nearly invisible because they use `borderColor` which is `fadedText10` (only 10% opacity). Since shadows don't provide enough contrast against dark backgrounds, the dropdowns appear to float without clear boundaries.

## Solution
Changed the dark mode border color in `getPopoverContainerStyle` from `theme.colors.borderColor` (fadedText10, 10% opacity) to `theme.colors.fadedText20` (30% opacity).

This provides better visibility while maintaining a subtle appearance that doesn't distract from the content.

## Affected Components
All components using `getPopoverContainerStyle`:
- Selectbox dropdown
- Multiselect dropdown  
- TimeInput dropdown
- DateInput popover
- DateTimeInput popover
- Popover body
- BaseColorPicker
- TopNavSection
- Modal dialogs
- DataFrame column menus

## Test Plan
- [x] Verify dropdowns have visible borders in dark mode
- [x] Verify borders are not too prominent/distracting
- [x] Verify light mode behavior is unchanged (borders still hidden)
- [x] Test across different dropdown components

Fixes #12954