### PR TITLE
refactor: remove all eslint-disable @typescript-eslint/no-unused-vars directives

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -686,8 +686,7 @@ export class App extends PureComponent<Props, State> {
             ScriptRunState.RUNNING,
             ScriptRunState.NOT_RUNNING
           )
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (err) {
+        } catch {
           // It's okay if this fails, the `measure` call is for debugging/profiling
         }
       }
@@ -2131,8 +2130,7 @@ export class App extends PureComponent<Props, State> {
       } else {
         windowToPrint = window
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (err) {
+    } catch {
       windowToPrint = window
     } finally {
       if (!windowToPrint) windowToPrint = window

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { PureComponent, ReactElement } from "react"
 
 import { act, screen, waitFor } from "@testing-library/react"
@@ -50,32 +48,32 @@ import {
  * Example StreamlitEndpoints implementation.
  */
 class Endpoints implements StreamlitEndpoints {
-  public setStaticConfigUrl(url: string | null): void {
+  public setStaticConfigUrl(_url: string | null): void {
     throw new Error("Unimplemented")
   }
 
   public sendClientErrorToHost(
-    component: string,
-    error: string | number,
-    message: string,
-    source: string,
-    customComponentName?: string
+    _component: string,
+    _error: string | number,
+    _message: string,
+    _source: string,
+    _customComponentName?: string
   ): void {
     throw new Error("Unimplemented")
   }
 
   public checkSourceUrlResponse(
-    sourceUrl: string,
-    componentName?: string
+    _sourceUrl: string,
+    _componentName?: string
   ): Promise<void> {
     return Promise.reject(new Error("Unimplemented"))
   }
 
-  public buildComponentURL(componentName: string, path: string): string {
+  public buildComponentURL(_componentName: string, path: string): string {
     return path
   }
 
-  public buildBidiComponentURL(componentName: string, path: string): string {
+  public buildBidiComponentURL(_componentName: string, path: string): string {
     return path
   }
 

--- a/frontend/app/src/util/ScreenCastRecorder.ts
+++ b/frontend/app/src/util/ScreenCastRecorder.ts
@@ -46,8 +46,7 @@ class ScreenCastRecorder {
         notNullOrUndefined(navigator.mediaDevices.getDisplayMedia) &&
         MediaRecorder.isTypeSupported(BLOB_TYPE)
       )
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
+    } catch {
       // In the event of an error, assume it won't support screencasts
       return false
     }

--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -144,8 +144,7 @@ If you are trying to access a Streamlit app running on another server, this coul
     if (url) {
       try {
         source = new URL(url).pathname
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (e) {
+      } catch {
         LOG.error(`unrecognized url: ${url}`)
       }
     }

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -299,6 +299,7 @@ export default defineConfig([
           args: "all",
           ignoreRestSiblings: false,
           argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
         },
       ],
       // It's safe to use functions before they're defined

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -155,10 +155,8 @@ export const DeckGlJsonChart: FC<DeckGLProps> = props => {
 
             if (selectionMap.size === 0) {
               // If the layer has nothing selected, remove the layer from the returned value
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { [layerId]: _, ...restIndices } =
                 currState.selection.indices
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { [layerId]: __, ...restObjects } =
                 currState.selection.objects
 

--- a/frontend/lib/src/components/elements/Json/Json.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.tsx
@@ -58,8 +58,7 @@ function Json({ element }: Readonly<JsonProps>): ReactElement {
     const error = ensureError(e)
     try {
       bodyObject = JSON5.parse(element.body)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (json5Error) {
+    } catch {
       // If content fails to parse as Json, rebuild the error message
       // to show where the problem occurred.
       const pos = parseInt(error.message.replace(/[^0-9]/g, ""), 10)

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -57,8 +57,7 @@ SaturationComponent.prototype.getContainerRenderWindow = function () {
       lastRenderWindow = renderWindow
       renderWindow = renderWindow.parent as Window & typeof globalThis
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
+  } catch {
     renderWindow = lastRenderWindow
   }
   return renderWindow

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -50,9 +50,12 @@ interface FixedSizeListItemProps {
 
 function FixedSizeListItem(props: FixedSizeListItemProps): ReactElement {
   const { data, index, style } = props
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { item, overrides, $isHighlighted, ...restChildProps } = data[index]
-    .props as OptionListProps & { $isHighlighted?: boolean }
+  const {
+    item,
+    overrides: _overrides,
+    $isHighlighted,
+    ...restChildProps
+  } = data[index].props as OptionListProps & { $isHighlighted?: boolean }
 
   // isCreatable is set by baseui when the option is not in the list of options and the user is typing a new one
   const label = item.isCreatable ? `Add: ${item.label}` : item.label

--- a/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
@@ -120,8 +120,7 @@ function BaseDateTimeColumn(
     try {
       defaultTimezoneOffset =
         applyTimezone(moment(), parameters.timezone)?.utcOffset() || undefined
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       // Do nothing
     }
   }

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -89,8 +89,7 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
     ) {
       try {
         displayTextRegex = new RegExp(configuredDisplayText, "us")
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
+      } catch {
         // The regex is invalid, interpret it as static display text.
         displayTextRegex = undefined
       }

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
@@ -63,8 +63,7 @@ export const JsonViewer: React.FC<JsonViewerProps> = ({
         typeof jsonValue === "string"
           ? JSON5.parse(jsonValue)
           : JSON5.parse(JSON5.stringify(jsonValue))
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       // Keep the parsed JSON as undefined.
       parsedJson = undefined
     }

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
@@ -316,8 +316,7 @@ export function toSafeArray(data: any): any[] {
       // Support for JSON arrays: ["foo", 1, null, "test"]
       try {
         return JSON.parse(data)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
+      } catch {
         return [data]
       }
     } else {
@@ -342,8 +341,7 @@ export function toSafeArray(data: any): any[] {
         ? value
         : toSafeString(value)
     )
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return [toSafeString(data)]
   }
 }
@@ -397,14 +395,12 @@ export function toSafeString(data: any): string {
   try {
     try {
       return toString(data)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       return JSON.stringify(data, (_key, value) =>
         typeof value === "bigint" ? Number(value) : value
       )
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     // This is most likely an object that cannot be converted to a string
     // console.log converts this to `[object Object]` which we are doing here as well:
     return `[${typeof data}]`
@@ -476,8 +472,7 @@ export function toSafeNumber(value: any): number | null {
       if (notNullOrUndefined(unformattedValue)) {
         return unformattedValue
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       // Do nothing here
     }
   } else if (value instanceof Int32Array) {
@@ -536,8 +531,7 @@ export function toJsonString(value: any): string {
       // so we convert them to a number as fallback
       typeof val === "bigint" ? Number(val) : val
     )
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     // If the value cannot be converted to a JSON string, return the stringified value
     return toSafeString(value)
   }
@@ -620,8 +614,7 @@ export function toSafeDate(value: any): Date | null | undefined {
         return parsedMomentTime.toDate()
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return undefined
   }
 
@@ -733,8 +726,7 @@ export function getLinkDisplayValueFromRegex(
 
     // if the regex doesn't find a match with the url, just use the url as display value
     return href
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     // if there was any error return the href
     return href
   }

--- a/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
@@ -66,8 +66,7 @@ export const useIntlLocale = (locale: string): Locale => {
   const weekInfo = useMemo(() => {
     try {
       return getWeekInfo(new Intl.Locale(locale))
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
+    } catch {
       return getWeekInfo(new Intl.Locale("en-US"))
     }
   }, [locale])

--- a/frontend/lib/src/dataframes/arrowParseUtils.ts
+++ b/frontend/lib/src/dataframes/arrowParseUtils.ts
@@ -140,8 +140,7 @@ function parseHeaderName(name: string, numLevels: number): string[] {
     return JSON.parse(
       name.trim().replace(/^\(/, "[").replace(/\)$/, "]").replace(/'/g, '"')
     )
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
+  } catch {
     // Add empty strings for the missing levels
     return [...Array(numLevels - 1).fill(""), name]
   }

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -234,8 +234,7 @@ export function getUrl(): string {
     } else {
       url = document.location.href
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
+  } catch {
     // CSP error might occur when trying to access parent frame
     url = document.location.href
   }
@@ -532,8 +531,7 @@ export function canAccessIFrame(iframe: HTMLIFrameElement): boolean {
     const doc = iframe.contentDocument || iframe.contentWindow.document
     const html = doc.body.innerHTML
     return html !== null && html !== ""
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
+  } catch {
     return false
   }
 }

--- a/frontend/utils/src/browser/index.ts
+++ b/frontend/utils/src/browser/index.ts
@@ -32,8 +32,7 @@ export function localStorageAvailable(): boolean {
     localStorage.setItem(testData, testData)
     localStorage.getItem(testData)
     localStorage.removeItem(testData)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
+  } catch {
     return false
   }
   return true


### PR DESCRIPTION
## Describe your changes

Cleaned up TypeScript ESLint warnings by removing unused variables in catch blocks and function parameters. Updated the ESLint configuration to allow variables prefixed with underscore to be unused, then replaced unused variables with either no variable binding (for catch blocks) or underscore-prefixed parameter names (for function parameters).

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: This is a code cleanup change that only removes unused variables and updates ESLint configuration. No functional behavior is modified.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.