### PR TITLE
[chore] Add AI skill and workflow for fixing flaky E2E tests

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -27,6 +27,7 @@ skills/*
 !skills/creating-pull-requests/
 !skills/updating-internal-docs/
 !skills/assessing-external-test-risk/
+!skills/fixing-flaky-e2e-tests/
 !skills/implementing-feature/
 
 # Allow agents

--- a/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
+++ b/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
@@ -146,9 +146,23 @@ assert_snapshot(element, name="snapshot")
 
 | Browser | Common Issues |
 |---------|---------------|
-| **Firefox** | Slower console logging, may retry failed requests |
+| **Firefox** | Slower console logging, may retry failed requests, subpixel rendering differences |
 | **Webkit** | May have timing differences with layout |
 | **Chromium** | Generally most reliable, use as baseline |
+
+### Firefox subpixel rendering flakiness
+
+**Symptom**: Firefox screenshots flake with 1-pixel differences due to subpixel rendering variations.
+
+**Fix**: Add a one-liner markdown element above the element being tested. This shifts the subpixel position to a more stable value:
+
+```python
+# In the test app (.py file)
+st.markdown("---")  # Stabilizes subpixel rendering for elements below
+st.date_input("Pick a date")
+```
+
+This is a workaround for Firefox's subpixel rendering behavior and can reduce snapshot flakiness when other timing fixes don't help.
 
 If you've exhausted timing fixes and the flakiness persists only on a specific browser due to known browser limitations (not test bugs), `skip_browser` may be appropriate as a **last resort**:
 

--- a/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
+++ b/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
@@ -68,6 +68,13 @@ After failure, examine:
 - `e2e_playwright/test-results/` - traces, screenshots, videos
 - `e2e_playwright/test-results/snapshot-updates/` - actual vs expected snapshots
 
+**For persistent snapshot flakiness**: If a test keeps failing due to snapshot mismatches, compare the actual vs expected images in `e2e_playwright/test-results/snapshot-updates/`. Look for:
+- Pixel-level differences (use an image diff tool or overlay)
+- Subtle layout shifts, font rendering variations, or timing artifacts
+- Browser-specific rendering quirks (especially Firefox subpixel issues)
+
+This helps identify whether the flakiness is due to timing (content not loaded), animation state, or browser rendering differences.
+
 ## Common causes and fixes
 
 ### Timing issues (most common)

--- a/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
+++ b/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: fixing-flaky-e2e-tests
+description: Diagnose and fix flaky Playwright e2e tests. Use when tests fail intermittently, show timeout errors, have snapshot mismatches, or exhibit browser-specific failures.
+---
+
+# Fixing flaky E2E tests
+
+Diagnose and fix flaky Playwright E2E tests in `e2e_playwright/`.
+
+## When to use
+
+- Tests fail intermittently (pass sometimes, fail others)
+- Timeout errors (`TimeoutError: wait_until timed out`)
+- Snapshot mismatches with pixel differences
+- Browser-specific failures (firefox, webkit, chromium)
+- User asks to fix top flaky tests from CI
+
+## Finding top flaky tests
+
+Run the script to identify the most flaky tests from recent CI runs:
+
+```bash
+uv run scripts/fetch_flaky_tests.py
+```
+
+Options:
+- `--days N`: Look back N days (default: 4)
+- `--top N`: Return top N flaky tests (default: 10)
+- `--min-reruns N`: Minimum total reruns to include (default: 2)
+- `--json`: Output as JSON for programmatic use
+
+The script downloads `playwright_test_stats` artifacts from successful `playwright.yml` runs and aggregates tests that required reruns.
+
+### Filtering tests to fix
+
+Skip tests already marked with `@pytest.mark.flaky`---these are known flaky tests being tracked separately.
+
+```bash
+# Check if a test file has the flaky marker
+grep -l "pytest.mark.flaky" e2e_playwright/<test_file>.py
+```
+
+## Investigation workflow
+
+### 1. Reproduce the flakiness locally (REQUIRED)
+
+**IMPORTANT**: Only attempt to fix tests that fail locally. If you cannot reproduce the flakiness after 25 runs, do NOT attempt a fix—the test may be flaky due to CI environment factors that cannot be addressed locally.
+
+Run the test up to 25 times with the affected browser(s). The loop breaks on first failure and captures full output:
+
+```bash
+for i in {1..25}; do
+  result=$(make run-e2e-test e2e_playwright/test_file.py::test_name -- --browser firefox 2>&1)
+  if echo "$result" | grep -q "FAILED"; then
+    echo "=== FAILURE ON RUN $i ==="
+    echo "$result"
+    break
+  fi
+  echo "Run $i: PASSED"
+done
+```
+
+If all 25 runs pass, skip this test and move to the next one.
+
+### 2. Check test artifacts
+
+After failure, examine:
+- `e2e_playwright/test-results/` - traces, screenshots, videos
+- `e2e_playwright/test-results/snapshot-updates/` - actual vs expected snapshots
+
+## Common causes and fixes
+
+### Timing issues (most common)
+
+**Symptom**: Screenshots taken before element fully renders, animations not complete.
+
+**Fix**: Add explicit waits before interactions or screenshots:
+
+```python
+# Before
+element.click()
+assert_snapshot(element, name="snapshot")
+
+# After
+element.click()
+expect(element).to_be_visible()  # Wait for visibility
+assert_snapshot(element, name="snapshot")
+```
+
+For popups/modals/calendars that animate:
+
+```python
+calendar = page.locator('[data-baseweb="calendar"]').first
+expect(calendar).to_be_visible()  # Wait for animation to complete
+assert_snapshot(calendar, name="calendar-snapshot")
+```
+
+### Browser retry causing extra events
+
+**Symptom**: Assertion expects exact count but gets more (e.g., `assert 44 == 41`).
+
+**Fix**: Use `>=` instead of `==` when browsers may retry failed operations:
+
+```python
+# Before
+assert error_count == expected_count
+
+# After - browsers may retry failed image loads
+assert error_count >= expected_count
+```
+
+### Timeout too short
+
+**Symptom**: `TimeoutError` on slower browsers.
+
+**Fix**: Increase timeout for operations that can be slow:
+
+```python
+# Before
+wait_until(app, lambda: check_condition(), timeout=10000)
+
+# After
+wait_until(app, lambda: check_condition(), timeout=20000)
+```
+
+### Snapshot mismatch due to timing
+
+**Symptom**: `Snapshot mismatch for ... (X pixels difference)`.
+
+**Causes**:
+- Element still animating when screenshot taken
+- Font rendering not complete
+- Async content not loaded
+
+**Fix**: Ensure element is stable before screenshot:
+
+```python
+element = page.locator(".my-element")
+expect(element).to_be_visible()
+# For elements with animations, wait for specific CSS state:
+expect(element).to_have_css("opacity", "1")
+assert_snapshot(element, name="snapshot")
+```
+
+## Browser-specific considerations
+
+| Browser | Common Issues |
+|---------|---------------|
+| **Firefox** | Slower console logging, may retry failed requests |
+| **Webkit** | May have timing differences with layout |
+| **Chromium** | Generally most reliable, use as baseline |
+
+Skip browser-specific tests when behavior is unfixable:
+
+```python
+@pytest.mark.skip_browser("webkit")
+def test_problematic_on_webkit(app: Page):
+    ...
+```
+
+## Verification
+
+After applying fix, verify with multiple runs:
+
+```bash
+# Run 10+ times to ensure stability
+for i in {1..10}; do
+  make run-e2e-test e2e_playwright/test_file.py::test_name -- --browser firefox 2>&1 | grep -E "(PASSED|FAILED)"
+done
+```
+
+Target: **10/10 passes** before considering fix complete.
+
+## Key utilities
+
+From `e2e_playwright.conftest`:
+- `wait_for_app_run(page)` - Wait for Streamlit script execution
+- `wait_for_app_loaded(page)` - Wait for initial app load
+- `wait_until(page, fn, timeout)` - Poll until condition is true
+
+From `e2e_playwright.shared.app_utils`:
+- `expect_no_skeletons(element)` - Wait for loading skeletons to disappear
+- `reset_focus(page)` - Click outside to trigger blur events
+- `reset_hovering(locator)` - Move mouse away from element
+
+## Complete workflow
+
+1. **Fetch flaky tests**: `uv run scripts/fetch_flaky_tests.py --top 10`
+
+2. **Filter out marked tests**: Skip tests with `@pytest.mark.flaky`
+
+3. **For each remaining test**:
+   - Read the test code to understand what it's testing
+   - Reproduce the flakiness locally (up to 25 runs)
+   - **Skip if not reproducible**: If 25 runs all pass, move to the next test
+   - Identify the root cause (timing, browser-specific, etc.)
+   - Apply the minimal fix
+   - Verify with 10+ runs on affected browser(s)
+
+4. **Run checks**: `make check` before committing
+
+## Rules
+
+- **Reproduce locally first**: Only fix tests you can reproduce locally (up to 25 runs)
+- **Minimal fixes**: Smallest change that fixes the issue
+- **Don't disable tests**: Never skip tests to "fix" flakiness
+- **Verify thoroughly**: Run 10+ times on affected browser after fix
+- **Preserve test intent**: Understand what the test is validating
+- **Document cause**: Add comments explaining why waits/timeouts are needed

--- a/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
+++ b/.claude/skills/fixing-flaky-e2e-tests/SKILL.md
@@ -150,13 +150,16 @@ assert_snapshot(element, name="snapshot")
 | **Webkit** | May have timing differences with layout |
 | **Chromium** | Generally most reliable, use as baseline |
 
-Skip browser-specific tests when behavior is unfixable:
+If you've exhausted timing fixes and the flakiness persists only on a specific browser due to known browser limitations (not test bugs), `skip_browser` may be appropriate as a **last resort**:
 
 ```python
-@pytest.mark.skip_browser("webkit")
+# Only use after confirming this is a browser-level limitation, not a fixable timing issue
+@pytest.mark.skip_browser("webkit", reason="Webkit has known layout timing issues with this element")
 def test_problematic_on_webkit(app: Page):
     ...
 ```
+
+**Important:** Using `skip_browser` requires justification. Prefer fixing the underlying timing issue first. See "Rules" section for guidance on when skipping is acceptable.
 
 ## Verification
 
@@ -203,7 +206,10 @@ From `e2e_playwright.shared.app_utils`:
 
 - **Reproduce locally first**: Only fix tests you can reproduce locally (up to 25 runs)
 - **Minimal fixes**: Smallest change that fixes the issue
-- **Don't disable tests**: Never skip tests to "fix" flakiness
+- **Don't disable tests without justification**: Never skip tests just to "fix" flakiness. `skip_browser` is acceptable only when:
+  1. You've exhausted all timing/wait fixes
+  2. The flakiness is due to a documented browser limitation (not a test bug)
+  3. You include a clear `reason` explaining why
 - **Verify thoroughly**: Run 10+ times on affected browser after fix
 - **Preserve test intent**: Understand what the test is validating
 - **Document cause**: Add comments explaining why waits/timeouts are needed

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -146,6 +146,7 @@ steps:
 | `ai-pr-review.yml` | `ai-review` label or manual | AI-powered code review using Cursor CLI |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
 | `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review and updates |
+| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing |
 
 ### Maintenance & Updates
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -144,6 +144,7 @@ steps:
 | `ai-pr-review.yml` | `ai-review` label or manual | AI-powered code review using Cursor CLI |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
 | `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review and updates |
+| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing |
 
 ### Maintenance & Updates
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -138,6 +138,7 @@ steps:
 | `ai-pr-review.yml` | `ai-review` label or manual | AI-powered code review using Cursor CLI |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
 | `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review and updates |
+| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing |
 
 ### Maintenance & Updates
 

--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -117,8 +117,8 @@ jobs:
           The GitHub CLI (gh) is available for READ operations.
 
           ## Task
-          Run the /fixing-flaky-e2e-tests skill to identify and fix the top \${TOP_N} flaky tests
-          from the last \${DAYS} days.
+          Run the /fixing-flaky-e2e-tests skill to identify and fix the top ${TOP_N} flaky tests
+          from the last ${DAYS} days.
 
           Implement all fixes directly. Do not ask for confirmation.
 

--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -1,0 +1,294 @@
+name: AI Fix Flaky E2E Tests
+
+on:
+  schedule:
+    # Run weekly on Fridays at 10:00 UTC (2:00 AM PST / 3:00 AM PDT)
+    - cron: "0 10 * * Fri"
+  workflow_dispatch:
+    inputs:
+      top_n:
+        description: "Number of top flaky tests to fix"
+        required: false
+        type: number
+        default: 5
+      days:
+        description: "Number of days to look back for flaky tests"
+        required: false
+        type: number
+        default: 4
+      model:
+        description: "Model to use for flaky test fixing"
+        required: false
+        type: string
+        default: "opus-4.6-thinking"
+      dry_run:
+        description: "Run without creating PR"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  MODEL: ${{ inputs.model || 'opus-4.6-thinking' }}
+  TOP_N: ${{ inputs.top_n || 5 }}
+  DAYS: ${{ inputs.days || 4 }}
+
+jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    if: github.repository == 'streamlit/streamlit'
+    outputs:
+      has_key: ${{ steps.check-key.outputs.has_key }}
+    steps:
+      - name: Check for API key
+        id: check-key
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "has_key=false" >> $GITHUB_OUTPUT
+            echo "::warning::CURSOR_API_KEY is not available."
+          else
+            echo "has_key=true" >> $GITHUB_OUTPUT
+          fi
+
+  ai-fix-flaky-tests:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has_key == 'true'
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
+    concurrency:
+      group: ${{ github.workflow }}-ai-fix-flaky-tests
+      cancel-in-progress: true
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: "recursive"
+
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+
+      - name: Setup virtual env
+        uses: ./.github/actions/make_init
+        with:
+          python_version: ${{ env.PYTHON_MAX_VERSION }}
+
+      - name: Install playwright
+        uses: ./.github/actions/playwright_install
+
+      - name: Build frontend
+        run: make frontend-with-profiler
+
+      - name: Install Cursor CLI
+        run: |
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+
+      - name: AI flaky test fixing
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PROMPT="You are operating in a GitHub Actions runner to diagnose and fix flaky E2E tests.
+
+          ## Context
+          - Repository: ${{ github.repository }}
+          - Main branch: develop
+          - Number of top flaky tests to fix: ${{ env.TOP_N }}
+          - Days to look back: ${{ env.DAYS }}
+
+          The repository is checked out at develop with full git history.
+          The dev environment is set up - you can run make commands.
+          Playwright browsers are installed for testing.
+          The frontend is built with profiler support.
+
+          The GitHub CLI (gh) is available for READ operations.
+
+          ## Task
+          Run the /fixing-flaky-e2e-tests skill to identify and fix the top ${{ env.TOP_N }} flaky tests
+          from the last ${{ env.DAYS }} days.
+
+          Implement all fixes directly. Do not ask for confirmation.
+
+          After completing the fixes, write a summary to 'work-tmp/changes.md' listing all
+          modifications made (create the work-tmp directory if it doesn't exist). If no changes were needed, write 'No flaky test fixes needed.' to work-tmp/changes.md
+          "
+          cursor-agent -p "$PROMPT" --force --model "$MODEL" --output-format=text
+
+      - name: Create patch
+        id: create-patch
+        run: |
+          mkdir -p work-tmp
+          if [ ! -f work-tmp/changes.md ]; then
+            echo "No flaky test fixes needed." > work-tmp/changes.md
+          fi
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes_found=true" >> $GITHUB_OUTPUT
+            git add -A
+            git diff --cached > work-tmp/flaky-fixes.patch
+            echo "Patch created:"
+            git diff --cached --stat
+          else
+            echo "changes_found=false" >> $GITHUB_OUTPUT
+            echo "No changes found"
+            touch work-tmp/flaky-fixes.patch
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: flaky-fixes-output
+          path: |
+            work-tmp/flaky-fixes.patch
+            work-tmp/changes.md
+          retention-days: 1
+
+  create-pr:
+    needs: [check-secrets, ai-fix-flaky-tests]
+    if: always() && needs.check-secrets.outputs.has_key == 'true' && needs.ai-fix-flaky-tests.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Download artifacts
+        id: download
+        uses: actions/download-artifact@v8
+        with:
+          name: flaky-fixes-output
+          path: work-tmp
+
+      - name: Apply patch
+        id: apply-patch
+        run: |
+          if [ -f work-tmp/changes.md ]; then
+            echo "changes_summary<<CHANGES_SUMMARY_HEREDOC_DELIMITER" >> $GITHUB_OUTPUT
+            cat work-tmp/changes.md >> $GITHUB_OUTPUT
+            echo "CHANGES_SUMMARY_HEREDOC_DELIMITER" >> $GITHUB_OUTPUT
+          else
+            echo "changes_summary=No summary available." >> $GITHUB_OUTPUT
+          fi
+
+          if [ -s work-tmp/flaky-fixes.patch ]; then
+            echo "Applying patch..."
+            git apply work-tmp/flaky-fixes.patch
+            echo "changes_found=true" >> $GITHUB_OUTPUT
+            git status --porcelain
+          else
+            echo "changes_found=false" >> $GITHUB_OUTPUT
+            echo "No changes to apply"
+          fi
+
+      - name: Configure Git
+        if: steps.apply-patch.outputs.changes_found == 'true'
+        run: |
+          git config user.name "Streamlit Bot"
+          git config user.email "core+streamlitbot-github@streamlit.io"
+
+      - name: Create branch
+        id: create-branch
+        if: steps.apply-patch.outputs.changes_found == 'true'
+        run: |
+          BRANCH_NAME="ai-fix-flaky-tests-$(date +%Y-%m-%d)-${{ github.run_number }}"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          git checkout -b "$BRANCH_NAME"
+
+      - name: Commit and push
+        if: steps.apply-patch.outputs.changes_found == 'true' && inputs.dry_run != true
+        env:
+          BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
+        run: |
+          git add -A
+          git commit -m "[test] AI-assisted flaky E2E test fixes"
+          git push origin "$BRANCH_NAME"
+
+      - name: Create PR
+        id: create_pr
+        if: ${{ steps.apply-patch.outputs.changes_found == 'true' && inputs.dry_run != true }}
+        uses: actions/github-script@v8
+        env:
+          BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
+          MODEL_NAME: ${{ env.MODEL }}
+          CHANGES_SUMMARY: ${{ steps.apply-patch.outputs.changes_summary }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const head = process.env.BRANCH_NAME;
+            const model = process.env.MODEL_NAME;
+            const changesSummary = process.env.CHANGES_SUMMARY;
+
+            const title = `[test] AI-assisted flaky E2E test fixes`;
+            const body = `## Summary
+
+            Automated PR to fix flaky E2E tests identified from recent CI runs.
+
+            This PR was created by the \`ai-fix-flaky-e2e-tests\` workflow using \`${model}\`.
+
+            ## Changes
+
+            ${changesSummary}
+
+            ---
+            *This is an automated flaky test fix by \`${model}\`.*`.replace(/^ +/gm, '');
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              head,
+              base: 'develop',
+              body,
+            });
+            core.setOutput('pr_url', pr.html_url);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['change:test', 'impact:internal'],
+            });
+
+      - name: Write step summary
+        env:
+          CHANGES_FOUND: ${{ steps.apply-patch.outputs.changes_found }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "## AI Flaky E2E Test Fix Summary";
+            echo "- Model: ${{ env.MODEL }}";
+            echo "- Top N tests: ${{ env.TOP_N }}";
+            echo "- Days looked back: ${{ env.DAYS }}";
+            echo "- Changes found: ${CHANGES_FOUND}";
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "- Dry run: true (no PR created)";
+            elif [ "${CHANGES_FOUND}" = "true" ]; then
+              echo "- PR: ${PR_URL:-n/a}";
+            else
+              echo "- No fixes needed, no PR created";
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -10,7 +10,7 @@ on:
         description: "Number of top flaky tests to fix"
         required: false
         type: number
-        default: 5
+        default: 10
       days:
         description: "Number of days to look back for flaky tests"
         required: false
@@ -29,7 +29,7 @@ on:
 
 env:
   MODEL: ${{ inputs.model || 'opus-4.6-thinking' }}
-  TOP_N: ${{ inputs.top_n || 5 }}
+  TOP_N: ${{ inputs.top_n || 10 }}
   DAYS: ${{ inputs.days || 4 }}
 
 jobs:

--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -99,14 +99,15 @@ jobs:
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_NAME: ${{ github.repository }}
         run: |
           PROMPT="You are operating in a GitHub Actions runner to diagnose and fix flaky E2E tests.
 
           ## Context
-          - Repository: ${{ github.repository }}
+          - Repository: ${REPO_NAME}
           - Main branch: develop
-          - Number of top flaky tests to fix: ${{ env.TOP_N }}
-          - Days to look back: ${{ env.DAYS }}
+          - Number of top flaky tests to fix: ${TOP_N}
+          - Days to look back: ${DAYS}
 
           The repository is checked out at develop with full git history.
           The dev environment is set up - you can run make commands.
@@ -116,8 +117,8 @@ jobs:
           The GitHub CLI (gh) is available for READ operations.
 
           ## Task
-          Run the /fixing-flaky-e2e-tests skill to identify and fix the top ${{ env.TOP_N }} flaky tests
-          from the last ${{ env.DAYS }} days.
+          Run the /fixing-flaky-e2e-tests skill to identify and fix the top \${TOP_N} flaky tests
+          from the last \${DAYS} days.
 
           Implement all fixes directly. Do not ask for confirmation.
 
@@ -137,7 +138,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "changes_found=true" >> $GITHUB_OUTPUT
             git add -A
-            git diff --cached > work-tmp/flaky-fixes.patch
+            git diff --cached --binary > work-tmp/flaky-fixes.patch
             echo "Patch created:"
             git diff --cached --stat
           else
@@ -280,9 +281,9 @@ jobs:
         run: |
           {
             echo "## AI Flaky E2E Test Fix Summary";
-            echo "- Model: ${{ env.MODEL }}";
-            echo "- Top N tests: ${{ env.TOP_N }}";
-            echo "- Days looked back: ${{ env.DAYS }}";
+            echo "- Model: $MODEL";
+            echo "- Top N tests: $TOP_N";
+            echo "- Days looked back: $DAYS";
             echo "- Changes found: ${CHANGES_FOUND}";
             if [ "${DRY_RUN}" = "true" ]; then
               echo "- Dry run: true (no PR created)";

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `debugging-streamlit` | When testing code changes, investigating bugs, or checking UI behavior |
 | `discovering-make-commands` | To list available `make` commands for build, test, lint, or format tasks |
 | `fixing-streamlit-ci` | When CI checks fail and you need to diagnose and fix errors |
+| `fixing-flaky-e2e-tests` | When E2E tests fail intermittently, show timeout errors, have snapshot mismatches, or exhibit browser-specific failures |
 | `implementing-feature` | When you have a spec folder, URL, or GitHub issue to implement end-to-end |
 | `understanding-streamlit-architecture` | When debugging cross-layer issues, understanding how features work end-to-end, or onboarding to the codebase |
 | `creating-pull-requests` | When changes are ready to be submitted as a PR with proper labels and formatting |

--- a/scripts/fetch_flaky_tests.py
+++ b/scripts/fetch_flaky_tests.py
@@ -1,0 +1,254 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Fetch the top flaky E2E tests from recent playwright.yml CI runs.
+
+This script analyzes successful playwright.yml workflow runs from the last N days,
+downloads their test-stats.json artifacts, and identifies tests that required reruns.
+
+Usage: uv run scripts/fetch_flaky_tests.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Final
+
+_BROWSERS: Final = ("chromium", "firefox", "webkit")
+
+
+def _run_gh_command(args: list[str]) -> str:
+    """Run a gh CLI command and return the output."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"Error running gh command: {' '.join(args)}", file=sys.stderr)
+        print(f"stderr: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout
+
+
+def _fetch_successful_workflow_runs(
+    days: int = 4, limit: int = 100
+) -> list[dict[str, Any]]:
+    """Fetch successful playwright.yml workflow runs from the last N days."""
+    since_date = datetime.now(timezone.utc) - timedelta(days=days)
+
+    output = _run_gh_command(
+        [
+            "run",
+            "list",
+            "--workflow=playwright.yml",
+            "--status=success",
+            f"--limit={limit}",
+            "--json=databaseId,createdAt,headSha,displayTitle",
+        ]
+    )
+
+    runs = json.loads(output)
+
+    return [
+        run
+        for run in runs
+        if datetime.fromisoformat(run["createdAt"].replace("Z", "+00:00")) >= since_date
+    ]
+
+
+def _download_test_stats(run_id: int, temp_dir: Path) -> dict[str, Any] | None:
+    """Download and extract test-stats.json from a workflow run's artifact."""
+    result = subprocess.run(
+        [
+            "gh",
+            "run",
+            "download",
+            str(run_id),
+            "--name=playwright_test_stats",
+            f"--dir={temp_dir / str(run_id)}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        return None
+
+    stats_file = temp_dir / str(run_id) / "test-stats.json"
+    if not stats_file.exists():
+        return None
+
+    with open(stats_file, encoding="utf-8") as f:
+        stats_data: dict[str, Any] = json.load(f)
+        return stats_data
+
+
+def _extract_flaky_tests(test_stats: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract tests that required reruns from test-stats.json."""
+    return [
+        {
+            "nodeid": detail["nodeid"],
+            "rerun_count": detail.get("rerun_count", 1),
+            "browser": detail.get("browser", "unknown"),
+            "final_outcome": detail.get("final_outcome", "unknown"),
+        }
+        for detail in test_stats.get("rerun_details", [])
+        if detail.get("rerun_count", 0) > 0
+    ]
+
+
+def _normalize_test_name(nodeid: str) -> str:
+    """Normalize test name by removing browser suffix for aggregation."""
+    for browser in _BROWSERS:
+        suffix = f"[{browser}]"
+        if nodeid.endswith(suffix):
+            return nodeid[: -len(suffix)]
+    return nodeid
+
+
+def _sort_key(item: dict[str, Any]) -> tuple[int, int]:
+    """Sort by total reruns (descending), then runs with reruns (descending)."""
+    return (-int(item["total_reruns"]), -int(item["runs_with_reruns"]))
+
+
+def _aggregate_flaky_tests(
+    all_flaky_tests: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Aggregate flaky tests across runs and count total reruns."""
+    rerun_counts: Counter[str] = Counter()
+    run_counts: Counter[str] = Counter()
+    browser_info: dict[str, set[str]] = {}
+
+    for test in all_flaky_tests:
+        normalized = _normalize_test_name(test["nodeid"])
+        rerun_counts[normalized] += test["rerun_count"]
+        run_counts[normalized] += 1
+        browser_info.setdefault(normalized, set()).add(test["browser"])
+
+    results = [
+        {
+            "nodeid": nodeid,
+            "total_reruns": total_reruns,
+            "runs_with_reruns": run_counts[nodeid],
+            "browsers": sorted(browser_info[nodeid]),
+        }
+        for nodeid, total_reruns in rerun_counts.items()
+    ]
+
+    results.sort(key=_sort_key)
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch top flaky E2E tests from recent CI runs"
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=4,
+        help="Number of days to look back (default: 4)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum number of workflow runs to fetch (default: 100)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="Number of top flaky tests to return (default: 10)",
+    )
+    parser.add_argument(
+        "--min-reruns",
+        type=int,
+        default=2,
+        help="Minimum total reruns to include (default: 2)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    args = parser.parse_args()
+
+    print(
+        f"Fetching successful playwright.yml runs from the last {args.days} days...",
+        file=sys.stderr,
+    )
+    runs = _fetch_successful_workflow_runs(days=args.days, limit=args.limit)
+    print(f"Found {len(runs)} successful runs", file=sys.stderr)
+
+    if not runs:
+        print("No successful runs found in the specified time range", file=sys.stderr)
+        sys.exit(0)
+
+    all_flaky_tests = []
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        for i, run in enumerate(runs):
+            run_id = run["databaseId"]
+            print(
+                f"Processing run {i + 1}/{len(runs)} (ID: {run_id})...",
+                file=sys.stderr,
+            )
+
+            test_stats = _download_test_stats(run_id, temp_path)
+            if test_stats:
+                flaky_tests = _extract_flaky_tests(test_stats)
+                all_flaky_tests.extend(flaky_tests)
+                if flaky_tests:
+                    print(
+                        f"  Found {len(flaky_tests)} tests with reruns",
+                        file=sys.stderr,
+                    )
+
+    aggregated = _aggregate_flaky_tests(all_flaky_tests)
+    filtered = [t for t in aggregated if t["total_reruns"] >= args.min_reruns]
+    top_flaky = filtered[: args.top]
+
+    if args.json:
+        print(json.dumps(top_flaky, indent=2))
+    else:
+        print("\n" + "=" * 70)
+        print(f"Top {len(top_flaky)} Flaky E2E Tests (last {args.days} days)")
+        print("=" * 70)
+
+        if not top_flaky:
+            print("No flaky tests found with the specified criteria.")
+        else:
+            for i, test in enumerate(top_flaky, 1):
+                print(f"\n{i}. {test['nodeid']}")
+                print(f"   Total reruns: {test['total_reruns']}")
+                print(f"   Runs with reruns: {test['runs_with_reruns']}")
+                print(f"   Browsers affected: {', '.join(test['browsers'])}")
+
+        print("\n" + "=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_flaky_tests.py
+++ b/scripts/fetch_flaky_tests.py
@@ -63,7 +63,6 @@ def _fetch_successful_workflow_runs(
             "run",
             "list",
             "--workflow=playwright.yml",
-            "--branch=develop",
             "--status=success",
             f"--limit={limit}",
             "--json=databaseId,createdAt,headSha,displayTitle",

--- a/scripts/fetch_flaky_tests.py
+++ b/scripts/fetch_flaky_tests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -129,8 +130,8 @@ def _normalize_test_name(nodeid: str) -> str:
 
 
 def _sort_key(item: dict[str, Any]) -> tuple[int, int]:
-    """Sort by total reruns (descending), then runs with reruns (descending)."""
-    return (-int(item["total_reruns"]), -int(item["runs_with_reruns"]))
+    """Sort by total reruns (descending), then browser rerun count (descending)."""
+    return (-int(item["total_reruns"]), -int(item["browser_rerun_count"]))
 
 
 def _aggregate_flaky_tests(
@@ -138,20 +139,22 @@ def _aggregate_flaky_tests(
 ) -> list[dict[str, Any]]:
     """Aggregate flaky tests across runs and count total reruns."""
     rerun_counts: Counter[str] = Counter()
-    run_counts: Counter[str] = Counter()
+    browser_rerun_counts: Counter[str] = Counter()
     browser_info: dict[str, set[str]] = {}
 
     for test in all_flaky_tests:
         normalized = _normalize_test_name(test["nodeid"])
         rerun_counts[normalized] += test["rerun_count"]
-        run_counts[normalized] += 1
+        browser_rerun_counts[normalized] += (
+            1  # Counts browser-specific entries, not distinct CI runs
+        )
         browser_info.setdefault(normalized, set()).add(test["browser"])
 
     results = [
         {
             "nodeid": nodeid,
             "total_reruns": total_reruns,
-            "runs_with_reruns": run_counts[nodeid],
+            "browser_rerun_count": browser_rerun_counts[nodeid],
             "browsers": sorted(browser_info[nodeid]),
         }
         for nodeid, total_reruns in rerun_counts.items()
@@ -244,7 +247,7 @@ def main() -> None:
             for i, test in enumerate(top_flaky, 1):
                 print(f"\n{i}. {test['nodeid']}")
                 print(f"   Total reruns: {test['total_reruns']}")
-                print(f"   Runs with reruns: {test['runs_with_reruns']}")
+                print(f"   Browser rerun count: {test['browser_rerun_count']}")
                 print(f"   Browsers affected: {', '.join(test['browsers'])}")
 
         print("\n" + "=" * 70)

--- a/scripts/fetch_flaky_tests.py
+++ b/scripts/fetch_flaky_tests.py
@@ -63,6 +63,7 @@ def _fetch_successful_workflow_runs(
             "run",
             "list",
             "--workflow=playwright.yml",
+            "--branch=develop",
             "--status=success",
             f"--limit={limit}",
             "--json=databaseId,createdAt,headSha,displayTitle",
@@ -111,7 +112,7 @@ def _extract_flaky_tests(test_stats: dict[str, Any]) -> list[dict[str, Any]]:
     return [
         {
             "nodeid": detail["nodeid"],
-            "rerun_count": detail.get("rerun_count", 1),
+            "rerun_count": detail.get("rerun_count", 0),
             "browser": detail.get("browser", "unknown"),
             "final_outcome": detail.get("final_outcome", "unknown"),
         }


### PR DESCRIPTION
## Describe your changes

Adds AI-powered tooling for diagnosing and fixing flaky E2E tests:

- New `/fixing-flaky-e2e-tests` skill with comprehensive instructions for reproducing, diagnosing, and fixing flaky Playwright tests
- Python script (`scripts/fetch_flaky_tests.py`) to identify top flaky tests from CI artifacts
- Weekly GitHub Actions workflow (`ai-fix-flaky-e2e-tests.yml`) that automatically creates PRs to fix flaky tests

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Documentation and tooling changes only, no runtime behavior modifications
- Python script follows repository conventions and passes all linting/type checks
- Workflow follows established patterns from `ai-update-docs.yml`

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | fixing-flaky-e2e-tests | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->