### PR TITLE
[Fix] Duplicate `GUEST_READY` messages on bypass

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -6331,7 +6331,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       expect(metricsMgr.setMetricsConfig).toHaveBeenCalledWith(metricsUrl)
     })
 
-    it("StreamlitConfig HOST_CONFIG values take precedence over endpoint response", () => {
+    it("keeps window allowedOrigins when endpoint returns a superset", () => {
       const windowOrigins = ["https://window-origin.com"]
       const windowMetricsUrl = "postMessage"
       globalThis.__mockStreamlitConfig = {
@@ -6354,12 +6354,16 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       vi.mocked(hostCommunicationMgr.setAllowedOrigins).mockClear()
       vi.mocked(metricsMgr.setMetricsConfig).mockClear()
 
-      // Simulate onHostConfigResp with conflicting values
+      // Simulate onHostConfigResp where endpoint returns a superset of origins.
+      // Window config should remain authoritative for allowedOrigins.
       const onHostConfigResp = getMockConnectionManagerProp("onHostConfigResp")
 
       act(() => {
         onHostConfigResp({
-          allowedOrigins: ["https://endpoint-origin.com"],
+          allowedOrigins: [
+            "https://window-origin.com",
+            "https://endpoint-origin.com",
+          ],
           useExternalAuthToken: false,
           metricsUrl: "https://metrics.endpoint.com",
           disableFullscreenMode: false,
@@ -6370,9 +6374,10 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         })
       })
 
-      // Verify StreamlitConfig values took precedence
+      // Verify StreamlitConfig values took precedence.
+      // HostCommunicationManager should still receive only windowOrigins here.
       expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith({
-        allowedOrigins: windowOrigins, // Window value, not endpoint
+        allowedOrigins: windowOrigins, // Window value, not endpoint superset
         useExternalAuthToken: true, // Window value, not endpoint
         enableCustomParentMessages: false,
         blockErrorDialogs: false,

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -6376,6 +6376,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
 
       // Verify StreamlitConfig values took precedence.
       // HostCommunicationManager should still receive only windowOrigins here.
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledTimes(1)
       expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith({
         allowedOrigins: windowOrigins, // Window value, not endpoint superset
         useExternalAuthToken: true, // Window value, not endpoint
@@ -6383,6 +6384,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         blockErrorDialogs: false,
       })
 
+      expect(metricsMgr.setMetricsConfig).toHaveBeenCalledTimes(1)
       expect(metricsMgr.setMetricsConfig).toHaveBeenCalledWith(
         windowMetricsUrl // Window value, not endpoint
       )
@@ -6473,6 +6475,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
 
       // Verify: allowedOrigins and useExternalAuthToken from window,
       // metricsUrl from endpoint (since not set in window config)
+      expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledTimes(1)
       expect(hostCommunicationMgr.setAllowedOrigins).toHaveBeenCalledWith({
         allowedOrigins: windowOrigins, // Window value
         useExternalAuthToken: true, // Window value
@@ -6480,6 +6483,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         blockErrorDialogs: false,
       })
 
+      expect(metricsMgr.setMetricsConfig).toHaveBeenCalledTimes(1)
       expect(metricsMgr.setMetricsConfig).toHaveBeenCalledWith(
         endpointMetricsUrl // Endpoint value (window had no metricsUrl)
       )

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -516,6 +516,9 @@ export class App extends PureComponent<Props, State> {
       blockErrorDialogs: hostConfig.blockErrorDialogs,
     })
 
+    // This can be called again later from onHostConfigResp during reconciliation.
+    // HostCommunicationManager.openHostCommunication is intentionally idempotent,
+    // so repeated setAllowedOrigins calls only update config values.
     this.hostCommunicationMgr.setAllowedOrigins(appConfig)
     this.setAppConfig(appConfig)
 
@@ -611,7 +614,10 @@ export class App extends PureComponent<Props, State> {
 
         // Set the metrics configuration:
         this.metricsMgr.setMetricsConfig(metricsUrl)
-        // Set the allowed origins configuration for the host communication:
+        // Set the allowed origins configuration for the host communication.
+        // This is called even in bypass mode where applyInitialHostConfig may have
+        // already called setAllowedOrigins. HostCommunicationManager handles this
+        // safely by making openHostCommunication idempotent.
         this.hostCommunicationMgr.setAllowedOrigins(appConfig)
         // Set the streamlit-app specific config settings in AppContext:
         this.setAppConfig(appConfig)

--- a/frontend/app/src/util/hostConfigHelpers.ts
+++ b/frontend/app/src/util/hostConfigHelpers.ts
@@ -70,6 +70,11 @@ export function preferWindowValue<T>(
  * takes precedence for the fast-path connection while still allowing the
  * endpoint to provide fallback values for unprovided fields.
  *
+ * Example:
+ * - windowConfig.allowedOrigins = ["https://origin-a.example.com"]
+ * - endpointConfig.allowedOrigins = ["https://origin-a.example.com", "https://origin-b.example.com"]
+ * - reconciled allowedOrigins = ["https://origin-a.example.com"]
+ *
  * @param windowConfig - Config from window.__streamlit.HOST_CONFIG
  * @param endpointConfig - Full config from the host-config endpoint
  * @returns Merged config with window values taking precedence when provided

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -22,9 +22,14 @@ import HostCommunicationManager, {
   HOST_COMM_VERSION,
 } from "~lib/hostComm/HostCommunicationManager"
 
+interface MockEventListenersResult {
+  dispatchEvent: (type: string, event: Event) => void
+  getListenerCount: (type: string) => number
+}
+
 // Mocking "message" event listeners on the window;
-// returns function to establish a listener
-function mockEventListeners(): (type: string, event: Event) => void {
+// returns helpers to dispatch events and inspect listener counts
+function mockEventListeners(): MockEventListenersResult {
   const listeners: { [name: string]: ((event: Event) => void)[] } = {}
 
   window.addEventListener = vi.fn(
@@ -34,19 +39,36 @@ function mockEventListeners(): (type: string, event: Event) => void {
     }
   )
 
-  return (type: string, event: Event): void =>
-    listeners[type].forEach(cb => cb(event))
+  window.removeEventListener = vi.fn(
+    (event: string, cb: EventListenerOrEventListenerObject) => {
+      if (listeners[event]) {
+        listeners[event] = listeners[event].filter(fn => fn !== cb)
+      }
+    }
+  )
+
+  return {
+    dispatchEvent: (type: string, event: Event): void =>
+      listeners[type]?.forEach(cb => cb(event)),
+    getListenerCount: (type: string): number => listeners[type]?.length ?? 0,
+  }
 }
 
 describe("HostCommunicationManager messaging", () => {
   let hostCommunicationMgr: HostCommunicationManager
 
   let dispatchEvent: (type: string, event: Event) => void
+  let getListenerCount: (type: string) => number
   let originalHash: string
 
   let setAllowedOriginsFunc: MockInstance
   let openCommFunc: MockInstance
   let sendMessageToHostFunc: MockInstance
+
+  const countHostMessages = (type: string): number =>
+    sendMessageToHostFunc.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { type: string }).type === type
+    ).length
 
   beforeEach(() => {
     hostCommunicationMgr = new HostCommunicationManager({
@@ -74,7 +96,7 @@ describe("HostCommunicationManager messaging", () => {
     })
 
     originalHash = window.location.hash
-    dispatchEvent = mockEventListeners()
+    ;({ dispatchEvent, getListenerCount } = mockEventListeners())
 
     setAllowedOriginsFunc = vi.spyOn(hostCommunicationMgr, "setAllowedOrigins")
     openCommFunc = vi.spyOn(hostCommunicationMgr, "openHostCommunication")
@@ -115,39 +137,32 @@ describe("HostCommunicationManager messaging", () => {
   })
 
   it("only sends GUEST_READY once when setAllowedOrigins is called multiple times", () => {
-    const countGuestReady = (): number =>
-      sendMessageToHostFunc.mock.calls.filter(
-        (call: unknown[]) =>
-          (call[0] as { type: string }).type === "GUEST_READY"
-      ).length
-
-    expect(countGuestReady()).toBe(1)
+    expect(countHostMessages("GUEST_READY")).toBe(1)
+    expect(getListenerCount("message")).toBe(1)
 
     hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
 
-    expect(countGuestReady()).toBe(1)
+    expect(countHostMessages("GUEST_READY")).toBe(1)
+    expect(getListenerCount("message")).toBe(1)
   })
 
   it("re-sends GUEST_READY after closeHostCommunication and a new setAllowedOrigins", () => {
-    const countGuestReady = (): number =>
-      sendMessageToHostFunc.mock.calls.filter(
-        (call: unknown[]) =>
-          (call[0] as { type: string }).type === "GUEST_READY"
-      ).length
-
-    expect(countGuestReady()).toBe(1)
+    expect(countHostMessages("GUEST_READY")).toBe(1)
+    expect(getListenerCount("message")).toBe(1)
 
     hostCommunicationMgr.closeHostCommunication()
+    expect(getListenerCount("message")).toBe(0)
 
     hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["https://devel.streamlit.test"],
       useExternalAuthToken: false,
     })
 
-    expect(countGuestReady()).toBe(2)
+    expect(countHostMessages("GUEST_READY")).toBe(2)
+    expect(getListenerCount("message")).toBe(1)
   })
 
   it("can process a received CLOSE_MODAL message", () => {
@@ -614,7 +629,7 @@ describe("HostCommunicationManager messaging", () => {
 
 describe("Test different origins", () => {
   let hostCommunicationMgr: HostCommunicationManager
-  let dispatchEvent: (type: string, event: Event) => void
+  let dispatchEvent: MockEventListenersResult["dispatchEvent"]
 
   beforeEach(() => {
     hostCommunicationMgr = new HostCommunicationManager({
@@ -640,8 +655,7 @@ describe("Test different origins", () => {
       restartWebsocketConnection: vi.fn(),
       terminateWebsocketConnection: vi.fn(),
     })
-
-    dispatchEvent = mockEventListeners()
+    ;({ dispatchEvent } = mockEventListeners())
   })
 
   afterEach(() => {
@@ -760,7 +774,7 @@ describe("HostCommunicationManager external auth token handling", () => {
   })
 
   it("waits to receive SET_AUTH_TOKEN message before resolving promise if useExternalAuthToken is true", async () => {
-    const dispatchEvent = mockEventListeners()
+    const { dispatchEvent } = mockEventListeners()
 
     hostCommunicationMgr.setAllowedOrigins({
       allowedOrigins: ["http://devel.streamlit.test"],

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -114,6 +114,42 @@ describe("HostCommunicationManager messaging", () => {
     )
   })
 
+  it("only sends GUEST_READY once when setAllowedOrigins is called multiple times", () => {
+    const countGuestReady = (): number =>
+      sendMessageToHostFunc.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { type: string }).type === "GUEST_READY"
+      ).length
+
+    expect(countGuestReady()).toBe(1)
+
+    hostCommunicationMgr.setAllowedOrigins({
+      allowedOrigins: ["https://devel.streamlit.test"],
+      useExternalAuthToken: false,
+    })
+
+    expect(countGuestReady()).toBe(1)
+  })
+
+  it("re-sends GUEST_READY after closeHostCommunication and a new setAllowedOrigins", () => {
+    const countGuestReady = (): number =>
+      sendMessageToHostFunc.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { type: string }).type === "GUEST_READY"
+      ).length
+
+    expect(countGuestReady()).toBe(1)
+
+    hostCommunicationMgr.closeHostCommunication()
+
+    hostCommunicationMgr.setAllowedOrigins({
+      allowedOrigins: ["https://devel.streamlit.test"],
+      useExternalAuthToken: false,
+    })
+
+    expect(countGuestReady()).toBe(2)
+  })
+
   it("can process a received CLOSE_MODAL message", () => {
     dispatchEvent(
       "message",

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -78,6 +78,8 @@ export default class HostCommunicationManager {
 
   private deferredAuthToken: PromiseWithResolvers<string | undefined>
 
+  private isHostCommOpen = false
+
   constructor(props: HostCommunicationProps) {
     this.props = props
 
@@ -86,10 +88,16 @@ export default class HostCommunicationManager {
   }
 
   /**
-   * Adds a listener for messages from the host
-   * sends message that guest is ready to receive messages
+   * Adds a listener for messages from the host and sends a GUEST_READY
+   * message. This is idempotent: subsequent calls are no-ops while the
+   * communication channel is open, ensuring only one listener is registered
+   * and only one GUEST_READY is sent per app lifecycle.
    */
   public openHostCommunication = (): void => {
+    if (this.isHostCommOpen) {
+      return
+    }
+    this.isHostCommOpen = true
     window.addEventListener("message", this.receiveHostMessage)
     this.sendMessageToHost({
       type: "GUEST_READY",
@@ -99,10 +107,12 @@ export default class HostCommunicationManager {
   }
 
   /**
-   * Cleans up message event listener
+   * Cleans up message event listener and resets the open flag so
+   * communication can be re-established if needed.
    */
   public closeHostCommunication = (): void => {
     window.removeEventListener("message", this.receiveHostMessage)
+    this.isHostCommOpen = false
   }
 
   /**


### PR DESCRIPTION
## Describe your changes
Fixes duplicate `GUEST_READY` message sent during initialization when the host-config bypass (window variable fast-path) is enabled.
When bypass is enabled, `setAllowedOrigins` is called twice during init:
1. From `applyInitialHostConfig()` — using window variables for the fast-path
2. From the `onHostConfigResp` callback — when background `doInitPings` resolves
Each call triggered `openHostCommunication()`, which unconditionally added a `receiveHostMessage` listener and sent `GUEST_READY`. This caused:
- Two `GUEST_READY` messages (which SiS interprets as connection issues)
- Duplicate `receiveHostMessage` listeners on `window`

This PR makes `openHostCommunication` idempotent by adding an `isHostCommOpen` flag. The first call opens communication (registers the listener, sends `GUEST_READY`). Subsequent calls are no-ops. The flag resets in `closeHostCommunication` for clean teardown.

This makes both bypass and non-bypass paths consistent: exactly one `GUEST_READY` per app lifecycle. Connection health continues to be communicated via the existing `WEBSOCKET_CONNECTED` / `WEBSOCKET_DISCONNECTED` messages, which are unaffected.

Addresses [SNOW-3225743](https://snowflakecomputing.atlassian.net/browse/SNOW-3225743)

### Behavior clarification
When `window.__streamlit.HOST_CONFIG` provides valid values, those values take precedence over endpoint values during reconciliation.
For example:
- window `allowedOrigins = [A]`
- endpoint `allowedOrigins = [A, B]`
- effective reconciled `allowedOrigins = [A]`
So this case has deterministic behavior and does not reopen host comms or emit extra `GUEST_READY` messages.

## Testing Plan
- JS Unit Tests: ✅ Added