### PR TITLE
Set a timeout on create release HTTP calls

### DIFF
--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -35,7 +35,7 @@ def create_release() -> None:
     header = {"Authorization": f"token {access_token}"}
 
     # Get the latest release tag to compare against
-    response = requests.get(f"{url}/latest", headers=header)
+    response = requests.get(f"{url}/latest", headers=header, timeout=10.0)
     previous_tag_name = None
     if response.status_code == 200:
         previous_tag_name = response.json()["tag_name"]
@@ -44,7 +44,7 @@ def create_release() -> None:
 
     # Generate the automated release notes
     payload = {"tag_name": tag, "previous_tag_name": previous_tag_name}
-    response = requests.post(f"{url}/generate-notes", json=payload, headers=header)
+    response = requests.post(f"{url}/generate-notes", json=payload, headers=header, timeout=10.0)
     body = None
     if response.status_code == 200:
         body = response.json()["body"]


### PR DESCRIPTION
Introduced a timeout parameter in scripts/create_release.py to avoid prolonged network calls.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile scripts/create_release.py`.

Context: py-http-timeout at scripts/create_release.py:38.