### PR TITLE
[fix] Python 3.14 PEP 649 annotation compatibility across `inspect.signature()` calls

### DIFF
--- a/lib/streamlit/elements/help.py
+++ b/lib/streamlit/elements/help.py
@@ -191,7 +191,9 @@ def _get_signature(obj: object) -> str | None:
 
     try:
         sig = str(inspect.signature(obj))
-    except ValueError:
+    except (ValueError, NameError):
+        # NameError: Python 3.14 PEP 649 deferred annotation evaluation can raise
+        # NameError for TYPE_CHECKING-only imports
         sig = "(...)"
     except TypeError:
         return None

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -20,6 +20,7 @@ import contextlib
 import functools
 import hashlib
 import inspect
+import sys
 import threading
 import time
 from abc import abstractmethod
@@ -588,7 +589,7 @@ def _get_positional_arg_name(func: Callable[..., Any], arg_index: int) -> str | 
     if arg_index < 0:
         return None
 
-    params: list[inspect.Parameter] = list(inspect.signature(func).parameters.values())
+    params = _get_func_parameters(func)
     if arg_index >= len(params):
         return None
 
@@ -599,3 +600,20 @@ def _get_positional_arg_name(func: Callable[..., Any], arg_index: int) -> str | 
         return params[arg_index].name
 
     return None
+
+
+def _get_func_parameters(func: Callable[..., Any]) -> list[inspect.Parameter]:
+    """Return the parameters of a function's signature.
+
+    On Python 3.14+, PEP 649 causes annotation evaluation to be deferred until
+    accessed. This can fail with NameError when annotations reference types
+    imported under TYPE_CHECKING. Since we only need parameter names and kinds
+    (not annotations), we use annotation_format=STRING to avoid evaluation.
+    """
+    if sys.version_info >= (3, 14):
+        from annotationlib import Format
+
+        return list(
+            inspect.signature(func, annotation_format=Format.STRING).parameters.values()
+        )
+    return list(inspect.signature(func).parameters.values())

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -588,7 +588,7 @@ def _get_positional_arg_name(func: Callable[..., Any], arg_index: int) -> str | 
     if arg_index < 0:
         return None
 
-    params = _get_func_parameters(func)
+    params = type_util.get_func_parameters(func)
     if arg_index >= len(params):
         return None
 
@@ -599,15 +599,3 @@ def _get_positional_arg_name(func: Callable[..., Any], arg_index: int) -> str | 
         return params[arg_index].name
 
     return None
-
-
-def _get_func_parameters(func: Callable[..., Any]) -> list[inspect.Parameter]:
-    """Return the parameters of a function's signature.
-
-    On Python 3.14+, PEP 649 causes annotation evaluation to be deferred until
-    accessed. This can fail with NameError when annotations reference types
-    imported under TYPE_CHECKING. Since we only need parameter names and kinds
-    (not annotations), we use ``annotation_format=Format.STRING`` to avoid
-    evaluation.
-    """
-    return type_util.get_func_parameters(func)

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -608,7 +608,8 @@ def _get_func_parameters(func: Callable[..., Any]) -> list[inspect.Parameter]:
     On Python 3.14+, PEP 649 causes annotation evaluation to be deferred until
     accessed. This can fail with NameError when annotations reference types
     imported under TYPE_CHECKING. Since we only need parameter names and kinds
-    (not annotations), we use annotation_format=STRING to avoid evaluation.
+    (not annotations), we use ``annotation_format=Format.STRING`` to avoid
+    evaluation.
     """
     if sys.version_info >= (3, 14):
         from annotationlib import Format

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -20,7 +20,6 @@ import contextlib
 import functools
 import hashlib
 import inspect
-import sys
 import threading
 import time
 from abc import abstractmethod
@@ -611,10 +610,4 @@ def _get_func_parameters(func: Callable[..., Any]) -> list[inspect.Parameter]:
     (not annotations), we use ``annotation_format=Format.STRING`` to avoid
     evaluation.
     """
