### PR TITLE
feat: better align cursor hooks to those from claude

### DIFF
--- a/.claude/hooks/post_edit_autofix.sh
+++ b/.claude/hooks/post_edit_autofix.sh
@@ -13,14 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# PostToolUse hook: Auto-format and fix lint errors in files after Edit/Write
+# Post-edit hook: Auto-format and fix lint errors in edited Python files.
+# Hook wiring:
+# - Claude: `.claude/settings.json` -> `PostToolUse` matcher `Edit|Write`
+# - Cursor: enable third-party Claude config so Cursor runs this via
+#   `.claude/settings.json` `PostToolUse` (`.cursor/hooks.json` is metrics-only).
 #
 # NOTE: This can be extended to other file types (e.g., TypeScript, JSON), but
 # any additions must be very fast since this runs on every file edit/write.
 
 INPUT=$(cat)
 
-# Support both Claude (.tool_input.file_path) and Cursor (.filePath) input formats
+# Support both known payload shapes:
+# - Claude: `.tool_input.file_path`
+# - Cursor: `.filePath` / `.file_path`
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .filePath // .file_path // empty')
 
 # Only process Python files

--- a/.claude/hooks/pre_bash_redirect.py
+++ b/.claude/hooks/pre_bash_redirect.py
@@ -13,8 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-PreToolUse(Bash) hook: enforce uv run for Python commands and block direct pytest on e2e_playwright.
+"""Enforce shell policy for shared Claude/Cursor hook flows.
+
+Hook wiring:
+- Claude: `.claude/settings.json` -> `PreToolUse` matcher `Bash`
+- Cursor: enable third-party Claude config so Cursor executes the same
+  `PreToolUse` hook from `.claude/settings.json` (`.cursor/hooks.json` is
+  metrics-only in this repo).
 
 Exit code semantics (as of Claude Code hooks):
 - exit 0: allow tool call
@@ -53,6 +58,35 @@ PYTEST_PATTERN = re.compile(
 UV_RUN_COMMANDS = ("python", "python3", "pytest", "ruff", "mypy", "ty", "streamlit")
 
 
+def _extract_command(payload: dict[str, object]) -> str:
+    """Extract command from Claude/Cursor hook payloads.
+
+    Returns an empty string if this payload is not a shell hook invocation.
+    """
+    event_name = payload.get("hook_event_name")
+
+    if event_name == "PreToolUse":
+        # Claude payload: {"tool_name":"Bash","tool_input":{"command":"..."}}
+        if payload.get("tool_name") != "Bash":
+            return ""
+        tool_input = payload.get("tool_input")
+        if isinstance(tool_input, dict):
+            command = tool_input.get("command", "")
+            return command if isinstance(command, str) else ""
+        return ""
+
+    # Fallback for compatibility if event names are omitted or changed.
+    # Also covers Cursor-style payloads with top-level `command`.
+    command = payload.get("command")
+    if isinstance(command, str):
+        return command
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        maybe_command = tool_input.get("command", "")
+        return maybe_command if isinstance(maybe_command, str) else ""
+    return ""
+
+
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
@@ -65,12 +99,9 @@ def main() -> None:
         )
         sys.exit(2)
 
-    if payload.get("hook_event_name") != "PreToolUse":
+    cmd = _extract_command(payload)
+    if not cmd:
         sys.exit(0)
-    if payload.get("tool_name") != "Bash":
-        sys.exit(0)
-
-    cmd = (payload.get("tool_input") or {}).get("command", "") or ""
     norm = re.sub(r"\s+", " ", cmd).strip()
 
     # Check if this is a pytest command targeting e2e_playwright

--- a/.claude/hooks/stop_check.sh
+++ b/.claude/hooks/stop_check.sh
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 # Stop hook: runs `make check` when Claude/Cursor finishes responding.
+# Hook wiring:
+# - Claude: `.claude/settings.json` -> `Stop`
+# - Cursor: enable third-party Claude config so Cursor runs this via
+#   `.claude/settings.json` `Stop` (`.cursor/hooks.json` is metrics-only).
 # If check fails, blocks the agent from stopping so it can fix issues.
 #
 # Compatible with both Claude Code and Cursor hooks:

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,29 +1,17 @@
 {
   "version": 1,
   "hooks": {
-    "beforeShellExecution": [
+    "preToolUse": [
       {
-        "type": "prompt",
-        "prompt": "Block if the command runs pytest on e2e_playwright tests. These tests should use 'make run-e2e-test <filename>' instead.",
-        "matcher": "(uv run )?(python[3]? -m )?pytest.*e2e_playwright"
-      },
-      {
-        "type": "prompt",
-        "prompt": "Block if the command starts with a Python tool (python, pytest, ruff, mypy, ty, streamlit) without 'uv run'. Use 'uv run <command> ...' instead.",
-        "matcher": "^(python[3]?|pytest|ruff|mypy|ty|streamlit)(\\s|$)"
-      }
-    ],
-    "afterFileEdit": [
-      {
-        "command": "$CURSOR_PROJECT_DIR/.claude/hooks/post_edit_autofix.sh",
+        "command": "uv run python \"$CURSOR_PROJECT_DIR/scripts/log_agent_metrics.py\" skill_invocation cursor_task_tool",
         "timeout": 5,
-        "matcher": "\\.py$"
+        "matcher": "Task"
       }
     ],
-    "stop": [
+    "subagentStart": [
       {
-        "command": "$CURSOR_PROJECT_DIR/.claude/hooks/stop_check.sh",
-        "timeout": 120
+        "command": "uv run python \"$CURSOR_PROJECT_DIR/scripts/log_agent_metrics.py\" subagent_invocation",
+        "timeout": 5
       }
     ]
   }

--- a/scripts/log_agent_metrics.py
+++ b/scripts/log_agent_metrics.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Append Claude skill/subagent metrics as NDJSON in work-tmp/agent-metrics.
+"""Append Claude/Cursor skill/subagent metrics as NDJSON in work-tmp/agent-metrics.
+
+Hook wiring:
+- Claude: `.claude/settings.json`
+  - `SubagentStart` -> `subagent_invocation`
+  - `PreToolUse` matcher `Skill` -> `skill_invocation`
+- Cursor: `.cursor/hooks.json`
+  - `subagentStart` -> `subagent_invocation`
+  - `preToolUse` matcher `Task` -> `skill_invocation` (task-oriented metric)
 
 Usage:
     log_agent_metrics.py skill_invocation [skill-name]   # name from arg or payload
