### PR TITLE
[chore] Add `gemini-3.1-pro` to default AI PR review models 

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
         required: false
         type: string
-        default: "gpt-5.3-codex-high,opus-4.6-thinking"
+        default: "gpt-5.3-codex-high,gemini-3.1-pro,opus-4.6-thinking"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,opus-4.6-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,gemini-3.1-pro,opus-4.6-thinking' }}
 
 jobs:
   # Job 1: Parse model list and check for API key


### PR DESCRIPTION
## Describe your changes

Adds `gemini-3.1-pro` to the default models used in the AI PR review workflow. This enables multi-model reviews with three models:

- `gpt-5.3-codex-high`
- `gemini-3.1-pro` (new)
- `opus-4.6-thinking` (judge model for consolidation)

## Testing Plan

- [ ] Manual workflow trigger to verify the new model works