### PR TITLE
feat(st.tabs): add height="stretch" support

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -393,11 +393,17 @@ export const BlockNodeRenderer = (
   }
 
   if (node.deltaBlock.tabContainer) {
+    const isStretchHeight = styles.height === "100%"
     const renderTabContent = (
       mappedChildProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
     ): ReactElement => {
       // avoid circular dependency where Tab uses VerticalBlock but VerticalBlock uses tabs
-      return <ContainerContentsWrapper {...mappedChildProps} height="auto" />
+      return (
+        <ContainerContentsWrapper
+          {...mappedChildProps}
+          height={isStretchHeight ? "100%" : "auto"}
+        />
+      )
     }
     // We can't use StyledLayoutWrapper for tabs currently because of the horizontal scrolling
     // management that is handled in the Tabs component. TODO(lwilby): Investigate whether it makes
@@ -407,6 +413,7 @@ export const BlockNodeRenderer = (
       isStale,
       renderTabContent,
       width: styles.width,
+      height: styles.height,
       flex: styles.flex,
       fragmentId: node.fragmentId,
     }

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -50,6 +50,7 @@ export interface TabProps extends BlockPropsWithoutWidth {
     childProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
   ) => ReactElement
   width: React.CSSProperties["width"]
+  height: React.CSSProperties["height"]
   flex: React.CSSProperties["flex"]
   fragmentId?: string
 }
@@ -60,6 +61,7 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
     node,
     isStale,
     width,
+    height,
     flex,
     widgetMgr,
     fragmentId,
@@ -198,6 +200,7 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
       data-testid="stTabs"
       isOverflowing={isOverflowing}
       width={width}
+      height={height}
       flex={flex}
     >
       <UITabs
@@ -248,6 +251,13 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
             style: () => ({
               // resetting transform to fix full screen wrapper
               transform: "none",
+              ...(height === "100%"
+                ? {
+                    display: "flex",
+                    flexDirection: "column" as const,
+                    height: "100%",
+                  }
+                : {}),
             }),
           },
         }}
@@ -294,6 +304,12 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
                     paddingRight: theme.spacing.none,
                     paddingBottom: theme.spacing.none,
                     paddingTop: theme.spacing.lg,
+                    ...(height === "100%"
+                      ? {
+                          flex: 1,
+                          minHeight: 0,
+                        }
+                      : {}),
                   }),
                 },
                 Tab: {

--- a/frontend/lib/src/components/elements/Tabs/styled-components.ts
+++ b/frontend/lib/src/components/elements/Tabs/styled-components.ts
@@ -20,13 +20,15 @@ import { transparentize } from "color2k"
 interface StyledTabContainerProps {
   isOverflowing: boolean
   width: React.CSSProperties["width"]
+  height: React.CSSProperties["height"]
   flex: React.CSSProperties["flex"]
 }
 
 export const StyledTabContainer = styled.div<StyledTabContainerProps>(
-  ({ isOverflowing, width, flex }) => ({
+  ({ isOverflowing, width, height, flex }) => ({
     position: isOverflowing ? "relative" : undefined,
     width: width || undefined,
+    height: height || undefined,
     flex: flex || undefined,
   })
 )

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -615,6 +615,7 @@ class LayoutsMixin:
         self,
         tabs: Sequence[str],
         *,
+        height: Literal["content", "stretch"] = "content",
         width: WidthWithoutContent = "stretch",
         default: str | None = None,
         key: Key | None = None,
@@ -659,6 +660,15 @@ class LayoutsMixin:
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
+        height : "content" or "stretch"
+            The height of the tab container. This can be one of the following:
+
+            - ``"content"`` (default): The height of the container matches the
+              height of its content.
+            - ``"stretch"``: The height of the container fills the parent
+              container. This is useful when using tabs inside a container
+              with a fixed height or inside a flex layout.
 
         width : "stretch" or int
             The width of the tab container. This can be one of the following:
@@ -919,6 +929,8 @@ class LayoutsMixin:
         block_proto.tab_container.SetInParent()
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
+        validate_height(height, allow_content=True)
+        block_proto.height_config.CopyFrom(get_height_config(height))
 
         # Compute the current tab index from the label
         try:


### PR DESCRIPTION
Fixes #12217.

Adds `height` parameter to `st.tabs()` supporting `"content"` (default) and `"stretch"` values. When `height="stretch"`, the tab container fills its parent container height, enabling tabs to work properly inside flex layouts and fixed-height containers.

**Example usage:**
```python
with st.container(horizontal=True, height=500):
    st.container(border=True, height="stretch")
    tab1, tab2 = st.tabs(["Tab 1", "Tab 2"], height="stretch")
    tab1.container(height="stretch", border=True)
```

Changes:

```
lib/streamlit/elements/layouts.py: Added height parameter to tabs() with validation and proto config
frontend/.../Block/Block.tsx: Pass styles.height to Tabs component, make tab content stretch when height is set
frontend/.../Tabs/Tabs.tsx: Accept height prop, apply flex layout to UITabs Root and TabPanel when stretching
frontend/.../Tabs/styled-components.ts: Add height to StyledTabContainer
```