### PR TITLE
[chore] Add `pragma: no cover` to defensive code paths

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -32,7 +32,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
 - Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
-- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths.
+- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths. Include a brief reason, e.g., `# pragma: no cover - optional dep` or `# pragma: no cover - defensive`.
 
 ### Typing Tests
 

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -32,6 +32,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
 - Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
+- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths.
 
 ### Typing Tests
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -30,6 +30,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
 - Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
+- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths.
 
 ### Typing Tests
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -30,7 +30,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
 - Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
-- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths.
+- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths. Include a brief reason, e.g., `# pragma: no cover - optional dep` or `# pragma: no cover - defensive`.
 
 ### Typing Tests
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -24,7 +24,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
 - Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
-- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths.
+- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths. Include a brief reason, e.g., `# pragma: no cover - optional dep` or `# pragma: no cover - defensive`.
 
 ### Typing Tests
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -24,6 +24,7 @@ coverage (90% or higher) of our Python code in `lib/streamlit`.
 - Preferably in the mirrored directory structure as the non-test files.
 - Naming: `my_example_test.py`
 - Anti-regression checks: Where practical, go beyond the happy path by covering a plausible failure mode or edge case (invalid input, boundary condition, absent side effect). Do **not** add assertions that are logically implied by an earlier assertion — e.g., if you assert `x is True`, asserting `x is not False` is a tautology and adds no value. See `lib/tests/AGENTS.md` for detailed guidance and examples.
+- Coverage exclusions: Use `# pragma: no cover` for code that cannot reasonably be tested, such as import fallbacks for optional dependencies, "should never happen" defensive checks, or platform-specific unreachable paths.
 
 ### Typing Tests
 

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -77,7 +77,7 @@ def is_authlib_installed() -> bool:
 
         if authlib_version_tuple < (1, 3, 2):
             return False
-    except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dep
         return False
     return True
 
@@ -140,7 +140,7 @@ def get_redirect_uri(auth_section: AttrDict) -> str | None:
 
     try:
         redirect_uri_parsed = urlparse(redirect_uri)
-    except ValueError:  # pragma: no cover
+    except ValueError:  # pragma: no cover - defensive
         raise StreamlitAuthError(
             f"Invalid redirect_uri: {redirect_uri}. Please check your configuration."
         )
@@ -241,7 +241,7 @@ def encode_provider_token(provider: str) -> str:
     """Returns a signed JWT token with the provider and expiration time."""
     try:
         from authlib.jose import jwt
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         raise StreamlitAuthError(
             """To use authentication features, you need to install Authlib>=1.3.2, e.g. via `pip install Authlib`."""
         ) from None
@@ -260,7 +260,7 @@ def decode_provider_token(provider_token: str) -> ProviderTokenPayload:
     """Decode the JWT token and validate the claims."""
     try:
         from authlib.jose import JoseError, JWTClaims, jwt
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         raise StreamlitAuthError(
             """To use authentication features, you need to install Authlib>=1.3.2, e.g. via `pip install Authlib`."""
         ) from None
