### PR TITLE
[Fix] Restore bound query params in URL with MPA

### DIFF
--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -311,6 +311,43 @@ def test_bound_widget_query_param_cleared_on_page_switch(page: Page, app_base_ur
     expect(page).not_to_have_url(re.compile(r"bound_cb="), timeout=7000)
 
 
+def test_bound_widget_query_param_restored_after_page_switch(
+    page: Page, app_base_url: str
+):
+    """Test that widget-bound query params are restored when navigating back."""
+    goto_app(page, build_app_url(app_base_url, query={"bound_cb": "true"}))
+
+    expect_prefixed_markdown(page, "bound_cb:", "True")
+    expect(page).to_have_url(re.compile(r"bound_cb=true"))
+
+    page.get_by_test_id("stSidebarNav").locator("a").nth(1).click()
+    wait_for_app_loaded(page)
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Page 2")
+    expect(page).not_to_have_url(re.compile(r"bound_cb="), timeout=7000)
+
+    page.get_by_test_id("stSidebarNav").locator("a").first.click()
+    wait_for_app_loaded(page)
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Main Page")
+    expect_prefixed_markdown(page, "bound_cb:", "True")
+    expect(page).to_have_url(re.compile(r"bound_cb=true"), timeout=7000)
+
+    # Negative check: default-value collapsing remains intact.
+    # A default false value should not appear in URL, including after round-trip.
+    goto_app(page, build_app_url(app_base_url, query={"bound_cb": "false"}))
+    expect_prefixed_markdown(page, "bound_cb:", "False")
+    expect(page).not_to_have_url(re.compile(r"bound_cb="), timeout=7000)
+
+    page.get_by_test_id("stSidebarNav").locator("a").nth(1).click()
+    wait_for_app_loaded(page)
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Page 2")
+
+    page.get_by_test_id("stSidebarNav").locator("a").first.click()
+    wait_for_app_loaded(page)
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Main Page")
+    expect_prefixed_markdown(page, "bound_cb:", "False")
+    expect(page).not_to_have_url(re.compile(r"bound_cb="), timeout=7000)
+
+
 def test_renders_logos(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that logos display properly in sidebar and main sections."""
 

--- a/e2e_playwright/multipage_apps/mpa_basics_test.py
+++ b/e2e_playwright/multipage_apps/mpa_basics_test.py
@@ -24,8 +24,10 @@ from e2e_playwright.conftest import (
 )
 from e2e_playwright.shared.app_utils import (
     click_button,
+    click_checkbox,
     expect_prefixed_markdown,
     get_button_group,
+    get_checkbox,
     get_segment_button,
     goto_app,
     wait_for_all_images_to_be_loaded,
@@ -314,7 +316,16 @@ def test_bound_widget_query_param_cleared_on_page_switch(page: Page, app_base_ur
 def test_bound_widget_query_param_restored_after_page_switch(
     page: Page, app_base_url: str
 ):
-    """Test that widget-bound query params are restored when navigating back."""
+    """Test that widget-bound query params are restored when navigating back.
+
+    Covers two flows:
+    1. URL-seeded: load with ?bound_cb=true, navigate away/back.
+    2. User-click: check the checkbox via UI interaction, navigate away/back.
+       This exercises value capture from _new_widget_state (the current value
+       from user interaction) rather than _old_state (stale compaction value).
+    Both flows verify the checkbox visual state, session state text, and URL.
+    """
+    # --- Flow 1: URL-seeded value persists across page navigation ---
     goto_app(page, build_app_url(app_base_url, query={"bound_cb": "true"}))
 
     expect_prefixed_markdown(page, "bound_cb:", "True")
@@ -330,9 +341,32 @@ def test_bound_widget_query_param_restored_after_page_switch(
     expect(page.get_by_test_id("stHeading")).to_contain_text("Main Page")
     expect_prefixed_markdown(page, "bound_cb:", "True")
     expect(page).to_have_url(re.compile(r"bound_cb=true"), timeout=7000)
+    cb = get_checkbox(page, "Bound checkbox")
+    expect(cb.locator("input")).to_be_checked()
 
-    # Negative check: default-value collapsing remains intact.
-    # A default false value should not appear in URL, including after round-trip.
+    # --- Flow 2: User-clicked value persists across page navigation ---
+    # Start fresh with no URL params so the checkbox defaults to False.
+    goto_app(page, build_app_url(app_base_url))
+    expect_prefixed_markdown(page, "bound_cb:", "False")
+    expect(cb.locator("input")).not_to_be_checked()
+
+    click_checkbox(page, "Bound checkbox")
+    expect_prefixed_markdown(page, "bound_cb:", "True")
+    expect(page).to_have_url(re.compile(r"bound_cb=true"), timeout=5000)
+
+    page.get_by_test_id("stSidebarNav").locator("a").nth(1).click()
+    wait_for_app_loaded(page)
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Page 2")
+
+    page.get_by_test_id("stSidebarNav").locator("a").first.click()
+    wait_for_app_loaded(page)
+    expect(page.get_by_test_id("stHeading")).to_contain_text("Main Page")
+    expect_prefixed_markdown(page, "bound_cb:", "True")
+    expect(page).to_have_url(re.compile(r"bound_cb=true"), timeout=7000)
+    cb = get_checkbox(page, "Bound checkbox")
+    expect(cb.locator("input")).to_be_checked()
+
+    # --- Negative check: default-value collapsing remains intact ---
     goto_app(page, build_app_url(app_base_url, query={"bound_cb": "false"}))
     expect_prefixed_markdown(page, "bound_cb:", "False")
     expect(page).not_to_have_url(re.compile(r"bound_cb="), timeout=7000)

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -564,6 +564,10 @@ class QueryParams(MutableMapping[str, str]):
         """
         return self._bindings_by_widget.get(widget_id)
 
+    def has_param(self, param_key: str) -> bool:
+        """Return whether a query parameter currently exists."""
+        return param_key in self._query_params
+
     def remove_param(self, param_key: str) -> bool:
         """Remove a query parameter without protection checks.
 
@@ -584,6 +588,18 @@ class QueryParams(MutableMapping[str, str]):
         if param_key in self._query_params:
             del self._query_params[param_key]
             self._send_query_param_msg()
+            return True
+        return False
+
+    def discard_param_no_forward_msg(self, param_key: str) -> bool:
+        """Remove a query parameter without sending a forward message.
+
+        This is used for backend-only cache cleanup when the frontend URL has
+        already removed the parameter (for example, default-value collapse on a
+        same-page rerun).
+        """
+        if param_key in self._query_params:
+            del self._query_params[param_key]
             return True
         return False
 
@@ -634,7 +650,7 @@ class QueryParams(MutableMapping[str, str]):
             return values[0]
         return values
 
-    def _set_corrected_value(self, param_key: str, value: Any, value_type: str) -> None:
+    def set_corrected_value(self, param_key: str, value: Any, value_type: str) -> None:
         """Set a corrected value for a query parameter.
 
         This is called when URL auto-correction is needed (e.g., after clamping
@@ -690,6 +706,10 @@ class QueryParams(MutableMapping[str, str]):
 
         self._query_params[param_key] = str_value
         self._send_query_param_msg()
+
+    # Keep alias for compatibility with existing internal call sites/tests.
+    def _set_corrected_value(self, param_key: str, value: Any, value_type: str) -> None:
+        self.set_corrected_value(param_key, value, value_type)
 
     def populate_from_query_string(
         self,

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -683,6 +683,8 @@ class QueryParams(MutableMapping[str, str]):
                 if value_type == "double_array_value"
                 else str(value)
             )
+        elif value_type == "bool_value" and isinstance(value, bool):
+            str_value = str(value).lower()
         else:
             str_value = str(value)
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -428,6 +428,12 @@ class SessionState:
     # widget state at one point.
     query_params: QueryParams = field(default_factory=QueryParams)
 
+    # Widget IDs that have registered with bind="query-params". This is a
+    # durable bound-intent snapshot that survives MPA page-transition
+    # sequencing where bindings and current-run metadata may already be gone by
+    # stale-widget cleanup time.
+    _query_param_bound_widget_ids: set[str] = field(default_factory=set)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -453,6 +459,7 @@ class SessionState:
         self._new_session_state.clear()
         self._new_widget_state.clear()
         self._key_id_mapper.clear()
+        self._query_param_bound_widget_ids.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -902,6 +909,27 @@ class SessionState:
             ctx.fragment_ids_this_run,
         )
 
+        # Before removing stale widget entries, preserve values for stale keyed
+        # widgets that were bound to query params under their user keys.
+        # _compact_state stores values under widget IDs (element IDs), which are
+        # removed below. Saving under user keys allows those values to persist.
+        # This is needed for MPA page transitions where widget bindings and
+        # current-run metadata for previous-page widgets may no longer exist.
+        wid_key_map = self._key_id_mapper.id_key_mapping
+        bound_preserved: dict[str, Any] = {}
+        for key, value in self._old_state.items():
+            if (
+                is_element_id(key)
+                and key in self._query_param_bound_widget_ids
+                and key in wid_key_map
+                and _is_stale_widget(
+                    self._new_widget_state.widget_metadata.get(key),
+                    active_widget_ids,
+                    ctx.fragment_ids_this_run,
+                )
+            ):
+                bound_preserved[wid_key_map[key]] = value
+
         # Remove entries from _old_state corresponding to
         # widgets not in widget_ids.
         self._old_state = {
@@ -916,6 +944,9 @@ class SessionState:
                 )
             )
         }
