### PR TITLE
feat: include pr-level comments in addressing-pr-review-comments skill

### DIFF
--- a/.claude/skills/addressing-pr-review-comments/SKILL.md
+++ b/.claude/skills/addressing-pr-review-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: addressing-pr-review-comments
-description: Address all valid review comments on a PR for the current branch in the streamlit/streamlit repo. Use when a PR has received reviewer feedback that needs to be addressed, including code changes, style fixes, and documentation updates.
+description: Address all valid review comments on a PR for the current branch in the streamlit/streamlit repo. Covers both inline review comments and general PR (issue) comments. Use when a PR has reviewer feedback to address, including code changes, style fixes, and documentation updates.
 ---
 
 # Address PR Comments
@@ -30,6 +30,8 @@ If auth fails, prompt user to run `gh auth login`.
 
 ### 2. Fetch PR data
 
+You must fetch both inline review comments and general PR (issue) comments. Use both when building the list of feedback to address. General comments have no file or line. Treat them as PR-level feedback.
+
 ```bash
 # PR details for current branch (extract PR number from here)
 gh pr view --json number,title,url,state,author,headRefName,baseRefName,reviewDecision,reviews,comments
@@ -41,7 +43,7 @@ gh api --paginate repos/streamlit/streamlit/pulls/{PR_NUMBER}/comments
 gh api --paginate repos/streamlit/streamlit/issues/{PR_NUMBER}/comments
 ```
 
-Get unresolved review threads via GraphQL:
+Get unresolved review threads via GraphQL (inline only; used for file/path/line). The query returns the first comment of each thread for display when listing threads; full comment bodies are already fetched via the REST `pulls/{PR_NUMBER}/comments` and `issues/{PR_NUMBER}/comments` APIs above. Note: `reviewThreads(first: 100)` returns at most 100 threads; for PRs with more unresolved threads, use cursor-based pagination (`pageInfo.hasNextPage` / `endCursor`) or rely on the REST comments list.
 
 ```bash
 gh api graphql -f query="
@@ -63,26 +65,38 @@ gh api graphql -f query="
 }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)]'
 ```
 
-**Tip:** Save outputs to `work-tmp/reviews/pr-{PR_NUMBER}-review-threads.json` for later reference if the data falls out of context.
+Issue comments (from `issues/{PR_NUMBER}/comments`) do not have a "resolved" flag. Consider all issue comments when building the actionable list, including the PR author's. Author comments can add useful context.
+
+**Tip:** Save outputs for later reference if the data falls out of context: `work-tmp/reviews/pr-{PR_NUMBER}-review-threads.json` for inline threads, and `work-tmp/reviews/pr-{PR_NUMBER}-issue-comments.json` for general PR comments.
 
 ### 3. Analyze comments
 
-**Include:** Unresolved threads, `issue`/`todo`/`chore` comments, maintainer feedback, `CHANGES_REQUESTED` reviews
+**Include:** Unresolved threads (inline), general PR comments from `issues/{PR}/comments`, `issue`/`todo`/`chore` comments, maintainer feedback, `CHANGES_REQUESTED` reviews. Include the PR author's comments when present. They can help clarify the problem space.
 
-**Exclude:** Resolved threads, `praise`/`thought`/`note` comments, PR author's own comments
+**Exclude:** Resolved threads, `praise`/`thought`/`note` comments
+
+**Skip status-only automated comments.** Ignore comments that are only status or check notifications with no actionable feedback. Examples: Snyk ("Snyk checks have passed. No issues have been found so far.") and comments from `.github/workflows/pr-preview.yml` that only say the PR is building or the preview is ready.
+
+**Include substantive bot feedback.** Include automated comments that contain actual review feedback. For example, AI review comments from the `github-actions` bot. Treat them like other review comments and validate before acting. Bot suggestions can be false positives.
+
+**General PR comments:** Analyze general PR comments (from `issues/{PR}/comments`) the same way as inline comments. Same include/exclude rules and conventional-comment types (`issue` / `todo` / `chore` / `suggestion` / etc.).
 
 **Critical analysis:** Before categorizing a comment or suggesting a response, thoroughly investigate the code and context:
+
 - **Read the code:** Carefully read the relevant code sections mentioned in the comment, including surrounding logic.
 - **Challenge assumptions:** Do not take the reviewer's comment or the original code's correctness for granted. Question both.
 - **Seek the truth:** Determine the most correct outcome—whether that means siding with the reviewer, defending the code, or proposing a new solution.
 - **Verify bot comments:** Bot suggestions may be false positives. Always validate the issue exists before acting.
