### PR TITLE
[feature] Watch editable installs in uv workspaces

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -828,7 +828,7 @@ _create_option(
 
         This option has no effect outside of uv workspaces.
     """,
-    default_val=True,
+    default_val=False,
     type_=bool,
 )
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -817,6 +817,21 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "server.watchEditableInstalls",
+    description="""
+        Watch files from editable-installed packages within uv workspaces.
+
+        When enabled and the app is running within a uv workspace, Streamlit
+        will watch files from workspace member packages that are installed in
+        editable mode. Changes to these files will trigger app reruns.
+
+        This option has no effect outside of uv workspaces.
+    """,
+    default_val=True,
+    type_=bool,
+)
+
 
 @_create_option("server.cookieSecret", type_=str, sensitive=True)
 @util.memoize

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -264,3 +264,119 @@ def get_main_script_directory(main_script: str) -> str:
     main_script_path = normalize_path_join(os.getcwd(), main_script)
 
     return os.path.dirname(main_script_path)
+
+
+def _find_uv_workspace_root(start_path: str) -> str | None:
+    """Find the root directory of a uv workspace by walking up from start_path."""
+    import tomllib
+
+    current = os.path.abspath(start_path)
+    if os.path.isfile(current):
+        current = os.path.dirname(current)
+
+    while current != os.path.dirname(current):  # Stop at filesystem root
+        pyproject_path = os.path.join(current, "pyproject.toml")
+        if os.path.isfile(pyproject_path):
+            with contextlib.suppress(Exception):
+                with open(pyproject_path, "rb") as f:
+                    data = tomllib.load(f)
+                if data.get("tool", {}).get("uv", {}).get("workspace"):
+                    return current
+        current = os.path.dirname(current)
+
+    return None
+
+
+def _get_workspace_member_paths(workspace_root: str) -> set[str]:
+    """Get absolute paths of all workspace member directories."""
+    import glob
+
+    import tomllib
+
+    pyproject_path = os.path.join(workspace_root, "pyproject.toml")
+    member_paths: set[str] = set()
+
+    with contextlib.suppress(Exception):
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+
+        workspace_config = data.get("tool", {}).get("uv", {}).get("workspace", {})
+        members = workspace_config.get("members", [])
+
+        for pattern in members:
+            full_pattern = os.path.join(workspace_root, pattern)
+            for match in glob.glob(full_pattern):
+                if os.path.isdir(match):
+                    member_paths.add(os.path.abspath(match))
+
+    # Always include the workspace root itself (it may contain a package)
+    member_paths.add(os.path.abspath(workspace_root))
+
+    return member_paths
+
+
+def get_editable_install_paths(main_script_path: str | None = None) -> set[str]:
+    """Get source directories of editable-installed packages within a uv workspace.
+
+    Only returns editable paths that are workspace members. Returns an empty set
+    outside of uv workspaces to avoid false positives. Editable installs are
+    detected via PEP 610 direct_url.json metadata.
+    """
+    if main_script_path is None:
+        return set()
+
+    workspace_root = _find_uv_workspace_root(main_script_path)
+    if workspace_root is None:
+        return set()
+
+    workspace_members = _get_workspace_member_paths(workspace_root)
+    if not workspace_members:
+        return set()
+
+    import json
+    from importlib.metadata import distributions
+    from urllib.request import url2pathname
+
+    editable_paths: set[str] = set()
+
+    for dist in distributions():
+        with contextlib.suppress(Exception):
+            direct_url_json = dist.read_text("direct_url.json")
+            if direct_url_json:
+                direct_url = json.loads(direct_url_json)
+                if direct_url.get("dir_info", {}).get("editable"):
+                    url = direct_url.get("url", "")
+                    if url.startswith("file://"):
+                        # url2pathname handles file:// URLs across platforms
+                        source_path = url2pathname(url[7:])
+                        abs_path = os.path.abspath(source_path)
+
+                        if abs_path in workspace_members:
+                            editable_paths.add(abs_path)
+
+    if editable_paths:
+        # Import logger lazily to avoid circular import with config.py
+        from streamlit.logger import get_logger
+
+        get_logger(__name__).debug(
+            "Detected editable install paths: %s", editable_paths
+        )
+
+    return editable_paths
+
+
+def file_in_editable_install(
+    filepath: str, editable_paths: set[str] | None = None
+) -> bool:
+    """Test whether a filepath is within an editable-installed package."""
+    if editable_paths is None:
+        editable_paths = get_editable_install_paths()
+
+    if not editable_paths:
+        return False
+
+    filepath = os.path.abspath(filepath)
+    return any(
+        filepath.startswith(editable_path + os.sep) or filepath == editable_path
+        for editable_path in editable_paths
+    )

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -65,6 +65,17 @@ class LocalSourcesWatcher:
         self._is_closed = False
         self._cached_sys_modules: set[str] = set()
 
+        # Cache editable install paths at startup for performance.
+        # This enables watching files from packages installed in editable/development
+        # mode within a uv workspace. Only activates when the app is in a uv workspace
+        # and server.watchEditableInstalls is enabled.
+        if config.get_option("server.watchEditableInstalls"):
+            self._editable_install_paths: set[str] = (
+                file_util.get_editable_install_paths(self._main_script_path)
+            )
+        else:
+            self._editable_install_paths = set()
+
         # Blacklist for folders that should not be watched
         self._folder_black_list = FolderBlackList(
             config.get_option("server.folderWatchBlacklist")
@@ -214,6 +225,9 @@ class LocalSourcesWatcher:
         return self._file_is_new(filepath) and (
             file_util.file_is_in_folder_glob(filepath, self._script_folder)
             or file_util.file_in_pythonpath(filepath)
+            or file_util.file_in_editable_install(
+                filepath, self._editable_install_paths
+            )
         )
 
     def update_watched_modules(self) -> None:

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -804,6 +804,7 @@ class ConfigTest(unittest.TestCase):
                 "server.sslKeyFile",
                 "server.trustedUserHeaders",
                 "server.useStarlette",
+                "server.watchEditableInstalls",
                 "ui.hideTopBar",
             ]
         )

--- a/lib/tests/streamlit/file_util_test.py
+++ b/lib/tests/streamlit/file_util_test.py
@@ -292,3 +292,236 @@ class FileInPythonPathTest(unittest.TestCase):
         assert (
             file_util.normalize_path_join("some", "random", "path", "../..") == "some"
         )
+
+
+class EditableInstallTest(unittest.TestCase):
+    """Tests for editable install detection."""
+
+    def test_get_editable_install_paths_returns_empty_without_script_path(self) -> None:
+        """Returns empty set when no main_script_path is provided."""
+        result = file_util.get_editable_install_paths()
+        assert result == set()
+
+    def test_get_editable_install_paths_returns_empty_outside_workspace(self) -> None:
+        """Returns empty set when not in a uv workspace."""
+        with patch.object(file_util, "_find_uv_workspace_root", return_value=None):
+            result = file_util.get_editable_install_paths("/some/app/main.py")
+            assert result == set()
+
+    @patch("importlib.metadata.distributions")
+    def test_get_editable_install_paths_parses_direct_url_in_workspace(
+        self, mock_distributions: MagicMock
+    ) -> None:
+        """Parses direct_url.json for editable detection in uv workspace."""
+        import json
+
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = json.dumps(
+            {"url": "file:///workspace/package", "dir_info": {"editable": True}}
+        )
+        mock_distributions.return_value = [mock_dist]
+
+        with (
+            patch.object(
+                file_util, "_find_uv_workspace_root", return_value="/workspace"
+            ),
+            patch.object(
+                file_util,
+                "_get_workspace_member_paths",
+                return_value={"/workspace/package"},
+            ),
+        ):
+            paths = file_util.get_editable_install_paths("/workspace/app/main.py")
+            assert "/workspace/package" in paths
+
+    @patch("importlib.metadata.distributions")
+    def test_get_editable_install_paths_ignores_non_member_editable(
+        self, mock_distributions: MagicMock
+    ) -> None:
+        """Ignores editable installs outside workspace members."""
+        import json
+
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = json.dumps(
+            {"url": "file:///other/package", "dir_info": {"editable": True}}
+        )
+        mock_distributions.return_value = [mock_dist]
+
+        with (
+            patch.object(
+                file_util, "_find_uv_workspace_root", return_value="/workspace"
+            ),
+            patch.object(
+                file_util,
+                "_get_workspace_member_paths",
+                return_value={"/workspace/package"},
+            ),
+        ):
+            paths = file_util.get_editable_install_paths("/workspace/app/main.py")
+            assert paths == set()
+
+    @patch("importlib.metadata.distributions")
+    def test_get_editable_install_paths_ignores_non_editable(
+        self, mock_distributions: MagicMock
+    ) -> None:
+        """Ignores non-editable installs."""
+        import json
+
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = json.dumps(
+            {"url": "file:///workspace/package", "dir_info": {}}
+        )
+        mock_distributions.return_value = [mock_dist]
+
+        with (
+            patch.object(
+                file_util, "_find_uv_workspace_root", return_value="/workspace"
+            ),
+            patch.object(
+                file_util,
+                "_get_workspace_member_paths",
+                return_value={"/workspace/package"},
+            ),
+        ):
+            paths = file_util.get_editable_install_paths("/workspace/app/main.py")
+            assert paths == set()
+
+    @patch("importlib.metadata.distributions")
+    def test_get_editable_install_paths_handles_missing_direct_url(
+        self, mock_distributions: MagicMock
+    ) -> None:
+        """Handles packages without direct_url.json gracefully."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = None
+        mock_distributions.return_value = [mock_dist]
+
+        with (
+            patch.object(
+                file_util, "_find_uv_workspace_root", return_value="/workspace"
+            ),
+            patch.object(
+                file_util,
+                "_get_workspace_member_paths",
+                return_value={"/workspace/package"},
+            ),
+        ):
+            paths = file_util.get_editable_install_paths("/workspace/app/main.py")
+            assert paths == set()
+
+    @patch("importlib.metadata.distributions")
+    def test_get_editable_install_paths_handles_exceptions(
+        self, mock_distributions: MagicMock
+    ) -> None:
+        """Handles exceptions during metadata reading gracefully."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.side_effect = Exception("Metadata error")
+        mock_distributions.return_value = [mock_dist]
+
+        with (
+            patch.object(
+                file_util, "_find_uv_workspace_root", return_value="/workspace"
+            ),
+            patch.object(
+                file_util,
+                "_get_workspace_member_paths",
+                return_value={"/workspace/package"},
+            ),
+        ):
+            paths = file_util.get_editable_install_paths("/workspace/app/main.py")
+            assert paths == set()
+
+
+@pytest.mark.parametrize(
+    ("filepath", "editable_paths", "expected"),
+    [
+        ("/workspace/pkg1/src/module.py", {"/workspace/pkg1"}, True),
+        ("/other/path/module.py", {"/workspace/pkg1"}, False),
+        ("/any/path.py", set(), False),
+        ("/workspace/pkg1", {"/workspace/pkg1"}, True),
+        ("/workspace/pkg123/module.py", {"/workspace/pkg"}, False),
+    ],
+    ids=[
+        "file_inside_editable",
+        "file_outside_editable",
+        "empty_set",
+        "exact_match",
+        "partial_name_no_match",
+    ],
+)
+def test_file_in_editable_install(
+    filepath: str, editable_paths: set[str], expected: bool
+) -> None:
+    """Tests file_in_editable_install with various path scenarios."""
+    assert file_util.file_in_editable_install(filepath, editable_paths) == expected
+
+
+class UvWorkspaceDetectionTest(unittest.TestCase):
+    """Tests for uv workspace detection functions."""
+
+    def test_find_uv_workspace_root_no_pyproject(self) -> None:
+        """Returns None when no pyproject.toml exists."""
+        with patch("os.path.isfile", return_value=False):
+            result = file_util._find_uv_workspace_root("/some/path/app.py")
+            assert result is None
+
+    def test_find_uv_workspace_root_no_workspace_section(self) -> None:
+        """Returns None when pyproject.toml has no workspace section."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyproject = os.path.join(tmpdir, "pyproject.toml")
+            with open(pyproject, "w", encoding="utf-8") as f:
+                f.write("[project]\nname = 'test'\n")
+
+            result = file_util._find_uv_workspace_root(
+                os.path.join(tmpdir, "app", "main.py")
+            )
+            assert result is None
+
+    def test_find_uv_workspace_root_with_workspace_section(self) -> None:
+        """Finds workspace root when pyproject.toml has workspace section."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyproject = os.path.join(tmpdir, "pyproject.toml")
+            with open(pyproject, "w", encoding="utf-8") as f:
+                f.write('[tool.uv.workspace]\nmembers = ["packages/*"]\n')
+
+            app_dir = os.path.join(tmpdir, "apps", "myapp")
+            os.makedirs(app_dir, exist_ok=True)
+
+            result = file_util._find_uv_workspace_root(os.path.join(app_dir, "main.py"))
+            assert result == tmpdir
+
+    def test_get_workspace_member_paths_includes_glob_matches(self) -> None:
+        """Resolves workspace member paths from glob patterns."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyproject = os.path.join(tmpdir, "pyproject.toml")
+            with open(pyproject, "w", encoding="utf-8") as f:
+                f.write('[tool.uv.workspace]\nmembers = ["packages/*"]\n')
+
+            pkg1 = os.path.join(tmpdir, "packages", "pkg1")
+            pkg2 = os.path.join(tmpdir, "packages", "pkg2")
+            os.makedirs(pkg1, exist_ok=True)
+            os.makedirs(pkg2, exist_ok=True)
+
+            result = file_util._get_workspace_member_paths(tmpdir)
+
+            assert os.path.abspath(tmpdir) in result
+            assert os.path.abspath(pkg1) in result
+            assert os.path.abspath(pkg2) in result
+
+    def test_get_workspace_member_paths_always_includes_root(self) -> None:
+        """Workspace root is always included in member paths."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyproject = os.path.join(tmpdir, "pyproject.toml")
+            with open(pyproject, "w", encoding="utf-8") as f:
+                f.write("[tool.uv.workspace]\n")
+
+            result = file_util._get_workspace_member_paths(tmpdir)
+
+            assert os.path.abspath(tmpdir) in result

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -47,6 +47,7 @@ def NOOP_CALLBACK(_filepath):
 
 
 @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
+@patch("streamlit.file_util.get_editable_install_paths", MagicMock(return_value=set()))
 class LocalSourcesWatcherTest(unittest.TestCase):
     def setUp(self):
         modules = [
@@ -549,3 +550,109 @@ def test_get_module_paths_outputs_abs_paths():
 
 def sort_args_list(args_list):
     return sorted(args_list, key=lambda args: args[0])
+
+
+class EditableInstallWatcherTest(unittest.TestCase):
+    """Tests for editable install watching."""
+
+    @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
+    @patch("streamlit.file_util.get_editable_install_paths")
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_watches_editable_install_modules(
+        self,
+        mock_path_watcher: MagicMock,
+        mock_get_editable: MagicMock,
+    ) -> None:
+        """Modules from editable installs are watched."""
+        editable_path = os.path.dirname(DUMMY_MODULE_1_FILE)
+        mock_get_editable.return_value = {editable_path}
+
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        sys.modules["EDITABLE_TEST_MODULE"] = DUMMY_MODULE_1
+
+        mock_path_watcher.reset_mock()
+        lsw.update_watched_modules()
+
+        watched_paths = [
+            call_args[0][0] for call_args in mock_path_watcher.call_args_list
+        ]
+        assert any(DUMMY_MODULE_1_FILE in p for p in watched_paths)
+
+        del sys.modules["EDITABLE_TEST_MODULE"]
+
+    @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
+    @patch("streamlit.file_util.get_editable_install_paths")
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_does_not_watch_non_editable_site_packages(
+        self, mock_path_watcher: MagicMock, mock_get_editable: MagicMock
+    ) -> None:
+        """Modules outside editable installs are not watched."""
+        mock_get_editable.return_value = {"/workspace/my_package"}
+
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        mock_module = MagicMock()
+        mock_module.__file__ = "/venv/lib/python3.10/site-packages/other_module.py"
+        mock_module.__name__ = "other_module"
+
+        mock_path_watcher.reset_mock()
+        with patch("sys.modules", {"other_module": mock_module}):
+            lsw.update_watched_modules()
+
+        watched_paths = [
+            call_args[0][0] for call_args in mock_path_watcher.call_args_list
+        ]
+        assert not any("site-packages" in p for p in watched_paths)
+
+    @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
+    @patch("streamlit.file_util.get_editable_install_paths")
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_editable_install_paths_cached_at_init(
+        self, _mock_path_watcher: MagicMock, mock_get_editable: MagicMock
+    ) -> None:
+        """Editable install paths are cached at watcher initialization."""
+        mock_get_editable.return_value = {"/workspace/pkg"}
+
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+
+        mock_get_editable.assert_called_once()
+        assert lsw._editable_install_paths == {"/workspace/pkg"}
+
+    @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
+    @patch("streamlit.file_util.get_editable_install_paths")
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_no_editable_installs_still_works(
+        self, mock_path_watcher: MagicMock, mock_get_editable: MagicMock
+    ) -> None:
+        """Watcher works normally when no editable installs exist."""
+        mock_get_editable.return_value = set()
+
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        mock_path_watcher.assert_called()
+        args, _ = mock_path_watcher.call_args_list[0]
+        assert os.path.realpath(args[0]) == os.path.realpath(SCRIPT_PATH)
+
+    @patch("streamlit.file_util.file_in_pythonpath", MagicMock(return_value=False))
+    @patch("streamlit.file_util.get_editable_install_paths")
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_config_disables_editable_install_watching(
+        self, mock_path_watcher: MagicMock, mock_get_editable: MagicMock
+    ) -> None:
+        """server.watchEditableInstalls=False disables editable watching."""
+        with patch(
+            "streamlit.watcher.local_sources_watcher.config.get_option",
+            side_effect=lambda opt: {
+                "server.folderWatchList": [],
+                "server.folderWatchBlacklist": [],
+                "server.watchEditableInstalls": False,
+            }.get(opt),
+        ):
+            lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+
+        mock_get_editable.assert_not_called()
+        assert lsw._editable_install_paths == set()


### PR DESCRIPTION
## Describe your changes

Adds automatic file watching for editable-installed packages within uv workspaces. When developing with a uv monorepo structure, changes to workspace member packages now trigger app reruns.

- Adds `server.watchEditableInstalls` config option (default: `True`)
- Detects uv workspaces by finding `[tool.uv.workspace]` in pyproject.toml
- Uses PEP 610 `direct_url.json` metadata to detect editable installs
- Only watches packages that are workspace members to avoid false positives

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/11037

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/file_util_test.py` — Tests workspace detection and editable install path resolution
  - `lib/tests/streamlit/watcher/local_sources_watcher_test.py` — Tests watcher integration with editable installs