### PR TITLE
[chore] Add `oxlint` as fast frontend / typescript linter

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -64,7 +64,7 @@ Selection of `make` commands for development (run in the repo root):
 
 - `frontend-fast`: Build the frontend (vite). [~40s]
 - `frontend-dev`: Start the frontend development server (hot-reload). [until stopped]
-- `frontend-lint`: Lint and check formatting of all frontend files (eslint). [~45s]
+- `frontend-lint`: Lint and check formatting of all frontend files (oxlint + eslint). [~45s]
 - `frontend-knip`: Run Knip dependency analysis. [~5s]
 - `frontend-types`: Run the TypeScript type checker on all files (tsc). [~15s]
 - `frontend-format`: Format all frontend files (prettier). [~10s]

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -9,7 +9,7 @@ alwaysApply: false
 # TypeScript Development Guide
 
 - TypeScript: v5
-- Linter: eslint v9
+- Linters: oxlint v1 + eslint v9
 - Formatter: prettier v3
 - Framework: React v18
 - Styling: @emotion/styled v11
@@ -138,7 +138,7 @@ Run from the repo root (requires Node major version from `.nvmrc`):
 
 - `make frontend-fast`: Build the frontend (vite).
 - `make frontend-dev`: Start the frontend development server (hot-reload).
-- `make frontend-lint`: Lint and check formatting of frontend files (eslint).
+- `make frontend-lint`: Lint and check formatting of frontend files (oxlint + eslint).
 - `make frontend-knip`: Run Knip dependency analysis.
 - `make frontend-types`: Run the TypeScript type checker (tsc).
 - `make frontend-format`: Format frontend files (prettier).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@ Selection of `make` commands for development (run in the repo root):
 
 - `frontend-fast`: Build the frontend (vite). [~40s]
 - `frontend-dev`: Start the frontend development server (hot-reload). [until stopped]
-- `frontend-lint`: Lint and check formatting of all frontend files (eslint). [~45s]
+- `frontend-lint`: Lint and check formatting of all frontend files (oxlint + eslint). [~45s]
 - `frontend-knip`: Run Knip dependency analysis. [~5s]
 - `frontend-types`: Run the TypeScript type checker on all files (tsc). [~15s]
 - `frontend-format`: Format all frontend files (prettier). [~10s]

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -7,7 +7,7 @@ applyTo: "**/*.ts, **/*.tsx"
 # TypeScript Development Guide
 
 - TypeScript: v5
-- Linter: eslint v9
+- Linters: oxlint v1 + eslint v9
 - Formatter: prettier v3
 - Framework: React v18
 - Styling: @emotion/styled v11
@@ -136,7 +136,7 @@ Run from the repo root (requires Node major version from `.nvmrc`):
 
 - `make frontend-fast`: Build the frontend (vite).
 - `make frontend-dev`: Start the frontend development server (hot-reload).
-- `make frontend-lint`: Lint and check formatting of frontend files (eslint).
+- `make frontend-lint`: Lint and check formatting of frontend files (oxlint + eslint).
 - `make frontend-knip`: Run Knip dependency analysis.
 - `make frontend-types`: Run the TypeScript type checker (tsc).
 - `make frontend-format`: Format frontend files (prettier).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,20 @@ repos:
         types_or: [python, pyi]
   - repo: local
     hooks:
+      - id: oxlint-frontend
+        name: Oxlint Frontend
+        entry: ./scripts/run_in_subdirectory.py frontend yarn exec oxlint --config ./.oxlintrc.json --fix --deny-warnings
+        files: ^frontend/(app|component-v2-lib|connection|eslint-plugin-streamlit-custom|lib|utils)/.*\.(js|jsx|ts|tsx)$
+        exclude: /vendor/
+        language: node
+        pass_filenames: true
       # Single prettier hook for all frontend source files.
       # Uses run_in_subdirectory.py to handle path translation for subdirectory files.
       # See: https://github.com/pre-commit/pre-commit/issues/1417
       - id: prettier-frontend
         name: Prettier Frontend
         entry: ./scripts/run_in_subdirectory.py frontend yarn exec prettier --write
-        files: ^frontend/(app|lib|connection|utils)/.*\.(js|jsx|ts|tsx)$
+        files: ^frontend/(app|component-v2-lib|connection|eslint-plugin-streamlit-custom|lib|utils)/.*\.(js|jsx|ts|tsx)$
         exclude: /vendor/
         language: node
         pass_filenames: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Selection of `make` commands for development (run in the repo root):
 
 - `frontend-fast`: Build the frontend (vite). [~40s]
 - `frontend-dev`: Start the frontend development server (hot-reload). [until stopped]
