### PR TITLE
fix: return original value from ProgressColumn getCellValue for CSV export

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
@@ -128,6 +128,30 @@ describe("ProgressColumn", () => {
     }
   )
 
+  it("returns original value from getCellValue when value exceeds max_value", () => {
+    // Regression test for #14244: getCellValue should return the original
+    // (unclamped) value, not the value clamped to max_value for visualization.
+    const mockColumn = getProgressColumn({
+      min_value: 0,
+      max_value: 10,
+    })
+    const cell = mockColumn.getCell(11)
+    // The visualization value is clamped to 10, but getCellValue (used for
+    // CSV export) should return the original value of 11.
+    expect((cell as RangeCellType).data?.value).toEqual(10) // clamped for display
+    expect(mockColumn.getCellValue(cell)).toEqual(11) // original for export
+  })
+
+  it("returns original value from getCellValue when value is below min_value", () => {
+    const mockColumn = getProgressColumn({
+      min_value: 5,
+      max_value: 10,
+    })
+    const cell = mockColumn.getCell(2)
+    expect((cell as RangeCellType).data?.value).toEqual(5) // clamped for display
+    expect(mockColumn.getCellValue(cell)).toEqual(2) // original for export
+  })
+
   it.each([
     ["foo"],
     [[]],

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -245,6 +245,15 @@ function ProgressColumn(
       if (cell.kind === GridCellKind.Loading) {
         return null
       }
+      // Use copyData (original value) instead of cell.data.value (clamped to
+      // min/max range for visualization). This ensures CSV exports and other
+      // consumers get the actual data, not the display-clamped value.
+      if (cell.copyData !== undefined && cell.copyData !== "") {
+        const parsed = Number(cell.copyData)
+        if (!Number.isNaN(parsed)) {
+          return parsed
+        }
+      }
       return cell.data?.value === undefined ? null : cell.data?.value
     },
   }


### PR DESCRIPTION
## Summary

Fixes the `ProgressColumn` `getCellValue()` method to return the original (unclamped) data value instead of the value clamped to `[min_value, max_value]` for the progress bar visualization.

## Problem

When a `ProgressColumn` has values outside its configured `max_value` (or below `min_value`), the "Download as CSV" export writes the clamped value instead of the actual data value.

For example, with `max_value=10` and a cell value of `11`:
- **Expected CSV value:** `11` (the real data)
- **Actual CSV value:** `10` (clamped to max_value)

The cell label correctly displays `11`, so the UI shows the right number but the exported CSV does not.

## Root Cause

`getCellValue()` returns `cell.data.value`, which is set to `normalizeCellValue` — the value clamped via `Math.min(max, Math.max(min, value))` for the progress bar visualization. The `copyData` field already stores the original unclamped value as `String(cellData)`, but `getCellValue()` didn't use it.

## Fix

Changed `getCellValue()` to parse the original value from `copyData` first, falling back to the clamped `cell.data.value` only if `copyData` is unavailable or not a valid number.

## Tests

Added two regression tests:
- Value exceeding `max_value` (11 with max=10): display is clamped to 10, `getCellValue` returns 11
- Value below `min_value` (2 with min=5): display is clamped to 5, `getCellValue` returns 2

Fixes #14244