### PR TITLE
fix(form): prevent "Missing Submit Button" error from flashing during initial page load

### DIFF
--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -63,6 +63,24 @@ describe("Form", () => {
     expect(formElement).toHaveClass("stForm")
   })
 
+  it("does not show error during initial load when script has not yet run", () => {
+    const props = getProps()
+
+    // Initial state: NOT_RUNNING (before any script has executed).
+    // The form should NOT flash the warning because the script hasn't
+    // started yet — the submit button delta may still be in transit.
+    renderWithContexts(<Form {...props} />, {
+      formsContext: {
+        formsData: defaultFormsData(),
+      },
+      scriptRunContext: {
+        scriptRunState: ScriptRunState.NOT_RUNNING,
+      },
+    })
+
+    expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
+  })
+
   it("shows error if !hasSubmitButton && scriptRunState==NOT_RUNNING", () => {
     const formId = "mockFormId"
     const props = getProps({ formId })

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -20,6 +20,7 @@ import {
   ReactNode,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react"
 
@@ -82,17 +83,35 @@ function Form(props: Props): ReactElement {
     widgetMgr.setFormSubmitBehaviors(formId, clearOnSubmit, enterToSubmit)
   }, [widgetMgr, formId, clearOnSubmit, enterToSubmit])
 
+  // Track whether the script has completed at least one run. The initial
+  // ScriptRunState is NOT_RUNNING (before the first script execution), so
+  // without this guard the warning would flash briefly during initial page
+  // load before the submit button delta has arrived.
+  const hasScriptRun = useRef(false)
+  if (
+    !hasScriptRun.current &&
+    scriptRunState === ScriptRunState.RUNNING
+  ) {
+    hasScriptRun.current = true
+  }
+
   // Determine if we need to show the "missing submit button" warning.
   // If we have a submit button, we don't show the warning, of course.
   // If we *don't* have a submit button, then we only mutate the showWarning
-  // flag when our scriptRunState is NOT_RUNNING. (If the script is still
-  // running, there might be an incoming SubmitButton delta that we just
+  // flag when our scriptRunState is NOT_RUNNING *and* the script has
+  // completed at least one run. (If the script is still running or hasn't
+  // started yet, there might be an incoming SubmitButton delta that we just
   // haven't seen yet.)
   const [showWarning, setShowWarning] = useState(false)
 
   if (hasSubmitButton && showWarning) {
     setShowWarning(false)
-  } else if (!hasSubmitButton && !showWarning && scriptNotRunning) {
+  } else if (
+    !hasSubmitButton &&
+    !showWarning &&
+    scriptNotRunning &&
+    hasScriptRun.current
+  ) {
     setShowWarning(true)
   }
 


### PR DESCRIPTION
## Summary

Fixes the "Missing Submit Button" error that briefly flashes when a form is loading on slow connections.

## Problem

The `Form` component shows a "Missing Submit Button" warning when `scriptRunState` is `NOT_RUNNING` and no submit button has been registered. However, the **initial** `ScriptRunState` (before any script execution) is also `NOT_RUNNING`. On slow connections, the form block renders and the component sees `NOT_RUNNING` + no submit button, triggering the warning before the submit button delta has even arrived.

## Fix

Track whether the script has completed at least one run by recording when `ScriptRunState` transitions through `RUNNING`. Only show the missing submit button warning after this has happened, preventing the false error during initial page load.

This aligns with the existing TODO in `ScriptRunState.ts` that acknowledges the missing `INITIAL` state.

## Changes

- **`Form.tsx`**: Added a `useRef` guard (`hasScriptRun`) that becomes `true` once the script enters `RUNNING` state. The warning is now gated on this flag.
- **`Form.test.tsx`**: Added a test case verifying the warning does not appear when the initial state is `NOT_RUNNING` and the script has never run.

## Testing

- Existing test for "shows error if !hasSubmitButton && scriptRunState==NOT_RUNNING" continues to pass (it starts from `RUNNING` → `NOT_RUNNING`).
- New test confirms warning does not flash during initial `NOT_RUNNING` state.

## Related Issue

Fixes #14247