### PR TITLE
[chore] Enable ruff DOC rules and fix docstring issues

### DIFF
--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -43,8 +43,8 @@ def echo(
         Whether to show the echoed code before or after the results of the
         executed code block.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import streamlit as st
     >>>
     >>> with st.echo():

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -212,8 +212,8 @@ def set_page_config(
         item that was specified in a previous call to ``st.set_page_config``,
         set its value to ``None`` in the dictionary.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import streamlit as st
     >>>
     >>> st.set_page_config(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -173,9 +173,8 @@ def set_user_option(key: str, value: Any) -> None:
     value
         The new value to assign to this config option.
 
-    Example
-    -------
-
+    Examples
+    --------
     >>> import streamlit as st
     >>>
     >>> st.set_option("client.showErrorDetails", True)
@@ -207,9 +206,8 @@ def get_option(key: str) -> Any:
         The config option key of the form "section.optionName". To see all
         available options, run ``streamlit config show`` in a terminal.
 
-    Example
-    -------
-
+    Examples
+    --------
     >>> import streamlit as st
     >>>
     >>> color = st.get_option("theme.primaryColor")

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -67,10 +67,6 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
             ``[connections.<connection_name>]`` config section in ``st.secrets``.
         kwargs : dict
             Any other kwargs to pass to this connection class' ``_connect`` method.
-
-        Returns
-        -------
-        None
         """
         self._connection_name = connection_name
         self._kwargs = kwargs
@@ -139,12 +135,8 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         reinitializing it. Note that some connection methods may already use ``reset()``
         in their error handling code.
 
-        Returns
-        -------
-        None
-
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> conn = st.connection("my_conn")

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -111,8 +111,8 @@ class AlertMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.error('This is an error', icon="🚨")
@@ -193,8 +193,8 @@ class AlertMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.warning('This is a warning', icon="⚠️")
@@ -274,8 +274,8 @@ class AlertMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.info('This is a purely informational message', icon="ℹ️")
@@ -356,8 +356,8 @@ class AlertMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.success('This is a success message!', icon="✅")

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -1022,8 +1022,8 @@ class ArrowMixin:
             The named dataset to concat. Optional. You can only pass in 1
             dataset (including the one in the data parameter).
 
-        Example
-        -------
+        Examples
+        --------
         >>> import time
         >>> import pandas as pd
         >>> import streamlit as st

--- a/lib/streamlit/elements/balloons.py
+++ b/lib/streamlit/elements/balloons.py
@@ -28,8 +28,8 @@ class BalloonsMixin:
     def balloons(self) -> DeltaGenerator:
         """Draw celebratory balloons.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.balloons()

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -439,8 +439,8 @@ class PydeckMixin:
             attribute notation. The attributes are described by the
             ``PydeckState`` dictionary schema.
 
-        Example
-        -------
+        Examples
+        --------
         Here's a chart using a HexagonLayer and a ScatterplotLayer. It uses either the
         light or dark map style, based on which Streamlit theme is currently active:
 

--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -72,8 +72,8 @@ class ExceptionMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> e = RuntimeError("This is an exception of type RuntimeError")

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -111,8 +111,8 @@ class GraphvizMixin:
               fixed height. If the content is larger than the specified
               height, scrolling is enabled.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>> import graphviz
         >>>

--- a/lib/streamlit/elements/help.py
+++ b/lib/streamlit/elements/help.py
@@ -69,9 +69,8 @@ class HelpMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
-
+        Examples
+        --------
         Don't remember how to initialize a dataframe? Try this:
 
         >>> import streamlit as st

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -98,8 +98,8 @@ class HtmlMixin:
             JavaScript is executed. Use this with caution and never pass
             untrusted input.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.html(

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -84,9 +84,8 @@ class IframeMixin:
             <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex>`_
             documentation on MDN.
 
-        Example
-        -------
-
+        Examples
+        --------
         >>> import streamlit.components.v1 as components
         >>>
         >>> components.iframe("https://example.com", height=500)
@@ -166,9 +165,8 @@ class IframeMixin:
             <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex>`_
             documentation on MDN.
 
-        Example
-        -------
-
+        Examples
+        --------
         >>> import streamlit.components.v1 as components
         >>>
         >>> components.html(

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -162,8 +162,8 @@ class ImageMixin:
 
             This parameter is only supported when displaying a single image.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>> st.image("sunrise.jpg", caption="Sunrise by the mountains")
 

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -88,8 +88,8 @@ class JsonMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.json(

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -372,11 +372,8 @@ def marshall_images(
     caption
         Image caption. If displaying multiple images, caption should be a
         list of captions (one for each image).
-    width
-        The desired width of the image or images. This parameter will be
-        passed to the frontend.
-        Positive values set the image width explicitly.
-        Negative values has some special. For details, see: `WidthBehaviour`
+    layout_config
+        The layout configuration for the image, including width settings.
     proto_imgs
         The ImageListProto to fill in.
     clamp

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -346,8 +346,8 @@ class MarkdownMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.latex(r'''
@@ -394,8 +394,8 @@ class MarkdownMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.divider()

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -334,8 +334,8 @@ class MediaMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> video_file = open("myvideo.mp4", "rb")
@@ -428,8 +428,8 @@ def _reshape_youtube_url(url: str) -> str | None:
     ----------
         url : str
 
-    Example
-    -------
+    Examples
+    --------
     >>> print(_reshape_youtube_url("https://youtu.be/_T8LGqJtuGc"))
 
     .. output::

--- a/lib/streamlit/elements/pdf.py
+++ b/lib/streamlit/elements/pdf.py
@@ -94,8 +94,8 @@ class PdfMixin:
               larger. If the viewer is not in a parent container, the height
               of the viewer matches the height of its content.
 
-        Example
-        -------
+        Examples
+        --------
         >>> st.pdf("https://example.com/sample.pdf")
         >>> st.pdf("https://example.com/sample.pdf", height=600)
         """

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -131,8 +131,8 @@ class ProgressMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         Here is an example of a progress bar increasing over time and disappearing when it reaches completion:
 
         >>> import streamlit as st

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -108,8 +108,8 @@ class PyplotMixin:
         **kwargs : any
             Arguments to pass to Matplotlib's savefig function.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import matplotlib.pyplot as plt
         >>> import streamlit as st
         >>> from numpy.random import default_rng as rng

--- a/lib/streamlit/elements/snow.py
+++ b/lib/streamlit/elements/snow.py
@@ -28,8 +28,8 @@ class SnowMixin:
     def snow(self) -> DeltaGenerator:
         """Draw celebratory snowfall.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.snow()

--- a/lib/streamlit/elements/spinner.py
+++ b/lib/streamlit/elements/spinner.py
@@ -85,8 +85,8 @@ class SpinnerMixin:
               the parent container, the width of the element matches the width
               of the parent container.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>> import time
         >>>

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -86,8 +86,8 @@ class TextMixin:
                 ``width="content"`` with short text, the alignment may not be
                 noticeable.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.text("This is text\n[and more text](that's not a Markdown link).")

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1983,9 +1983,8 @@ class VegaChartsMixin:
             notation. The attributes are described by the ``VegaLiteState``
             dictionary schema.
 
-        Example
-        -------
-
+        Examples
+        --------
         >>> import altair as alt
         >>> import pandas as pd
         >>> import streamlit as st
@@ -2229,8 +2228,8 @@ class VegaChartsMixin:
             notation. The attributes are described by the ``VegaLiteState``
             dictionary schema.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import pandas as pd
         >>> import streamlit as st
         >>> from numpy.random import default_rng as rng

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1025,8 +1025,8 @@ class ButtonMixin:
             ``False`` otherwise. If ``on_click`` is ``"ignore"``, this returns a
             ``DeltaGenerator``.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.link_button("Go to gallery", "https://streamlit.io/gallery")
@@ -1183,8 +1183,8 @@ class ButtonMixin:
             ``None`` (default), all non-embed query parameters are cleared during
             navigation.
 
-        Example
-        -------
+        Examples
+        --------
         **Example 1: Basic usage**
 
         The following example shows how to create page links in a multipage app

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -184,8 +184,8 @@ class CheckboxMixin:
         bool
             Whether or not the checkbox is checked.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> agree = st.checkbox("I agree")
@@ -337,8 +337,8 @@ class CheckboxMixin:
         bool
             Whether or not the toggle is checked.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> on = st.toggle("Activate feature")

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -206,8 +206,8 @@ class ColorPickerMixin:
         str
             The selected color as a hex string.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> color = st.color_picker("Pick A Color", "#00f900")

--- a/lib/streamlit/elements/widgets/menu_button.py
+++ b/lib/streamlit/elements/widgets/menu_button.py
@@ -238,8 +238,8 @@ class MenuButtonMixin:
 
             This is a copy of the selected option, not the original.
 
-        Example
-        -------
+        Examples
+        --------
         .. code-block:: python
             :filename: streamlit_app.py
 

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -111,9 +111,9 @@ class MultiSelectSerde(Generic[T]):
         formatted_option_to_option_index : dict[str, int]
             A mapping from formatted option strings to their corresponding indices in
             the options sequence.
-        default_option_index : int or None, optional
-            The index of the default option to use when no selection is made.
-            If None, no default option is selected.
+        default_options_indices : list[int] or None, optional
+            The indices of the default options to use when no selection is made.
+            If None, no default options are selected.
         format_func : Callable[[Any], str], optional
             Function to format options for comparison. Used to compare values by their
             string representation instead of using == directly. This is necessary because

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -418,8 +418,8 @@ class NumberInputMixin:
             The current value of the numeric input widget or ``None`` if the widget
             is empty. The return type will match the data type of the value parameter.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> number = st.number_input("Insert a number")

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -358,8 +358,8 @@ class RadioMixin:
 
             This is a copy of the selected option, not the original.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> genre = st.radio(

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -306,8 +306,8 @@ class TextWidgetsMixin:
             The current value of the text input widget or ``None`` if no value has been
             provided by the user.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> title = st.text_input("Movie title", "Life of Brian")
@@ -671,8 +671,8 @@ class TextWidgetsMixin:
             The current value of the text area widget or ``None`` if no value has been
             provided by the user.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> txt = st.text_area(

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -839,8 +839,8 @@ class TimeWidgetsMixin:
             The current value of the time input widget or ``None`` if no time has been
             selected.
 
-        Example
-        -------
+        Examples
+        --------
         **Example 1: Basic usage**
 
         >>> import datetime

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -119,8 +119,8 @@ class WriteMixin:
             is a string. Otherwise, this is a list of all the streamed objects.
             The return value is fully compatible as input for ``st.write``.
 
-        Example
-        -------
+        Examples
+        --------
         You can pass an OpenAI stream as shown in our tutorial, `Build a \
         basic LLM chat app <https://docs.streamlit.io/develop/tutorials/llms\
         /build-conversational-apps#build-a-chatgpt-like-app>`_. Alternatively,
@@ -340,11 +340,6 @@ class WriteMixin:
             .. note::
                 If you only want to insert HTML or CSS without Markdown text,
                 we recommend using ``st.html`` instead.
-
-
-        Returns
-        -------
-        None
 
         Examples
         --------

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -600,10 +600,6 @@ class AppSession:
             The fragment IDs of the fragments being executed in this script run. Only
             set for the SCRIPT_STARTED event. If this value is falsy, this script run
             must be for the full script.
-
-        clear_forward_msg_queue : bool
-            If set (the default), clears the queue of forward messages to be sent to the
-            browser. Set only for the SCRIPT_STARTED event.
         """
 
         if (

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -556,8 +556,8 @@ class CacheDataAPI:
             consider adjusting the ``server.websocketPingInterval``
             configuration option.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> @st.cache_data

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -485,8 +485,8 @@ class CacheResourceAPI:
             consider adjusting the ``server.websocketPingInterval``
             configuration option.
 
-        Example
-        -------
+        Examples
+        --------
         **Example 1: Global cache**
 
         By default, an ``@st.cache_resource``-decorated function uses a global cache.

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -435,8 +435,8 @@ class CachedFunc(Generic[P, R]):
         **kwargs: Any
             Keyword arguments of the cached function.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>> import time
         >>>

--- a/lib/streamlit/runtime/caching/legacy_cache_api.py
+++ b/lib/streamlit/runtime/caching/legacy_cache_api.py
@@ -83,8 +83,8 @@ def cache(
         The maximum number of seconds to keep an entry in the cache, or
         None if cache entries should not expire. The default is None.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import streamlit as st
     >>>
     >>> @st.cache

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -256,8 +256,8 @@ class ContextProxy:
         type : "light", "dark"
             The theme type inferred from the background color of the app.
 
-        Example
-        -------
+        Examples
+        --------
         Access the theme type of the app:
 
         >>> import streamlit as st
@@ -277,8 +277,8 @@ class ContextProxy:
     def timezone(self) -> str | None:
         """The read-only timezone of the user's browser.
 
-        Example
-        -------
+        Examples
+        --------
         Access the user's timezone, and format a datetime to display locally:
 
         >>> import streamlit as st
@@ -306,8 +306,8 @@ class ContextProxy:
     def timezone_offset(self) -> int | None:
         """The read-only timezone offset of the user's browser.
 
-        Example
-        -------
+        Examples
+        --------
         Access the user's timezone offset, and format a datetime to display locally:
 
         >>> import streamlit as st
@@ -340,8 +340,8 @@ class ContextProxy:
         .. |navigator.language| replace:: ``navigator.language``
         .. _navigator.language: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
 
-        Example
-        -------
+        Examples
+        --------
         Access the user's locale to display locally:
 
         >>> import streamlit as st
@@ -367,8 +367,8 @@ class ContextProxy:
         query parameters or anchors are present in the URL, they are removed
         and not included in this value.
 
-        Example
-        -------
+        Examples
+        --------
         Conditionally show content when you access your app through
         ``localhost``:
 
@@ -397,8 +397,8 @@ class ContextProxy:
         address is ``None``. Otherwise, the IP address is determined from the
         WebSocket connection and may be an IPv4 or IPv6 address.
 
-        Example
-        -------
+        Examples
+        --------
         Check if the user has an IPv4 or IPv6 address:
 
         >>> import streamlit as st
@@ -433,8 +433,8 @@ class ContextProxy:
         embedding settings are not accessible through ``st.query_params`` or
         ``st.context.url``.
 
-        Example
-        -------
+        Examples
+        --------
         Conditionally show content when the app is running in an embedded
         context:
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -487,8 +487,8 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
     name : str or None
     Overwrite the function name with a custom name that is used for telemetry tracking.
 
-    Example
-    -------
+    Examples
+    --------
     >>> @st.gather_metrics
     ... def my_command(url):
     ...     return url

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -481,19 +481,15 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
 
     Parameters
     ----------
-    func : callable
-    The function to track for telemetry.
-
-    name : str or None
-    Overwrite the function name with a custom name that is used for telemetry tracking.
+    name : str
+        The name to use for telemetry tracking.
+    func : callable or None
+        The function to track for telemetry. If ``None`` (default), returns a
+        decorator that can be applied to a function.
 
     Examples
     --------
-    >>> @st.gather_metrics
-    ... def my_command(url):
-    ...     return url
-
-    >>> @st.gather_metrics(name="custom_name")
+    >>> @st.gather_metrics("my_command")
     ... def my_command(url):
     ...     return url
     """

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -335,12 +335,6 @@ class Secrets(Mapping[str, Any]):
         """Parse our secrets.toml files if they're not already parsed.
         This function is safe to call from multiple threads.
 
-        Parameters
-        ----------
-        print_exceptions : bool
-            If True, then exceptions will be printed with `st.error` before
-            being re-raised.
-
         Raises
         ------
             StreamlitSecretNotFoundError

--- a/lib/streamlit/runtime/state/query_params_proxy.py
+++ b/lib/streamlit/runtime/state/query_params_proxy.py
@@ -134,13 +134,7 @@ class QueryParamsProxy(MutableMapping[str, str]):
 
     @gather_metrics("query_params.clear")
     def clear(self) -> None:
-        """
-        Clear all query parameters from the URL of the app.
-
-        Returns
-        -------
-        None
-        """
+        """Clear all query parameters from the URL of the app."""
         with get_session_state().query_params() as qp:
             qp.clear()
 
@@ -201,8 +195,8 @@ class QueryParamsProxy(MutableMapping[str, str]):
         params: dict
             A dictionary used to replace the current query parameters.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import streamlit as st
         >>>
         >>> st.query_params.from_dict({"foo": "bar", "baz": [1, "two"]})

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -107,9 +107,8 @@ def is_type(obj: object, fqn_type_pattern: str | re.Pattern[str]) -> bool:
         The fully-qualified type string or a regular expression.
         Regexes should start with `^` and end with `$`.
 
-    Example
-    -------
-
+    Examples
+    --------
     To check whether something is a Matplotlib Figure without importing
     matplotlib, use:
 
@@ -461,12 +460,6 @@ def is_altair_version_less_than(v: str) -> bool:
     -------
     bool
 
-
-    Raises
-    ------
-    InvalidVersion
-        If the version strings are not valid.
-
     """
     import altair as alt
 
@@ -476,11 +469,6 @@ def is_altair_version_less_than(v: str) -> bool:
 def is_version_less_than(v1: str, v2: str) -> bool:
     """Return True if the v1 version string is less than the v2 version string
     based on semantic versioning.
-
-    Raises
-    ------
-    InvalidVersion
-        If the version strings are not valid.
     """
     from packaging import version
 

--- a/lib/streamlit/web/server/bidi_component_request_handler.py
+++ b/lib/streamlit/web/server/bidi_component_request_handler.py
@@ -160,11 +160,8 @@ class BidiComponentRequestHandler(tornado.web.RequestHandler):
     def options(self) -> None:
         """Handle preflight CORS requests.
 
-        Returns
-        -------
-        None
-            Responds with HTTP ``204 No Content`` to indicate that the actual
-            request can proceed.
+        Responds with HTTP ``204 No Content`` to indicate that the actual
+        request can proceed.
         """
         self.set_status(204)
         self.finish()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,11 @@ ignore = [
   "SLF", # Checks unexpected for private member access.
   "BLE", # Checks for blind except statements.
   "CPY", # Checks for copyright statement.
-  "DOC", # Checks for correct docstring format.
+  # DOC rules for enforcing docstring completeness (too noisy):
+  "DOC201", # Checks for missing return documentation.
+  "DOC402", # Checks for missing yield documentation.
+  "DOC501", # Checks for missing exception documentation.
+  "DOC502", # Checks for extraneous exception documentation.
   # Ignored rules:
   "A002",    # Checks if function argument shadows a Python builtin.
   "ANN401",  # Checks that `any` is not used as an annotation.
@@ -269,6 +273,7 @@ extend-safe-fixes = ["TC002", "TC003"]
 # files, use the noqa ignore comment on top of the given file.
 "e2e_playwright/**" = [
   "B018",   # Allow useless expressions (e.g., for side effects in tests).
+  "DOC",    # Ignore docstring correctness rules.
   "N999",   # Allow invalid module names (test files use descriptive names).
   "NPY002", # Allow legacy numpy random generation.
   "PD",     # Ignore pandas-vet rules (test data manipulation patterns).
@@ -281,7 +286,8 @@ extend-safe-fixes = ["TC002", "TC003"]
 "lib/tests/**" = [
   "ANN",     # Ignore annotation rules (test functions don't need full typing).
   "ARG",     # Allow unused arguments (common in test fixtures and mocks).
-  "D",       # Ignore docstring rules (tests are self-documenting via names).
+  "D",       # Ignore docstring rules.
+  "DOC",     # Ignore docstring correctness rules.
   "FURB118", # Allow all operators (tests may use operator module intentionally).
   "FURB189", # Allow subclassing of builtin types (for test mocking).
   "INP",     # Allow implicit namespace packages (test directories).
@@ -306,6 +312,9 @@ known-first-party = ["streamlit", "shared", "tests", "e2e_playwright"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.pydoclint]
+ignore-one-line-docstrings = true
 
 [tool.ruff.lint.pycodestyle]
 # Allow lines (e.g. comments) up to 120 characters instead of 88,

--- a/scripts/pypi_nightly_create_tag.py
+++ b/scripts/pypi_nightly_create_tag.py
@@ -36,11 +36,6 @@ def get_latest_streamlit_version() -> Version:
     NB: this involves a network call, so it could raise an error
     or take a long time.
 
-    Parameters
-    ----------
-    timeout : float or None
-        The request timeout.
-
     Returns
     -------
     str


### PR DESCRIPTION
## Describe your changes

Enables ruff's DOC (documentation) rules for enhanced docstring linting and fixes docstring issues across the codebase.

- Selectively enables DOC rules while ignoring noisy completeness checks (DOC201, DOC402, DOC501, DOC502)
- Adds `ignore-one-line-docstrings = true` for pydoclint to reduce noise on simple docstrings
- Standardizes `Example` section headers to `Examples` (plural) per NumPy convention
- Removes unnecessary `Returns None` documentation sections
- Fixes parameter documentation to match actual function signatures

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Documentation-only changes with no behavioral modifications
- All existing unit tests pass
- Linting and type checking pass with new rules enabled

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 9 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->