### PR TITLE
fix: buf commands utilize yarn exec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,13 +91,13 @@ repos:
         files: ^(pyproject\.toml|\.pre-commit-config\.yaml)$
       - id: proto-format
         name: Buf Format Protos
-        entry: ./frontend/node_modules/.bin/buf format -w proto
+        entry: ./scripts/run_in_subdirectory.py frontend yarn exec buf format -w ../proto
         files: ^proto/.*\.proto$
         language: system
         pass_filenames: false
       - id: proto-lint
         name: Buf Lint Protos
-        entry: ./frontend/node_modules/.bin/buf lint proto
+        entry: ./scripts/run_in_subdirectory.py frontend yarn exec buf lint ../proto
         files: ^proto/.*\.proto$
         language: system
         pass_filenames: false


### PR DESCRIPTION
## Describe your changes

Updated the pre-commit hooks for protobuf formatting and linting to follow the pattern of other execution methods. The `proto-format` and `proto-lint` hooks now use `./scripts/run_in_subdirectory.py` to execute `yarn exec buf` commands from the frontend directory, rather than directly calling the buf binary from `./frontend/node_modules/.bin/`, which sometimes threw permission errors.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Ran `pre-commit run --all-files` locally
- This is covered by CI

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.