### PR TITLE
chore: align versions of cache and setup-node actions

### DIFF
--- a/.github/actions/make_init/action.yml
+++ b/.github/actions/make_init/action.yml
@@ -37,7 +37,7 @@ runs:
       run: corepack enable
       shell: bash
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: ".nvmrc"
         cache: "yarn"
@@ -95,7 +95,7 @@ runs:
     - if: inputs.use_cached_venv == 'true'
       name: Restore virtualenv from cache
       id: cache-virtualenv
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .venv
         key: v2-python-venv-py${{ inputs.python_version }}-${{ hashFiles('**/python_cache_key.md5') }}

--- a/.github/actions/playwright_install/action.yml
+++ b/.github/actions/playwright_install/action.yml
@@ -47,7 +47,7 @@ runs:
     #   - runner.os and runner.arch: to scope to the correct platform
     #   - Playwright version: to bust cache on browser upgrades
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.pw-version.outputs.version }}


### PR DESCRIPTION
## Describe your changes

Updated GitHub Actions dependencies to their latest versions:
- Upgraded `actions/setup-node` from v4 to v6 in the make_init action
- Upgraded `actions/cache` from v4 to v5 in both make_init and playwright_install actions

These updates ensure the CI pipeline uses the most recent versions of these actions with improved performance and security fixes.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Changes are reflected in CI runs.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.