### PR TITLE
[chore] Fix flaky spinner snapshot test on Firefox

### DIFF
--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -70,18 +70,21 @@ st.header("Spinner - width examples")
 
 if st.button("Run spinner with content width (default)"):
     with st.spinner("Loading with content width...", width="content"):
-        time.sleep(2)
+        # Longer sleep for snapshot tests to complete before spinner disappears
+        time.sleep(5)
 
 if st.button("Run spinner with stretch width"):
     with st.spinner("Loading with stretch width...", width="stretch"):
-        time.sleep(2)
+        # Longer sleep for snapshot tests to complete before spinner disappears
+        time.sleep(5)
 
 if st.button("Run spinner with 300px width"):
     with st.spinner(
         "Loading with 300px width.... the text is long and does not fit in the width",
         width=300,
     ):
-        time.sleep(2)
+        # Longer sleep for snapshot tests to complete before spinner disappears
+        time.sleep(5)
 
 # Regression test for issue #13658: container elements in spinner context
 if st.button("Run spinner with container"):


### PR DESCRIPTION
## Describe your changes

Fixes flaky `test_spinner_width_300px_snapshot[firefox]` test that intermittently fails with "Element is not attached to the DOM" during screenshot.

- Increases spinner sleep duration from 2s to 5s for width-related spinner buttons
- Provides sufficient buffer for snapshot tests to complete before spinner disappears

**Root cause:** On slower browsers (Firefox, especially in CI), the time between the visibility check and screenshot capture could exceed the remaining sleep time, causing the spinner to detach.

## Testing Plan

- [x] E2E Tests
  - `e2e_playwright/st_spinner_test.py` — Verified 10/10 passes on Firefox

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | fixing-flaky-e2e-tests | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->