### PR TITLE
[docs] Add autonomy instructions to agent and skill files

### DIFF
--- a/.claude/agents/fixing-pr.md
+++ b/.claude/agents/fixing-pr.md
@@ -13,7 +13,7 @@ skills:
 
 Automates the PR maintenance loop: wait for CI, fix failures, address review comments, validate, push, and repeat until CI passes.
 
-**This agent runs fully autonomously.** Make decisions without asking for human input. Only stop and report to the user when encountering truly unfixable issues (e.g., merge conflicts with unclear expected behavior, missing PR).
+**Be fully autonomous** — Do NOT stop or pause to ask for confirmation. Go from current state to passing CI without human intervention. Make decisions without asking for human input. Note any open questions or ambiguities in PR comments rather than blocking on them. Only stop and report to the user when encountering truly unfixable issues (e.g., merge conflicts with unclear expected behavior, missing PR).
 
 ## Context
 

--- a/.claude/agents/fixing-pr.md
+++ b/.claude/agents/fixing-pr.md
@@ -13,7 +13,7 @@ skills:
 
 Automates the PR maintenance loop: wait for CI, fix failures, address review comments, validate, push, and repeat until CI passes.
 
-**Be fully autonomous** — Do NOT stop or pause to ask for confirmation. Go from current state to passing CI without human intervention. Make decisions without asking for human input. Note any open questions or ambiguities in PR comments rather than blocking on them. Only stop and report to the user when encountering truly unfixable issues (e.g., merge conflicts with unclear expected behavior, missing PR).
+**Be fully autonomous** — Do NOT stop or pause to ask for confirmation. Go from current state to passing CI without human intervention. Make decisions without asking for human input. Note any open questions or ambiguities in a PR conversation comment (under the Conversation tab) rather than blocking on them. Only stop and report to the user when encountering truly unfixable issues (e.g., merge conflicts with unclear expected behavior, missing PR).
 
 ## Context
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Finalizes branch changes for merging by simplifying code, running c
 
 Prepares the current branch for merge by running quality checks, simplifying code, and creating a PR if one doesn't exist.
 
-**Be fully autonomous** — Do NOT stop or pause to ask for confirmation. Go from current state to merge-ready PR without human intervention. Note any open questions or ambiguities in the PR description rather than blocking on them.
+**Be fully autonomous** — Do NOT stop or pause to ask for confirmation. Go from current state to merge-ready PR without human intervention. Note any open questions or ambiguities in a PR conversation comment (under the Conversation tab) rather than blocking on them.
 
 ## Workflow
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -7,6 +7,8 @@ description: Finalizes branch changes for merging by simplifying code, running c
 
 Prepares the current branch for merge by running quality checks, simplifying code, and creating a PR if one doesn't exist.
 
+**Be fully autonomous** — Do NOT stop or pause to ask for confirmation. Go from current state to merge-ready PR without human intervention. Note any open questions or ambiguities in the PR description rather than blocking on them.
+
 ## Workflow
 
 Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding.


### PR DESCRIPTION
## Describe your changes

Adds explicit autonomy instructions to internal Claude agent and skill documentation:

- **fixing-pr.md**: Clarifies that the agent should run fully autonomously without pausing for confirmation, noting any open questions in PR comments rather than blocking
- **finalizing-pr/SKILL.md**: Adds the same autonomy instructions for the PR finalization workflow

These changes ensure AI agents proceed autonomously through the full workflow without unnecessary human intervention.

## Testing Plan

- Documentation-only changes, no behavior modifications
- No code changes requiring tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->