### PR TITLE
Fix stale anchor preserved when clearing transient nodes

### DIFF
--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -267,15 +267,31 @@ describe("ClearStaleNodeVisitor", () => {
   })
 
   describe("visitTransientNode", () => {
-    it("restores anchor for transient cleared in current run", () => {
+    it("restores anchor for transient cleared in current run when anchor is current", () => {
       const currentRunId = "current"
-      const anchor = text("anchor", "old_run")
+      const anchor = text("anchor", currentRunId)
       const clearedTransient = new TransientNode(currentRunId, anchor, [], 1)
 
       const visitor = new ClearStaleNodeVisitor(currentRunId)
       const result = visitor.visitTransientNode(clearedTransient)
 
       expect(result).toBe(anchor)
+    })
+
+    it("returns undefined for transient cleared in current run when anchor is stale", () => {
+      const currentRunId = "current"
+      const staleAnchor = text("anchor", "old_run")
+      const clearedTransient = new TransientNode(
+        currentRunId,
+        staleAnchor,
+        [],
+        1
+      )
+
+      const visitor = new ClearStaleNodeVisitor(currentRunId)
+      const result = visitor.visitTransientNode(clearedTransient)
+
+      expect(result).toBeUndefined()
     })
 
     it("returns undefined when both anchor and transients are stale", () => {

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.test.ts
@@ -294,6 +294,27 @@ describe("ClearStaleNodeVisitor", () => {
       expect(result).toBeUndefined()
     })
 
+    it("preserves stale anchor without fragmentId during fragment run when transient is cleared", () => {
+      // Scenario: A transient cleared in the current run has an anchor from a
+      // previous run that has no fragmentId. During a fragment run, elements
+      // without fragmentId should be preserved (not cleared as stale).
+      const currentRunId = "current"
+      const staleAnchorNoFragment = text("anchor", "old_run") // no fragmentId
+      const clearedTransient = new TransientNode(
+        currentRunId,
+        staleAnchorNoFragment,
+        [],
+        1
+      )
+
+      const visitor = new ClearStaleNodeVisitor(currentRunId, ["fragment1"])
+      const result = visitor.visitTransientNode(clearedTransient)
+
+      // The anchor should be preserved because it doesn't have a fragmentId
+      // and we're in a fragment run (visitElementNode preserves such elements)
+      expect(result).toBe(staleAnchorNoFragment)
+    })
+
     it("returns undefined when both anchor and transients are stale", () => {
       const t = new TransientNode(
         "runA",

--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -143,12 +143,14 @@ export class ClearStaleNodeVisitor implements AppNodeVisitor<
   visitTransientNode(node: TransientNode): AppNode | undefined {
     // If a transient was explicitly cleared in this run, restore its anchor directly.
     // This prevents removing the anchor as stale before non-transient updates can reattach.
+    // However, we still need to check if the anchor itself is stale - it may have been
+    // captured from a previous run and should be filtered out.
     if (
       node.scriptRunId === this.currentScriptRunId &&
       node.transientNodes.length === 0 &&
       node.anchor
     ) {
-      return node.anchor
+      return node.anchor.accept(this)
     }
 
     // Check whether the anchor element and transient elements are stale


### PR DESCRIPTION
## Describe your changes

Fixes a regression introduced in #13849 where stale elements from previous script runs could persist after spinner completion.

**Root cause:** When a transient node (spinner) captured an element from a previous run as its anchor, and the transient was cleared, the anchor was restored directly without checking if it was stale.

**The fix:** Change `return node.anchor` to `return node.anchor.accept(this)` so the anchor is also checked for staleness before being restored.

## GitHub Issue Link (if applicable)

Closes #14249

## Testing Plan

- [x] Unit tests: Added test case for stale anchor scenario
- [x] Manual testing: Verified fix using reproduction steps from issue

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->