### PR TITLE
[chore] Add optional e2e test support to make check

### DIFF
--- a/.claude/skills/checking-changes/SKILL.md
+++ b/.claude/skills/checking-changes/SKILL.md
@@ -24,4 +24,5 @@ This runs formatting, linting, type checking, and unit tests on all uncommitted 
 
 ## Notes
 
-- E2E tests are not included; use `make run-e2e-test e2e_playwright/<test>_test.py` separately if needed
+- E2E tests are not included by default; use `E2E_CHECK=true make check` to also run changed e2e tests
+- E2E snapshot mismatches can be ignored (they require manual updates)

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -54,7 +54,7 @@ Review the recommendations from step 6. For each recommendation:
 
 ### 8. Run checks (second pass)
 
-Run the /checking-changes skill in a subagent (uses `make check`) to validate the changes. Wait for completion, then fix any issues found before proceeding. Don't run other checks besides `make check` in this step.
+Run the /checking-changes skill in a subagent with `E2E_CHECK=true make check` to also run changed e2e tests. Wait for completion, then fix any issues found before proceeding. Snapshot mismatches can be ignored (they require manual updates).
 
 ### 9. Create or update PR
 

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -49,8 +49,7 @@ alwaysApply: true
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands. [~1s]
-- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
-  - Use `E2E_CHECK=true make check` to also run changed E2E tests (maps app scripts to their test files automatically).
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Add `E2E_CHECK=true` to include E2E tests. [varies by changes]
 - `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
 - `autofix`: Autofix linting and formatting errors. [~30s]
 

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -50,6 +50,7 @@ Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands. [~1s]
 - `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
+  - Use `E2E_CHECK=true make check` to also run changed E2E tests (maps app scripts to their test files automatically).
 - `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
 - `autofix`: Autofix linting and formatting errors. [~30s]
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,8 +43,7 @@
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands. [~1s]
-- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
-  - Use `E2E_CHECK=true make check` to also run changed E2E tests (maps app scripts to their test files automatically).
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Add `E2E_CHECK=true` to include E2E tests. [varies by changes]
 - `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
 - `autofix`: Autofix linting and formatting errors. [~30s]
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,7 @@ Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands. [~1s]
 - `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
+  - Use `E2E_CHECK=true make check` to also run changed E2E tests (maps app scripts to their test files automatically).
 - `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
 - `autofix`: Autofix linting and formatting errors. [~30s]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands. [~1s]
 - `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
+  - Use `E2E_CHECK=true make check` to also run changed E2E tests (maps app scripts to their test files automatically).
 - `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
 - `autofix`: Autofix linting and formatting errors. [~30s]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,7 @@
 Selection of `make` commands for development (run in the repo root):
 
 - `help`: Show all available make commands. [~1s]
-- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Recommended for verifying the current state of the codebase before committing. [varies by changes]
-  - Use `E2E_CHECK=true make check` to also run changed E2E tests (maps app scripts to their test files automatically).
+- `check`: Run all checks (format, lint, types, unit tests) on changed files only. Add `E2E_CHECK=true` to include E2E tests. [varies by changes]
 - `protobuf`: Recompile Protobufs for Python and the frontend. [~5s]
 - `autofix`: Autofix linting and formatting errors. [~30s]
 

--- a/Makefile
+++ b/Makefile
@@ -612,7 +612,7 @@ check:
 	@# Set E2E_CHECK=true to also run changed e2e tests (in background, parallel to frontend)
 	@# Note: ty runs on all files (not just changed) because include/exclude config is ignored for single files, and ty is fast
 	@FE_OUT=$$(mktemp) || { echo "Failed to create temp file"; exit 1; }; \
-	E2E_OUT=$$(mktemp) || { echo "Failed to create temp file"; exit 1; }; \
+	E2E_OUT=""; \
 	FE_FILES=$$(uv run python scripts/get_changed_files.py --frontend --strip-prefix frontend/); \
 	FE_CHECK=$$(uv run python scripts/get_changed_files.py --frontend); \
 	FE_TESTS=$$(uv run python scripts/get_changed_files.py --frontend-tests --strip-prefix frontend/); \
@@ -643,6 +643,7 @@ check:
 	) > "$$FE_OUT" 2>&1 & FE_PID=$$!; \
 	E2E_PID=""; \
 	if [ "$$E2E_CHECK" = "true" ]; then \