+- **General comments without file/line:** If a comment does not reference a file or line, infer scope from the text (e.g. "add a test" points to a test file, "update the doc" to docs). If scope is unclear, list possible locations when presenting options.
 
 **Action types** (per [conventional comments](https://conventionalcomments.org)): `issue` / `todo` / `chore` (must fix) · `suggestion` (consider) · `nitpick` (optional) · `question` (clarify) · `praise` / `thought` / `note` (skip)
 
 ### 4. Present options
 
+The list below combines actionable inline comments and general PR comments. For general comments use "(general)" or "PR-level" instead of `{file_path}:{line}`.
+
 ```
-Found {N} unresolved comments on PR #{NUMBER}: {TITLE}
+Found {N} actionable comments ({X} inline, {Y} general) on PR #{NUMBER}: {TITLE}
 Review Decision: {APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED}
 
 Actionable Items:
@@ -92,7 +106,7 @@ Actionable Items:
    @{reviewer}: "{comment text}"
    Action: {what will be done}
 
-2. [todo] {file_path}:{line}
+2. [todo] (general)
    @{reviewer}: "{comment text}"
    Action: {what will be done}
 
@@ -108,7 +122,7 @@ Actionable Items:
    @{reviewer}: "{comment text}"
    Action: {what will be done} (optional)
 
-6. [question] {file_path}:{line}
+6. [question] (general)
    @{reviewer}: "{comment text}"
    Action: Clarify with user
 
@@ -123,10 +137,13 @@ Options: "1-5" | "all" | "1,2,3" | "skip 4,5"
 ### 5. Apply fixes
 
 For each selected item:
-1. Read the affected file
+
+1. Read the affected file (for general comments, infer from comment content; see below)
 2. Assess complexity - flag high-complexity fixes to user instead of applying
 3. Apply minimal fix
 4. Prepare brief reply text for the PR comment
+
+For general (non-inline) comments there is no path or line on the comment. Infer the affected file from the comment content, or treat as PR-level (e.g. "update README", "add a test"). If the target is unclear, list options and let the user choose before applying.
 
 **High-complexity fixes:** If a fix requires large refactors, new abstractions, or risky changes disproportionate to the comment, stop and present the trade-off to the user. Let them decide whether to proceed, push back, or find a simpler approach.
 
@@ -138,6 +155,7 @@ git diff --stat
 ```
 
 Report:
+
 - Changes per comment with suggested reply text
 - Remaining unaddressed comments
 - Skipped items (questions, bot false positives)
@@ -150,21 +168,24 @@ Report:
 Summary of Changes
 ─────────────────────────────────────────────────────────
 
-Addressed 3 of 5 comments:
+Addressed 4 of 6 comments:
 
 ✅ #1 [issue]: Fixed null check in utils.py
    Reply: "Added null check as suggested. Good catch!"
 
-✅ #2 [nitpick]: Renamed variable to snake_case
+✅ #2 [chore] (general): Updated README as requested
+   Reply: "Done, README updated."
+
+✅ #3 [nitpick]: Renamed variable to snake_case
    Reply: "Fixed, thanks for the consistency note."
 
-✅ #3 [todo]: Added docstring to function
+✅ #4 [todo]: Added docstring to function
    Reply: "Added comprehensive docstring."
 
-⏭️ #4 [question]: Skipped - requires your input
+⏭️ #5 [question]: Skipped - requires your input
    Question: "Should this handle the edge case of empty lists?"
 
-🤖 #5 [suggestion] (bot): Skipped - false positive
+🤖 #6 [suggestion] (bot): Skipped - false positive
    Bot suggested: "Variable may be undefined"
    Reason: Variable is always initialized in the preceding block
 
@@ -198,12 +219,13 @@ gh api repos/streamlit/streamlit/issues/{PR_NUMBER}/comments \
 
 ## Rules
 
+- **Both sources**: Consider both inline review comments and general PR comments when building the list of feedback to address.
 - **Minimal fixes**: Address exactly what was requested
 - **Flag complexity**: If a fix requires significant refactoring, flag it to user first
 - **Verify bot comments**: Always validate before acting
 - **Preserve intent**: Don't change unrelated code
 - **Reply suggestions**: Provide brief, professional reply text for each addressed comment
-- **Skip**: Resolved threads, info-only comments, praise, incorrect bot suggestions
+- **Skip**: Resolved threads, info-only comments, praise, incorrect bot suggestions, and status-only automated comments (e.g. Snyk "checks passed", pr-preview build status).
 
 ## Error handling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `implementing-feature` | When you have a spec folder, URL, or GitHub issue to implement end-to-end |
 | `understanding-streamlit-architecture` | When debugging cross-layer issues, understanding how features work end-to-end, or onboarding to the codebase |
 | `creating-pull-requests` | When changes are ready to be submitted as a PR with proper labels and formatting |
-| `addressing-pr-review-comments` | When a PR has reviewer feedback that needs to be addressed |
+| `addressing-pr-review-comments` | When a PR has reviewer feedback to address, including inline and general PR comments |
 | `updating-internal-docs` | After significant codebase changes to review and update internal documentation |
 | `finalizing-pr` | When changes are ready to merge — runs quality checks, simplifies code, and creates/updates the PR |
 


### PR DESCRIPTION
## Describe your changes

Enhanced the addressing-pr-review-comments skill to handle both inline review comments and general PR (issue) comments. Previously, the skill only processed inline review comments attached to specific files and lines. Now it also considers general PR-level comments that don't have file/line associations.

Key improvements:
- Added fetching and processing of general PR comments from the `issues/{PR}/comments` endpoint
- Updated analysis logic to handle comments without file/line context by inferring scope from comment content
- Enhanced the presentation format to distinguish between inline and general comments
- Added logic to skip status-only automated comments (like Snyk checks or build notifications) while including substantive bot feedback
- Updated the action application process to handle general comments by inferring target files from comment text
- Clarified that PR author comments should be included as they can provide useful context

## Testing Plan

- N/A - Skill change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.