### PR TITLE
refactor: replace usages of any with meaningful types

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 /**
  * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
  *
@@ -25,7 +24,7 @@ import {
   waitFor,
 } from "@testing-library/react"
 import { cloneDeep } from "lodash-es"
-import { type Mock } from "vitest"
+import { type Mock, type MockInstance } from "vitest"
 
 import {
   getMenuLabels,
@@ -50,6 +49,7 @@ import {
   getHostSpecifiedTheme,
   HOST_COMM_VERSION,
   HostCommunicationManager,
+  type IHostToGuestMessage,
   isEmbed,
   isToolbarDisplayed,
   lightTheme,
@@ -181,8 +181,10 @@ vi.mock("@streamlit/connection", async () => {
 })
 
 vi.mock("~lib/SessionInfo", async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const actualModule = await vi.importActual<any>("~lib/SessionInfo")
+  const actualModule =
+    await vi.importActual<typeof import("~lib/SessionInfo")>(
+      "~lib/SessionInfo"
+    )
 
   const MockedClass = vi.fn().mockImplementation(function (this: SessionInfo) {
     return new actualModule.SessionInfo()
@@ -201,14 +203,13 @@ vi.mock("~lib/SessionInfo", async () => {
 })
 
 vi.mock("~lib/hostComm/HostCommunicationManager", async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const actualModule = await vi.importActual<any>(
-    "~lib/hostComm/HostCommunicationManager"
-  )
+  const actualModule = await vi.importActual<
+    typeof import("~lib/hostComm/HostCommunicationManager")
+  >("~lib/hostComm/HostCommunicationManager")
 
   const MockedClass = vi.fn().mockImplementation(function (
     this: HostCommunicationManager,
-    ...props: never[]
+    ...props: ConstructorParameters<typeof actualModule.default>
   ) {
     const hostCommunicationMgr = new actualModule.default(...props)
     vi.spyOn(hostCommunicationMgr, "sendMessageToHost")
@@ -225,12 +226,13 @@ vi.mock("~lib/hostComm/HostCommunicationManager", async () => {
 })
 
 vi.mock("~lib/WidgetStateManager", async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const actualModule = await vi.importActual<any>("~lib/WidgetStateManager")
+  const actualModule = await vi.importActual<
+    typeof import("~lib/WidgetStateManager")
+  >("~lib/WidgetStateManager")
 
   const MockedClass = vi.fn().mockImplementation(function (
     this: WidgetStateManager,
-    ...props: never[]
+    ...props: ConstructorParameters<typeof actualModule.WidgetStateManager>
   ) {
     const widgetStateManager = new actualModule.WidgetStateManager(...props)
 
@@ -246,14 +248,13 @@ vi.mock("~lib/WidgetStateManager", async () => {
 })
 
 vi.mock("@streamlit/app/src/MetricsManager", async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const actualModule = await vi.importActual<any>(
-    "@streamlit/app/src/MetricsManager"
-  )
+  const actualModule = await vi.importActual<
+    typeof import("@streamlit/app/src/MetricsManager")
+  >("@streamlit/app/src/MetricsManager")
 
   const MockedClass = vi.fn().mockImplementation(function (
     this: MetricsManager,
-    ...props: never[]
+    ...props: ConstructorParameters<typeof actualModule.MetricsManager>
   ) {
     const metricsMgr = new actualModule.MetricsManager(...props)
     vi.spyOn(metricsMgr, "enqueue")
@@ -268,12 +269,13 @@ vi.mock("@streamlit/app/src/MetricsManager", async () => {
 })
 
 vi.mock("~lib/FileUploadClient", async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const actualModule = await vi.importActual<any>("~lib/FileUploadClient")
+  const actualModule = await vi.importActual<
+    typeof import("~lib/FileUploadClient")
+  >("~lib/FileUploadClient")
 
   const MockedClass = vi.fn().mockImplementation(function (
     this: FileUploadClient,
-    ...props: never[]
+    ...props: ConstructorParameters<typeof actualModule.FileUploadClient>
   ) {
     return new actualModule.FileUploadClient(...props)
   })
@@ -390,9 +392,13 @@ function renderApp(props: Props): RenderResult {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function getStoredValue<T>(Type: any): T {
-  return Type.mock.results[Type.mock.results.length - 1].value
+function getStoredValue<T>(
+  // At runtime, vi.mock() adds a `.mock` property to the class constructor.
+  // We accept `unknown` and use vi.mocked() internally to access it safely.
+  Type: unknown
+): T {
+  const mocked = vi.mocked(Type as (...args: unknown[]) => T)
+  return mocked.mock.results[mocked.mock.results.length - 1].value as T
 }
 
 function getMockConnectionManager(isConnected = false): ConnectionManager {
@@ -404,8 +410,9 @@ function getMockConnectionManager(isConnected = false): ConnectionManager {
   return connectionManager
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function getMockConnectionManagerProp(propName: string): any {
+function getMockConnectionManagerProp(
+  propName: string
+): (...args: unknown[]) => void {
   // @ts-expect-error - connectionManager.props is private
   return getStoredValue<ConnectionManager>(ConnectionManager).props[propName]
 }
@@ -1796,8 +1803,7 @@ describe("App", () => {
   // Using this to test the functionality provided through st.query_params.
   // Please see https://github.com/streamlit/streamlit/issues/2887 for more context on this.
   describe("App.handlePageInfoChanged", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    let pushStateSpy: any
+    let pushStateSpy: MockInstance
 
     beforeEach(() => {
       window.history.pushState({}, "", "/")
@@ -4412,8 +4418,14 @@ describe("App", () => {
       return hostCommunicationMgr
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    function fireWindowPostMessage(message: any): void {
+    /** Distributive Omit that works correctly over union types. */
+    type DistributiveOmit<T, K extends keyof T> = T extends unknown
+      ? Omit<T, K>
+      : never
+
+    function fireWindowPostMessage(
+      message: DistributiveOmit<IHostToGuestMessage, "stCommVersion">
+    ): void {
       fireEvent(
         window,
         new MessageEvent("message", {
@@ -4919,7 +4931,7 @@ describe("App", () => {
 
         fireWindowPostMessage({
           type: "SET_MENU_ITEMS",
-          items: [{ type: "option", label: "Fork this App", key: "fork" }],
+          items: [{ type: "text", label: "Fork this App", key: "fork" }],
         })
 
         // Verify host menu item was added in correct position
@@ -5219,8 +5231,7 @@ describe("App", () => {
   })
 
   describe("page change URL handling", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    let pushStateSpy: any
+    let pushStateSpy: MockInstance
 
     beforeEach(() => {
       window.history.pushState({}, "", "/")

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -228,10 +228,14 @@ export const LOG = getLogger("App")
 
 declare global {
   interface Window {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    streamlitDebug: any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    iFrameResizer: any
+    streamlitDebug: {
+      clearForwardMsgCache: () => void
+      disconnectWebsocket: () => void
+      shutdownRuntime: () => void
+    }
+    iFrameResizer: {
+      heightCalculationMethod: () => number
+    }
     __streamlit_profiles__?: Record<
       string,
       CircularBuffer<{
@@ -941,11 +945,20 @@ export class App extends PureComponent<Props, State> {
   handleMessage = (msgProto: ForwardMsg): void => {
     // We don't have an immutableProto here, so we can't use
     // the dispatchOneOf helper
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const dispatchProto = (obj: any, name: string, funcs: any): any => {
-      const whichOne = obj[name]
+
+    const dispatchProto = (
+      obj: ForwardMsg,
+      name: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+      funcs: Record<string, (value: any) => void>
+    ): void => {
+      const whichOne = (obj as unknown as Record<string, unknown>)[
+        name
+      ] as string
       if (whichOne in funcs) {
-        return funcs[whichOne](obj[whichOne])
+        return funcs[whichOne](
+          (obj as unknown as Record<string, unknown>)[whichOne]
+        )
       }
       throw new Error(`Cannot handle ${name} "${whichOne}".`)
     }

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -149,8 +149,7 @@ export class MetricsManager {
   }
 
   // Fallback - Checks if cached in localStorage, otherwise fetches the config from a default URL
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  private async requestDefaultMetricsConfig(): Promise<any> {
+  private async requestDefaultMetricsConfig(): Promise<void> {
     const isLocalStoreAvailable = localStorageAvailable()
 
     if (isLocalStoreAvailable) {

--- a/frontend/app/src/StreamlitLib.test.tsx
+++ b/frontend/app/src/StreamlitLib.test.tsx
@@ -263,8 +263,7 @@ describe("StreamlitLibExample", () => {
 
   it("handles Delta messages", async () => {
     // there's nothing within the app ui to cycle through script run messages so we need a reference
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    let streamlitLibInstance: any
+    let streamlitLibInstance: StreamlitLibExample | null = null
     render(
       <StreamlitLibExample
         ref={ref => {
@@ -285,11 +284,15 @@ describe("StreamlitLibExample", () => {
       deltaPath: [0, 0], // main container, first element
     })
 
+    expect(streamlitLibInstance).not.toBeNull()
+    // The ref callback has set the instance by this point
+    const instance = streamlitLibInstance as unknown as StreamlitLibExample
+
     // Send the delta to our app (wrap in act() because these cause state updates)
     act(() => {
-      streamlitLibInstance.beginScriptRun("newScriptRun")
-      streamlitLibInstance.handleDeltaMsg(delta, metadata)
-      streamlitLibInstance.endScriptRun()
+      instance.beginScriptRun("newScriptRun")
+      instance.handleDeltaMsg(delta, metadata)
+      instance.endScriptRun()
     })
 
     // our "Please wait..." alert should be gone, because it

--- a/frontend/app/src/components/DeployButton/DeployButton.tsx
+++ b/frontend/app/src/components/DeployButton/DeployButton.tsx
@@ -21,8 +21,7 @@ import { BaseButton, BaseButtonKind } from "@streamlit/lib"
 import { DeployButtonContainer } from "./styled-components"
 
 interface IDeployButtonProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onClick: (event: MouseEvent<HTMLButtonElement>) => any
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void
 }
 
 const DeployButton: FC<IDeployButtonProps> = ({ onClick }) => {

--- a/frontend/app/src/components/FontFaceDeclaration/FontFaceDeclaration.tsx
+++ b/frontend/app/src/components/FontFaceDeclaration/FontFaceDeclaration.tsx
@@ -18,15 +18,21 @@ import { ReactElement } from "react"
 
 import { css, Global } from "@emotion/react"
 
+import { IFontFace } from "@streamlit/protobuf"
+
+interface BackwardCompatibleFontFace extends IFontFace {
+  // Legacy custom-theme payloads may still send deprecated weight.
+  weight?: string | number
+}
+
 interface FontFaceDeclarationProps {
-  fontFaces: object[]
+  fontFaces: BackwardCompatibleFontFace[]
 }
 
 const FontFaceDeclaration = ({
   fontFaces,
 }: FontFaceDeclarationProps): ReactElement => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const fontMarkup = fontFaces.map((font: any) => {
+  const fontMarkup = fontFaces.map((font: BackwardCompatibleFontFace) => {
     const { family, weight, weightRange, url, style, unicodeRange } = font
     // weight is deprecated in favour of weightRange, but we support it for
     // backwards compatibility.

--- a/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/ThemedSidebar.test.tsx
@@ -63,20 +63,22 @@ describe("ThemedSidebar Component", () => {
 })
 
 describe("createSidebarTheme", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const createMockTheme = (overrides: any = {}): ThemeConfig => ({
-    name: "mockTheme",
-    basewebTheme: {},
-    primitives: {},
-    themeInput: {},
-    emotion: {
-      colors: {
-        secondaryBg: "#FFFFFF",
-        bgColor: "#F0F0F0",
+  const createMockTheme = (
+    overrides: Record<string, unknown> = {}
+  ): ThemeConfig =>
+    ({
+      name: "mockTheme",
+      basewebTheme: {},
+      primitives: {},
+      themeInput: {},
+      emotion: {
+        colors: {
+          secondaryBg: "#FFFFFF",
+          bgColor: "#F0F0F0",
+        },
       },
-    },
-    ...overrides,
-  })
+      ...overrides,
+    }) as ThemeConfig
 
   it("creates a light theme when background is light", () => {
     const theme = createMockTheme()

--- a/frontend/app/src/components/Sidebar/styled-components.ts
+++ b/frontend/app/src/components/Sidebar/styled-components.ts
@@ -174,8 +174,7 @@ interface StyledLogoProps {
   sidebarWidth?: string
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function translateLogoHeight(theme: any, size: string): string {
+function translateLogoHeight(theme: EmotionTheme, size: string): string {
   if (size === "small") {
     return theme.sizes.smallLogoHeight
   } else if (size === "large") {

--- a/frontend/app/src/util/ScreenCastRecorder.ts
+++ b/frontend/app/src/util/ScreenCastRecorder.ts
@@ -112,13 +112,11 @@ class ScreenCastRecorder {
       return false
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const logRecorderError = (e: any): void => {
-      LOG.warn(`mediaRecorder.start threw an error: ${e}`)
+    const logRecorderError = (e: unknown): void => {
+      LOG.warn(`mediaRecorder.start threw an error: ${String(e)}`)
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    this.mediaRecorder.onerror = (e: any): void => {
+    this.mediaRecorder.onerror = (e: Event): void => {
       logRecorderError(e)
       this.onErrorOrStopCallback()
     }

--- a/frontend/app/src/util/useThemeManager.ts
+++ b/frontend/app/src/util/useThemeManager.ts
@@ -32,7 +32,11 @@ import {
   setCachedThemeSelection,
   ThemeConfig,
 } from "@streamlit/lib"
-import { CustomThemeConfig, ICustomThemeConfig } from "@streamlit/protobuf"
+import {
+  CustomThemeConfig,
+  ICustomThemeConfig,
+  IFontFace,
+} from "@streamlit/protobuf"
 
 export type FontSources = Record<string, string>
 
@@ -80,7 +84,7 @@ export function useThemeManager(): [
 ] {
   const defaultTheme = getDefaultTheme()
   const [theme, setTheme] = useState<ThemeConfig>(defaultTheme)
-  const [fontFaces, setFontFaces] = useState<object[]>(
+  const [fontFaces, setFontFaces] = useState<IFontFace[]>(
     defaultTheme.themeInput?.fontFaces ?? []
   )
   const [fontSources, setFontSources] = useState<FontSources | null>(null)
@@ -184,7 +188,7 @@ export function useThemeManager(): [
     // If fonts are coming from a URL, they need to be imported through the FontFaceDeclaration
     // component. So let's store them in state so we can pass them as props.
     if (themeInfo.fontFaces) {
-      setFontFaces(themeInfo.fontFaces as object[])
+      setFontFaces(themeInfo.fontFaces)
     }
 
     // Collect and process font sources from both main theme and sidebar theme

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import type { AxiosRequestConfig, AxiosResponse } from "axios"
+import type {
+  AxiosProgressEvent,
+  AxiosRequestConfig,
+  AxiosResponse,
+} from "axios"
 import { getLogger } from "loglevel"
 
 import { IAppPage } from "@streamlit/protobuf"
@@ -256,8 +260,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     fileUploadUrl: string,
     file: File,
     _sessionId: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    onUploadProgress?: (progressEvent: any) => void,
+    onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
     signal?: AbortSignal
   ): Promise<void> {
     const form = new FormData()
@@ -365,8 +368,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
    * CSRF headers if client has CSRF protection enabled.
    * Uses dynamic import to load axios only when needed (file upload/delete operations).
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  private async csrfRequest<T = any, R = AxiosResponse<T>>(
+  private async csrfRequest<T = unknown, R = AxiosResponse<T>>(
     url: string,
     params: AxiosRequestConfig
   ): Promise<R> {

--- a/frontend/connection/src/StaticConnection.tsx
+++ b/frontend/connection/src/StaticConnection.tsx
@@ -16,23 +16,21 @@
 
 import { getLogger } from "loglevel"
 
-import { ForwardMsgList } from "@streamlit/protobuf"
+import { ForwardMsg, ForwardMsgList } from "@streamlit/protobuf"
 import { localStorageAvailable } from "@streamlit/utils"
 
 import { ConnectionState } from "./ConnectionState"
-import { ErrorDetails, StreamlitEndpoints } from "./types"
+import {
+  ErrorDetails,
+  OnConnectionStateChange,
+  OnMessage,
+  StreamlitEndpoints,
+} from "./types"
 
 // TODO: Change this to a stable location and eventually make it configurable
 // Holds url for static asset location
 const STATIC_ASSET_CONFIG = "https://data.streamlit.io/static.json"
 export const LOG = getLogger("StaticConnection")
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-type OnMessage = (ForwardMsg: any) => void
-type OnConnectionStateChange = (
-  connectionState: ConnectionState,
-  errMsg?: ErrorDetails
-) => void
 
 // Fetches the static asset url from the config file
 export async function getStaticConfig(): Promise<string> {
@@ -120,7 +118,7 @@ export async function dispatchAppForwardMessages(
 
   // Dispatches each ForwardMsg to be handled by App.tsx's handleMessage
   forwardMsgList.messages.forEach(msg => {
-    onMessage(msg)
+    onMessage(msg as ForwardMsg)
   })
 }
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@streamlit/utils", async () => {
 })
 
 import { zip } from "lodash-es"
+import { MockInstance } from "vitest"
 import { default as WS } from "vitest-websocket-mock"
 
 import { BackMsg } from "@streamlit/protobuf"
@@ -1099,8 +1100,7 @@ describe("WebsocketConnection auth token handling", () => {
 
   let websocketSpy: (url: string, protocols?: string | string[]) => void
   let originalWebSocket: typeof WebSocket
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let pingServerSpy: any
+  let pingServerSpy: MockInstance
 
   class MockWebSocket {
     public url: string
@@ -1150,8 +1150,13 @@ describe("WebsocketConnection auth token handling", () => {
     // Prevent the internal ping loop from scheduling timers or websockets
     // for these auth-only tests.
     pingServerSpy = vi
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      .spyOn(WebsocketConnection.prototype as any, "pingServer")
+      .spyOn(
+        WebsocketConnection.prototype as unknown as Record<
+          string,
+          () => Promise<void>
+        >,
+        "pingServer"
+      )
       .mockResolvedValue(undefined)
   })
 

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -116,8 +116,7 @@ export interface Args {
 }
 
 interface MessageQueue {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [index: number]: any
+  [index: number]: ForwardMsg
 }
 
 const LOG = getLogger("WebsocketConnection")

--- a/frontend/connection/src/types.ts
+++ b/frontend/connection/src/types.ts
@@ -20,12 +20,13 @@
  * Returns a promise with the index of the URI that worked.
  */
 
-import { IAppPage } from "@streamlit/protobuf"
+import type { AxiosProgressEvent } from "axios"
+
+import { ForwardMsg, IAppPage } from "@streamlit/protobuf"
 
 import { ConnectionState } from "./ConnectionState"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export type OnMessage = (ForwardMsg: any) => void
+export type OnMessage = (ForwardMsg: ForwardMsg) => void
 
 export interface ErrorDetails {
   message: string
@@ -156,8 +157,7 @@ export interface StreamlitEndpoints {
     fileUploadUrl: string,
     file: File,
     sessionId: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    onUploadProgress?: (progressEvent: any) => void,
+    onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
     signal?: AbortSignal
   ): Promise<void>
 

--- a/frontend/lib/src/FileUploadClient.ts
+++ b/frontend/lib/src/FileUploadClient.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { AxiosProgressEvent } from "axios"
 import { isEqual } from "lodash-es"
 import { getLogger } from "loglevel"
 import { v4 as uuidv4 } from "uuid"
@@ -102,8 +103,7 @@ export class FileUploadClient {
     widget: WidgetInfo,
     fileUploadUrl: string,
     file: File,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    onUploadProgress?: (progressEvent: any) => void,
+    onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
     signal?: AbortSignal
   ): Promise<void> {
     this.offsetPendingRequestCount(widget.formId, 1)

--- a/frontend/lib/src/StreamlitEndpoints.ts
+++ b/frontend/lib/src/StreamlitEndpoints.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { AxiosProgressEvent } from "axios"
+
 import { IAppPage } from "@streamlit/protobuf"
 
 export type FileUploadClientConfig = {
@@ -120,8 +122,7 @@ export interface StreamlitEndpoints {
     fileUploadUrl: string,
     file: File,
     sessionId: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    onUploadProgress?: (progressEvent: any) => void,
+    onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
     signal?: AbortSignal
   ): Promise<void>
 

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -259,8 +259,7 @@ export class WidgetStateManager {
   // A dictionary that maps elementId -> element state keys -> element state values.
   // This is used to store frontend-only state for elements.
   // This state is not never sent to the server.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  private readonly elementStates = new Map<string, Map<string, any>>()
+  private readonly elementStates = new Map<string, Map<string, unknown>>()
 
   /**
    * Debouncing helpers for trigger widgets.
@@ -716,8 +715,7 @@ export class WidgetStateManager {
 
   public setJsonValue(
     widget: WidgetInfo,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    value: any,
+    value: unknown,
     source: Source,
     fragmentId: string | undefined
   ): void {
@@ -1018,9 +1016,11 @@ export class WidgetStateManager {
    * Get the element state value for the given element ID and key, if it exists.
    * This is a frontend-only state that is never sent to the server.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  public getElementState(elementId: string, key: string): any {
-    return this.elementStates.get(elementId)?.get(key)
+  public getElementState<T = unknown>(
+    elementId: string,
+    key: string
+  ): T | undefined {
+    return this.elementStates.get(elementId)?.get(key) as T | undefined
   }
 
   /**
@@ -1031,19 +1031,23 @@ export class WidgetStateManager {
    *
    * @param {string} elementId - The unique identifier of the element.
    * @param {string} key - The key to set
-   * @param {any} value - The value to set for the element's state.
+   * @param {unknown} value - The value to set for the element's state.
    * @returns {void}
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  public setElementState(elementId: string, key: string, value: any): void {
+  public setElementState(
+    elementId: string,
+    key: string,
+    value: unknown
+  ): void {
     if (!this.elementStates.has(elementId)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      this.elementStates.set(elementId, new Map<string, any>())
+      this.elementStates.set(elementId, new Map<string, unknown>())
     }
 
     // It's expected here that there is always an initialized map for an elementId
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    ;(this.elementStates.get(elementId) as Map<string, any>).set(key, value)
+    const stateMap = this.elementStates.get(elementId)
+    if (stateMap) {
+      stateMap.set(key, value)
+    }
   }
 
   /**

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
+import {
+  Block as BlockProto,
+  type IBlock,
+  streamlit,
+} from "@streamlit/protobuf"
 
 import { BlockNode, ElementNode } from "~lib/AppNode"
 import { ScriptRunState } from "~lib/ScriptRunState"
@@ -262,8 +266,7 @@ describe("getBorderBackwardsCompatible", () => {
 describe("shouldActivateScrollToBottom", () => {
   // Helper function to create a proper BlockNode instance for testing
   const createBlockNode = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parentDeltaBlock: any,
+    parentDeltaBlock: IBlock,
     hasChatMessageChild: boolean = false
   ): BlockNode => {
     const children = []

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/CustomTheme.tsx
@@ -20,8 +20,10 @@ import { getGray30, getGray70 } from "~lib/theme/getColors"
 import type { EmotionTheme } from "~lib/theme/types"
 import { convertRemToPx } from "~lib/theme/utils"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function applyStreamlitTheme(config: any, theme: EmotionTheme): any {
+export function applyStreamlitTheme(
+  config: object | undefined,
+  theme: EmotionTheme
+): object {
   // This theming config contains multiple hard coded spacing values.
   // The reason is that we currently only have rem values in our spacing
   // definitions and vega lite requires numerical (pixel) values.
@@ -140,8 +142,10 @@ export function applyStreamlitTheme(config: any, theme: EmotionTheme): any {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function applyThemeDefaults(config: any, theme: EmotionTheme): any {
+export function applyThemeDefaults(
+  config: object | undefined,
+  theme: EmotionTheme
+): object {
   const { colors, fontSizes, genericFonts } = theme
   const themeFonts = {
     labelFont: genericFonts.bodyFont,

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/arrowUtils.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/arrowUtils.ts
@@ -16,6 +16,7 @@
 
 import {
   DataFrameCellType,
+  DataType,
   getTimezone,
   isDatetimeType,
   isDateType,
@@ -77,10 +78,12 @@ export interface WrappedNamedDataset {
   data: Quiver
 }
 
+/** A single row of data for VegaLite visualization, mapping field names to cell values. */
+type VegaLiteDataRow = Record<string, DataType>
+
 export function getInlineData(
   quiverData: Quiver | null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): { [field: string]: any }[] | null {
+): VegaLiteDataRow[] | null {
   if (!quiverData || quiverData.dimensions.numDataRows === 0) {
     return null
   }
@@ -90,15 +93,13 @@ export function getInlineData(
 
 export function getDataArrays(
   datasets: WrappedNamedDataset[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): { [dataset: string]: any[] } | null {
+): Record<string, VegaLiteDataRow[]> | null {
   const datasetMapping = getDataSets(datasets)
   if (isNullOrUndefined(datasetMapping)) {
     return null
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const datasetArrays: { [dataset: string]: any[] } = {}
+  const datasetArrays: Record<string, VegaLiteDataRow[]> = {}
 
   for (const [name, dataset] of Object.entries(datasetMapping)) {
     datasetArrays[name] = getDataArray(dataset)
@@ -133,13 +134,12 @@ export function getDataSets(
  *
  * @param {Quiver} quiverData - The Quiver data object to extract data from.
  * @param {number} [startIndex=0] - The starting index for data extraction.
- * @returns {Array.<{ [field: string]: any }>} An array of data objects for visualization.
+ * @returns {VegaLiteDataRow[]} An array of data objects for visualization.
  */
 export function getDataArray(
   quiverData: Quiver,
   startIndex = 0
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): { [field: string]: any }[] {
+): VegaLiteDataRow[] {
   if (quiverData.dimensions.numDataRows === 0) {
     return []
   }
@@ -158,8 +158,7 @@ export function getDataArray(
       isDateType(firstIndexColumnType))
 
   for (let rowIndex = startIndex; rowIndex < numDataRows; rowIndex++) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const row: { [field: string]: any } = {}
+    const row: VegaLiteDataRow = {}
 
     if (hasSupportedIndex) {
       const { content: indexValue } = quiverData.getCell(rowIndex, 0)

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaElementPreprocessor.ts
@@ -25,6 +25,21 @@ import { resolveNamedColorsInSpec } from "./colorUtils"
 import { applyStreamlitTheme, applyThemeDefaults } from "./CustomTheme"
 
 /**
+ * A loosely-typed VegaLite spec after JSON parsing.
+ * We use Record<string, unknown> because we mutate the spec in place
+ * and access dynamic keys that don't align with the strict vega-lite TopLevelSpec type.
+ */
+type VegaLiteSpec = Record<string, unknown>
+
+/** A single VegaLite selection/binding parameter within spec.params. */
+interface VegaLiteParam {
+  select?:
+    | string
+    | { type?: string; encodings?: string[]; [key: string]: unknown }
+  [key: string]: unknown
+}
+
+/**
  * Fix bug where Vega Lite was vertically-cropping the x-axis in some cases.
  */
 const BOTTOM_PADDING = 20
@@ -38,18 +53,19 @@ const BOTTOM_PADDING = 20
  *
  * @param spec The Vega-Lite specification of the chart.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function prepareSpecForSelections(spec: any): void {
+function prepareSpecForSelections(spec: VegaLiteSpec): void {
   if ("params" in spec && "encoding" in spec) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    spec.params.forEach((param: any) => {
+    ;(spec.params as VegaLiteParam[]).forEach((param: VegaLiteParam) => {
       if (!("select" in param)) {
         // We are only interested in transforming select parameters.
         // Other parameters are skipped.
         return
       }
 
-      if (["interval", "point"].includes(param.select)) {
+      if (
+        typeof param.select === "string" &&
+        ["interval", "point"].includes(param.select)
+      ) {
         // The select object can be either a single string (short-hand) specifying
         // "interval" or "point" or an object that can contain additional
         // properties as defined here: https://vega.github.io/vega-lite/docs/selection.html
@@ -60,7 +76,11 @@ function prepareSpecForSelections(spec: any): void {
         }
       }
 
-      if (!("type" in param.select)) {
+      if (
+        typeof param.select !== "object" ||
+        param.select === null ||
+        !("type" in param.select)
+      ) {
         // The type property is required in the spec.
         // But we check anyways and skip all parameters that don't have it.
         return
@@ -75,7 +95,9 @@ function prepareSpecForSelections(spec: any): void {
         // the chart to the selection parameter. This is required so that points
         // selections are correctly resolved to a PointSelection and not an IndexSelection:
         // https://github.com/altair-viz/altair/issues/3285#issuecomment-1858860696
-        param.select.encodings = Object.keys(spec.encoding)
+        param.select.encodings = Object.keys(
+          spec.encoding as Record<string, unknown>
+        )
       }
     })
   }
@@ -90,8 +112,7 @@ const generateSpec = (
   theme: EmotionTheme,
   containerWidth: number,
   containerHeight?: number
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): any => {
+): VegaLiteSpec => {
   const spec = JSON.parse(inputSpec)
 
   // Normalize legacy "0"/non-positive sizing semantics: Historically, a
@@ -149,8 +170,7 @@ const generateSpec = (
     spec.width = containerWidth
 
     if ("vconcat" in spec) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      spec.vconcat.forEach((child: any) => {
+      ;(spec.vconcat as (VegaLiteSpec | null)[]).forEach(child => {
         // Skip non-object children (defensive check)
         if (child === null || typeof child !== "object") {
           return
@@ -257,7 +277,10 @@ export const useVegaElementPreprocessor = (
     id,
     formId,
     vegaLiteTheme,
-    spec,
+    // generateSpec returns a parsed object, but VegaLiteChartElement.spec
+    // is typed as string. Downstream consumers (useVegaEmbed) pass this
+    // directly to vega-embed which accepts both strings and objects.
+    spec: spec as unknown as string,
     selectionMode,
     data,
     datasets,

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
@@ -82,8 +82,7 @@ describe("useVegaEmbed hook", () => {
   let mockWidgetMgr: Mocked<WidgetStateManager>
   let mockVegaView: Mocked<VegaView>
   let mockEmbedReturn: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    vgSpec: any
+    vgSpec: Record<string, unknown>
     view: Mocked<VegaView>
     finalize: () => void
   }
@@ -115,8 +114,7 @@ describe("useVegaEmbed hook", () => {
     ;(useVegaLiteSelections as Mock).mockReturnValue({
       maybeConfigureSelections: vi
         .fn()
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        .mockImplementation((view: any) => view),
+        .mockImplementation((view: VegaView) => view),
       onFormCleared: vi.fn(),
     })
 
@@ -133,12 +131,16 @@ describe("useVegaEmbed hook", () => {
 
   it("creates a new Vega view via embed, finalizes existing view, inserts data, and returns a VegaView", async () => {
     const containerRef = { current: null }
-    const chartElement = {
+    const chartElement: VegaLiteChartElement = {
       id: "chartId",
       data: null,
       datasets: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+      spec: "",
+      useContainerWidth: false,
+      vegaLiteTheme: "",
+      selectionMode: [],
+      formId: "",
+    }
 
     // mount hook
     const { result } = renderHook(() =>
@@ -193,12 +195,16 @@ describe("useVegaEmbed hook", () => {
 
   it("finalizes old view if one exists before creating a new one", async () => {
     const containerRef = { current: null }
-    const chartElement = {
+    const chartElement: VegaLiteChartElement = {
       id: "chartId",
       data: null,
       datasets: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+      spec: "",
+      useContainerWidth: false,
+      vegaLiteTheme: "",
+      selectionMode: [],
+      formId: "",
+    }
 
     // mount hook
     const { result } = renderHook(() =>
@@ -233,12 +239,16 @@ describe("useVegaEmbed hook", () => {
   })
 
   it("throws an error if containerRef is missing", async () => {
-    const chartElement = {
+    const chartElement: VegaLiteChartElement = {
       id: "chartId",
       data: null,
       datasets: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+      spec: "",
+      useContainerWidth: false,
+      vegaLiteTheme: "",
+      selectionMode: [],
+      formId: "",
+    }
 
     const { result } = renderHook(() =>
       useVegaEmbed(chartElement, mockWidgetMgr)
@@ -252,12 +262,16 @@ describe("useVegaEmbed hook", () => {
   })
 
   it("finalizeView finalizes and clears references", async () => {
-    const chartElement = {
+    const chartElement: VegaLiteChartElement = {
       id: "chartId",
       data: null,
       datasets: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+      spec: "",
+      useContainerWidth: false,
+      vegaLiteTheme: "",
+      selectionMode: [],
+      formId: "",
+    }
     const { result } = renderHook(() =>
       useVegaEmbed(chartElement, mockWidgetMgr)
     )
@@ -289,12 +303,16 @@ describe("useVegaEmbed hook", () => {
   })
 
   it("updateView returns null if no vegaView is present", async () => {
-    const chartElement = {
+    const chartElement: VegaLiteChartElement = {
       id: "chartId",
       data: null,
       datasets: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+      spec: "",
+      useContainerWidth: false,
+      vegaLiteTheme: "",
+      selectionMode: [],
+      formId: "",
+    }
     const { result } = renderHook(() =>
       useVegaEmbed(chartElement, mockWidgetMgr)
     )
@@ -307,12 +325,16 @@ describe("useVegaEmbed hook", () => {
   })
 
   it("updateView updates data and datasets, then runs async", async () => {
-    const chartElement = {
+    const chartElement: VegaLiteChartElement = {
       id: "chartId",
       data: null,
       datasets: [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+      spec: "",
+      useContainerWidth: false,
+      vegaLiteTheme: "",
+      selectionMode: [],
+      formId: "",
+    }
 
     const { result } = renderHook(() =>
       useVegaEmbed(chartElement, mockWidgetMgr)
@@ -332,8 +354,7 @@ describe("useVegaEmbed hook", () => {
       dimensions: { dataRows: 5, dataCols: 2 },
       isEmpty: () => false,
       columnTypes: { index: ["int"], data: ["int"] },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+    } as unknown as Quiver
 
     await act(async () => {
       await result.current.updateView(quiverData, [])

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
@@ -18,7 +18,7 @@ import { RefObject, useCallback, useEffect, useRef, useState } from "react"
 
 import { getLogger } from "loglevel"
 import { truthy, View as VegaView } from "vega"
-import embed from "vega-embed"
+import embed, { VisualizationSpec } from "vega-embed"
 import { expressionInterpreter } from "vega-interpreter"
 
 import { useFormClearHelper } from "~lib/components/widgets/Form/FormClearHelper"
@@ -41,8 +41,7 @@ const LOG = getLogger("useVegaEmbed")
 interface UseVegaEmbedOutput {
   createView: (
     containerRef: RefObject<HTMLDivElement>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    spec: any
+    spec: VisualizationSpec | string
   ) => Promise<VegaView | null>
   updateView: (
     data: Quiver | null,
@@ -112,8 +111,7 @@ export function useVegaEmbed(
   const createView = useCallback(
     async (
       containerRef: RefObject<HTMLDivElement>,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      spec: any
+      spec: VisualizationSpec | string
     ): Promise<VegaView | null> => {
       if (containerRef.current === null) {
         throw new Error("Element missing.")

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.test.ts
@@ -49,8 +49,9 @@ describe("useVegaLiteSelections", () => {
 
     const debouncedMock = debounce as Mock
     // By default, the mocked debounce simply calls its callback immediately.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    debouncedMock.mockImplementation((_delay: number, fn: any) => fn)
+    debouncedMock.mockImplementation(
+      (_delay: number, fn: (...args: unknown[]) => void) => fn
+    )
   })
 
   afterEach(() => {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaLiteSelections.ts
@@ -36,8 +36,7 @@ const DEBOUNCE_TIME_MS = 150
  * in the Python code.
  */
 interface VegaLiteState {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  selection: Record<string, any>
+  selection: Record<string, unknown>
 }
 
 interface UseVegaLiteSelectionsOutput {
@@ -138,7 +137,10 @@ export const useVegaLiteSelections = (
       // Try to load the previous state of the chart from the element state.
       // This is useful to restore the selection state when the component is re-mounted
       // or when its put into fullscreen mode.
-      const viewState = widgetMgr.getElementState(chartId, "viewState")
+      const viewState = widgetMgr.getElementState<{
+        signals?: unknown
+        data?: unknown
+      }>(chartId, "viewState")
       if (notNullOrUndefined(viewState)) {
         try {
           return vegaView.setState(viewState)

--- a/frontend/lib/src/components/elements/Audio/Audio.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.tsx
@@ -50,7 +50,7 @@ function Audio({
 
     // Recover the state in case this component got unmounted
     // and mounted again for the same element.
-    const preventAutoplayState = elementMgr.getElementState(
+    const preventAutoplayState = elementMgr.getElementState<boolean>(
       element.id,
       "preventAutoplay"
     )

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -128,7 +128,10 @@ function getDefaultState(
     return EMPTY_STATE
   }
 
-  const initialFigureState = widgetMgr.getElementState(element.id, "selection")
+  const initialFigureState = widgetMgr.getElementState<DeckGlElementState>(
+    element.id,
+    "selection"
+  )
 
   return initialFigureState ?? EMPTY_STATE
 }
@@ -543,22 +546,20 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
   useEffect(() => {
     // If the ViewState on the server has changed, apply the diff to the current state
     if (!isEqual(deck.initialViewState, initialViewState)) {
-      const diff = Object.keys(deck.initialViewState).reduce(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        (diffArg, key): any => {
-          // @ts-expect-error
-          if (deck.initialViewState[key] === initialViewState?.[key]) {
-            return diffArg
-          }
+      const diff = Object.keys(deck.initialViewState).reduce<
+        Record<string, unknown>
+      >((diffArg, key): Record<string, unknown> => {
+        // @ts-expect-error
+        if (deck.initialViewState[key] === initialViewState?.[key]) {
+          return diffArg
+        }
 
-          return {
-            ...diffArg,
-            // @ts-expect-error
-            [key]: deck.initialViewState[key],
-          }
-        },
-        {}
-      )
+        return {
+          ...diffArg,
+          // @ts-expect-error
+          [key]: deck.initialViewState[key],
+        }
+      }, {})
 
       setViewState(existing => ({ ...existing, ...diff }))
       setInitialViewState(deck.initialViewState)

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -16,7 +16,11 @@
 
 import { fireEvent, screen } from "@testing-library/react"
 
-import { ImageList as ImageListProto, streamlit } from "@streamlit/protobuf"
+import {
+  type IImage,
+  ImageList as ImageListProto,
+  streamlit,
+} from "@streamlit/protobuf"
 
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { mockEndpoints } from "~lib/mocks/mocks"
@@ -335,8 +339,7 @@ describe("ImageList Element", () => {
       ])(
         "sets crossOrigin to $expected when $scenario",
         ({ expected, resourceCrossOriginMode, imgs }) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const props = getProps({ imgs: imgs as any })
+          const props = getProps({ imgs: imgs as IImage[] })
           renderWithContexts(<ImageList {...props} />, {
             libConfigContext: {
               resourceCrossOriginMode,
@@ -418,8 +421,7 @@ describe("ImageList Element", () => {
       ])(
         "does not set crossOrigin when $scenario",
         ({ resourceCrossOriginMode, imgs }) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const props = getProps({ imgs: imgs as any })
+          const props = getProps({ imgs: imgs as IImage[] })
           renderWithContexts(<ImageList {...props} />, {
             libConfigContext: {
               resourceCrossOriginMode,

--- a/frontend/lib/src/components/elements/LinkButton/styled-components.ts
+++ b/frontend/lib/src/components/elements/LinkButton/styled-components.ts
@@ -41,8 +41,7 @@ export interface BaseLinkButtonProps {
   href: string
   target: string
   rel: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onClick: (event: MouseEvent<HTMLAnchorElement>) => any
+  onClick: (event: MouseEvent<HTMLAnchorElement>) => void
 }
 
 type RequiredBaseLinkButtonProps = Required<BaseLinkButtonProps>

--- a/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.test.tsx
@@ -138,7 +138,9 @@ describe("PlotlyChart CustomTheme", () => {
       const layout = {}
       const result = layoutWithThemeDefaults(layout, theme)
 
-      expect(result.font.family).toBe(theme.genericFonts.bodyFont)
+      expect((result.font as Record<string, unknown>).family).toBe(
+        theme.genericFonts.bodyFont
+      )
       expect(result.paper_bgcolor).toBe(theme.colors.bgColor)
       expect(result.plot_bgcolor).toBe(theme.colors.secondaryBg)
     })
@@ -150,7 +152,7 @@ describe("PlotlyChart CustomTheme", () => {
       }
       const result = layoutWithThemeDefaults(layout, theme)
 
-      expect(result.font.family).toBe("Arial")
+      expect((result.font as Record<string, unknown>).family).toBe("Arial")
       expect(result.paper_bgcolor).toBe("red")
       // Should still apply missing ones
       expect(result.plot_bgcolor).toBe(theme.colors.secondaryBg)

--- a/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/CustomTheme.tsx
@@ -37,8 +37,7 @@ const LOG = getLogger("PlotlyChart:CustomTheme")
  * @param theme - Theme from useEmotionTheme()
  */
 export function applyStreamlitThemeTemplateLayout(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  layout: any,
+  layout: Record<string, unknown>,
   theme: EmotionTheme
 ): void {
   const { genericFonts, colors, fontSizes } = theme
@@ -400,17 +399,26 @@ export function replaceTemporaryColors(
  * spec.data, spec.layout.template.data, and spec.layout.template.layout
  * @param spec - spec
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function applyStreamlitTheme(spec: any, theme: EmotionTheme): void {
+export function applyStreamlitTheme(
+  spec: Record<string, unknown>,
+  theme: EmotionTheme
+): void {
   try {
-    applyStreamlitThemeTemplateLayout(spec.layout.template.layout, theme)
+    const layout = spec.layout as Record<string, unknown>
+    const template = layout.template as Record<string, unknown>
+    applyStreamlitThemeTemplateLayout(
+      template.layout as Record<string, unknown>,
+      theme
+    )
   } catch (e) {
     const err = ensureError(e)
     LOG.error(err)
   }
-  if ("title" in spec.layout) {
-    spec.layout.title = merge(spec.layout.title, {
-      text: `<b>${spec.layout.title.text}</b>`,
+  const layout = spec.layout as Record<string, unknown>
+  if ("title" in layout) {
+    const title = layout.title as Record<string, unknown>
+    layout.title = merge(title, {
+      text: `<b>${String(title.text)}</b>`,
     })
   }
 }
@@ -422,11 +430,9 @@ export function applyStreamlitTheme(spec: any, theme: EmotionTheme): void {
  * @returns modified spec.layout
  */
 export function layoutWithThemeDefaults(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  layout: any,
+  layout: Record<string, unknown>,
   theme: EmotionTheme
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): any {
+): Record<string, unknown> {
   const { colors, genericFonts } = theme
 
   const themeDefaults = {
@@ -443,7 +449,7 @@ export function layoutWithThemeDefaults(
     ...layout,
     font: {
       ...themeDefaults.font,
-      ...layout.font,
+      ...(layout.font as Record<string, unknown> | undefined),
     },
     paper_bgcolor: layout.paper_bgcolor || themeDefaults.paper_bgcolor,
     plot_bgcolor: layout.plot_bgcolor || themeDefaults.plot_bgcolor,

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { act, render, screen } from "@testing-library/react"
+import type { PlotParams } from "react-plotly.js"
 
 import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"
 
@@ -71,9 +72,8 @@ const createWidgetManager = (): WidgetStateManager => {
   return mgr
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getLastPlotProps(): any {
-  return MockPlot.mock.calls[MockPlot.mock.calls.length - 1][0]
+function getLastPlotProps(): PlotParams {
+  return MockPlot.mock.calls[MockPlot.mock.calls.length - 1][0] as PlotParams
 }
 
 // Static test data - extracted to module level per coding guidelines
@@ -106,8 +106,13 @@ describe("PlotlyChart Component", () => {
     }
 
     return render(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      <ElementFullscreenContext.Provider value={finalContext as any}>
+      <ElementFullscreenContext.Provider
+        value={
+          finalContext as React.ComponentProps<
+            typeof ElementFullscreenContext.Provider
+          >["value"]
+        }
+      >
         <PlotlyChart
           element={DEFAULT_ELEMENT}
           widgetMgr={widgetMgr}
@@ -254,11 +259,10 @@ describe("PlotlyChart Component", () => {
     renderComponent({ element })
 
     const lastCallProps = getLastPlotProps()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const mockEvent = {} as any
+    const mockEvent = {} as Readonly<Plotly.PlotSelectionEvent>
 
     act(() => {
-      lastCallProps.onSelected(mockEvent)
+      lastCallProps.onSelected?.(mockEvent)
     })
 
     expect(handleSelection).toHaveBeenCalledWith(
@@ -280,7 +284,7 @@ describe("PlotlyChart Component", () => {
     const lastCallProps = getLastPlotProps()
 
     act(() => {
-      lastCallProps.onDeselect()
+      lastCallProps.onDeselect?.()
     })
 
     // It should call sendEmptySelection
@@ -306,7 +310,7 @@ describe("PlotlyChart Component", () => {
     expect(lastCallProps.onDoubleClick).toBeDefined()
 
     act(() => {
-      lastCallProps.onDoubleClick()
+      lastCallProps.onDoubleClick?.()
     })
 
     // Double-click should reset selections by calling sendEmptySelection
@@ -331,10 +335,17 @@ describe("PlotlyChart Component", () => {
     renderComponent()
 
     const lastCallProps = getLastPlotProps()
-    const newFigure = { data: [], layout: { title: "New Title" } }
+    const newFigure = {
+      data: [],
+      layout: { title: "New Title" },
+      frames: null,
+    }
 
     act(() => {
-      lastCallProps.onUpdate(newFigure)
+      lastCallProps.onUpdate?.(
+        newFigure as Parameters<NonNullable<PlotParams["onUpdate"]>>[0],
+        document.createElement("div")
+      )
     })
 
     expect(widgetMgr.setElementState).toHaveBeenCalledWith(
@@ -350,10 +361,9 @@ describe("PlotlyChart Component", () => {
     const lastCallProps = getLastPlotProps()
     const config = lastCallProps.config
 
-    expect(config.modeBarButtonsToAdd).toBeDefined()
-    const fullscreenButton = config.modeBarButtonsToAdd.find(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (b: any) => b.name === "Fullscreen"
+    expect(config?.modeBarButtonsToAdd).toBeDefined()
+    const fullscreenButton = config?.modeBarButtonsToAdd?.find(
+      b => typeof b === "object" && b.name === "Fullscreen"
     )
     expect(fullscreenButton).toBeDefined()
   })
@@ -364,13 +374,17 @@ describe("PlotlyChart Component", () => {
 
     const lastCallProps = getLastPlotProps()
     const config = lastCallProps.config
-    const fullscreenButton = config.modeBarButtonsToAdd.find(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (b: any) => b.name === "Fullscreen"
+    const fullscreenButton = config?.modeBarButtonsToAdd?.find(
+      b => typeof b === "object" && b.name === "Fullscreen"
     )
 
     act(() => {
-      fullscreenButton.click()
+      if (typeof fullscreenButton === "object") {
+        fullscreenButton.click(
+          document.createElement("div") as unknown as Plotly.PlotlyHTMLElement,
+          new MouseEvent("click")
+        )
+      }
     })
 
     expect(expandMock).toHaveBeenCalled()

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -123,7 +123,10 @@ export function PlotlyChart({
     // If there was already a state with a figure using the same id,
     // use that to recover the state. This happens in some situations
     // where a component un-mounts and mounts again.
-    const initialFigureState = widgetMgr.getElementState(element.id, "figure")
+    const initialFigureState = widgetMgr.getElementState<PlotlyFigureType>(
+      element.id,
+      "figure"
+    )
     if (initialFigureState) {
       return initialFigureState
     }

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
@@ -156,8 +156,10 @@ describe("PlotlyChart utils", () => {
     })
 
     it("should handle an event with no points or selections", () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const event = { points: undefined, selections: undefined } as any
+      const event = {
+        points: undefined,
+        selections: undefined,
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -176,8 +178,7 @@ describe("PlotlyChart utils", () => {
             customdata: [10, null, { extraInfo: 7 }],
           },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -204,8 +205,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -224,8 +224,7 @@ describe("PlotlyChart utils", () => {
         selections: [
           { type: "path", xref: "x", yref: "y", path: "M4.0,8.0L4.0,7.8Z" },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -244,8 +243,7 @@ describe("PlotlyChart utils", () => {
         selections: [
           { type: "path", xref: "x", yref: "y", path: "M4.0,8.0L4.0,7.8Z" },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -273,8 +271,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -293,8 +290,7 @@ describe("PlotlyChart utils", () => {
       const event = {
         points: [],
         selections: [],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
       const widgetMgr = getWidgetMgr()
 
       vi.spyOn(widgetMgr, "setStringValue")
@@ -332,8 +328,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
 
       const widgetMgr = getWidgetMgr()
 
@@ -375,8 +370,7 @@ describe("PlotlyChart utils", () => {
             y1: "1",
           },
         ],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as Plotly.PlotSelectionEvent
 
       handleSelection(
         lassoEventAndBoxEvent,

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.ts
@@ -39,14 +39,52 @@ interface PlotlySelection extends SelectionRange {
   yref: string
 }
 
+/**
+ * A selection shape from Plotly's selection event.
+ * Can be either a box (rect) or lasso (path) selection.
+ * Uses Record to allow passing to parseBoxSelection.
+ */
+interface PlotlySelectionShape extends Record<string, unknown> {
+  type: string
+  xref: string
+  yref: string
+  path?: string
+}
+
+/**
+ * Extended point data from Plotly selection events.
+ * Plotly's type definitions are incomplete, so we extend PlotDatum
+ * with additional properties that exist at runtime.
+ */
+interface PlotlySelectionPoint extends Plotly.PlotDatum {
+  data: Plotly.PlotData & { legendgroup?: string }
+  fullData?: unknown
+  pointIndices?: number[]
+  legendgroup?: string
+}
+
+/**
+ * Extended point data for hierarchical chart click events (treemap/sunburst).
+ * These charts include additional properties not in the standard PlotDatum.
+ */
+interface PlotlyHierarchicalPoint extends Plotly.PlotDatum {
+  id?: string
+  parent?: string
+  label?: string
+  value?: number
+  currentPath?: string
+  percentRoot?: number
+  percentEntry?: number
+  percentParent?: number
+}
+
 // This is the state that is sent to the backend
 // This needs to be the same structure that is also defined
 // in the Python code. Uses snake case to be compatible with the
 // Python naming conventions.
 interface PlotlyWidgetState {
   selection: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    points: Array<any>
+    points: Array<Record<string, unknown>>
     point_indices: number[]
     box: PlotlySelection[]
     lasso: PlotlySelection[]
@@ -117,8 +155,9 @@ export function parseLassoPath(pathData: string): SelectionRange {
  * @param {Object} selection - The box selection object to be parsed.
  * @returns {SelectionRange} An object containing two arrays: `x` for all x coordinates and `y` for all y coordinates.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function parseBoxSelection(selection: any): SelectionRange {
+export function parseBoxSelection(
+  selection: Record<string, unknown>
+): SelectionRange {
   const hasRequiredFields =
     "x0" in selection &&
     "x1" in selection &&
@@ -129,8 +168,8 @@ export function parseBoxSelection(selection: any): SelectionRange {
     return { x: [], y: [] }
   }
 
-  const x: number[] = [selection.x0, selection.x1]
-  const y: number[] = [selection.y0, selection.y1]
+  const x: number[] = [selection.x0 as number, selection.x1 as number]
+  const y: number[] = [selection.y0 as number, selection.y1 as number]
   return { x, y }
 }
 
@@ -190,16 +229,14 @@ export function handleSelection(
   const selectedPointIndices = new Set<number>()
   const selectedBoxes: PlotlySelection[] = []
   const selectedLassos: PlotlySelection[] = []
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const selectedPoints: Array<any> = []
+  const selectedPoints: Array<Record<string, unknown>> = []
 
   // event.selections doesn't show up in the PlotSelectionEvent
   // @ts-expect-error
   const { selections, points } = event
 
   if (points) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    points.forEach(function (point: any) {
+    points.forEach(function (point: PlotlySelectionPoint) {
       selectedPoints.push({
         ...point,
         legendgroup: point.data.legendgroup || undefined,
@@ -225,8 +262,7 @@ export function handleSelection(
   }
 
   if (selections) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    selections.forEach((selection: any) => {
+    selections.forEach((selection: PlotlySelectionShape) => {
       // box selection
       if (selection.type === "rect") {
         const xAndy = parseBoxSelection(selection)
@@ -239,7 +275,7 @@ export function handleSelection(
         selectedBoxes.push(returnSelection)
       }
       // lasso selection
-      if (selection.type === "path") {
+      if (selection.type === "path" && selection.path) {
         const xAndy = parseLassoPath(selection.path)
         const returnSelection: PlotlySelection = {
           xref: selection.xref,
@@ -253,9 +289,8 @@ export function handleSelection(
   }
 
   selectionState.selection.point_indices = Array.from(selectedPointIndices)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  selectionState.selection.points = selectedPoints.map((point: any) =>
-    keysToSnakeCase(point)
+  selectionState.selection.points = selectedPoints.map(
+    (point: Record<string, unknown>) => keysToSnakeCase(point)
   )
 
   selectionState.selection.box = selectedBoxes
@@ -341,8 +376,7 @@ export function handleClickEvent(
     return
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Plotly event types are incomplete
-  const point = event.points[0] as any
+  const point = event.points[0] as PlotlyHierarchicalPoint
 
   // Check if this is a hierarchical chart click (treemap/sunburst)
   // These charts have 'id' and 'parent' properties in their click events

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -46,8 +46,9 @@ export interface TabProps extends BlockPropsWithoutWidth {
   widgetsDisabled: boolean
   node: BlockNode
   isStale: boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  renderTabContent: (childProps: any) => ReactElement
+  renderTabContent: (
+    childProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
+  ) => ReactElement
   width: React.CSSProperties["width"]
   flex: React.CSSProperties["flex"]
   fragmentId?: string

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -56,7 +56,7 @@ function Video({
 
     // Recover the state in case this component got unmounted
     // and mounted again for the same element.
-    const preventAutoplayState = elementMgr.getElementState(
+    const preventAutoplayState = elementMgr.getElementState<boolean>(
       element.id,
       "preventAutoplay"
     )

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -51,8 +51,7 @@ export enum BaseButtonSize {
 export interface BaseButtonProps {
   kind: BaseButtonKind
   size?: BaseButtonSize
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => any
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void
   disabled?: boolean
   // If true, the button should take up container's full width
   containerWidth?: boolean

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -70,8 +70,7 @@ export interface BaseColorPickerProps {
   showValue?: boolean
   label: string
   labelVisibility?: LabelVisibilityOptions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onChange: (value: string) => any
+  onChange: (value: string) => void
   help?: string
 }
 

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -45,8 +45,7 @@ export interface Props {
   value: string | null
   onChange: (value: string | null) => void
   disabled: boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  options: any[]
+  options: string[]
   label?: string | null
   labelVisibility?: LabelVisibilityOptions
   help?: string
@@ -123,7 +122,7 @@ const Selectbox: FC<Props> = ({
     valueToUiSingle,
     createFilterOptions,
   } = useSelectCommon({
-    options: opts as string[],
+    options: opts,
     isMulti: false,
     acceptNewOptions,
     placeholderInput: placeholder,

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -81,121 +81,126 @@ function FixedSizeListItem(props: FixedSizeListItemProps): ReactElement {
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-const VirtualDropdown = forwardRef<any, any>((props, ref) => {
-  const theme = useEmotionTheme()
-  const scrollbarGutterSize = useScrollbarGutterSize()
-  const { innerHeight: windowHeight } = useWindowDimensionsContext()
+interface VirtualDropdownProps {
+  children?: React.ReactNode
+}
 
-  // TODO: Update to match React best practices
-  // eslint-disable-next-line @eslint-react/no-children-to-array
-  const children = Children.toArray(props.children) as ReactElement[]
+const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
+  (props, ref) => {
+    const theme = useEmotionTheme()
+    const scrollbarGutterSize = useScrollbarGutterSize()
+    const { innerHeight: windowHeight } = useWindowDimensionsContext()
 
-  if (!children[0]?.props.item) {
-    const childrenProps = children[0] ? children[0].props : {}
-    return (
-      <StyledList
-        $style={{
-          height: theme.sizes.emptyDropdownHeight,
-          paddingLeft: theme.spacing.none,
-          paddingRight: theme.spacing.none,
-          paddingTop: theme.spacing.none,
-          paddingBottom: theme.spacing.none,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          // Somehow this adds an additional shadow, even though we already have
-          // one on the popover, so we need to remove it here.
-          boxShadow: "none",
-          overflow: "hidden",
-        }}
-        ref={ref}
-        data-testid="stSelectboxVirtualDropdownEmpty"
-      >
-        <StyledEmptyState
+    // TODO: Update to match React best practices
+    // eslint-disable-next-line @eslint-react/no-children-to-array
+    const children = Children.toArray(props.children) as ReactElement[]
+
+    if (!children[0]?.props.item) {
+      const childrenProps = children[0] ? children[0].props : {}
+      return (
+        <StyledList
           $style={{
+            height: theme.sizes.emptyDropdownHeight,
             paddingLeft: theme.spacing.none,
             paddingRight: theme.spacing.none,
             paddingTop: theme.spacing.none,
             paddingBottom: theme.spacing.none,
-            color: theme.colors.fadedText60,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            // Somehow this adds an additional shadow, even though we already have
+            // one on the popover, so we need to remove it here.
+            boxShadow: "none",
+            overflow: "hidden",
           }}
-          {...childrenProps}
-        />
+          ref={ref}
+          data-testid="stSelectboxVirtualDropdownEmpty"
+        >
+          <StyledEmptyState
+            $style={{
+              paddingLeft: theme.spacing.none,
+              paddingRight: theme.spacing.none,
+              paddingTop: theme.spacing.none,
+              paddingBottom: theme.spacing.none,
+              color: theme.colors.fadedText60,
+            }}
+            {...childrenProps}
+          />
+        </StyledList>
+      )
+    }
+
+    const maxHeight = Math.min(
+      convertRemToPx(theme.sizes.maxDropdownHeight),
+      windowHeight * 0.7 // 70vh constraint on popover body
+    )
+    const contentHeight =
+      children.length * convertRemToPx(theme.sizes.dropdownItemHeight)
+    const height = Math.min(maxHeight, contentHeight)
+
+    // Check if scrollbar will be visible (content exceeds max height)
+    const hasScrollbar = contentHeight > maxHeight
+
+    // Only account for scrollbar gutter when scrollbar is actually visible
+    // and we're in classic scrollbar mode (gutter > 0)
+    const effectiveGutterSize = hasScrollbar ? scrollbarGutterSize : 0
+
+    // Find the highlighted (selected) item so we can scroll to it on open
+    const itemSize = convertRemToPx(theme.sizes.dropdownItemHeight)
+    const highlightedIndex = children.findIndex(
+      child =>
+        (child.props as OptionListProps & { $isHighlighted?: boolean })
+          .$isHighlighted
+    )
+    // Center the highlighted item in view; stay at top if first or none highlighted
+    const initialScrollOffset =
+      highlightedIndex > 0
+        ? Math.max(0, highlightedIndex * itemSize - height / 2 + itemSize / 2)
+        : 0
+
+    return (
+      <StyledList
+        ref={ref}
+        $style={{
+          // Padding to inset items from the edges (no right padding so scrollbar sits at edge)
+          paddingTop: theme.spacing.none,
+          paddingBottom: theme.spacing.none,
+          paddingLeft: theme.spacing.none,
+          paddingRight: theme.spacing.none,
+          // Somehow this adds an additional shadow, even though we already have
+          // one on the popover, so we need to remove it here.
+          boxShadow: "none",
+        }}
+        data-testid="stSelectboxVirtualDropdown"
+      >
+        <FixedSizeList
+          width="100%"
+          height={height}
+          itemCount={children.length}
+          itemData={children}
+          itemKey={(index: number, data: { props: OptionListProps }[]) => {
+            const { id, value } = data[index].props.item
+
+            // For all current use cases, id should always be defined, but
+            // we also allow the value to be used as a fallback.
+            return id ?? value
+          }}
+          itemSize={itemSize}
+          initialScrollOffset={initialScrollOffset}
+          style={
+            {
+              // Pass scrollbar gutter size to children via CSS custom property
+              // so they can adjust their margins when scrollbar is visible in classic mode.
+              "--scrollbar-gutter-size": `${effectiveGutterSize}px`,
+            } as React.CSSProperties
+          }
+        >
+          {FixedSizeListItem}
+        </FixedSizeList>
       </StyledList>
     )
   }
-
-  const maxHeight = Math.min(
-    convertRemToPx(theme.sizes.maxDropdownHeight),
-    windowHeight * 0.7 // 70vh constraint on popover body
-  )
-  const contentHeight =
-    children.length * convertRemToPx(theme.sizes.dropdownItemHeight)
-  const height = Math.min(maxHeight, contentHeight)
-
-  // Check if scrollbar will be visible (content exceeds max height)
-  const hasScrollbar = contentHeight > maxHeight
-
-  // Only account for scrollbar gutter when scrollbar is actually visible
-  // and we're in classic scrollbar mode (gutter > 0)
-  const effectiveGutterSize = hasScrollbar ? scrollbarGutterSize : 0
-
-  // Find the highlighted (selected) item so we can scroll to it on open
-  const itemSize = convertRemToPx(theme.sizes.dropdownItemHeight)
-  const highlightedIndex = children.findIndex(
-    child =>
-      (child.props as OptionListProps & { $isHighlighted?: boolean })
-        .$isHighlighted
-  )
-  // Center the highlighted item in view; stay at top if first or none highlighted
-  const initialScrollOffset =
-    highlightedIndex > 0
-      ? Math.max(0, highlightedIndex * itemSize - height / 2 + itemSize / 2)
-      : 0
-
-  return (
-    <StyledList
-      ref={ref}
-      $style={{
-        // Padding to inset items from the edges (no right padding so scrollbar sits at edge)
-        paddingTop: theme.spacing.none,
-        paddingBottom: theme.spacing.none,
-        paddingLeft: theme.spacing.none,
-        paddingRight: theme.spacing.none,
-        // Somehow this adds an additional shadow, even though we already have
-        // one on the popover, so we need to remove it here.
-        boxShadow: "none",
-      }}
-      data-testid="stSelectboxVirtualDropdown"
-    >
-      <FixedSizeList
-        width="100%"
-        height={height}
-        itemCount={children.length}
-        itemData={children}
-        itemKey={(index: number, data: { props: OptionListProps }[]) => {
-          const { id, value } = data[index].props.item
-
-          // For all current use cases, id should always be defined, but
-          // we also allow the value to be used as a fallback.
-          return id ?? value
-        }}
-        itemSize={itemSize}
-        initialScrollOffset={initialScrollOffset}
-        style={
-          {
-            // Pass scrollbar gutter size to children via CSS custom property
-            // so they can adjust their margins when scrollbar is visible in classic mode.
-            "--scrollbar-gutter-size": `${effectiveGutterSize}px`,
-          } as React.CSSProperties
-        }
-      >
-        {FixedSizeListItem}
-      </FixedSizeList>
-    </StyledList>
-  )
-})
+)
 
 VirtualDropdown.displayName = "VirtualDropdown"
 

--- a/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
+++ b/frontend/lib/src/components/shared/ProgressBar/ProgressBar.tsx
@@ -17,11 +17,11 @@
 import { ReactElement } from "react"
 
 import { mergeOverrides } from "baseui"
-import { Overrides } from "baseui/overrides"
 import {
   type ProgressBarOverrides,
   ProgressBar as UIProgressBar,
 } from "baseui/progress-bar"
+import { type Theme } from "baseui/styles"
 
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 
@@ -32,8 +32,7 @@ export enum Size {
 
 interface ProgressBarProps {
   value: number
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  overrides?: Overrides<any>
+  overrides?: ProgressBarOverrides
   size?: Size
 }
 
@@ -50,7 +49,7 @@ function ProgressBar({
     lg: theme.spacing.xl,
     xl: theme.spacing.twoXL,
   }
-  const defaultOverrides: Overrides<ProgressBarOverrides> = {
+  const defaultOverrides: ProgressBarOverrides = {
     BarContainer: {
       style: {
         marginTop: theme.spacing.none,
@@ -60,8 +59,7 @@ function ProgressBar({
       },
     },
     Bar: {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      style: ({ $theme }: { $theme: any }) => ({
+      style: ({ $theme }: { $theme: Theme }) => ({
         marginTop: theme.spacing.none,
         marginBottom: theme.spacing.none,
         marginRight: theme.spacing.none,

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -31,12 +31,9 @@ export interface Props {
   disabled: boolean
   horizontal: boolean
   value: number | null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onChange: (selectedIndex: number) => any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  options: any[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  captions: any[]
+  onChange: (selectedIndex: number) => void
+  options: string[]
+  captions: string[]
   label?: string
   labelVisibility?: LabelVisibilityOptions
   help?: string

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -18,6 +18,7 @@ import { ReactElement } from "react"
 
 import { cleanup, screen, within } from "@testing-library/react"
 import { transparentize } from "color2k"
+import type { Element } from "hast"
 import ReactMarkdown from "react-markdown"
 
 import IsDialogContext from "~lib/components/core/IsDialogContext"
@@ -1184,8 +1185,7 @@ describe("CustomPreTag", () => {
 })
 
 describe("CustomMediaTag", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mockNode = { tagName: "img" } as any
+  const mockNode = { tagName: "img" } as Element
   const mockProps = {
     src: "test-image.jpg",
     alt: "Test image",
@@ -1260,8 +1260,7 @@ describe("CustomMediaTag", () => {
     ])(
       "should render $tagName element with crossOrigin='$expected' when $scenario",
       ({ tagName, expected, resourceCrossOriginMode, src, extraProps }) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const node = { tagName } as any
+        const node = { tagName } as Element
         const props = { src, ...extraProps }
 
         const { container } = renderWithContexts(
@@ -1326,8 +1325,7 @@ describe("CustomMediaTag", () => {
     ])(
       "should render $tagName element without crossOrigin when $scenario",
       ({ tagName, resourceCrossOriginMode, src, extraProps }) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const node = { tagName } as any
+        const node = { tagName } as Element
         const props = { src, ...extraProps }
 
         const { container } = renderWithContexts(

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -34,8 +34,7 @@ function convertRemToEm(s: string): string {
   return s.replace(/rem$/, "em")
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function sharedMarkdownStyle(theme: Theme): any {
+function sharedMarkdownStyle(theme: Theme): Record<string, unknown> {
   return {
     a: {
       color: theme.colors.link,
@@ -91,8 +90,7 @@ function getMarkdownHeadingDefinitions(
   theme: Theme,
   isInDialog: boolean,
   isCaption: boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): any {
+): Record<string, unknown> {
   return {
     "h1, h2, h3, h4, h5, h6": {
       fontFamily: theme.genericFonts.headingFont,
@@ -418,8 +416,7 @@ export const StyledHeadingWithActionElements = styled.div(({ theme }) => ({
   // Show link icon when hovering or when focus is within the heading container.
   // We use opacity instead of visibility so the link remains in the tab order.
   "&:hover, &:focus-within": {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    [StyledLinkIcon as any]: {
+    [StyledLinkIcon as unknown as string]: {
       opacity: 1,
       pointerEvents: "auto",
     },

--- a/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
+++ b/frontend/lib/src/components/shared/Toolbar/Toolbar.tsx
@@ -16,7 +16,6 @@
 
 import { ReactElement } from "react"
 
-import { StyledComponent } from "@emotion/styled"
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
 import { Fullscreen, FullscreenExit } from "@emotion-icons/material-outlined"
 
@@ -28,7 +27,11 @@ import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/Streamli
 import Tooltip, { Placement } from "~lib/components/shared/Tooltip/Tooltip"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 
-import { StyledToolbar, StyledToolbarWrapper } from "./styled-components"
+import {
+  StyledToolbar,
+  StyledToolbarWrapper,
+  type StyledToolbarWrapperProps,
+} from "./styled-components"
 
 export interface ToolbarActionProps {
   label: string
@@ -91,8 +94,7 @@ export interface ToolbarProps {
   onCollapse?: () => void
   isFullScreen?: boolean
   locked?: boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  target?: StyledComponent<any, any, any>
+  target?: StyledToolbarWrapperProps["target"]
   disableFullscreenMode?: boolean
 }
 

--- a/frontend/lib/src/components/shared/Toolbar/styled-components.ts
+++ b/frontend/lib/src/components/shared/Toolbar/styled-components.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import styled, { StyledComponent } from "@emotion/styled"
+import { ComponentSelector } from "@emotion/serialize"
+import styled from "@emotion/styled"
 
 import { hasLightBackgroundColor } from "~lib/theme/getColors"
 
 export const TOP_DISTANCE = "-2.65rem"
 
-interface StyledToolbarWrapperProps {
+/** A styled component usable as a CSS selector in template literals. */
+type StyledComponentSelector = ComponentSelector & { toString(): string }
+
+export interface StyledToolbarWrapperProps {
   locked?: boolean
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  target?: StyledComponent<any, any, any>
+  target?: StyledComponentSelector
 }
 
 export const StyledToolbarWrapper = styled.div<StyledToolbarWrapperProps>(

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen, waitFor } from "@testing-library/react"
+import { RenderResult, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { BaseProvider, LightTheme } from "baseui"
 
@@ -32,8 +32,7 @@ const getProps = (
 })
 
 // Wrap in BaseProvider to avoid warnings
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-const renderTooltip = (props: Partial<TooltipProps> = {}): any => {
+const renderTooltip = (props: Partial<TooltipProps> = {}): RenderResult => {
   return render(
     <BaseProvider theme={LightTheme}>
       <Tooltip {...getProps(props)} />

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
@@ -119,8 +119,8 @@ describe("TooltipIcon element", () => {
         theme={mockTheme.emotion}
         baseuiTheme={mockTheme.basewebTheme}
       >
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Intentionally bypass types to validate runtime safety. */}
-        <TooltipIcon content="Help text" ariaLabel={"" as any} />
+        {/* Passing an empty string to validate runtime safety for ariaLabel fallback. */}
+        <TooltipIcon content="Help text" ariaLabel="" />
       </ThemeProvider>
     )
 

--- a/frontend/lib/src/components/shared/WindowDimensions/Provider.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/Provider.test.tsx
@@ -28,8 +28,7 @@ describe("WindowDimensionsProvider", () => {
   it("should provide the width and height of the window and take into account the theme padding", () => {
     vi.spyOn(window, "getComputedStyle").mockReturnValue({
       fontSize: "16px",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any)
+    } as CSSStyleDeclaration)
 
     const MyComponent: FC = () => {
       const dimensions = useWindowDimensionsContext()

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -39,13 +39,12 @@ const expectHighlightStyle = (
   element: HTMLElement,
   should_exist = true
 ): void => {
-  // eslint-disable-next-line vitest/valid-expect, @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let expectCheck: any = expect(element)
-  if (!should_exist) {
-    expectCheck = expect.not
+  if (should_exist) {
+    // Active/selected buttons have the primary color (rgb(255, 75, 75))
+    expect(element).toHaveStyle("color: rgb(255, 75, 75);")
+  } else {
+    expect(element).not.toHaveStyle("color: rgb(255, 75, 75);")
   }
-  // Active/selected buttons have the primary color (rgb(255, 75, 75))
-  expectCheck.toHaveStyle("color: rgb(255, 75, 75);")
 }
 
 const getButtonGroupButtons = (): HTMLElement[] => {

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -25,6 +25,7 @@ import {
 } from "react"
 
 import { X } from "@emotion-icons/open-iconic"
+import type { AxiosProgressEvent } from "axios"
 import { isEqual } from "lodash-es"
 import { getLogger } from "loglevel"
 import { flushSync } from "react-dom"
@@ -364,13 +365,15 @@ const CameraInput = ({
    * Callback for file upload progress. Updates a single file's local progress state.
    */
   const onUploadProgress = useCallback(
-    (event: ProgressEvent, fileId: number): void => {
+    (event: AxiosProgressEvent, fileId: number): void => {
       const file = getFile(fileId)
       if (isNullOrUndefined(file) || file.status.type !== "uploading") {
         return
       }
 
-      const newProgress = Math.round((event.loaded * 100) / event.total)
+      const newProgress = event.total
+        ? Math.round((event.loaded * 100) / event.total)
+        : 0
       if (file.status.progress === newProgress) {
         return
       }

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInputButton.tsx
@@ -26,8 +26,7 @@ import {
 } from "./styled-components"
 
 export interface CameraInputButtonProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => any
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void
   disabled?: boolean
   progress?: number | null
   children?: ReactNode

--- a/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
@@ -21,8 +21,7 @@ import styled, { CSSObject } from "@emotion/styled"
 import type { EmotionTheme } from "~lib/theme/types"
 
 interface CameraInputButtonProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => any
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void
   disabled?: boolean
   children: ReactNode
   progress?: number | null

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -33,6 +33,7 @@ import {
   Close,
   ErrorOutline,
 } from "@emotion-icons/material-rounded"
+import type { AxiosProgressEvent } from "axios"
 import { Textarea as UITextArea } from "baseui/textarea"
 import { useDropzone } from "react-dropzone"
 
@@ -436,14 +437,16 @@ function ChatInput({
       },
       uploadClient,
       element,
-      onUploadProgress: (e: ProgressEvent, fileId: number) => {
+      onUploadProgress: (e: AxiosProgressEvent, fileId: number) => {
         setFiles(prevFiles => {
           const file = getFile(fileId, prevFiles)
           if (isNullOrUndefined(file) || file.status.type !== "uploading") {
             return prevFiles
           }
 
-          const newProgress = Math.round((e.loaded * 100) / e.total)
+          const newProgress = e.total
+            ? Math.round((e.loaded * 100) / e.total)
+            : 0
           if (file.status.progress === newProgress) {
             return prevFiles
           }

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/ChatFileUploadDropzone.tsx
@@ -16,6 +16,8 @@
 
 import { memo } from "react"
 
+import type { DropzoneInputProps, DropzoneRootProps } from "react-dropzone"
+
 import { AcceptFileValue } from "~lib/util/utils"
 
 import {
@@ -28,10 +30,8 @@ import {
 } from "./styled-components"
 
 interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  getRootProps: any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  getInputProps: any
+  getRootProps: <T extends DropzoneRootProps>(props?: T) => T
+  getInputProps: <T extends DropzoneInputProps>(props?: T) => T
   acceptFile: AcceptFileValue
 }
 

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createFileUploadHandler.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createFileUploadHandler.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { AxiosProgressEvent } from "axios"
+
 import { IFileURLs } from "@streamlit/protobuf"
 
 import { UploadFileInfo } from "~lib/components/shared/UploadedFile/UploadFileInfo"
@@ -26,7 +28,7 @@ interface CreateUploadFileParams {
   updateFile: (id: number, fileInfo: UploadFileInfo) => void
   uploadClient: FileUploadClient
   element: WidgetInfo
-  onUploadProgress: (e: ProgressEvent, id: number) => void
+  onUploadProgress: (e: AxiosProgressEvent, id: number) => void
   onUploadComplete: (id: number, fileURLs: IFileURLs) => void
 }
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -704,8 +704,7 @@ describe("ComponentInstance", () => {
           source: iframe.contentWindow,
         })
       )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const widgetMgr = (WidgetStateManager as any).mock.instances[0]
+      const widgetMgr = vi.mocked(WidgetStateManager).mock.instances[0]
       expect(widgetMgr.setJsonValue).toHaveBeenCalledWith(
         element,
         jsonValue,
@@ -768,8 +767,7 @@ describe("ComponentInstance", () => {
           source: iframe.contentWindow,
         })
       )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const widgetMgr = (WidgetStateManager as any).mock.instances[0]
+      const widgetMgr = vi.mocked(WidgetStateManager).mock.instances[0]
       expect(widgetMgr.setBytesValue).toHaveBeenCalledWith(
         element,
         bytesValue,
@@ -818,8 +816,7 @@ describe("ComponentInstance", () => {
           source: iframe.contentWindow,
         })
       )
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const widgetMgr = (WidgetStateManager as any).mock.instances[0]
+      const widgetMgr = vi.mocked(WidgetStateManager).mock.instances[0]
       expect(widgetMgr.setJsonValue).not.toHaveBeenCalled()
 
       expect(logWarnSpy).toHaveBeenCalledWith(
@@ -917,8 +914,7 @@ describe("ComponentInstance", () => {
             source: iframe.contentWindow,
           })
         )
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        const widgetMgr = (WidgetStateManager as any).mock.instances[0]
+        const widgetMgr = vi.mocked(WidgetStateManager).mock.instances[0]
         expect(widgetMgr.setJsonValue).not.toHaveBeenCalled()
 
         expect(logWarnSpy).toHaveBeenCalledWith(
@@ -929,10 +925,8 @@ describe("ComponentInstance", () => {
   })
 
   function renderMsg(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    args: { [name: string]: any },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    dataframes: any[],
+    args: Record<string, unknown>,
+    dataframes: unknown[],
     disabled = false,
     theme = {
       ...toExportedTheme(mockTheme.emotion),
@@ -940,8 +934,7 @@ describe("ComponentInstance", () => {
       font: mockTheme.emotion.genericFonts.bodyFont,
       base: bgColorToBaseString(mockTheme.emotion.colors.bgColor),
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  ): any {
+  ): Record<string, unknown> {
     return forwardMsg(StreamlitMessageType.RENDER, {
       args,
       dfs: dataframes,
@@ -950,15 +943,16 @@ describe("ComponentInstance", () => {
     })
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  function forwardMsg(type: StreamlitMessageType, data: any): any {
+  function forwardMsg(
+    type: StreamlitMessageType,
+    data: Record<string, unknown>
+  ): Record<string, unknown> {
     return { type, ...data }
   }
 
   /** Create a ComponentInstance.props.element prop with the given args. */
   function createElementProp(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    jsonArgs: { [name: string]: any } = {},
+    jsonArgs: Record<string, unknown> = {},
     specialArgs: SpecialArg[] = [],
     overrides: Partial<IComponentInstanceProto> = {}
   ): ComponentInstanceProto {

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.tsx
@@ -232,9 +232,10 @@ function ComponentInstance(props: Props): ReactElement {
   // custom components that define a height property, e.g. in Python
   // my_custom_component(height=100). undefined means no explicit height
   // was specified, but will be set to the default height of 0.
-  const [frameHeight, setFrameHeight] = useState<number | undefined>(() =>
-    isNaN(parsedNewArgs.height) ? undefined : parsedNewArgs.height
-  )
+  const [frameHeight, setFrameHeight] = useState<number | undefined>(() => {
+    const height = parsedNewArgs.height as number | undefined
+    return height === undefined || isNaN(height) ? undefined : height
+  })
 
   // Use a ref for the ready-state so that we can differentiate between sending renderMessages due to props-changes
   // and when the componentReady callback is called (for the first time)

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.test.ts
@@ -32,10 +32,8 @@ describe("ComponentRegistry", () => {
     const { onMessageEvent } = registry
 
     // Create some mocks
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const msgSource1: any = {}
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const msgSource2: any = {}
+    const msgSource1 = {} as MessageEventSource
+    const msgSource2 = {} as MessageEventSource
     const msgListener1 = vi.fn()
     const msgListener2 = vi.fn()
 

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentRegistry.ts
@@ -18,12 +18,12 @@ import { getLogger } from "loglevel"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { isNullOrUndefined } from "~lib/util/utils"
 
+import type { IframeMessage } from "./componentUtils"
 import { ComponentMessageType } from "./enums"
 
 type ComponentMessageListener = (
   type: ComponentMessageType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  data: any
+  data: IframeMessage
 ) => void
 
 const LOG = getLogger("ComponentRegistry")

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.test.ts
@@ -139,12 +139,11 @@ describe("test componentUtils", () => {
     it("should send message to iframe", () => {
       const handleAction = vi.fn()
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const mockIframe: any = {
+      const mockIframe = {
         contentWindow: {
           postMessage: handleAction,
         },
-      }
+      } as unknown as HTMLIFrameElement
 
       const args = { foo: "bar" }
       const dataframeArgs = [{ key: "foo", value: "bar" }]
@@ -177,8 +176,7 @@ describe("test componentUtils", () => {
     it("should not send message when iframe is undefined", () => {
       const handleAction = vi.fn()
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const mockIframe: any = undefined
+      const mockIframe = undefined
       sendRenderMessage({}, [], false, mockTheme.emotion, mockIframe)
       expect(handleAction).toBeCalledTimes(0)
     })
@@ -186,10 +184,9 @@ describe("test componentUtils", () => {
     it("should not send message when iframe's content window is undefined", () => {
       const handleAction = vi.fn()
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const mockIframe: any = {
+      const mockIframe = {
         contentWindow: undefined,
-      }
+      } as unknown as HTMLIFrameElement
       sendRenderMessage({}, [], false, mockTheme.emotion, mockIframe)
       expect(handleAction).toBeCalledTimes(0)
     })

--- a/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/componentUtils.tsx
@@ -19,6 +19,7 @@ import { getLogger } from "loglevel"
 import {
   ArrowDataframe,
   ComponentInstance as ComponentInstanceProto,
+  IArrowTable,
   ISpecialArg,
   SpecialArg as SpecialArgProto,
 } from "@streamlit/protobuf"
@@ -43,8 +44,7 @@ type ReadyMessage = {
 }
 type ComponentValueMessage = {
   /* the value sent from the custom component can be anything */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  value: any
+  value: unknown
   dataType: ValueType
 }
 type FrameHeightMessage = {
@@ -66,13 +66,11 @@ export interface IframeMessageHandlerProps {
 }
 
 export interface Args {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [name: string]: any
+  [name: string]: unknown
 }
 export interface DataframeArg {
   key: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  value: any
+  value: unknown
 }
 
 /**
@@ -163,7 +161,9 @@ export function createIframeMessageHandler(
           )
         } else {
           frameHeightCallback(
-            tryGetValue(data as FrameHeightMessage, "height")
+            tryGetValue(data as FrameHeightMessage, "height") as
+              | number
+              | undefined
           )
         }
         break
@@ -290,8 +290,7 @@ export function sendRenderMessage(
  * @returns undefined
  */
 function handleSetComponentValue(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  value: any, // we do not know what data the custom component is sending us, so we use 'any' here
+  value: unknown, // we do not know what data the custom component is sending us
   dataType: ValueType,
   source: Source,
   element: ComponentInstanceProto,
@@ -305,10 +304,15 @@ function handleSetComponentValue(
 
   switch (dataType) {
     case "dataframe":
-      widgetMgr.setArrowValue(element, value, source, fragmentId)
+      widgetMgr.setArrowValue(
+        element,
+        value as IArrowTable,
+        source,
+        fragmentId
+      )
       break
     case "bytes":
-      widgetMgr.setBytesValue(element, value, source, fragmentId)
+      widgetMgr.setBytesValue(element, value as Uint8Array, source, fragmentId)
       break
     default:
       widgetMgr.setJsonValue(element, value, source, fragmentId)
@@ -317,12 +321,11 @@ function handleSetComponentValue(
 
 /** Return the property with the given name, if it exists. */
 function tryGetValue(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  obj: any,
+  obj: object,
   name: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  defaultValue: any = undefined
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): any {
-  return Object.hasOwn(obj, name) ? obj[name] : defaultValue
+  defaultValue: unknown = undefined
+): unknown {
+  return Object.hasOwn(obj, name)
+    ? (obj as Record<string, unknown>)[name]
+    : defaultValue
 }

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -24,6 +24,7 @@ import { Quiver } from "~lib/dataframes/Quiver"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { TEN_BY_TEN } from "~lib/mocks/arrow/tenByTen"
 import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 // Track DataEditor calls for assertions - separate from the component so we can use forwardRef
 const dataEditorMockFn = vi.fn()
@@ -59,8 +60,7 @@ const getProps = (
   disabled: false,
   widgetMgr: {
     getStringValue: vi.fn(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  } as any,
+  } as unknown as WidgetStateManager,
 })
 
 const { ResizeObserver } = window

--- a/frontend/lib/src/components/widgets/DataFrame/arrowUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/arrowUtils.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { GridCellKind } from "@glideapps/glide-data-grid"
+import { type CustomCell, GridCellKind } from "@glideapps/glide-data-grid"
 import {
   Binary,
   Bool as BoolType,
@@ -792,8 +792,9 @@ describe("getCellFromArrow", () => {
       styledCell,
       undefined
     )
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect((cell as any).data.displayDate).toEqual("FOOO")
+    expect(
+      (cell as CustomCell<Record<string, unknown>>).data.displayDate
+    ).toEqual("FOOO")
   })
 
   it("doesn't apply display content from styler if format is set", () => {
@@ -853,8 +854,9 @@ describe("getCellFromArrow", () => {
     const cell = getCellFromArrow(MOCK_TIME_COLUMN, arrowCell, styledCell)
     // Should use the formatted value from the cell and not the displayContent
     // from pandas styler
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect((cell as any).data.displayDate).toEqual("2021")
+    expect(
+      (cell as CustomCell<Record<string, unknown>>).data.displayDate
+    ).toEqual("2021")
   })
 
   it("parses numeric timestamps for time columns into valid Date values", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.test.ts
@@ -345,8 +345,7 @@ describe("ChartColumn", () => {
     [false, [0]],
   ])(
     "supports numerical array-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: any[] | null) => {
+    (input: unknown, value: number[] | null) => {
       const mockColumn = getBarChartColumn()
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
@@ -361,8 +360,7 @@ describe("ChartColumn", () => {
     [["foo", "bar"]],
     [[0.1, 0.4, "foo"]],
     [[0.1, 0.4, null]],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  ])("%p results in error cell", (input: any) => {
+  ])("%p results in error cell", (input: unknown) => {
     const mockColumn = getLineChartColumn()
     const cell = mockColumn.getCell(input)
     expect(isErrorCell(cell)).toEqual(true)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ChartColumn.ts
@@ -69,7 +69,7 @@ function BaseChartColumn(
   chart_type: "line" | "bar" | "area",
   theme: EmotionTheme
 ): BaseColumn {
-  const parameters = mergeColumnParameters(
+  const parameters = mergeColumnParameters<ChartColumnParams>(
     // Default parameters:
     {
       y_min: null,
@@ -78,7 +78,7 @@ function BaseChartColumn(
     },
     // User parameters:
     props.columnTypeOptions
-  ) as ChartColumnParams
+  )
 
   let defaultColor: string | undefined
   if (parameters.color === "auto" || parameters.color === "auto-inverse") {
@@ -115,8 +115,7 @@ function BaseChartColumn(
           : ":material/area_chart:",
     sortMode: "default",
     isEditable: false, // Chart column is always read-only
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any): GridCell {
+    getCell(data?: unknown): GridCell {
       if (isNullOrUndefined(data)) {
         // TODO(lukasmasuch): Use a missing cell?
         return getEmptyCell()

--- a/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
@@ -86,8 +86,7 @@ describe("CheckboxColumn", () => {
     ["", null],
   ])(
     "supports boolean compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: boolean | null) => {
+    (input: unknown, value: boolean | null) => {
       const mockColumn = CheckboxColumn(
         MOCK_CHECKBOX_COLUMN_PROPS,
         mockTheme.emotion
@@ -100,8 +99,7 @@ describe("CheckboxColumn", () => {
 
   it.each([["foo"], [12345], [0.1], [["foo", "bar"]]])(
     "%p results in error cell: %p",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any) => {
+    (input: unknown) => {
       const mockColumn = CheckboxColumn(
         MOCK_CHECKBOX_COLUMN_PROPS,
         mockTheme.emotion

--- a/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.test.ts
@@ -168,16 +168,14 @@ describe("DateTimeColumn", () => {
     ["1671951600", "2022-12-25T07:00:00.000"],
   ])(
     "supports datetime-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: string | null) => {
+    (input: unknown, value: string | null) => {
       const mockColumn = DateTimeColumn(MOCK_DATETIME_COLUMN_TEMPLATE)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
     }
   )
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  it.each([[NaN], ["foo"]])("%p results in error cell", (input: any) => {
+  it.each([[NaN], ["foo"]])("%p results in error cell", (input: unknown) => {
     const mockColumn = DateTimeColumn(MOCK_DATETIME_COLUMN_TEMPLATE)
     const cell = mockColumn.getCell(input)
     expect(isErrorCell(cell)).toEqual(true)
@@ -277,10 +275,9 @@ describe("DateTimeColumn", () => {
       arrowType: {
         ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType,
         pandasType: {
-          ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType.pandasType,
+          ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType.pandasType!,
           metadata: { timezone: "+05:00" },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        } as any,
+        },
       },
     }
 
@@ -301,10 +298,9 @@ describe("DateTimeColumn", () => {
       arrowType: {
         ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType,
         pandasType: {
-          ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType.pandasType,
+          ...MOCK_DATETIME_COLUMN_TEMPLATE.arrowType.pandasType!,
           metadata: { timezone: "America/New_York" },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        } as any,
+        },
       },
     }
 
@@ -488,16 +484,14 @@ describe("DateColumn", () => {
     ["1671951600", "2022-12-25"],
   ])(
     "supports date-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: string | null) => {
+    (input: unknown, value: string | null) => {
       const mockColumn = DateColumn(MOCK_DATE_COLUMN_TEMPLATE)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
     }
   )
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  it.each([[NaN], ["foo"]])("%p results in error cell", (input: any) => {
+  it.each([[NaN], ["foo"]])("%p results in error cell", (input: unknown) => {
     const mockColumn = DateColumn(MOCK_DATE_COLUMN_TEMPLATE)
     const cell = mockColumn.getCell(input)
     expect(isErrorCell(cell)).toEqual(true)
@@ -681,16 +675,14 @@ describe("TimeColumn", () => {
     ["1671951600", "07:00:00.000"],
   ])(
     "supports time-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: string | null) => {
+    (input: unknown, value: string | null) => {
       const mockColumn = TimeColumn(MOCK_TIME_COLUMN_TEMPLATE)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
     }
   )
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  it.each([[NaN], ["foo"]])("%p results in error cell", (input: any) => {
+  it.each([[NaN], ["foo"]])("%p results in error cell", (input: unknown) => {
     const mockColumn = TimeColumn(MOCK_TIME_COLUMN_TEMPLATE)
     const cell = mockColumn.getCell(input)
     expect(isErrorCell(cell)).toEqual(true)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/DateTimeColumn.ts
@@ -100,7 +100,7 @@ function BaseDateTimeColumn(
   toISOString: (date: Date) => string,
   timezone?: string
 ): BaseColumn {
-  const parameters = mergeColumnParameters(
+  const parameters = mergeColumnParameters<DateTimeColumnParams>(
     // Default parameters:
     {
       format: defaultFormat,
@@ -109,7 +109,7 @@ function BaseDateTimeColumn(
     },
     // User parameters:
     props.columnTypeOptions
-  ) as DateTimeColumnParams
+  )
 
   let defaultTimezoneOffset: number | undefined = undefined
   if (notNullOrUndefined(parameters.timezone)) {
@@ -154,8 +154,7 @@ function BaseDateTimeColumn(
     },
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const validateInput = (data?: any): boolean | Date => {
+  const validateInput = (data?: unknown): boolean | Date => {
     const cellData: Date | null | undefined = toSafeDate(data)
     if (cellData === null) {
       if (props.isRequired) {
@@ -202,8 +201,7 @@ function BaseDateTimeColumn(
           : ":material/calendar_today:",
     sortMode: "default",
     validateInput,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any, validate?: boolean): GridCell {
+    getCell(data?: unknown, validate?: boolean): GridCell {
       if (validate === true) {
         const validationResult = validateInput(data)
         if (validationResult === false) {
@@ -304,9 +302,10 @@ function BaseDateTimeColumn(
 export default function DateTimeColumn(props: BaseColumnProps): BaseColumn {
   // Do a smart selection of the default format based on the step size
   let defaultFormat = "YYYY-MM-DD HH:mm:ss"
-  if (props.columnTypeOptions?.step >= 60) {
+  const step = props.columnTypeOptions?.step as number | undefined
+  if (step !== undefined && step >= 60) {
     defaultFormat = "YYYY-MM-DD HH:mm"
-  } else if (props.columnTypeOptions?.step < 1) {
+  } else if (step !== undefined && step < 1) {
     defaultFormat = "YYYY-MM-DD HH:mm:ss.SSS"
   }
 
@@ -344,9 +343,10 @@ DateTimeColumn.isEditableType = true
 export function TimeColumn(props: BaseColumnProps): BaseColumn {
   // Do a smart selection of the default format based on the step size
   let defaultFormat = "HH:mm:ss"
-  if (props.columnTypeOptions?.step >= 60) {
+  const step = props.columnTypeOptions?.step as number | undefined
+  if (step !== undefined && step >= 60) {
     defaultFormat = "HH:mm"
-  } else if (props.columnTypeOptions?.step < 1) {
+  } else if (step !== undefined && step < 1) {
     defaultFormat = "HH:mm:ss.SSS"
   }
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.test.ts
@@ -90,8 +90,7 @@ describe("ImageColumn", () => {
     [undefined, null],
   ])(
     "supports string-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: string | null) => {
+    (input: unknown, value: string | null) => {
       const mockColumn = ImageColumn(MOCK_IMAGE_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ImageColumn.ts
@@ -43,8 +43,7 @@ function ImageColumn(props: BaseColumnProps): BaseColumn {
     typeIcon: ":material/image:",
     sortMode: "default",
     isEditable: false, // Image columns are always read-only
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any): GridCell {
+    getCell(data?: unknown): GridCell {
       // The native image cell implementation in glide-data-grid expects an array
       // of image URLs. For our usecase, we only support single images. We
       // need to wrap the image URL in an array to have it compatible with the

--- a/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.test.ts
@@ -92,8 +92,7 @@ describe("JsonColumn", () => {
     [undefined, null, ""],
   ])(
     "handles different JSON-compatible values (%p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, expected: any, displayValue: string) => {
+    (input: unknown, expected: unknown, displayValue: string) => {
       const mockColumn = JsonColumn(MOCK_JSON_COLUMN_PROPS)
       const cell = mockColumn.getCell(input) as JsonCell
       expect(mockColumn.getCellValue(cell)).toEqual(expected)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/JsonColumn.ts
@@ -52,8 +52,7 @@ function JsonColumn(props: BaseColumnProps): BaseColumn {
     typeIcon: ":material/code_blocks:",
     sortMode: "default",
     isEditable: false, // Json columns are read-only.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any): GridCell {
+    getCell(data?: unknown): GridCell {
       try {
         const displayValue = notNullOrUndefined(data)
           ? removeLineBreaks(toJsonString(data))

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.test.ts
@@ -22,7 +22,7 @@ import { Field, Utf8 } from "apache-arrow"
 import { DataFrameCellType } from "~lib/dataframes/arrowTypeUtils"
 
 import LinkColumn from "./LinkColumn"
-import { ErrorCell, isErrorCell } from "./utils"
+import { ErrorCell, isErrorCell, isMissingValueCell } from "./utils"
 
 const MOCK_LINK_COLUMN_PROPS = {
   id: "1",
@@ -71,8 +71,7 @@ describe("LinkColumn", () => {
     // should also be supported by the UrlColumn.
   ])(
     "supports string-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: any | null) => {
+    (input: unknown, value: unknown) => {
       const mockColumn = LinkColumn(MOCK_LINK_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
@@ -300,8 +299,7 @@ describe("LinkColumn", () => {
     const cell = mockColumn.getCell(null) as UriCell
 
     expect(cell.data).toBeNull()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect((cell as any).isMissingValue).toBe(true)
+    expect(isMissingValueCell(cell)).toBe(true)
   })
 
   it("opens link in new tab with correct parameters", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/LinkColumn.ts
@@ -147,20 +147,18 @@ function LinkColumn(props: BaseColumnProps): BaseColumn {
     typeIcon: ":material/link:",
     sortMode: "default",
     validateInput,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any, validate?: boolean): GridCell {
+    getCell(data?: unknown, validate?: boolean): GridCell {
       if (isNullOrUndefined(data)) {
         return {
           ...cellTemplate,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-          data: null as any,
+          data: null as unknown as string,
           isMissingValue: true,
           onClickUri: () => {},
           themeOverride: undefined,
         } as UriCell
       }
 
-      const href: string = data
+      const href = toSafeString(data)
       if (typeof validateRegex === "string") {
         // The regex is invalid, we return an error to indicate this
         // to the developer:

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.test.ts
@@ -103,8 +103,7 @@ describe("ListColumn", () => {
     ],
   ])(
     "supports array-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: any[] | null) => {
+    (input: unknown, value: unknown[] | null) => {
       const mockColumn = ListColumn(MOCK_LIST_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
@@ -122,8 +121,7 @@ describe("ListColumn", () => {
     [[true, false], "true,false"],
   ])(
     "correctly prepares data for copy (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, copyData: string | undefined) => {
+    (input: unknown, copyData: string | undefined) => {
       const mockColumn = ListColumn(MOCK_LIST_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect((cell as MultiSelectCellType).copyData).toEqual(copyData)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ListColumn.ts
@@ -70,7 +70,7 @@ function ListColumn(props: BaseColumnProps): BaseColumn {
         } satisfies MultiSelectCellType
       }
 
-      const cellData = toSafeArray(data)
+      const cellData = toSafeArray(data) as string[]
 
       return {
         ...cellTemplate,

--- a/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.test.ts
@@ -127,8 +127,7 @@ describe("MultiselectColumn", () => {
 
   it.each([[null], [undefined]])(
     "%p is interpreted as missing value",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- casting for test inputs only
-    (input: any) => {
+    (input: unknown) => {
       const mockColumn = getMultiselectColumn({ options: ["foo", "bar"] })
       const mockCell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(mockCell)).toEqual(null)
@@ -206,8 +205,12 @@ describe("prepareOptions", () => {
       ],
     ],
   ])("normalizes %j into %j", (input, expected) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- casting for test inputs only
-    expect(prepareOptions(input as any, mockTheme.emotion)).toEqual(expected)
+    expect(
+      prepareOptions(
+        input as Parameters<typeof prepareOptions>[0],
+        mockTheme.emotion
+      )
+    ).toEqual(expected)
   })
 
   it("applies theme color mapping and blends for named colors", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/MultiselectColumn.ts
@@ -123,7 +123,7 @@ function MultiselectColumn(
   props: BaseColumnProps,
   theme: EmotionTheme
 ): BaseColumn {
-  const parameters = mergeColumnParameters(
+  const parameters = mergeColumnParameters<MultiselectColumnParams>(
     // Default parameters:
     {
       options: [],
@@ -131,7 +131,7 @@ function MultiselectColumn(
     },
     // User parameters:
     props.columnTypeOptions
-  ) as MultiselectColumnParams
+  )
 
   const preparedOptions = prepareOptions(parameters.options, theme)
   const uniqueOptions = new Set(preparedOptions.map(opt => opt.value))
@@ -172,9 +172,9 @@ function MultiselectColumn(
         } satisfies MultiSelectCellType
       }
 
-      let cellData = toSafeArray(data)
-
-      cellData = cellData.map((x: unknown) => toSafeString(x).trim())
+      let cellData: string[] = toSafeArray(data).map((x: unknown) =>
+        toSafeString(x).trim()
+      )
 
       if (
         validate &&

--- a/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.test.ts
@@ -164,10 +164,8 @@ describe("NumberColumn", () => {
 
     const mockCell = mockColumn.getCell("104")
     expect(mockCell.kind).toEqual(GridCellKind.Number)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect((mockCell as any).fixedDecimals).toEqual(0)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect((mockCell as any).allowNegative).toEqual(false)
+    expect((mockCell as NumberCell).fixedDecimals).toEqual(0)
+    expect((mockCell as NumberCell).allowNegative).toEqual(false)
   })
 
   it.each([
@@ -259,8 +257,7 @@ describe("NumberColumn", () => {
     ["--123"],
     ["2,,2"],
     ["12345678987654321"],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  ])("%p results in error cell", (input: any) => {
+  ])("%p results in error cell", (input: unknown) => {
     const mockColumn = getNumberColumn(MOCK_FLOAT_ARROW_TYPE)
     const cell = mockColumn.getCell(input)
     expect(isErrorCell(cell)).toEqual(true)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/NumberColumn.ts
@@ -67,17 +67,17 @@ export interface NumberColumnParams {
  * This supports float, integer, and unsigned integer types.
  */
 function NumberColumn(props: BaseColumnProps): BaseColumn {
-  const parameters = mergeColumnParameters(
+  const parameters = mergeColumnParameters<NumberColumnParams>(
     // Default parameters:
     {
       // Set step to 1 for integer types
       step: isIntegerType(props.arrowType) ? 1 : undefined,
       // if uint (unsigned int), only positive numbers are allowed
       min_value: isUnsignedIntegerType(props.arrowType) ? 0 : undefined,
-    } as NumberColumnParams,
+    },
     // User parameters:
     props.columnTypeOptions
-  ) as NumberColumnParams
+  )
 
   // If no custom format is provided & the column type is duration or period,
   // instruct the column to use the arrow formatting for the display value.
@@ -110,8 +110,7 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
     thousandSeparator: "",
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const validateInput = (data?: any): boolean | number => {
+  const validateInput = (data?: unknown): boolean | number => {
     let cellData: number | null = toSafeNumber(data)
 
     if (isNullOrUndefined(cellData)) {
@@ -161,8 +160,7 @@ function NumberColumn(props: BaseColumnProps): BaseColumn {
     sortMode: "smart",
     typeIcon: ":material/tag:",
     validateInput,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any, validate?: boolean): GridCell {
+    getCell(data?: unknown, validate?: boolean): GridCell {
       if (validate === true) {
         const validationResult = validateInput(data)
         if (validationResult === false) {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.test.ts
@@ -92,8 +92,7 @@ describe("ObjectColumn", () => {
     [undefined, null],
   ])(
     "supports string-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: string | null) => {
+    (input: unknown, value: string | null) => {
       const mockColumn = ObjectColumn(MOCK_OBJECT_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ObjectColumn.ts
@@ -48,8 +48,7 @@ function ObjectColumn(props: BaseColumnProps): BaseColumn {
     sortMode: "default",
     typeIcon: ":material/data_object:",
     isEditable: false, // Object columns are read-only.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any): GridCell {
+    getCell(data?: unknown): GridCell {
       try {
         const cellData = notNullOrUndefined(data) ? toSafeString(data) : null
         const displayData = notNullOrUndefined(cellData)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
@@ -120,8 +120,7 @@ describe("ProgressColumn", () => {
     [0.1234, 0.1234],
   ])(
     "supports number-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: number | null) => {
+    (input: unknown, value: number | null) => {
       const mockColumn = getProgressColumn()
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)
@@ -136,8 +135,7 @@ describe("ProgressColumn", () => {
     ["123.124.123"],
     ["--123"],
     ["2,,2"],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  ])("%p results in error cell", (input: any) => {
+  ])("%p results in error cell", (input: unknown) => {
     const mockColumn = getProgressColumn()
     const cell = mockColumn.getCell(input)
     expect(isErrorCell(cell)).toEqual(true)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -77,7 +77,7 @@ function ProgressColumn(
 ): BaseColumn {
   const isInteger = isIntegerType(props.arrowType)
 
-  const parameters = mergeColumnParameters(
+  const parameters = mergeColumnParameters<ProgressColumnParams>(
     // Default parameters:
     {
       min_value: 0,
@@ -85,10 +85,10 @@ function ProgressColumn(
       format: isInteger ? "%3d%%" : "percent",
       step: isInteger ? 1 : undefined,
       color: undefined,
-    } as ProgressColumnParams,
+    },
     // User parameters:
     props.columnTypeOptions
-  ) as ProgressColumnParams
+  )
 
   const fixedDecimals =
     isNullOrUndefined(parameters.step) || Number.isNaN(parameters.step)
@@ -133,8 +133,7 @@ function ProgressColumn(
     sortMode: "smart",
     typeIcon: ":material/commit:",
     isEditable: false, // Progress column is always readonly
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any): GridCell {
+    getCell(data?: unknown): GridCell {
       if (isNullOrUndefined(data)) {
         // TODO(lukasmasuch): Use a missing cell?
         return getEmptyCell()

--- a/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.test.ts
@@ -176,8 +176,7 @@ describe("SelectboxColumn", () => {
 
   it.each([[null], [undefined], [""]])(
     "%p is interpreted as missing value",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any) => {
+    (input: unknown) => {
       const mockColumn = getSelectboxColumn(MOCK_CATEGORICAL_TYPE, {
         options: ["foo", "bar"],
       })
@@ -329,7 +328,8 @@ describe("prepareOptions", () => {
     [null as unknown as unknown[], []],
     [undefined as unknown as unknown[], []],
   ])("normalizes %j into %j", (input, expected) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- casting for test inputs only
-    expect(prepareOptions(input as any)).toEqual(expected)
+    expect(
+      prepareOptions(input as Parameters<typeof prepareOptions>[0])
+    ).toEqual(expected)
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/SelectboxColumn.ts
@@ -84,7 +84,7 @@ function SelectboxColumn(props: BaseColumnProps): BaseColumn {
   // based on the options type.
   let dataType: "number" | "boolean" | "string" = "string"
 
-  const parameters = mergeColumnParameters(
+  const parameters = mergeColumnParameters<SelectboxColumnParams>(
     // Default parameters:
     {
       options: isBooleanType(props.arrowType)
@@ -93,7 +93,7 @@ function SelectboxColumn(props: BaseColumnProps): BaseColumn {
     },
     // User parameters:
     props.columnTypeOptions
-  ) as SelectboxColumnParams
+  )
 
   const isSelectOption = (obj: unknown): obj is SelectOption =>
     typeof obj === "object" &&
@@ -144,8 +144,7 @@ function SelectboxColumn(props: BaseColumnProps): BaseColumn {
     kind: "selectbox",
     sortMode: "default",
     typeIcon: ":material/arrow_drop_down_circle:",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any, validate?: boolean): GridCell {
+    getCell(data?: unknown, validate?: boolean): GridCell {
       // Empty string refers to a missing value
       let cellData = null
       if (notNullOrUndefined(data) && data !== "") {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.test.ts
@@ -81,8 +81,7 @@ describe("TextColumn", () => {
     [undefined, null],
   ])(
     "supports string-compatible value (%p parsed as %p)",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (input: any, value: string | null) => {
+    (input: unknown, value: string | null) => {
       const mockColumn = TextColumn(MOCK_TEXT_COLUMN_PROPS)
       const cell = mockColumn.getCell(input)
       expect(mockColumn.getCellValue(cell)).toEqual(value)

--- a/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/TextColumn.ts
@@ -70,8 +70,7 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
     style: props.isPinned ? "faded" : "normal",
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const validateInput = (data?: any): boolean | string => {
+  const validateInput = (data?: unknown): boolean | string => {
     if (isNullOrUndefined(data)) {
       if (props.isRequired) {
         return false
@@ -106,8 +105,7 @@ function TextColumn(props: BaseColumnProps): BaseColumn {
     sortMode: "default",
     typeIcon: ":material/notes:",
     validateInput,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    getCell(data?: any, validate?: boolean): GridCell {
+    getCell(data?: unknown, validate?: boolean): GridCell {
       if (typeof validateRegex === "string") {
         // The regex is invalid, we return an error to indicate this
         // to the developer:

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.test.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { GridCellKind } from "@glideapps/glide-data-grid"
+import { type CustomCell, GridCellKind } from "@glideapps/glide-data-grid"
 
-import renderer from "./JsonCell"
+import renderer, { type JsonCell } from "./JsonCell"
 
 describe("JsonCell renderer", () => {
   const mockTheme = {
@@ -29,8 +29,7 @@ describe("JsonCell renderer", () => {
       data: { kind: "json-cell", value: { test: "value" } },
       allowOverlay: true,
       copyData: "",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+    } as unknown as CustomCell
 
     expect(renderer.isMatch(jsonCell)).toBe(true)
   })
@@ -42,11 +41,14 @@ describe("JsonCell renderer", () => {
 
     const cell = {
       data: { kind: "json-cell", value: { test: "value" } },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    } as any
+    } as unknown as JsonCell
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion -- TODO: Replace 'any' with a more specific type.
-    const width = renderer.measure!(ctx, cell, mockTheme as any)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const width = renderer.measure!(
+      ctx,
+      cell,
+      mockTheme as Parameters<NonNullable<typeof renderer.measure>>[2]
+    )
     expect(width).toBeGreaterThan(0)
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonCell.tsx
@@ -80,8 +80,8 @@ export const JsonTextCellEditor: ReturnType<
  */
 const renderer: CustomRenderer<JsonCell> = {
   kind: GridCellKind.Custom,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  isMatch: (c): c is JsonCell => (c.data as any).kind === "json-cell",
+  isMatch: (c): c is JsonCell =>
+    (c.data as Record<string, unknown>).kind === "json-cell",
   draw: (args, cell) => {
     const { value, displayValue } = cell.data
     drawTextCell(

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Theme as GlideTheme } from "@glideapps/glide-data-grid"
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
@@ -25,7 +26,7 @@ const mockTheme = {
   bgCell: "#ffffff",
   fontFamily: "Arial",
   baseFontStyle: "14px",
-}
+} as GlideTheme
 
 describe("JsonViewer", () => {
   it("renders valid JSON object correctly", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
@@ -15,7 +15,10 @@
  */
 
 import styled from "@emotion/styled"
-import { TextCellEntry } from "@glideapps/glide-data-grid"
+import {
+  type Theme as GlideTheme,
+  TextCellEntry,
+} from "@glideapps/glide-data-grid"
 import { getLuminance } from "color2k"
 import JSON5 from "json5"
 import ReactJson from "react-json-view"
@@ -37,8 +40,7 @@ const StyledJsonWrapper = styled.div(({ theme }) => ({
 
 interface JsonViewerProps {
   jsonValue: string | object | undefined | null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  theme: any
+  theme: GlideTheme
 }
 
 /**

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MediaCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MediaCell.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GridCellKind } from "@glideapps/glide-data-grid"
+import { type CustomCell, GridCellKind } from "@glideapps/glide-data-grid"
 import { screen } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
@@ -44,8 +44,7 @@ describe("MediaCell renderer", () => {
           },
           allowOverlay: true,
           copyData: "",
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any
+        } as unknown as CustomCell
 
         expect(renderer.isMatch(mediaCell)).toBe(true)
       })
@@ -53,8 +52,7 @@ describe("MediaCell renderer", () => {
       it("measures cell width correctly", () => {
         const ctx = {
           measureText: (text: string) => ({ width: text.length * 10 }),
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any
+        } as unknown as CanvasRenderingContext2D
 
         const cell = {
           data: {
@@ -62,11 +60,14 @@ describe("MediaCell renderer", () => {
             mediaType,
             src: "https://example.com/media.mp4",
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any
+        } as unknown as MediaCell
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-explicit-any
-        const width = renderer.measure!(ctx, cell, mockTheme as any)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const width = renderer.measure!(
+          ctx,
+          cell,
+          mockTheme as Parameters<NonNullable<typeof renderer.measure>>[2]
+        )
         expect(width).toBeGreaterThan(0)
         expect(width).toBe(
           expectedIcon.length * 10 + mockTheme.cellHorizontalPadding * 2
@@ -81,8 +82,7 @@ describe("MediaCell renderer", () => {
       data: { kind: "json-cell", value: {} },
       allowOverlay: true,
       copyData: "",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any
+    } as unknown as CustomCell
 
     expect(renderer.isMatch(otherCell)).toBe(false)
   })
@@ -106,8 +106,9 @@ describe("MediaCellEditor", () => {
   })
 
   // Cast the editor to a callable function type for testing
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const editor = MediaCellEditor as (cell: any) => JSX.Element | null
+  const editor = MediaCellEditor as (cell: {
+    value: MediaCell
+  }) => JSX.Element | null
 
   it.each([
     ["audio", "https://example.com/audio.mp3", "Audio player"],

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { GridCellKind } from "@glideapps/glide-data-grid"
+import {
+  type CustomCell,
+  GridCellKind,
+  type Item,
+} from "@glideapps/glide-data-grid"
 import {
   cleanup,
   fireEvent,
@@ -100,8 +104,7 @@ describe("prepareOptions", () => {
   it.each(testCases)(
     "should correctly prepare options for react-select",
     testCase => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing various input types
-      const result = prepareOptions(testCase.input as any)
+      const result = prepareOptions(testCase.input)
       expect(result).toEqual(testCase.expected)
     }
   )
@@ -302,8 +305,10 @@ describe("onPaste", () => {
 
   testCases.forEach(({ input, cellProps, expected }) => {
     it(`should correctly handle pasting "${input}"`, () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing onPaste with various input types
-      const result = renderer.onPaste?.(input, cellProps as any)
+      const result = renderer.onPaste?.(
+        input,
+        cellProps as MultiSelectCell["data"]
+      )
       expect(result).toEqual(expected)
     })
   })
@@ -336,10 +341,28 @@ function hasOption(container: HTMLElement, optionText: string): boolean {
   return within(listBox).queryByText(optionText) !== null
 }
 
+/** Helper to extract the editor component from provideEditor result. */
+function getEditor(
+  cell: MultiSelectCell
+): React.FunctionComponent<Record<string, unknown>> {
+  const result = renderer.provideEditor?.({
+    ...cell,
+    location: [0, 0] as Item,
+  })
+  if (result === undefined || !("editor" in result)) {
+    throw new Error("provideEditor did not return an editor")
+  }
+  return result.editor as React.FunctionComponent<Record<string, unknown>>
+}
+
 describe("Multi Select Editor", () => {
   afterEach(cleanup)
 
-  function getMockCell(props: Partial<MultiSelectCell> = {}): MultiSelectCell {
+  function getMockCell(
+    props: Partial<Omit<MultiSelectCell, "data">> & {
+      data?: Partial<MultiSelectCell["data"]>
+    } = {}
+  ): MultiSelectCell {
     return {
       kind: GridCellKind.Custom,
       allowOverlay: true,
@@ -359,14 +382,7 @@ describe("Multi Select Editor", () => {
   }
 
   it("renders into the dom with correct value", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing provideEditor
-    const Editor = (renderer.provideEditor as any)?.({
-      ...getMockCell(),
-      location: [0, 0],
-    }).editor
-    if (Editor === undefined) {
-      throw new Error("Editor is invalid")
-    }
+    const Editor = getEditor(getMockCell())
 
     const mockCellOnChange = vi.fn()
     render(
@@ -386,14 +402,7 @@ describe("Multi Select Editor", () => {
 
   it("allows to select values", async () => {
     const mockCell = getMockCell()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing provideEditor
-    const Editor = (renderer.provideEditor as any)?.({
-      ...mockCell,
-      location: [0, 0],
-    }).editor
-    if (Editor === undefined) {
-      throw new Error("Editor is invalid")
-    }
+    const Editor = getEditor(mockCell)
 
     const mockCellOnChange = vi.fn()
     render(
@@ -430,14 +439,7 @@ describe("Multi Select Editor", () => {
 
   it("is disabled if readonly", () => {
     const mockCell = getMockCell({ readonly: true })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing provideEditor
-    const Editor = (renderer.provideEditor as any)?.({
-      ...mockCell,
-      location: [0, 0],
-    }).editor
-    if (Editor === undefined) {
-      throw new Error("Editor is invalid")
-    }
+    const Editor = getEditor(mockCell)
 
     const mockCellOnChange = vi.fn()
     render(
@@ -455,16 +457,8 @@ describe("Multi Select Editor", () => {
   })
 
   it("allowDuplicates allows to select values multiple times", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing with allowDuplicates
-    const mockCell = getMockCell({ data: { allowDuplicates: true } } as any)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing provideEditor
-    const Editor = (renderer.provideEditor as any)?.({
-      ...mockCell,
-      location: [0, 0],
-    }).editor
-    if (Editor === undefined) {
-      throw new Error("Editor is invalid")
-    }
+    const mockCell = getMockCell({ data: { allowDuplicates: true } })
+    const Editor = getEditor(mockCell)
 
     const mockCellOnChange = vi.fn()
     render(
@@ -511,14 +505,7 @@ describe("Multi Select Editor", () => {
         values: ["option1", "option2"],
       },
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing provideEditor
-    const Editor = (renderer.provideEditor as any)?.({
-      ...mockCell,
-      location: [0, 0],
-    }).editor
-    if (Editor === undefined) {
-      throw new Error("Editor is invalid")
-    }
+    const Editor = getEditor(mockCell)
 
     const mockCellOnChange = vi.fn()
     render(
@@ -562,14 +549,7 @@ describe("Multi Select Editor", () => {
         values: ["option1"],
       },
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing provideEditor
-    const Editor = (renderer.provideEditor as any)?.({
-      ...mockCell,
-      location: [0, 0],
-    }).editor
-    if (Editor === undefined) {
-      throw new Error("Editor is invalid")
-    }
+    const Editor = getEditor(mockCell)
 
     const mockCellOnChange = vi.fn()
     render(
@@ -613,6 +593,9 @@ describe("Multi Select Editor", () => {
 })
 
 describe("MultiSelectCell renderer", () => {
+  /** The theme type expected by renderer.measure */
+  type MeasureTheme = Parameters<NonNullable<typeof renderer.measure>>[2]
+
   const mockTheme = {
     cellHorizontalPadding: 8,
     bubblePadding: 4,
@@ -629,8 +612,7 @@ describe("MultiSelectCell renderer", () => {
       },
       allowOverlay: true,
       copyData: "",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing isMatch
-    } as any
+    } as CustomCell
 
     expect(renderer.isMatch(multiSelectCell)).toBe(true)
   })
@@ -641,8 +623,7 @@ describe("MultiSelectCell renderer", () => {
       data: { kind: "other-cell" },
       allowOverlay: true,
       copyData: "",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing isMatch
-    } as any
+    } as CustomCell
 
     expect(renderer.isMatch(otherCell)).toBe(false)
   })
@@ -661,11 +642,10 @@ describe("MultiSelectCell renderer", () => {
           { value: "option2", label: "Option 2" },
         ],
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing measure
-    } as any
+    } as unknown as MultiSelectCell
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion -- Testing measure
-    const width = renderer.measure!(ctx, cell, mockTheme as any)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- renderer.measure is defined for this cell type
+    const width = renderer.measure!(ctx, cell, mockTheme as MeasureTheme)
     expect(width).toBeGreaterThan(0)
   })
 
@@ -680,11 +660,10 @@ describe("MultiSelectCell renderer", () => {
         values: [],
         options: [],
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing measure
-    } as any
+    } as unknown as MultiSelectCell
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion -- Testing measure
-    const width = renderer.measure!(ctx, cell, mockTheme as any)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- renderer.measure is defined for this cell type
+    const width = renderer.measure!(ctx, cell, mockTheme as MeasureTheme)
     expect(width).toBe(mockTheme.cellHorizontalPadding * 2)
   })
 
@@ -699,11 +678,10 @@ describe("MultiSelectCell renderer", () => {
         values: null,
         options: [],
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing measure
-    } as any
+    } as unknown as MultiSelectCell
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion -- Testing measure
-    const width = renderer.measure!(ctx, cell, mockTheme as any)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- renderer.measure is defined for this cell type
+    const width = renderer.measure!(ctx, cell, mockTheme as MeasureTheme)
     expect(width).toBe(mockTheme.cellHorizontalPadding * 2)
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.tsx
@@ -112,7 +112,7 @@ const StyledPortalWrap = styled.div`
  * @returns The prepared options in the format required by react-select.
  */
 export const prepareOptions = (
-  options: readonly (string | SelectOption)[]
+  options: readonly (string | SelectOption | null | undefined)[]
 ): { value: string; label?: string; color?: string }[] => {
   return options.map(option => {
     if (typeof option === "string") {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.test.ts
@@ -193,8 +193,7 @@ describe("arrayToCopyValue", () => {
     [["hello,world", 42, true], "hello world,42,true"],
     [[{ foo: "bar" }], "[object Object]"],
   ])("converts %s to copy string '%s'", (input, expected) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(arrayToCopyValue(input as any)).toBe(expected)
+    expect(arrayToCopyValue(input as unknown[])).toBe(expected)
   })
 })
 
@@ -582,15 +581,13 @@ describe("toJsonString", () => {
     // Circular reference (should use toSafeString fallback)
     [
       (() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        const circular: any = { a: 1 }
+        const circular: Record<string, unknown> = { a: 1 }
         circular.self = circular
         return circular
       })(),
       "[object Object]",
     ],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  ])("converts %o to JSON string %s", (input: any, expected: string) => {
+  ])("converts %o to JSON string %s", (input: unknown, expected: string) => {
     expect(toJsonString(input)).toBe(expected)
   })
 })
@@ -653,9 +650,9 @@ describe("isMaybeJson", () => {
     }
   )
 
-  it("returns undefined for null and undefined values", () => {
-    expect(isMaybeJson(null)).toBeUndefined()
-    expect(isMaybeJson(undefined)).toBeUndefined()
+  it("returns false for null and undefined values", () => {
+    expect(isMaybeJson(null)).toBe(false)
+    expect(isMaybeJson(undefined)).toBe(false)
   })
 })
 

--- a/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/utils.ts
@@ -73,8 +73,7 @@ export interface BaseColumnProps {
   /**
    * Configuration options related to the column type.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  readonly columnTypeOptions?: Record<string, any>
+  readonly columnTypeOptions?: Record<string, unknown>
   /** The content alignment of the column. */
   readonly contentAlignment?: "left" | "center" | "right"
   /** The default value of the column used when adding a new row. */
@@ -103,14 +102,11 @@ export interface BaseColumn extends BaseColumnProps {
   // Validate the input data for compatibility with the column type:
   // Either returns a boolean indicating if the data is valid or not, or
   // returns the corrected value.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents -- TODO: Replace 'any' with a more specific type.
-  validateInput?(data?: any): boolean | any
+  validateInput?(data?: unknown): unknown
   // Get a cell with the provided data for the column type:
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  getCell(data?: any, validate?: boolean): GridCell
+  getCell(data?: unknown, validate?: boolean): GridCell
   // Get the raw value of the given cell:
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents -- TODO: Replace 'any' with a more specific type.
-  getCellValue(cell: GridCell): any | null
+  getCellValue(cell: GridCell): unknown
 }
 
 /**
@@ -268,22 +264,19 @@ export function toGlideColumn(column: BaseColumn): GridColumn {
  *
  * @returns The merged column parameters.
  */
-export function mergeColumnParameters(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  defaultParams: Record<string, any> | undefined | null,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  userParams: Record<string, any> | undefined | null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): Record<string, any> {
+export function mergeColumnParameters<T = Record<string, unknown>>(
+  defaultParams: Record<string, unknown> | undefined | null,
+  userParams: Record<string, unknown> | undefined | null
+): T {
   if (isNullOrUndefined(defaultParams)) {
-    return userParams || {}
+    return (userParams || {}) as T
   }
 
   if (isNullOrUndefined(userParams)) {
-    return defaultParams || {}
+    return (defaultParams || {}) as T
   }
 
-  return merge(defaultParams, userParams)
+  return merge(defaultParams, userParams) as T
 }
 
 /**
@@ -294,8 +287,7 @@ export function mergeColumnParameters(
  *
  * @returns The converted array or an empty array if the value cannot be interpreted as an array.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toSafeArray(data: any): any[] {
+export function toSafeArray(data: unknown): unknown[] {
   if (isNullOrUndefined(data)) {
     return []
   }
@@ -335,8 +327,7 @@ export function toSafeArray(data: any): any[] {
       return [toSafeString(parsedData)]
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    return parsedData.map((value: any) =>
+    return parsedData.map((value: unknown) =>
       ["string", "number", "boolean", "null"].includes(typeof value)
         ? value
         : toSafeString(value)
@@ -377,9 +368,8 @@ export function isEditableArrayValue(data: unknown): boolean {
  *
  * @returns `true` if the data might be a JSON string.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function isMaybeJson(data: any): boolean {
-  return data?.startsWith("{") && data.endsWith("}")
+export function isMaybeJson(data: unknown): boolean {
+  return typeof data === "string" && data.startsWith("{") && data.endsWith("}")
 }
 
 /**
@@ -390,8 +380,7 @@ export function isMaybeJson(data: any): boolean {
  *
  * @return The converted string or a string showing the type of the object as fallback.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toSafeString(data: any): string {
+export function toSafeString(data: unknown): string {
   try {
     try {
       return toString(data)
@@ -416,8 +405,7 @@ export function toSafeString(data: any): string {
  * @return The converted boolean, null if the value is empty or undefined if the
  *         value cannot be interpreted as a boolean.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toSafeBoolean(value: any): boolean | null | undefined {
+export function toSafeBoolean(value: unknown): boolean | null | undefined {
   if (isNullOrUndefined(value)) {
     return null
   }
@@ -447,8 +435,7 @@ export function toSafeBoolean(value: any): boolean | null | undefined {
  * @returns The converted number or null if the value is empty or undefined or NaN if the
  *          value cannot be interpreted as a number.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toSafeNumber(value: any): number | null {
+export function toSafeNumber(value: unknown): number | null {
   // TODO(lukasmasuch): Should this return null as replacement for NaN?
 
   if (isNullOrUndefined(value)) {
@@ -489,18 +476,16 @@ export function toSafeNumber(value: any): number | null {
  * @param array - The array to convert.
  * @returns The string representation of the array.
  */
-export function arrayToCopyValue(array?: object[] | null): string {
+export function arrayToCopyValue(array?: unknown[] | null): string {
   if (isNullOrUndefined(array)) {
     return ""
   }
 
   return toSafeString(
-    array.map((x: object) =>
+    array.map((x: unknown) =>
       // Replace commas with spaces since commas are used to
       // separate the list items.
-      typeof x === "string" && (x as string).includes(",")
-        ? (x as string).replace(/,/g, " ")
-        : x
+      typeof x === "string" && x.includes(",") ? x.replace(/,/g, " ") : x
     )
   )
 }
@@ -513,8 +498,7 @@ export function arrayToCopyValue(array?: object[] | null): string {
  *
  * @returns The converted JSON string or a string showing the type of the object as fallback.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toJsonString(value: any): string {
+export function toJsonString(value: unknown): string {
   if (isNullOrUndefined(value)) {
     return ""
   }
@@ -547,8 +531,7 @@ export function toJsonString(value: any): string {
  *
  * @returns The converted date or null if the value cannot be interpreted as a date.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toSafeDate(value: any): Date | null | undefined {
+export function toSafeDate(value: unknown): Date | null | undefined {
   if (isNullOrUndefined(value)) {
     return null
   }

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/EditingState.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/EditingState.ts
@@ -74,10 +74,8 @@ class EditingState {
       // We use snake case here since this is the widget state
       // that is sent and used in the backend. Therefore, it should
       // conform with the Python naming conventions.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      edited_rows: {} as Record<number, Record<string, any>>,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      added_rows: [] as Record<string, any>[],
+      edited_rows: {} as Record<number, Record<string, unknown>>,
+      added_rows: [] as Record<string, unknown>[],
       deleted_rows: [] as number[],
     }
 
@@ -86,8 +84,7 @@ class EditingState {
     // row position -> column name -> edited value
     this.editedCells.forEach(
       (row: Map<number, GridCell>, rowIndex: number, _map) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        const editedRow: Record<string, any> = {}
+        const editedRow: Record<string, unknown> = {}
         row.forEach((cell: GridCell, colIndex: number) => {
           const column = columnsByIndex.get(colIndex)
           if (column) {
@@ -102,8 +99,7 @@ class EditingState {
     // we use for the JSON-compatible widget state:
     // List of column name -> edited value
     this.addedRows.forEach((row: Map<number, GridCell>) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      const addedRow: Record<string, any> = {}
+      const addedRow: Record<string, unknown> = {}
       // This flags is used to check if the row is incomplete
       // (i.e. missing required values) and should therefore not be included in
       // the current state version.
@@ -193,8 +189,7 @@ class EditingState {
     // Loop through all added rows and transform into the format that
     // we use for the editing state:
     // List of column index -> edited value
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    editingState.added_rows.forEach((row: Record<string, any>) => {
+    editingState.added_rows.forEach((row: Record<string, unknown>) => {
       const addedRow: Map<number, GridCell> = new Map()
       // Initialize all columns with null (empty) values first
       // This is necessary to ensure that all columns are present in the added row.

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnFormatting.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnFormatting.ts
@@ -17,6 +17,7 @@
 import { useCallback } from "react"
 
 import { updateColumnConfigTypeProps } from "./columnConfigUtils"
+import { ColumnConfigProps } from "./useColumnLoader"
 
 type ColumnFormattingReturn = {
   // A callback to change the format of a column
@@ -33,8 +34,7 @@ type ColumnFormattingReturn = {
  */
 function useColumnFormatting(
   setColumnConfigMapping: React.Dispatch<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    React.SetStateAction<Map<string, any>>
+    React.SetStateAction<Map<string, ColumnConfigProps>>
   >
 ): ColumnFormattingReturn {
   const changeColumnFormat = useCallback(

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.test.ts
@@ -144,8 +144,7 @@ describe("applyColumnConfig", () => {
     const column1 = applyColumnConfig(MOCK_COLUMNS[1], columnConfig)
     expect(column1.isEditable).toBe(true)
     expect(column1.width).toBe(COLUMN_WIDTH_MAPPING.small)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect((column1.columnTypeOptions as any).type).toBe("text")
+    expect(column1.columnTypeOptions?.type).toBe("text")
     expect(column1).toEqual({
       ...MOCK_COLUMNS[1],
       width: COLUMN_WIDTH_MAPPING.small,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnLoader.ts
@@ -104,8 +104,10 @@ const mergeColumnConfig = (
   source: ColumnConfigProps
 ): ColumnConfigProps => {
   // Don't merge arrays, just overwrite the old value with the new value
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const customMergeArrays = (_objValue: object, srcValue: object): any => {
+  const customMergeArrays = (
+    _objValue: object,
+    srcValue: object
+  ): object | undefined => {
     // If the new value is an array, just return it as is (overwriting the old)
     if (isArray(srcValue)) {
       return srcValue
@@ -210,8 +212,9 @@ export function applyColumnConfig(
  *
  * @returns the user-defined column configuration.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function getColumnConfig(configJson: string): Map<string, any> {
+export function getColumnConfig(
+  configJson: string
+): Map<string, ColumnConfigProps> {
   if (!configJson) {
     return new Map()
   }
@@ -232,8 +235,7 @@ type ColumnLoaderReturn = {
   allColumns: BaseColumn[]
   // Callback to set the column config state:
   setColumnConfigMapping: Dispatch<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    SetStateAction<Map<string, any>>
+    SetStateAction<Map<string, ColumnConfigProps>>
   >
 }
 
@@ -295,8 +297,7 @@ function useColumnLoader(
   // We need that to allow changing the column config state
   // (e.g. via changes by the user in the UI)
   const [columnConfigMapping, setColumnConfigMapping] =
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    useState<Map<string, any>>(parsedColumnConfig)
+    useState<Map<string, ColumnConfigProps>>(parsedColumnConfig)
 
   // Resync state whenever the parsed column config from the proto changes:
   useEffect(() => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnPinning.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnPinning.ts
@@ -19,6 +19,7 @@ import { Dispatch, SetStateAction, useCallback, useMemo } from "react"
 import { BaseColumn } from "~lib/components/widgets/DataFrame/columns"
 
 import { updateColumnConfigTypeProps } from "./columnConfigUtils"
+import { ColumnConfigProps } from "./useColumnLoader"
 
 type ColumnPinningReturn = {
   // The number of columns to freeze.
@@ -51,8 +52,7 @@ function useColumnPinning(
   minColumnWidth: number,
   clearSelection: (keepRows?: boolean, keepColumns?: boolean) => void,
   setColumnConfigMapping: Dispatch<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    SetStateAction<Map<string, any>>
+    SetStateAction<Map<string, ColumnConfigProps>>
   >
 ): ColumnPinningReturn {
   // This is a simple heuristic to prevent the pinned columns

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnVisibility.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useColumnVisibility.ts
@@ -17,6 +17,7 @@
 import { useCallback } from "react"
 
 import { updateColumnConfigTypeProps } from "./columnConfigUtils"
+import { ColumnConfigProps } from "./useColumnLoader"
 
 type ColumnVisibilityReturn = {
   // Hides a column.
@@ -38,8 +39,7 @@ type ColumnVisibilityReturn = {
 function useColumnVisibility(
   clearSelection: (keepRows?: boolean, keepColumns?: boolean) => void,
   setColumnConfigMapping: React.Dispatch<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    React.SetStateAction<Map<string, any>>
+    React.SetStateAction<Map<string, ColumnConfigProps>>
   >
 ): ColumnVisibilityReturn {
   const hideColumn = useCallback(

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
@@ -32,8 +32,7 @@ const mockClose = vi.fn()
 
 // The native-file-system-adapter is not available in tests, so we need to mock it.
 vi.mock("native-file-system-adapter", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  showSaveFilePicker: vi.fn().mockImplementation((_object: any) => {
+  showSaveFilePicker: vi.fn().mockImplementation((_object: unknown) => {
     return {
       createWritable: vi.fn().mockImplementation(() => {
         return {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -42,8 +42,7 @@ const CSV_SPECIAL_CHARS_REGEX = new RegExp(
 )
 const LOG = getLogger("useDataExporter")
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function toCsvRow(rowValues: any[]): string {
+export function toCsvRow(rowValues: unknown[]): string {
   return (
     rowValues.map(cell => escapeValue(cell)).join(CSV_DELIMITER) +
     CSV_ROW_DELIMITER
@@ -55,8 +54,7 @@ export function toCsvRow(rowValues: any[]): string {
  *
  * Makes sure that the value is a string, and special characters are escaped correctly.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function escapeValue(value: any): string {
+function escapeValue(value: unknown): string {
   if (isNullOrUndefined(value)) {
     return ""
   }
@@ -109,8 +107,7 @@ async function writeCsv(
   await writable.write(textEncoder.encode(toCsvRow(headers)))
 
   for (let row = 0; row < numRows; row++) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const rowData: any[] = []
+    const rowData: unknown[] = []
     columns.forEach((column: BaseColumn, col: number, _map) => {
       rowData.push(column.getCellValue(getCellContent([col, row])))
     })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useRowHover.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useRowHover.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { GridMouseEventArgs } from "@glideapps/glide-data-grid"
 import { act, renderHook } from "@testing-library/react"
 
 import { CustomGridTheme } from "./useCustomTheme"
@@ -47,8 +48,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 1], // [col, row]
         kind: "cell",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any)
+      } as unknown as GridMouseEventArgs)
     })
 
     // Check that row 1 has hover theme
@@ -71,8 +71,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 1],
         kind: "cell",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any)
+      } as unknown as GridMouseEventArgs)
     })
 
     // Simulate mouse leaving (undefined location)
@@ -80,8 +79,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: undefined,
         kind: "out-of-bounds",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any)
+      } as unknown as GridMouseEventArgs)
     })
 
     // Check that hover theme is cleared
@@ -97,8 +95,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 1],
         kind: "cell",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any)
+      } as unknown as GridMouseEventArgs)
     })
 
     // Move to row 2
@@ -106,8 +103,7 @@ describe("useRowHover hook", () => {
       result.current.onItemHovered?.({
         location: [0, 2],
         kind: "cell",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any)
+      } as unknown as GridMouseEventArgs)
     })
 
     // Check that row 1 no longer has hover theme

--- a/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
@@ -42,10 +42,8 @@ export const StyledResizableContainer =
       },
 
       "& .dvn-scroller": {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        ["overflowX" as any]: "auto !important",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-        ["overflowY" as any]: "auto !important",
+        ["overflowX" as unknown as string]: "auto !important",
+        ["overflowY" as unknown as string]: "auto !important",
       },
       "& .gdg-search-bar": {
         ...getPopoverContainerStyle(theme),

--- a/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/useIntlLocale.tsx
@@ -40,15 +40,15 @@ type IntlWeekInfo = {
  * @param {Intl.Locale} intlLocale - The locale for which to retrieve week
  * information.
  */
+/** Extended Intl.Locale with weekInfo support (not yet in all TS lib versions). */
+interface IntlLocaleWithWeekInfo extends Intl.Locale {
+  getWeekInfo?: () => IntlWeekInfo
+  weekInfo?: IntlWeekInfo
+}
+
 const getWeekInfo = (intlLocale: Intl.Locale): IntlWeekInfo | null => {
-  return (
-    // Casting is necessary here since the types are not yet up-to-date
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (intlLocale as any)?.getWeekInfo?.() ??
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (intlLocale as any)?.weekInfo ??
-    null
-  )
+  const locale = intlLocale as IntlLocaleWithWeekInfo
+  return locale?.getWeekInfo?.() ?? locale?.weekInfo ?? null
 }
 
 /**

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.tsx
@@ -16,6 +16,7 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
+import type { AxiosProgressEvent } from "axios"
 import { isEqual, zip } from "lodash-es"
 import { flushSync } from "react-dom"
 import { FileRejection } from "react-dropzone"
@@ -372,13 +373,15 @@ const FileUploader = ({
    * Update the file status when the upload has progressed.
    */
   const onUploadProgress = useCallback(
-    (event: ProgressEvent, fileId: number): void => {
+    (event: AxiosProgressEvent, fileId: number): void => {
       const file = getFile(fileId)
       if (isNullOrUndefined(file) || file.status.type !== "uploading") {
         return
       }
 
-      const newProgress = Math.round((event.loaded * 100) / event.total)
+      const newProgress = event.total
+        ? Math.round((event.loaded * 100) / event.total)
+        : 0
       if (file.status.progress === newProgress) {
         return
       }

--- a/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
+++ b/frontend/lib/src/components/widgets/FileUploader/styled-components.ts
@@ -163,52 +163,42 @@ export const StyledFileError = styled.small(({ theme }) => ({
 export const StyledFileErrorIcon = styled.span({})
 
 const compactFileUploader = (theme: EmotionTheme): CSSObject => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledFileDropzoneSection as any]: {
+  [StyledFileDropzoneSection.toString()]: {
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
     height: "auto",
     gap: theme.spacing.sm,
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledFileDropzoneInstructionsFileUploaderIcon as any]: {
+  [StyledFileDropzoneInstructionsFileUploaderIcon.toString()]: {
     display: "none",
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledFileDropzoneInstructionsText as any]: {
+  [StyledFileDropzoneInstructionsText.toString()]: {
     marginBottom: theme.spacing.twoXS,
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledUploadedFiles as any]: {
+  [StyledUploadedFiles.toString()]: {
     paddingRight: theme.spacing.lg,
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledUploadedFile as any]: {
+  [StyledUploadedFile.toString()]: {
     maxWidth: "inherit",
     flex: 1,
     alignItems: "flex-start",
     marginBottom: theme.spacing.sm,
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledUploadedFileName as any]: {
+  [StyledUploadedFileName.toString()]: {
     width: theme.sizes.full,
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledUploadedFileData as any]: {
+  [StyledUploadedFileData.toString()]: {
     flexDirection: "column",
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledFileError as any]: {
+  [StyledFileError.toString()]: {
     height: "auto",
     whiteSpace: "initial",
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledFileErrorIcon as any]: {
+  [StyledFileErrorIcon.toString()]: {
     display: "none",
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  [StyledUploadedFilesListItem as any]: {
+  [StyledUploadedFilesListItem.toString()]: {
     margin: theme.spacing.none,
     padding: theme.spacing.none,
   },

--- a/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/withPagination/withPagination.tsx
@@ -23,21 +23,20 @@ import { usePrevious } from "~lib/util/Hooks"
 import Pagination from "./Pagination"
 
 export interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  items: any[]
+  items: unknown[]
   pageSize: number
   resetOnAdd: boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-const calculateNumPages = (items: any[], pageSize: number): number =>
+const calculateNumPages = (items: unknown[], pageSize: number): number =>
   Math.ceil(items.length / pageSize)
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- HOC wraps components with arbitrary props; `any` is required for React's ComponentType variance in the passthrough pattern with hoistNonReactStatics.
+type WrappableComponent = ComponentType<any>
+
 const withPagination = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  WrappedComponent: ComponentType<React.PropsWithChildren<any>>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): ComponentType<React.PropsWithChildren<any>> => {
+  WrappedComponent: WrappableComponent
+): WrappableComponent => {
   const WithPagination = ({
     pageSize,
     items,
@@ -49,8 +48,7 @@ const withPagination = (
       calculateNumPages(items, pageSize)
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    const prevItems: any[] = usePrevious(items)
+    const prevItems = usePrevious(items)
 
     useEffect(() => {
       if (prevItems && prevItems.length !== items.length) {

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -16,6 +16,8 @@
 
 import { screen } from "@testing-library/react"
 
+import { Button as SubmitButtonProto } from "@streamlit/protobuf"
+
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
 import {
@@ -100,8 +102,7 @@ describe("Form", () => {
     // regardless of ScriptRunState.
     const formsDataWithButton = createFormsData()
     formsDataWithButton.submitButtons.set(formId, [
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test mock
-      { formId } as any,
+      { formId } as SubmitButtonProto,
     ])
     rerenderWithContexts(<Form {...props} />, {
       formsContext: {

--- a/frontend/lib/src/components/widgets/MenuButton/MenuButton.tsx
+++ b/frontend/lib/src/components/widgets/MenuButton/MenuButton.tsx
@@ -71,8 +71,13 @@ interface MenuOptionProps {
   onClick?: MouseEventHandler<HTMLLIElement>
   onMouseEnter?: MouseEventHandler<HTMLLIElement>
   onKeyDown?: KeyboardEventHandler<HTMLLIElement>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any
+  /** BaseUI internal props that are destructured but not forwarded to DOM. */
+  $disabled?: boolean
+  $isFocused?: boolean
+  $size?: string
+  resetMenu?: () => void
+  renderAll?: boolean
+  [key: string]: unknown
 }
 
 /** Menu option component for BaseUI StatefulMenu override. */

--- a/frontend/lib/src/dataframes/Quiver.ts
+++ b/frontend/lib/src/dataframes/Quiver.ts
@@ -285,8 +285,7 @@ export class Quiver {
    *
    * Index columns only exist if the DataFrame was created based on a Pandas DataFrame.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  private getIndexValue(rowIndex: number, columnIndex: number): any {
+  private getIndexValue(rowIndex: number, columnIndex: number): DataType {
     const index = this._pandasIndexData[columnIndex]
     const value =
       index instanceof Vector ? index.get(rowIndex) : index[rowIndex]
@@ -294,8 +293,7 @@ export class Quiver {
   }
 
   /** Get the raw value of a data cell. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  private getDataValue(rowIndex: number, columnIndex: number): any {
+  private getDataValue(rowIndex: number, columnIndex: number): DataType {
     return this._data.getChildAt(columnIndex)?.get(rowIndex)
   }
 

--- a/frontend/lib/src/dataframes/arrowFormatUtils.test.ts
+++ b/frontend/lib/src/dataframes/arrowFormatUtils.test.ts
@@ -345,8 +345,12 @@ describe("formatPeriodFromFreq", () => {
     [1, "W", "1"],
     [1, "W-INVALID", "1"],
   ])("formats %s with frequency %s to %s", (value, freq, expected) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    expect(formatPeriodFromFreq(value, freq as any)).toEqual(expected)
+    expect(
+      formatPeriodFromFreq(
+        value,
+        freq as Parameters<typeof formatPeriodFromFreq>[1]
+      )
+    ).toEqual(expected)
   })
 })
 

--- a/frontend/lib/src/dataframes/arrowFormatUtils.ts
+++ b/frontend/lib/src/dataframes/arrowFormatUtils.ts
@@ -440,8 +440,7 @@ function formatPeriod(duration: number | bigint, field?: Field): string {
  * @param field The field metadata from arrow containing metadata about the column.
  * @returns The formatted JSON string.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function formatObject(object: any, field?: Field): string {
+function formatObject(object: unknown, field?: Field): string {
   if (field?.type instanceof Struct) {
     // This type is used by python dictionary values
 

--- a/frontend/lib/src/dataframes/arrowTypeUtils.ts
+++ b/frontend/lib/src/dataframes/arrowTypeUtils.ts
@@ -73,8 +73,7 @@ export interface PandasColumnMetadata {
    * Column-specific metadata. Only used by certain column types
    * (e.g. CategoricalIndex has `num_categories`.)
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  metadata: Record<string, any> | null
+  metadata: PandasRangeIndex | Record<string, unknown> | null
 
   /** The name of the column. */
   name: string | null
@@ -155,8 +154,7 @@ export interface ArrowType {
  * @param vector The Arrow vector to convert.
  * @returns The list of strings.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function convertVectorToList(vector: Vector<any>): string[] {
+export function convertVectorToList(vector: Vector): string[] {
   const values = []
 
   for (let i = 0; i < vector.length; i++) {
@@ -179,7 +177,11 @@ export function getPandasTypeName(type: ArrowType): string | undefined {
 
 /** Returns the timezone of the arrow type metadata. */
 export function getTimezone(type: ArrowType): string | undefined {
-  return type.arrowField?.type?.timezone ?? type.pandasType?.metadata?.timezone
+  const timezone =
+    type.arrowField?.type?.timezone ??
+    (type.pandasType?.metadata as Record<string, unknown> | null | undefined)
+      ?.timezone
+  return typeof timezone === "string" ? timezone : undefined
 }
 
 /** True if the arrow type is an integer type.

--- a/frontend/lib/src/hooks/useScrollSpy.test.ts
+++ b/frontend/lib/src/hooks/useScrollSpy.test.ts
@@ -20,8 +20,10 @@ import useScrollSpy from "./useScrollSpy"
 
 describe("useScrollSpy hook", () => {
   let target: HTMLElement
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let eventHandler: ({ timeStampLow }: any) => void
+  let eventHandler: (event: {
+    timeStampLow: number
+    target: EventTarget | null
+  }) => void
 
   beforeEach(() => {
     vi.useFakeTimers()

--- a/frontend/lib/src/hooks/useScrollSpy.ts
+++ b/frontend/lib/src/hooks/useScrollSpy.ts
@@ -20,6 +20,12 @@ import useTimeout from "./useTimeout"
 
 const DEFAULT_DEBOUNCE_MS = 100
 
+/** Scroll event augmented with a low-resolution timestamp for debouncing. */
+interface ScrollSpyEvent {
+  timeStampLow: number
+  target: EventTarget | null
+}
+
 /**
  * A hook to add a scroll event listener to a target element with debouncing.
  *
@@ -39,14 +45,12 @@ const DEFAULT_DEBOUNCE_MS = 100
  */
 export default function useScrollSpy(
   target: HTMLElement | null,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  eventHandler: ({ timeStampLow }: any) => void,
+  eventHandler: (event: ScrollSpyEvent) => void,
   active: boolean
 ): void {
   const onEventRef = useRef(eventHandler)
   const lastInvocationRef = useRef(0)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const pendingEventRef = useRef<any>()
+  const pendingEventRef = useRef<ScrollSpyEvent>()
 
   useEffect(() => {
     onEventRef.current = eventHandler
@@ -68,8 +72,7 @@ export default function useScrollSpy(
     )
 
   const debouncer = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (event: any) => {
+    (event: ScrollSpyEvent) => {
       const now = Date.now()
       const elapsedMs = now - lastInvocationRef.current
       if (elapsedMs > DEFAULT_DEBOUNCE_MS) {
@@ -87,11 +90,13 @@ export default function useScrollSpy(
   )
 
   const handleEvent = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    (event: any) => {
-      event.timeStampLow = Date.now()
+    (event: Event) => {
+      const scrollSpyEvent: ScrollSpyEvent = {
+        timeStampLow: Date.now(),
+        target: event.target,
+      }
 
-      debouncer(event)
+      debouncer(scrollSpyEvent)
     },
     [debouncer]
   )
@@ -105,12 +110,12 @@ export default function useScrollSpy(
     }
 
     target.addEventListener("scroll", handleEvent, { passive: true })
-    handleEvent({ target })
+    debouncer({ timeStampLow: Date.now(), target })
 
     return () => {
       target.removeEventListener("scroll", handleEvent)
       cancelDebouncedEvent()
       pendingEventRef.current = undefined
     }
-  }, [active, cancelDebouncedEvent, handleEvent, target])
+  }, [active, cancelDebouncedEvent, debouncer, handleEvent, target])
 }

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -24,15 +24,15 @@ import HostCommunicationManager, {
 
 // Mocking "message" event listeners on the window;
 // returns function to establish a listener
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-function mockEventListeners(): (type: string, event: any) => void {
+function mockEventListeners(): (type: string, event: Event) => void {
   const listeners: { [name: string]: ((event: Event) => void)[] } = {}
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  window.addEventListener = vi.fn((event: string, cb: any) => {
-    listeners[event] = listeners[event] || []
-    listeners[event].push(cb)
-  })
+  window.addEventListener = vi.fn(
+    (event: string, cb: EventListenerOrEventListenerObject) => {
+      listeners[event] = listeners[event] || []
+      listeners[event].push(cb as EventListener)
+    }
+  )
 
   return (type: string, event: Event): void =>
     listeners[type].forEach(cb => cb(event))
@@ -578,8 +578,7 @@ describe("HostCommunicationManager messaging", () => {
 
 describe("Test different origins", () => {
   let hostCommunicationMgr: HostCommunicationManager
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let dispatchEvent: any
+  let dispatchEvent: (type: string, event: Event) => void
 
   beforeEach(() => {
     hostCommunicationMgr = new HostCommunicationManager({

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -174,8 +174,7 @@ export default class HostCommunicationManager {
    * Register a function to handle a message from the Host
    */
   public receiveHostMessage = (event: MessageEvent): void => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents -- TODO: Replace 'any' with a more specific type.
-    const message: VersionedMessage<IHostToGuestMessage> | any = event.data
+    const message = event.data as VersionedMessage<IHostToGuestMessage>
 
     // Messages coming from the parent frame of a deployed Streamlit app
     // may not be coming from a trusted source (even if we've set the CSP

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -91,6 +91,9 @@ export type IHostToGuestMessage = {
       type: "CLOSE_MODALS"
     }
   | {
+      type: "CLOSE_MODAL"
+    }
+  | {
       type: "REQUEST_PAGE_CHANGE"
       pageScriptHash: string
     }
@@ -167,6 +170,11 @@ export type IHostToGuestMessage = {
     }
   | {
       type: "TERMINATE_WEBSOCKET_CONNECTION"
+    }
+  | {
+      type: "SET_FILE_UPLOAD_CLIENT_CONFIG"
+      prefix: string
+      headers: Record<string, string>
     }
 )
 

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -105,6 +105,7 @@ export type {
   AppConfig,
   DeployedAppMetadata,
   IGuestToHostMessage,
+  IHostToGuestMessage,
   IMenuItem,
   IToolbarItem,
 } from "./hostComm/types"

--- a/frontend/lib/src/render-tree/test-utils.ts
+++ b/frontend/lib/src/render-tree/test-utils.ts
@@ -169,7 +169,7 @@ interface CustomMatchers<R = unknown> {
 }
 
 declare module "vitest" {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type -- TODO: Replace 'any' with a more specific type.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type -- Must match vitest's Assertion<T> signature which has no default type parameter.
   interface Assertion<T = any> extends CustomMatchers<T> {}
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface AsymmetricMatchersContaining extends CustomMatchers {}

--- a/frontend/lib/src/theme/createBaseUiTheme.ts
+++ b/frontend/lib/src/theme/createBaseUiTheme.ts
@@ -84,8 +84,7 @@ const createBaseUiThemePrimitives = (
  */
 const createBaseUiThemeOverrides = (
   theme: EmotionTheme
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): Record<string, any> => {
+): Record<string, unknown> => {
   const { inSidebar, colors, genericFonts, fontSizes, lineHeights, radii } =
     theme
 
@@ -247,8 +246,7 @@ const createBaseUiThemeOverrides = (
 export const createBaseUiTheme = (
   theme: EmotionTheme,
   primitives = lightBaseThemePrimitives
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): BaseTheme & Record<string, any> =>
+): BaseTheme =>
   createBaseTheme(
     createBaseUiThemePrimitives(primitives, theme),
     createBaseUiThemeOverrides(theme)

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -66,17 +66,16 @@ const matchMediaFillers = {
 
 const LOG = getLogger("theme:utils")
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-const windowLocationSearch = (search: string): any => ({
+const windowLocationSearch = (search: string): Pick<Window, "location"> => ({
   location: {
     search,
-  },
+  } as Location,
 })
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-const windowMatchMedia = (theme: "light" | "dark"): any => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  matchMedia: (query: any) => ({
+const windowMatchMedia = (
+  theme: "light" | "dark"
+): Pick<Window, "matchMedia"> => ({
+  matchMedia: (query: string) => ({
     matches: query === `(prefers-color-scheme: ${theme})`,
     media: query,
     ...matchMediaFillers,

--- a/frontend/lib/src/util/Hooks.test.ts
+++ b/frontend/lib/src/util/Hooks.test.ts
@@ -16,8 +16,7 @@
 
 import { useIsOverflowing } from "./Hooks"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-const stateSetters: Array<any> = []
+const stateSetters: Array<ReturnType<typeof vi.fn>> = []
 
 vi.mock("react", async () => ({
   __esModule: true,

--- a/frontend/lib/src/util/Hooks.ts
+++ b/frontend/lib/src/util/Hooks.ts
@@ -22,9 +22,8 @@ import {
   useState,
 } from "react"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export const usePrevious = (value: any): any => {
-  const valueRef = useRef()
+export const usePrevious = <T>(value: T): T | undefined => {
+  const valueRef = useRef<T>()
 
   useEffect(() => {
     valueRef.current = value

--- a/frontend/lib/src/util/UriUtil.test.ts
+++ b/frontend/lib/src/util/UriUtil.test.ts
@@ -118,14 +118,12 @@ describe("isValidOrigin", () => {
     // issue is fixed.
     const OrigURL = globalThis.URL
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      globalThis.URL = function (url: string, ...rest: any[]) {
+      globalThis.URL = function (url: string, ...rest: string[]) {
         if (url.includes("*")) {
           throw new Error("Invalid URL")
         }
         return new OrigURL(url, ...rest)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-      } as any
+      } as unknown as typeof URL
       expect(
         isValidOrigin(
           "https://*.streamlit.app",

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -39,13 +39,13 @@ export const GENERATED_ELEMENT_ID_PREFIX = "$$ID"
  * will only be called after the full interval has elapsed since the last
  * call.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-export function debounce(delay: number, fn: any): any {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  let timerId: any
+export function debounce<TArgs extends unknown[]>(
+  delay: number,
+  fn: (...args: TArgs) => void
+): (...args: TArgs) => void {
+  let timerId: ReturnType<typeof setTimeout> | null = null
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  return (...args: any[]) => {
+  return (...args: TArgs) => {
     if (timerId) {
       clearTimeout(timerId)
     }
@@ -395,8 +395,10 @@ export function isValidElementId(
  * If the element has a valid ID, returns it. Otherwise, returns undefined.
  */
 export function getElementId(element: Element): string | undefined {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  const elementId = get(element as any, [requireNonNull(element.type), "id"])
+  const elementId = get(element as unknown as Record<string, unknown>, [
+    requireNonNull(element.type),
+    "id",
+  ])
   if (elementId && isValidElementId(elementId)) {
     // We only care about valid element IDs (with the correct prefix)
     return elementId
@@ -649,10 +651,8 @@ export function extractPageNameFromPathName(
  * // }
  */
 export function keysToSnakeCase(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-  obj: Record<string, any>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-): Record<string, any> {
+  obj: Record<string, unknown>
+): Record<string, unknown> {
   return Object.keys(obj).reduce(
     (acc, key) => {
       const newKey = decamelize(key, {
@@ -661,13 +661,13 @@ export function keysToSnakeCase(
       let value = obj[key]
 
       if (value && typeof value === "object" && !Array.isArray(value)) {
-        value = keysToSnakeCase(value)
+        value = keysToSnakeCase(value as Record<string, unknown>)
       }
 
       if (Array.isArray(value)) {
         value = value.map(item =>
           item !== null && typeof item === "object"
-            ? keysToSnakeCase(item)
+            ? keysToSnakeCase(item as Record<string, unknown>)
             : item
         )
       }
@@ -675,8 +675,7 @@ export function keysToSnakeCase(
       acc[newKey] = value
       return acc
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
-    {} as Record<string, any>
+    {} as Record<string, unknown>
   )
 }
 

--- a/frontend/utils/src/polyfills/index.ts
+++ b/frontend/utils/src/polyfills/index.ts
@@ -31,7 +31,7 @@ declare global {
   interface PromiseWithResolvers<T> {
     promise: Promise<T>
     resolve: (value: T | PromiseLike<T>) => void
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Must match the built-in PromiseWithResolvers type signature from lib.es2024.promise.d.ts.
     reject: (reason?: any) => void
   }
 


### PR DESCRIPTION
## Describe your changes

- Replaces `any` and their associated `eslint-disable` directives for 98.7% of all existing usages (307 disables -> 4 disables)

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Covered by existing type system / CI.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