-    if sys.version_info >= (3, 14):
-        from annotationlib import Format
-
-        return list(
-            inspect.signature(func, annotation_format=Format.STRING).parameters.values()
-        )
-    return list(inspect.signature(func).parameters.values())
+    return type_util.get_func_parameters(func)

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -267,9 +267,11 @@ def _fragment(
         # Immediate execute the wrapped fragment since we are in a full app run
         return wrapped_fragment()
 
-    with contextlib.suppress(AttributeError):
+    with contextlib.suppress(AttributeError, NameError):
         # Make this a well-behaved decorator by preserving important function
         # attributes.
+        # NameError: Python 3.14 PEP 649 deferred annotation evaluation can raise
+        # NameError for TYPE_CHECKING-only imports in inspect.signature()
         wrap.__dict__.update(non_optional_func.__dict__)
         wrap.__signature__ = inspect.signature(non_optional_func)  # type: ignore
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -549,9 +549,11 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
 
         return result
 
-    with contextlib.suppress(AttributeError):
+    with contextlib.suppress(AttributeError, NameError):
         # Make this a well-behaved decorator by preserving important function
         # attributes.
+        # NameError: Python 3.14 PEP 649 deferred annotation evaluation can raise
+        # NameError for TYPE_CHECKING-only imports in inspect.signature()
         wrapped_func.__dict__.update(non_optional_func.__dict__)
         wrapped_func.__signature__ = inspect.signature(non_optional_func)  # type: ignore
     return cast("F", wrapped_func)

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Sized
 from functools import wraps
 from typing import Any, Final, TypeVar, cast, overload
 
-from streamlit import config, file_util, util
+from streamlit import config, file_util, type_util, util
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.PageProfile_pb2 import Argument, Command
@@ -381,7 +381,6 @@ def _get_arg_keywords(func: Callable[..., Any]) -> list[str]:
 
     See: https://github.com/streamlit/streamlit/issues/14324
     """
-    from streamlit import type_util
 
     params = type_util.get_func_parameters(func)
     # Filter to POSITIONAL_ONLY and POSITIONAL_OR_KEYWORD to match getfullargspec().args

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -366,11 +366,40 @@ def _get_arg_metadata(arg: object) -> str | None:
     return None
 
 
+def _get_arg_keywords(func: Callable[..., Any]) -> list[str]:
+    """Return argument names from a function's signature.
+
+    This returns argument names matching the behavior of getfullargspec().args:
+    - Only POSITIONAL_OR_KEYWORD parameters (not keyword-only)
+    - Includes 'self' for bound methods
+
+    On Python 3.14+, PEP 649 causes annotation evaluation to be deferred until
+    accessed. This can fail with NameError when annotations reference types
+    imported under TYPE_CHECKING. Since we only need parameter names (not
+    annotations), we use ``annotation_format=Format.STRING`` to avoid
+    evaluation.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    from streamlit import type_util
+
+    params = type_util.get_func_parameters(func)
+    # Filter to only POSITIONAL_OR_KEYWORD params to match getfullargspec().args
+    names = [
+        p.name for p in params if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ]
+    # For bound methods, prepend 'self' since signature() removes it but
+    # getfullargspec() includes it
+    if inspect.ismethod(func):
+        names.insert(0, "self")
+    return names
+
+
 def _get_command_telemetry(
     _command_func: Callable[..., Any], _command_name: str, *args: Any, **kwargs: Any
 ) -> Command:
     """Get telemetry information for the given callable and its arguments."""
-    arg_keywords = inspect.getfullargspec(_command_func).args
+    arg_keywords = _get_arg_keywords(_command_func)
     self_arg: Any | None = None
     arguments: list[Argument] = []
     is_method = inspect.ismethod(_command_func)

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -370,7 +370,7 @@ def _get_arg_keywords(func: Callable[..., Any]) -> list[str]:
     """Return argument names from a function's signature.
 
     This returns argument names matching the behavior of getfullargspec().args:
-    - Only POSITIONAL_OR_KEYWORD parameters (not keyword-only)
+    - Both POSITIONAL_ONLY and POSITIONAL_OR_KEYWORD parameters (not keyword-only)
     - Includes 'self' for bound methods
 
     On Python 3.14+, PEP 649 causes annotation evaluation to be deferred until
@@ -384,9 +384,12 @@ def _get_arg_keywords(func: Callable[..., Any]) -> list[str]:
     from streamlit import type_util
 
     params = type_util.get_func_parameters(func)
-    # Filter to only POSITIONAL_OR_KEYWORD params to match getfullargspec().args
+    # Filter to POSITIONAL_ONLY and POSITIONAL_OR_KEYWORD to match getfullargspec().args
     names = [
-        p.name for p in params if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        p.name
+        for p in params
+        if p.kind
+        in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
     ]
     # For bound methods, prepend 'self' since signature() removes it but
     # getfullargspec() includes it

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -301,7 +301,8 @@ def get_func_parameters(func: Callable[..., Any]) -> list[inspect.Parameter]:
     accessed. This can fail with NameError when annotations reference types
     imported under TYPE_CHECKING. Since we only need parameter names and kinds
     (not annotations), we use ``annotation_format=Format.STRING`` to avoid
-    evaluation.
+    evaluation. Note that on Python 3.14+, the returned Parameter.annotation
+    values will be strings rather than actual types.
 
     See: https://github.com/streamlit/streamlit/issues/14324
     """

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -18,10 +18,12 @@ from __future__ import annotations
 
 import dataclasses
 import re
+import sys
 import types
 from collections import UserList, deque
 from collections.abc import (
     AsyncGenerator,
+    Callable,
     Generator,
     ItemsView,
     Iterable,
@@ -46,6 +48,8 @@ from typing import (
 from streamlit.errors import StreamlitAPIException
 
 if TYPE_CHECKING:
+    import inspect
+
     import graphviz
     import sympy
     from plotly.graph_objs import Figure
@@ -288,6 +292,28 @@ def is_delta_generator(obj: object) -> TypeGuard[DeltaGenerator]:
 def is_function(x: object) -> TypeGuard[types.FunctionType]:
     """Return True if x is a function."""
     return isinstance(x, types.FunctionType)
+
+
+def get_func_parameters(func: Callable[..., Any]) -> list[inspect.Parameter]:
+    """Return the parameters of a function's signature.
+
+    On Python 3.14+, PEP 649 causes annotation evaluation to be deferred until
+    accessed. This can fail with NameError when annotations reference types
+    imported under TYPE_CHECKING. Since we only need parameter names and kinds
+    (not annotations), we use ``annotation_format=Format.STRING`` to avoid
+    evaluation.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import inspect
+
+    if sys.version_info >= (3, 14):
+        from annotationlib import Format
+
+        return list(
+            inspect.signature(func, annotation_format=Format.STRING).parameters.values()
+        )
+    return list(inspect.signature(func).parameters.values())
 
 
 def has_callable_attr(obj: object, name: str) -> bool:

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -581,35 +581,15 @@ def test_get_signature_handles_pep649_annotations() -> None:
 
     See: https://github.com/streamlit/streamlit/issues/14324
     """
-    import types
-
-    from annotationlib import Format, ForwardRef
-
     from streamlit.elements.help import _get_signature
+    from tests.testutil import create_pep649_function
 
-    # Create a function with an __annotate__ that raises NameError when evaluated,
-    # simulating PEP 649 deferred annotation behavior for undefined types.
     def base_func(items: object) -> None:
         pass
 
-    def annotate_raises(format: Format) -> dict[str, object]:
-        """Annotate function that raises NameError like PEP 649 with undefined types."""
-        if format == Format.VALUE:
-            raise NameError("name 'UndefinedType' is not defined")
-        if format == Format.STRING:
-            return {"items": "UndefinedType", "return": "None"}
-        # FORWARDREF format
-        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
-
-    # Create a new function with our custom __annotate__
-    func = types.FunctionType(
-        base_func.__code__,
-        base_func.__globals__,
-        base_func.__name__,
-        base_func.__defaults__,
-        base_func.__closure__,
+    func = create_pep649_function(
+        base_func, {"items": "UndefinedType", "return": "None"}
     )
-    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
     # Verify that inspect.signature() without STRING format raises NameError
     with pytest.raises(NameError, match="UndefinedType"):

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 import unittest
 from unittest.mock import patch
 
@@ -63,8 +64,6 @@ class StHelpTest(DeltaGeneratorTestCase):
         assert ds.name == ""
         assert ds.value == "None"
         assert ds.type == "NoneType"
-
-        import sys
 
         if sys.version_info >= (3, 13):
             assert ds.doc_string == "The type of the None singleton."
@@ -567,3 +566,55 @@ class StHelpAPITest(DeltaGeneratorTestCase):
         """Test that help() raises an error for invalid width values."""
         with pytest.raises(StreamlitInvalidWidthError, match="Invalid width"):
             st.help(st, width=width)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
+)
+def test_get_signature_handles_pep649_annotations() -> None:
+    """Handles PEP 649 deferred annotations referencing undefined types.
+
+    On Python 3.14+, inspect.signature() raises NameError for annotations
+    referencing types imported under TYPE_CHECKING. Our fix catches NameError
+    and returns '(...)' as a fallback signature.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import types
+
+    from annotationlib import Format, ForwardRef
+
+    from streamlit.elements.help import _get_signature
+
+    # Create a function with an __annotate__ that raises NameError when evaluated,
+    # simulating PEP 649 deferred annotation behavior for undefined types.
+    def base_func(items: object) -> None:
+        pass
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return {"items": "UndefinedType", "return": "None"}
+        # FORWARDREF format
+        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
+
+    # Create a new function with our custom __annotate__
+    func = types.FunctionType(
+        base_func.__code__,
+        base_func.__globals__,
+        base_func.__name__,
+        base_func.__defaults__,
+        base_func.__closure__,
+    )
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
+
+    # Verify that inspect.signature() without STRING format raises NameError
+    with pytest.raises(NameError, match="UndefinedType"):
+        inspect.signature(func)
+
+    # Our _get_signature should handle this gracefully by returning "(...)
+    signature = _get_signature(func)
+    assert signature == "(...)"

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -110,19 +110,41 @@ def test_get_func_parameters_handles_pep649_annotations() -> None:
     See: https://github.com/streamlit/streamlit/issues/14324
     """
     import inspect
+    import types
 
-    # Use exec() to avoid `from __future__ import annotations` which would
-    # make all annotations strings and bypass PEP 649 behavior.
-    namespace: dict[str, object] = {}
-    exec(
-        "def func(items: UndefinedType) -> None: pass",
-        namespace,
+    from annotationlib import Format
+
+    # Create a function with an __annotate__ that raises NameError when evaluated,
+    # simulating PEP 649 deferred annotation behavior for undefined types.
+    def base_func(items: object) -> None:
+        pass
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return {"items": "UndefinedType", "return": "None"}
+        # FORWARDREF format
+        from annotationlib import ForwardRef
+
+        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
+
+    # Create a new function with our custom __annotate__
+    func = types.FunctionType(
+        base_func.__code__,
+        base_func.__globals__,
+        base_func.__name__,
+        base_func.__defaults__,
+        base_func.__closure__,
     )
-    func = namespace["func"]
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
-    with pytest.raises(NameError):
-        inspect.signature(func)  # type: ignore[arg-type]
+    # Verify that inspect.signature() without STRING format raises NameError
+    with pytest.raises(NameError, match="UndefinedType"):
+        inspect.signature(func)
 
-    params = _get_func_parameters(func)  # type: ignore[arg-type]
+    # Our _get_func_parameters should handle this gracefully
+    params = _get_func_parameters(func)
     assert len(params) == 1
     assert params[0].name == "items"

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+import sys
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -19,6 +22,8 @@ import pytest
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_utils import (
+    _get_func_parameters,
+    _get_positional_arg_name,
     get_session_id_or_throw,
 )
 from streamlit.runtime.scriptrunner_utils import script_run_context
@@ -45,3 +50,79 @@ class GetSessionIdOrThrowTest(TestCase):
             mock_get_ctx.return_value = None
             with pytest.raises(StreamlitAPIException):
                 get_session_id_or_throw()
+
+
+def _func_positional(first: int, second: str, third: float) -> None:
+    pass
+
+
+def _func_with_kwonly(a: int, *, kwonly: str) -> None:
+    pass
+
+
+def _func_with_varargs(a: int, *args: str) -> None:
+    pass
+
+
+@pytest.mark.parametrize(
+    ("func", "arg_index", "expected"),
+    [
+        (_func_positional, 0, "first"),
+        (_func_positional, 1, "second"),
+        (_func_positional, 2, "third"),
+        (_func_positional, -1, None),
+        (_func_positional, 3, None),
+        (_func_with_kwonly, 0, "a"),
+        (_func_with_kwonly, 1, None),
+        (_func_with_varargs, 0, "a"),
+        (_func_with_varargs, 1, None),
+    ],
+    ids=[
+        "first_positional",
+        "second_positional",
+        "third_positional",
+        "negative_index",
+        "out_of_range",
+        "before_kwonly",
+        "kwonly_param",
+        "before_varargs",
+        "varargs_param",
+    ],
+)
+def test_get_positional_arg_name(
+    func: object, arg_index: int, expected: str | None
+) -> None:
+    """Returns the parameter name for positional args, None otherwise."""
+    assert _get_positional_arg_name(func, arg_index) == expected  # type: ignore[arg-type]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
+)
+def test_get_func_parameters_handles_pep649_annotations() -> None:
+    """Handles PEP 649 deferred annotations referencing undefined types.
+
+    On Python 3.14+, inspect.signature() raises NameError for annotations
+    referencing types imported under TYPE_CHECKING. Our fix uses
+    annotation_format=STRING to avoid evaluation.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import inspect
+
+    # Use exec() to avoid `from __future__ import annotations` which would
+    # make all annotations strings and bypass PEP 649 behavior.
+    namespace: dict[str, object] = {}
+    exec(
+        "def func(items: UndefinedType) -> None: pass",
+        namespace,
+    )
+    func = namespace["func"]
+
+    with pytest.raises(NameError):
+        inspect.signature(func)  # type: ignore[arg-type]
+
+    params = _get_func_parameters(func)  # type: ignore[arg-type]
+    assert len(params) == 1
+    assert params[0].name == "items"

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -23,7 +23,6 @@ import pytest
 
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.caching.cache_utils import (
-    _get_func_parameters,
     _get_positional_arg_name,
     get_session_id_or_throw,
 )
@@ -149,7 +148,9 @@ def test_get_func_parameters_handles_pep649_annotations() -> None:
     with pytest.raises(NameError, match="UndefinedType"):
         inspect.signature(func)
 
-    # Our _get_func_parameters should handle this gracefully
-    params = _get_func_parameters(func)
+    # Our get_func_parameters should handle this gracefully
+    from streamlit.type_util import get_func_parameters
+
+    params = get_func_parameters(func)
     assert len(params) == 1
     assert params[0].name == "items"

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 from unittest import TestCase
 from unittest.mock import patch
@@ -98,59 +97,3 @@ def test_get_positional_arg_name(
 ) -> None:
     """Returns the parameter name for positional args, None otherwise."""
     assert _get_positional_arg_name(func, arg_index) == expected
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
-)
-def test_get_func_parameters_handles_pep649_annotations() -> None:
-    """Handles PEP 649 deferred annotations referencing undefined types.
-
-    On Python 3.14+, inspect.signature() raises NameError for annotations
-    referencing types imported under TYPE_CHECKING. Our fix uses
-    annotation_format=STRING to avoid evaluation.
-
-    See: https://github.com/streamlit/streamlit/issues/14324
-    """
-    import inspect
-    import types
-
-    from annotationlib import Format
-
-    # Create a function with an __annotate__ that raises NameError when evaluated,
-    # simulating PEP 649 deferred annotation behavior for undefined types.
-    def base_func(items: object) -> None:
-        pass
-
-    def annotate_raises(format: Format) -> dict[str, object]:
-        """Annotate function that raises NameError like PEP 649 with undefined types."""
-        if format == Format.VALUE:
-            raise NameError("name 'UndefinedType' is not defined")
-        if format == Format.STRING:
-            return {"items": "UndefinedType", "return": "None"}
-        # FORWARDREF format
-        from annotationlib import ForwardRef
-
-        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
-
-    # Create a new function with our custom __annotate__
-    func = types.FunctionType(
-        base_func.__code__,
-        base_func.__globals__,
-        base_func.__name__,
-        base_func.__defaults__,
-        base_func.__closure__,
-    )
-    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
-
-    # Verify that inspect.signature() without STRING format raises NameError
-    with pytest.raises(NameError, match="UndefinedType"):
-        inspect.signature(func)
-
-    # Our get_func_parameters should handle this gracefully
-    from streamlit.type_util import get_func_parameters
-
-    params = get_func_parameters(func)
-    assert len(params) == 1
-    assert params[0].name == "items"

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -27,6 +28,10 @@ from streamlit.runtime.caching.cache_utils import (
     get_session_id_or_throw,
 )
 from streamlit.runtime.scriptrunner_utils import script_run_context
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
 
 
 def function_for_testing(
@@ -90,10 +95,10 @@ def _func_with_varargs(a: int, *args: str) -> None:
     ],
 )
 def test_get_positional_arg_name(
-    func: object, arg_index: int, expected: str | None
+    func: Callable[..., Any], arg_index: int, expected: str | None
 ) -> None:
     """Returns the parameter name for positional args, None otherwise."""
-    assert _get_positional_arg_name(func, arg_index) == expected  # type: ignore[arg-type]
+    assert _get_positional_arg_name(func, arg_index) == expected
 
 
 @pytest.mark.skipif(

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import sys
 import unittest
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
@@ -608,3 +609,77 @@ class FragmentCannotWriteToOutsidePathTest(DeltaGeneratorTestCase):
         element_producer: ELEMENT_PRODUCER,
     ):
         _app(element_producer)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
+)
+def test_fragment_decorator_handles_pep649_annotations() -> None:
+    """Handles PEP 649 deferred annotations when preserving function signature.
+
+    On Python 3.14+, inspect.signature() raises NameError for annotations
+    referencing types imported under TYPE_CHECKING. Our fix catches NameError
+    via contextlib.suppress when setting __signature__ on decorated functions.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import inspect
+    import types
+    from unittest.mock import MagicMock
+
+    from annotationlib import Format, ForwardRef
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.delta_generator_singletons import context_dg_stack
+    from streamlit.runtime.fragment import fragment
+
+    # Create a function with an __annotate__ that raises NameError when evaluated,
+    # simulating PEP 649 deferred annotation behavior for undefined types.
+    def base_func(items: object) -> None:
+        pass
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return {"items": "UndefinedType", "return": "None"}
+        # FORWARDREF format
+        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
+
+    # Create a new function with our custom __annotate__
+    func = types.FunctionType(
+        base_func.__code__,
+        base_func.__globals__,
+        base_func.__name__,
+        base_func.__defaults__,
+        base_func.__closure__,
+    )
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
+
+    # Verify that inspect.signature() without STRING format raises NameError
+    with pytest.raises(NameError, match="UndefinedType"):
+        inspect.signature(func)
+
+    # Set up the required context for fragment to work
+    root_container = MagicMock()
+    original_dg_stack = context_dg_stack.get()
+    context_dg_stack.set(
+        (
+            DeltaGenerator(
+                root_container=root_container,
+                cursor=MagicMock(root_container=root_container),
+            ),
+        )
+    )
+
+    try:
+        # Apply the fragment decorator - should not raise NameError
+        decorated = fragment(func)
+
+        # The decorator should complete without error, even though __signature__
+        # couldn't be set due to NameError. The function should still work.
+        assert decorated.__name__ == "base_func"
+    finally:
+        context_dg_stack.set(original_dg_stack)

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -625,38 +625,19 @@ def test_fragment_decorator_handles_pep649_annotations() -> None:
     See: https://github.com/streamlit/streamlit/issues/14324
     """
     import inspect
-    import types
     from unittest.mock import MagicMock
-
-    from annotationlib import Format, ForwardRef
 
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.delta_generator_singletons import context_dg_stack
     from streamlit.runtime.fragment import fragment
+    from tests.testutil import create_pep649_function
 
-    # Create a function with an __annotate__ that raises NameError when evaluated,
-    # simulating PEP 649 deferred annotation behavior for undefined types.
     def base_func(items: object) -> None:
         pass
 
-    def annotate_raises(format: Format) -> dict[str, object]:
-        """Annotate function that raises NameError like PEP 649 with undefined types."""
-        if format == Format.VALUE:
-            raise NameError("name 'UndefinedType' is not defined")
-        if format == Format.STRING:
-            return {"items": "UndefinedType", "return": "None"}
-        # FORWARDREF format
-        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
-
-    # Create a new function with our custom __annotate__
-    func = types.FunctionType(
-        base_func.__code__,
-        base_func.__globals__,
-        base_func.__name__,
-        base_func.__defaults__,
-        base_func.__closure__,
+    func = create_pep649_function(
+        base_func, {"items": "UndefinedType", "return": "None"}
     )
-    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
     # Verify that inspect.signature() without STRING format raises NameError
     with pytest.raises(NameError, match="UndefinedType"):

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -519,39 +519,16 @@ def test_get_arg_keywords_handles_pep649_annotations() -> None:
     See: https://github.com/streamlit/streamlit/issues/14324
     """
     import inspect
-    import types
-
-    from annotationlib import Format, ForwardRef
 
     from streamlit.runtime.metrics_util import _get_arg_keywords
+    from tests.testutil import create_pep649_function
 
-    # Create a function with an __annotate__ that raises NameError when evaluated,
-    # simulating PEP 649 deferred annotation behavior for undefined types.
     def base_func(items: object, count: int) -> None:
         pass
 
-    def annotate_raises(format: Format) -> dict[str, object]:
-        """Annotate function that raises NameError like PEP 649 with undefined types."""
-        if format == Format.VALUE:
-            raise NameError("name 'UndefinedType' is not defined")
-        if format == Format.STRING:
-            return {"items": "UndefinedType", "count": "int", "return": "None"}
-        # FORWARDREF format
-        return {
-            "items": ForwardRef("UndefinedType"),
-            "count": ForwardRef("int"),
-            "return": ForwardRef("None"),
-        }
-
-    # Create a new function with our custom __annotate__
-    func = types.FunctionType(
-        base_func.__code__,
-        base_func.__globals__,
-        base_func.__name__,
-        base_func.__defaults__,
-        base_func.__closure__,
+    func = create_pep649_function(
+        base_func, {"items": "UndefinedType", "count": "int", "return": "None"}
     )
-    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
     # Verify that inspect.getfullargspec() without STRING format fails
     # On Python 3.14, getfullargspec() catches the NameError from annotation
@@ -578,35 +555,16 @@ def test_gather_metrics_decorator_handles_pep649_annotations() -> None:
     See: https://github.com/streamlit/streamlit/issues/14324
     """
     import inspect
-    import types
-
-    from annotationlib import Format, ForwardRef
 
     from streamlit.runtime.metrics_util import gather_metrics
+    from tests.testutil import create_pep649_function
 
-    # Create a function with an __annotate__ that raises NameError when evaluated,
-    # simulating PEP 649 deferred annotation behavior for undefined types.
     def base_func(items: object) -> str:
         return "result"
 
-    def annotate_raises(format: Format) -> dict[str, object]:
-        """Annotate function that raises NameError like PEP 649 with undefined types."""
-        if format == Format.VALUE:
-            raise NameError("name 'UndefinedType' is not defined")
-        if format == Format.STRING:
-            return {"items": "UndefinedType", "return": "str"}
-        # FORWARDREF format
-        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("str")}
-
-    # Create a new function with our custom __annotate__
-    func = types.FunctionType(
-        base_func.__code__,
-        base_func.__globals__,
-        base_func.__name__,
-        base_func.__defaults__,
-        base_func.__closure__,
+    func = create_pep649_function(
+        base_func, {"items": "UndefinedType", "return": "str"}
     )
-    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
     # Verify that inspect.signature() without STRING format raises NameError
     with pytest.raises(NameError, match="UndefinedType"):

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import sys
 import unittest
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, mock_open, patch
 
 import pandas as pd
+import pytest
 from parameterized import parameterized
 
 import streamlit as st
@@ -479,3 +481,117 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
             [command.name for command in ctx.tracked_commands]
         ).most_common()
         assert command_counts[0][1] <= metrics_util._MAX_TRACKED_PER_COMMAND
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
+)
+def test_get_arg_keywords_handles_pep649_annotations() -> None:
+    """Handles PEP 649 deferred annotations when getting argument names.
+
+    On Python 3.14+, inspect.getfullargspec() can raise NameError for annotations
+    referencing types imported under TYPE_CHECKING. Our _get_arg_keywords helper
+    uses annotation_format=Format.STRING to avoid evaluation.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import inspect
+    import types
+
+    from annotationlib import Format, ForwardRef
+
+    from streamlit.runtime.metrics_util import _get_arg_keywords
+
+    # Create a function with an __annotate__ that raises NameError when evaluated,
+    # simulating PEP 649 deferred annotation behavior for undefined types.
+    def base_func(items: object, count: int) -> None:
+        pass
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return {"items": "UndefinedType", "count": "int", "return": "None"}
+        # FORWARDREF format
+        return {
+            "items": ForwardRef("UndefinedType"),
+            "count": ForwardRef("int"),
+            "return": ForwardRef("None"),
+        }
+
+    # Create a new function with our custom __annotate__
+    func = types.FunctionType(
+        base_func.__code__,
+        base_func.__globals__,
+        base_func.__name__,
+        base_func.__defaults__,
+        base_func.__closure__,
+    )
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
+
+    # Verify that inspect.getfullargspec() without STRING format raises NameError
+    with pytest.raises(NameError, match="UndefinedType"):
+        inspect.getfullargspec(func)
+
+    # Our _get_arg_keywords should handle this gracefully
+    keywords = _get_arg_keywords(func)
+    assert keywords == ["items", "count"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
+)
+def test_gather_metrics_decorator_handles_pep649_annotations() -> None:
+    """Handles PEP 649 deferred annotations when preserving function signature.
+
+    On Python 3.14+, inspect.signature() raises NameError for annotations
+    referencing types imported under TYPE_CHECKING. Our fix catches NameError
+    via contextlib.suppress when setting __signature__ on decorated functions.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import inspect
+    import types
+
+    from annotationlib import Format, ForwardRef
+
+    from streamlit.runtime.metrics_util import gather_metrics
+
+    # Create a function with an __annotate__ that raises NameError when evaluated,
+    # simulating PEP 649 deferred annotation behavior for undefined types.
+    def base_func(items: object) -> str:
+        return "result"
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return {"items": "UndefinedType", "return": "str"}
+        # FORWARDREF format
+        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("str")}
+
+    # Create a new function with our custom __annotate__
+    func = types.FunctionType(
+        base_func.__code__,
+        base_func.__globals__,
+        base_func.__name__,
+        base_func.__defaults__,
+        base_func.__closure__,
+    )
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
+
+    # Verify that inspect.signature() without STRING format raises NameError
+    with pytest.raises(NameError, match="UndefinedType"):
+        inspect.signature(func)
+
+    # Apply the gather_metrics decorator - should not raise NameError
+    decorated = gather_metrics("test_command", func)
+
+    # The decorator should complete without error, even though __signature__
+    # couldn't be set due to NameError. The function should still work.
+    assert decorated.__name__ == "base_func"
+    assert decorated("test_items") == "result"

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -531,8 +531,10 @@ def test_get_arg_keywords_handles_pep649_annotations() -> None:
     )
     func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
-    # Verify that inspect.getfullargspec() without STRING format raises NameError
-    with pytest.raises(NameError, match="UndefinedType"):
+    # Verify that inspect.getfullargspec() without STRING format fails
+    # On Python 3.14, getfullargspec() catches the NameError from annotation
+    # evaluation and re-raises as TypeError("unsupported callable")
+    with pytest.raises((NameError, TypeError)):
         inspect.getfullargspec(func)
 
     # Our _get_arg_keywords should handle this gracefully

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -483,6 +483,28 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         assert command_counts[0][1] <= metrics_util._MAX_TRACKED_PER_COMMAND
 
 
+def test_get_arg_keywords_includes_positional_only_params() -> None:
+    """_get_arg_keywords includes POSITIONAL_ONLY params like getfullargspec().args.
+
+    This test ensures that _get_arg_keywords correctly matches the behavior of
+    inspect.getfullargspec().args, which includes both POSITIONAL_ONLY and
+    POSITIONAL_OR_KEYWORD parameters.
+    """
+    from streamlit.runtime.metrics_util import _get_arg_keywords
+
+    def func_with_posonly(a: int, b: str, /, c: float, d: bool) -> None:
+        pass
+
+    def func_without_posonly(a: int, b: str, c: float, d: bool) -> None:
+        pass
+
+    # Should include positional-only params (a, b) AND positional-or-keyword (c, d)
+    assert _get_arg_keywords(func_with_posonly) == ["a", "b", "c", "d"]
+
+    # Regular function should work the same as before
+    assert _get_arg_keywords(func_without_posonly) == ["a", "b", "c", "d"]
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 14),
     reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -212,40 +212,20 @@ def test_get_func_parameters_handles_pep649_annotations() -> None:
 
     On Python 3.14+, inspect.signature() raises NameError for annotations
     referencing types imported under TYPE_CHECKING. Our fix uses
-    annotation_format=STRING to avoid evaluation.
+    annotation_format=Format.STRING to avoid evaluation.
 
     See: https://github.com/streamlit/streamlit/issues/14324
     """
     import inspect
-    import types
 
-    from annotationlib import Format
+    from tests.testutil import create_pep649_function
 
-    # Create a function with an __annotate__ that raises NameError when evaluated,
-    # simulating PEP 649 deferred annotation behavior for undefined types.
     def base_func(items: object) -> None:
         pass
 
-    def annotate_raises(format: Format) -> dict[str, object]:
-        """Annotate function that raises NameError like PEP 649 with undefined types."""
-        if format == Format.VALUE:
-            raise NameError("name 'UndefinedType' is not defined")
-        if format == Format.STRING:
-            return {"items": "UndefinedType", "return": "None"}
-        # FORWARDREF format
-        from annotationlib import ForwardRef
-
-        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
-
-    # Create a new function with our custom __annotate__
-    func = types.FunctionType(
-        base_func.__code__,
-        base_func.__globals__,
-        base_func.__name__,
-        base_func.__defaults__,
-        base_func.__closure__,
+    func = create_pep649_function(
+        base_func, {"items": "UndefinedType", "return": "None"}
     )
-    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
 
     # Verify that inspect.signature() without STRING format raises NameError
     with pytest.raises(NameError, match="UndefinedType"):

--- a/lib/tests/streamlit/type_util_test.py
+++ b/lib/tests/streamlit/type_util_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import sys
 import unittest
 from collections import namedtuple
 from typing import Any
@@ -200,3 +201,59 @@ class TypeUtilTest(unittest.TestCase):
 
         sync_gen = type_util.async_generator_to_sync(async_gen())
         assert "".join(sync_gen) == "hello world !"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="PEP 649 deferred annotation evaluation is only in Python 3.14+",
+)
+def test_get_func_parameters_handles_pep649_annotations() -> None:
+    """Handles PEP 649 deferred annotations referencing undefined types.
+
+    On Python 3.14+, inspect.signature() raises NameError for annotations
+    referencing types imported under TYPE_CHECKING. Our fix uses
+    annotation_format=STRING to avoid evaluation.
+
+    See: https://github.com/streamlit/streamlit/issues/14324
+    """
+    import inspect
+    import types
+
+    from annotationlib import Format
+
+    # Create a function with an __annotate__ that raises NameError when evaluated,
+    # simulating PEP 649 deferred annotation behavior for undefined types.
+    def base_func(items: object) -> None:
+        pass
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return {"items": "UndefinedType", "return": "None"}
+        # FORWARDREF format
+        from annotationlib import ForwardRef
+
+        return {"items": ForwardRef("UndefinedType"), "return": ForwardRef("None")}
+
+    # Create a new function with our custom __annotate__
+    func = types.FunctionType(
+        base_func.__code__,
+        base_func.__globals__,
+        base_func.__name__,
+        base_func.__defaults__,
+        base_func.__closure__,
+    )
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
+
+    # Verify that inspect.signature() without STRING format raises NameError
+    with pytest.raises(NameError, match="UndefinedType"):
+        inspect.signature(func)
+
+    # Our get_func_parameters should handle this gracefully
+    from streamlit.type_util import get_func_parameters
+
+    params = get_func_parameters(func)
+    assert len(params) == 1
+    assert params[0].name == "items"

--- a/lib/tests/testutil.py
+++ b/lib/tests/testutil.py
@@ -118,3 +118,63 @@ def create_snowpark_session() -> Session:
         yield session
     finally:
         session.close()
+
+
+def create_pep649_function(
+    base_func: object, string_annotations: dict[str, str]
+) -> object:
+    """Create a function with PEP 649-style annotations that raise NameError.
+
+    This helper creates a function with a custom __annotate__ that simulates
+    PEP 649 deferred annotation behavior: raises NameError when annotations
+    are evaluated in VALUE format (like types imported under TYPE_CHECKING).
+
+    Parameters
+    ----------
+    base_func
+        The base function to copy. Its code, globals, name, defaults, and
+        closure will be preserved.
+    string_annotations
+        A dict mapping parameter/return names to their string representations.
+        E.g., {"items": "UndefinedType", "return": "None"}
+
+    Returns
+    -------
+    object
+        A new function with a custom __annotate__ that:
+        - Raises NameError("name 'UndefinedType' is not defined") for VALUE format
+        - Returns string_annotations for STRING format
+        - Returns ForwardRef-wrapped values for FORWARDREF format
+
+    Examples
+    --------
+    >>> def my_func(items: object) -> None:
+    ...     pass
+    >>> pep649_func = create_pep649_function(
+    ...     my_func, {"items": "UndefinedType", "return": "None"}
+    ... )
+    >>> import inspect
+    >>> inspect.signature(pep649_func)  # Raises NameError
+    """
+    import types
+
+    from annotationlib import Format, ForwardRef
+
+    def annotate_raises(format: Format) -> dict[str, object]:
+        """Annotate function that raises NameError like PEP 649 with undefined types."""
+        if format == Format.VALUE:
+            raise NameError("name 'UndefinedType' is not defined")
+        if format == Format.STRING:
+            return string_annotations
+        # FORWARDREF format
+        return {k: ForwardRef(v) for k, v in string_annotations.items()}
+
+    func = types.FunctionType(
+        base_func.__code__,  # type: ignore[union-attr]
+        base_func.__globals__,  # type: ignore[union-attr]
+        base_func.__name__,  # type: ignore[union-attr]
+        base_func.__defaults__,  # type: ignore[union-attr]
+        base_func.__closure__,  # type: ignore[union-attr]
+    )
+    func.__annotate__ = annotate_raises  # type: ignore[attr-defined]
+    return func


### PR DESCRIPTION
## Describe your changes

Fixes Python 3.14 PEP 649 compatibility across multiple `inspect.signature()` call sites. On Python 3.14+, deferred annotation evaluation can raise `NameError` for functions using type annotations that reference types imported under `if TYPE_CHECKING:`.

**Implementation:**
- Added centralized `get_func_parameters()` helper in `type_util.py` with `annotation_format=Format.STRING` on Python 3.14+
- Added `_get_arg_keywords()` helper in `metrics_util.py` for PEP 649-safe argument name extraction

**Fixed locations:**
- `@st.cache_data` / `@st.cache_resource` — Uses `type_util.get_func_parameters()`
- `st.help()` — Added `NameError` handling in `_get_signature()`
- `@st.fragment` — Added `NameError` to `contextlib.suppress()`
- Internal metrics decorator — Uses `_get_arg_keywords()` and added `NameError` to `contextlib.suppress()`

## GitHub Issue Link (if applicable)

- Closes #14324

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/runtime/caching/cache_utils_test.py` — Tests `get_func_parameters()` via `_get_positional_arg_name()` with PEP 649 simulation
  - `lib/tests/streamlit/elements/help_test.py` — Tests `_get_signature()` handling of PEP 649 annotations
  - `lib/tests/streamlit/runtime/fragment_test.py` — Tests fragment decorator handling of PEP 649 annotations
  - `lib/tests/streamlit/runtime/metrics_util_test.py` — Tests `_get_arg_keywords()` and `gather_metrics()` decorator handling

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 2 |
| subagent | general-purpose | 7 |
| subagent | reviewing-local-changes | 2 |
| subagent | simplifying-local-changes | 2 |

</details>
<!-- agent-metrics-end -->