### PR TITLE
[feature] Add `st.file_uploader` support to AppTest

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -56,6 +56,7 @@ from streamlit.testing.v1.element_tree import (
     Exception,  # noqa: A004
     Expander,
     Feedback,
+    FileUploader,
     Header,
     Info,
     Json,
@@ -361,6 +362,10 @@ class AppTest:
             args=self.args,
             kwargs=self.kwargs,
         )
+
+        # Register any files from FileUploader widgets with the file manager
+        self._register_uploaded_files(script_runner)
+
         with patch_config_options({"global.appTest": True}):
             self._tree = script_runner.run(
                 widget_state, self.query_params, timeout, self._page_hash
@@ -377,6 +382,27 @@ class AppTest:
         Runtime._instance = None
 
         return self
+
+    def _register_uploaded_files(self, script_runner: LocalScriptRunner) -> None:
+        """Register files from FileUploader widgets with the file manager."""
+        from streamlit.runtime.uploaded_file_manager import UploadedFileRec
+
+        for widget in self._tree.file_uploader:
+            for (
+                file_id,
+                filename,
+                content,
+                mime_type,
+            ) in widget._get_files_to_register():
+                file_rec = UploadedFileRec(
+                    file_id=file_id,
+                    name=filename,
+                    type=mime_type,
+                    data=content,
+                )
+                script_runner._uploaded_file_mgr.add_file(  # type: ignore[attr-defined]
+                    script_runner._session_id, file_rec
+                )
 
     def run(self, *, timeout: float | None = None) -> AppTest:
         """Run the script from the current state.
@@ -684,6 +710,20 @@ class AppTest:
             ``at.feedback(key="my_key")`` to access by key.
         """
         return self._tree.feedback
+
+    @property
+    def file_uploader(self) -> WidgetList[FileUploader]:
+        """Sequence of all ``st.file_uploader`` widgets.
+
+        Returns
+        -------
+        WidgetList of FileUploader
+            Sequence of all ``st.file_uploader`` widgets. Individual widgets can
+            be accessed from a WidgetList by index (order on the page) or key.
+            For example, ``at.file_uploader[0]`` for the first widget or
+            ``at.file_uploader(key="my_key")`` for a widget with a given key.
+        """
+        return self._tree.file_uploader
 
     @property
     def expander(self) -> Sequence[Expander]:

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -400,9 +400,7 @@ class AppTest:
                     type=mime_type,
                     data=content,
                 )
