### PR TITLE
[fix] Only store access token when explicitly exposed in auth

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -299,6 +299,27 @@ def generate_default_provider_section(auth_section: AttrDict) -> dict[str, Any]:
     return default_provider_section
 
 
+def get_tokens_to_store(token_payload: Mapping[str, Any]) -> dict[str, str]:
+    """Select which OAuth tokens should be persisted in auth cookies.
+
+    Always retains the ID token when available so logout can send an
+    ``id_token_hint`` to providers that support RP-initiated logout. The
+    access token is only persisted when ``expose_tokens`` explicitly opts in.
+    """
+    stored_tokens: dict[str, str] = {}
+
+    id_token = token_payload.get("id_token")
+    if isinstance(id_token, str):
+        stored_tokens["id_token"] = id_token
+
+    if "access" in get_expose_tokens_config():
+        access_token = token_payload.get("access_token")
+        if isinstance(access_token, str):
+            stored_tokens["access_token"] = access_token
+
+    return stored_tokens
+
+
 def set_cookie_with_chunks(
     set_single_cookie_fn: Callable[[str, str], None],
     create_signed_value_fn: Callable[[str, str], bytes],

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -28,6 +28,7 @@ from streamlit.auth_util import (
     get_origin_from_redirect_uri,
     get_redirect_uri,
     get_secrets_auth_section,
+    get_tokens_to_store,
     get_validated_redirect_uri,
     set_cookie_with_chunks,
 )
@@ -87,12 +88,13 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
             AUTH_COOKIE_NAME,
             user_info,
         )
-        set_cookie_with_chunks(
-            self._set_single_cookie,
-            self._create_signed_value,
-            TOKENS_COOKIE_NAME,
-            tokens,
-        )
+        if tokens:
+            set_cookie_with_chunks(
+                self._set_single_cookie,
+                self._create_signed_value,
+                TOKENS_COOKIE_NAME,
+                tokens,
+            )
 
     def _set_single_cookie(self, cookie_name: str, value: str) -> None:
         """Set a single cookie."""
@@ -275,7 +277,7 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         user = cast("dict[str, Any]", token.get("userinfo"))
 
         cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
-        tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
+        tokens = get_tokens_to_store(token)
 
         if user:
             self.set_auth_cookie(cookie_value, tokens)

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -95,6 +95,12 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
                 TOKENS_COOKIE_NAME,
                 tokens,
             )
+        else:
+            clear_cookie_and_chunks(
+                self._get_signed_cookie,
+                self.clear_cookie,
+                TOKENS_COOKIE_NAME,
+            )
 
     def _set_single_cookie(self, cookie_name: str, value: str) -> None:
         """Set a single cookie."""

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -31,6 +31,7 @@ from streamlit.auth_util import (
     get_origin_from_redirect_uri,
     get_redirect_uri,
     get_secrets_auth_section,
+    get_tokens_to_store,
     get_validated_redirect_uri,
     set_cookie_with_chunks,
 )
@@ -222,12 +223,13 @@ async def _set_auth_cookie(
         USER_COOKIE_NAME,
         user_info,
     )
