### PR TITLE
[refactor] Rename internal `DeltaGenerator.id` to `_id` 

### DIFF
--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -438,7 +438,7 @@ class DeltaGenerator(
         return self._provided_cursor is None
 
     @property
-    def id(self) -> str:
+    def _id(self) -> str:
         return str(id(self))
 
     def _get_transient_cursor(self) -> cursor.Cursor:
@@ -559,9 +559,9 @@ class DeltaGenerator(
         caching.save_element_message(
             delta_type,
             element_proto,
-            invoked_dg_id=self.id,
-            used_dg_id=dg.id,
-            returned_dg_id=output_dg.id,
+            invoked_dg_id=self._id,
+            used_dg_id=dg._id,
+            returned_dg_id=output_dg._id,
             layout_config=layout_config,
         )
 
@@ -620,9 +620,9 @@ class DeltaGenerator(
 
         caching.save_block_message(
             block_proto,
-            invoked_dg_id=self.id,
-            used_dg_id=dg.id,
-            returned_dg_id=block_dg.id,
+            invoked_dg_id=self._id,
+            used_dg_id=dg._id,
+            returned_dg_id=block_dg._id,
         )
 
         return block_dg

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -760,8 +760,8 @@ class DataCache(Cache[R]):
         The value must be pickleable.
         """
         try:
-            main_id = st._main.id
-            sidebar_id = st.sidebar.id
+            main_id = st._main._id
+            sidebar_id = st.sidebar._id
             entry = CachedResult(value, messages, main_id, sidebar_id)
             pickled_entry = pickle.dumps(entry)
         except (pickle.PicklingError, TypeError) as exc:

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -695,8 +695,8 @@ class ResourceCache(Cache[R]):
     @gather_metrics("_cache_resource_object")
     def write_result(self, key: str, value: R, messages: list[MsgData]) -> None:
         """Write a value and associated messages to the cache."""
-        main_id = st._main.id
-        sidebar_id = st.sidebar.id
+        main_id = st._main._id
+        sidebar_id = st.sidebar._id
 
         with self._mem_cache_lock:
             self._mem_cache[key] = CachedResult(value, messages, main_id, sidebar_id)

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -106,7 +106,7 @@ class RunWarningTest(unittest.TestCase):
         }
 
         # Add public commands that only exist in the delta generator:
-        expected_api = expected_api.union({"add_rows", "id", "dg"})
+        expected_api = expected_api.union({"add_rows", "dg"})
 
         assert api == expected_api
 

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -81,9 +81,9 @@ def as_replay_test_data() -> CachedResult:
     """
     return CachedResult(
         1,
-        [ElementMsgData("text", TextProto(body="1"), st._main.id, "")],
-        st._main.id,
-        st.sidebar.id,
+        [ElementMsgData("text", TextProto(body="1"), st._main._id, "")],
+        st._main._id,
+        st.sidebar._id,
     )
 
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -75,7 +75,7 @@ def as_cached_result(value: Any) -> CachedResult:
     """Creates cached results for a function that returned `value`
     and did not execute any elements.
     """
-    return CachedResult(value, [], st._main.id, st.sidebar.id)
+    return CachedResult(value, [], st._main._id, st.sidebar._id)
 
 
 class CommonCacheTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

Renames `DeltaGenerator.id` property to `DeltaGenerator._id` to indicate it's an internal implementation detail.

- The `.id` property was only used internally for cache message replay tracking
- Public properties or functions on the DeltaGenerator interface are considered part of the public API.
- Making it `._id` prevents accidental user dependency on this internal mechanism
- Updated all internal usages in caching modules and tests

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python) — `delta_generator_test.py` updated to remove `id` from public API expectations

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |

</details>
<!-- agent-metrics-end -->