### PR TITLE
[fix] Toast disappears during st.rerun() (#7740)

### DIFF
--- a/e2e_playwright/st_toast.py
+++ b/e2e_playwright/st_toast.py
@@ -39,3 +39,7 @@ def toast_notification():
 
 
 st.button("Trigger dialog", on_click=toast_notification)
+
+if st.button("Toast and rerun"):
+    st.toast("Toast before rerun", icon="✅")
+    st.rerun()

--- a/e2e_playwright/st_toast_test.py
+++ b/e2e_playwright/st_toast_test.py
@@ -160,3 +160,23 @@ def test_toast_adjusts_for_custom_theme(
     toast.hover()
 
     assert_snapshot(toast, name="toast-custom-theme")
+
+
+def test_toast_persists_through_rerun(app: Page):
+    """Test that toasts persist through st.rerun() (issue #7740)."""
+    # Wait for initial toasts to time out
+    app.wait_for_timeout(4500)
+
+    rerun_toast = app.get_by_text("Toast before rerun")
+    expect(rerun_toast).not_to_be_visible()
+
+    # Click button that triggers toast and immediate rerun
+    click_button(app, "Toast and rerun")
+    wait_for_app_loaded(app)
+
+    # The toast should be visible despite the rerun
+    expect(rerun_toast).to_be_visible()
+
+    # Toast should still disappear after its default duration (4 seconds)
+    app.wait_for_timeout(4500)
+    expect(rerun_toast).not_to_be_visible()

--- a/e2e_playwright/st_toast_test.py
+++ b/e2e_playwright/st_toast_test.py
@@ -29,10 +29,14 @@ def test_default_toast_rendering(
 
     toasts = themed_app.get_by_test_id("stToast")
     expect(toasts).to_have_count(3)
-    toasts.nth(2).hover()
 
-    expect(toasts.nth(2)).to_contain_text("🐶This is a default toast message")
-    assert_snapshot(toasts.nth(2), name="toast-default")
+    # Use content-based selection instead of positional index
+    default_toast = toasts.filter(has_text="This is a default toast message")
+    expect(default_toast).to_be_visible()
+    default_toast.hover()
+
+    expect(default_toast).to_contain_text("🐶This is a default toast message")
+    assert_snapshot(default_toast, name="toast-default")
 
 
 def test_collapsed_toast_rendering(
@@ -45,13 +49,17 @@ def test_collapsed_toast_rendering(
 
     toasts = themed_app.get_by_test_id("stToast")
     expect(toasts).to_have_count(3)
-    toasts.nth(1).hover()
 
-    expect(toasts.nth(1)).to_contain_text(
+    # Use content-based selection instead of positional index
+    collapsed_toast = toasts.filter(has_text="Random toast message that is a really")
+    expect(collapsed_toast).to_be_visible()
+    collapsed_toast.hover()
+
+    expect(collapsed_toast).to_contain_text(
         "🦄Random toast message that is a really really really really really really "
         "really long message, going wayview moreClose"
     )
-    assert_snapshot(toasts.nth(1), name="toast-collapsed")
+    assert_snapshot(collapsed_toast, name="toast-collapsed")
 
 
 def test_expanded_toast_rendering(
@@ -64,18 +72,22 @@ def test_expanded_toast_rendering(
 
     toasts = themed_app.get_by_test_id("stToast")
     expect(toasts).to_have_count(3)
-    toasts.nth(1).hover()
+
+    # Use content-based selection instead of positional index
+    expandable_toast = toasts.filter(has_text="Random toast message that is a really")
+    expect(expandable_toast).to_be_visible()
+    expandable_toast.hover()
 
     expand = themed_app.get_by_text("view more")
     expect(expand).to_have_count(1)
     expand.click()
 
-    expect(toasts.nth(1)).to_contain_text(
+    expect(expandable_toast).to_contain_text(
         "🦄Random toast message that is a really really really really really really "
         "really long message, going way past the 3 line limitview lessClose"
     )
     reset_hovering(themed_app)
-    assert_snapshot(toasts.nth(1), name="toast-expanded")
+    assert_snapshot(expandable_toast, name="toast-expanded")
 
 
 def test_toast_with_material_icon_rendering(
@@ -88,10 +100,14 @@ def test_toast_with_material_icon_rendering(
 
     toasts = themed_app.get_by_test_id("stToast")
     expect(toasts).to_have_count(3)
-    toasts.nth(0).hover()
 
-    expect(toasts.nth(0)).to_contain_text("cabinYour edited image was saved!Close")
-    assert_snapshot(toasts.nth(0), name="toast-material-icon")
+    # Use content-based selection instead of positional index
+    material_toast = toasts.filter(has_text="Your edited image was saved!")
+    expect(material_toast).to_be_visible()
+    material_toast.hover()
+
+    expect(material_toast).to_contain_text("cabinYour edited image was saved!Close")
+    assert_snapshot(material_toast, name="toast-material-icon")
 
 
 def test_toast_above_dialog(app: Page, assert_snapshot: ImageCompareFunction):

--- a/frontend/lib/src/components/elements/Toast/Toast.test.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.test.tsx
@@ -33,7 +33,7 @@ import ThemeProvider from "~lib/components/core/ThemeProvider"
 import { mockTheme } from "~lib/mocks/mockTheme"
 import { render } from "~lib/test_util"
 
-import Toast, { shortenMessage, ToastProps } from "./Toast"
+import Toast, { clearActiveToasts, shortenMessage, ToastProps } from "./Toast"
 
 // A Toaster Container is required to render Toasts
 // Don't import the actual one from EventContainer as that lives on app side
@@ -82,6 +82,8 @@ describe("Toast Component", () => {
     await act(async () => {
       toaster.clear()
     })
+    // Clear the active toasts tracking so subsequent tests can create toasts
+    clearActiveToasts()
 
     // Ensure any pending BaseWeb toast timers are executed and then cleared
     act(() => {

--- a/frontend/lib/src/components/elements/Toast/Toast.tsx
+++ b/frontend/lib/src/components/elements/Toast/Toast.tsx
@@ -45,6 +45,22 @@ export interface ToastProps {
   element: ToastProto
 }
 
+/**
+ * Tracks active toasts by content hash to prevent duplicates.
+ * Key: content hash (body + icon + duration), Value: toaster key
+ * This allows toasts to persist through script reruns while avoiding
+ * duplicate creation during theme changes or remounts.
+ */
+const activeToasts = new Map<string, React.Key>()
+
+/**
+ * Clears the active toasts tracking. Used for testing.
+ * @internal
+ */
+export function clearActiveToasts(): void {
+  activeToasts.clear()
+}
+
 function generateToastOverrides(theme: EmotionTheme): ToastOverrides {
   const lightBackground = hasLightBackgroundColor(theme)
   return {
@@ -162,6 +178,16 @@ function Toast({ element }: Readonly<ToastProps>): ReactElement {
       return
     }
 
+    // Create a content hash to identify unique toasts
+    const contentHash = `${body}|${icon}|${duration}`
+
+    // Skip if this exact toast is already active (prevents duplicates on remount)
+    const existingKey = activeToasts.get(contentHash)
+    if (existingKey !== undefined) {
+      setToastKey(existingKey)
+      return
+    }
+
     // Uses toaster utility to create toast on mount and generate unique key
     // to reference that toast for update/removal
     const autoHideDurationMs = notNullOrUndefined(duration)
@@ -175,18 +201,21 @@ function Toast({ element }: Readonly<ToastProps>): ReactElement {
       autoHideDuration: autoHideDurationMs,
     })
     setToastKey(newKey)
+    activeToasts.set(contentHash, newKey)
 
-    return () => {
-      // Disable transition so toast doesn't flicker on removal
-      toaster.update(newKey, {
-        overrides: { Body: { style: { display: "none" } } },
-      })
-      // Remove toast on unmount
-      toaster.clear(newKey)
+    // Remove from tracking when toast auto-hides (skip for duration=0 which never hides).
+    // This timeout is intentionally not cleaned up on unmount - it manages global tracking
+    // that should persist regardless of component lifecycle.
+    if (autoHideDurationMs > 0) {
+      // eslint-disable-next-line no-restricted-globals, @eslint-react/web-api/no-leaked-timeout -- Intentional: global tracking cleanup
+      setTimeout(() => {
+        activeToasts.delete(contentHash)
+      }, autoHideDurationMs)
     }
 
-    // Array must be empty to run as mount/cleanup
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
+    // Don't cleanup on unmount - toasts should persist until auto-hide.
+    // This fixes issue #7740 where toasts disappeared during st.rerun().
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Run only on mount
   }, [])
 
   useEffect(() => {

--- a/lib/streamlit/runtime/forward_msg_queue.py
+++ b/lib/streamlit/runtime/forward_msg_queue.py
@@ -139,6 +139,7 @@ class ForwardMsgQueue:
                     "parent_message",
                     "page_info_changed",
                 }
+                or _is_toast_delta(msg)
                 or (
                     # preserve all messages if this is a fragment rerun and...
                     fragment_ids_this_run is not None
@@ -171,6 +172,22 @@ class ForwardMsgQueue:
 
     def __len__(self) -> int:
         return len(self._queue)
+
+
+def _is_toast_delta(msg: ForwardMsg) -> bool:
+    """Return True if the ForwardMsg is a toast delta.
+
+    Toast messages are preserved through reruns because they are ephemeral
+    notifications that should display regardless of script lifecycle.
+    """
+    if not msg.HasField("delta"):
+        return False
+
+    delta = msg.delta
+    if delta.WhichOneof("type") != "new_element":
+        return False
+
+    return delta.new_element.WhichOneof("type") == "toast"
 
 
 def _is_composable_message(msg: ForwardMsg) -> bool:

--- a/lib/tests/streamlit/runtime/forward_msg_queue_test.py
+++ b/lib/tests/streamlit/runtime/forward_msg_queue_test.py
@@ -363,3 +363,29 @@ class ForwardMsgQueueTest(unittest.TestCase):
         fmq.enqueue(TEXT_DELTA_MSG2)
 
         assert count == 0
+
+    def test_clear_retains_toast_deltas(self):
+        """Test that toast deltas persist through queue clear (issue #7740)."""
+        fmq = ForwardMsgQueue()
+
+        toast_delta_msg = ForwardMsg()
+        toast_delta_msg.delta.new_element.toast.body = "Toast before rerun"
+        toast_delta_msg.delta.new_element.toast.icon = "✅"
+        toast_delta_msg.metadata.delta_path[:] = make_delta_path(
+            RootContainer.EVENT, (), 0
+        )
+
+        text_delta_msg = ForwardMsg()
+        text_delta_msg.delta.new_element.text.body = "Some text"
+        text_delta_msg.metadata.delta_path[:] = make_delta_path(
+            RootContainer.MAIN, (), 0
+        )
+
+        fmq.enqueue(NEW_SESSION_MSG)
+        fmq.enqueue(toast_delta_msg)
+        fmq.enqueue(text_delta_msg)
+
+        fmq.clear(retain_lifecycle_msgs=True)
+
+        # Toast delta should be preserved, regular text delta should be dropped
+        assert fmq._queue == [NEW_SESSION_MSG, toast_delta_msg]


### PR DESCRIPTION
## Summary

Fixes #7740 where `st.toast()` followed by `st.rerun()` wasn't displaying the toast.

- Preserves toast deltas through queue clears during script reruns (backend)
- Tracks active toasts by content to prevent duplicates while allowing persistence through reruns (frontend)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/runtime/forward_msg_queue_test.py` — Tests toast delta preservation through queue clear
  - `frontend/lib/src/components/elements/Toast/Toast.test.tsx` — Tests with updated active toast tracking
- [x] E2E Tests (Playwright)
  - `e2e_playwright/st_toast_test.py` — Tests toast persists through `st.rerun()`

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->