### PR TITLE
Allow multiline text in st.column_config.TextColumn

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.test.ts
@@ -164,3 +164,25 @@ describe("TextColumn", () => {
     expect(isErrorCell(cell)).toEqual(false)
   })
 })
+
+describe("TextColumn multiline support", () => {
+  it("should enable wrapping when multiline = true", () => {
+    const column = TextColumn({
+      ...MOCK_TEXT_COLUMN_PROPS,
+      columnTypeOptions: { multiline: true },
+    })
+
+    const cell = column.getCell("test", true) as TextCell
+    expect(cell.allowWrapping).toBe(true)
+  })
+
+  it("should enable wrapping when multiline = false", () => {
+    const column = TextColumn({
+      ...MOCK_TEXT_COLUMN_PROPS,
+      columnTypeOptions: { multiline: false },
+    })
+
+    const cell = column.getCell("test", true) as TextCell
+    expect(cell.allowWrapping).toBe(false)
+  })
+})

--- a/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.ts
@@ -35,6 +35,10 @@ export interface TextColumnParams {
    * Regular expression that the input's value must match for the value to pass.
    */
   readonly validate?: string
+  /**
+   * Determines if the text input should have multiple lines through line breaks.
+   */
+  readonly multiline?: boolean
 }
 
 /**
@@ -64,7 +68,7 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
     displayData: "",
     allowOverlay: true,
     contentAlign: props.contentAlignment,
-    allowWrapping: props.isWrappingAllowed,
+    allowWrapping: parameters.multiline ?? false,
     readonly: !props.isEditable,
     // The text in pinned columns should be faded.
     style: props.isPinned ? "faded" : "normal",
@@ -90,9 +94,11 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
       corrected = true
     }
 
+    const dataToValidate = cellData
+
     if (
       validateRegex instanceof RegExp &&
-      validateRegex.test(cellData) === false
+      validateRegex.test(dataToValidate) === false
     ) {
       return false
     }
@@ -132,7 +138,9 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
       try {
         const cellData = notNullOrUndefined(data) ? toSafeString(data) : null
         const displayData = notNullOrUndefined(cellData)
-          ? removeLineBreaks(cellData) // Remove line breaks to show all content in the cell
+          ? parameters.multiline
+            ? cellData
+            : removeLineBreaks(cellData) // Remove line breaks to show all content in the cell
           : ""
         return {
           ...cellTemplate,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -317,12 +317,24 @@ function useColumnLoader(
     shouldUseContainerWidthValue ||
     (notNullOrUndefined(configuredWidth) && configuredWidth > 0)
 
+  const hasMultilineColumn = useMemo(() => {
+    for (const config of columnConfigMapping.values()) {
+      const typeConfig = config.type_config as
+        | Record<string, unknown>
+        | undefined
+      if (typeConfig?.multiline === true) {
+        return true
+      }
+    }
+    return false
+  }, [columnConfigMapping])
   // Allow content wrapping if the configured row height is greater than 4rem.
   // 4rem was arbitrarily chosen because it looks and feels good. Its using rem
   // so that it adapts to changes in the root font size (configurable by the user).
   const isWrappingAllowed: boolean =
-    notNullOrUndefined(element.rowHeight) &&
-    element.rowHeight > convertRemToPx("4rem")
+    hasMultilineColumn ||
+    (notNullOrUndefined(element.rowHeight) &&
+      element.rowHeight > convertRemToPx("4rem"))
 
   // Converts the columns from Arrow into columns compatible with glide-data-grid
   const allColumns: BaseColumn[] = useMemo(() => {

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -132,6 +132,7 @@ class TextColumnConfig(TypedDict):
     type: Literal["text"]
     max_chars: NotRequired[int | None]
     validate: NotRequired[str | None]
+    multiline: NotRequired[bool | None]
 
 
 class CheckboxColumnConfig(TypedDict):
@@ -618,6 +619,7 @@ def TextColumn(
     default: str | None = None,
     max_chars: int | None = None,
     validate: str | None = None,
+    multiline: bool | None = None,
 ) -> ColumnConfig:
     r"""Configure a text column in ``st.dataframe`` or ``st.data_editor``.
 
@@ -686,6 +688,11 @@ def TextColumn(
         values are validated against. If the user input is invalid, it will not
         be submitted.
 
+    multiline: bool or None
+        Determines if the text input should have multiple lines or a single line. This
+        allows the user to add in line breaks if they wish. For backwards compatibility
+        and default behavior, the text will otherwise only be on a single line.
+
     Examples
     --------
     >>> import pandas as pd
@@ -706,7 +713,8 @@ def TextColumn(
     >>>             default="st.",
     >>>             max_chars=50,
     >>>             validate=r"^st\.[a-z_]+$",
-    >>>         )
+    >>>             multiline=True,
+    >>>         ),
     >>>     },
     >>>     hide_index=True,
     >>> )
@@ -725,7 +733,7 @@ def TextColumn(
         pinned=pinned,
         default=default,
         type_config=TextColumnConfig(
-            type="text", max_chars=max_chars, validate=validate
+            type="text", max_chars=max_chars, validate=validate, multiline=multiline
         ),
     )
 

--- a/lib/streamlit/hello/multiline_page.py
+++ b/lib/streamlit/hello/multiline_page.py
@@ -1,0 +1,42 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+import streamlit as st
+from streamlit.hello.utils import show_code
+
+
+def multiline_page() -> None:
+    df2 = pd.DataFrame({"test": ["line1\nline2", "another row"]})
+    st.data_editor(
+        df2,
+        column_config={
+            "test": st.column_config.TextColumn("Test", multiline=True, max_chars=100),
+        },
+        hide_index=True,
+    )
+
+
+st.set_page_config(page_title="Multiline page")
+st.title("Multiline page")
+st.write(
+    """
+    This is a testing page for the change request to add multiline functionality to st.data_editor for
+    the column.
+    """
+)
+
+multiline_page()
+show_code(multiline_page)

--- a/lib/streamlit/hello/streamlit_app.py
+++ b/lib/streamlit/hello/streamlit_app.py
@@ -47,6 +47,10 @@ def run() -> None:
                     title="Animation demo",
                     icon=":material/animation:",
                 ),
+                st.Page(
+                    dir_path / "multiline_page.py",
+                    title="Multiline page",
+                ),
             ]
         }
     )

--- a/lib/tests/streamlit/elements/lib/column_types_test.py
+++ b/lib/tests/streamlit/elements/lib/column_types_test.py
@@ -133,6 +133,37 @@ class ColumnTypesTest(unittest.TestCase):
             "type_config": {"type": "text", "max_chars": 10, "validate": "^[a-zA-Z]+$"},
         }, "Should have all the properties defined."
 
+    def test_text_column_multiline(self):
+        """Test TextColumn with multiline parameter."""
+        config = TextColumn(multiline=True)
+        result = remove_none_values(config)
+
+        assert result["type_config"]["type"] == "text"
+        assert result["type_config"]["multiline"] is True
+
+    def test_text_column_multiline_false(self):
+        """Test TextColumn where multiline=False. (All text on one line)"""
+        config = TextColumn(multiline=False)
+        result = remove_none_values(config)
+
+        assert result["type_config"]["type"] == "text"
+        assert result["type_config"]["multiline"] is False
+
+    def test_text_column_all_params(self):
+        """Test a TextColumn configuration with all parameters."""
+        config = TextColumn(
+            label="Comments",
+            max_chars=500,
+            multiline=True,
+            validate=r"^[\w\s\.\,\!\?\n]*$",
+        )
+        result = remove_none_values(config)
+
+        assert result["label"] == "Comments"
+        assert result["type_config"]["max_chars"] == 500
+        assert result["type_config"]["multiline"] is True
+        assert result["type_config"]["validate"] == r"^[\w\s\.\,\!\?\n]*$"
+
     def test_checkbox_column(self):
         """Test CheckboxColumn creation."""
 


### PR DESCRIPTION
## Describe your changes
This pull request introduces support within entry lines of st.data_editor, allowing text columns to support newline characters in their information. This allows the data to stretch to the page, and also displays all lines in the extended editing mode.
## Screenshot or video (only for visual changes)
### Before
<img width="762" height="619" alt="MultilineChangeReqBefore" src="https://github.com/user-attachments/assets/40a34736-324b-4dc4-a4aa-ed3c109433e9" />

### After
<img width="781" height="670" alt="MultilineChangeReqAfter" src="https://github.com/user-attachments/assets/3fbf6b65-d724-474b-9913-aa86508871ec" />

## GitHub Issue Link (if applicable)
[https://github.com/streamlit/streamlit/issues/13504](url)

## Testing Plan

- Added additional tests in column_types_test.py and TextColumn.text.ts to verify that the new parameter for a TextColumn is properly supported and handled, as well as the frontend receiving the correct information for the multiline configuration.
- Created a multiline_page.py test page in the hello directory in order to verify that changes are successfully reflected in a testing environment.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