+		E2E_OUT=$$(mktemp) || { echo "Failed to create E2E temp file"; exit 1; }; \
 		E2E_TESTS=$$(uv run python scripts/get_changed_files.py --e2e --strip-prefix e2e_playwright/); \
 		if [ -n "$$E2E_TESTS" ]; then \
 			( \

--- a/Makefile
+++ b/Makefile
@@ -609,8 +609,10 @@ check:
 	echo ""
 	@# Start frontend (format, lint, types, tests) in background, run Python + pre-commit + Python tests in foreground
 	@# Set FAST_CHECK=true to skip mypy, frontend-types, and unit tests
+	@# Set E2E_CHECK=true to also run changed e2e tests (in background, parallel to frontend)
 	@# Note: ty runs on all files (not just changed) because include/exclude config is ignored for single files, and ty is fast
 	@FE_OUT=$$(mktemp) || { echo "Failed to create temp file"; exit 1; }; \
+	E2E_OUT=$$(mktemp) || { echo "Failed to create temp file"; exit 1; }; \
 	FE_FILES=$$(uv run python scripts/get_changed_files.py --frontend --strip-prefix frontend/); \
 	FE_CHECK=$$(uv run python scripts/get_changed_files.py --frontend); \
 	FE_TESTS=$$(uv run python scripts/get_changed_files.py --frontend-tests --strip-prefix frontend/); \
@@ -639,6 +641,17 @@ check:
 			cd frontend && yarn vitest run $$FE_TESTS; \
 		fi \
 	) > "$$FE_OUT" 2>&1 & FE_PID=$$!; \
+	E2E_PID=""; \
+	if [ "$$E2E_CHECK" = "true" ]; then \
+		E2E_TESTS=$$(uv run python scripts/get_changed_files.py --e2e --strip-prefix e2e_playwright/); \
+		if [ -n "$$E2E_TESTS" ]; then \
+			( \
+				echo "=== E2E: tests (playwright) ===" && \
+				echo "Running: $$E2E_TESTS" && \
+				cd e2e_playwright && uv run pytest $$E2E_TESTS --tracing retain-on-failure --reruns 0 `# No retries for faster local checks` \
+			) > "$$E2E_OUT" 2>&1 & E2E_PID=$$!; \
+		fi; \
+	fi; \
 	PY_FILES=$$(uv run python scripts/get_changed_files.py --python); \
 	PY_EXIT=0; \
 	if [ -n "$$PY_FILES" ]; then \
@@ -662,7 +675,8 @@ check:
 	fi; \
 	if [ $$PY_EXIT -ne 0 ]; then \
 		kill $$FE_PID 2>/dev/null; \
-		rm -f "$$FE_OUT"; \
+		[ -n "$$E2E_PID" ] && kill $$E2E_PID 2>/dev/null; \
+		rm -f "$$FE_OUT" "$$E2E_OUT"; \
 		echo "=== Python checks failed! ==="; \
 		exit 1; \
 	fi; \
@@ -672,7 +686,8 @@ check:
 		SKIP=prettier-frontend uv run pre-commit run --files $$CHANGED && \
 		echo "" || { \
 			kill $$FE_PID 2>/dev/null; \
-			rm -f "$$FE_OUT"; \
+			[ -n "$$E2E_PID" ] && kill $$E2E_PID 2>/dev/null; \
+			rm -f "$$FE_OUT" "$$E2E_OUT"; \
 			echo "=== Pre-commit hooks failed! ==="; \
 			exit 1; \
 		}; \
@@ -684,7 +699,8 @@ check:
 		uv run pytest -c lib/pyproject.toml -v $$PY_TESTS && \
 		echo "" || { \
 			kill $$FE_PID 2>/dev/null; \
-			rm -f "$$FE_OUT"; \
+			[ -n "$$E2E_PID" ] && kill $$E2E_PID 2>/dev/null; \
+			rm -f "$$FE_OUT" "$$E2E_OUT"; \
 			echo "=== Python tests failed! ==="; \
 			exit 1; \
 		}; \
@@ -693,8 +709,18 @@ check:
 	wait $$FE_PID || FE_EXIT=1; \
 	cat "$$FE_OUT"; \
 	rm -f "$$FE_OUT"; \
