### PR TITLE
refactor: utilize useId instead of uniqueId

### DIFF
--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.tsx
@@ -19,6 +19,7 @@ import {
   ReactElement,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -26,7 +27,6 @@ import {
 
 import { Minus, Plus } from "@emotion-icons/open-iconic"
 import { Input as UIInput } from "baseui/input"
-import { uniqueId } from "lodash-es"
 
 import { NumberInput as NumberInputProto } from "@streamlit/protobuf"
 
@@ -159,7 +159,7 @@ const NumberInput: React.FC<Props> = ({
   // Additional local state for UI interactions
   const [isFocused, setIsFocused] = useState(false)
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
-  const [id] = useState(() => uniqueId("number_input_"))
+  const id = useId()
 
   const inForm = isInForm({ formId: elementFormId })
   // Allows form submission on Enter & displays Enter instructions, or if not in form and state is dirty

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { FC, memo, useCallback, useRef, useState } from "react"
+import { FC, memo, useCallback, useId, useRef, useState } from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
-import { uniqueId } from "lodash-es"
 
 import { Element, TextArea as TextAreaProto } from "@streamlit/protobuf"
 
@@ -91,8 +90,7 @@ const TextArea: FC<Props> = ({
   fragmentId,
   outerElement,
 }) => {
-  // eslint-disable-next-line react-hooks/refs -- TODO: Do not access ref during render
-  const id = useRef(uniqueId("text_area_")).current
+  const id = useId()
 
   const { width, elementRef } = useCalculatedDimensions()
 

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useCallback, useState } from "react"
+import { memo, ReactElement, useCallback, useId, useState } from "react"
 
 import { Input as UIInput } from "baseui/input"
-import { uniqueId } from "lodash-es"
 
 import { TextInput as TextInputProto } from "@streamlit/protobuf"
 
@@ -109,7 +108,7 @@ function TextInput({
   const [focused, setFocused] = useState(false)
 
   const theme = useEmotionTheme()
-  const [id] = useState(() => uniqueId("text_input_"))
+  const id = useId()
   const { placeholder, formId, icon, maxChars } = element
 
   const commitWidgetValue = useCallback((): void => {


### PR DESCRIPTION
## Describe your changes

Replace `lodash-es` `uniqueId` with React's native `useId` hook in NumberInput, TextArea, and TextInput components. This change uses React's built-in solution for generating unique IDs.

## Screenshot or video (only for visual changes)

N/A - No visual changes

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Explanation of why no additional tests are needed**: This is a refactoring change that replaces one ID generation method with another. The functionality remains identical - both methods generate unique IDs for form elements. React's `useId` is specifically designed for this use case and provides the same guarantees.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.