@@ -78,6 +86,15 @@ def _read_payload() -> dict[str, Any]:
         return data if isinstance(data, dict) else {}
     except json.JSONDecodeError:
         return {}
+
+
+def _get_project_dir() -> str:
+    """Resolve project directory from hook environment variables."""
+    return (
+        os.environ.get("CLAUDE_PROJECT_DIR")
+        or os.environ.get("CURSOR_PROJECT_DIR")
+        or os.getcwd()
+    )
 
 
 def _normalize_optional(value: Any) -> str | None:
@@ -210,7 +227,7 @@ def _post_stats_to_pr(project_dir: str) -> int:
 
 def main() -> int:
     """Log a skill or subagent invocation to an NDJSON file."""
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = _get_project_dir()
 
     if len(sys.argv) > 1 and sys.argv[1] == "--stats":
         return _print_stats(project_dir)
@@ -225,15 +242,29 @@ def main() -> int:
 
     if source_tag == "skill_invocation":
         entry_type = "skill"
-        # Use explicit name if provided, else extract from PreToolUse payload
+        # We intentionally treat Cursor Task-tool invocations as skill-like usage
+        # to keep a single aggregated "invocation mix" metric across providers.
+        # Use explicit name if provided, else extract from hook payload.
         if explicit_name:
             name = explicit_name
         else:
             tool_input = payload.get("tool_input") or {}
-            name = tool_input.get("skill") or ""
+            if not isinstance(tool_input, dict):
+                tool_input = {}
+            name = (
+                tool_input.get("skill")
+                or payload.get("tool_name")
+                or tool_input.get("name")
+                or ""
+            )
     elif source_tag == "subagent_invocation":
         entry_type = "subagent"
-        name = explicit_name or str(payload.get("agent_type") or "")
+        name = explicit_name or str(
+            payload.get("agent_type")
+            or payload.get("subagent_type")
+            or payload.get("subagent_model")
+            or ""
+        )
     else:
         return 0
 
@@ -244,7 +275,9 @@ def main() -> int:
     entry = {
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "branch": branch,
-        "session_id": _normalize_optional(payload.get("session_id")),
+        "session_id": _normalize_optional(
+            payload.get("session_id") or payload.get("conversation_id")
+        ),
         "type": entry_type,
         "name": _normalize_optional(name),
     }


### PR DESCRIPTION
## Describe your changes

- Made **Claude hooks** the primary policy source and reduced **Cursor hooks** to a minimal override layer.
- Reduced `.cursor/hooks.json` to only 2 metrics hooks:
  - `preToolUse` (`matcher: "Task"`) -> `scripts/log_agent_metrics.py skill_invocation cursor_task_tool`
  - `subagentStart` -> `scripts/log_agent_metrics.py subagent_invocation`
- Removed overlapping Cursor hooks that were duplicating Claude behavior:
  - removed `beforeShellExecution`
  - removed `afterFileEdit`
  - removed `stop`
- Removed prompt-based Cursor shell rules; shell policy is now enforced via Claude hook flow.
- Updated `.claude/hooks/pre_bash_redirect.py` to accept both payload formats:
  - Claude-style `tool_input.command`
  - Cursor-style top-level `command`
- Preserved existing shell policy behavior:
  - blocks direct `python|python3|pytest|ruff|mypy|ty|streamlit` without `uv run`
  - blocks `pytest` targeting `e2e_playwright`
- Updated `scripts/log_agent_metrics.py` for cross-provider compatibility:
  - project dir fallback: `CLAUDE_PROJECT_DIR -> CURSOR_PROJECT_DIR -> cwd`
  - subagent name fallback: `agent_type -> subagent_type -> subagent_model`
  - session id fallback: `session_id -> conversation_id`
  - broader skill-name extraction from hook payloads
- Added inline comments in shared scripts to document exactly where each hook is wired and which payload fields are expected.
- Net effect: removed duplicate policy/format/stop execution paths while keeping Cursor-specific metrics coverage.

## Screenshot or video (only for visual changes)

Before:
<img width="671" height="564" alt="Screenshot 2026-03-13 at 9 38 37 AM" src="https://github.com/user-attachments/assets/68686fd5-87b9-4903-bdc9-ec4dd2310d08" />

After:
<img width="668" height="481" alt="Screenshot 2026-03-13 at 9 38 23 AM" src="https://github.com/user-attachments/assets/587a7abc-b5fb-416e-8723-1ef1ac46e0dc" />

## GitHub Issue Link (if applicable)

## Testing Plan

- Tested locally

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
