### PR TITLE
refactor(ccv2): rename BidiComponentResult to ComponentResult

### DIFF
--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -21,7 +21,7 @@ import pandas as pd
 import streamlit as st
 
 if TYPE_CHECKING:
-    from streamlit.components.v2.bidi_component import BidiComponentResult
+    from streamlit.components.v2.bidi_component import ComponentResult
     from streamlit.elements.lib.layout_utils import Height, Width
     from streamlit.runtime.state.common import WidgetCallback
 
@@ -107,7 +107,7 @@ def stateful_component(
     width: Width = "stretch",
     height: Height = "content",
     default: dict[str, Any] | None = None,
-) -> BidiComponentResult:
+) -> ComponentResult:
     return _STATEFUL_CMP(
         key=key,
         data=data,
@@ -165,7 +165,7 @@ def trigger_component(
     data: Any | None = None,
     on_foo_change: WidgetCallback | None = None,
     on_bar_change: WidgetCallback | None = None,
-) -> BidiComponentResult:
+) -> ComponentResult:
     return _TRIGGER_CMP(
         key=key,
         data=data,
@@ -228,7 +228,7 @@ def ctx_component(
     data: Any | None = None,
     on_text_change: WidgetCallback | None = None,
     on_clicked_change: WidgetCallback | None = None,
-) -> BidiComponentResult:
+) -> ComponentResult:
     return _CTX_CMP(
         key=key,
         data=data,
@@ -382,7 +382,7 @@ with st.container():
     def _remount_stateful_component(
         *,
         key: str,
-    ) -> BidiComponentResult:
+    ) -> ComponentResult:
         # Resolve initial values: prefer session_state if available, else fall back to default values
         state_value = st.session_state.get(key)
         initial_defaults: dict[str, Any] = {"range": 10, "text": "hello"}
@@ -496,7 +496,7 @@ div {
         on_formValues_change: WidgetCallback | None = None,  # noqa: N803
         on_clicked_change: WidgetCallback | None = None,
         default: dict[str, Any] | None = None,
-    ) -> BidiComponentResult:
+    ) -> ComponentResult:
         return _BASIC_CMP(
             key=key,
             data=data,
@@ -570,7 +570,7 @@ export default function(component) {
         html=_HOTKEY_HTML,
     )
 
-    def hotkey_regression_component(*, key: str) -> BidiComponentResult:
+    def hotkey_regression_component(*, key: str) -> ComponentResult:
         return _HOTKEY_CMP(key=key)
 
     hotkey_result = hotkey_regression_component(key="hotkey_regression_component")
@@ -611,7 +611,7 @@ export default function(component) {
         html=_ARROW_HTML,
     )
 
-    def arrow_component(*, key: str, data: Any) -> BidiComponentResult:
+    def arrow_component(*, key: str, data: Any) -> ComponentResult:
         return _ARROW_CMP(key=key, data=data)
 
     df = pd.DataFrame({"a": [1, 2, 3]})

--- a/e2e_playwright/bidi_components/session_state_interactions.py
+++ b/e2e_playwright/bidi_components/session_state_interactions.py
@@ -14,7 +14,7 @@
 
 
 import streamlit as st
-from streamlit.components.v2.bidi_component import BidiComponentResult
+from streamlit.components.v2.bidi_component import ComponentResult
 
 interactive_text_input_definition = st.components.v2.component(
     "interactive_text_input",
@@ -46,9 +46,7 @@ interactive_text_input_definition = st.components.v2.component(
 )
 
 
-def interactive_text_input(
-    label: str, initial_value: str, key: str
-) -> BidiComponentResult:
+def interactive_text_input(label: str, initial_value: str, key: str) -> ComponentResult:
     component_state = st.session_state.get(key, {})
     data = {
         "label": label,

--- a/lib/streamlit/components/v2/__init__.py
+++ b/lib/streamlit/components/v2/__init__.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from streamlit.components.v2.bidi_component import BidiComponentResult
+    from streamlit.components.v2.bidi_component import ComponentResult
     from streamlit.elements.lib.layout_utils import Height, Width
     from streamlit.runtime.state.common import WidgetCallback
 
@@ -149,7 +149,7 @@ def _create_component_callable(
         width: Width = "stretch",
         height: Height = "content",
         **on_callbacks: WidgetCallback | None,
-    ) -> BidiComponentResult:
+    ) -> ComponentResult:
         """Mount the component.
 
         Parameters
@@ -171,7 +171,7 @@ def _create_component_callable(
 
         Returns
         -------
-        BidiComponentResult
+        ComponentResult
             Component state.
         """
         import streamlit as st
@@ -291,7 +291,7 @@ def component(
         The component's mounting command.
 
         This callable accepts the component parameters like ``key`` and
-        ``data`` and returns a ``BidiComponentResult`` object with the
+        ``data`` and returns a ``ComponentResult`` object with the
         component's state. The mounting command can be included in a
         user-friendly wrapper function to provide a simpler API. A mounting
         command can be called multiple times in an app to create multiple

--- a/lib/streamlit/components/v2/bidi_component/__init__.py
+++ b/lib/streamlit/components/v2/bidi_component/__init__.py
@@ -15,6 +15,9 @@
 from __future__ import annotations
 
 from streamlit.components.v2.bidi_component.main import BidiComponentMixin
-from streamlit.components.v2.bidi_component.state import BidiComponentResult
+from streamlit.components.v2.bidi_component.state import (
+    BidiComponentResult,
+    ComponentResult,
+)
 
-__all__ = ["BidiComponentMixin", "BidiComponentResult"]
+__all__ = ["BidiComponentMixin", "BidiComponentResult", "ComponentResult"]

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -28,7 +28,7 @@ from streamlit.components.v2.bidi_component.serialization import (
     serialize_mixed_data,
 )
 from streamlit.components.v2.bidi_component.state import (
-    BidiComponentResult,
+    ComponentResult,
     unwrap_component_state,
 )
 from streamlit.components.v2.presentation import make_bidi_component_presenter
@@ -277,7 +277,7 @@ class BidiComponentMixin:
         width: Width = "stretch",
         height: Height = "content",
         **kwargs: WidgetCallback | None,
-    ) -> BidiComponentResult:
+    ) -> ComponentResult:
         """Add a bidirectional component instance to the app.
 
         This method uses a component that has already been registered with the
@@ -317,7 +317,7 @@ class BidiComponentMixin:
 
         Returns
         -------
-        BidiComponentResult
+        ComponentResult
             A dictionary-like object that holds the component's state and
             trigger values.
 
@@ -337,7 +337,7 @@ class BidiComponentMixin:
 
         if ctx is None:
             # Create an empty state with the default value and return it
-            return BidiComponentResult({}, {})
+            return ComponentResult({}, {})
 
         # Get the component definition from the registry
         from streamlit.runtime import Runtime
@@ -529,7 +529,7 @@ class BidiComponentMixin:
 
         state_vals = unwrap_component_state(component_state.value)
 
-        return BidiComponentResult(state_vals, trigger_vals)
+        return ComponentResult(state_vals, trigger_vals)
 
     @property
     def dg(self) -> DeltaGenerator:

--- a/lib/streamlit/components/v2/bidi_component/state.py
+++ b/lib/streamlit/components/v2/bidi_component/state.py
@@ -31,7 +31,7 @@ class BidiComponentState(TypedDict, total=False):
     # (kept empty to reflect open set of keys)
 
 
-class BidiComponentResult(AttributeDictionary):
+class ComponentResult(AttributeDictionary):
     """The schema for the custom component result object.
 
     The custom component result object is a dictionary-like object that
@@ -56,7 +56,7 @@ class BidiComponentResult(AttributeDictionary):
         state_vals: dict[str, Any] | None = None,
         trigger_vals: dict[str, Any] | None = None,
     ) -> None:
