### PR TITLE
refactor: replace fireEvent with userEvent where possible

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -23,6 +23,9 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react"
+import userEvent, {
+  PointerEventsCheckLevel,
+} from "@testing-library/user-event"
 import { cloneDeep } from "lodash-es"
 import { type Mock, type MockInstance } from "vitest"
 
@@ -455,15 +458,13 @@ function sendForwardMessage(
 }
 
 function openCacheModal(): void {
-  // TODO: Utilize user-event instead of fireEvent
-  // eslint-disable-next-line testing-library/prefer-user-event
+  // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
   fireEvent.keyDown(document.body, {
     key: "c",
     which: 67,
   })
 
-  // TODO: Utilize user-event instead of fireEvent
-  // eslint-disable-next-line testing-library/prefer-user-event
+  // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
   fireEvent.keyUp(document.body, {
     key: "c",
     which: 67,
@@ -724,8 +725,7 @@ describe("App", () => {
       getStoredValue<WidgetStateManager>(WidgetStateManager)
     expect(widgetStateManager.sendUpdateWidgetsMessage).not.toHaveBeenCalled()
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
+    // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
     fireEvent.keyDown(document.body, {
       key: "r",
       which: 82,
@@ -2051,7 +2051,7 @@ describe("App", () => {
       ).toBe("baz")
     })
 
-    it("preserves query params from state when navigating to different page", () => {
+    it("preserves query params from state when navigating to different page", async () => {
       renderApp(getProps())
 
       const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
@@ -2096,9 +2096,11 @@ describe("App", () => {
       // Clear only the hostCommunicationMgr mock before navigation
       ;(hostCommunicationMgr.sendMessageToHost as Mock).mockClear()
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.click(navLinks[1])
+      // Sidebar nav links can have pointer-events: none in this test context.
+      const user = userEvent.setup({
+        pointerEventsCheck: PointerEventsCheckLevel.Never,
+      })
+      await user.click(navLinks[1])
 
       expect(
         // @ts-expect-error
@@ -3951,8 +3953,7 @@ describe("App", () => {
 
       getMockConnectionManager(true)
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
+      // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
       fireEvent.keyPress(screen.getByTestId("stApp"), {
         key: "c",
         which: 67,
@@ -4221,7 +4222,7 @@ describe("App", () => {
 
       // trigger a state transition to RERUN_REQUESTED
       getMockConnectionManager(true)
-      // eslint-disable-next-line testing-library/prefer-user-event
+      // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
       fireEvent.keyDown(document.body, {
         key: "r",
         which: 82,
@@ -5377,8 +5378,7 @@ describe("App", () => {
       // Clear only the hostCommunicationMgr mock before navigation
       ;(hostCommunicationMgr.sendMessageToHost as Mock).mockClear()
 
-      // TODO: Utilize user-event instead of fireEvent
-      // eslint-disable-next-line testing-library/prefer-user-event
+      // eslint-disable-next-line testing-library/prefer-user-event -- navLinks have pointer-events:none which userEvent.click respects but the real browser click works
       fireEvent.click(navLinks[1])
 
       expect(
@@ -5675,7 +5675,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       scriptIsRunning: false,
     })
 
-    // eslint-disable-next-line testing-library/prefer-user-event
+    // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
     fireEvent.keyDown(document.body, {
       key: "r",
       which: 82, // Key code for 'r'
@@ -5684,7 +5684,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
     // Wait for state updates from rerunScript to propagate if any were async.
     // sendRerunBackMsg, which sets hasReceivedNewSession to false, is called synchronously in this path.
     await act(async () => {
-      // Wrapping in act to ensure all microtasks related to fireEvent are flushed.
+      // Wrapping in act to ensure all microtasks related to keyboard event are flushed.
       // Even if it appears as a no-op, it can be important for timing in RTL tests.
       return Promise.resolve()
     })

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -584,9 +584,6 @@ describe("Sidebar Component", () => {
     })
   })
 
-  // Tests for click-outside behavior use fireEvent.mouseDown because we're specifically
-  // testing the mousedown event handler, not general click behavior
-  /* eslint-disable testing-library/prefer-user-event */
   describe("Click Outside Behavior on Mobile", () => {
     beforeEach(() => {
       // Set mobile viewport (less than theme.breakpoints.md which is typically 768px)
@@ -615,6 +612,7 @@ describe("Sidebar Component", () => {
 
       // Click on main app area - should NOT collapse on desktop
       const mainApp = screen.getByTestId("stApp")
+      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
       fireEvent.mouseDown(mainApp)
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
@@ -629,6 +627,7 @@ describe("Sidebar Component", () => {
       })
 
       // Click inside sidebar
+      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
       fireEvent.mouseDown(screen.getByTestId("stSidebarContent"))
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
@@ -654,6 +653,7 @@ describe("Sidebar Component", () => {
       document.body.appendChild(portalElement)
 
       // Click on element outside the main app container - should NOT collapse
+      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
       fireEvent.mouseDown(portalElement)
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
@@ -669,6 +669,7 @@ describe("Sidebar Component", () => {
 
       // Click on main app area
       const mainApp = screen.getByTestId("stApp")
+      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
       fireEvent.mouseDown(mainApp)
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -259,11 +259,8 @@ describe("Selectbox widget", () => {
     const selectboxInput = screen.getByRole("combobox")
 
     // Simulate deleting a character
-    // we are using fireEvent here instead of userEvent because userEvent
-    // did not trigger the backspace event correctly.
-
     act(() => {
-      // eslint-disable-next-line testing-library/prefer-user-event
+      // eslint-disable-next-line testing-library/prefer-user-event -- userEvent.keyboard("{Backspace}") causes a timeout with this BaseWeb combobox
       fireEvent.keyDown(selectboxInput, {
         key: "Backspace",
         keyCode: 8,

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -283,8 +283,7 @@ describe("DateInput widget", () => {
     render(<DateInput {...props} />)
     const dateInput = screen.getByTestId("stDateInputField")
 
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
+    // eslint-disable-next-line testing-library/prefer-user-event -- fireEvent.change needed to set value to null (userEvent.clear sets to empty string, not null)
     fireEvent.change(dateInput, {
       target: { value: newDateDisplay },
     })
@@ -292,8 +291,7 @@ describe("DateInput widget", () => {
     expect(dateInput).toHaveValue(newDateDisplay)
 
     // Simulating clearing the date input
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
+    // eslint-disable-next-line testing-library/prefer-user-event -- fireEvent.change needed to set value to null (userEvent.clear sets to empty string, not null)
     fireEvent.change(dateInput, {
       target: { value: null },
     })
@@ -368,7 +366,8 @@ describe("DateInput widget", () => {
     ).toBeTruthy()
   })
 
-  it("resets its value when form is cleared", () => {
+  it("resets its value when form is cleared", async () => {
+    const user = userEvent.setup()
     // Create a widget in a clearOnSubmit form
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -378,11 +377,8 @@ describe("DateInput widget", () => {
     render(<DateInput {...props} />)
 
     const dateInput = screen.getByTestId("stDateInputField")
-    // TODO: Utilize user-event instead of fireEvent
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(dateInput, {
-      target: { value: newDateDisplay },
-    })
+    await user.clear(dateInput)
+    await user.type(dateInput, newDateDisplay)
 
     expect(dateInput).toHaveValue(newDateDisplay)
     expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(

--- a/frontend/lib/src/components/widgets/MenuButton/MenuButton.test.tsx
+++ b/frontend/lib/src/components/widgets/MenuButton/MenuButton.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { vi } from "vitest"
 
@@ -92,9 +92,7 @@ describe("MenuButton widget", () => {
     // Wait for menu to appear and click the menuitem
     await screen.findByTestId("stMenuButtonBody")
     const optionB = screen.getByRole("menuitem", { name: "Option B" })
-    // Using fireEvent instead of userEvent to avoid flaky tests with BaseUI's StatefulMenu
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(optionB)
+    await user.click(optionB)
 
     // Wait for menu to close (indicates callback was invoked)
     await waitFor(() => {
@@ -120,9 +118,7 @@ describe("MenuButton widget", () => {
     // Wait for menu to appear and click the menuitem
     await screen.findByTestId("stMenuButtonBody")
     const optionA = screen.getByRole("menuitem", { name: "Option A" })
-    // Using fireEvent instead of userEvent to avoid flaky tests with BaseUI's StatefulMenu
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(optionA)
+    await user.click(optionA)
 
     // Wait for menu to close (indicates callback was invoked)
     await waitFor(() => {

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, fireEvent, screen, waitFor } from "@testing-library/react"
+import { act, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import {
@@ -53,17 +53,15 @@ const getProps = (
   ...props,
 })
 
-const triggerChangeEvent = (
-  element: Element,
+const triggerChangeEvent = async (
+  element: HTMLElement,
   key: "ArrowLeft" | "ArrowRight"
-): void => {
-  fireEvent.focus(element)
-  // TODO: Utilize user-event instead of fireEvent
-  // eslint-disable-next-line testing-library/prefer-user-event
-  fireEvent.keyDown(element, { key })
-  // TODO: Utilize user-event instead of fireEvent
-  // eslint-disable-next-line testing-library/prefer-user-event
-  fireEvent.keyUp(element, { key })
+): Promise<void> => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  act(() => {
+    element.focus()
+  })
+  await user.keyboard(`{${key}}`)
 }
 
 describe("Slider widget", () => {
@@ -168,7 +166,7 @@ describe("Slider widget", () => {
       expect(slider).toHaveAttribute("aria-valuemax", `${props.element.max}`)
     })
 
-    it("handles value changes", () => {
+    it("handles value changes", async () => {
       const props = getProps()
 
       render(<Slider {...props} />)
@@ -176,7 +174,7 @@ describe("Slider widget", () => {
 
       const slider = screen.getByRole("slider")
 
-      triggerChangeEvent(slider, "ArrowRight")
+      await triggerChangeEvent(slider, "ArrowRight")
 
       expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
         props.element,
@@ -188,7 +186,7 @@ describe("Slider widget", () => {
       expect(slider).toHaveAttribute("aria-valuenow", "6")
     })
 
-    it("resets its value when form is cleared", () => {
+    it("resets its value when form is cleared", async () => {
       // Create a widget in a clearOnSubmit form
       const props = getProps({ formId: "form" })
       props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -199,7 +197,7 @@ describe("Slider widget", () => {
 
       const slider = screen.getByRole("slider")
 
-      triggerChangeEvent(slider, "ArrowRight")
+      await triggerChangeEvent(slider, "ArrowRight")
 
       expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenLastCalledWith(
         props.element,
@@ -324,12 +322,12 @@ describe("Slider widget", () => {
     })
 
     describe("value should be within bounds", () => {
-      it("start > end", () => {
+      it("start > end", async () => {
         const props = getProps({ default: [5, 5] })
         render(<Slider {...props} />)
 
         const firstSlider = screen.getAllByRole("slider")[0]
-        triggerChangeEvent(firstSlider, "ArrowRight")
+        await triggerChangeEvent(firstSlider, "ArrowRight")
 
         expect(screen.getAllByRole("slider")[0]).toHaveAttribute(
           "aria-valuenow",
@@ -337,48 +335,48 @@ describe("Slider widget", () => {
         )
       })
 
-      it("start < min", () => {
+      it("start < min", async () => {
         const props = getProps({ default: [0, 10] })
         render(<Slider {...props} />)
 
         const firstSlider = screen.getAllByRole("slider")[0]
-        triggerChangeEvent(firstSlider, "ArrowLeft")
+        await triggerChangeEvent(firstSlider, "ArrowLeft")
 
         expect(firstSlider).toHaveAttribute("aria-valuenow", "0")
       })
 
-      it("start > max", () => {
+      it("start > max", async () => {
         const props = getProps({ default: [10] })
         render(<Slider {...props} />)
 
         const slider = screen.getByRole("slider")
-        triggerChangeEvent(slider, "ArrowRight")
+        await triggerChangeEvent(slider, "ArrowRight")
 
         expect(slider).toHaveAttribute("aria-valuenow", "10")
       })
 
-      it("end < min", () => {
+      it("end < min", async () => {
         const props = getProps({ default: [0] })
         render(<Slider {...props} />)
 
         const slider = screen.getByRole("slider")
-        triggerChangeEvent(slider, "ArrowLeft")
+        await triggerChangeEvent(slider, "ArrowLeft")
 
         expect(slider).toHaveAttribute("aria-valuenow", "0")
       })
 
-      it("end > max", () => {
+      it("end > max", async () => {
         const props = getProps({ default: [0, 10] })
         render(<Slider {...props} />)
 
         const secondSlider = screen.getAllByRole("slider")[1]
-        triggerChangeEvent(secondSlider, "ArrowRight")
+        await triggerChangeEvent(secondSlider, "ArrowRight")
 
         expect(secondSlider).toHaveAttribute("aria-valuenow", "10")
       })
     })
 
-    it("handles value changes", () => {
+    it("handles value changes", async () => {
       const props = getProps({ default: [1, 9] })
 
       render(<Slider {...props} />)
@@ -386,7 +384,7 @@ describe("Slider widget", () => {
 
       const sliders = screen.getAllByRole("slider")
 
-      triggerChangeEvent(sliders[1], "ArrowRight")
+      await triggerChangeEvent(sliders[1], "ArrowRight")
 
       expect(props.widgetMgr.setDoubleArrayValue).toHaveBeenCalledWith(
         props.element,
@@ -469,7 +467,7 @@ describe("Slider widget", () => {
       expect(slider).toHaveAttribute("aria-valuetext", "orange")
     })
 
-    it("updates aria-valuetext correctly", () => {
+    it("updates aria-valuetext correctly", async () => {
       const originalProps = {
         default: [1],
         min: 0,
@@ -489,7 +487,7 @@ describe("Slider widget", () => {
       render(<Slider {...props} />)
 
       const slider = screen.getByRole("slider")
-      triggerChangeEvent(slider, "ArrowRight")
+      await triggerChangeEvent(slider, "ArrowRight")
 
       expect(slider).toHaveAttribute("aria-valuetext", "yellow")
     })
@@ -548,7 +546,7 @@ describe("Slider widget", () => {
       expect(props.widgetMgr.setDoubleArrayValue).not.toHaveBeenCalled()
     })
 
-    it("handles value changes with setStringArrayValue", () => {
+    it("handles value changes with setStringArrayValue", async () => {
       const props = getProps({
         default: [1],
         min: 0,
@@ -570,7 +568,7 @@ describe("Slider widget", () => {
       vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
       const slider = screen.getByRole("slider")
-      triggerChangeEvent(slider, "ArrowRight")
+      await triggerChangeEvent(slider, "ArrowRight")
 
       expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,
@@ -580,7 +578,7 @@ describe("Slider widget", () => {
       )
     })
 
-    it("handles range value changes with setStringArrayValue", () => {
+    it("handles range value changes with setStringArrayValue", async () => {
       const props = getProps({
         default: [1, 4],
         min: 0,
@@ -602,7 +600,7 @@ describe("Slider widget", () => {
       vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
       const sliders = screen.getAllByRole("slider")
-      triggerChangeEvent(sliders[1], "ArrowRight")
+      await triggerChangeEvent(sliders[1], "ArrowRight")
 
       expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
         props.element,


### PR DESCRIPTION
## Describe your changes

Migrated test interactions from `fireEvent` to `userEvent` where appropriate and improved ESLint comment explanations. Updated several test functions to be async and use `userEvent` for more realistic user interactions, particularly for click events and keyboard input. Retained `fireEvent` in specific cases where it's necessary for testing low-level event handlers or working around library limitations, with detailed explanations in the ESLint disable comments.

## Testing Plan

- Unit Tests (JS and/or Python) - All existing tests continue to pass with more realistic user interactions

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.