### PR TITLE
[docs] Clarify `client.toolbarMode` docs for deploy button visibility

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -605,14 +605,17 @@ _create_option(
     "client.toolbarMode",
     description="""
         Change the visibility of items in the toolbar and options menu
-        (top right of the app).
+        (top right of the app). The menu and toolbar contain viewer options
+        (e.g. print, record screen, theme toggle) and developer options
+        (e.g. deploy, rerun, clear cache).
 
         Allowed values:
         - "auto"      : Show the developer options if the app is accessed through
                         localhost or through Streamlit Community Cloud as a developer.
                         Hide them otherwise.
         - "developer" : Show the developer options.
-        - "viewer"    : Hide the developer options.
+        - "viewer"    : Hide the developer options, including the rerun, clear
+                        cache, and deploy button from the toolbar and menu.
         - "minimal"   : Show only options set externally (e.g. through
                         Streamlit Community Cloud) or through st.set_page_config.
                         If there are no options left, hide the menu.


### PR DESCRIPTION
## Summary

Improves the `client.toolbarMode` config option documentation to clarify:
- Developer options include the deploy button, rerun, and clear cache
- Using `viewer` mode hides the rerun, clear cache, and deploy button for app viewers

## Github Issue

- Closes #9579

## Testing Plan

- Documentation-only change, no behavior modifications

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->