### PR TITLE
fix: Initialize BidiComponentManager in AppTest to support st.components.v2

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -30,6 +30,7 @@ from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
+from streamlit.components.v2.component_manager import BidiComponentManager
 from streamlit.runtime.secrets import Secrets
 from streamlit.runtime.state.common import TESTING_KEY
 from streamlit.runtime.state.safe_session_state import SafeSessionState
@@ -339,6 +340,7 @@ class AppTest:
             MemoryMediaFileStorage("/mock/media")
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
+        mock_runtime.bidi_component_registry = BidiComponentManager()
         Runtime._instance = mock_runtime
         script_cache = ScriptCache()
         # Reset to ensure st.navigation works correctly regardless of prior test state.


### PR DESCRIPTION
## Summary

Fixes #14274

When `AppTest` runs apps that use `st.components.v2` custom components, it crashes with `TypeError: bad argument type for built-in operation`. This happens because the mock `Runtime` in `AppTest._run()` does not have a properly initialized `bidi_component_registry`.

## Root Cause

1. `AppTest._run()` creates a `MagicMock(spec=Runtime)` with explicit setup for `media_file_mgr` and `cache_storage_manager`
2. The `bidi_component_registry` attribute is left as an auto-generated `MagicMock` attribute
3. When a v2 component runs, `Runtime.instance().bidi_component_registry.get(component_name)` returns a `MagicMock` object instead of a real `BidiComponentDefinition`
4. This causes the protobuf field assignment at `bidi_component_proto.js_content = component_def.js_content or ""` to fail with `TypeError: bad argument type for built-in operation`

## Fix

This PR adds `BidiComponentManager` initialization to `AppTest._run()`:

```python
from streamlit.components.v2.component_manager import BidiComponentManager

mock_runtime = MagicMock(spec=Runtime)
mock_runtime.media_file_mgr = MediaFileManager(
    MemoryMediaFileStorage("/mock/media")
)
mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
mock_runtime.bidi_component_registry = BidiComponentManager()  # Added this line
Runtime._instance = mock_runtime
```

## Testing

This fix allows the reproducer from #14274 to work correctly:

```python
# my_component.py
from streamlit.components.v2 import component

_my_component = component(
    "my_component",
    html='<div id="root">hello</div>',
)

def my_component(text: str, key: str | None = None):
    return _my_component(key=key, data={"text": text})
```

```python
# app.py
import streamlit as st
from my_component import my_component

st.title("Test")
my_component("hello", key="test")
```

```python
# test_app.py
from streamlit.testing.v1 import AppTest

def test_v2_component():
    app = AppTest.from_file("app.py", default_timeout=10)
    app.run()
    assert not app.exception, [e.message for e in app.exception]
```

**Before**: Test fails with `TypeError: bad argument type for built-in operation`
**After**: Test passes successfully

## Impact

- **Scope**: Only affects `AppTest` framework
- **Backward Compatibility**: Yes, only adds missing functionality
- **Breaking Changes**: None
- **Risk**: Low, minimal change with clear scope

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested this fix with the reproducer from #14274