+	E2E_EXIT=0; \
+	if [ -n "$$E2E_PID" ]; then \
+		wait $$E2E_PID || E2E_EXIT=1; \
+		cat "$$E2E_OUT"; \
+	fi; \
+	rm -f "$$E2E_OUT"; \
 	if [ $$FE_EXIT -ne 0 ]; then \
 		echo "=== Frontend checks failed! ==="; \
+		exit 1; \
+	fi; \
+	if [ $$E2E_EXIT -ne 0 ]; then \
+		echo "=== E2E tests failed! ==="; \
 		exit 1; \
 	fi
 	@echo "=== All checks passed! ==="

--- a/Makefile
+++ b/Makefile
@@ -648,7 +648,7 @@ check:
 			( \
 				echo "=== E2E: tests (playwright) ===" && \
 				echo "Running: $$E2E_TESTS" && \
-				cd e2e_playwright && uv run pytest $$E2E_TESTS --tracing retain-on-failure --reruns 0 `# No retries for faster local checks` \
+				cd e2e_playwright && uv run pytest $$E2E_TESTS --tracing retain-on-failure --reruns 0 \
 			) > "$$E2E_OUT" 2>&1 & E2E_PID=$$!; \
 		fi; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -721,6 +721,8 @@ check:
 	fi; \
 	if [ $$E2E_EXIT -ne 0 ]; then \
 		echo "=== E2E tests failed! ==="; \
+		echo "If you implemented changes in the frontend, make sure to call 'make frontend-fast' to use the up-to-date frontend build in the test."; \
+		echo "You can find test-results in ./e2e_playwright/test-results"; \
 		exit 1; \
 	fi
 	@echo "=== All checks passed! ==="

--- a/scripts/get_changed_files.py
+++ b/scripts/get_changed_files.py
@@ -28,8 +28,11 @@ Usage:
 
 Output is space-separated file paths, suitable for passing to commands.
 
-Note: Files with spaces in their paths are not supported and will be ignored.
-This is a limitation of the space-separated output format used for shell consumption.
+Notes
+-----
+- Files with spaces in their paths are not supported and will be ignored.
+  This is a limitation of the space-separated output format used for shell consumption.
+- The --e2e flag maps app scripts to their corresponding tests (foo.py -> foo_test.py).
 """
 
 from __future__ import annotations
@@ -243,12 +246,32 @@ def get_frontend_test_files(files: list[str]) -> list[str]:
 
 
 def get_e2e_files(files: list[str]) -> list[str]:
-    """Get e2e test files."""
-    result = []
+    """Get e2e test files, including mapped tests from changed app scripts.
+
+    Maps app scripts to test files: foo.py -> foo_test.py
+    """
+    test_files: set[str] = set()
+
     for f in files:
-        if f.startswith(E2E_PREFIX) and f.endswith(PYTHON_TEST_SUFFIX):
-            result.append(f)
-    return result
+        if not f.startswith(E2E_PREFIX) or not f.endswith(".py"):
+            continue
+
+        # Skip conftest.py and __init__.py
+        filename = Path(f).name
+        if filename in {"conftest.py", "__init__.py"}:
+            continue
+
+        # Direct test file
+        if f.endswith(PYTHON_TEST_SUFFIX):
+            test_files.add(f)
+            continue
+
+        # Map app script to test file: foo.py -> foo_test.py
+        test_file = re.sub(r"\.py$", PYTHON_TEST_SUFFIX, f)
+        if (REPO_ROOT / test_file).exists():
+            test_files.add(test_file)
+
+    return sorted(test_files)
 
 
 def main() -> int:


### PR DESCRIPTION
## Describe your changes

Adds optional E2E test execution to `make check` for faster local validation of E2E-related changes:

- Add `E2E_CHECK=true` environment variable to run changed E2E tests in parallel with frontend checks
- Enhance `get_changed_files.py` to map app scripts to their corresponding test files (foo.py → foo_test.py)
- Update skill docs and AGENTS.md to document the new option

## Testing Plan

- [x] Verified `make check` still works without `E2E_CHECK` (no behavior change)
- [x] Verified `E2E_CHECK=true make check` runs changed E2E tests in parallel
- [x] Pre-commit hooks pass
- [x] All linting and type checks pass

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 3 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->