### PR TITLE
[feature] Stable Block.id for passive keyed layout containers

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1598,14 +1598,7 @@ export class App extends PureComponent<Props, State> {
             // Converting App to a functional component would let us use
             // useEffect and remove this suppress entirely.
             // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
-            const { elements, blockIds } = this.state.elements.getActiveIds()
-            const activeWidgetIds = new Set([
-              ...Array.from(elements)
-                .map(element => getElementId(element))
-                .filter(notUndefined),
-              ...blockIds,
-            ])
-            this.widgetMgr.removeInactive(activeWidgetIds)
+            this.removeInactiveWidgetState()
           }
         )
       }
@@ -1664,16 +1657,24 @@ export class App extends PureComponent<Props, State> {
         // Converting App to a functional component would let us use
         // useEffect and remove this suppress entirely.
         // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
-        const { elements, blockIds } = this.state.elements.getActiveIds()
-        const activeWidgetIds = new Set([
-          ...Array.from(elements)
-            .map(element => getElementId(element))
-            .filter(notUndefined),
-          ...blockIds,
-        ])
-        this.widgetMgr.removeInactive(activeWidgetIds)
+        this.removeInactiveWidgetState()
       }
     )
+  }
+
+  /**
+   * Remove widget and element state for items no longer present in the
+   * current render tree.
+   */
+  private removeInactiveWidgetState(): void {
+    const { elements, blockIds } = this.state.elements.getActiveIds()
+    const activeIds = new Set([
+      ...Array.from(elements)
+        .map(element => getElementId(element))
+        .filter(notUndefined),
+      ...blockIds,
+    ])
+    this.widgetMgr.removeInactive(activeIds)
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1593,13 +1593,14 @@ export class App extends PureComponent<Props, State> {
           () => {
             // Tell the WidgetManager which widgets still exist. It will remove
             // widget state for widgets that have been removed.
-            const activeWidgetIds = new Set(
-              // TODO: Update to match React best practices
-              // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
-              Array.from(this.state.elements.getElements())
+            // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
+            const { elements, blockIds } = this.state.elements.getActiveIds()
+            const activeWidgetIds = new Set([
+              ...Array.from(elements)
                 .map(element => getElementId(element))
-                .filter(notUndefined)
-            )
+                .filter(notUndefined),
+              ...blockIds,
+            ])
             this.widgetMgr.removeInactive(activeWidgetIds)
           }
         )
@@ -1654,13 +1655,14 @@ export class App extends PureComponent<Props, State> {
         }
       },
       () => {
-        const activeWidgetIds = new Set(
-          // TODO: Update to match React best practices
-          // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
-          Array.from(this.state.elements.getElements())
+        // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
+        const { elements, blockIds } = this.state.elements.getActiveIds()
+        const activeWidgetIds = new Set([
+          ...Array.from(elements)
             .map(element => getElementId(element))
-            .filter(notUndefined)
-        )
+            .filter(notUndefined),
+          ...blockIds,
+        ])
         this.widgetMgr.removeInactive(activeWidgetIds)
       }
     )

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1593,6 +1593,10 @@ export class App extends PureComponent<Props, State> {
           () => {
             // Tell the WidgetManager which widgets still exist. It will remove
             // widget state for widgets that have been removed.
+            // TODO(not urgent): this.state in a setState callback is a false
+            // positive — the callback runs after the update is committed.
+            // Converting App to a functional component would let us use
+            // useEffect and remove this suppress entirely.
             // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
             const { elements, blockIds } = this.state.elements.getActiveIds()
             const activeWidgetIds = new Set([
@@ -1655,6 +1659,10 @@ export class App extends PureComponent<Props, State> {
         }
       },
       () => {
+        // TODO(not urgent): this.state in a setState callback is a false
+        // positive — the callback runs after the update is committed.
+        // Converting App to a functional component would let us use
+        // useEffect and remove this suppress entirely.
         // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
         const { elements, blockIds } = this.state.elements.getActiveIds()
         const activeWidgetIds = new Set([

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1591,13 +1591,6 @@ export class App extends PureComponent<Props, State> {
             }
           },
           () => {
-            // Tell the WidgetManager which widgets still exist. It will remove
-            // widget state for widgets that have been removed.
-            // TODO(not urgent): this.state in a setState callback is a false
-            // positive — the callback runs after the update is committed.
-            // Converting App to a functional component would let us use
-            // useEffect and remove this suppress entirely.
-            // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
             this.removeInactiveWidgetState()
           }
         )
@@ -1652,11 +1645,6 @@ export class App extends PureComponent<Props, State> {
         }
       },
       () => {
-        // TODO(not urgent): this.state in a setState callback is a false
-        // positive — the callback runs after the update is committed.
-        // Converting App to a functional component would let us use
-        // useEffect and remove this suppress entirely.
-        // eslint-disable-next-line @eslint-react/no-access-state-in-setstate
         this.removeInactiveWidgetState()
       }
     )
@@ -1664,7 +1652,10 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Remove widget and element state for items no longer present in the
-   * current render tree.
+   * current render tree. Called from setState callbacks where this.state
+   * access is a false positive (the callback runs after the update is
+   * committed). Converting App to a functional component would let us
+   * use useEffect and remove this suppress entirely.
    */
   private removeInactiveWidgetState(): void {
     const { elements, blockIds } = this.state.elements.getActiveIds()

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -388,6 +388,26 @@ export class AppRoot {
     return visitor.elements
   }
 
+  /**
+   * Return all active element IDs and block IDs in the tree.
+   * Block IDs are collected from blocks that have a stable identity
+   * (e.g. keyed layout containers), and are needed to prevent
+   * elementStates entries from being garbage-collected.
+   */
+  public getActiveIds(): {
+    elements: Set<Element>
+    blockIds: Set<string>
+  } {
+    const visitor = new ElementsSetVisitor()
+
+    this.main.accept(visitor)
+    this.sidebar.accept(visitor)
+    this.event.accept(visitor)
+    this.bottom.accept(visitor)
+
+    return { elements: visitor.elements, blockIds: visitor.blockIds }
+  }
+
   private addElement(
     deltaPath: number[],
     scriptRunId: string,

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -377,15 +377,7 @@ export class AppRoot {
 
   /** Return a Set containing all Elements in the tree. */
   public getElements(): Set<Element> {
-    const visitor = new ElementsSetVisitor()
-
-    // Visit each major section of the app
-    this.main.accept(visitor)
-    this.sidebar.accept(visitor)
-    this.event.accept(visitor)
-    this.bottom.accept(visitor)
-
-    return visitor.elements
+    return this.getActiveIds().elements
   }
 
   /**

--- a/frontend/lib/src/render-tree/test-utils.ts
+++ b/frontend/lib/src/render-tree/test-utils.ts
@@ -86,6 +86,20 @@ export function block(
   )
 }
 
+/** Create a BlockNode with a specific block-level id. */
+export function blockWithId(
+  id: string,
+  children: AppNode[] = [],
+  scriptRunId = NO_SCRIPT_RUN_ID
+): BlockNode {
+  return new BlockNode(
+    FAKE_SCRIPT_HASH,
+    children,
+    makeProto(BlockProto, { id }),
+    scriptRunId
+  )
+}
+
 /** Create a table element node with the given properties. */
 export function table(scriptRunId = NO_SCRIPT_RUN_ID): ElementNode {
   const element = makeProto(Element, {

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
@@ -14,28 +14,10 @@
  * limitations under the License.
  */
 
-import { Block as BlockProto } from "@streamlit/protobuf"
-
-import { AppNode, NO_SCRIPT_RUN_ID } from "~lib/render-tree/AppNode.interface"
-import { BlockNode } from "~lib/render-tree/BlockNode"
-import {
-  block,
-  FAKE_SCRIPT_HASH,
-  makeProto,
-  text,
-} from "~lib/render-tree/test-utils"
+import { block, blockWithId, text } from "~lib/render-tree/test-utils"
 import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { ElementsSetVisitor } from "./ElementsSetVisitor"
-
-function blockWithId(id: string, children: AppNode[] = []): BlockNode {
-  return new BlockNode(
-    FAKE_SCRIPT_HASH,
-    children,
-    makeProto(BlockProto, { id }),
-    NO_SCRIPT_RUN_ID
-  )
-}
 
 describe("ElementsSetVisitor", () => {
   describe("visitElementNode", () => {

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
@@ -14,10 +14,28 @@
  * limitations under the License.
  */
 
-import { block, text } from "~lib/render-tree/test-utils"
+import { Block as BlockProto } from "@streamlit/protobuf"
+
+import { AppNode, NO_SCRIPT_RUN_ID } from "~lib/render-tree/AppNode.interface"
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import {
+  block,
+  FAKE_SCRIPT_HASH,
+  makeProto,
+  text,
+} from "~lib/render-tree/test-utils"
 import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { ElementsSetVisitor } from "./ElementsSetVisitor"
+
+function blockWithId(id: string, children: AppNode[] = []): BlockNode {
+  return new BlockNode(
+    FAKE_SCRIPT_HASH,
+    children,
+    makeProto(BlockProto, { id }),
+    NO_SCRIPT_RUN_ID
+  )
+}
 
 describe("ElementsSetVisitor", () => {
   describe("visitElementNode", () => {
@@ -182,6 +200,53 @@ describe("ElementsSetVisitor", () => {
       const elements = ElementsSetVisitor.collectElements(emptyBlock)
 
       expect(elements.size).toBe(0)
+    })
+  })
+
+  describe("blockIds collection", () => {
+    it("collects block ids from blocks with id set", () => {
+      const idBlock = blockWithId("$$ID-abc123-my_key")
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(idBlock)
+
+      expect(visitor.blockIds.size).toBe(1)
+      expect(visitor.blockIds.has("$$ID-abc123-my_key")).toBe(true)
+    })
+
+    it("does not collect ids from blocks without id", () => {
+      const noIdBlock = block([text("child")])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(noIdBlock)
+
+      expect(visitor.blockIds.size).toBe(0)
+    })
+
+    it("collects ids from nested blocks", () => {
+      const innerBlock = blockWithId("$$ID-inner-key1", [text("inner")])
+      const outerBlock = blockWithId("$$ID-outer-key2", [innerBlock])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(outerBlock)
+
+      expect(visitor.blockIds.size).toBe(2)
+      expect(visitor.blockIds.has("$$ID-inner-key1")).toBe(true)
+      expect(visitor.blockIds.has("$$ID-outer-key2")).toBe(true)
+      expect(visitor.elements.size).toBe(1)
+    })
+
+    it("collects elements and block ids simultaneously", () => {
+      const child = text("child")
+      const idBlock = blockWithId("$$ID-abc-mykey", [child])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(idBlock)
+
+      expect(visitor.elements.size).toBe(1)
+      expect(visitor.elements.has(child.element)).toBe(true)
+      expect(visitor.blockIds.size).toBe(1)
+      expect(visitor.blockIds.has("$$ID-abc-mykey")).toBe(true)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
@@ -23,18 +23,25 @@ import { TransientNode } from "~lib/render-tree/TransientNode"
 import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
 
 /**
- * A visitor that collects all Elements from an AppNode tree.
+ * A visitor that collects all Elements and stable block IDs from an AppNode
+ * tree.
  *
- * This visitor uses a mutable Set for performance, accumulating elements
- * as it traverses the tree. The visitor methods return the Set directly
- * for convenience, but the return value only needs to be used at the end
- * of the traversal.
+ * - `elements`: all Element protos found in ElementNodes.
+ * - `blockIds`: IDs from BlockNodes that have a stable identity (e.g. keyed
+ *   layout containers). These are used to prevent `elementStates` entries
+ *   from being garbage-collected.
+ *
+ * This visitor uses mutable Sets for performance, accumulating results
+ * as it traverses the tree. The visitor methods return the element Set
+ * directly for convenience, but the return value only needs to be used
+ * at the end of the traversal.
  *
  * Usage:
  * ```typescript
  * const visitor = new ElementsSetVisitor()
  * rootNode.accept(visitor)
  * const elements = visitor.elements
+ * const blockIds = visitor.blockIds
  * ```
  */
 export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
@@ -39,9 +39,11 @@ import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.in
  */
 export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
   public readonly elements: Set<Element>
+  public readonly blockIds: Set<string>
 
   constructor() {
     this.elements = new Set<Element>()
+    this.blockIds = new Set<string>()
   }
 
   visitElementNode(node: ElementNode): Set<Element> {
@@ -50,7 +52,9 @@ export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
   }
 
   visitBlockNode(node: BlockNode): Set<Element> {
-    // Visit each child and accumulate elements in our mutable set
+    if (node.deltaBlock?.id) {
+      this.blockIds.add(node.deltaBlock.id)
+    }
     for (const child of node.children) {
       child.accept(this)
     }

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -866,7 +866,16 @@ class LayoutsMixin:
         is_stateful = on_change != "ignore"
 
         element_id: str | None = None
+        block_id: str | None = None
         current_tab_label = tabs[default_index]
+
+        if not is_stateful and key is not None:
+            block_id = compute_and_register_element_id(
+                "tabs",
+                user_key=key,
+                dg=self.dg,
+                key_as_main_identity=True,
+            )
 
         if is_stateful:
             is_callback = callable(on_change)
@@ -930,6 +939,9 @@ class LayoutsMixin:
 
         if is_stateful and element_id is not None:
             block_proto.tab_container.id = element_id
+
+        if block_id is not None:
+            block_proto.id = block_id
 
         tab_cls = get_dg_singleton_instance().tab_container_cls
         tab_container = self.dg._block(block_proto)
@@ -1171,6 +1183,15 @@ class LayoutsMixin:
 
         current_expanded = expanded
         element_id: str | None = None
+        block_id: str | None = None
+
+        if not is_stateful and key is not None:
+            block_id = compute_and_register_element_id(
+                "expander",
+                user_key=key,
+                dg=self.dg,
+                key_as_main_identity=True,
+            )
 
         if is_stateful:
             is_callback = callable(on_change)
@@ -1224,6 +1245,9 @@ class LayoutsMixin:
         block_proto.expandable.CopyFrom(expandable_proto)
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
+
+        if block_id is not None:
+            block_proto.id = block_id
 
         expander_dg = cast(
             "ExpanderContainer",
@@ -1517,6 +1541,15 @@ class LayoutsMixin:
 
         current_open = False
         element_id: str | None = None
+        block_id: str | None = None
+
+        if not is_stateful and key is not None:
+            block_id = compute_and_register_element_id(
+                "popover",
+                user_key=key,
+                dg=self.dg,
+                key_as_main_identity=True,
+            )
 
         if is_stateful:
             is_callback = callable(on_change)
@@ -1578,6 +1611,9 @@ class LayoutsMixin:
 
         validate_width(width, allow_content=True)
         block_proto.width_config.CopyFrom(get_width_config(width))
+
+        if block_id is not None:
+            block_proto.id = block_id
 
         popover_dg = cast(
             "PopoverContainer",

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -885,14 +885,13 @@ class LayoutsMixin:
             element_id = compute_and_register_element_id(
                 "tabs",
                 user_key=key,
-                key_as_main_identity=True,
+                key_as_main_identity=False,
                 dg=self.dg,
                 tabs=tuple(tabs),
                 width=width,
                 default=default,
             )
-            if key is not None:
-                block_id = element_id
+            block_id = element_id
 
             serde = _TabsSerde(default_label=tabs[default_index])
 
@@ -914,8 +913,8 @@ class LayoutsMixin:
             block_id = compute_and_register_element_id(
                 "tabs",
                 user_key=key,
+                key_as_main_identity=False,
                 dg=self.dg,
-                key_as_main_identity=True,
             )
 
         def tab_proto(label: str) -> BlockProto:
@@ -1201,15 +1200,14 @@ class LayoutsMixin:
             element_id = compute_and_register_element_id(
                 "expander",
                 user_key=key,
-                key_as_main_identity=True,
+                key_as_main_identity=False,
                 dg=self.dg,
                 label=label,
                 expanded=expanded,
                 icon=icon,
                 width=width,
             )
-            if key is not None:
-                block_id = element_id
+            block_id = element_id
 
             serde = _ExpanderSerde(expanded=expanded)
 
@@ -1229,8 +1227,8 @@ class LayoutsMixin:
             block_id = compute_and_register_element_id(
                 "expander",
                 user_key=key,
+                key_as_main_identity=False,
                 dg=self.dg,
-                key_as_main_identity=True,
             )
         expandable_proto = BlockProto.Expandable()
         expandable_proto.expanded = current_expanded
@@ -1560,7 +1558,7 @@ class LayoutsMixin:
             element_id = compute_and_register_element_id(
                 "popover",
                 user_key=key,
-                key_as_main_identity=True,
+                key_as_main_identity=False,
                 dg=self.dg,
                 label=label,
                 type=type,
@@ -1569,8 +1567,7 @@ class LayoutsMixin:
                 disabled=disabled,
                 width=width,
             )
-            if key is not None:
-                block_id = element_id
+            block_id = element_id
 
             serde = _PopoverSerde()
 
@@ -1590,8 +1587,8 @@ class LayoutsMixin:
             block_id = compute_and_register_element_id(
                 "popover",
                 user_key=key,
+                key_as_main_identity=False,
                 dg=self.dg,
-                key_as_main_identity=True,
             )
 
         popover_proto = BlockProto.Popover()

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -869,14 +869,6 @@ class LayoutsMixin:
         block_id: str | None = None
         current_tab_label = tabs[default_index]
 
-        if not is_stateful and key is not None:
-            block_id = compute_and_register_element_id(
-                "tabs",
-                user_key=key,
-                dg=self.dg,
-                key_as_main_identity=True,
-            )
-
         if is_stateful:
             is_callback = callable(on_change)
             check_widget_policies(
@@ -895,7 +887,12 @@ class LayoutsMixin:
                 user_key=key,
                 key_as_main_identity=True,
                 dg=self.dg,
+                tabs=tuple(tabs),
+                width=width,
+                default=default,
             )
+            if key is not None:
+                block_id = element_id
 
             serde = _TabsSerde(default_label=tabs[default_index])
 
@@ -911,9 +908,15 @@ class LayoutsMixin:
             )
 
             current_tab_label = tabs_state.value
-            # Validate that the label exists in the tab list
             if current_tab_label not in tabs:
                 current_tab_label = tabs[default_index]
+        elif key is not None:
+            block_id = compute_and_register_element_id(
+                "tabs",
+                user_key=key,
+                dg=self.dg,
+                key_as_main_identity=True,
+            )
 
         def tab_proto(label: str) -> BlockProto:
             tab_proto = BlockProto()
@@ -1182,14 +1185,6 @@ class LayoutsMixin:
         element_id: str | None = None
         block_id: str | None = None
 
-        if not is_stateful and key is not None:
-            block_id = compute_and_register_element_id(
-                "expander",
-                user_key=key,
-                dg=self.dg,
-                key_as_main_identity=True,
-            )
-
         if is_stateful:
             is_callback = callable(on_change)
             check_widget_policies(
@@ -1208,7 +1203,13 @@ class LayoutsMixin:
                 user_key=key,
                 key_as_main_identity=True,
                 dg=self.dg,
+                label=label,
+                expanded=expanded,
+                icon=icon,
+                width=width,
             )
+            if key is not None:
+                block_id = element_id
 
             serde = _ExpanderSerde(expanded=expanded)
 
@@ -1224,6 +1225,13 @@ class LayoutsMixin:
             )
 
             current_expanded = expander_state.value
+        elif key is not None:
+            block_id = compute_and_register_element_id(
+                "expander",
+                user_key=key,
+                dg=self.dg,
+                key_as_main_identity=True,
+            )
         expandable_proto = BlockProto.Expandable()
         expandable_proto.expanded = current_expanded
         expandable_proto.label = label
@@ -1536,14 +1544,6 @@ class LayoutsMixin:
         element_id: str | None = None
         block_id: str | None = None
 
-        if not is_stateful and key is not None:
-            block_id = compute_and_register_element_id(
-                "popover",
-                user_key=key,
-                dg=self.dg,
-                key_as_main_identity=True,
-            )
-
         if is_stateful:
             is_callback = callable(on_change)
             check_widget_policies(
@@ -1562,7 +1562,15 @@ class LayoutsMixin:
                 user_key=key,
                 key_as_main_identity=True,
                 dg=self.dg,
+                label=label,
+                type=type,
+                help=help,
+                icon=icon,
+                disabled=disabled,
+                width=width,
             )
+            if key is not None:
+                block_id = element_id
 
             serde = _PopoverSerde()
 
@@ -1578,6 +1586,13 @@ class LayoutsMixin:
             )
 
             current_open = popover_state.value
+        elif key is not None:
+            block_id = compute_and_register_element_id(
+                "popover",
+                user_key=key,
+                dg=self.dg,
+                key_as_main_identity=True,
+            )
 
         popover_proto = BlockProto.Popover()
         popover_proto.label = label

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -893,11 +893,8 @@ class LayoutsMixin:
             element_id = compute_and_register_element_id(
                 "tabs",
                 user_key=key,
-                key_as_main_identity=False,
+                key_as_main_identity=True,
                 dg=self.dg,
-                tabs=tuple(tabs),
-                width=width,
-                default=default,
             )
 
             serde = _TabsSerde(default_label=tabs[default_index])
@@ -1209,12 +1206,8 @@ class LayoutsMixin:
             element_id = compute_and_register_element_id(
                 "expander",
                 user_key=key,
-                key_as_main_identity=False,
+                key_as_main_identity=True,
                 dg=self.dg,
-                label=label,
-                expanded=expanded,
-                icon=icon,
-                width=width,
             )
 
             serde = _ExpanderSerde(expanded=expanded)
@@ -1567,14 +1560,8 @@ class LayoutsMixin:
             element_id = compute_and_register_element_id(
                 "popover",
                 user_key=key,
-                key_as_main_identity=False,
+                key_as_main_identity=True,
                 dg=self.dg,
-                label=label,
-                type=type,
-                help=help,
-                icon=icon,
-                disabled=disabled,
-                width=width,
             )
 
             serde = _PopoverSerde()

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -1535,7 +1535,7 @@ class TabsTest(DeltaGeneratorTestCase):
         tab_container_block = all_deltas[0]
         assert tab_container_block.add_block.id != ""
         assert "my_tabs" in tab_container_block.add_block.id
-        assert tab_container_block.add_block.tab_container.id == ""
+        assert not tab_container_block.add_block.tab_container.HasField("id")
 
     def test_passive_key_without_key_does_not_set_block_id(self):
         """Test that tabs without key does not set block-level id."""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -467,6 +467,20 @@ class ExpanderTest(DeltaGeneratorTestCase):
         assert "my_expander" in expander_block.add_block.id
         assert not expander_block.add_block.expandable.HasField("id")
 
+    def test_passive_key_block_id_stable_when_params_change(self):
+        """Test that block.id remains stable when label and expanded change."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.expander("label 1", key="stable_exp", expanded=False)
+            id1 = self.get_delta_from_queue().add_block.id
+
+            st.expander("label 2", key="stable_exp", expanded=True)
+            id2 = self.get_delta_from_queue().add_block.id
+
+            assert id1 == id2
+
     def test_on_change_rerun_with_key_accessible_via_session_state(self):
         """Test that on_change='rerun' with key makes state accessible."""
         st.expander("label", key="my_exp", on_change="rerun")
@@ -1014,6 +1028,32 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         assert "my_pop" in popover_block.add_block.id
         assert not popover_block.add_block.popover.HasField("id")
 
+    def test_passive_key_block_id_stable_when_params_change(self):
+        """Test that block.id remains stable when label and type change."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.popover("Open", key="stable_pop", type="primary")
+            id1 = self.get_delta_from_queue().add_block.id
+
+            st.popover("Click me", key="stable_pop", type="secondary")
+            id2 = self.get_delta_from_queue().add_block.id
+
+            assert id1 == id2
+
+    def test_on_change_rerun_does_not_set_block_id(self):
+        """Test that on_change='rerun' does not set the block-level id."""
+        st.popover("label", key="my_pop", on_change="rerun")
+        popover_block = self.get_delta_from_queue()
+        assert popover_block.add_block.id == ""
+
+    def test_on_change_callback_does_not_set_block_id(self):
+        """Test that a callable on_change does not set the block-level id."""
+        st.popover("label", key="cb_pop2", on_change=lambda: None)
+        popover_block = self.get_delta_from_queue()
+        assert popover_block.add_block.id == ""
+
     def test_callback_enables_state_tracking(self):
         """Test that passing a callable on_change enables state tracking."""
         popover = st.popover("label", on_change=lambda: None)
@@ -1484,6 +1524,34 @@ class TabsTest(DeltaGeneratorTestCase):
     def test_passive_key_without_key_does_not_set_block_id(self):
         """Test that tabs without key does not set block-level id."""
         st.tabs(["A", "B"])
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.id == ""
+
+    def test_passive_key_block_id_stable_when_tabs_change(self):
+        """Test that block.id remains stable when tab labels change."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.tabs(["A", "B"], key="stable_tabs")
+            id1 = self.get_all_deltas_from_queue()[0].add_block.id
+
+            st.tabs(["X", "Y", "Z"], key="stable_tabs")
+            id2 = self.get_all_deltas_from_queue()[0].add_block.id
+
+            assert id1 == id2
+
+    def test_on_change_rerun_does_not_set_block_id(self):
+        """Test that on_change='rerun' does not set the block-level id."""
+        st.tabs(["A", "B"], key="my_tabs", on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.id == ""
+
+    def test_on_change_callback_does_not_set_block_id(self):
+        """Test that a callable on_change does not set the block-level id."""
+        st.tabs(["A", "B"], key="cb_tabs2", on_change=lambda: None)
         all_deltas = self.get_all_deltas_from_queue()
         tab_container_block = all_deltas[0]
         assert tab_container_block.add_block.id == ""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -435,11 +435,11 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander = st.expander("label", expanded=True, on_change="rerun")
         assert expander.open is True
 
-    def test_on_change_rerun_without_key_does_not_set_block_id(self):
-        """Test that on_change='rerun' without key does not set block-level id."""
+    def test_on_change_rerun_without_key_sets_block_id(self):
+        """Test that on_change='rerun' without key still sets block-level id."""
         st.expander("label", on_change="rerun")
         expander_block = self.get_delta_from_queue()
-        assert expander_block.add_block.id == ""
+        assert expander_block.add_block.id != ""
 
     def test_on_change_rerun_with_key_sets_block_id(self):
         """Test that on_change='rerun' with key sets the block-level id."""
@@ -473,20 +473,6 @@ class ExpanderTest(DeltaGeneratorTestCase):
         assert expander_block.add_block.id != ""
         assert "my_expander" in expander_block.add_block.id
         assert not expander_block.add_block.expandable.HasField("id")
-
-    def test_passive_key_block_id_stable_when_params_change(self):
-        """Test that block.id remains stable when label and expanded change."""
-        with patch(
-            "streamlit.elements.lib.utils._register_element_id",
-            return_value=MagicMock(),
-        ):
-            st.expander("label 1", key="stable_exp", expanded=False)
-            id1 = self.get_delta_from_queue().add_block.id
-
-            st.expander("label 2", key="stable_exp", expanded=True)
-            id2 = self.get_delta_from_queue().add_block.id
-
-            assert id1 == id2
 
     def test_on_change_rerun_with_key_accessible_via_session_state(self):
         """Test that on_change='rerun' with key makes state accessible."""
@@ -1036,20 +1022,6 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         assert "my_pop" in popover_block.add_block.id
         assert not popover_block.add_block.popover.HasField("id")
 
-    def test_passive_key_block_id_stable_when_params_change(self):
-        """Test that block.id remains stable when label and type change."""
-        with patch(
-            "streamlit.elements.lib.utils._register_element_id",
-            return_value=MagicMock(),
-        ):
-            st.popover("Open", key="stable_pop", type="primary")
-            id1 = self.get_delta_from_queue().add_block.id
-
-            st.popover("Click me", key="stable_pop", type="secondary")
-            id2 = self.get_delta_from_queue().add_block.id
-
-            assert id1 == id2
-
     def test_on_change_rerun_with_key_sets_block_id(self):
         """Test that on_change='rerun' with key sets the block-level id."""
         st.popover("label", key="my_pop", on_change="rerun")
@@ -1057,11 +1029,11 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
         assert popover_block.add_block.id != ""
         assert "my_pop" in popover_block.add_block.id
 
-    def test_on_change_rerun_without_key_does_not_set_block_id(self):
-        """Test that on_change='rerun' without key does not set block-level id."""
+    def test_on_change_rerun_without_key_sets_block_id(self):
+        """Test that on_change='rerun' without key still sets block-level id."""
         st.popover("label", on_change="rerun")
         popover_block = self.get_delta_from_queue()
-        assert popover_block.add_block.id == ""
+        assert popover_block.add_block.id != ""
 
     def test_on_change_callback_sets_block_id(self):
         """Test that a callable on_change with key sets the block-level id."""
@@ -1544,20 +1516,6 @@ class TabsTest(DeltaGeneratorTestCase):
         tab_container_block = all_deltas[0]
         assert tab_container_block.add_block.id == ""
 
-    def test_passive_key_block_id_stable_when_tabs_change(self):
-        """Test that block.id remains stable when tab labels change."""
-        with patch(
-            "streamlit.elements.lib.utils._register_element_id",
-            return_value=MagicMock(),
-        ):
-            st.tabs(["A", "B"], key="stable_tabs")
-            id1 = self.get_all_deltas_from_queue()[0].add_block.id
-
-            st.tabs(["X", "Y", "Z"], key="stable_tabs")
-            id2 = self.get_all_deltas_from_queue()[0].add_block.id
-
-            assert id1 == id2
-
     def test_on_change_rerun_with_key_sets_block_id(self):
         """Test that on_change='rerun' with key sets the block-level id."""
         st.tabs(["A", "B"], key="my_tabs", on_change="rerun")
@@ -1566,12 +1524,12 @@ class TabsTest(DeltaGeneratorTestCase):
         assert tab_container_block.add_block.id != ""
         assert "my_tabs" in tab_container_block.add_block.id
 
-    def test_on_change_rerun_without_key_does_not_set_block_id(self):
-        """Test that on_change='rerun' without key does not set block-level id."""
+    def test_on_change_rerun_without_key_sets_block_id(self):
+        """Test that on_change='rerun' without key still sets block-level id."""
         st.tabs(["A", "B"], on_change="rerun")
         all_deltas = self.get_all_deltas_from_queue()
         tab_container_block = all_deltas[0]
-        assert tab_container_block.add_block.id == ""
+        assert tab_container_block.add_block.id != ""
 
     def test_on_change_callback_sets_block_id(self):
         """Test that a callable on_change with key sets the block-level id."""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -435,11 +435,18 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander = st.expander("label", expanded=True, on_change="rerun")
         assert expander.open is True
 
-    def test_on_change_rerun_does_not_set_block_id(self):
-        """Test that on_change='rerun' does not set the block-level id."""
+    def test_on_change_rerun_without_key_does_not_set_block_id(self):
+        """Test that on_change='rerun' without key does not set block-level id."""
         st.expander("label", on_change="rerun")
         expander_block = self.get_delta_from_queue()
         assert expander_block.add_block.id == ""
+
+    def test_on_change_rerun_with_key_sets_block_id(self):
+        """Test that on_change='rerun' with key sets the block-level id."""
+        st.expander("label", key="my_exp", on_change="rerun")
+        expander_block = self.get_delta_from_queue()
+        assert expander_block.add_block.id != ""
+        assert "my_exp" in expander_block.add_block.id
 
     def test_on_change_rerun_sets_id(self):
         """Test that on_change='rerun' sets id in the expandable proto."""
@@ -513,11 +520,12 @@ class ExpanderTest(DeltaGeneratorTestCase):
         assert expander.open is True
         assert st.session_state.cb_exp is True
 
-    def test_on_change_callback_does_not_set_block_id(self):
-        """Test that a callback does not set the block-level id."""
+    def test_on_change_callback_sets_block_id(self):
+        """Test that a callback with key sets the block-level id."""
         st.expander("label", key="cb_exp2", on_change=lambda: None)
         expander_block = self.get_delta_from_queue()
-        assert expander_block.add_block.id == ""
+        assert expander_block.add_block.id != ""
+        assert "cb_exp2" in expander_block.add_block.id
 
     def _get_expander_widget_state(self) -> WidgetState:
         """Find the expander's WidgetState by matching its element id."""
@@ -1042,17 +1050,25 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
 
             assert id1 == id2
 
-    def test_on_change_rerun_does_not_set_block_id(self):
-        """Test that on_change='rerun' does not set the block-level id."""
+    def test_on_change_rerun_with_key_sets_block_id(self):
+        """Test that on_change='rerun' with key sets the block-level id."""
         st.popover("label", key="my_pop", on_change="rerun")
+        popover_block = self.get_delta_from_queue()
+        assert popover_block.add_block.id != ""
+        assert "my_pop" in popover_block.add_block.id
+
+    def test_on_change_rerun_without_key_does_not_set_block_id(self):
+        """Test that on_change='rerun' without key does not set block-level id."""
+        st.popover("label", on_change="rerun")
         popover_block = self.get_delta_from_queue()
         assert popover_block.add_block.id == ""
 
-    def test_on_change_callback_does_not_set_block_id(self):
-        """Test that a callable on_change does not set the block-level id."""
+    def test_on_change_callback_sets_block_id(self):
+        """Test that a callable on_change with key sets the block-level id."""
         st.popover("label", key="cb_pop2", on_change=lambda: None)
         popover_block = self.get_delta_from_queue()
-        assert popover_block.add_block.id == ""
+        assert popover_block.add_block.id != ""
+        assert "cb_pop2" in popover_block.add_block.id
 
     def test_callback_enables_state_tracking(self):
         """Test that passing a callable on_change enables state tracking."""
@@ -1542,19 +1558,28 @@ class TabsTest(DeltaGeneratorTestCase):
 
             assert id1 == id2
 
-    def test_on_change_rerun_does_not_set_block_id(self):
-        """Test that on_change='rerun' does not set the block-level id."""
+    def test_on_change_rerun_with_key_sets_block_id(self):
+        """Test that on_change='rerun' with key sets the block-level id."""
         st.tabs(["A", "B"], key="my_tabs", on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.id != ""
+        assert "my_tabs" in tab_container_block.add_block.id
+
+    def test_on_change_rerun_without_key_does_not_set_block_id(self):
+        """Test that on_change='rerun' without key does not set block-level id."""
+        st.tabs(["A", "B"], on_change="rerun")
         all_deltas = self.get_all_deltas_from_queue()
         tab_container_block = all_deltas[0]
         assert tab_container_block.add_block.id == ""
 
-    def test_on_change_callback_does_not_set_block_id(self):
-        """Test that a callable on_change does not set the block-level id."""
+    def test_on_change_callback_sets_block_id(self):
+        """Test that a callable on_change with key sets the block-level id."""
         st.tabs(["A", "B"], key="cb_tabs2", on_change=lambda: None)
         all_deltas = self.get_all_deltas_from_queue()
         tab_container_block = all_deltas[0]
-        assert tab_container_block.add_block.id == ""
+        assert tab_container_block.add_block.id != ""
+        assert "cb_tabs2" in tab_container_block.add_block.id
 
     def test_on_change_callback_sets_id(self) -> None:
         """Test that a callable on_change sets id on the tab container proto."""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -459,11 +459,13 @@ class ExpanderTest(DeltaGeneratorTestCase):
         expander_block = self.get_delta_from_queue()
         assert not expander_block.add_block.expandable.HasField("id")
 
-    def test_key_without_on_change_does_not_set_block_id(self):
-        """Test that key alone (without on_change='rerun') does not set block id."""
+    def test_passive_key_sets_block_id(self):
+        """Test that key with on_change='ignore' sets block-level id for stable identity."""
         st.expander("label", key="my_expander")
         expander_block = self.get_delta_from_queue()
-        assert expander_block.add_block.id == ""
+        assert expander_block.add_block.id != ""
+        assert "my_expander" in expander_block.add_block.id
+        assert not expander_block.add_block.expandable.HasField("id")
 
     def test_on_change_rerun_with_key_accessible_via_session_state(self):
         """Test that on_change='rerun' with key makes state accessible."""
@@ -1003,12 +1005,14 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
 
     def test_on_change_ignore_with_key_open_remains_none(self):
         """Test that on_change='ignore' with a key keeps .open as None,
-        does not register widget state, and does not set block id."""
+        does not register widget state, but sets block-level id."""
         popover = st.popover("label", key="my_pop", on_change="ignore")
         assert popover.open is None
         assert "my_pop" not in st.session_state
         popover_block = self.get_delta_from_queue()
-        assert popover_block.add_block.id == ""
+        assert popover_block.add_block.id != ""
+        assert "my_pop" in popover_block.add_block.id
+        assert not popover_block.add_block.popover.HasField("id")
 
     def test_callback_enables_state_tracking(self):
         """Test that passing a callable on_change enables state tracking."""
@@ -1467,6 +1471,22 @@ class TabsTest(DeltaGeneratorTestCase):
         for tab in tabs:
             assert tab.open is None
         assert "my_tabs" not in st.session_state
+
+    def test_passive_key_sets_block_id(self):
+        """Test that key with on_change='ignore' sets block-level id for stable identity."""
+        st.tabs(["A", "B"], key="my_tabs", on_change="ignore")
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.id != ""
+        assert "my_tabs" in tab_container_block.add_block.id
+        assert tab_container_block.add_block.tab_container.id == ""
+
+    def test_passive_key_without_key_does_not_set_block_id(self):
+        """Test that tabs without key does not set block-level id."""
+        st.tabs(["A", "B"])
+        all_deltas = self.get_all_deltas_from_queue()
+        tab_container_block = all_deltas[0]
+        assert tab_container_block.add_block.id == ""
 
     def test_on_change_callback_sets_id(self) -> None:
         """Test that a callable on_change sets id on the tab container proto."""

--- a/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
+++ b/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
@@ -94,10 +94,12 @@ This provides:
 
 **`on_change` transition:** `Block.id` is always set when `key` is provided, in both
 passive and stateful modes — it drives the CSS `st-key-*` class and (in passive mode) the
-`elementStates` key. Both paths use `key_as_main_identity=True` so the ID is key-based and
-stable across parameter changes, consistent with other Streamlit widgets. The element-level
-ID (e.g. `tabContainer.id`) is what distinguishes a widget from a passive container.
-Changing `on_change` from `"ignore"` to `"rerun"` adds the element-level ID and calls
+`elementStates` key. Both paths use `key_as_main_identity=False`, so the ID incorporates
+all parameters alongside the key and remains stable as long as parameters don't change.
+Enabling `key_as_main_identity=True` (so the ID is based solely on the key and stable
+across parameter changes) is tracked in #14416. The element-level ID (e.g.
+`tabContainer.id`) is what distinguishes a widget from a passive container. Changing
+`on_change` from `"ignore"` to `"rerun"` adds the element-level ID and calls
 `register_widget` — widget state becomes the source of truth and the `elementStates` entry
 keyed by `Block.id` is no longer read.
 

--- a/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
+++ b/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
@@ -66,18 +66,19 @@ When `key` is provided, compute `Block.id` using `compute_and_register_element_i
 elements, producing the standard `$$ID-<hash>-<user_key>` format.
 
 ```python
-# New passive path (on_change="ignore" + key).
-# The stateful path computes an element-level ID (e.g. expandable_proto.id)
-# via compute_and_register_element_id with key_as_main_identity=True.
-# The change here is to also compute a block-level ID for the passive case
-# — setting block_proto.id only (not the element-level ID), so the container
-# is not registered as a widget.
-if user_key and not is_stateful:
+# Both paths use key_as_main_identity=True so the ID is key-based.
+# In the stateful path, the same ID is used for both block_proto.id and
+# the element-level ID (e.g. expandable_proto.id). In the passive path,
+# only block_proto.id is set — no element-level ID, no widget registration.
+if is_stateful:
+    element_id = compute_and_register_element_id(
+        element_type, user_key=user_key, dg=dg, key_as_main_identity=True, **kwargs,
+    )
+    if user_key:
+        block_proto.id = element_id
+elif user_key:
     block_proto.id = compute_and_register_element_id(
-        element_type,
-        user_key=user_key,
-        dg=dg,
-        key_as_main_identity=True,
+        element_type, user_key=user_key, dg=dg, key_as_main_identity=True,
     )
 ```
 
@@ -93,17 +94,14 @@ This provides:
 **Fragment compatibility:** `compute_and_register_element_id` incorporates
 `ctx.active_script_hash`, so `Block.id` is stable across full and fragment reruns.
 
-**`on_change` transition:** In the passive path (`on_change="ignore"` + `key`), only
-`Block.id` is set — the container is not registered as a widget and `elementStates` keyed
-by `Block.id` drives persistence. In the stateful path (`on_change="rerun"` or callable),
-only the element-level ID (e.g. `tabContainer.id`) is set — the container is registered as
-a widget and backend widget state becomes the source of truth.
-
-Both paths use `key_as_main_identity=True` so the ID is key-based and stable across
-parameter changes (label, tab labels, expanded, etc.), consistent with other Streamlit
-widgets. Changing `on_change` from `"ignore"` to `"rerun"` transitions from frontend
-`elementStates` persistence to backend widget state — the `elementStates` entry is
-no longer read and will be garbage-collected.
+**`on_change` transition:** `Block.id` is always set when `key` is provided, in both
+passive and stateful modes — it drives the CSS `st-key-*` class and (in passive mode) the
+`elementStates` key. Both paths use `key_as_main_identity=True` so the ID is key-based and
+stable across parameter changes, consistent with other Streamlit widgets. The element-level
+ID (e.g. `tabContainer.id`) is what distinguishes a widget from a passive container.
+Changing `on_change` from `"ignore"` to `"rerun"` adds the element-level ID and calls
+`register_widget` — widget state becomes the source of truth and the `elementStates` entry
+keyed by `Block.id` is no longer read.
 
 ### Frontend State Store
 

--- a/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
+++ b/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
@@ -61,32 +61,30 @@ truth and are unaffected by remounts.
 
 ### Stable Identity via `key`
 
-When `key` is provided, compute `Block.id` using `compute_and_register_element_id` with
-`key_as_main_identity=True`. This is the same function used for all other keyed Streamlit
-elements, producing the standard `$$ID-<hash>-<user_key>` format.
+When `key` is provided, compute `Block.id` using `compute_and_register_element_id`.
+The key is included in the hash, producing the standard `$$ID-<hash>-<user_key>` format.
 
 ```python
-# Both paths use key_as_main_identity=True so the ID is key-based.
-# In the stateful path, the same ID is used for both block_proto.id and
-# the element-level ID (e.g. expandable_proto.id). In the passive path,
-# only block_proto.id is set — no element-level ID, no widget registration.
+# In the stateful path, block_proto.id is always set to element_id so that
+# even keyless stateful containers get a Block.id for frontend use.
+# In the passive path, only block_proto.id is set — no element-level ID,
+# no widget registration.
 if is_stateful:
     element_id = compute_and_register_element_id(
-        element_type, user_key=user_key, dg=dg, key_as_main_identity=True, **kwargs,
+        element_type, user_key=user_key, key_as_main_identity=False, dg=dg, **kwargs,
     )
-    if user_key:
-        block_proto.id = element_id
+    block_proto.id = element_id
 elif user_key:
     block_proto.id = compute_and_register_element_id(
-        element_type, user_key=user_key, dg=dg, key_as_main_identity=True,
+        element_type, user_key=user_key, key_as_main_identity=False, dg=dg,
     )
 ```
 
 This provides:
 
-- **Stable identity across remounts:** The `Block.id` is derived from the key and
-  `active_script_hash`, independent of the element's position in the render tree.
-  Conditional elements above the container can change freely without affecting the ID.
+- **Stable identity across remounts:** When `key` is provided, the `Block.id` includes
+  the key in its hash, so the ID is independent of the element's position in the render
+  tree. Conditional elements above the container can change freely without affecting the ID.
 - **CSS class `st-key-<keyname>`:** The `$$ID-<hash>-<user_key>` format is recognized by
   `isValidElementId` / `getKeyFromId`, which produce the `st-key-*` CSS class on the
   outermost DOM element. No changes to the existing CSS key infrastructure are needed.

--- a/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
+++ b/specs/2026-02-26-layout-container-state-persistence/tech-spec.md
@@ -67,9 +67,11 @@ elements, producing the standard `$$ID-<hash>-<user_key>` format.
 
 ```python
 # New passive path (on_change="ignore" + key).
-# The stateful path already computes element_id and sets both block_proto.id
-# and the element-level ID (e.g. expandable_proto.id). The change here is to
-# also compute it for the passive case — setting block_proto.id only.
+# The stateful path computes an element-level ID (e.g. expandable_proto.id)
+# via compute_and_register_element_id with key_as_main_identity=True.
+# The change here is to also compute a block-level ID for the passive case
+# — setting block_proto.id only (not the element-level ID), so the container
+# is not registered as a widget.
 if user_key and not is_stateful:
     block_proto.id = compute_and_register_element_id(
         element_type,
@@ -91,12 +93,17 @@ This provides:
 **Fragment compatibility:** `compute_and_register_element_id` incorporates
 `ctx.active_script_hash`, so `Block.id` is stable across full and fragment reruns.
 
-**`on_change` transition:** `Block.id` is always set when `key` is provided, in both
-passive and stateful modes (it drives the CSS class and the `elementStates` key). The
-element-level ID (e.g. `tabContainer.id`) is what distinguishes a widget from a passive
-container. Changing `on_change` from `"ignore"` to `"rerun"` adds the element-level ID
-and calls `register_widget` — widget state becomes the source of truth and the
-`elementStates` entry keyed by `Block.id` is no longer read.
+**`on_change` transition:** In the passive path (`on_change="ignore"` + `key`), only
+`Block.id` is set — the container is not registered as a widget and `elementStates` keyed
+by `Block.id` drives persistence. In the stateful path (`on_change="rerun"` or callable),
+only the element-level ID (e.g. `tabContainer.id`) is set — the container is registered as
+a widget and backend widget state becomes the source of truth.
+
+Both paths use `key_as_main_identity=True` so the ID is key-based and stable across
+parameter changes (label, tab labels, expanded, etc.), consistent with other Streamlit
+widgets. Changing `on_change` from `"ignore"` to `"rerun"` transitions from frontend
+`elementStates` persistence to backend widget state — the `elementStates` entry is
+no longer read and will be garbage-collected.
 
 ### Frontend State Store
 


### PR DESCRIPTION
## Describe your changes

Sets a stable `Block.id` via `compute_and_register_element_id` (with `key_as_main_identity=True`) for `st.tabs`, `st.expander`, and `st.popover` when `key` is provided and `on_change="ignore"` (the default). This gives these containers a position-independent identity — the foundation for frontend state persistence across remounts.

- Only `Block.id` is set, not the element-level ID (`tabContainer.id` / `expandable.id` / `popover.id`), so `session_state[key]` is not populated and the element is not registered as a widget
- Frontend `ElementsSetVisitor` now collects `Block.id` values and includes them in the active ID set passed to `removeInactive`, preventing `elementStates` entries from being garbage-collected

Follow-up PRs will wire up `useWidgetManagerElementState` in each component to persist active tab / expanded / open state across remounts, and apply `st-key-*` CSS classes.

## GitHub Issue Link (if applicable)

Addresses https://github.com/streamlit/streamlit/issues/8239

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - Python: `block_proto.id` set for passive keyed containers, absent without key, element-level ID not set
  - Frontend: `ElementsSetVisitor` collects block IDs from nested trees, ignores blocks without IDs

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.