-    set_cookie_with_chunks(
-        set_single_cookie,
-        _create_signed_value_wrapper,
-        TOKENS_COOKIE_NAME,
-        tokens,
-    )
+    if tokens:
+        set_cookie_with_chunks(
+            set_single_cookie,
+            _create_signed_value_wrapper,
+            TOKENS_COOKIE_NAME,
+            tokens,
+        )
 
 
 def _set_single_cookie(
@@ -550,7 +552,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
     response = await _redirect_to_base(base_url)
 
     cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
-    tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
+    tokens = get_tokens_to_store(token)
     if user:
         await _set_auth_cookie(response, cookie_value, tokens)
     else:  # pragma: no cover - error path

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -202,7 +202,10 @@ def _get_cookie_path() -> str:
 
 
 async def _set_auth_cookie(
-    response: Response, user_info: dict[str, Any], tokens: dict[str, Any]
+    response: Response,
+    request: Request,
+    user_info: dict[str, Any],
+    tokens: dict[str, Any],
 ) -> None:
     """Set the auth cookies with signed user info and tokens.
 
@@ -212,6 +215,8 @@ async def _set_auth_cookie(
     behavior when switching between Tornado and Starlette backends.
 
     Cookies may be split into multiple chunks if they exceed browser limits.
+    If tokens is empty, any existing token cookies will be cleared to prevent
+    stale tokens from persisting.
     """
 
     def set_single_cookie(cookie_name: str, value: str) -> None:
@@ -229,6 +234,21 @@ async def _set_auth_cookie(
             _create_signed_value_wrapper,
             TOKENS_COOKIE_NAME,
             tokens,
+        )
+    else:
+        # Clear any existing token cookies to prevent stale tokens from persisting
+        cookie_path = _get_cookie_path()
+
+        def get_single_cookie(cookie_name: str) -> bytes | None:
+            return _get_signed_cookie_from_request(request, cookie_name)
+
+        def clear_single_cookie(cookie_name: str) -> None:
+            response.delete_cookie(cookie_name, path=cookie_path)
+
+        clear_cookie_and_chunks(
+            get_single_cookie,
+            clear_single_cookie,
+            TOKENS_COOKIE_NAME,
         )
 
 
@@ -554,7 +574,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
     cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
     tokens = get_tokens_to_store(token)
     if user:
-        await _set_auth_cookie(response, cookie_value, tokens)
+        await _set_auth_cookie(response, request, cookie_value, tokens)
     else:  # pragma: no cover - error path
         _LOGGER.error(
             "OAuth provider '%s' did not return user information during callback.",

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -31,6 +31,7 @@ from streamlit.auth_util import (
     get_expose_tokens_config,
     get_redirect_uri,
     get_signing_secret,
+    get_tokens_to_store,
     set_cookie_with_chunks,
 )
 from streamlit.errors import StreamlitAuthError
@@ -225,6 +226,73 @@ class ExposeTokensConfigTest(unittest.TestCase):
                 "Invalid expose_tokens configuration. Only 'id' and 'access' are allowed."
                 in str(exc_info.value)
             )
+
+
+@pytest.mark.parametrize(
+    ("expose_tokens_config", "token_payload", "expected"),
+    [
+        # Default behavior: only ID token is stored
+        (
+            None,
+            {"id_token": "test-id-token", "access_token": "test-access-token"},
+            {"id_token": "test-id-token"},
+        ),
+        # Access exposed: both tokens stored
+        (
+            ["access"],
+            {"id_token": "test-id-token", "access_token": "test-access-token"},
+            {"id_token": "test-id-token", "access_token": "test-access-token"},
+        ),
+        # Empty payload: returns empty dict
+        (
+            None,
+            {},
+            {},
+        ),
+        # Only access token in payload (no ID token)
+        (
+            ["access"],
+            {"access_token": "test-access-token"},
+            {"access_token": "test-access-token"},
+        ),
+        # Non-string token values are ignored
+        (
+            ["access"],
+            {"id_token": None, "access_token": 12345},
+            {},
+        ),
+    ],
+    ids=[
+        "default_keeps_only_id_token",
+        "access_exposed_keeps_both",
+        "empty_payload_returns_empty",
+        "only_access_token_in_payload",
+        "non_string_tokens_ignored",
+    ],
+)
+def test_tokens_to_store(
+    expose_tokens_config: list[str] | None,
+    token_payload: dict[str, Any],
+    expected: dict[str, str],
+) -> None:
+    """Verify tokens are stored based on expose_tokens configuration and payload."""
+    secrets_config: dict[str, Any] = {
+        "redirect_uri": "http://localhost:8501/oauth2callback",
+        "cookie_secret": "test_cookie_secret",
+    }
+    if expose_tokens_config is not None:
+        secrets_config["expose_tokens"] = expose_tokens_config
+
+    with patch(
+        "streamlit.auth_util.secrets_singleton",
+        MagicMock(
+            load_if_toml_exists=MagicMock(return_value=True),
+            get=MagicMock(return_value=secrets_config),
+        ),
+    ):
+        result = get_tokens_to_store(token_payload)
+
+    assert result == expected
 
 
 class CookieChunkingTest(unittest.TestCase):

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -397,7 +397,6 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
                 "provider": "google",
             },
             {
-                "access_token": "test_access_token",
                 "id_token": "test_id_token",
             },
         )

--- a/specs/2025-11-19-auth-oidc-tokens/product-spec.md
+++ b/specs/2025-11-19-auth-oidc-tokens/product-spec.md
@@ -100,6 +100,12 @@ if st.user:
 | `streamlit_user`   | User identity claims (chunked if needed) | Existing behavior               |
 | `streamlit_tokens` | Token payload (chunked if needed)        | HTTP-only, Secure, SameSite=Lax |
 
+**Token storage behavior:**
+
+- The **ID token** is always stored when available, regardless of `expose_tokens`, to support RP-initiated logout via `id_token_hint`
+- The **access token** is only stored when `expose_tokens` explicitly includes `"access"`
+- The `streamlit_tokens` cookie is only set if there are tokens to store
+
 - Tokens **never stored in `session_state`**
 
 - Tokens **never accessible to browser JavaScript**


### PR DESCRIPTION
## Describe your changes

Fixes OAuth token storage to only persist access tokens when explicitly enabled via `expose_tokens` configuration, aligning implementation with the intended product spec behavior.

- Access tokens are now opt-in: only stored when `expose_tokens = ["access"]` is configured
- ID token is always retained (needed for RP-initiated logout via `id_token_hint`)
- Token cookie is only set if there are tokens to store

This addresses a regression in 1.53 where access tokens were stored by default, causing:
- Large cookies that triggered chunking (e.g., "Split cookie into 2 chunks" log messages)
- Potential 502 errors on deployments with strict header size limits (NGINX Ingress)

## GitHub Issue Link (if applicable)

- Closes #14290

## Testing Plan

- [x] Unit Tests (Python) — `lib/tests/streamlit/auth_util_test.py` covers token selection logic including edge cases (empty payload, missing tokens, non-string values)
- [x] Unit Tests (Python) — `lib/tests/streamlit/web/server/oauth_authlib_routes_test.py` updated to verify default behavior

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | Explore | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 5 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->