### PR TITLE
[fix] Add missing `contents:read` permission for nightly/release workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,6 +93,7 @@ jobs:
       ref: ${{needs.create-nightly-tag.outputs.tag}}
     permissions:
       # Required by check-e2e-test-count job (only runs on PRs, not nightly)
+      contents: read
       actions: read
       pull-requests: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       ref: ${{ github.ref_name }}
     permissions:
       # Required by check-e2e-test-count job (only runs on PRs, not releases)
+      contents: read
       actions: read
       pull-requests: write
 


### PR DESCRIPTION
## Describe your changes

Adds the missing `contents: read` permission to the `run-playwright-tests` job in nightly and release workflows.

The `check-e2e-test-count` job in `playwright.yml` requires `contents: read`, but the caller workflows only granted `actions: read` and `pull-requests: write`. GitHub validates reusable workflow permissions statically, so even though `check-e2e-test-count` only runs on PRs (not nightly/releases), the permission must be available.

## GitHub Issue(s)

Fixes the "Invalid workflow file" error in nightly.yml.

## Testing Plan

- [ ] CI validation (workflows will be validated by GitHub Actions)