@@ -393,7 +393,9 @@ def _set_split_cookie(
 
     # If there is not enough space for the base64-encoded value, raise an error.
     # We need at least 4 bytes for a minimal base64-encoded value.
-    if available_for_base64_value < SINGLE_BYTE_BASE64_SIZE:  # pragma: no cover
+    if (
+        available_for_base64_value < SINGLE_BYTE_BASE64_SIZE
+    ):  # pragma: no cover - defensive
         raise StreamlitAuthError("Not enough space available for the signed value.")
 
     # Convert from base64 space to raw value space (base64 has 4/3 expansion ratio)
@@ -454,7 +456,7 @@ def get_cookie_with_chunks(
     # Parse chunk count
     try:
         chunk_count = int(match.group(1))
-    except (ValueError, TypeError):  # pragma: no cover
+    except (ValueError, TypeError):  # pragma: no cover - defensive
         _LOGGER.exception("Invalid chunk count for cookie '%s'", cookie_name)
         return None
 
@@ -502,7 +504,7 @@ def clear_cookie_and_chunks(
         # Clear additional chunk cookies (starting from 1, since main cookie is chunk 0)
         for i in range(1, chunk_count + 1):
             clear_single_cookie_fn(f"{cookie_name}_{i}")
-    except (ValueError, TypeError):  # pragma: no cover
+    except (ValueError, TypeError):  # pragma: no cover - defensive
         # If count is invalid, but we already cleared the main cookie
         # so we can ignore it
         pass

--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -77,7 +77,7 @@ def is_authlib_installed() -> bool:
 
         if authlib_version_tuple < (1, 3, 2):
             return False
-    except (ImportError, ModuleNotFoundError):
+    except (ImportError, ModuleNotFoundError):  # pragma: no cover
         return False
     return True
 
@@ -140,7 +140,7 @@ def get_redirect_uri(auth_section: AttrDict) -> str | None:
 
     try:
         redirect_uri_parsed = urlparse(redirect_uri)
-    except ValueError:
+    except ValueError:  # pragma: no cover
         raise StreamlitAuthError(
             f"Invalid redirect_uri: {redirect_uri}. Please check your configuration."
         )
@@ -241,7 +241,7 @@ def encode_provider_token(provider: str) -> str:
     """Returns a signed JWT token with the provider and expiration time."""
     try:
         from authlib.jose import jwt
-    except ImportError:
+    except ImportError:  # pragma: no cover
         raise StreamlitAuthError(
             """To use authentication features, you need to install Authlib>=1.3.2, e.g. via `pip install Authlib`."""
         ) from None
@@ -260,7 +260,7 @@ def decode_provider_token(provider_token: str) -> ProviderTokenPayload:
     """Decode the JWT token and validate the claims."""
     try:
         from authlib.jose import JoseError, JWTClaims, jwt
-    except ImportError:
+    except ImportError:  # pragma: no cover
         raise StreamlitAuthError(
             """To use authentication features, you need to install Authlib>=1.3.2, e.g. via `pip install Authlib`."""
         ) from None
@@ -393,7 +393,7 @@ def _set_split_cookie(
 
     # If there is not enough space for the base64-encoded value, raise an error.
     # We need at least 4 bytes for a minimal base64-encoded value.
-    if available_for_base64_value < SINGLE_BYTE_BASE64_SIZE:
+    if available_for_base64_value < SINGLE_BYTE_BASE64_SIZE:  # pragma: no cover
         raise StreamlitAuthError("Not enough space available for the signed value.")
 
     # Convert from base64 space to raw value space (base64 has 4/3 expansion ratio)
@@ -454,7 +454,7 @@ def get_cookie_with_chunks(
     # Parse chunk count
     try:
         chunk_count = int(match.group(1))
-    except (ValueError, TypeError):
+    except (ValueError, TypeError):  # pragma: no cover
         _LOGGER.exception("Invalid chunk count for cookie '%s'", cookie_name)
         return None
 
@@ -502,7 +502,7 @@ def clear_cookie_and_chunks(
         # Clear additional chunk cookies (starting from 1, since main cookie is chunk 0)
         for i in range(1, chunk_count + 1):
             clear_single_cookie_fn(f"{cookie_name}_{i}")
-    except (ValueError, TypeError):
+    except (ValueError, TypeError):  # pragma: no cover
         # If count is invalid, but we already cleared the main cookie
         # so we can ignore it
         pass

--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -32,7 +32,7 @@ def print_to_cli(message: str, **kwargs: Any) -> None:
         import click
 
         click.secho(message, **kwargs)
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         print(message, flush=True)  # noqa: T201
 
 
@@ -47,7 +47,7 @@ def style_for_cli(message: str, **kwargs: Any) -> str:
         import click
 
         return click.style(message, **kwargs)
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         return message
 
 
@@ -103,6 +103,6 @@ def open_browser(url: str) -> None:
         return
 
     # Unsupported platform - should never happen in standard environments
-    import platform  # pragma: no cover
+    import platform  # pragma: no cover - unsupported platform
 
-    raise errors.Error(f'Cannot open browser in platform "{platform.system()}"')  # ty: ignore[unresolved-attribute]  # pragma: no cover
+    raise errors.Error(f'Cannot open browser in platform "{platform.system()}"')  # ty: ignore[unresolved-attribute]  # pragma: no cover - unsupported platform

--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -32,7 +32,7 @@ def print_to_cli(message: str, **kwargs: Any) -> None:
         import click
 
         click.secho(message, **kwargs)
-    except ImportError:
+    except ImportError:  # pragma: no cover
         print(message, flush=True)  # noqa: T201
 
 
@@ -47,7 +47,7 @@ def style_for_cli(message: str, **kwargs: Any) -> str:
         import click
 
         return click.style(message, **kwargs)
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return message
 
 
@@ -102,6 +102,7 @@ def open_browser(url: str) -> None:
         _open_browser_with_command("open", url)
         return
 
-    import platform
+    # Unsupported platform - should never happen in standard environments
+    import platform  # pragma: no cover
 
-    raise errors.Error(f'Cannot open browser in platform "{platform.system()}"')  # ty: ignore[unresolved-attribute]
+    raise errors.Error(f'Cannot open browser in platform "{platform.system()}"')  # ty: ignore[unresolved-attribute]  # pragma: no cover

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -96,7 +96,7 @@ def _new_fragment_id_queue(
         )
 
     new_queue = list(dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue))
-    if not new_queue:  # pragma: no cover
+    if not new_queue:  # pragma: no cover - defensive
         raise RuntimeError(
             "Could not find current_fragment_id in fragment_id_queue. This should never happen."
         )

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -96,7 +96,7 @@ def _new_fragment_id_queue(
         )
 
     new_queue = list(dropwhile(lambda x: x != ctx.current_fragment_id, curr_queue))
-    if not new_queue:
+    if not new_queue:  # pragma: no cover
         raise RuntimeError(
             "Could not find current_fragment_id in fragment_id_queue. This should never happen."
         )

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -34,7 +34,7 @@ def _get_module_name(caller_frame: FrameType) -> str:
     # Get the caller's module name. `__name__` gives us the module's
     # fully-qualified name, which includes its package.
     module = inspect.getmodule(caller_frame)
-    if module is None:
+    if module is None:  # pragma: no cover
         raise RuntimeError("module is None. This should never happen.")
     module_name = module.__name__
 
@@ -101,11 +101,11 @@ def declare_component(
 
     # Get our stack frame.
     current_frame: FrameType | None = inspect.currentframe()
-    if current_frame is None:
+    if current_frame is None:  # pragma: no cover
         raise RuntimeError("current_frame is None. This should never happen.")
     # Get the stack frame of our calling function.
     caller_frame = current_frame.f_back
-    if caller_frame is None:
+    if caller_frame is None:  # pragma: no cover
         raise RuntimeError("caller_frame is None. This should never happen.")
 
     module_name = _get_module_name(caller_frame)

--- a/lib/streamlit/components/v1/component_registry.py
+++ b/lib/streamlit/components/v1/component_registry.py
@@ -34,7 +34,7 @@ def _get_module_name(caller_frame: FrameType) -> str:
     # Get the caller's module name. `__name__` gives us the module's
     # fully-qualified name, which includes its package.
     module = inspect.getmodule(caller_frame)
-    if module is None:  # pragma: no cover
+    if module is None:  # pragma: no cover - defensive
         raise RuntimeError("module is None. This should never happen.")
     module_name = module.__name__
 
@@ -101,11 +101,11 @@ def declare_component(
 
     # Get our stack frame.
     current_frame: FrameType | None = inspect.currentframe()
-    if current_frame is None:  # pragma: no cover
+    if current_frame is None:  # pragma: no cover - defensive
         raise RuntimeError("current_frame is None. This should never happen.")
     # Get the stack frame of our calling function.
     caller_frame = current_frame.f_back
-    if caller_frame is None:  # pragma: no cover
+    if caller_frame is None:  # pragma: no cover - defensive
         raise RuntimeError("caller_frame is None. This should never happen.")
 
     module_name = _get_module_name(caller_frame)

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -121,7 +121,7 @@ class CustomComponent(BaseCustomComponent):
             import pyarrow  # noqa: F401, ICN001
 
             from streamlit.components.v1 import component_arrow
-        except ImportError:
+        except ImportError:  # pragma: no cover
             raise StreamlitAPIException(
                 """To use Custom Components in Streamlit, you need to install
 PyArrow. To do so locally:

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -121,7 +121,7 @@ class CustomComponent(BaseCustomComponent):
             import pyarrow  # noqa: F401, ICN001
 
             from streamlit.components.v1 import component_arrow
-        except ImportError:  # pragma: no cover
+        except ImportError:  # pragma: no cover - optional dep
             raise StreamlitAPIException(
                 """To use Custom Components in Streamlit, you need to install
 PyArrow. To do so locally:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -369,7 +369,7 @@ def _delete_option(key: str) -> None:
 
     Only for use in testing.
     """
-    if _config_options is None:
+    if _config_options is None:  # pragma: no cover
         raise RuntimeError(
             "_config_options should always be populated here. This should never happen."
         )

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -369,7 +369,7 @@ def _delete_option(key: str) -> None:
 
     Only for use in testing.
     """
-    if _config_options is None:  # pragma: no cover
+    if _config_options is None:  # pragma: no cover - defensive
         raise RuntimeError(
             "_config_options should always be populated here. This should never happen."
         )

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -799,7 +799,7 @@ def convert_arrow_table_to_arrow_bytes(table: pa.Table) -> bytes:
     """
     try:
         table = _maybe_truncate_table(table)
-    except RecursionError as err:
+    except RecursionError as err:  # pragma: no cover
         # This is a very unlikely edge case, but we want to make sure that
         # it doesn't lead to unexpected behavior.
         # If there is a recursion error, we just return the table as-is
@@ -970,8 +970,8 @@ def convert_anything_to_list(obj: OptionSequence[V_co]) -> list[V_co]:
             if data_df.empty
             else cast("list[V_co]", list(data_df.iloc[:, 0].to_list()))
         )
-    except errors.StreamlitAPIException:
-        # Wrap the object into a list
+    except errors.StreamlitAPIException:  # pragma: no cover
+        # Defensive fallback: wrap the object into a list if conversion fails
         return [obj]  # type: ignore
 
 
@@ -1037,7 +1037,7 @@ def _maybe_truncate_table(
             displayed_rows = string_util.simplify_number(table.num_rows)
             total_rows = string_util.simplify_number(table.num_rows + truncated_rows)
 
-            if displayed_rows == total_rows:
+            if displayed_rows == total_rows:  # pragma: no cover
                 # If the simplified numbers are the same,
                 # we just display the exact numbers.
                 displayed_rows = str(table.num_rows)
@@ -1087,7 +1087,7 @@ def is_colum_type_arrow_incompatible(column: Series[Any] | Index[Any]) -> bool:
         if inferred_type == "mixed":
             # This includes most of the more complex/custom types (objects, dicts,
             # lists, ...)
-            if len(column) == 0 or not hasattr(column, "iloc"):
+            if len(column) == 0 or not hasattr(column, "iloc"):  # pragma: no cover
                 # The column seems to be invalid, so we assume it is incompatible.
                 # But this would most likely never happen since empty columns
                 # cannot be mixed.

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -799,7 +799,7 @@ def convert_arrow_table_to_arrow_bytes(table: pa.Table) -> bytes:
     """
     try:
         table = _maybe_truncate_table(table)
-    except RecursionError as err:  # pragma: no cover
+    except RecursionError as err:  # pragma: no cover - defensive
         # This is a very unlikely edge case, but we want to make sure that
         # it doesn't lead to unexpected behavior.
         # If there is a recursion error, we just return the table as-is
@@ -970,7 +970,7 @@ def convert_anything_to_list(obj: OptionSequence[V_co]) -> list[V_co]:
             if data_df.empty
             else cast("list[V_co]", list(data_df.iloc[:, 0].to_list()))
         )
-    except errors.StreamlitAPIException:  # pragma: no cover
+    except errors.StreamlitAPIException:  # pragma: no cover - defensive
         # Defensive fallback: wrap the object into a list if conversion fails
         return [obj]  # type: ignore
 
@@ -1037,7 +1037,7 @@ def _maybe_truncate_table(
             displayed_rows = string_util.simplify_number(table.num_rows)
             total_rows = string_util.simplify_number(table.num_rows + truncated_rows)
 
-            if displayed_rows == total_rows:  # pragma: no cover
+            if displayed_rows == total_rows:  # pragma: no cover - defensive
                 # If the simplified numbers are the same,
                 # we just display the exact numbers.
                 displayed_rows = str(table.num_rows)
@@ -1087,7 +1087,9 @@ def is_colum_type_arrow_incompatible(column: Series[Any] | Index[Any]) -> bool:
         if inferred_type == "mixed":
             # This includes most of the more complex/custom types (objects, dicts,
             # lists, ...)
-            if len(column) == 0 or not hasattr(column, "iloc"):  # pragma: no cover
+            if len(column) == 0 or not hasattr(
+                column, "iloc"
+            ):  # pragma: no cover - defensive
                 # The column seems to be invalid, so we assume it is incompatible.
                 # But this would most likely never happen since empty columns
                 # cannot be mixed.

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -1183,7 +1183,9 @@ def _get_size_encoding(
             f"This does not look like a valid size: {size_value!r}"
         )
 
-    if size_column is not None or size_value is not None:  # pragma: no cover
+    if (
+        size_column is not None or size_value is not None
+    ):  # pragma: no cover - defensive
         raise Error(
             f"Chart type {chart_type.name} does not support size argument. "
             "This should never happen!"

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -1183,7 +1183,7 @@ def _get_size_encoding(
             f"This does not look like a valid size: {size_value!r}"
         )
 
-    if size_column is not None or size_value is not None:
+    if size_column is not None or size_value is not None:  # pragma: no cover
         raise Error(
             f"Chart type {chart_type.name} does not support size argument. "
             "This should never happen!"

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -176,7 +176,7 @@ class Dialog(DeltaGenerator):
     def _update(self, should_open: bool) -> None:
         """Send an updated proto message to indicate the open-status for the dialog."""
 
-        if self._current_proto is None or self._delta_path is None:
+        if self._current_proto is None or self._delta_path is None:  # pragma: no cover
             raise RuntimeError(
                 "Dialog not correctly initialized. This should never happen."
             )

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -176,7 +176,9 @@ class Dialog(DeltaGenerator):
     def _update(self, should_open: bool) -> None:
         """Send an updated proto message to indicate the open-status for the dialog."""
 
-        if self._current_proto is None or self._delta_path is None:  # pragma: no cover
+        if (
+            self._current_proto is None or self._delta_path is None
+        ):  # pragma: no cover - defensive
             raise RuntimeError(
                 "Dialog not correctly initialized. This should never happen."
             )

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -131,7 +131,7 @@ class StatusContainer(DeltaGenerator):
             The new state of the status container. This mainly changes the
             icon. If None, the state is not changed.
         """
-        if self._current_proto is None or self._delta_path is None:
+        if self._current_proto is None or self._delta_path is None:  # pragma: no cover
             raise RuntimeError(
                 "StatusContainer is not correctly initialized. This should never happen."
             )

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -131,7 +131,9 @@ class StatusContainer(DeltaGenerator):
             The new state of the status container. This mainly changes the
             icon. If None, the state is not changed.
         """
-        if self._current_proto is None or self._delta_path is None:  # pragma: no cover
+        if (
+            self._current_proto is None or self._delta_path is None
+        ):  # pragma: no cover - defensive
             raise RuntimeError(
                 "StatusContainer is not correctly initialized. This should never happen."
             )

--- a/lib/streamlit/elements/pdf.py
+++ b/lib/streamlit/elements/pdf.py
@@ -43,7 +43,7 @@ def _get_pdf_component() -> Any | None:
         import streamlit_pdf  # type: ignore
 
         return streamlit_pdf.pdf_viewer
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         return None
 
 

--- a/lib/streamlit/elements/pdf.py
+++ b/lib/streamlit/elements/pdf.py
@@ -43,7 +43,7 @@ def _get_pdf_component() -> Any | None:
         import streamlit_pdf  # type: ignore
 
         return streamlit_pdf.pdf_viewer
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return None
 
 

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -199,7 +199,7 @@ def marshall(
         import matplotlib.pyplot as plt
 
         plt.ioff()
-    except ImportError:
+    except ImportError:  # pragma: no cover
         raise ImportError("pyplot() command requires matplotlib")
 
     # You can call .savefig() on a Figure object or directly on the pyplot

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -199,7 +199,7 @@ def marshall(
         import matplotlib.pyplot as plt
 
         plt.ioff()
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         raise ImportError("pyplot() command requires matplotlib")
 
     # You can call .savefig() on a Figure object or directly on the pyplot

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -150,7 +150,7 @@ class ChatInputValue(MutableMapping[str, Any]):
             raise KeyError(f"Invalid key: {item}")
         try:
             return getattr(self, item)  # type: ignore[no-any-return]
-        except AttributeError:  # pragma: no cover
+        except AttributeError:  # pragma: no cover - defensive
             raise KeyError(f"Invalid key: {item}") from None
 
     def __getattribute__(self, name: str) -> Any:
@@ -177,7 +177,7 @@ class ChatInputValue(MutableMapping[str, Any]):
             raise KeyError(f"Invalid key: {key}")
         try:
             delattr(self, key)
-        except AttributeError:  # pragma: no cover
+        except AttributeError:  # pragma: no cover - defensive
             raise KeyError(f"Invalid key: {key}") from None
 
     def to_dict(self) -> dict[str, str | list[UploadedFile] | UploadedFile | None]:
@@ -257,7 +257,7 @@ def _pop_upload_files(
         return []
 
     ctx = get_script_run_ctx()
-    if ctx is None:  # pragma: no cover
+    if ctx is None:  # pragma: no cover - defensive
         return []
 
     uploaded_file_info = files_value.uploaded_file_info
@@ -320,7 +320,7 @@ def _pop_audio_file(
         return None
 
     ctx = get_script_run_ctx()
-    if ctx is None:  # pragma: no cover
+    if ctx is None:  # pragma: no cover - defensive
         return None
 
     file_recs_list = ctx.uploaded_file_mgr.get_files(

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -150,7 +150,7 @@ class ChatInputValue(MutableMapping[str, Any]):
             raise KeyError(f"Invalid key: {item}")
         try:
             return getattr(self, item)  # type: ignore[no-any-return]
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             raise KeyError(f"Invalid key: {item}") from None
 
     def __getattribute__(self, name: str) -> Any:
@@ -177,7 +177,7 @@ class ChatInputValue(MutableMapping[str, Any]):
             raise KeyError(f"Invalid key: {key}")
         try:
             delattr(self, key)
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             raise KeyError(f"Invalid key: {key}") from None
 
     def to_dict(self) -> dict[str, str | list[UploadedFile] | UploadedFile | None]:
@@ -257,7 +257,7 @@ def _pop_upload_files(
         return []
 
     ctx = get_script_run_ctx()
-    if ctx is None:
+    if ctx is None:  # pragma: no cover
         return []
 
     uploaded_file_info = files_value.uploaded_file_info
@@ -320,7 +320,7 @@ def _pop_audio_file(
         return None
 
     ctx = get_script_run_ctx()
-    if ctx is None:
+    if ctx is None:  # pragma: no cover
         return None
 
     file_recs_list = ctx.uploaded_file_mgr.get_files(

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -250,7 +250,7 @@ class LLMThought:
     def complete(self, final_label: str | None = None) -> None:
         """Finish the thought."""
         if final_label is None and self._state == LLMThoughtState.RUNNING_TOOL:
-            if self._last_tool is None:  # pragma: no cover
+            if self._last_tool is None:  # pragma: no cover - defensive
                 raise RuntimeError(
                     "_last_tool should never be null when _state == RUNNING_TOOL"
                 )
@@ -330,7 +330,7 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
         """Return our current LLMThought. Raise an error if we have no current
         thought.
         """
-        if self._current_thought is None:  # pragma: no cover
+        if self._current_thought is None:  # pragma: no cover - defensive
             raise RuntimeError("Current LLMThought is unexpectedly None!")
         return self._current_thought
 

--- a/lib/streamlit/external/langchain/streamlit_callback_handler.py
+++ b/lib/streamlit/external/langchain/streamlit_callback_handler.py
@@ -250,7 +250,7 @@ class LLMThought:
     def complete(self, final_label: str | None = None) -> None:
         """Finish the thought."""
         if final_label is None and self._state == LLMThoughtState.RUNNING_TOOL:
-            if self._last_tool is None:
+            if self._last_tool is None:  # pragma: no cover
                 raise RuntimeError(
                     "_last_tool should never be null when _state == RUNNING_TOOL"
                 )
@@ -330,7 +330,7 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
         """Return our current LLMThought. Raise an error if we have no current
         thought.
         """
-        if self._current_thought is None:
+        if self._current_thought is None:  # pragma: no cover
             raise RuntimeError("Current LLMThought is unexpectedly None!")
         return self._current_thought
 

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -606,7 +606,7 @@ class AppSession:
             browser. Set only for the SCRIPT_STARTED event.
         """
 
-        if self._event_loop != asyncio.get_running_loop():
+        if self._event_loop != asyncio.get_running_loop():  # pragma: no cover
             raise RuntimeError(
                 "This function must only be called on the eventloop thread the AppSession was created on. "
                 "This should never happen."
@@ -626,7 +626,7 @@ class AppSession:
         if event == ScriptRunnerEvent.SCRIPT_STARTED:
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_IS_RUNNING
-            if page_script_hash is None:
+            if page_script_hash is None:  # pragma: no cover
                 raise RuntimeError(
                     "page_script_hash must be set for the SCRIPT_STARTED event. This should never happen."
                 )
@@ -677,7 +677,7 @@ class AppSession:
             else:
                 # The script didn't complete successfully: send the exception
                 # to the frontend.
-                if exception is None:
+                if exception is None:  # pragma: no cover
                     raise RuntimeError(
                         "exception must be set for the SCRIPT_STOPPED_WITH_COMPILE_ERROR event. "
                         "This should never happen."
@@ -699,7 +699,7 @@ class AppSession:
                 self._local_sources_watcher.update_watched_modules()
 
         elif event == ScriptRunnerEvent.SHUTDOWN:
-            if client_state is None:
+            if client_state is None:  # pragma: no cover
                 raise RuntimeError(
                     "client_state must be set for the SHUTDOWN event. This should never happen."
                 )
@@ -714,7 +714,7 @@ class AppSession:
             self._scriptrunner = None
 
         elif event == ScriptRunnerEvent.ENQUEUE_FORWARD_MSG:
-            if forward_msg is None:
+            if forward_msg is None:  # pragma: no cover
                 raise RuntimeError(
                     "null forward_msg in ENQUEUE_FORWARD_MSG event. This should never happen."
                 )

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -606,7 +606,9 @@ class AppSession:
             browser. Set only for the SCRIPT_STARTED event.
         """
 
-        if self._event_loop != asyncio.get_running_loop():  # pragma: no cover
+        if (
+            self._event_loop != asyncio.get_running_loop()
+        ):  # pragma: no cover - defensive
             raise RuntimeError(
                 "This function must only be called on the eventloop thread the AppSession was created on. "
                 "This should never happen."
@@ -626,7 +628,7 @@ class AppSession:
         if event == ScriptRunnerEvent.SCRIPT_STARTED:
             if self._state != AppSessionState.SHUTDOWN_REQUESTED:
                 self._state = AppSessionState.APP_IS_RUNNING
-            if page_script_hash is None:  # pragma: no cover
+            if page_script_hash is None:  # pragma: no cover - defensive
                 raise RuntimeError(
                     "page_script_hash must be set for the SCRIPT_STARTED event. This should never happen."
                 )
@@ -677,7 +679,7 @@ class AppSession:
             else:
                 # The script didn't complete successfully: send the exception
                 # to the frontend.
-                if exception is None:  # pragma: no cover
+                if exception is None:  # pragma: no cover - defensive
                     raise RuntimeError(
                         "exception must be set for the SCRIPT_STOPPED_WITH_COMPILE_ERROR event. "
                         "This should never happen."
@@ -699,7 +701,7 @@ class AppSession:
                 self._local_sources_watcher.update_watched_modules()
 
         elif event == ScriptRunnerEvent.SHUTDOWN:
-            if client_state is None:  # pragma: no cover
+            if client_state is None:  # pragma: no cover - defensive
                 raise RuntimeError(
                     "client_state must be set for the SHUTDOWN event. This should never happen."
                 )
@@ -714,7 +716,7 @@ class AppSession:
             self._scriptrunner = None
 
         elif event == ScriptRunnerEvent.ENQUEUE_FORWARD_MSG:
-            if forward_msg is None:  # pragma: no cover
+            if forward_msg is None:  # pragma: no cover - defensive
                 raise RuntimeError(
                     "null forward_msg in ENQUEUE_FORWARD_MSG event. This should never happen."
                 )

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -563,7 +563,7 @@ def _make_function_key(cache_type: CacheType, func: Callable[..., Any]) -> str:
     source_code: str | bytes
     try:
         source_code = inspect.getsource(func)
-    except (OSError, TypeError) as ex:  # pragma: no cover
+    except (OSError, TypeError) as ex:  # pragma: no cover - defensive
         _LOGGER.debug(
             "Failed to retrieve function's source code when building its key; "
             "falling back to bytecode.",

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -563,7 +563,7 @@ def _make_function_key(cache_type: CacheType, func: Callable[..., Any]) -> str:
     source_code: str | bytes
     try:
         source_code = inspect.getsource(func)
-    except (OSError, TypeError) as ex:
+    except (OSError, TypeError) as ex:  # pragma: no cover
         _LOGGER.debug(
             "Failed to retrieve function's source code when building its key; "
             "falling back to bytecode.",

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -183,7 +183,7 @@ def _fragment(
             # fragment runs will generally run in a new script run, thus we'll have a
             # new ctx.
             ctx = get_script_run_ctx(suppress_warning=True)
-            if ctx is None:  # pragma: no cover
+            if ctx is None:  # pragma: no cover - defensive
                 raise RuntimeError("ctx is None. This should never happen.")
 
             if ctx.fragment_ids_this_run:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -183,7 +183,7 @@ def _fragment(
             # fragment runs will generally run in a new script run, thus we'll have a
             # new ctx.
             ctx = get_script_run_ctx(suppress_warning=True)
-            if ctx is None:
+            if ctx is None:  # pragma: no cover
                 raise RuntimeError("ctx is None. This should never happen.")
 
             if ctx.fragment_ids_this_run:

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -401,7 +401,7 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        if existing_session_id and session_id_override:
+        if existing_session_id and session_id_override:  # pragma: no cover
             raise RuntimeError(
                 "Only one of existing_session_id and session_id_override should be set. "
                 "This should never happen."

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -401,7 +401,7 @@ class Runtime:
         -----
         Threading: UNSAFE. Must be called on the eventloop thread.
         """
-        if existing_session_id and session_id_override:  # pragma: no cover
+        if existing_session_id and session_id_override:  # pragma: no cover - defensive
             raise RuntimeError(
                 "Only one of existing_session_id and session_id_override should be set. "
                 "This should never happen."

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -379,7 +379,7 @@ class ScriptRunner:
             self._run_script(request.rerun_data)
             request = self._requests.on_scriptrunner_ready()
 
-        if request.type != ScriptRequestType.STOP:  # pragma: no cover
+        if request.type != ScriptRequestType.STOP:  # pragma: no cover - defensive
             raise RuntimeError(
                 f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
             )
@@ -446,7 +446,7 @@ class ScriptRunner:
         if request.type == ScriptRequestType.RERUN:
             raise RerunException(request.rerun_data)
 
-        if request.type != ScriptRequestType.STOP:  # pragma: no cover
+        if request.type != ScriptRequestType.STOP:  # pragma: no cover - defensive
             raise RuntimeError(
                 f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
             )

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -379,7 +379,7 @@ class ScriptRunner:
             self._run_script(request.rerun_data)
             request = self._requests.on_scriptrunner_ready()
 
-        if request.type != ScriptRequestType.STOP:
+        if request.type != ScriptRequestType.STOP:  # pragma: no cover
             raise RuntimeError(
                 f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
             )
@@ -446,7 +446,7 @@ class ScriptRunner:
         if request.type == ScriptRequestType.RERUN:
             raise RerunException(request.rerun_data)
 
-        if request.type != ScriptRequestType.STOP:
+        if request.type != ScriptRequestType.STOP:  # pragma: no cover
             raise RuntimeError(
                 f"Unrecognized ScriptRequestType: {request.type}. This should never happen."
             )

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -284,7 +284,7 @@ class ScriptRequests:
                 self._state = ScriptRequestType.CONTINUE
                 return ScriptRequest(ScriptRequestType.RERUN, self._rerun_data)
 
-            if self._state != ScriptRequestType.STOP:  # pragma: no cover
+            if self._state != ScriptRequestType.STOP:  # pragma: no cover - defensive
                 raise RuntimeError(
                     f"Unrecognized ScriptRunnerState: {self._state}. This should never happen."
                 )

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -284,7 +284,7 @@ class ScriptRequests:
                 self._state = ScriptRequestType.CONTINUE
                 return ScriptRequest(ScriptRequestType.RERUN, self._rerun_data)
 
-            if self._state != ScriptRequestType.STOP:
+            if self._state != ScriptRequestType.STOP:  # pragma: no cover
                 raise RuntimeError(
                     f"Unrecognized ScriptRunnerState: {self._state}. This should never happen."
                 )

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -535,7 +535,7 @@ class SessionState:
 
         At least one of the arguments must have a value.
         """
-        if user_key is None and widget_id is None:
+        if user_key is None and widget_id is None:  # pragma: no cover
             raise ValueError(
                 "user_key and widget_id cannot both be None. This should never happen."
             )

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -535,7 +535,7 @@ class SessionState:
 
         At least one of the arguments must have a value.
         """
-        if user_key is None and widget_id is None:  # pragma: no cover
+        if user_key is None and widget_id is None:  # pragma: no cover - defensive
             raise ValueError(
                 "user_key and widget_id cannot both be None. This should never happen."
             )

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -100,7 +100,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:
-        if existing_session_id and session_id_override:
+        if existing_session_id and session_id_override:  # pragma: no cover
             raise RuntimeError(
                 "Only one of existing_session_id and session_id_override should be truthy. "
                 "This should never happen."
@@ -147,7 +147,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
             "Created new session for client %s. Session ID: %s", id(client), session.id
         )
 
-        if session.id in self._active_session_info_by_id:
+        if session.id in self._active_session_info_by_id:  # pragma: no cover
             raise RuntimeError(
                 f"session.id '{session.id}' registered multiple times. "
                 "This should never happen."

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -100,7 +100,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
         existing_session_id: str | None = None,
         session_id_override: str | None = None,
     ) -> str:
-        if existing_session_id and session_id_override:  # pragma: no cover
+        if existing_session_id and session_id_override:  # pragma: no cover - defensive
             raise RuntimeError(
                 "Only one of existing_session_id and session_id_override should be truthy. "
                 "This should never happen."
@@ -147,7 +147,9 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
             "Created new session for client %s. Session ID: %s", id(client), session.id
         )
 
-        if session.id in self._active_session_info_by_id:  # pragma: no cover
+        if (
+            session.id in self._active_session_info_by_id
+        ):  # pragma: no cover - defensive
             raise RuntimeError(
                 f"session.id '{session.id}' registered multiple times. "
                 "This should never happen."

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -63,7 +63,7 @@ def page_sort_key(script_path: Path) -> tuple[float, str]:
 
     # Failing this should only be possible if script_path isn't a Python
     # file, which should never happen.
-    if len(matches) == 0:
+    if len(matches) == 0:  # pragma: no cover
         raise ValueError(
             f"{script_path} is not a Python file. This should never happen."
         )

--- a/lib/streamlit/source_util.py
+++ b/lib/streamlit/source_util.py
@@ -63,7 +63,7 @@ def page_sort_key(script_path: Path) -> tuple[float, str]:
 
     # Failing this should only be possible if script_path isn't a Python
     # file, which should never happen.
-    if len(matches) == 0:  # pragma: no cover
+    if len(matches) == 0:  # pragma: no cover - defensive
         raise ValueError(
             f"{script_path} is not a Python file. This should never happen."
         )

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -32,7 +32,7 @@ def adjust_years(input_date: date, years: int) -> date:
         if input_date.month == 2 and input_date.day == 29:
             return input_date.replace(year=input_date.year + years, month=2, day=28)
 
-        raise StreamlitAPIException(  # pragma: no cover
+        raise StreamlitAPIException(  # pragma: no cover - defensive
             f"Date {input_date} does not exist in the target year {input_date.year + years}. "
             "This should never happen. Please report this bug."
         ) from err

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -32,7 +32,7 @@ def adjust_years(input_date: date, years: int) -> date:
         if input_date.month == 2 and input_date.day == 29:
             return input_date.replace(year=input_date.year + years, month=2, day=28)
 
-        raise StreamlitAPIException(
+        raise StreamlitAPIException(  # pragma: no cover
             f"Date {input_date} does not exist in the target year {input_date.year + years}. "
             "This should never happen. Please report this bug."
         ) from err

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -184,7 +184,7 @@ def is_sympy_expression(obj: object) -> TypeGuard[sympy.Expr]:
         import sympy
 
         return isinstance(obj, sympy.Expr)
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return False
 
 
@@ -346,7 +346,8 @@ def dump_pydantic_sequence(obj: Sequence[object]) -> list[dict[str, Any]]:
     if has_callable_attr(first_element, "model_dump"):
         # Use mode="json" to ensure proper serialization of types like Decimal
         return [item.model_dump(mode="json") for item in obj]  # type: ignore
-    return [item.dict() for item in obj]  # type: ignore
+    # Pydantic v1 fallback
+    return [item.dict() for item in obj]  # type: ignore  # pragma: no cover
 
 
 def _is_from_streamlit(obj: object) -> bool:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -184,7 +184,7 @@ def is_sympy_expression(obj: object) -> TypeGuard[sympy.Expr]:
         import sympy
 
         return isinstance(obj, sympy.Expr)
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         return False
 
 
@@ -347,7 +347,7 @@ def dump_pydantic_sequence(obj: Sequence[object]) -> list[dict[str, Any]]:
         # Use mode="json" to ensure proper serialization of types like Decimal
         return [item.model_dump(mode="json") for item in obj]  # type: ignore
     # Pydantic v1 fallback
-    return [item.dict() for item in obj]  # type: ignore  # pragma: no cover
+    return [item.dict() for item in obj]  # type: ignore  # pragma: no cover - pydantic v1 compat
 
 
 def _is_from_streamlit(obj: object) -> bool:

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -60,7 +60,7 @@ def _is_watchdog_available() -> bool:
         import watchdog  # noqa: F401
 
         return True
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return False
 
 

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -60,7 +60,7 @@ def _is_watchdog_available() -> bool:
         import watchdog  # noqa: F401
 
         return True
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: no cover - optional dep
         return False
 
 

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -407,10 +407,10 @@ def test_prog_name() -> None:
 
     parent = click.get_current_context().parent
 
-    if parent is None:
+    if parent is None:  # pragma: no cover
         raise AssertionError("parent is None")
 
-    if parent.command_path != "streamlit test":
+    if parent.command_path != "streamlit test":  # pragma: no cover
         raise AssertionError(
             f"Parent command path is {parent.command_path} not streamlit test."
         )

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -407,10 +407,10 @@ def test_prog_name() -> None:
 
     parent = click.get_current_context().parent
 
-    if parent is None:  # pragma: no cover
+    if parent is None:  # pragma: no cover - defensive
         raise AssertionError("parent is None")
 
-    if parent.command_path != "streamlit test":  # pragma: no cover
+    if parent.command_path != "streamlit test":  # pragma: no cover - defensive
         raise AssertionError(
             f"Parent command path is {parent.command_path} not streamlit test."
         )


### PR DESCRIPTION
## Describe your changes

Adds `# pragma: no cover` comments to exclude defensive code paths from test coverage metrics. This improves coverage accuracy without changing any runtime behavior.

- Excludes import fallbacks for optional dependencies (authlib, click, watchdog, pyarrow, sympy, matplotlib, streamlit_pdf)
- Excludes "should never happen" invariant checks in runtime, session management, and script execution
- Excludes platform-specific unreachable code (e.g., unsupported platform handling)
- Excludes backward compatibility paths (e.g., Pydantic v1 fallback)

## Testing Plan

- No additional tests needed - changes are comment-only metadata for coverage tools
- All existing unit tests pass (1655 passed)
- No functional code changes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.