### PR TITLE
[fix] Form warning shown before first script run completes

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -90,6 +90,7 @@ import {
   hasLightBackgroundColor,
   HostCommunicationManager,
   IMenuItem,
+  INITIAL_SCRIPT_RUN_ID,
   isEmbed,
   isInChildFrame,
   isKeyboardEventFromEditableTarget,
@@ -221,8 +222,6 @@ interface State {
   inputsDisabled: boolean
   scriptChangedOnDisk: boolean
 }
-
-const INITIAL_SCRIPT_RUN_ID = "<null>"
 
 export const LOG = getLogger("App")
 

--- a/frontend/lib/src/components/core/ScriptRunContext.tsx
+++ b/frontend/lib/src/components/core/ScriptRunContext.tsx
@@ -18,6 +18,12 @@ import { createContext } from "react"
 
 import { ScriptRunState } from "~lib/ScriptRunState"
 
+/**
+ * Sentinel value for scriptRunId before the first script run has been received.
+ * Used to distinguish between "script not running" and "never received a script run".
+ */
+export const INITIAL_SCRIPT_RUN_ID = "<null>"
+
 export interface ScriptRunContextProps {
   /**
    * The app's current ScriptRunState. This is used in combination with
@@ -42,10 +48,11 @@ export interface ScriptRunContextProps {
    * the frontend discards "stale" elements (that is, elements with a non-current
    * scriptRunId).
    *
-   * Consumed by: BlockNodeRenderer, ElementNodeRenderer, Tabs
+   * Consumed by: BlockNodeRenderer, ElementNodeRenderer, Tabs, Form
    * @see Block
    * @see ElementNodeRenderer
    * @see Tabs
+   * @see Form
    */
   scriptRunId: string
 
@@ -68,7 +75,7 @@ export interface ScriptRunContextProps {
  */
 export const ScriptRunContext = createContext<ScriptRunContextProps>({
   scriptRunState: ScriptRunState.NOT_RUNNING,
-  scriptRunId: "<null>",
+  scriptRunId: INITIAL_SCRIPT_RUN_ID,
   fragmentIdsThisRun: [],
 })
 

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -16,6 +16,7 @@
 
 import { screen } from "@testing-library/react"
 
+import { INITIAL_SCRIPT_RUN_ID } from "~lib/components/core/ScriptRunContext"
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
 import {
@@ -109,6 +110,22 @@ describe("Form", () => {
       },
     })
     expect(screen.getByTestId("stForm")).toBeInTheDocument()
+    expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
+  })
+
+  it("does not show error before the first script run completes", () => {
+    // Before any script run, scriptRunId is INITIAL_SCRIPT_RUN_ID and state is
+    // NOT_RUNNING. We should not show the warning in this initial state.
+    renderWithContexts(<Form {...getProps()} />, {
+      formsContext: {
+        formsData: defaultFormsData(),
+      },
+      scriptRunContext: {
+        scriptRunId: INITIAL_SCRIPT_RUN_ID,
+        scriptRunState: ScriptRunState.NOT_RUNNING,
+      },
+    })
+
     expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
   })
 })

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -24,7 +24,10 @@ import {
 } from "react"
 
 import { FormsContext } from "~lib/components/core/FormsContext"
-import { ScriptRunContext } from "~lib/components/core/ScriptRunContext"
+import {
+  INITIAL_SCRIPT_RUN_ID,
+  ScriptRunContext,
+} from "~lib/components/core/ScriptRunContext"
 import AlertElement from "~lib/components/elements/AlertElement"
 import { Kind } from "~lib/components/shared/AlertContainer"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
@@ -74,7 +77,8 @@ function Form(props: Props): ReactElement {
     submitButtons !== undefined && submitButtons.length > 0
 
   // Consume ScriptRunContext to get script run state
-  const { scriptRunState } = useContext(ScriptRunContext)
+  const { scriptRunId, scriptRunState } = useContext(ScriptRunContext)
+  const hasReceivedScriptRun = scriptRunId !== INITIAL_SCRIPT_RUN_ID
   const scriptNotRunning = scriptRunState === ScriptRunState.NOT_RUNNING
 
   // Tell WidgetStateManager if this form is `clearOnSubmit` and `enterToSubmit`
@@ -92,7 +96,12 @@ function Form(props: Props): ReactElement {
 
   if (hasSubmitButton && showWarning) {
     setShowWarning(false)
-  } else if (!hasSubmitButton && !showWarning && scriptNotRunning) {
+  } else if (
+    !hasSubmitButton &&
+    !showWarning &&
+    hasReceivedScriptRun &&
+    scriptNotRunning
+  ) {
     setShowWarning(true)
   }
 

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -37,7 +37,10 @@ export type { LibConfigContextProps } from "./components/core/LibConfigContext"
 export { NavigationContext } from "./components/core/NavigationContext"
 export type { NavigationContextProps } from "./components/core/NavigationContext"
 export { PortalProvider } from "./components/core/Portal/PortalProvider"
-export { ScriptRunContext } from "./components/core/ScriptRunContext"
+export {
+  INITIAL_SCRIPT_RUN_ID,
+  ScriptRunContext,
+} from "./components/core/ScriptRunContext"
 export type { ScriptRunContextProps } from "./components/core/ScriptRunContext"
 export { SidebarConfigContext } from "./components/core/SidebarConfigContext"
 export type { SidebarConfigContextProps } from "./components/core/SidebarConfigContext"


### PR DESCRIPTION
## Describe your changes

Fixes a bug where the "Missing Submit Button" warning was incorrectly shown before the first script run completed. This occurred because `ScriptRunState.NOT_RUNNING` is both the real idle state and the initial placeholder state, and the code was not distinguishing between these two cases.

- Move `INITIAL_SCRIPT_RUN_ID` constant from `App.tsx` to `ScriptRunContext.tsx` and export it
- Use the constant in `Form.tsx` to check if a real script run has ever occurred before showing the warning

## Testing Plan

- [x] Unit Tests (JS)
  - `frontend/lib/src/components/widgets/Form/Form.test.tsx` - Tests the initial state edge case

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 4 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->