### PR TITLE
Fix ProgressColumn CSV export using clamped values instead of originals

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -244,6 +244,13 @@ function ProgressColumn(
       if (cell.kind === GridCellKind.Loading) {
         return null
       }
+      // Use copyData (original unclamped value) instead of cell.data.value
+      // which is clamped to min/max for visualization purposes.
+      // This ensures CSV export preserves the raw data values.
+      if (cell.copyData) {
+        const num = Number(cell.copyData)
+        return Number.isNaN(num) ? null : num
+      }
       return cell.data?.value === undefined ? null : cell.data?.value
     },
   }


### PR DESCRIPTION
## Summary

Fixes #14244

When a `ProgressColumn` has `max_value` set and data exceeds that value, the "Download as CSV" export writes the clamped value instead of the original raw data. For example, a value of `11` with `max_value=10` exports as `10`.

**Root cause:** `getCellValue()` returns `cell.data.value`, which is clamped to `[min_value, max_value]` for the progress bar visualization. The CSV export calls `getCellValue()`, so it gets the clamped value.

**Fix:** `getCellValue()` now reads from `cell.copyData` first, which stores the original unclamped value as a string (set in `getCell()` via `copyData: String(cellData)`). This preserves raw data in exports while keeping the visual clamping for the progress bar.

## Test plan

- [ ] Run existing `ProgressColumn.test.ts` tests — they should pass since existing test cases use values within range
- [ ] Add a test case: create a ProgressColumn with `max_value: 10`, call `getCell(11)`, then verify `getCellValue(cell)` returns `11` (not `10`)
- [ ] Manual test: run the reproducer from the issue, click "Download as CSV", verify the CSV contains `11` not `10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)