### PR TITLE
fix(testing): initialize BidiComponentManager in AppTest mock runtime

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 from urllib import parse
 
+from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.runtime import Runtime
 from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
@@ -339,6 +340,7 @@ class AppTest:
             MemoryMediaFileStorage("/mock/media")
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime.bidi_component_registry = BidiComponentManager()
         Runtime._instance = mock_runtime
         script_cache = ScriptCache()
         # Reset to ensure st.navigation works correctly regardless of prior test state.

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -268,6 +268,29 @@ def test_navigation_with_callable_pages():
     assert "Content from page 1" in at.markdown.values
 
 
+def test_v2_custom_component():
+    """Test AppTest can run apps that use st.components.v2 custom components.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/14274
+    """
+
+    def script():
+        import streamlit as st
+        from streamlit.components.v2 import component
+
+        _my_component = component(
+            "my_test_component",
+            html='<div id="root">hello</div>',
+        )
+
+        st.title("Test")
+        _my_component(key="test", data={"text": "hello"})
+
+    at = AppTest.from_function(script).run()
+    assert not at.exception, [e.message for e in at.exception]
+    assert at.title[0].value == "Test"
+
+
 def test_navigation_resets_pages_manager_state():
     """Test AppTest resets PagesManager.uses_pages_directory before running.
 


### PR DESCRIPTION
## Summary

`AppTest._run()` creates a `MagicMock(spec=Runtime)` but does not configure `bidi_component_registry`, so any app that uses `st.components.v2` custom components crashes with:

```
TypeError: bad argument type for built-in operation
```

The crash occurs because `get_bidi_component_manager()` returns a MagicMock attribute instead of a real `BidiComponentManager`. Component registration silently no-ops on the mock, and later, when `_bidi_component()` tries to set protobuf string fields from MagicMock objects, the built-in protobuf C code raises the TypeError.

## Fix

Initialize a real `BidiComponentManager` instance on the mock runtime, alongside the existing `MediaFileManager` and `MemoryCacheStorageManager`:

```python
mock_runtime.bidi_component_registry = BidiComponentManager()
```

This ensures component registration and lookup work correctly during `AppTest` runs.

## Test

Added `test_v2_custom_component` that registers and mounts a v2 custom component inside `AppTest.from_function()`, verifying no exception is raised.

Fixes #14274