### PR TITLE
[docs] Add Streamlit library VISION.md

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,21 @@
+# Streamlit Vision
+
+Streamlit should be the default code-first framework for data apps.
+
+We already lead in Python. The next step is to keep that lead in the agentic coding era and make Streamlit the default choice for building data apps for anyone, not just Python experts.
+
+We win if Streamlit is the fastest way to turn code into a useful, beautiful, production-ready data app.
+
+Durable priorities:
+- Preserve the core magic: simple, script-like, readable, joyful development.
+- Raise the ceiling: close the gaps that push serious apps toward custom frontend stacks.
+- Be agent-native: make Streamlit a top target for AI-generated, AI-maintained apps.
+- Own the code-first dashboard space: richer data interaction, stronger performance, better viewer experience.
+
+Guardrails:
+- The core API stays Python; expansion is about who can build with Streamlit, not about adding other languages.
+- Python-first in product design, but not Python-only in market ambition.
+- Opinionated about data apps, not a generic web framework.
+- Win through leverage, polish, and enough flexibility that Streamlit does not feel like a limitation, not by trying to match React's full customization surface.
+
+Decision lens for agents: prefer work that makes Streamlit simpler to build with, stronger in production, better for agents, and more compelling for code-first data apps.


### PR DESCRIPTION
## Describe your changes

Adds a vision document for the Streamlit library that captures the strategic direction:

- Streamlit should be the default code-first framework for data apps
- Durable priorities: preserve simplicity, raise the ceiling, be agent-native, own the code-first dashboard space
- Guardrails: Python-first API, opinionated for data apps, win through leverage and polish

## Testing Plan

- Documentation-only change, no tests needed

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->