### PR TITLE
[fix] Restore tooltip on st.multiselect selected options

### DIFF
--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -763,3 +763,24 @@ def test_multiselect_query_param_duplicate_values_deduplicated(
     expect(page).not_to_have_url(
         re.compile(r"bound_multi=Red&bound_multi=Blue&bound_multi=Red")
     )
+
+
+def test_multiselect_selected_tags_have_title_attribute(app: Page):
+    """Test that selected tags have title attributes for tooltips (issue #14351).
+
+    The title attribute enables the browser's native tooltip to show when hovering
+    over selected options, which is especially helpful for truncated long values.
+    """
+    # Get multiselect 4 which has default selections: ["tea", "water"]
+    ms = get_multiselect(app, "multiselect 4")
+
+    # Verify tags have title attributes set to their option values
+    tea_tag = ms.locator('span[data-baseweb="tag"] span[title="tea"]')
+    water_tag = ms.locator('span[data-baseweb="tag"] span[title="water"]')
+
+    expect(tea_tag).to_be_visible()
+    expect(water_tag).to_be_visible()
+
+    # Verify the title attributes have correct values
+    expect(tea_tag).to_have_attribute("title", "tea")
+    expect(water_tag).to_have_attribute("title", "water")

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -765,11 +765,12 @@ def test_multiselect_query_param_duplicate_values_deduplicated(
     )
 
 
-def test_multiselect_selected_tags_have_title_attribute(app: Page):
-    """Test that selected tags have title attributes for tooltips (issue #14351).
+def test_multiselect_selected_tags_have_working_tooltips(app: Page):
+    """Test that selected tags have working native tooltips (issue #14351).
 
     The title attribute enables the browser's native tooltip to show when hovering
     over selected options, which is especially helpful for truncated long values.
+    This requires both the title attribute AND pointer-events: auto on the text span.
     """
     # Get multiselect 4 which has default selections: ["tea", "water"]
     ms = get_multiselect(app, "multiselect 4")
@@ -784,3 +785,19 @@ def test_multiselect_selected_tags_have_title_attribute(app: Page):
     # Verify the title attributes have correct values
     expect(tea_tag).to_have_attribute("title", "tea")
     expect(water_tag).to_have_attribute("title", "water")
+
+    # Verify pointer-events is "auto" so the native tooltip can appear on hover
+    # (the fix for issue #14351 re-enabled pointer-events on the text span)
+    tea_pointer_events = tea_tag.evaluate(
+        "el => window.getComputedStyle(el).pointerEvents"
+    )
+    assert tea_pointer_events == "auto", (
+        f"Expected pointer-events: auto, got: {tea_pointer_events}"
+    )
+
+    water_pointer_events = water_tag.evaluate(
+        "el => window.getComputedStyle(el).pointerEvents"
+    )
+    assert water_pointer_events == "auto", (
+        f"Expected pointer-events: auto, got: {water_pointer_events}"
+    )

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -513,6 +513,14 @@ const Multiselect: FC<Props> = props => {
                       pointerEvents: "none",
                     },
                   },
+                  Text: {
+                    style: {
+                      // Re-enable pointer events for the text so the title
+                      // tooltip is shown on hover (pointerEvents: none on Root
+                      // disables it by default)
+                      pointerEvents: "auto",
+                    },
+                  },
                   Action: {
                     style: {
                       paddingLeft: theme.spacing.none,


### PR DESCRIPTION
## Describe your changes

Fixes a regression introduced in v1.55.0 where tooltips no longer appear when hovering over selected options in `st.multiselect`.

**Root cause:** PR #13796 added `pointerEvents: "none"` to the Tag Root element to allow clicks to pass through to the input field. This unintentionally disabled the browser's native `title` tooltip on the tag text.

**Fix:** Added `pointerEvents: "auto"` to the Text override of the Tag component, re-enabling hover events specifically on the text element so the native tooltip appears. This follows the same pattern already used for the Action (close button) override.

## GitHub Issue Link (if applicable)

- Closes #14351

## Testing Plan

- [x] Unit Tests - All 44 existing Multiselect tests pass
- [x] E2E Tests - Added `test_multiselect_selected_tags_have_title_attribute` to verify tags have title attributes for tooltips

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->