### PR TITLE
[chore] Add GitHub issue linking guidance to finalizing-pr skill

### DIFF
--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -66,7 +66,9 @@ Check if a PR exists for the current branch:
 gh pr view --json number,title,url
 ```
 
-**If no PR exists**, create one following the guidelines in `wiki/pull-requests.md` (please read!). Add appropriate labels and fill in the body based on `.github/pull_request_template.md` (skip the video/screenshot section):
+**If no PR exists**, create one following the guidelines in `wiki/pull-requests.md` (please read!). Add appropriate labels and fill in the body based on `.github/pull_request_template.md` (skip the video/screenshot section).
+
+**Link related issues:** Add `- Closes #12345` to the PR description for any known GitHub issues this PR resolves.
 
 **Required labels:**
 
@@ -87,6 +89,10 @@ gh pr create --base develop --title "[type] Description" --body "$(cat <<'EOF'
 
 - Change 1
 - Change 2
+
+## GitHub Issues (if applicable)
+
+- Closes #12345
 
 ## Testing Plan
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -90,7 +90,7 @@ gh pr create --base develop --title "[type] Description" --body "$(cat <<'EOF'
 - Change 1
 - Change 2
 
-## GitHub Issues (if applicable)
+## GitHub Issue Link (if applicable)
 
 - Closes #12345
 


### PR DESCRIPTION
## Describe your changes

- Add guidance to link related GitHub issues in PR descriptions using `- Closes #12345`
- Add `## GitHub Issues (if applicable)` section to the PR body template example

## Testing Plan

- [x] Documentation-only change, no tests required

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->