-                script_runner._uploaded_file_mgr.add_file(  # type: ignore[attr-defined]
-                    script_runner._session_id, file_rec
-                )
+                script_runner.register_file(file_rec)
 
     def run(self, *, timeout: float | None = None) -> AppTest:
         """Run the script from the current state.

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from streamlit.proto.Element_pb2 import Element as ElementProto
     from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
     from streamlit.proto.Feedback_pb2 import Feedback as FeedbackProto
+    from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.proto.Heading_pb2 import Heading as HeadingProto
     from streamlit.proto.Json_pb2 import Json as JsonProto
@@ -879,6 +880,177 @@ class Feedback(Widget):
         """Set the value of the feedback widget. (int or None)"""  # noqa: D400
         self._value = v
         return self
+
+
+@dataclass(repr=False)
+class FileUploader(Widget):
+    r"""A representation of ``st.file_uploader``.
+
+    Files are provided as tuples of (filename, content, mime_type).
+
+    Example
+    -------
+    >>> at = AppTest.from_string('''
+    ...     import streamlit as st
+    ...     uploaded = st.file_uploader("Upload a file")
+    ...     if uploaded:
+    ...         st.write(f"Uploaded: {uploaded.name}")
+    ... ''')
+    >>> at.run()
+    >>> at.file_uploader[0].set_value(("data.csv", b"col1,col2\n1,2", "text/csv"))
+    >>> at.run()
+    >>> at.markdown[0].value
+    'Uploaded: data.csv'
+    """
+
+    # Stores list of (file_id, filename, content, mime_type) tuples
+    _files: list[tuple[str, str, bytes, str]] | None
+
+    proto: FileUploaderProto = field(repr=False)
+    label: str
+    help: str
+    form_id: str
+
+    def __init__(self, proto: FileUploaderProto, root: ElementTree) -> None:
+        super().__init__(proto, root)
+        self._files = None
+        self.type = "file_uploader"
+
+    @property
+    def accept_multiple_files(self) -> bool:
+        """Whether multiple files can be uploaded. (bool)"""  # noqa: D400
+        return self.proto.multiple_files
+
+    @property
+    def accept_directory(self) -> bool:
+        """Whether directory uploads are accepted. (bool)"""  # noqa: D400
+        return self.proto.accept_directory
+
+    @property
+    def allowed_type(self) -> list[str]:
+        """Allowed file types for upload. (list of str)"""  # noqa: D400
+        return list(self.proto.type)
+
+    def set_value(  # type: ignore[override,unused-ignore]
+        self,
+        files: (tuple[str, bytes, str] | Sequence[tuple[str, bytes, str]] | None),
+    ) -> Self:
+        """Set the uploaded file(s) for testing.
+
+        Parameters
+        ----------
+        files
+            A tuple of (filename, content, mime_type) for single file upload,
+            or a sequence of such tuples for multiple file upload.
+            Set to ``None`` to clear uploaded files.
+
+        Returns
+        -------
+        FileUploader
+            The FileUploader instance for method chaining.
+        """
+        from uuid import uuid4
+
+        if files is None:
+            self._files = None
+        elif isinstance(files, tuple) and len(files) == 3 and isinstance(files[0], str):
+            # Single file as tuple (filename, content, mime_type)
+            single_file = cast(  # type: ignore[redundant-cast]
+                "tuple[str, bytes, str]", files
+            )
+            filename, content, mime_type = single_file
+            self._files = [(str(uuid4()), filename, content, mime_type)]
+        else:
+            # Multiple files
+            files_list = cast("Sequence[tuple[str, bytes, str]]", files)
+            self._files = [
+                (str(uuid4()), filename, content, mime_type)
+                for filename, content, mime_type in files_list
+            ]
+        return self
+
+    def upload(
+        self,
+        filename: str,
+        content: bytes,
+        mime_type: str = "application/octet-stream",
+    ) -> Self:
+        """Upload a single file for testing.
+
+        Parameters
+        ----------
+        filename
+            The name of the file.
+        content
+            The file content as bytes.
+        mime_type
+            The MIME type of the file. Defaults to "application/octet-stream".
+
+        Returns
+        -------
+        FileUploader
+            The FileUploader instance for method chaining.
+        """
+        from uuid import uuid4
+
+        if self._files is None:
+            self._files = []
+        self._files.append((str(uuid4()), filename, content, mime_type))
+        return self
+
+    def clear(self) -> Self:
+        """Clear all uploaded files.
+
+        Returns
+        -------
+        FileUploader
+            The FileUploader instance for method chaining.
+        """
+        self._files = None
+        return self
+
+    def _get_files_to_register(self) -> list[tuple[str, str, bytes, str]]:
+        """Return files to register: list of (file_id, filename, content, mime_type)."""
+        return self._files or []
+
+    @property
+    def _widget_state(self) -> WidgetState:
+        """Protobuf message representing the state of the widget."""
+        from streamlit.proto.Common_pb2 import (
+            FileUploaderState as FileUploaderStateProto,
+        )
+
+        ws = WidgetState()
+        ws.id = self.id
+
+        if not self._files:
+            return ws
+
+        # Create file uploader state proto with pre-generated file IDs
+        state_proto = FileUploaderStateProto()
+
+        for file_id, filename, content, _mime_type in self._files:
+            file_info = state_proto.uploaded_file_info.add()
+            file_info.file_id = file_id
+            file_info.name = filename
+            file_info.size = len(content)
+            file_info.file_urls.file_id = file_id
+            file_info.file_urls.upload_url = f"/mock/upload/test session id/{file_id}"
+            file_info.file_urls.delete_url = f"/mock/upload/test session id/{file_id}"
+
+        ws.file_uploader_state_value.CopyFrom(state_proto)
+        return ws
+
+    @property
+    def value(self) -> Any:
+        """The current uploaded file(s).
+
+        Returns the UploadedFile object(s) or None, depending on the
+        ``accept_multiple_files`` setting.
+        """
+        state = self.root.session_state
+        assert state
+        return state[self.id]
 
 
 @dataclass(repr=False)
@@ -1792,6 +1964,10 @@ class Block:
         return WidgetList(self.get("feedback"))  # type: ignore
 
     @property
+    def file_uploader(self) -> WidgetList[FileUploader]:
+        return WidgetList(self.get("file_uploader"))  # type: ignore
+
+    @property
     def expander(self) -> Sequence[Expander]:
         return self.get("expander")  # type: ignore
 
@@ -2255,6 +2431,8 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                 new_node = Exception(elt.exception, root=root)
             elif ty == "feedback":
                 new_node = Feedback(elt.feedback, root=root)
+            elif ty == "file_uploader":
+                new_node = FileUploader(elt.file_uploader, root=root)
             elif ty == "heading":
                 if elt.heading.tag == HeadingProtoTag.TITLE_TAG.value:
                     new_node = Title(elt.heading, root=root)

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -904,7 +904,8 @@ class FileUploader(Widget):
     """
 
     # Stores list of (file_id, filename, content, mime_type) tuples
