### PR TITLE
[fix] Add missing bidi_component_registry mock in threading test

### DIFF
--- a/lib/tests/streamlit/runtime/runtime_threading_test.py
+++ b/lib/tests/streamlit/runtime/runtime_threading_test.py
@@ -53,6 +53,7 @@ class RuntimeThreadingTest(IsolatedAsyncioTestCase):
                     media_file_storage=MagicMock(),
                     uploaded_file_manager=MagicMock(),
                     component_registry=MagicMock(),
+                    bidi_component_registry=MagicMock(),
                     session_manager_class=MagicMock,
                     session_storage=MagicMock(),
                     cache_storage_manager=MagicMock(),


### PR DESCRIPTION
## Describe your changes

Adds missing `bidi_component_registry` mock parameter to `RuntimeConfig` in threading test, fixing test failures after the new parameter was introduced.

## Testing Plan

- [x] Unit Tests: The modified test now passes with the complete mock configuration

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->