### PR TITLE
[feature] `st.expander` & `st.popover` state persistence and CSS key class

### DIFF
--- a/e2e_playwright/st_expander.py
+++ b/e2e_playwright/st_expander.py
@@ -253,3 +253,16 @@ with st.expander(
     st.write("Callback args expander content")
 
 st.write(f"Callback args result: {st.session_state.cb_args_result}")
+
+# ============================================================================
+# State Persistence Test — keyed expander should persist open/close across remount
+# ============================================================================
+
+persist_show = st.toggle(
+    "Show extra text above expander", key="persist_expander_toggle"
+)
+if persist_show:
+    st.write("Extra text inserted above expander")
+
+with st.expander("Persist expander", expanded=False, key="persist_expander"):
+    st.write("Persist expander content")

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Final
 
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
-from e2e_playwright.shared.app_utils import check_top_level_class, get_expander
+from e2e_playwright.shared.app_utils import (
+    check_top_level_class,
+    click_toggle,
+    get_element_by_key,
+    get_expander,
+)
 
 EXPANDER_HEADER_IDENTIFIER = "summary"
 
-NUMBER_OF_EXPANDERS: Final = 21
+NUMBER_OF_EXPANDERS: Final = 22
 
 
 def test_expander_displays_correctly(
@@ -368,3 +374,36 @@ def test_expander_callback_with_args_kwargs(app: Page):
 
     # Callback should have received args and kwargs
     expect(app.get_by_text("Callback args result: hello-toggled-world")).to_be_visible()
+
+
+def test_keyed_expander_css_key_class(app: Page):
+    """Keyed expander should have the st-key-* CSS class on the outermost element."""
+    keyed_expander = get_element_by_key(app, "persist_expander")
+    expect(keyed_expander).to_have_class(re.compile(r"st-key-persist_expander"))
+
+
+def test_keyed_expander_persist_expanded_across_remount(app: Page):
+    """Toggling a conditional element above a keyed expander shifts the delta path,
+    but the expanded state should be preserved via elementStates.
+    """
+    keyed_expander = get_element_by_key(app, "persist_expander")
+
+    # Initially collapsed — expand it
+    keyed_expander.locator("summary").click()
+    expect(keyed_expander.get_by_text("Persist expander content")).to_be_visible()
+
+    # Toggle the conditional element above — causes a rerun and delta path shift
+    click_toggle(app, "Show extra text above expander")
+    expect(app.get_by_text("Extra text inserted above expander")).to_be_visible()
+
+    # The keyed expander should still be expanded
+    keyed_expander = get_element_by_key(app, "persist_expander")
+    expect(keyed_expander.get_by_text("Persist expander content")).to_be_visible()
+
+    # Toggle back — another rerun and delta path shift
+    click_toggle(app, "Show extra text above expander")
+    expect(app.get_by_text("Extra text inserted above expander")).not_to_be_visible()
+
+    # Still expanded
+    keyed_expander = get_element_by_key(app, "persist_expander")
+    expect(keyed_expander.get_by_text("Persist expander content")).to_be_visible()

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -221,13 +221,5 @@ def callback_popover_fragment() -> None:
 
 callback_popover_fragment()
 
-# ============================================================================
-# State Persistence Test — keyed popover should persist open/close across remount
-# ============================================================================
-
-persist_show = st.toggle("Show extra text above popover", key="persist_popover_toggle")
-if persist_show:
-    st.write("Extra text inserted above popover")
-
 with st.popover("Persist popover", key="persist_popover"):
     st.write("Persist popover content")

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -221,5 +221,9 @@ def callback_popover_fragment() -> None:
 
 callback_popover_fragment()
 
+if st.session_state.get("persist_popover_shift"):
+    st.write("Extra text above popover")
+
 with st.popover("Persist popover", key="persist_popover"):
     st.write("Persist popover content")
+    st.checkbox("Shift delta path", key="persist_popover_shift")

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -220,3 +220,14 @@ def callback_popover_fragment() -> None:
 
 
 callback_popover_fragment()
+
+# ============================================================================
+# State Persistence Test — keyed popover should persist open/close across remount
+# ============================================================================
+
+persist_show = st.toggle("Show extra text above popover", key="persist_popover_toggle")
+if persist_show:
+    st.write("Extra text inserted above popover")
+
+with st.popover("Persist popover", key="persist_popover"):
+    st.write("Persist popover content")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -21,7 +21,6 @@ from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
-    click_toggle,
     expect_markdown,
     get_element_by_key,
     get_popover,
@@ -362,32 +361,3 @@ def test_keyed_popover_css_key_class(app: Page):
     """Keyed popover should have the st-key-* CSS class on the outermost element."""
     keyed_popover = get_element_by_key(app, "persist_popover")
     expect(keyed_popover).to_have_class(re.compile(r"st-key-persist_popover"))
-
-
-def test_keyed_popover_persist_closed_across_remount(app: Page):
-    """Clicking outside a popover closes it (onClickOutside). This test verifies
-    that the closed state is persisted: after the toggle shifts the delta path,
-    the popover stays closed (its elementStates entry says 'open=false') rather
-    than reverting to whatever proto default the server sends.
-
-    Note: popover persistence for the *open* state is harder to test in E2E
-    because any click outside the popover body triggers onClickOutside, closing
-    it before the rerun. The underlying mechanism is the same as expander/tabs
-    persistence (elementStates), which is tested there.
-    """
-    keyed_popover = get_element_by_key(app, "persist_popover")
-
-    # Open and close the popover to store open=false
-    keyed_popover.get_by_test_id("stPopoverButton").click()
-    expect(app.get_by_text("Persist popover content")).to_be_visible()
-    keyed_popover.get_by_test_id("stPopoverButton").click()
-    expect(app.get_by_text("Persist popover content")).not_to_be_visible()
-
-    # Toggle the conditional element above — causes a rerun and delta path shift
-    click_toggle(app, "Show extra text above popover")
-    wait_for_app_run(app)
-    expect(app.get_by_text("Extra text inserted above popover")).to_be_visible()
-
-    # The keyed popover should still be closed after remount
-    keyed_popover = get_element_by_key(app, "persist_popover")
-    expect(app.get_by_text("Persist popover content")).not_to_be_visible()

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -357,6 +357,21 @@ def test_popover_callback_in_fragment(app: Page):
     expect(app.get_by_text("Fragment callback count: 2")).to_be_visible()
 
 
+def test_keyed_popover_persists_open_state_across_rerun(app: Page):
+    """Test that a keyed popover stays open after a rerun triggered by keyboard shortcut."""
+    # Open the keyed popover
+    open_popover(app, "Persist popover")
+    expect(app.get_by_text("Persist popover content")).to_be_visible()
+
+    # Trigger a rerun via "r" keyboard shortcut — avoids clicking outside
+    # the popover which would close it
+    app.keyboard.press("r")
+    wait_for_app_run(app)
+
+    # The popover should still be open after the rerun
+    expect(app.get_by_text("Persist popover content")).to_be_visible()
+
+
 def test_keyed_popover_css_key_class(app: Page):
     """Keyed popover should have the st-key-* CSS class on the outermost element."""
     keyed_popover = get_element_by_key(app, "persist_popover")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -21,6 +21,7 @@ from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
+    click_checkbox,
     expect_markdown,
     get_element_by_key,
     get_popover,
@@ -357,18 +358,30 @@ def test_popover_callback_in_fragment(app: Page):
     expect(app.get_by_text("Fragment callback count: 2")).to_be_visible()
 
 
-def test_keyed_popover_persists_open_state_across_rerun(app: Page):
-    """Test that a keyed popover stays open after a rerun triggered by keyboard shortcut."""
+def test_keyed_popover_persists_open_state_across_remount(app: Page):
+    """Clicking a checkbox inside a keyed popover that adds an element above the
+    popover shifts the delta path, but the open state should be preserved via
+    elementStates.
+    """
     # Open the keyed popover
     open_popover(app, "Persist popover")
     expect(app.get_by_text("Persist popover content")).to_be_visible()
 
-    # Trigger a rerun via "r" keyboard shortcut — avoids clicking outside
-    # the popover which would close it
-    app.keyboard.press("r")
-    wait_for_app_run(app)
+    # Click the checkbox inside the popover — triggers a rerun that inserts an
+    # element above the popover, shifting its delta path (remount)
+    click_checkbox(app, "Shift delta path")
 
-    # The popover should still be open after the rerun
+    # The extra text should now appear above the popover
+    expect(app.get_by_text("Extra text above popover")).to_be_visible()
+
+    # The popover should still be open after the delta-path shift
+    expect(app.get_by_text("Persist popover content")).to_be_visible()
+
+    # Uncheck — another delta-path shift back
+    click_checkbox(app, "Shift delta path")
+    expect(app.get_by_text("Extra text above popover")).not_to_be_visible()
+
+    # Still open
     expect(app.get_by_text("Persist popover content")).to_be_visible()
 
 

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import re
+
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
+    click_toggle,
     expect_markdown,
     get_element_by_key,
     get_popover,
@@ -30,7 +34,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(21)
+    expect(popover_elements).to_have_count(22)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -352,3 +356,38 @@ def test_popover_callback_in_fragment(app: Page):
 
     # Callback should have fired again
     expect(app.get_by_text("Fragment callback count: 2")).to_be_visible()
+
+
+def test_keyed_popover_css_key_class(app: Page):
+    """Keyed popover should have the st-key-* CSS class on the outermost element."""
+    keyed_popover = get_element_by_key(app, "persist_popover")
+    expect(keyed_popover).to_have_class(re.compile(r"st-key-persist_popover"))
+
+
+def test_keyed_popover_persist_closed_across_remount(app: Page):
+    """Clicking outside a popover closes it (onClickOutside). This test verifies
+    that the closed state is persisted: after the toggle shifts the delta path,
+    the popover stays closed (its elementStates entry says 'open=false') rather
+    than reverting to whatever proto default the server sends.
+
+    Note: popover persistence for the *open* state is harder to test in E2E
+    because any click outside the popover body triggers onClickOutside, closing
+    it before the rerun. The underlying mechanism is the same as expander/tabs
+    persistence (elementStates), which is tested there.
+    """
+    keyed_popover = get_element_by_key(app, "persist_popover")
+
+    # Open and close the popover to store open=false
+    keyed_popover.get_by_test_id("stPopoverButton").click()
+    expect(app.get_by_text("Persist popover content")).to_be_visible()
+    keyed_popover.get_by_test_id("stPopoverButton").click()
+    expect(app.get_by_text("Persist popover content")).not_to_be_visible()
+
+    # Toggle the conditional element above — causes a rerun and delta path shift
+    click_toggle(app, "Show extra text above popover")
+    wait_for_app_run(app)
+    expect(app.get_by_text("Extra text inserted above popover")).to_be_visible()
+
+    # The keyed popover should still be closed after remount
+    keyed_popover = get_element_by_key(app, "persist_popover")
+    expect(app.get_by_text("Persist popover content")).not_to_be_visible()

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -326,6 +326,7 @@ describe("BlockNodeRenderer CSS key class placement", () => {
       [],
       new BlockProto({
         allowEmpty: true,
+        vertical: true,
         id: "$$ID-abc123-my_container",
       })
     )

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -23,8 +23,9 @@ import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 import { BlockNode } from "~lib/AppNode"
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
-import { FlexBoxContainer, VerticalBlock } from "./Block"
+import { BlockNodeRenderer, FlexBoxContainer, VerticalBlock } from "./Block"
 
 const FAKE_SCRIPT_HASH = "fake_script_hash"
 
@@ -276,5 +277,62 @@ describe("FlexBoxContainer layout props", () => {
     })
     renderWithContexts(makeVerticalBlockComponent(block))
     expect(screen.getByTestId("stVerticalBlock")).toHaveStyle(expectedStyle)
+  })
+})
+
+describe("BlockNodeRenderer CSS key class placement", () => {
+  const widgetMgr = new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+
+  function makeBlockNodeComponent(node: BlockNode): ReactElement {
+    return (
+      <BlockNodeRenderer
+        node={node}
+        scriptRunId=""
+        scriptRunState={ScriptRunState.NOT_RUNNING}
+        widgetsDisabled={false}
+        widgetMgr={widgetMgr}
+        // @ts-expect-error
+        uploadClient={undefined}
+      />
+    )
+  }
+
+  it("places st-key-* on StyledLayoutWrapper for expander blocks", () => {
+    const node = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({
+        allowEmpty: true,
+        expandable: { label: "test expander", expanded: false },
+        id: "$$ID-abc123-my_expander",
+      })
+    )
+
+    renderWithContexts(makeBlockNodeComponent(node))
+
+    const layoutWrapper = screen.getByTestId("stLayoutWrapper")
+    expect(layoutWrapper).toHaveClass("st-key-my_expander")
+
+    const innerBlock = screen.getByTestId("stVerticalBlock")
+    expect(innerBlock.className).not.toContain("st-key-")
+  })
+
+  it("keeps st-key-* on stVerticalBlock for plain containers (no StyledLayoutWrapper duplication)", () => {
+    const node = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({
+        allowEmpty: true,
+        id: "$$ID-abc123-my_container",
+      })
+    )
+
+    renderWithContexts(makeBlockNodeComponent(node))
+
+    const verticalBlock = screen.getByTestId("stVerticalBlock")
+    expect(verticalBlock).toHaveClass("st-key-my_container")
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -320,20 +320,23 @@ describe("BlockNodeRenderer CSS key class placement", () => {
     expect(innerBlock.className).not.toContain("st-key-")
   })
 
-  it("keeps st-key-* on stVerticalBlock for plain containers (no StyledLayoutWrapper duplication)", () => {
+  it("places st-key-* on StyledLayoutWrapper for popover blocks", () => {
     const node = new BlockNode(
       FAKE_SCRIPT_HASH,
       [],
       new BlockProto({
         allowEmpty: true,
-        vertical: true,
-        id: "$$ID-abc123-my_container",
+        popover: { label: "test popover" },
+        id: "$$ID-abc123-my_popover",
       })
     )
 
     renderWithContexts(makeBlockNodeComponent(node))
 
-    const verticalBlock = screen.getByTestId("stVerticalBlock")
-    expect(verticalBlock).toHaveClass("st-key-my_container")
+    const layoutWrapper = screen.getByTestId("stLayoutWrapper")
+    expect(layoutWrapper).toHaveClass("st-key-my_popover")
+
+    const innerBlock = screen.getByTestId("stVerticalBlock")
+    expect(innerBlock.className).not.toContain("st-key-")
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -117,10 +117,6 @@ interface ContainerContentsWrapperProps extends BaseBlockProps {
   node: BlockNode
   height: React.CSSProperties["height"]
   isRoot?: boolean
-  /** CSS key extracted from block id (e.g. "my_key"). When provided the
-   *  corresponding st-key-* class is added to the container div. Omit when
-   *  a parent wrapper already applies the class. */
-  userKey?: string
 }
 
 export const ContainerContentsWrapper = (
@@ -145,10 +141,7 @@ export const ContainerContentsWrapper = (
     >
       <StyledFlexContainerBlock
         {...defaultStyles}
-        className={classNames(
-          getClassnamePrefix(Direction.VERTICAL),
-          convertKeyToClassName(props.userKey)
-        )}
+        className={getClassnamePrefix(Direction.VERTICAL)}
         data-testid={getClassnamePrefix(Direction.VERTICAL)}
       >
         <ChildRenderer {...props} />
@@ -297,9 +290,10 @@ export const BlockNodeRenderer = (
     notNullOrUndefined(node.deltaBlock.popover)
 
   let containerElement: ReactElement | undefined
-  // Whether the CSS key class will be applied on StyledLayoutWrapper instead
-  // of ContainerContentsWrapper. True for containers whose outermost DOM
-  // element is StyledLayoutWrapper (expander, popover) per the spec.
+  // Whether the CSS key class (st-key-*) is applied on StyledLayoutWrapper.
+  // Gating this per container so we can analyze each one to confirm that
+  // applying it on the wrapper makes sense. Currently enabled for expander
+  // and popover only.
   let keyClassOnWrapper = false
 
   const userKey = getKeyFromId(node.deltaBlock.id)
@@ -308,7 +302,6 @@ export const BlockNodeRenderer = (
       {...childProps}
       disableFullscreenMode={disableFullscreenMode}
       height="100%"
-      userKey={userKey}
     />
   )
 

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -133,7 +133,15 @@ export const ContainerContentsWrapper = (
     border: false,
   }
 
-  const userKey = getKeyFromId(props.node.deltaBlock.id)
+  // Suppress the CSS key class when this vertical block is the inner content
+  // of a container element (expander, popover, etc.) — the container component
+  // itself applies the class on its outermost element.
+  const isContainerContent = Boolean(
+    props.node.deltaBlock.expandable || props.node.deltaBlock.popover
+  )
+  const userKey = isContainerContent
+    ? undefined
+    : getKeyFromId(props.node.deltaBlock.id)
   return (
     <FlexContextProvider
       direction={Direction.VERTICAL}
@@ -340,6 +348,7 @@ export const BlockNodeRenderer = (
         element={node.deltaBlock.popover as BlockProto.Popover}
         stretchWidth={shouldWidthStretch(node.deltaBlock.widthConfig)}
         widgetMgr={props.widgetMgr}
+        blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
         {child}

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -332,11 +332,7 @@ export const BlockNodeRenderer = (
         blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
-        <ContainerContentsWrapper
-          {...childProps}
-          disableFullscreenMode={disableFullscreenMode}
-          height="100%"
-        />
+        {child}
       </Expander>
     )
   }
@@ -352,11 +348,7 @@ export const BlockNodeRenderer = (
         blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
-        <ContainerContentsWrapper
-          {...childProps}
-          disableFullscreenMode={disableFullscreenMode}
-          height="100%"
-        />
+        {child}
       </Popover>
     )
   }

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -117,9 +117,10 @@ interface ContainerContentsWrapperProps extends BaseBlockProps {
   node: BlockNode
   height: React.CSSProperties["height"]
   isRoot?: boolean
-  /** When true, omit the st-key-* class because a parent wrapper already
-   *  applies it (e.g. StyledLayoutWrapper for expander/popover). */
-  suppressKeyClass?: boolean
+  /** CSS key extracted from block id (e.g. "my_key"). When provided the
+   *  corresponding st-key-* class is added to the container div. Omit when
+   *  a parent wrapper already applies the class. */
+  userKey?: string
 }
 
 export const ContainerContentsWrapper = (
@@ -136,9 +137,6 @@ export const ContainerContentsWrapper = (
     border: false,
   }
 
-  const userKey = props.suppressKeyClass
-    ? undefined
-    : getKeyFromId(props.node.deltaBlock.id)
   return (
     <FlexContextProvider
       direction={Direction.VERTICAL}
@@ -149,7 +147,7 @@ export const ContainerContentsWrapper = (
         {...defaultStyles}
         className={classNames(
           getClassnamePrefix(Direction.VERTICAL),
-          convertKeyToClassName(userKey)
+          convertKeyToClassName(props.userKey)
         )}
         data-testid={getClassnamePrefix(Direction.VERTICAL)}
       >
@@ -304,11 +302,13 @@ export const BlockNodeRenderer = (
   // element is StyledLayoutWrapper (expander, popover) per the spec.
   let keyClassOnWrapper = false
 
+  const userKey = getKeyFromId(node.deltaBlock.id)
   const child: ReactElement = (
     <ContainerContentsWrapper
       {...childProps}
       disableFullscreenMode={disableFullscreenMode}
       height="100%"
+      userKey={userKey}
     />
   )
 
@@ -331,14 +331,6 @@ export const BlockNodeRenderer = (
 
   if (node.deltaBlock.expandable) {
     keyClassOnWrapper = true
-    const childSuppressed = (
-      <ContainerContentsWrapper
-        {...childProps}
-        disableFullscreenMode={disableFullscreenMode}
-        height="100%"
-        suppressKeyClass
-      />
-    )
     containerElement = (
       <Expander
         isStale={isStale}
@@ -347,21 +339,17 @@ export const BlockNodeRenderer = (
         blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
-        {childSuppressed}
+        <ContainerContentsWrapper
+          {...childProps}
+          disableFullscreenMode={disableFullscreenMode}
+          height="100%"
+        />
       </Expander>
     )
   }
 
   if (node.deltaBlock.popover) {
     keyClassOnWrapper = true
-    const childSuppressed = (
-      <ContainerContentsWrapper
-        {...childProps}
-        disableFullscreenMode={disableFullscreenMode}
-        height="100%"
-        suppressKeyClass
-      />
-    )
     containerElement = (
       <Popover
         empty={node.isEmpty}
@@ -371,7 +359,11 @@ export const BlockNodeRenderer = (
         blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
-        {childSuppressed}
+        <ContainerContentsWrapper
+          {...childProps}
+          disableFullscreenMode={disableFullscreenMode}
+          height="100%"
+        />
       </Popover>
     )
   }
@@ -443,13 +435,12 @@ export const BlockNodeRenderer = (
   }
 
   if (containerElement) {
-    const userKey = keyClassOnWrapper
-      ? getKeyFromId(node.deltaBlock.id)
-      : undefined
     return (
       <StyledLayoutWrapper
         data-testid="stLayoutWrapper"
-        className={convertKeyToClassName(userKey)}
+        className={convertKeyToClassName(
+          keyClassOnWrapper ? userKey : undefined
+        )}
         {...styles}
       >
         {containerElement}

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -117,6 +117,9 @@ interface ContainerContentsWrapperProps extends BaseBlockProps {
   node: BlockNode
   height: React.CSSProperties["height"]
   isRoot?: boolean
+  /** When true, omit the st-key-* class because a parent wrapper already
+   *  applies it (e.g. StyledLayoutWrapper for expander/popover). */
+  suppressKeyClass?: boolean
 }
 
 export const ContainerContentsWrapper = (
@@ -133,13 +136,7 @@ export const ContainerContentsWrapper = (
     border: false,
   }
 
-  // Suppress the CSS key class when this vertical block is the inner content
-  // of a container element (expander, popover, etc.) — the container component
-  // itself applies the class on its outermost element.
-  const isContainerContent = Boolean(
-    props.node.deltaBlock.expandable || props.node.deltaBlock.popover
-  )
-  const userKey = isContainerContent
+  const userKey = props.suppressKeyClass
     ? undefined
     : getKeyFromId(props.node.deltaBlock.id)
   return (
@@ -302,6 +299,11 @@ export const BlockNodeRenderer = (
     notNullOrUndefined(node.deltaBlock.popover)
 
   let containerElement: ReactElement | undefined
+  // Whether the CSS key class will be applied on StyledLayoutWrapper instead
+  // of ContainerContentsWrapper. True for containers whose outermost DOM
+  // element is StyledLayoutWrapper (expander, popover) per the spec.
+  let keyClassOnWrapper = false
+
   const child: ReactElement = (
     <ContainerContentsWrapper
       {...childProps}
@@ -328,6 +330,15 @@ export const BlockNodeRenderer = (
   }
 
   if (node.deltaBlock.expandable) {
+    keyClassOnWrapper = true
+    const childSuppressed = (
+      <ContainerContentsWrapper
+        {...childProps}
+        disableFullscreenMode={disableFullscreenMode}
+        height="100%"
+        suppressKeyClass
+      />
+    )
     containerElement = (
       <Expander
         isStale={isStale}
@@ -336,12 +347,21 @@ export const BlockNodeRenderer = (
         blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
-        {child}
+        {childSuppressed}
       </Expander>
     )
   }
 
   if (node.deltaBlock.popover) {
+    keyClassOnWrapper = true
+    const childSuppressed = (
+      <ContainerContentsWrapper
+        {...childProps}
+        disableFullscreenMode={disableFullscreenMode}
+        height="100%"
+        suppressKeyClass
+      />
+    )
     containerElement = (
       <Popover
         empty={node.isEmpty}
@@ -351,7 +371,7 @@ export const BlockNodeRenderer = (
         blockId={node.deltaBlock.id || undefined}
         fragmentId={node.fragmentId}
       >
-        {child}
+        {childSuppressed}
       </Popover>
     )
   }
@@ -423,8 +443,15 @@ export const BlockNodeRenderer = (
   }
 
   if (containerElement) {
+    const userKey = keyClassOnWrapper
+      ? getKeyFromId(node.deltaBlock.id)
+      : undefined
     return (
-      <StyledLayoutWrapper data-testid="stLayoutWrapper" {...styles}>
+      <StyledLayoutWrapper
+        data-testid="stLayoutWrapper"
+        className={convertKeyToClassName(userKey)}
+        {...styles}
+      >
         {containerElement}
       </StyledLayoutWrapper>
     )

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -309,3 +309,128 @@ describe("widget mode (widgetMgr + element.id)", () => {
     expect(expander.className).not.toContain("st-key-")
   })
 })
+
+describe("passive state persistence", () => {
+  it("reads stored expanded state on mount", () => {
+    const blockId = "$$ID-abc123-my_expander"
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(true)
+
+    const props = getProps({ expanded: false }, { widgetMgr, blockId })
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    expect(widgetMgr.getElementState).toHaveBeenCalledWith(blockId, "expanded")
+    expect(screen.getByText("test")).toBeVisible()
+  })
+
+  it("uses proto default when no stored state exists", () => {
+    const blockId = "$$ID-abc123-my_expander"
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(undefined)
+
+    const props = getProps({ expanded: false }, { widgetMgr, blockId })
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    expect(screen.getByText("test")).not.toBeVisible()
+  })
+
+  it("stores expanded state on toggle", async () => {
+    const user = userEvent.setup()
+    const blockId = "$$ID-abc123-my_expander"
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "setElementState")
+
+    const props = getProps({ expanded: false }, { widgetMgr, blockId })
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    await user.click(screen.getByText("hi"))
+
+    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
+      blockId,
+      "expanded",
+      true
+    )
+  })
+
+  it("does NOT persist state when no blockId is set", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "setElementState")
+
+    const props = getProps({ expanded: false }, { widgetMgr })
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    await user.click(screen.getByText("hi"))
+
+    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+  })
+
+  it("does NOT persist state for widget-mode expanders", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "setElementState")
+
+    const props = getProps(
+      { expanded: false, id: "widget-123" },
+      { widgetMgr, blockId: "$$ID-abc123-my_expander" }
+    )
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    await user.click(screen.getByText("hi"))
+
+    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+  })
+
+  it("uses server state even when elementStates has a stale value (widget mode)", () => {
+    const blockId = "$$ID-abc123-my_expander"
+    const widgetMgr = createWidgetMgr()
+
+    // Pre-populate elementStates with stale "expanded = true"
+    widgetMgr.setElementState(blockId, "expanded", true)
+
+    // Widget mode: server says collapsed (expanded=false)
+    const props = getProps(
+      { expanded: false, id: "widget-123" },
+      { widgetMgr, blockId }
+    )
+
+    render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    // Server value should win — content should NOT be visible (collapsed)
+    expect(screen.getByText("test")).not.toBeVisible()
+  })
+})

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -385,7 +385,7 @@ describe("passive state persistence", () => {
     // Pre-populate elementStates with stale "expanded = true"
     widgetMgr.setElementState(blockId, "expanded", true)
 
-    // Widget mode: server says collapsed (expanded=false)
+    // Widget mode (element.id set → on_change="rerun"): server says collapsed
     const props = getProps(
       { expanded: false, id: "widget-123" },
       { widgetMgr, blockId }

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -25,6 +25,12 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Expander, { ExpanderProps } from "./Expander"
 
+const createWidgetMgr = (): WidgetStateManager =>
+  new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+
 const getProps = (
   elementProps: Partial<BlockProto.Expandable> = {},
   props: Partial<ExpanderProps> = {}
@@ -35,14 +41,9 @@ const getProps = (
     ...elementProps,
   }),
   isStale: false,
+  widgetMgr: createWidgetMgr(),
   ...props,
 })
-
-const createWidgetMgr = (): WidgetStateManager =>
-  new WidgetStateManager({
-    sendRerunBackMsg: vi.fn(),
-    formsDataChanged: vi.fn(),
-  })
 
 describe("Expander container", () => {
   it("renders without crashing", () => {
@@ -282,40 +283,14 @@ describe("widget mode (widgetMgr + element.id)", () => {
 
     expect(setBoolValueSpy).not.toHaveBeenCalled()
   })
-
-  it("adds CSS class from blockId key", () => {
-    const props = getProps({}, { blockId: "$$ID-abc123-my_expander" })
-
-    render(
-      <Expander {...props}>
-        <div>test</div>
-      </Expander>
-    )
-
-    const expander = screen.getByTestId("stExpander")
-    expect(expander).toHaveClass("st-key-my_expander")
-  })
-
-  it("does not add CSS class when blockId is absent", () => {
-    const props = getProps()
-
-    render(
-      <Expander {...props}>
-        <div>test</div>
-      </Expander>
-    )
-
-    const expander = screen.getByTestId("stExpander")
-    expect(expander.className).not.toContain("st-key-")
-  })
 })
 
 describe("passive state persistence", () => {
-  it("reads stored expanded state on mount", () => {
+  it("restores expanded state from elementStates on mount", () => {
     const blockId = "$$ID-abc123-my_expander"
     const widgetMgr = createWidgetMgr()
 
-    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(true)
+    widgetMgr.setElementState(blockId, "expanded", true)
 
     const props = getProps({ expanded: false }, { widgetMgr, blockId })
 
@@ -325,15 +300,13 @@ describe("passive state persistence", () => {
       </Expander>
     )
 
-    expect(widgetMgr.getElementState).toHaveBeenCalledWith(blockId, "expanded")
+    // Stored state (true) overrides proto default (false)
     expect(screen.getByText("test")).toBeVisible()
   })
 
   it("uses proto default when no stored state exists", () => {
     const blockId = "$$ID-abc123-my_expander"
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(undefined)
 
     const props = getProps({ expanded: false }, { widgetMgr, blockId })
 
@@ -346,12 +319,10 @@ describe("passive state persistence", () => {
     expect(screen.getByText("test")).not.toBeVisible()
   })
 
-  it("stores expanded state on toggle", async () => {
+  it("persists expanded state on toggle", async () => {
     const user = userEvent.setup()
     const blockId = "$$ID-abc123-my_expander"
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "setElementState")
 
     const props = getProps({ expanded: false }, { widgetMgr, blockId })
 
@@ -363,18 +334,12 @@ describe("passive state persistence", () => {
 
     await user.click(screen.getByText("hi"))
 
-    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
-      blockId,
-      "expanded",
-      true
-    )
+    expect(widgetMgr.getElementState(blockId, "expanded")).toBe(true)
   })
 
   it("does NOT persist state when no blockId is set", async () => {
     const user = userEvent.setup()
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "setElementState")
 
     const props = getProps({ expanded: false }, { widgetMgr })
 
@@ -386,18 +351,18 @@ describe("passive state persistence", () => {
 
     await user.click(screen.getByText("hi"))
 
-    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+    // No blockId → toggled state (true) should NOT have been stored
+    expect(widgetMgr.getElementState("", "expanded")).not.toBe(true)
   })
 
   it("does NOT persist state for widget-mode expanders", async () => {
     const user = userEvent.setup()
+    const blockId = "$$ID-abc123-my_expander"
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "setElementState")
 
     const props = getProps(
       { expanded: false, id: "widget-123" },
-      { widgetMgr, blockId: "$$ID-abc123-my_expander" }
+      { widgetMgr, blockId }
     )
 
     render(
@@ -408,7 +373,9 @@ describe("passive state persistence", () => {
 
     await user.click(screen.getByText("hi"))
 
-    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+    // Widget mode: persistence should not write expanded state
+    // (the hook id is "" so nothing meaningful is stored)
+    expect(widgetMgr.getElementState(blockId, "expanded")).toBeUndefined()
   })
 
   it("uses server state even when elementStates has a stale value (widget mode)", () => {

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -16,16 +16,11 @@
 
 import { memo, ReactElement, useCallback, useState } from "react"
 
-import classNames from "classnames"
-
 import { Block as BlockProto } from "@streamlit/protobuf"
 
-import {
-  convertKeyToClassName,
-  getKeyFromId,
-} from "~lib/components/core/Block/utils"
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
+import useWidgetManagerElementState from "~lib/hooks/useWidgetManagerElementState"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
@@ -97,17 +92,20 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   // CSS key styling without implying widget mode.
   const widgetId = element.id || undefined
   const isWidget = Boolean(widgetMgr && widgetId)
-  const shouldPersist = Boolean(blockId) && !isWidget
+  const isPassivelyKeyed = Boolean(blockId) && !isWidget
 
-  // Resolve initial expanded state: stored elementState wins over proto
-  const storedExpanded =
-    shouldPersist && widgetMgr
-      ? (widgetMgr.getElementState(blockId ?? "", "expanded") as
-          | boolean
-          | undefined)
-      : undefined
-  const initialExpanded =
-    storedExpanded !== undefined ? storedExpanded : element.expanded
+  // Persist expanded state across remounts via elementStates.
+  // The hook is always called (Rules of Hooks) but only effective when
+  // isPassivelyKeyed — otherwise the empty id produces a no-op entry.
+  const [storedExpanded, setStoredExpanded] =
+    useWidgetManagerElementState<boolean>({
+      widgetMgr: widgetMgr!,
+      id: isPassivelyKeyed ? (blockId ?? "") : "",
+      key: "expanded",
+      defaultValue: element.expanded,
+    })
+
+  const initialExpanded = isPassivelyKeyed ? storedExpanded : element.expanded
 
   // Callback to notify backend of toggle (only used in widget mode)
   const handleWidgetToggle = useCallback(
@@ -124,19 +122,17 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
     [widgetMgr, widgetId, fragmentId]
   )
 
-  // Callback for passive persistence (only used when shouldPersist)
+  // Callback for passive persistence (only when passively keyed)
   const handlePersistToggle = useCallback(
     (newOpen: boolean): void => {
-      if (widgetMgr && blockId) {
-        widgetMgr.setElementState(blockId, "expanded", newOpen)
-      }
+      setStoredExpanded(newOpen)
     },
-    [widgetMgr, blockId]
+    [setStoredExpanded]
   )
 
   const onToggle = isWidget
     ? handleWidgetToggle
-    : shouldPersist
+    : isPassivelyKeyed
       ? handlePersistToggle
       : undefined
 
@@ -159,13 +155,8 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
     setIsHovered(false)
   }
 
-  const userKey = getKeyFromId(blockId)
-
   return (
-    <StyledExpandableContainer
-      className={classNames("stExpander", convertKeyToClassName(userKey))}
-      data-testid="stExpander"
-    >
+    <StyledExpandableContainer className="stExpander" data-testid="stExpander">
       <StyledDetails
         isStale={isStale}
         ref={detailsRef}

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -70,7 +70,7 @@ const ExpanderIcon = (props: ExpanderIconProps): ReactElement => {
 export interface ExpanderProps {
   element: BlockProto.Expandable
   isStale: boolean
-  widgetMgr?: WidgetStateManager
+  widgetMgr: WidgetStateManager
   /** Block-level ID for CSS key styling (may be set without widget mode). */
   blockId?: string
   fragmentId?: string
@@ -99,7 +99,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   // isPassivelyKeyed — otherwise the empty id produces a no-op entry.
   const [storedExpanded, setStoredExpanded] =
     useWidgetManagerElementState<boolean>({
-      widgetMgr: widgetMgr!,
+      widgetMgr,
       id: isPassivelyKeyed ? (blockId ?? "") : "",
       key: "expanded",
       defaultValue: element.expanded ?? false,

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -97,6 +97,17 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   // CSS key styling without implying widget mode.
   const widgetId = element.id || undefined
   const isWidget = Boolean(widgetMgr && widgetId)
+  const shouldPersist = Boolean(blockId) && !isWidget
+
+  // Resolve initial expanded state: stored elementState wins over proto
+  const storedExpanded =
+    shouldPersist && widgetMgr
+      ? (widgetMgr.getElementState(blockId!, "expanded") as
+          | boolean
+          | undefined)
+      : undefined
+  const initialExpanded =
+    storedExpanded !== undefined ? storedExpanded : element.expanded
 
   // Callback to notify backend of toggle (only used in widget mode)
   const handleWidgetToggle = useCallback(
@@ -113,11 +124,27 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
     [widgetMgr, widgetId, fragmentId]
   )
 
+  // Callback for passive persistence (only used when shouldPersist)
+  const handlePersistToggle = useCallback(
+    (newOpen: boolean): void => {
+      if (widgetMgr && blockId) {
+        widgetMgr.setElementState(blockId, "expanded", newOpen)
+      }
+    },
+    [widgetMgr, blockId]
+  )
+
+  const onToggle = isWidget
+    ? handleWidgetToggle
+    : shouldPersist
+      ? handlePersistToggle
+      : undefined
+
   const { isOpen, detailsRef, summaryRef, contentRef, handleToggle } =
     useDetailsAnimation({
-      backendExpanded: element.expanded,
+      backendExpanded: initialExpanded,
       label,
-      onToggle: isWidget ? handleWidgetToggle : undefined,
+      onToggle,
     })
 
   // Determine which icon to show

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -102,9 +102,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   // Resolve initial expanded state: stored elementState wins over proto
   const storedExpanded =
     shouldPersist && widgetMgr
-      ? (widgetMgr.getElementState(blockId!, "expanded") as
-          | boolean
-          | undefined)
+      ? (widgetMgr.getElementState(blockId, "expanded") as boolean | undefined)
       : undefined
   const initialExpanded =
     storedExpanded !== undefined ? storedExpanded : element.expanded

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -102,7 +102,7 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
       widgetMgr: widgetMgr!,
       id: isPassivelyKeyed ? (blockId ?? "") : "",
       key: "expanded",
-      defaultValue: element.expanded,
+      defaultValue: element.expanded ?? false,
     })
 
   const initialExpanded = isPassivelyKeyed ? storedExpanded : element.expanded

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -102,7 +102,9 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
   // Resolve initial expanded state: stored elementState wins over proto
   const storedExpanded =
     shouldPersist && widgetMgr
-      ? (widgetMgr.getElementState(blockId, "expanded") as boolean | undefined)
+      ? (widgetMgr.getElementState(blockId ?? "", "expanded") as
+          | boolean
+          | undefined)
       : undefined
   const initialExpanded =
     storedExpanded !== undefined ? storedExpanded : element.expanded

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -25,10 +25,18 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Popover, { PopoverProps } from "./Popover"
 
+vi.mock("~lib/WidgetStateManager")
+
 const createMockWidgetMgr = (): Mocked<WidgetStateManager> =>
   ({
     setBoolValue: vi.fn(),
   }) as unknown as Mocked<WidgetStateManager>
+
+const createWidgetMgr = (): WidgetStateManager =>
+  new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
 
 const getProps = (
   elementProps: Partial<BlockProto.Popover> = {},
@@ -270,5 +278,162 @@ describe("Dynamic popover (widget mode)", () => {
     // The sync effect should only update local UI state, not send a value
     // back to the backend (which would cause a feedback loop).
     expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
+  })
+})
+
+describe("CSS key class", () => {
+  it("applies st-key-* class when blockId is a valid element id", () => {
+    const props = getProps({}, { blockId: "$$ID-abc123-my_popover" })
+
+    render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    const popover = screen.getByTestId("stPopover")
+    expect(popover).toHaveClass("st-key-my_popover")
+  })
+
+  it("does not apply st-key-* class when blockId is absent", () => {
+    const props = getProps()
+
+    render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    const popover = screen.getByTestId("stPopover")
+    expect(popover.className).not.toContain("st-key-")
+  })
+})
+
+describe("passive state persistence", () => {
+  it("reads stored open state on mount", async () => {
+    const user = userEvent.setup()
+    const blockId = "$$ID-abc123-my_popover"
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(true)
+
+    const props = getProps({}, { widgetMgr, blockId })
+
+    render(
+      <Popover {...props}>
+        <div>popover content</div>
+      </Popover>
+    )
+
+    expect(widgetMgr.getElementState).toHaveBeenCalledWith(blockId, "open")
+    const trigger = screen.getByRole("button").closest("[aria-expanded]")
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("uses proto default when no stored state exists", () => {
+    const blockId = "$$ID-abc123-my_popover"
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(undefined)
+
+    const props = getProps({}, { widgetMgr, blockId })
+
+    render(
+      <Popover {...props}>
+        <div>popover content</div>
+      </Popover>
+    )
+
+    const trigger = screen.getByRole("button").closest("[aria-expanded]")
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("stores open state on toggle", async () => {
+    const user = userEvent.setup()
+    const blockId = "$$ID-abc123-my_popover"
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "setElementState")
+
+    const props = getProps({}, { widgetMgr, blockId })
+
+    render(
+      <Popover {...props}>
+        <div>popover content</div>
+      </Popover>
+    )
+
+    await user.click(screen.getByText("label"))
+
+    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
+      blockId,
+      "open",
+      true
+    )
+  })
+
+  it("does NOT persist state when no blockId is set", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "setElementState")
+
+    const props = getProps({}, { widgetMgr })
+
+    render(
+      <Popover {...props}>
+        <div>popover content</div>
+      </Popover>
+    )
+
+    await user.click(screen.getByText("label"))
+
+    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+  })
+
+  it("does NOT persist state for widget-mode popovers", async () => {
+    const user = userEvent.setup()
+    const widgetMgr = createWidgetMgr()
+
+    vi.spyOn(widgetMgr, "setElementState")
+
+    const props = getProps(
+      { id: "widget-123" },
+      { widgetMgr, blockId: "$$ID-abc123-my_popover" }
+    )
+
+    render(
+      <Popover {...props}>
+        <div>popover content</div>
+      </Popover>
+    )
+
+    await user.click(screen.getByText("label"))
+
+    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+  })
+
+  it("uses server state even when elementStates has a stale value (widget mode)", () => {
+    const blockId = "$$ID-abc123-my_popover"
+    const widgetMgr = createWidgetMgr()
+
+    // Pre-populate elementStates with stale "open = true"
+    widgetMgr.setElementState(blockId, "open", true)
+
+    // Widget mode: server says closed (open=false)
+    const props = getProps(
+      { open: false, id: "widget-123" },
+      { widgetMgr, blockId }
+    )
+
+    render(
+      <Popover {...props}>
+        <div>popover content</div>
+      </Popover>
+    )
+
+    // Server value should win — popover should be closed
+    const trigger = screen.getByRole("button").closest("[aria-expanded]")
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
   })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -16,7 +16,6 @@
 
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
-import { Mocked } from "vitest"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 
@@ -24,13 +23,6 @@ import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Popover, { PopoverProps } from "./Popover"
-
-vi.mock("~lib/WidgetStateManager")
-
-const createMockWidgetMgr = (): Mocked<WidgetStateManager> =>
-  ({
-    setBoolValue: vi.fn(),
-  }) as unknown as Mocked<WidgetStateManager>
 
 const createWidgetMgr = (): WidgetStateManager =>
   new WidgetStateManager({
@@ -50,6 +42,7 @@ const getProps = (
   }),
   empty: false,
   stretchWidth: false,
+  widgetMgr: createWidgetMgr(),
   ...props,
 })
 
@@ -144,11 +137,11 @@ describe("Popover container", () => {
 describe("Dynamic popover (widget mode)", () => {
   it("calls widgetMgr.setBoolValue on toggle for widget popovers", async () => {
     const user = userEvent.setup()
-    const widgetMgr = createMockWidgetMgr()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
 
     const widgetId = "popover-widget-id"
     const fragmentId = "frag-1"
-    // id on the element signals widget mode
     const props = getProps({ id: widgetId }, { widgetMgr, fragmentId })
 
     render(
@@ -159,7 +152,7 @@ describe("Dynamic popover (widget mode)", () => {
 
     await user.click(screen.getByText("label"))
 
-    expect(widgetMgr.setBoolValue).toHaveBeenCalledWith(
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
       { id: widgetId },
       true,
       { fromUi: true },
@@ -169,9 +162,9 @@ describe("Dynamic popover (widget mode)", () => {
 
   it("does NOT call widgetMgr.setBoolValue for non-widget popovers", async () => {
     const user = userEvent.setup()
-    const widgetMgr = createMockWidgetMgr()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
 
-    // No id → not a widget (even though widgetMgr is available)
     const props = getProps({}, { widgetMgr })
 
     render(
@@ -182,12 +175,13 @@ describe("Dynamic popover (widget mode)", () => {
 
     await user.click(screen.getByText("label"))
 
-    expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
+    expect(setBoolValueSpy).not.toHaveBeenCalled()
   })
 
   it("sends false when closing a widget popover", async () => {
     const user = userEvent.setup()
-    const widgetMgr = createMockWidgetMgr()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
 
     const widgetId = "popover-widget-id"
     const fragmentId = "frag-1"
@@ -199,18 +193,16 @@ describe("Dynamic popover (widget mode)", () => {
       </Popover>
     )
 
-    // Open the popover
     await user.click(screen.getByText("label"))
-    expect(widgetMgr.setBoolValue).toHaveBeenLastCalledWith(
+    expect(setBoolValueSpy).toHaveBeenLastCalledWith(
       { id: widgetId },
       true,
       { fromUi: true },
       fragmentId
     )
 
-    // Close by clicking the button again
     await user.click(screen.getByText("label"))
-    expect(widgetMgr.setBoolValue).toHaveBeenLastCalledWith(
+    expect(setBoolValueSpy).toHaveBeenLastCalledWith(
       { id: widgetId },
       false,
       { fromUi: true },
@@ -219,9 +211,9 @@ describe("Dynamic popover (widget mode)", () => {
   })
 
   it("does NOT sync element.open for non-widget popovers", () => {
-    const widgetMgr = createMockWidgetMgr()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
 
-    // No id — non-widget popover
     const props = getProps({ open: false }, { widgetMgr })
 
     const { rerender } = render(
@@ -233,7 +225,6 @@ describe("Dynamic popover (widget mode)", () => {
     const trigger = screen.getByRole("button").closest("[aria-expanded]")
     expect(trigger).toHaveAttribute("aria-expanded", "false")
 
-    // Rerender with open=true but still no id
     const updatedProps = getProps({ open: true }, { widgetMgr })
 
     rerender(
@@ -242,13 +233,13 @@ describe("Dynamic popover (widget mode)", () => {
       </Popover>
     )
 
-    // Should remain closed — non-widget popovers ignore element.open changes
     expect(trigger).toHaveAttribute("aria-expanded", "false")
-    expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
+    expect(setBoolValueSpy).not.toHaveBeenCalled()
   })
 
   it("syncs open state when element.open changes programmatically", () => {
-    const widgetMgr = createMockWidgetMgr()
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
 
     const widgetId = "popover-widget-id"
     const props = getProps({ open: false, id: widgetId }, { widgetMgr })
@@ -259,11 +250,9 @@ describe("Dynamic popover (widget mode)", () => {
       </Popover>
     )
 
-    // Initially closed — trigger element should indicate collapsed state
     const trigger = screen.getByRole("button").closest("[aria-expanded]")
     expect(trigger).toHaveAttribute("aria-expanded", "false")
 
-    // Backend sets open=true (programmatic control via session_state)
     const updatedProps = getProps({ open: true, id: widgetId }, { widgetMgr })
 
     rerender(
@@ -272,49 +261,17 @@ describe("Dynamic popover (widget mode)", () => {
       </Popover>
     )
 
-    // Trigger should now indicate expanded state
     expect(trigger).toHaveAttribute("aria-expanded", "true")
-
-    // The sync effect should only update local UI state, not send a value
-    // back to the backend (which would cause a feedback loop).
-    expect(widgetMgr.setBoolValue).not.toHaveBeenCalled()
-  })
-})
-
-describe("CSS key class", () => {
-  it("applies st-key-* class when blockId is a valid element id", () => {
-    const props = getProps({}, { blockId: "$$ID-abc123-my_popover" })
-
-    render(
-      <Popover {...props}>
-        <div>content</div>
-      </Popover>
-    )
-
-    const popover = screen.getByTestId("stPopover")
-    expect(popover).toHaveClass("st-key-my_popover")
-  })
-
-  it("does not apply st-key-* class when blockId is absent", () => {
-    const props = getProps()
-
-    render(
-      <Popover {...props}>
-        <div>content</div>
-      </Popover>
-    )
-
-    const popover = screen.getByTestId("stPopover")
-    expect(popover.className).not.toContain("st-key-")
+    expect(setBoolValueSpy).not.toHaveBeenCalled()
   })
 })
 
 describe("passive state persistence", () => {
-  it("reads stored open state on mount", () => {
+  it("restores open state from elementStates on mount", () => {
     const blockId = "$$ID-abc123-my_popover"
     const widgetMgr = createWidgetMgr()
 
-    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(true)
+    widgetMgr.setElementState(blockId, "open", true)
 
     const props = getProps({}, { widgetMgr, blockId })
 
@@ -324,7 +281,7 @@ describe("passive state persistence", () => {
       </Popover>
     )
 
-    expect(widgetMgr.getElementState).toHaveBeenCalledWith(blockId, "open")
+    // Stored state (true) overrides proto default (false)
     const trigger = screen.getByRole("button").closest("[aria-expanded]")
     expect(trigger).toHaveAttribute("aria-expanded", "true")
   })
@@ -332,8 +289,6 @@ describe("passive state persistence", () => {
   it("uses proto default when no stored state exists", () => {
     const blockId = "$$ID-abc123-my_popover"
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "getElementState").mockReturnValue(undefined)
 
     const props = getProps({}, { widgetMgr, blockId })
 
@@ -347,12 +302,10 @@ describe("passive state persistence", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "false")
   })
 
-  it("stores open state on toggle", async () => {
+  it("persists open state on toggle", async () => {
     const user = userEvent.setup()
     const blockId = "$$ID-abc123-my_popover"
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "setElementState")
 
     const props = getProps({}, { widgetMgr, blockId })
 
@@ -364,18 +317,12 @@ describe("passive state persistence", () => {
 
     await user.click(screen.getByText("label"))
 
-    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
-      blockId,
-      "open",
-      true
-    )
+    expect(widgetMgr.getElementState(blockId, "open")).toBe(true)
   })
 
   it("does NOT persist state when no blockId is set", async () => {
     const user = userEvent.setup()
     const widgetMgr = createWidgetMgr()
-
-    vi.spyOn(widgetMgr, "setElementState")
 
     const props = getProps({}, { widgetMgr })
 
@@ -387,19 +334,16 @@ describe("passive state persistence", () => {
 
     await user.click(screen.getByText("label"))
 
-    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+    // No blockId → toggled state (true) should NOT have been stored
+    expect(widgetMgr.getElementState("", "open")).not.toBe(true)
   })
 
   it("does NOT persist state for widget-mode popovers", async () => {
     const user = userEvent.setup()
+    const blockId = "$$ID-abc123-my_popover"
     const widgetMgr = createWidgetMgr()
 
-    vi.spyOn(widgetMgr, "setElementState")
-
-    const props = getProps(
-      { id: "widget-123" },
-      { widgetMgr, blockId: "$$ID-abc123-my_popover" }
-    )
+    const props = getProps({ id: "widget-123" }, { widgetMgr, blockId })
 
     render(
       <Popover {...props}>
@@ -409,7 +353,8 @@ describe("passive state persistence", () => {
 
     await user.click(screen.getByText("label"))
 
-    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+    // Widget mode: persistence should not write open state
+    expect(widgetMgr.getElementState(blockId, "open")).toBeUndefined()
   })
 
   it("uses server state even when elementStates has a stale value (widget mode)", () => {

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -364,7 +364,7 @@ describe("passive state persistence", () => {
     // Pre-populate elementStates with stale "open = true"
     widgetMgr.setElementState(blockId, "open", true)
 
-    // Widget mode: server says closed (open=false)
+    // Widget mode (element.id set → on_change="rerun"): server says closed
     const props = getProps(
       { open: false, id: "widget-123" },
       { widgetMgr, blockId }

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -310,8 +310,7 @@ describe("CSS key class", () => {
 })
 
 describe("passive state persistence", () => {
-  it("reads stored open state on mount", async () => {
-    const user = userEvent.setup()
+  it("reads stored open state on mount", () => {
     const blockId = "$$ID-abc123-my_popover"
     const widgetMgr = createWidgetMgr()
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -17,15 +17,10 @@
 import { memo, ReactElement, useCallback, useContext, useState } from "react"
 
 import { PLACEMENT, TRIGGER_TYPE, Popover as UIPopover } from "baseui/popover"
-import classNames from "classnames"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 import { notNullOrUndefined } from "@streamlit/utils"
 
-import {
-  convertKeyToClassName,
-  getKeyFromId,
-} from "~lib/components/core/Block/utils"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import {
   Box,
@@ -41,6 +36,7 @@ import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
+import useWidgetManagerElementState from "~lib/hooks/useWidgetManagerElementState"
 import { convertRemToPx } from "~lib/theme/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -78,17 +74,19 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // stateful widget (on_change="rerun").
   const widgetId = element.id
   const isWidget = Boolean(widgetId)
-  const shouldPersist = Boolean(blockId) && !isWidget
+  const isPassivelyKeyed = Boolean(blockId) && !isWidget
 
-  // Resolve initial open state: stored elementState wins over proto
-  const storedOpen =
-    shouldPersist && widgetMgr
-      ? (widgetMgr.getElementState(blockId ?? "", "open") as
-          | boolean
-          | undefined)
-      : undefined
-  const initialOpen =
-    storedOpen !== undefined ? storedOpen : (element.open ?? false)
+  // Persist open state across remounts via elementStates.
+  // The hook is always called (Rules of Hooks) but only effective when
+  // isPassivelyKeyed — otherwise the empty id produces a no-op entry.
+  const [storedOpen, setStoredOpen] = useWidgetManagerElementState<boolean>({
+    widgetMgr: widgetMgr!,
+    id: isPassivelyKeyed ? (blockId ?? "") : "",
+    key: "open",
+    defaultValue: element.open ?? false,
+  })
+
+  const initialOpen = isPassivelyKeyed ? storedOpen : (element.open ?? false)
 
   // Single state with optimistic updates for instant UI feedback.
   const [open, setOpen] = useState(initialOpen)
@@ -108,20 +106,10 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // can remove the need for this as part of the BaseWeb migration.
   const { width: calculatedWidth, elementRef } = useCalculatedDimensions()
 
-  const persistOpen = useCallback(
-    (newOpen: boolean): void => {
-      if (shouldPersist && widgetMgr && blockId) {
-        widgetMgr.setElementState(blockId, "open", newOpen)
-      }
-    },
-    [shouldPersist, widgetMgr, blockId]
-  )
-
   // Handle popover toggle with optimistic updates
   const handleToggle = useCallback((): void => {
     const newOpen = !open
 
-    // Optimistic update
     setOpen(newOpen)
 
     if (widgetId) {
@@ -131,10 +119,10 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         { fromUi: true },
         fragmentId
       )
-    } else {
-      persistOpen(newOpen)
+    } else if (isPassivelyKeyed) {
+      setStoredOpen(newOpen)
     }
-  }, [open, widgetMgr, widgetId, fragmentId, persistOpen])
+  }, [open, widgetMgr, widgetId, fragmentId, isPassivelyKeyed, setStoredOpen])
 
   const handleClose = useCallback((): void => {
     setOpen(false)
@@ -146,12 +134,10 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         { fromUi: true },
         fragmentId
       )
-    } else {
-      persistOpen(false)
+    } else if (isPassivelyKeyed) {
+      setStoredOpen(false)
     }
-  }, [widgetMgr, widgetId, fragmentId, persistOpen])
-
-  const userKey = getKeyFromId(blockId)
+  }, [widgetMgr, widgetId, fragmentId, isPassivelyKeyed, setStoredOpen])
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
@@ -161,11 +147,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   }
 
   return (
-    <Box
-      data-testid="stPopover"
-      className={classNames("stPopover", convertKeyToClassName(userKey))}
-      ref={elementRef}
-    >
+    <Box data-testid="stPopover" className="stPopover" ref={elementRef}>
       <UIPopover
         triggerType={TRIGGER_TYPE.click}
         placement={PLACEMENT.bottomLeft}

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -83,7 +83,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // Resolve initial open state: stored elementState wins over proto
   const storedOpen =
     shouldPersist && widgetMgr
-      ? (widgetMgr.getElementState(blockId!, "open") as boolean | undefined)
+      ? (widgetMgr.getElementState(blockId, "open") as boolean | undefined)
       : undefined
   const initialOpen =
     storedOpen !== undefined ? storedOpen : (element.open ?? false)

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -17,10 +17,15 @@
 import { memo, ReactElement, useCallback, useContext, useState } from "react"
 
 import { PLACEMENT, TRIGGER_TYPE, Popover as UIPopover } from "baseui/popover"
+import classNames from "classnames"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
 import { notNullOrUndefined } from "@streamlit/utils"
 
+import {
+  convertKeyToClassName,
+  getKeyFromId,
+} from "~lib/components/core/Block/utils"
 import IsSidebarContext from "~lib/components/core/IsSidebarContext"
 import {
   Box,
@@ -51,6 +56,8 @@ export interface PopoverProps {
   // rewrite the min width calculation to translate rem to px.
   stretchWidth: boolean
   widgetMgr?: WidgetStateManager
+  /** Block-level ID for CSS key styling and passive persistence. */
+  blockId?: string
   fragmentId?: string
 }
 
@@ -60,6 +67,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   children,
   stretchWidth,
   widgetMgr,
+  blockId,
   fragmentId,
 }): ReactElement => {
   const isInSidebar = useContext(IsSidebarContext)
@@ -69,10 +77,19 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // id is only set when the backend registers the popover as a
   // stateful widget (on_change="rerun").
   const widgetId = element.id
+  const isWidget = Boolean(widgetId)
+  const shouldPersist = Boolean(blockId) && !isWidget
+
+  // Resolve initial open state: stored elementState wins over proto
+  const storedOpen =
+    shouldPersist && widgetMgr
+      ? (widgetMgr.getElementState(blockId!, "open") as boolean | undefined)
+      : undefined
+  const initialOpen =
+    storedOpen !== undefined ? storedOpen : (element.open ?? false)
 
   // Single state with optimistic updates for instant UI feedback.
-  // Initialize from backend state.
-  const [open, setOpen] = useState(element.open ?? false)
+  const [open, setOpen] = useState(initialOpen)
 
   // Sync backend state changes (for programmatic control via session_state).
   // Uses render-time comparison instead of useEffect — no DOM side effects needed.
@@ -89,6 +106,15 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // can remove the need for this as part of the BaseWeb migration.
   const { width: calculatedWidth, elementRef } = useCalculatedDimensions()
 
+  const persistOpen = useCallback(
+    (newOpen: boolean): void => {
+      if (shouldPersist && widgetMgr && blockId) {
+        widgetMgr.setElementState(blockId, "open", newOpen)
+      }
+    },
+    [shouldPersist, widgetMgr, blockId]
+  )
+
   // Handle popover toggle with optimistic updates
   const handleToggle = useCallback((): void => {
     const newOpen = !open
@@ -97,15 +123,16 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     setOpen(newOpen)
 
     if (widgetId) {
-      // Send state update to backend
       widgetMgr?.setBoolValue(
         { id: widgetId },
         newOpen,
         { fromUi: true },
         fragmentId
       )
+    } else {
+      persistOpen(newOpen)
     }
-  }, [open, widgetMgr, widgetId, fragmentId])
+  }, [open, widgetMgr, widgetId, fragmentId, persistOpen])
 
   const handleClose = useCallback((): void => {
     setOpen(false)
@@ -117,8 +144,12 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         { fromUi: true },
         fragmentId
       )
+    } else {
+      persistOpen(false)
     }
-  }, [widgetMgr, widgetId, fragmentId])
+  }, [widgetMgr, widgetId, fragmentId, persistOpen])
+
+  const userKey = getKeyFromId(blockId)
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
@@ -128,7 +159,11 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   }
 
   return (
-    <Box data-testid="stPopover" className="stPopover" ref={elementRef}>
+    <Box
+      data-testid="stPopover"
+      className={classNames("stPopover", convertKeyToClassName(userKey))}
+      ref={elementRef}
+    >
       <UIPopover
         triggerType={TRIGGER_TYPE.click}
         placement={PLACEMENT.bottomLeft}

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -51,7 +51,7 @@ export interface PopoverProps {
   // TODO (lawilby): This is can probably be simplified if we
   // rewrite the min width calculation to translate rem to px.
   stretchWidth: boolean
-  widgetMgr?: WidgetStateManager
+  widgetMgr: WidgetStateManager
   /** Block-level ID for CSS key styling and passive persistence. */
   blockId?: string
   fragmentId?: string
@@ -80,7 +80,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // The hook is always called (Rules of Hooks) but only effective when
   // isPassivelyKeyed — otherwise the empty id produces a no-op entry.
   const [storedOpen, setStoredOpen] = useWidgetManagerElementState<boolean>({
-    widgetMgr: widgetMgr!,
+    widgetMgr,
     id: isPassivelyKeyed ? (blockId ?? "") : "",
     key: "open",
     defaultValue: element.open ?? false,

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -83,7 +83,9 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // Resolve initial open state: stored elementState wins over proto
   const storedOpen =
     shouldPersist && widgetMgr
-      ? (widgetMgr.getElementState(blockId, "open") as boolean | undefined)
+      ? (widgetMgr.getElementState(blockId ?? "", "open") as
+          | boolean
+          | undefined)
       : undefined
   const initialOpen =
     storedOpen !== undefined ? storedOpen : (element.open ?? false)


### PR DESCRIPTION
## Summary

Third PR in the layout container state persistence stack (after #14332 and #14354).

Adds frontend state persistence for keyed `st.expander` and `st.popover` elements via `elementStates`. When a `key` is provided in passive mode (`on_change="ignore"`), the expanded/open state survives component remounts caused by delta path shifts.

### Changes

**Frontend (Expander.tsx)**
- Reads stored `expanded` state from `elementStates` on mount when `shouldPersist` is true
- Writes `expanded` state to `elementStates` on toggle via `handlePersistToggle`
- Widget mode (`on_change="rerun"`) is explicitly protected — `elementStates` is never read/written; server state always takes precedence

**Frontend (Popover.tsx)**
- Same pattern: reads/writes `open` state to `elementStates` in passive mode
- Widget mode protection identical to Expander

**Frontend (Block.tsx)**
- `ContainerContentsWrapper` suppresses the `st-key-*` CSS class on the inner `StyledFlexContainerBlock` when it detects the block is inside an expander or popover, avoiding duplication with the container's own outermost element

**CSS Key Class**
- `st-key-*` class applied to the outermost element of both `st.expander` and `st.popover`

### Test Plan

- [x] Unit tests: passive state persistence (read on mount, write on toggle)
- [x] Unit tests: widget-mode guards (no elementStates read/write, server value wins over stale stored state)
- [x] Unit tests: CSS key class presence/absence
- [x] E2E tests: `test_keyed_expander_css_key_class` and `test_keyed_expander_persist_expanded_across_remount`
- [x] E2E tests: `test_keyed_popover_css_key_class` and `test_keyed_popover_persist_closed_across_remount`

**Depends on:** #14354