-    _files: list[tuple[str, str, bytes, str]] | None
+    # InitialValue means no explicit set_value/upload/clear was called
+    _files: list[tuple[str, str, bytes, str]] | InitialValue | None
 
     proto: FileUploaderProto = field(repr=False)
     label: str
@@ -913,7 +914,7 @@ class FileUploader(Widget):
 
     def __init__(self, proto: FileUploaderProto, root: ElementTree) -> None:
         super().__init__(proto, root)
-        self._files = None
+        self._files = InitialValue()
         self.type = "file_uploader"
 
     @property
@@ -993,7 +994,7 @@ class FileUploader(Widget):
         """
         from uuid import uuid4
 
-        if self._files is None:
+        if self._files is None or isinstance(self._files, InitialValue):
             self._files = []
         self._files.append((str(uuid4()), filename, content, mime_type))
         return self
@@ -1010,8 +1011,42 @@ class FileUploader(Widget):
         return self
 
     def _get_files_to_register(self) -> list[tuple[str, str, bytes, str]]:
-        """Return files to register: list of (file_id, filename, content, mime_type)."""
-        return self._files or []
+        """Return files to register: list of (file_id, filename, content, mime_type).
+
+        If no explicit set_value/upload/clear was called, derive from existing
+        UploadedFile(s) in session_state to persist files across runs.
+        """
+        # If explicitly set, use that value
+        if not isinstance(self._files, InitialValue):
+            return self._files or []
+
+        # Fall back to existing UploadedFile(s) in session_state
+        from streamlit.runtime.uploaded_file_manager import UploadedFile
+
+        state = self.root.session_state
+        if not state:
+            return []
+
+        try:
+            current_value = state[self.id]
+        except KeyError:
+            return []
+
+        if current_value is None:
+            return []
+
+        # Handle both single file and multiple files
+        files_list: list[UploadedFile] = []
+        if isinstance(current_value, list):
+            files_list = current_value
+        elif isinstance(current_value, UploadedFile):
+            files_list = [current_value]
+
+        return [
+            (f.file_id, f.name, f.getvalue(), f.type)
+            for f in files_list
+            if isinstance(f, UploadedFile)
+        ]
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1023,13 +1058,18 @@ class FileUploader(Widget):
         ws = WidgetState()
         ws.id = self.id
 
-        if not self._files:
+        # Use _get_files_to_register which handles fallback to session_state
+        files_to_use = self._get_files_to_register()
+
+        if not files_to_use:
+            # Return empty state only if explicitly cleared (not InitialValue)
+            # or if there are no files in session_state
             return ws
 
         # Create file uploader state proto with pre-generated file IDs
         state_proto = FileUploaderStateProto()
 
-        for file_id, filename, content, _mime_type in self._files:
+        for file_id, filename, content, _mime_type in files_to_use:
             file_info = state_proto.uploaded_file_info.add()
             file_info.file_id = file_id
             file_info.name = filename

--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from streamlit.runtime.pages_manager import PagesManager
     from streamlit.runtime.scriptrunner_utils.script_run_context import ScriptRunContext
     from streamlit.runtime.state.safe_session_state import SafeSessionState
+    from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 
 
 class LocalScriptRunner(ScriptRunner):
@@ -90,6 +91,24 @@ class LocalScriptRunner(ScriptRunner):
                 self.forward_msg_queue.enqueue(forward_msg)
 
         self.on_event.connect(record_event, weak=False)
+
+    def register_file(self, file_rec: UploadedFileRec) -> None:
+        """Register an uploaded file with the file manager.
+
+        This is a typed helper method to avoid accessing private attributes
+        directly from AppTest.
+
+        Parameters
+        ----------
+        file_rec
+            The uploaded file record to register.
+        """
+        # Cast to MemoryUploadedFileManager since that's what LocalScriptRunner uses.
+        # The Protocol UploadedFileManager doesn't include add_file.
+        from typing import cast
+
+        file_mgr = cast("MemoryUploadedFileManager", self._uploaded_file_mgr)
+        file_mgr.add_file(self._session_id, file_rec)
 
     def join(self) -> None:
         """Wait for the script thread to finish, if it is running."""

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1219,3 +1219,88 @@ def test_file_uploader_with_key():
 
     assert at.file_uploader("uploader1").label == "First uploader"
     assert at.file_uploader("uploader2").label == "Second uploader"
+
+
+def test_file_uploader_persists_across_runs():
+    """Test that uploaded files persist across subsequent runs without re-setting."""
+
+    def script():
+        import streamlit as st
+
+        uploaded_file = st.file_uploader("Upload a file")
+        if uploaded_file is not None:
+            st.write(f"Uploaded: {uploaded_file.name}")
+            content = uploaded_file.read().decode("utf-8")
+            st.write(f"Content: {content}")
+        else:
+            st.write("No file uploaded")
+
+        # Add a button to trigger reruns
+        if st.button("Click me"):
+            st.write("Button clicked")
+
+    at = AppTest.from_function(script).run()
+    assert at.markdown[0].value == "No file uploaded"
+
+    # Upload a file
+    at.file_uploader[0].set_value(("test.txt", b"Hello, World!", "text/plain"))
+    at.run()
+
+    assert at.file_uploader[0].value is not None
+    assert at.file_uploader[0].value.name == "test.txt"
+    assert at.markdown[0].value == "Uploaded: test.txt"
+    assert at.markdown[1].value == "Content: Hello, World!"
+
+    # Run again WITHOUT re-setting the file - it should persist
+    at.run()
+
+    assert at.file_uploader[0].value is not None
+    assert at.file_uploader[0].value.name == "test.txt"
+    assert at.markdown[0].value == "Uploaded: test.txt"
+    assert at.markdown[1].value == "Content: Hello, World!"
+
+    # Click the button and run - file should still persist
+    at.button[0].click()
+    at.run()
+
+    assert at.file_uploader[0].value is not None
+    assert at.file_uploader[0].value.name == "test.txt"
+    assert at.markdown[0].value == "Uploaded: test.txt"
+    assert "Button clicked" in [m.value for m in at.markdown]
+
+
+def test_file_uploader_multiple_persists_across_runs():
+    """Test that multiple uploaded files persist across subsequent runs."""
+
+    def script():
+        import streamlit as st
+
+        files = st.file_uploader("Upload files", accept_multiple_files=True)
+        if files:
+            for f in files:
+                st.write(f"File: {f.name}")
+        else:
+            st.write("No files uploaded")
+
+    at = AppTest.from_function(_multi_file_script).run()
+    assert at.file_uploader[0].value == []
+
+    # Upload multiple files
+    at.file_uploader[0].set_value(
+        [
+            ("file1.txt", b"Content 1", "text/plain"),
+            ("file2.txt", b"Content 2", "text/plain"),
+        ]
+    )
+    at.run()
+
+    assert len(at.file_uploader[0].value) == 2
+    assert at.markdown[0].value == "File: file1.txt"
+    assert at.markdown[1].value == "File: file2.txt"
+
+    # Run again WITHOUT re-setting - files should persist
+    at.run()
+
+    assert len(at.file_uploader[0].value) == 2
+    assert at.markdown[0].value == "File: file1.txt"
+    assert at.markdown[1].value == "File: file2.txt"

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1101,3 +1101,121 @@ def test_widget_list_call_by_key_not_found():
 
     with pytest.raises(KeyError):
         at.button("nonexistent")
+
+
+def test_file_uploader_single():
+    """Test st.file_uploader with single file upload."""
+
+    def script():
+        import streamlit as st
+
+        uploaded_file = st.file_uploader("Upload a file")
+        if uploaded_file is not None:
+            st.write(f"Uploaded: {uploaded_file.name}")
+            st.write(f"Size: {uploaded_file.size}")
+            st.write(f"Type: {uploaded_file.type}")
+            content = uploaded_file.read().decode("utf-8")
+            st.write(f"Content: {content}")
+
+    at = AppTest.from_function(script).run()
+    assert at.file_uploader[0].value is None
+    assert len(at.text) == 0
+
+    # Upload a file
+    at.file_uploader[0].set_value(("test.txt", b"Hello, World!", "text/plain"))
+    at.run()
+
+    assert at.file_uploader[0].value is not None
+    assert at.file_uploader[0].value.name == "test.txt"
+    assert at.markdown[0].value == "Uploaded: test.txt"
+    assert at.markdown[1].value == "Size: 13"
+    assert at.markdown[2].value == "Type: text/plain"
+    assert at.markdown[3].value == "Content: Hello, World!"
+
+    # Verify repr does not throw
+    repr(at.file_uploader[0])
+
+
+def _multi_file_script():
+    """Shared script for multi-file upload tests."""
+    import streamlit as st
+
+    files = st.file_uploader("Upload files", accept_multiple_files=True)
+    if files:
+        for f in files:
+            st.write(f"File: {f.name}")
+
+
+def test_file_uploader_multiple():
+    """Test st.file_uploader with multiple file uploads."""
+    at = AppTest.from_function(_multi_file_script).run()
+    assert at.file_uploader[0].value == []
+    assert at.file_uploader[0].accept_multiple_files is True
+
+    # Upload multiple files using set_value
+    at.file_uploader[0].set_value(
+        [
+            ("file1.txt", b"Content 1", "text/plain"),
+            ("file2.txt", b"Content 2", "text/plain"),
+        ]
+    )
+    at.run()
+
+    assert len(at.file_uploader[0].value) == 2
+    assert at.markdown[0].value == "File: file1.txt"
+    assert at.markdown[1].value == "File: file2.txt"
+
+
+def test_file_uploader_upload_method():
+    """Test st.file_uploader with upload() method for chaining."""
+    at = AppTest.from_function(_multi_file_script).run()
+
+    # Use upload() method for chaining
+    at.file_uploader[0].upload("doc1.txt", b"Doc 1", "text/plain")
+    at.file_uploader[0].upload("doc2.txt", b"Doc 2", "text/plain")
+    at.run()
+
+    assert len(at.file_uploader[0].value) == 2
+    assert at.markdown[0].value == "File: doc1.txt"
+    assert at.markdown[1].value == "File: doc2.txt"
+
+
+def test_file_uploader_clear():
+    """Test st.file_uploader clear() method."""
+
+    def script():
+        import streamlit as st
+
+        uploaded = st.file_uploader("Upload a file")
+        if uploaded:
+            st.write(f"Uploaded: {uploaded.name}")
+        else:
+            st.write("No file uploaded")
+
+    at = AppTest.from_function(script).run()
+    assert at.markdown[0].value == "No file uploaded"
+
+    # Upload a file
+    at.file_uploader[0].set_value(("test.txt", b"content", "text/plain"))
+    at.run()
+    assert at.markdown[0].value == "Uploaded: test.txt"
+
+    # Clear the file
+    at.file_uploader[0].clear()
+    at.run()
+    assert at.markdown[0].value == "No file uploaded"
+
+
+def test_file_uploader_with_key():
+    """Test st.file_uploader can be accessed by key."""
+
+    def script():
+        import streamlit as st
+
+        st.file_uploader("First uploader", key="uploader1")
+        st.file_uploader("Second uploader", key="uploader2")
+
+    at = AppTest.from_function(script).run()
+
+    assert at.file_uploader("uploader1").label == "First uploader"
+    assert at.file_uploader("uploader2").label == "Second uploader"


### PR DESCRIPTION
## Describe your changes

Adds `st.file_uploader` support to the AppTest testing framework, addressing a long-standing feature request.

- Add `FileUploader` widget class to `element_tree.py` with `set_value()`, `upload()`, and `clear()` methods
- Add file registration logic to `app_test.py` that registers uploaded files with `MemoryUploadedFileManager` before script runs
- Add comprehensive unit tests covering single/multiple file uploads, incremental uploads, and clearing

**Example usage:**
```python
def test_file_upload():
    at = AppTest.from_file("app.py")
    at.run()
    
    # Upload a file
    at.file_uploader[0].set_value(("data.csv", b"col1,col2\n1,2", "text/csv"))
    at.run()
    
    # Or upload multiple files
    at.file_uploader[0].set_value([
        ("file1.txt", b"content1", "text/plain"),
        ("file2.txt", b"content2", "text/plain"),
    ])
    at.run()
```

## GitHub Issue Link (if applicable)

- Closes #8093

## Testing Plan

- [x] Unit Tests (Python)
  - Test single file upload
  - Test multiple file upload  
  - Test incremental upload via `upload()` method
  - Test clearing files via `clear()` method
  - Test key-based widget access

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 2 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | Explore | 2 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 3 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->