-- `frontend-lint`: Lint and check formatting of all frontend files (eslint). [~45s]
+- `frontend-lint`: Lint and check formatting of all frontend files (oxlint + eslint). [~45s]
 - `frontend-knip`: Run Knip dependency analysis. [~5s]
 - `frontend-types`: Run the TypeScript type checker on all files (tsc). [~15s]
 - `frontend-format`: Format all frontend files (prettier). [~10s]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ make python-types
 
 ### Javascript / Typescript
 
-For Javascript/Typescript, we utilize Prettier and ESLint.
+For Javascript/Typescript, we utilize Prettier, oxlint, and ESLint.
 
 #### Formatting
 

--- a/Makefile
+++ b/Makefile
@@ -627,6 +627,10 @@ check:
 			cd frontend && yarn exec prettier --write $$FE_FILES && \
 			cd .. && \
 			echo "" && \
+			echo "=== Frontend: lint (oxlint) ===" && \
+			cd frontend && yarn exec oxlint --config ./.oxlintrc.json --fix --deny-warnings $$FE_FILES && \
+			cd .. && \
+			echo "" && \
 			echo "=== Frontend: lint (eslint) ===" && \
 			cd frontend && yarn exec eslint --fix $$FE_FILES && \
 			cd .. && \
@@ -694,7 +698,7 @@ check:
 	CHANGED=$$(uv run python scripts/get_changed_files.py --all); \
 	if [ -n "$$CHANGED" ]; then \
 		echo "=== Pre-commit hooks ===" && \
-		SKIP=prettier-frontend uv run pre-commit run --files $$CHANGED && \
+		SKIP=oxlint-frontend,prettier-frontend uv run pre-commit run --files $$CHANGED && \
 		echo "" || { \
 			kill $$FE_PID 2>/dev/null; \
 			[ -n "$$E2E_PID" ] && kill $$E2E_PID 2>/dev/null; \

--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["lib/src/vendor/**"]
+}

--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -1,11 +1,3 @@
 {
-  "ignorePatterns": ["lib/src/vendor/**"],
-  "overrides": [
-    {
-      "files": ["lib/src/components/shared/Profiler/CircularBuffer.ts"],
-      "rules": {
-        "unicorn/no-new-array": "off"
-      }
-    }
-  ]
+  "ignorePatterns": ["lib/src/vendor/**"]
 }

--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -1,3 +1,11 @@
 {
-  "ignorePatterns": ["lib/src/vendor/**"]
+  "ignorePatterns": ["lib/src/vendor/**"],
+  "overrides": [
+    {
+      "files": ["lib/src/components/shared/Profiler/CircularBuffer.ts"],
+      "rules": {
+        "unicorn/no-new-array": "off"
+      }
+    }
+  ]
 }

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,7 +1,7 @@
 # TypeScript Development Guide
 
 - TypeScript: v5
-- Linter: eslint v9
+- Linters: oxlint v1 + eslint v9
 - Formatter: prettier v3
 - Framework: React v18
 - Styling: @emotion/styled v11
@@ -130,7 +130,7 @@ Run from the repo root (requires Node major version from `.nvmrc`):
 
 - `make frontend-fast`: Build the frontend (vite).
 - `make frontend-dev`: Start the frontend development server (hot-reload).