-        """Initialize a BidiComponentResult.
+        """Initialize a ComponentResult.
 
         Parameters
         ----------
@@ -80,6 +80,10 @@ class BidiComponentResult(AttributeDictionary):
                 **state_vals,
             }
         )
+
+
+# Deprecated alias kept for backwards compatibility.
+BidiComponentResult = ComponentResult
 
 
 def unwrap_component_state(raw_state: Any) -> dict[str, Any]:

--- a/lib/streamlit/components/v2/types.py
+++ b/lib/streamlit/components/v2/types.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from streamlit.components.v2.bidi_component.state import BidiComponentResult
+    from streamlit.components.v2.bidi_component.state import ComponentResult
     from streamlit.elements.lib.layout_utils import Height, Width
     from streamlit.runtime.state.common import WidgetCallback
 
@@ -49,7 +49,7 @@ class ComponentRenderer(Protocol):
     '''Signature of the mounting command returned by ``st.components.v2.component``.
 
     This callable mounts a bidirectional component in a Streamlit app and
-    returns a ``BidiComponentResult`` object that exposes the component's
+    returns a ``ComponentResult`` object that exposes the component's
     state and trigger values.
 
     For published components, this callable is often wrapped in a user-friendly
@@ -157,7 +157,7 @@ class ComponentRenderer(Protocol):
 
     Returns
     -------
-    BidiComponentResult
+    ComponentResult
         Component state object that exposes state and trigger values.
 
     Examples
@@ -305,7 +305,7 @@ class ComponentRenderer(Protocol):
         width: Width = "stretch",
         height: Height = "content",
         **on_callbacks: WidgetCallback | None,
-    ) -> BidiComponentResult: ...
+    ) -> ComponentResult: ...
 
 
 __all__ = [

--- a/lib/tests/streamlit/components/v2/bidi_component/test_state.py
+++ b/lib/tests/streamlit/components/v2/bidi_component/test_state.py
@@ -14,22 +14,25 @@
 
 from __future__ import annotations
 
-from streamlit.components.v2.bidi_component.state import BidiComponentResult
+from streamlit.components.v2.bidi_component.state import (
+    BidiComponentResult,
+    ComponentResult,
+)
 
 
 def test_bidi_component_result_empty() -> None:
     """Test empty result handling."""
-    result = BidiComponentResult()
+    result = ComponentResult()
     assert dict(result) == {}
 
 
 def test_bidi_component_result_merges_state_and_trigger_values() -> None:
-    """Test that BidiComponentResult surfaces trigger and state values."""
+    """Test that ComponentResult surfaces trigger and state values."""
 
     state_vals = {"foo": "bar"}
     trigger_vals = {"on_click": 42}
 
-    result = BidiComponentResult(state_vals=state_vals, trigger_vals=trigger_vals)
+    result = ComponentResult(state_vals=state_vals, trigger_vals=trigger_vals)
 
     assert result["foo"] == "bar"
     assert result.foo == "bar"
@@ -44,7 +47,14 @@ def test_bidi_component_result_merge_order() -> None:
     state_vals = {"shared": "state", "state_only": "value"}
     trigger_vals = {"shared": "trigger", "trigger_only": "value"}
 
-    result = BidiComponentResult(state_vals=state_vals, trigger_vals=trigger_vals)
+    result = ComponentResult(state_vals=state_vals, trigger_vals=trigger_vals)
 
     assert list(result.keys()) == ["shared", "trigger_only", "state_only"]
     assert result.shared == "state"
+
+
+def test_bidi_component_result_alias_remains_supported() -> None:
+    """Test that BidiComponentResult remains an alias for ComponentResult."""
+    result = BidiComponentResult(state_vals={"foo": "bar"})
+    assert BidiComponentResult is ComponentResult
+    assert isinstance(result, ComponentResult)

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -29,7 +29,7 @@ from streamlit.components.v2.bidi_component.main import (
     BidiComponentMixin,
     _make_trigger_id,
 )
-from streamlit.components.v2.bidi_component.state import BidiComponentResult
+from streamlit.components.v2.bidi_component.state import ComponentResult
 from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.components.v2.component_registry import BidiComponentDefinition
 from streamlit.errors import (
@@ -173,15 +173,15 @@ def test_multiple_trigger_ids_are_all_internal() -> None:
     assert len(trigger_ids) == len(set(trigger_ids)), "All trigger IDs should be unique"
 
 
-def test_result_merges_state_and_trigger_values_and_exposes_dg():
-    """BidiComponentResult should behave like a mapping/attribute dict and expose the dg."""
+def test_result_merges_state_and_trigger_values():
+    """ComponentResult should behave like a mapping/attribute dict."""
 
     # Arrange
     state_vals = {"foo": 123, "bar": "abc"}
     trigger_vals = {"clicked": True, "changed": {"value": 42}}
 
     # Act
-    result = BidiComponentResult(state_vals, trigger_vals)
+    result = ComponentResult(state_vals, trigger_vals)
 
     # Assert mapping access
     assert result["foo"] == 123
@@ -251,7 +251,7 @@ class BidiComponentMixinTest(DeltaGeneratorTestCase):
     - Parsing of ``on_<event>_change`` kwargs into an event-to-callback mapping
     - Registration of the per-run aggregator trigger widget with
       ``value_type`` equal to ``"json_trigger_value"``
-    - ``BidiComponentResult`` exposes event keys and merges persistent state
+    - ``ComponentResult`` exposes event keys and merges persistent state
       with trigger values
     - Callbacks and widget metadata are correctly stored in ``SessionState``
       for the current run
@@ -295,7 +295,7 @@ class BidiComponentMixinTest(DeltaGeneratorTestCase):
         # ------------------------------------------------------------------
         # Assert - return type & merged keys
         # ------------------------------------------------------------------
-        assert isinstance(result, BidiComponentResult)
+        assert isinstance(result, ComponentResult)
         # No state set yet, but we expect trigger keys to exist with None
         assert "click" in result
         assert result.click is None

--- a/lib/tests/streamlit/runtime/state/test_presentation.py
+++ b/lib/tests/streamlit/runtime/state/test_presentation.py
@@ -328,7 +328,7 @@ def test_bidi_presenter_state_overrides_duplicate_keys() -> None:
     """State must override trigger values on duplicate keys.
 
     This verifies the merge precedence documented in the presenter and in
-    BidiComponentResult: triggers are surfaced first, but persistent state
+    ComponentResult: triggers are surfaced first, but persistent state
     wins for duplicate keys.
     """
 


### PR DESCRIPTION
## Describe your changes

- Promote `ComponentResult` as the canonical CCV2 result type across the public API, internal type hints, and docstrings to align naming with the rest of the v2 surface.
- Keep `BidiComponentResult` as a backward-compatible alias to avoid breaking existing imports and user code. Update tests and e2e typing annotations to use `ComponentResult`, and add explicit compatibility coverage for the alias.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Adds a backwards compat test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
