### PR TITLE
Fix st.exception links overflow at small widths

### DIFF
--- a/frontend/lib/src/components/elements/ExceptionElement/styled-components.ts
+++ b/frontend/lib/src/components/elements/ExceptionElement/styled-components.ts
@@ -45,6 +45,7 @@ export const StyledExceptionMessage = styled.div({
 export const StyledExceptionLinks = styled.div(({ theme }) => ({
   fontSize: theme.fontSizes.sm,
   display: "flex",
+  flexWrap: "wrap",
   gap: theme.spacing.md,
   justifyContent: "flex-end",
   underline: true,


### PR DESCRIPTION
## Summary
- Add `flexWrap: "wrap"` to `StyledExceptionLinks` so that the "Copy", "Ask Google", and "Ask ChatGPT" action links wrap to the next line instead of overflowing when the `st.exception` container is narrow.

Fixes #12870

## Test plan
- [ ] Render an `st.exception` in a narrow container (e.g. `st.container(width=100)`) and verify the links wrap instead of overflowing
- [ ] Verify normal-width `st.exception` still displays links in a single row

🤖 Generated with [Claude Code](https://claude.com/claude-code)