### PR TITLE
fix: Add border around dropdowns in dark mode

### DIFF
--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -39,6 +39,7 @@ import {
   BaseButtonKind,
   CopyButton,
   DynamicIcon,
+  getPopoverContainerStyle,
   Icon,
   IGuestToHostMessage,
   IMenuItem,
@@ -1050,9 +1051,9 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
             "data-testid": "stMainMenuPopover",
             className: "stMainMenuPopover",
           },
-          style: {
-            boxShadow: theme.shadows.popover,
-          },
+          style: () => ({
+            ...getPopoverContainerStyle(theme),
+          }),
         },
       }}
     >


### PR DESCRIPTION
Fixes #12954

The `MainMenu` popover in `MainMenu.tsx` was using a hardcoded `boxShadow: theme.shadows.popover` style on its `Body` override, which provided no visual separation from the background in dark mode since shadows are ineffective there. All other dropdown components (Selectbox, Multiselect, TimeInput, Popover, etc.) already used `getPopoverContainerStyle` from `frontend/lib/src/components/shared/Base/styled-components.ts`, which conditionally renders a visible border in dark mode and a box-shadow in light mode. The fix replaces the direct shadow style in `MainMenu.tsx` with `...getPopoverContainerStyle(theme)`, bringing the main menu popover in line with the rest of the dropdown components. Verified by inspecting the shared function logic which sets `borderColor` to `theme.colors.borderColor` in dark mode and matches the background color in light mode.