-- `make frontend-lint`: Lint and check formatting of frontend files (eslint).
+- `make frontend-lint`: Lint and check formatting of frontend files (oxlint + eslint).
 - `make frontend-knip`: Run Knip dependency analysis.
 - `make frontend-types`: Run the TypeScript type checker (tsc).
 - `make frontend-format`: Format frontend files (prettier).

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -74,7 +74,7 @@ describe("DefaultStreamlitEndpoints", () => {
   describe("buildComponentURL()", () => {
     it("errors if no serverURI", () => {
       // If we never connect to a server, getComponentURL will fail:
-      let serverURI: URL | undefined
+      const serverURI: URL | undefined = undefined
       const endpoint = new DefaultStreamlitEndpoints({
         getServerUri: () => serverURI,
         csrfEnabled: true,

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -74,7 +74,7 @@ describe("DefaultStreamlitEndpoints", () => {
   describe("buildComponentURL()", () => {
     it("errors if no serverURI", () => {
       // If we never connect to a server, getComponentURL will fail:
-      const serverURI: URL | undefined = undefined
+      const serverURI = undefined
       const endpoint = new DefaultStreamlitEndpoints({
         getServerUri: () => serverURI,
         csrfEnabled: true,

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -377,7 +377,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
       if (notNullOrUndefined(xsrfCookie)) {
         params.headers = {
           "X-Xsrftoken": xsrfCookie,
-          ...(params.headers || {}),
+          ...params.headers,
         }
         params.withCredentials = true
       }

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -283,7 +283,7 @@ export const BlockNodeRenderer = (
     fragmentIdsThisRun
   )
 
-  const childProps = { ...props, ...{ node } }
+  const childProps = { ...props, node }
 
   // Disable fullscreen mode if already disabled by parent
   // (e.g., via libConfig or ancestor dialog/popover),

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
@@ -113,7 +113,7 @@ export const useVegaLiteSelections = (
             // Update the component-internal selection state
             const updatedSelections = {
               selection: {
-                ...(currentWidgetState?.selection || {}),
+                ...currentWidgetState?.selection,
                 [name]: processedSelection || {},
               } as VegaLiteState,
             }

--- a/frontend/lib/src/components/shared/Profiler/CircularBuffer.ts
+++ b/frontend/lib/src/components/shared/Profiler/CircularBuffer.ts
@@ -33,6 +33,7 @@ export class CircularBuffer<T> {
   constructor(size: number) {
     // Using sparse array intentionally - dense arrays would iterate over all
     // entries in filter/map even before being written to.
+    // oxlint-disable-next-line unicorn/no-new-array
     this._buffer = new Array<T>(size)
     this._size = size
     this._index = 0

--- a/frontend/lib/src/components/shared/Profiler/CircularBuffer.ts
+++ b/frontend/lib/src/components/shared/Profiler/CircularBuffer.ts
@@ -31,7 +31,7 @@ export class CircularBuffer<T> {
    * @param {number} size - The size of the buffer.
    */
   constructor(size: number) {
-    this._buffer = new Array(size)
+    this._buffer = Array.from({ length: size })
     this._size = size
     this._index = 0
     this._wrappedCount = 0

--- a/frontend/lib/src/components/shared/Profiler/CircularBuffer.ts
+++ b/frontend/lib/src/components/shared/Profiler/CircularBuffer.ts
@@ -31,7 +31,9 @@ export class CircularBuffer<T> {
    * @param {number} size - The size of the buffer.
    */
   constructor(size: number) {
-    this._buffer = Array.from({ length: size })
+    // Using sparse array intentionally - dense arrays would iterate over all
+    // entries in filter/map even before being written to.
+    this._buffer = new Array<T>(size)
     this._size = size
     this._index = 0
     this._wrappedCount = 0

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -1087,7 +1087,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       ({
         ...BASE_RENDERERS,
         a: LinkWithTargetBlank,
-        ...(overrideComponents || {}),
+        ...overrideComponents,
       }) as Components,
     [overrideComponents]
   )

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
@@ -353,7 +353,7 @@ describe("Multi Select Editor", () => {
           { value: "option2", label: "Option 2", color: "blue" },
         ],
         values: [],
-        ...(props?.data ?? {}),
+        ...props?.data,
       },
     }
   }

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/columnConfigUtils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/columnConfigUtils.ts
@@ -36,15 +36,15 @@ export const updateColumnConfigTypeProps = ({
   const existingConfig = newColumnConfigMapping.get(columnId)
 
   const baseConfig = {
-    ...(existingConfig || {}),
-    ...(updatedProps || {}),
+    ...existingConfig,
+    ...updatedProps,
   }
 
   // Only add type_config if either existing or updated config has it
   if (existingConfig?.type_config || updatedProps?.type_config) {
     baseConfig.type_config = {
-      ...(existingConfig?.type_config || {}),
-      ...(updatedProps?.type_config || {}),
+      ...existingConfig?.type_config,
+      ...updatedProps?.type_config,
     }
   }
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -600,8 +600,8 @@ describe("DateInput widget", () => {
         // Freeze both Date and moment.now so BaseWeb quick select and our code
         // agree on "now"
         const MockDate = class extends RealDate {
-          // @ts-expect-error Mocked constructor
           constructor(...args: unknown[]) {
+            super()
             // If no args, return fixed date instance
             if (args.length === 0) {
               return new RealDate(STATIC_NOW)

--- a/frontend/lib/src/dataframes/arrowConcatUtils.ts
+++ b/frontend/lib/src/dataframes/arrowConcatUtils.ts
@@ -106,8 +106,15 @@ but was expecting \`${JSON.stringify(expectedIndexTypes)}\`.
     // if both indexes are of type "range" and they have different
     // metadata (start, step, stop) values, the metadata of the given
     // index will be ignored.
-    const { step, stop } = baseIndexTypes[0].pandasType
-      ?.metadata as PandasRangeIndex
+    const rangeIndexMetadata = baseIndexTypes[0].pandasType?.metadata as
+      | PandasRangeIndex
+      | undefined
+    if (!rangeIndexMetadata) {
+      throw new Error(
+        "Range index metadata is missing from the base dataframe."
+      )
+    }
+    const { step, stop } = rangeIndexMetadata
     appendIndex = [
       range(
         stop,
@@ -212,11 +219,18 @@ but was expecting \`${JSON.stringify(expectedIndexTypes)}\`.
     // if the index type is "range", there will only be one element in the index array.
     if (isRangeIndexType(indexType) && indexType.pandasType) {
       const { stop, step } = indexType.pandasType.metadata as PandasRangeIndex
+      const appendRangeIndexMetadata = appendIndexTypes[0].pandasType
+        ?.metadata as PandasRangeIndex | undefined
+      if (!appendRangeIndexMetadata) {
+        throw new Error(
+          "Range index metadata is missing from the appended dataframe."
+        )
+      }
       const {
         start: appendStart,
         stop: appendStop,
         step: appendStep,
-      } = appendIndexTypes[0].pandasType?.metadata as PandasRangeIndex
+      } = appendRangeIndexMetadata
       const appendRangeIndexLength = (appendStop - appendStart) / appendStep
       const newStop = stop + appendRangeIndexLength * step
       return {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,8 +20,10 @@
     "testCoverage": "vitest run --coverage",
     "format": "yarn workspaces foreach --all --parallel run format",
     "formatCheck": "yarn workspaces foreach --all --parallel run formatCheck",
-    "lint": "yarn workspaces foreach --all --parallel run lint",
-    "lint:fix": "yarn workspaces foreach --all --parallel run lint:fix",
+    "oxlint": "yarn exec oxlint --config ./.oxlintrc.json --deny-warnings app/src component-v2-lib/src connection/src eslint-plugin-streamlit-custom/src lib/src utils/src",
+    "oxlint:fix": "yarn exec oxlint --config ./.oxlintrc.json --fix --deny-warnings app/src component-v2-lib/src connection/src eslint-plugin-streamlit-custom/src lib/src utils/src",
+    "lint": "yarn oxlint && yarn workspaces foreach --all --parallel run lint",
+    "lint:fix": "yarn oxlint:fix && yarn workspaces foreach --all --parallel run lint:fix",
     "knip": "knip"
   },
   "resolutions": {
@@ -71,6 +73,7 @@
     "globals": "^17.4.0",
     "jiti": "^2.6.1",
     "knip": "^5.86.0",
+    "oxlint": "^1.53.0",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2713,6 +2713,139 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxlint/binding-android-arm-eabi@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-android-arm-eabi@npm:1.53.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-android-arm64@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-android-arm64@npm:1.53.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-darwin-arm64@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-darwin-arm64@npm:1.53.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-darwin-x64@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-darwin-x64@npm:1.53.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-freebsd-x64@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-freebsd-x64@npm:1.53.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm-gnueabihf@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-arm-gnueabihf@npm:1.53.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm-musleabihf@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-arm-musleabihf@npm:1.53.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm64-gnu@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-arm64-gnu@npm:1.53.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm64-musl@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-arm64-musl@npm:1.53.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-ppc64-gnu@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-ppc64-gnu@npm:1.53.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-riscv64-gnu@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-riscv64-gnu@npm:1.53.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-riscv64-musl@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-riscv64-musl@npm:1.53.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-s390x-gnu@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-s390x-gnu@npm:1.53.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-x64-gnu@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-x64-gnu@npm:1.53.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-x64-musl@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-linux-x64-musl@npm:1.53.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-openharmony-arm64@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-openharmony-arm64@npm:1.53.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-win32-arm64-msvc@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-win32-arm64-msvc@npm:1.53.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-win32-ia32-msvc@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-win32-ia32-msvc@npm:1.53.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-win32-x64-msvc@npm:1.53.0":
+  version: 1.53.0
+  resolution: "@oxlint/binding-win32-x64-msvc@npm:1.53.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@paulirish/trace_engine@npm:0.0.61":
   version: 0.0.61
   resolution: "@paulirish/trace_engine@npm:0.0.61"
@@ -14329,6 +14462,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxlint@npm:^1.53.0":
+  version: 1.53.0
+  resolution: "oxlint@npm:1.53.0"
+  dependencies:
+    "@oxlint/binding-android-arm-eabi": "npm:1.53.0"
+    "@oxlint/binding-android-arm64": "npm:1.53.0"
+    "@oxlint/binding-darwin-arm64": "npm:1.53.0"
+    "@oxlint/binding-darwin-x64": "npm:1.53.0"
+    "@oxlint/binding-freebsd-x64": "npm:1.53.0"
+    "@oxlint/binding-linux-arm-gnueabihf": "npm:1.53.0"
+    "@oxlint/binding-linux-arm-musleabihf": "npm:1.53.0"
+    "@oxlint/binding-linux-arm64-gnu": "npm:1.53.0"
+    "@oxlint/binding-linux-arm64-musl": "npm:1.53.0"
+    "@oxlint/binding-linux-ppc64-gnu": "npm:1.53.0"
+    "@oxlint/binding-linux-riscv64-gnu": "npm:1.53.0"
+    "@oxlint/binding-linux-riscv64-musl": "npm:1.53.0"
+    "@oxlint/binding-linux-s390x-gnu": "npm:1.53.0"
+    "@oxlint/binding-linux-x64-gnu": "npm:1.53.0"
+    "@oxlint/binding-linux-x64-musl": "npm:1.53.0"
+    "@oxlint/binding-openharmony-arm64": "npm:1.53.0"
+    "@oxlint/binding-win32-arm64-msvc": "npm:1.53.0"
+    "@oxlint/binding-win32-ia32-msvc": "npm:1.53.0"
+    "@oxlint/binding-win32-x64-msvc": "npm:1.53.0"
+  peerDependencies:
+    oxlint-tsgolint: ">=0.15.0"
+  dependenciesMeta:
+    "@oxlint/binding-android-arm-eabi":
+      optional: true
+    "@oxlint/binding-android-arm64":
+      optional: true
+    "@oxlint/binding-darwin-arm64":
+      optional: true
+    "@oxlint/binding-darwin-x64":
+      optional: true
+    "@oxlint/binding-freebsd-x64":
+      optional: true
+    "@oxlint/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxlint/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxlint/binding-linux-arm64-gnu":
+      optional: true
+    "@oxlint/binding-linux-arm64-musl":
+      optional: true
+    "@oxlint/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxlint/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxlint/binding-linux-riscv64-musl":
+      optional: true
+    "@oxlint/binding-linux-s390x-gnu":
+      optional: true
+    "@oxlint/binding-linux-x64-gnu":
+      optional: true
+    "@oxlint/binding-linux-x64-musl":
+      optional: true
+    "@oxlint/binding-openharmony-arm64":
+      optional: true
+    "@oxlint/binding-win32-arm64-msvc":
+      optional: true
+    "@oxlint/binding-win32-ia32-msvc":
+      optional: true
+    "@oxlint/binding-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    oxlint-tsgolint:
+      optional: true
+  bin:
+    oxlint: bin/oxlint
+  checksum: 10c0/378c17f9b0a6a792606c96e409ee792de336cbbef9e94ea9e9d35b6f601353dfda356213738fc14f4ebc0d33ddd8a5987e412ee642f7599940e283370e2d0154
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^3.0.2":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
@@ -16988,6 +17194,7 @@ __metadata:
     globals: "npm:^17.4.0"
     jiti: "npm:^2.6.1"
     knip: "npm:^5.86.0"
+    oxlint: "npm:^1.53.0"
     prettier: "npm:^3.8.1"
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.54.0"


### PR DESCRIPTION
## Describe your changes

Adds [oxlint](https://oxc.rs/docs/guide/usage/linter) as a fast linter to complement eslint in the frontend tooling pipeline.

- Runs before eslint in `make check` and pre-commit hooks (~20ms vs ~45s for eslint)
- Applied auto-fixes to existing code: simplified spread patterns, added missing `super()` call, improved null checks
- Configuration at `frontend/.oxlintrc.json` with minimal setup (default rules, vendor exclusions)

## Testing Plan

- No new tests needed - this is tooling configuration
- All existing frontend tests pass
- Verified with `make check` (formatting, linting, types, unit tests)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 3 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->