+
+        # Re-add preserved query-param-bound values under user keys.
+        self._old_state.update(bound_preserved)
 
         # Remove query param bindings and URL params for stale widgets.
         # For fragment runs, preserve widgets outside the running fragment(s).
@@ -973,11 +1004,13 @@ class SessionState:
         # Handle query param binding
         url_value_seeded = False
         if metadata.bind == "query-params" and user_key is not None:
+            self._query_param_bound_widget_ids.add(widget_id)
             url_value_seeded = self._handle_query_param_binding(
                 metadata, user_key, widget_id
             )
         elif metadata.bind is None and user_key is not None:
             # Widget stopped using bind — clean up any stale binding
+            self._query_param_bound_widget_ids.discard(widget_id)
             self.query_params.unbind_and_clear_param(widget_id)
 
         if (
@@ -996,6 +1029,23 @@ class SessionState:
         # mutated by user code.
         widget_value = cast("T", self[widget_id])
         widget_value = deepcopy(widget_value)
+
+        # Restore bound widget value to URL when the URL param is missing.
+        # We do this after value resolution so the URL mirrors what users see.
+        # Programmatic st.session_state values set during this run remain
+        # excluded from auto-sync.
+        if (
+            metadata.bind == "query-params"
+            and user_key is not None
+            and user_key not in self.query_params._query_params
+            and user_key not in self._new_session_state
+        ):
+            default_value = metadata.deserializer(None)
+            if widget_value != default_value:
+                serialized = metadata.serializer(widget_value)
+                self.query_params._set_corrected_value(
+                    user_key, serialized, metadata.value_type
+                )
 
         # widget_value_changed indicates to the caller that the widget's
         # current value is different from what is in the frontend.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1047,16 +1047,15 @@ class SessionState:
             if (
                 widget_value != default_value
                 and user_key in self._old_state
-                and user_key not in self.query_params._query_params
+                and not self.query_params.has_param(user_key)
                 and user_key not in self._new_session_state
             ):
                 serialized = metadata.serializer(widget_value)
-                self.query_params._set_corrected_value(
+                self.query_params.set_corrected_value(
                     user_key, serialized, metadata.value_type
                 )
             elif widget_value == default_value:
-                if user_key in self.query_params._query_params:
-                    del self.query_params._query_params[user_key]
+                self.query_params.discard_param_no_forward_msg(user_key)
 
         # widget_value_changed indicates to the caller that the widget's
         # current value is different from what is in the frontend.
@@ -1224,7 +1223,7 @@ class SessionState:
         if serialized_value == parsed_value:
             return  # No correction needed
 
-        self.query_params._set_corrected_value(
+        self.query_params.set_corrected_value(
             user_key, serialized_value, metadata.value_type
         )
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -959,6 +959,11 @@ class SessionState:
             self._new_widget_state.widget_metadata,
         )
 
+        # Keep only bound-intent entries that still have a key mapping.
+        # This prevents unbounded growth across long sessions with many stale
+        # widget IDs while preserving currently mapped keyed widgets.
+        self._query_param_bound_widget_ids.intersection_update(wid_key_map.keys())
+
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
         return self._new_widget_state.widget_metadata.get(widget_id)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -904,20 +904,14 @@ class SessionState:
         if ctx is None:
             return
 
-        self._new_widget_state.remove_stale_widgets(
-            active_widget_ids,
-            ctx.fragment_ids_this_run,
-        )
-
-        # Before removing stale widget entries, preserve values for stale keyed
-        # widgets that were bound to query params under their user keys.
-        # _compact_state stores values under widget IDs (element IDs), which are
-        # removed below. Saving under user keys allows those values to persist.
-        # This is needed for MPA page transitions where widget bindings and
-        # current-run metadata for previous-page widgets may no longer exist.
+        # Before any cleanup, capture the current value for bound stale widgets.
+        # The most recent value may live in _new_widget_state (e.g. from
+        # set_widgets_from_proto after a user interaction) rather than _old_state
+        # (which holds the value from the previous compaction).  We must read it
+        # through the full lookup chain before _new_widget_state is cleaned.
         wid_key_map = self._key_id_mapper.id_key_mapping
         bound_preserved: dict[str, Any] = {}
-        for key, value in self._old_state.items():
+        for key in self._old_state:
             if (
                 is_element_id(key)
                 and key in self._query_param_bound_widget_ids
@@ -928,10 +922,18 @@ class SessionState:
                     ctx.fragment_ids_this_run,
                 )
             ):
-                bound_preserved[wid_key_map[key]] = value
+                user_key = wid_key_map[key]
+                try:
+                    bound_preserved[user_key] = self._getitem(key, user_key)
+                except KeyError:
+                    bound_preserved[user_key] = self._old_state[key]
 
-        # Remove entries from _old_state corresponding to
-        # widgets not in widget_ids.
+        self._new_widget_state.remove_stale_widgets(
+            active_widget_ids,
+            ctx.fragment_ids_this_run,
+        )
+
+        # Remove entries from _old_state corresponding to stale widgets.
         self._old_state = {
             k: v
             for k, v in self._old_state.items()
@@ -1047,6 +1049,7 @@ class SessionState:
         # The backend's _query_params is not refreshed on same-page reruns, so
         # it can hold entries the frontend already deleted.  Cleaning them here
         # prevents _send_query_param_msg from re-broadcasting stale params.
+        restored_bound_value = False
         if metadata.bind == "query-params" and user_key is not None:
             default_value = metadata.deserializer(None)
             if (
@@ -1059,14 +1062,19 @@ class SessionState:
                 self.query_params.set_corrected_value(
                     user_key, serialized, metadata.value_type
                 )
+                restored_bound_value = True
             elif widget_value == default_value:
                 self.query_params.discard_param_no_forward_msg(user_key)
 
         # widget_value_changed indicates to the caller that the widget's
         # current value is different from what is in the frontend.
-        widget_value_changed = user_key is not None and self.is_new_state_value(
-            user_key
-        )
+        # Also true when a preserved bound value was restored to the URL —
+        # the frontend is rendering the widget for the first time on this page
+        # and needs to be told to use the backend's resolved value instead of
+        # the widget's default.
+        widget_value_changed = (
+            user_key is not None and self.is_new_state_value(user_key)
+        ) or restored_bound_value
 
         return RegisterWidgetResult(widget_value, widget_value_changed)
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1030,22 +1030,33 @@ class SessionState:
         widget_value = cast("T", self[widget_id])
         widget_value = deepcopy(widget_value)
 
-        # Restore bound widget value to URL when the URL param is missing.
-        # We do this after value resolution so the URL mirrors what users see.
-        # Programmatic st.session_state values set during this run remain
-        # excluded from auto-sync.
-        if (
-            metadata.bind == "query-params"
-            and user_key is not None
-            and user_key not in self.query_params._query_params
-            and user_key not in self._new_session_state
-        ):
+        # Sync bound widget value ↔ URL after value resolution.
+        #
+        # Non-default restore: write param when it was lost (page nav / remount).
+        # The user_key-in-_old_state guard ensures this only fires for values
+        # that were explicitly preserved under a user key by _remove_stale_widgets.
+        # Compacted programmatic sets (st.session_state["k"] = v) are stored
+        # under widget IDs only, so the guard correctly excludes them.
+        #
+        # Default collapsing: remove stale params the frontend already cleared.
+        # The backend's _query_params is not refreshed on same-page reruns, so
+        # it can hold entries the frontend already deleted.  Cleaning them here
+        # prevents _send_query_param_msg from re-broadcasting stale params.
+        if metadata.bind == "query-params" and user_key is not None:
             default_value = metadata.deserializer(None)
-            if widget_value != default_value:
+            if (
+                widget_value != default_value
+                and user_key in self._old_state
+                and user_key not in self.query_params._query_params
+                and user_key not in self._new_session_state
+            ):
                 serialized = metadata.serializer(widget_value)
                 self.query_params._set_corrected_value(
                     user_key, serialized, metadata.value_type
                 )
+            elif widget_value == default_value:
+                if user_key in self.query_params._query_params:
+                    del self.query_params._query_params[user_key]
 
         # widget_value_changed indicates to the caller that the widget's
         # current value is different from what is in the frontend.

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -1319,12 +1319,18 @@ class SetCorrectedValueTest(DeltaGeneratorTestCase):
         [
             ("string", "corrected", "string_value", "corrected"),
             ("int", 42, "int_value", "42"),
+            ("bool_true", True, "bool_value", "true"),
+            ("bool_false", False, "bool_value", "false"),
             ("float_whole", 5.0, "double_value", "5.0"),
             ("float_decimal", 3.14, "double_value", "3.14"),
         ]
     )
     def test_set_corrected_value_scalar(
-        self, _name: str, value: str | int | float, value_type: str, expected: str
+        self,
+        _name: str,
+        value: str | int | float | bool,
+        value_type: str,
+        expected: str,
     ) -> None:
         """Test setting corrected scalar values."""
         self.query_params._set_corrected_value("key", value, value_type)

--- a/lib/tests/streamlit/runtime/state/query_params_test.py
+++ b/lib/tests/streamlit/runtime/state/query_params_test.py
@@ -1280,6 +1280,11 @@ class RemoveParamTest(DeltaGeneratorTestCase):
         self.query_params = QueryParams()
         self.query_params._query_params = {"foo": "bar", "baz": "qux"}
 
+    def test_has_param(self) -> None:
+        """Test has_param returns whether a parameter exists."""
+        assert self.query_params.has_param("foo") is True
+        assert self.query_params.has_param("missing") is False
+
     def test_remove_param_removes_existing_param(self) -> None:
         """Test that remove_param removes an existing parameter."""
         result = self.query_params.remove_param("foo")
@@ -1307,9 +1312,24 @@ class RemoveParamTest(DeltaGeneratorTestCase):
         with pytest.raises(IndexError):
             self.get_message_from_queue(0)
 
+    def test_discard_param_no_forward_msg_removes_existing_param(self) -> None:
+        """Test discarding a cached param does not forward URL updates."""
+        result = self.query_params.discard_param_no_forward_msg("foo")
+        assert result is True
+        assert "foo" not in self.query_params._query_params
+        with pytest.raises(IndexError):
+            self.get_message_from_queue(0)
+
+    def test_discard_param_no_forward_msg_returns_false_for_missing(self) -> None:
+        """Test discard returns False when parameter is absent."""
+        result = self.query_params.discard_param_no_forward_msg("nonexistent")
+        assert result is False
+        with pytest.raises(IndexError):
+            self.get_message_from_queue(0)
+
 
 class SetCorrectedValueTest(DeltaGeneratorTestCase):
-    """Tests for URL auto-correction via _set_corrected_value."""
+    """Tests for URL auto-correction via set_corrected_value."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -1333,7 +1353,7 @@ class SetCorrectedValueTest(DeltaGeneratorTestCase):
         expected: str,
     ) -> None:
         """Test setting corrected scalar values."""
-        self.query_params._set_corrected_value("key", value, value_type)
+        self.query_params.set_corrected_value("key", value, value_type)
         assert self.query_params._query_params["key"] == expected
 
     @parameterized.expand(
@@ -1352,7 +1372,7 @@ class SetCorrectedValueTest(DeltaGeneratorTestCase):
         self, _name: str, value: list, value_type: str, expected: list[str]
     ) -> None:
         """Test setting corrected list values."""
-        self.query_params._set_corrected_value("key", value, value_type)
+        self.query_params.set_corrected_value("key", value, value_type)
         assert self.query_params._query_params["key"] == expected
 
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -883,7 +883,11 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state._new_widget_state.set_from_value("foo", "bar")
         assert not self.session_state._widget_changed("foo")
 
-    def test_remove_stale_widgets(self):
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MagicMock(fragment_ids_this_run=None),
+    )
+    def test_remove_stale_widgets(self, mock_ctx: MagicMock):
         existing_widget_key = f"{GENERATED_ELEMENT_ID_PREFIX}-existing_widget"
         generated_widget_key = f"{GENERATED_ELEMENT_ID_PREFIX}-removed_widget"
 
@@ -1459,6 +1463,7 @@ class MockScriptRunCtx:
     """Mock script run context for testing."""
 
     active_script_hash: str = "main_hash"
+    fragment_ids_this_run: list[str] | None = None
 
 
 class HandleQueryParamBindingTest(DeltaGeneratorTestCase):
@@ -1631,6 +1636,205 @@ class RegisterWidgetUnbindTest(DeltaGeneratorTestCase):
 
         assert not self.query_params.is_bound("plain")
         assert len(self.query_params._bindings_by_widget) == 0
+
+
+class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
+    """Tests for preserving bound values during stale-widget cleanup."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+        self.query_params = self.session_state.query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_preserves_bound_widget_value_when_metadata_and_binding_are_gone(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Preserve stale bound keyed values in realistic MPA cleanup order."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_test_widget_metadata(widget_id)
+
+        # Run 1 on source page: bind and set a non-default value.
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+
+        # Compaction stores under widget_id in _old_state and clears _new_widget_state.
+        self.session_state._compact_state()
+        assert widget_id in self.session_state._old_state
+        assert "my_widget" not in self.session_state._old_state
+        # On page transitions, current-run metadata may not contain stale widgets.
+        self.session_state._new_widget_state.widget_metadata.clear()
+        assert widget_id not in self.session_state._new_widget_state.widget_metadata
+
+        # MPA filtering unbinds stale page widgets before stale cleanup runs.
+        self.query_params.unbind_widget(widget_id)
+        assert self.query_params.get_binding_for_widget(widget_id) is None
+
+        # Cleanup should still preserve value under user key.
+        self.session_state._remove_stale_widgets(set())
+        assert widget_id not in self.session_state._old_state
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_does_not_preserve_unbound_widget_value(self, mock_ctx: MagicMock) -> None:
+        """Unbound stale keyed widgets should not preserve user-key value."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x if x is not None else "default",
+            serializer=lambda x: x,
+            value_type="string_value",
+            bind=None,
+        )
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert widget_id not in self.session_state._old_state
+        assert "my_widget" not in self.session_state._old_state
+
+
+class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
+    """Tests for URL sync in register_widget for bound widgets."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+        self.query_params = self.session_state.query_params
+
+    def _setup_remount_state(self, value: str = "custom_value") -> WidgetMetadata:
+        """Create remount state where value persists but URL param is missing."""
+        self.session_state._old_state["my_widget"] = value
+        self.session_state._set_key_widget_mapping("$$ID-hash-my_widget", "my_widget")
+        return _create_test_widget_metadata("$$ID-hash-my_widget")
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_syncs_persisted_value_to_url_when_param_missing(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Remount with persisted non-default value restores missing URL param."""
+        metadata = self._setup_remount_state("custom_value")
+        self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert self.query_params._query_params["my_widget"] == "custom_value"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_skips_url_sync_when_param_already_present(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Skip redundant URL writes when param already exists."""
+        self.query_params.set_with_no_forward_msg("my_widget", "custom_value")
+        metadata = self._setup_remount_state("custom_value")
+
+        with patch.object(
+            self.query_params, "_set_corrected_value"
+        ) as mock_set_corrected:
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            mock_set_corrected.assert_not_called()
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_skips_url_sync_for_default_value(self, mock_ctx: MagicMock) -> None:
+        """Default value should remain collapsed from URL."""
+        metadata = self._setup_remount_state("default")
+        self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert "my_widget" not in self.query_params._query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_skips_url_sync_when_session_state_set(self, mock_ctx: MagicMock) -> None:
+        """Programmatic st.session_state set this run should not sync to URL."""
+        metadata = self._setup_remount_state("old_value")
+        self.session_state._new_session_state["my_widget"] = "programmatic_value"
+
+        with patch.object(
+            self.query_params, "_set_corrected_value"
+        ) as mock_set_corrected:
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            mock_set_corrected.assert_not_called()
+
+
+class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):
+    """Tests conditional remount behavior for bound vs unbound widgets."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+        self.query_params = self.session_state.query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_bound_conditional_remount_restores_value_and_url(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Bound remount restores persisted value and re-syncs URL."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_test_widget_metadata(widget_id)
+
+        # Initial mount and user-set value.
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.query_params.set_with_no_forward_msg("my_widget", "custom_value")
+
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert "my_widget" in self.session_state._old_state
+        assert "my_widget" not in self.query_params._query_params
+
+        remounted = self.session_state.register_widget(metadata, user_key="my_widget")
+        assert remounted.value == "custom_value"
+        assert self.query_params._query_params["my_widget"] == "custom_value"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_unbound_conditional_remount_still_resets(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Unbound remount behavior remains reset to default."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = WidgetMetadata(
+            id=widget_id,
+            deserializer=lambda x: x if x is not None else "default",
+            serializer=lambda x: x,
+            value_type="string_value",
+            bind=None,
+        )
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert "my_widget" not in self.session_state._old_state
+
+        remounted = self.session_state.register_widget(metadata, user_key="my_widget")
+        assert remounted.value == "default"
+        assert "my_widget" not in self.query_params._query_params
 
 
 class SeedWidgetFromUrlTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1701,6 +1701,23 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
         assert widget_id not in self.session_state._old_state
         assert "my_widget" not in self.session_state._old_state
 
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_prunes_unmapped_bound_widget_ids(self, mock_ctx: MagicMock) -> None:
+        """Stale bound-intent IDs without a key mapping are pruned."""
+        kept_widget_id = "$$ID-hash-kept"
+        stale_widget_id = "$$ID-hash-stale"
+        self.session_state._set_key_widget_mapping(kept_widget_id, "kept")
+        self.session_state._query_param_bound_widget_ids.update(
+            {kept_widget_id, stale_widget_id}
+        )
+
+        self.session_state._remove_stale_widgets(set())
+
+        assert self.session_state._query_param_bound_widget_ids == {kept_widget_id}
+
 
 class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
     """Tests for URL sync in register_widget for bound widgets."""
@@ -1741,7 +1758,7 @@ class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
         metadata = self._setup_remount_state("custom_value")
 
         with patch.object(
-            self.query_params, "_set_corrected_value"
+            self.query_params, "set_corrected_value"
         ) as mock_set_corrected:
             self.session_state.register_widget(metadata, user_key="my_widget")
             mock_set_corrected.assert_not_called()
@@ -1787,7 +1804,7 @@ class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
         self.session_state._new_session_state["my_widget"] = "programmatic_value"
 
         with patch.object(
-            self.query_params, "_set_corrected_value"
+            self.query_params, "set_corrected_value"
         ) as mock_set_corrected:
             self.session_state.register_widget(metadata, user_key="my_widget")
             mock_set_corrected.assert_not_called()
@@ -1808,7 +1825,7 @@ class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
         metadata = _create_test_widget_metadata(widget_id)
 
         with patch.object(
-            self.query_params, "_set_corrected_value"
+            self.query_params, "set_corrected_value"
         ) as mock_set_corrected:
             self.session_state.register_widget(metadata, user_key="my_widget")
             mock_set_corrected.assert_not_called()

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1761,6 +1761,26 @@ class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
         "streamlit.runtime.state.session_state.get_script_run_ctx",
         return_value=MockScriptRunCtx(),
     )
+    def test_removes_stale_param_when_value_is_default(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Stale URL param for a default-valued widget is cleaned up.
+
+        The backend's _query_params is not updated on same-page reruns, so it
+        can hold entries the frontend already cleared.  register_widget must
+        remove these to prevent _send_query_param_msg from re-broadcasting
+        stale params when another widget's sync fires.
+        """
+        self.query_params.set_with_no_forward_msg("my_widget", "old_non_default")
+        metadata = self._setup_remount_state("default")
+        self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert "my_widget" not in self.query_params._query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
     def test_skips_url_sync_when_session_state_set(self, mock_ctx: MagicMock) -> None:
         """Programmatic st.session_state set this run should not sync to URL."""
         metadata = self._setup_remount_state("old_value")
@@ -1771,6 +1791,29 @@ class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
         ) as mock_set_corrected:
             self.session_state.register_widget(metadata, user_key="my_widget")
             mock_set_corrected.assert_not_called()
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_skips_url_sync_for_compacted_programmatic_set(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Value from a previous programmatic set (compacted under widget ID only)
+        should not sync to URL.  Only values preserved under user keys by
+        _remove_stale_widgets trigger URL restore."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state[widget_id] = "programmatic_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_test_widget_metadata(widget_id)
+
+        with patch.object(
+            self.query_params, "_set_corrected_value"
+        ) as mock_set_corrected:
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            mock_set_corrected.assert_not_called()
+
+        assert "my_widget" not in self.query_params._query_params
 
 
 class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1705,6 +1705,38 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
         "streamlit.runtime.state.session_state.get_script_run_ctx",
         return_value=MockScriptRunCtx(),
     )
+    def test_preserves_current_value_from_new_widget_state(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """When _old_state has a stale value but _new_widget_state has the current
+        value (from user interaction after compaction), preservation should capture
+        the more recent _new_widget_state value, not the stale _old_state value."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_test_widget_metadata(widget_id)
+
+        # Run 1: register with default.
+        self.session_state.register_widget(metadata, user_key="my_widget")
+
+        # Compact (stores default in _old_state).
+        self.session_state._compact_state()
+        assert self.session_state._old_state[widget_id] == "default"
+
+        # User interaction updates _new_widget_state (simulates set_widgets_from_proto).
+        self.session_state._new_widget_state.set_from_value(widget_id, "user_value")
+        self.session_state._set_widget_metadata(metadata)
+
+        # Stale cleanup (MPA page change) — _old_state has "default" but
+        # _new_widget_state has "user_value". Preservation should capture
+        # "user_value".
+        self.session_state._remove_stale_widgets(set())
+
+        assert widget_id not in self.session_state._old_state
+        assert self.session_state._old_state["my_widget"] == "user_value"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
     def test_prunes_unmapped_bound_widget_ids(self, mock_ctx: MagicMock) -> None:
         """Stale bound-intent IDs without a key mapping are pruned."""
         kept_widget_id = "$$ID-hash-kept"
@@ -1831,6 +1863,52 @@ class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
             mock_set_corrected.assert_not_called()
 
         assert "my_widget" not in self.query_params._query_params
+
+
+class RegisterWidgetValueChangedTest(DeltaGeneratorTestCase):
+    """Tests for widget_value_changed when bound values are restored."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+        self.query_params = self.session_state.query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_when_bound_value_restored(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """When a preserved bound value is restored to URL, value_changed
+        should be True so the frontend proto carries the correct value."""
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping("$$ID-hash-my_widget", "my_widget")
+        metadata = _create_test_widget_metadata("$$ID-hash-my_widget")
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_false_when_no_restore_needed(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """On normal same-page rerun with param already present, value_changed
+        should be False (no restore needed)."""
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping("$$ID-hash-my_widget", "my_widget")
+        self.query_params.set_with_no_forward_msg("my_widget", "custom_value")
+        metadata = _create_test_widget_metadata("$$ID-hash-my_widget")
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is False
 
 
 class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes
When a widget uses `bind="query-params"` in a multi-page app, navigating away and back causes the URL parameter to be lost even though the widget's value persists in session state. This breaks URL shareability — the widget displays the correct value but the URL no longer reflects it.

The root cause is two-fold:
1. `_remove_stale_widgets` deletes the widget's value from `_old_state` during page transitions (stored under the widget ID, which is an element ID that gets filtered as stale), with no mechanism to preserve it for later remount.
2. `register_widget` has no code path to restore a missing URL parameter from a persisted non-default widget value.

**Changes:**
- **Value preservation** (`_remove_stale_widgets`): Before the stale filter runs, save bound keyed widget values under their user keys in `_old_state`. User keys are not element IDs, so they survive the filter. A durable `_query_param_bound_widget_ids` set tracks bound intent across page transitions where bindings and metadata may already be cleaned up.
- **URL sync** (`register_widget`): After value resolution, restore the URL parameter when `bind="query-params"` is active, the param is missing, the value is non-default, and no programmatic `st.session_state` set occurred this run. Default-value collapsing is preserved (defaults never appear in URL).
- **Bool normalization** (`_set_corrected_value`): Write `true`/`false` instead of `True`/`False` for bool query params to match URL conventions.

### GitHub Issue
Closes https://github.com/streamlit/streamlit/issues/14350

## Testing Plan
- Unit Tests (JS and/or Python): ✅ 
- E2E Tests: ✅ 
- Manual Testing: ✅ 