### PR TITLE
feat: support integer and pixel string values for gap parameter in st…

### DIFF
--- a/e2e_playwright/st_layouts_container_gap_size.py
+++ b/e2e_playwright/st_layouts_container_gap_size.py
@@ -32,6 +32,8 @@ GAPS = cast(
         "large",
         "xlarge",
         "xxlarge",
+        16,
+        "24px",
     ],
 )
 

--- a/e2e_playwright/st_layouts_container_gap_size_test.py
+++ b/e2e_playwright/st_layouts_container_gap_size_test.py
@@ -26,6 +26,8 @@ GAPS = [
     "large",
     "xlarge",
     "xxlarge",
+    16,
+    "24px",
 ]
 
 

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -259,6 +259,21 @@ describe("FlexBoxContainer layout props", () => {
       { gapConfig: { gapSize: streamlit.GapSize.NONE } },
       "gap: 0;",
     ],
+    [
+      "gap: custom",
+      { gapConfig: { gapSize: streamlit.GapSize.CUSTOM, customGapPx: 12 } },
+      "gap: 12px;",
+    ],
+    [
+      "gap: custom with missing customGapPx falls back",
+      { gapConfig: { gapSize: streamlit.GapSize.CUSTOM } },
+      "gap: 1rem;",
+    ],
+    [
+      "gap: custom with invalid customGapPx falls back",
+      { gapConfig: { gapSize: streamlit.GapSize.CUSTOM, customGapPx: Number.NaN } },
+      "gap: 1rem;",
+    ],
   ])("should apply %s", (_desc, flexContainer, expectedStyle) => {
     const block: BlockNode = makeVerticalBlock([], {
       flexContainer,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -127,7 +127,7 @@ export const ContainerContentsWrapper = (
   const defaultStyles: StyledFlexContainerBlockProps = {
     direction: Direction.VERTICAL,
     flex: 1,
-    gap: streamlit.GapSize.SMALL,
+    gap: { gapSize: streamlit.GapSize.SMALL },
     height: props.height,
     // eslint-disable-next-line streamlit-custom/no-hardcoded-theme-values
     border: false,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -176,8 +176,9 @@ export const FlexBoxContainer = (
     gap:
       // This is backwards compatible with old proto messages since previously
       // the gap size was defaulted to small.
-      props.node.deltaBlock.flexContainer?.gapConfig?.gapSize ??
-      streamlit.GapSize.SMALL,
+      props.node.deltaBlock.flexContainer?.gapConfig ?? {
+        gapSize: streamlit.GapSize.SMALL,
+      },
     direction: direction,
     // This is also backwards compatible since previously wrap was not added
     // to the flex container.
@@ -379,7 +380,7 @@ export const BlockNodeRenderer = (
     return (
       <StyledColumn
         weight={node.deltaBlock.column.weight ?? 0}
-        gap={getColumnGapSize(node.deltaBlock.column)}
+        gap={getColumnGapConfig(node.deltaBlock.column)}
         verticalAlignment={
           node.deltaBlock.column.verticalAlignment ?? undefined
         }

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -59,7 +59,7 @@ import {
   convertKeyToClassName,
   getBorderBackwardsCompatible,
   getClassnamePrefix,
-  getColumnGapSize,
+  getColumnGapConfig,
   getKeyFromId,
   isComponentStale,
   shouldActivateScrollToBottom,

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -26,10 +26,12 @@ import type { EmotionTheme } from "~lib/theme/types"
 import { assertNever } from "~lib/util/assertNever"
 
 function translateGapWidth(
-  gap: streamlit.GapSize | undefined,
+  gapConfig: streamlit.IGapConfig | undefined | null,
   theme: EmotionTheme
 ): string {
-  switch (gap) {
+  if (!gapConfig) return theme.spacing.lg
+
+  switch (gapConfig.gapSize) {
     case streamlit.GapSize.XXSMALL:
       return theme.spacing.twoXS
     case streamlit.GapSize.XSMALL:
@@ -46,6 +48,8 @@ function translateGapWidth(
       return theme.spacing.sixXL
     case streamlit.GapSize.NONE:
       return theme.spacing.none
+    case streamlit.GapSize.CUSTOM:
+      return `${gapConfig.customGapPx}px`
     default:
       return theme.spacing.lg
   }
@@ -143,7 +147,7 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
 
 interface StyledColumnProps {
   weight: number
-  gap: streamlit.GapSize | undefined
+  gap: streamlit.IGapConfig | undefined | null
   showBorder: boolean
   verticalAlignment?: BlockProto.Column.VerticalAlignment
 }
@@ -239,7 +243,7 @@ const getJustifyContent = (
 
 export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
-  gap?: streamlit.GapSize | undefined
+  gap?: streamlit.IGapConfig | undefined | null
   flex?: React.CSSProperties["flex"]
   // This marks the prop as a transient property so it is
   // not passed to the DOM. It overlaps with a valid attribute

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -48,8 +48,13 @@ function translateGapWidth(
       return theme.spacing.sixXL
     case streamlit.GapSize.NONE:
       return theme.spacing.none
-    case streamlit.GapSize.CUSTOM:
-      return `${gapConfig.customGapPx}px`
+    case streamlit.GapSize.CUSTOM: {
+      const customGapPx = gapConfig.customGapPx
+      if (typeof customGapPx !== "number" || Number.isNaN(customGapPx)) {
+        return theme.spacing.lg
+      }
+      return `${customGapPx}px`
+    }
     default:
       return theme.spacing.lg
   }

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -196,8 +196,16 @@ export function getColumnGapConfig(
  */
 export function getColumnGapSize(
   columnProto: BlockProto.IColumn
-): streamlit.IGapConfig | undefined | null {
-  return getColumnGapConfig(columnProto)
+): streamlit.GapSize {
+  const gapSize = getColumnGapConfig(columnProto)?.gapSize
+  if (
+    gapSize !== undefined &&
+    gapSize !== null &&
+    gapSize !== streamlit.GapSize.GAP_UNDEFINED
+  ) {
+    return gapSize
+  }
+  return streamlit.GapSize.SMALL
 }
 
 export function checkFlexContainerBackwardsCompatibile(

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -190,6 +190,16 @@ export function getColumnGapConfig(
   return columnProto.gapConfig
 }
 
+/**
+ * @deprecated Use `getColumnGapConfig` instead.
+ * Kept for backward compatibility with existing imports and tests.
+ */
+export function getColumnGapSize(
+  columnProto: BlockProto.IColumn
+): streamlit.IGapConfig | undefined | null {
+  return getColumnGapConfig(columnProto)
+}
+
 export function checkFlexContainerBackwardsCompatibile(
   blockProto: BlockProto
 ): boolean {

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -184,13 +184,10 @@ export function getKeyFromId(
   return userKey === "None" ? undefined : userKey
 }
 
-export function getColumnGapSize(
+export function getColumnGapConfig(
   columnProto: BlockProto.IColumn
-): streamlit.GapSize {
-  if (columnProto.gapConfig?.gapSize) {
-    return columnProto.gapConfig.gapSize
-  }
-  return streamlit.GapSize.SMALL
+): streamlit.IGapConfig | undefined | null {
+  return columnProto.gapConfig
 }
 
 export function checkFlexContainerBackwardsCompatibile(

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -214,7 +214,7 @@ class LayoutsMixin:
               When ``horizontal`` is ``True``, ``"distribute"`` aligns the
               elements the same as ``"top"``.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", None, int, or str
             The minimum gap size between the elements inside the container.
             This can be one of the following:
 
@@ -226,6 +226,8 @@ class LayoutsMixin:
             - ``"xlarge"``: 6rem gap between the elements.
             - ``"xxlarge"``: 8rem gap between the elements.
             - ``None``: No gap between the elements.
+            - An integer specifying the gap in pixels.
+            - A string specifying the gap in pixels (e.g. ``"16px"``).
 
             The rem unit is relative to the ``theme.baseFontSize``
             configuration option.
@@ -330,8 +332,8 @@ class LayoutsMixin:
         block_proto = BlockProto()
         block_proto.allow_empty = False
         block_proto.flex_container.border = border or False
-        block_proto.flex_container.gap_config.gap_size = get_gap_size(
-            gap, "st.container"
+        block_proto.flex_container.gap_config.CopyFrom(
+            get_gap_size(gap, "st.container")
         )
 
         validate_horizontal_alignment(horizontal_alignment)
@@ -415,7 +417,7 @@ class LayoutsMixin:
               Or ``[1, 2, 3]`` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", None, int, or str
             The size of the gap between the columns. This can be one of the
             following:
 
@@ -427,6 +429,8 @@ class LayoutsMixin:
             - ``"xlarge"``: 6rem gap between the columns.
             - ``"xxlarge"``: 8rem gap between the columns.
             - ``None``: No gap between the columns.
+            - An integer specifying the gap in pixels.
+            - A string specifying the gap in pixels (e.g. ``"16px"``).
 
             The rem unit is relative to the ``theme.baseFontSize``
             configuration option.
@@ -579,9 +583,7 @@ class LayoutsMixin:
                 element_type="st.columns",
             )
 
-        gap_size = get_gap_size(gap, "st.columns")
-        gap_config = GapConfig()
-        gap_config.gap_size = gap_size
+        gap_config = get_gap_size(gap, "st.columns")
 
         def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -45,7 +45,6 @@ from streamlit.errors import (
     StreamlitValueError,
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
-from streamlit.proto.GapSize_pb2 import GapConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import register_widget

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -221,6 +221,7 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
     elif isinstance(gap, int):
         if gap < 0:
             raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        config.gap_size = GapSize.CUSTOM
         config.custom_gap_px = gap
     elif isinstance(gap, str):
         gap_size = gap.lower()
@@ -231,6 +232,7 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
                 px_val = int(gap_size[:-2])
                 if px_val < 0:
                     raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+                config.gap_size = GapSize.CUSTOM
                 config.custom_gap_px = px_val
             except ValueError:
                 raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -31,6 +31,8 @@ from streamlit.proto.HeightConfig_pb2 import HeightConfig
 from streamlit.proto.TextAlignmentConfig_pb2 import TextAlignmentConfig
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
 
+_MAX_CUSTOM_GAP_PX = (2**32) - 1
+
 WidthWithoutContent: TypeAlias = int | Literal["stretch"]
 Width: TypeAlias = int | Literal["stretch", "content"]
 HeightWithoutContent: TypeAlias = int | Literal["stretch"]
@@ -219,7 +221,7 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
     if gap is None:
         config.gap_size = GapSize.NONE
     elif isinstance(gap, int):
-        if gap < 0:
+        if gap < 0 or gap > _MAX_CUSTOM_GAP_PX:
             raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
         config.gap_size = GapSize.CUSTOM
         config.custom_gap_px = gap
@@ -230,7 +232,7 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
         elif gap_size.endswith("px"):
             try:
                 px_val = int(gap_size[:-2])
-                if px_val < 0:
+                if px_val < 0 or px_val > _MAX_CUSTOM_GAP_PX:
                     raise StreamlitInvalidColumnGapError(
                         gap=gap, element_type=element_type
                     )

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -221,7 +221,6 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
     elif isinstance(gap, int):
         if gap < 0:
             raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
-        config.gap_size = GapSize.CUSTOM
         config.custom_gap_px = gap
     elif isinstance(gap, str):
         gap_size = gap.lower()
@@ -232,7 +231,6 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
                 px_val = int(gap_size[:-2])
                 if px_val < 0:
                     raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
-                config.gap_size = GapSize.CUSTOM
                 config.custom_gap_px = px_val
             except ValueError:
                 raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
@@ -242,6 +240,13 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
         raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
 
     return config
+
+
+def get_gap_size_enum(gap: Gap | None, element_type: str) -> GapSize:
+    """Return only the GapSize enum for the given gap configuration.
+    Convenience wrapper for callers that only need the enum value.
+    """
+    return get_gap_size(gap=gap, element_type=element_type).gap_size
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -231,7 +231,9 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
             try:
                 px_val = int(gap_size[:-2])
                 if px_val < 0:
-                    raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+                    raise StreamlitInvalidColumnGapError(
+                        gap=gap, element_type=element_type
+                    )
                 config.gap_size = GapSize.CUSTOM
                 config.custom_gap_px = px_val
             except ValueError:
@@ -242,13 +244,6 @@ def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
         raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
 
     return config
-
-
-def get_gap_size_enum(gap: Gap | None, element_type: str) -> GapSize:
-    """Return only the GapSize enum for the given gap configuration.
-    Convenience wrapper for callers that only need the enum value.
-    """
-    return get_gap_size(gap=gap, element_type=element_type).gap_size
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -26,7 +26,7 @@ from streamlit.errors import (
     StreamlitInvalidWidthError,
 )
 from streamlit.proto.Block_pb2 import Block
-from streamlit.proto.GapSize_pb2 import GapSize
+from streamlit.proto.GapSize_pb2 import GapConfig, GapSize
 from streamlit.proto.HeightConfig_pb2 import HeightConfig
 from streamlit.proto.TextAlignmentConfig_pb2 import TextAlignmentConfig
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
@@ -41,9 +41,11 @@ SpaceSize: TypeAlias = (
         "stretch", "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge"
     ]
 )
-Gap: TypeAlias = Literal[
-    "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge"
-]
+Gap: TypeAlias = (
+    Literal["xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge"]
+    | int
+    | str
+)
 HorizontalAlignment: TypeAlias = Literal["left", "center", "right", "distribute"]
 VerticalAlignment: TypeAlias = Literal["top", "center", "bottom", "distribute"]
 TextAlignment: TypeAlias = Literal["left", "center", "right", "justify"]
@@ -200,8 +202,10 @@ def get_height_config(height: Height | SpaceSize) -> HeightConfig:
     return height_config
 
 
-def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
-    """Convert a gap string or None to a GapSize proto value."""
+def get_gap_size(gap: Gap | None, element_type: str) -> GapConfig:
+    """Convert a gap string, integer, or None to a GapConfig proto message."""
+    config = GapConfig()
+
     gap_mapping = {
         "xxsmall": GapSize.XXSMALL,
         "xsmall": GapSize.XSMALL,
@@ -212,16 +216,32 @@ def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
         "xxlarge": GapSize.XXLARGE,
     }
 
-    if isinstance(gap, str):
+    if gap is None:
+        config.gap_size = GapSize.NONE
+    elif isinstance(gap, int):
+        if gap < 0:
+            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        config.gap_size = GapSize.CUSTOM
+        config.custom_gap_px = gap
+    elif isinstance(gap, str):
         gap_size = gap.lower()
-        valid_sizes = gap_mapping.keys()
+        if gap_size in gap_mapping:
+            config.gap_size = gap_mapping[gap_size]
+        elif gap_size.endswith("px"):
+            try:
+                px_val = int(gap_size[:-2])
+                if px_val < 0:
+                    raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+                config.gap_size = GapSize.CUSTOM
+                config.custom_gap_px = px_val
+            except ValueError:
+                raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        else:
+            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+    else:
+        raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
 
-        if gap_size in valid_sizes:
-            return gap_mapping[gap_size]
-    elif gap is None:
-        return GapSize.NONE
-
-    raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+    return config
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -251,11 +251,11 @@ class StreamlitInvalidVerticalAlignmentError(LocalizableStreamlitException):
 class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
     """Exception raised when an invalid value is specified for gap."""
 
-    def __init__(self, gap: str, element_type: str) -> None:
+    def __init__(self, gap: Any, element_type: str) -> None:
         super().__init__(
             'The `gap` argument to `{element_type}` must be `"xxsmall"`, '
             '`"xsmall"`, `"small"`, `"medium"`, `"large"`, `"xlarge"`, '
-            '`"xxlarge"`, or `"none"`. \n'
+            '`"xxlarge"`, `None`, a non-negative integer, or a pixel string like `"16px"`. \n'
             "The argument passed was {gap}.",
             gap=gap,
             element_type=element_type,

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -236,10 +236,8 @@ class ColumnsTest(DeltaGeneratorTestCase):
         columns_blocks = all_deltas[1:4]
 
         assert (
-            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
-                "gap_value"
-            )
-            == "custom_gap_px"
+            horizontal_container.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
         )
         assert (
             horizontal_container.add_block.flex_container.gap_config.custom_gap_px == 16
@@ -247,8 +245,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
 
         for col_block in columns_blocks:
             assert (
-                col_block.add_block.column.gap_config.WhichOneof("gap_value")
-                == "custom_gap_px"
+                col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
             )
             assert col_block.add_block.column.gap_config.custom_gap_px == 16
 
@@ -263,10 +260,8 @@ class ColumnsTest(DeltaGeneratorTestCase):
         columns_blocks = all_deltas[1:4]
 
         assert (
-            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
-                "gap_value"
-            )
-            == "custom_gap_px"
+            horizontal_container.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
         )
         assert (
             horizontal_container.add_block.flex_container.gap_config.custom_gap_px == 24
@@ -274,8 +269,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
 
         for col_block in columns_blocks:
             assert (
-                col_block.add_block.column.gap_config.WhichOneof("gap_value")
-                == "custom_gap_px"
+                col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
             )
             assert col_block.add_block.column.gap_config.custom_gap_px == 24
 
@@ -820,8 +814,8 @@ class ContainerTest(DeltaGeneratorTestCase):
         st.container(gap=16)
         container_block = self.get_delta_from_queue()
         assert (
-            container_block.add_block.flex_container.gap_config.WhichOneof("gap_value")
-            == "custom_gap_px"
+            container_block.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
         )
         assert container_block.add_block.flex_container.gap_config.custom_gap_px == 16
 
@@ -830,8 +824,8 @@ class ContainerTest(DeltaGeneratorTestCase):
         st.container(gap="24px")
         container_block = self.get_delta_from_queue()
         assert (
-            container_block.add_block.flex_container.gap_config.WhichOneof("gap_value")
-            == "custom_gap_px"
+            container_block.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
         )
         assert container_block.add_block.flex_container.gap_config.custom_gap_px == 24
 

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -244,9 +244,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
         )
 
         for col_block in columns_blocks:
-            assert (
-                col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
-            )
+            assert col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
             assert col_block.add_block.column.gap_config.custom_gap_px == 16
 
     def test_columns_pixel_string_gap(self):
@@ -268,9 +266,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
         )
 
         for col_block in columns_blocks:
-            assert (
-                col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
-            )
+            assert col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
             assert col_block.add_block.column.gap_config.custom_gap_px == 24
 
     @parameterized.expand(

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -236,15 +236,20 @@ class ColumnsTest(DeltaGeneratorTestCase):
         columns_blocks = all_deltas[1:4]
 
         assert (
-            horizontal_container.add_block.flex_container.gap_config.gap_size
-            == GapSize.CUSTOM
+            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
+                "gap_value"
+            )
+            == "custom_gap_px"
         )
         assert (
             horizontal_container.add_block.flex_container.gap_config.custom_gap_px == 16
         )
 
         for col_block in columns_blocks:
-            assert col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
+            assert (
+                col_block.add_block.column.gap_config.WhichOneof("gap_value")
+                == "custom_gap_px"
+            )
             assert col_block.add_block.column.gap_config.custom_gap_px == 16
 
     def test_columns_pixel_string_gap(self):
@@ -258,15 +263,20 @@ class ColumnsTest(DeltaGeneratorTestCase):
         columns_blocks = all_deltas[1:4]
 
         assert (
-            horizontal_container.add_block.flex_container.gap_config.gap_size
-            == GapSize.CUSTOM
+            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
+                "gap_value"
+            )
+            == "custom_gap_px"
         )
         assert (
             horizontal_container.add_block.flex_container.gap_config.custom_gap_px == 24
         )
 
         for col_block in columns_blocks:
-            assert col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
+            assert (
+                col_block.add_block.column.gap_config.WhichOneof("gap_value")
+                == "custom_gap_px"
+            )
             assert col_block.add_block.column.gap_config.custom_gap_px == 24
 
     @parameterized.expand(
@@ -810,8 +820,8 @@ class ContainerTest(DeltaGeneratorTestCase):
         st.container(gap=16)
         container_block = self.get_delta_from_queue()
         assert (
-            container_block.add_block.flex_container.gap_config.gap_size
-            == GapSize.CUSTOM
+            container_block.add_block.flex_container.gap_config.WhichOneof("gap_value")
+            == "custom_gap_px"
         )
         assert container_block.add_block.flex_container.gap_config.custom_gap_px == 16
 
@@ -820,8 +830,8 @@ class ContainerTest(DeltaGeneratorTestCase):
         st.container(gap="24px")
         container_block = self.get_delta_from_queue()
         assert (
-            container_block.add_block.flex_container.gap_config.gap_size
-            == GapSize.CUSTOM
+            container_block.add_block.flex_container.gap_config.WhichOneof("gap_value")
+            == "custom_gap_px"
         )
         assert container_block.add_block.flex_container.gap_config.custom_gap_px == 24
 

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -156,21 +156,11 @@ class ColumnsTest(DeltaGeneratorTestCase):
         # "small" gap arg
         assert len(all_deltas) == 4
         assert (
-            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
-                "gap_spec"
-            )
-            == "gap_size"
-        )
-        assert (
             horizontal_container.add_block.flex_container.gap_config.gap_size
             == GapSize.SMALL
         )
 
         for col_block in columns_blocks:
-            assert (
-                col_block.add_block.column.gap_config.WhichOneof("gap_spec")
-                == "gap_size"
-            )
             assert col_block.add_block.column.gap_config.gap_size == GapSize.SMALL
 
     def test_columns_with_medium_gap(self):
@@ -187,21 +177,11 @@ class ColumnsTest(DeltaGeneratorTestCase):
         # "medium" gap arg
         assert len(all_deltas) == 4
         assert (
-            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
-                "gap_spec"
-            )
-            == "gap_size"
-        )
-        assert (
             horizontal_container.add_block.flex_container.gap_config.gap_size
             == GapSize.MEDIUM
         )
 
         for col_block in columns_blocks:
-            assert (
-                col_block.add_block.column.gap_config.WhichOneof("gap_spec")
-                == "gap_size"
-            )
             assert col_block.add_block.column.gap_config.gap_size == GapSize.MEDIUM
 
     def test_columns_with_large_gap(self):
@@ -218,21 +198,11 @@ class ColumnsTest(DeltaGeneratorTestCase):
         # "large" gap arg
         assert len(all_deltas) == 4
         assert (
-            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
-                "gap_spec"
-            )
-            == "gap_size"
-        )
-        assert (
             horizontal_container.add_block.flex_container.gap_config.gap_size
             == GapSize.LARGE
         )
 
         for col_block in columns_blocks:
-            assert (
-                col_block.add_block.column.gap_config.WhichOneof("gap_spec")
-                == "gap_size"
-            )
             assert col_block.add_block.column.gap_config.gap_size == GapSize.LARGE
 
     def test_columns_with_none_gap(self):
@@ -248,29 +218,63 @@ class ColumnsTest(DeltaGeneratorTestCase):
         # 4 elements will be created: 1 horizontal block, 3 columns, each receives
         # "none" gap arg
         assert (
-            horizontal_container.add_block.flex_container.gap_config.WhichOneof(
-                "gap_spec"
-            )
-            == "gap_size"
-        )
-        assert (
             horizontal_container.add_block.flex_container.gap_config.gap_size
             == GapSize.NONE
         )
 
         for col_block in columns_blocks:
-            assert (
-                col_block.add_block.column.gap_config.WhichOneof("gap_spec")
-                == "gap_size"
-            )
             assert col_block.add_block.column.gap_config.gap_size == GapSize.NONE
+
+    def test_columns_integer_gap(self):
+        """Test that it works correctly with integer gap argument"""
+
+        st.columns(3, gap=16)
+
+        all_deltas = self.get_all_deltas_from_queue()
+
+        horizontal_container = all_deltas[0]
+        columns_blocks = all_deltas[1:4]
+
+        assert (
+            horizontal_container.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
+        )
+        assert (
+            horizontal_container.add_block.flex_container.gap_config.custom_gap_px == 16
+        )
+
+        for col_block in columns_blocks:
+            assert col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
+            assert col_block.add_block.column.gap_config.custom_gap_px == 16
+
+    def test_columns_pixel_string_gap(self):
+        """Test that it works correctly with pixel string gap argument"""
+
+        st.columns(3, gap="24px")
+
+        all_deltas = self.get_all_deltas_from_queue()
+
+        horizontal_container = all_deltas[0]
+        columns_blocks = all_deltas[1:4]
+
+        assert (
+            horizontal_container.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
+        )
+        assert (
+            horizontal_container.add_block.flex_container.gap_config.custom_gap_px == 24
+        )
+
+        for col_block in columns_blocks:
+            assert col_block.add_block.column.gap_config.gap_size == GapSize.CUSTOM
+            assert col_block.add_block.column.gap_config.custom_gap_px == 24
 
     @parameterized.expand(
         [
             "invalid",
-            5,
+            -5,
             "5rem",
-            "10px",
+            "invalidpx",
         ]
     )
     def test_columns_with_invalid_gap(self, invalid_gap):
@@ -800,6 +804,26 @@ class ContainerTest(DeltaGeneratorTestCase):
         assert (
             container_block.add_block.flex_container.gap_config.gap_size == expected_gap
         )
+
+    def test_container_integer_gap(self):
+        """Test that st.container sets the integer gap property correctly."""
+        st.container(gap=16)
+        container_block = self.get_delta_from_queue()
+        assert (
+            container_block.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
+        )
+        assert container_block.add_block.flex_container.gap_config.custom_gap_px == 16
+
+    def test_container_pixel_string_gap(self):
+        """Test that st.container sets the pixel string gap property correctly."""
+        st.container(gap="24px")
+        container_block = self.get_delta_from_queue()
+        assert (
+            container_block.add_block.flex_container.gap_config.gap_size
+            == GapSize.CUSTOM
+        )
+        assert container_block.add_block.flex_container.gap_config.custom_gap_px == 24
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -211,15 +211,43 @@ class LayoutUtilsTest(unittest.TestCase):
         ]
     )
     def test_get_gap_size_valid(self, gap: str | None, expected: GapSize.ValueType):
-        """get_gap_size maps valid inputs to GapSize values, None to GapSize.NONE."""
+        """get_gap_size maps named sizes and None to the expected GapConfig enum value."""
 
-        assert get_gap_size(gap, "st.columns") == expected
+        gap_config = get_gap_size(gap, "st.columns")
+        assert gap_config.gap_size == expected
 
     def test_get_gap_size_invalid(self):
         """get_gap_size raises for invalid gap strings."""
 
         with pytest.raises(StreamlitInvalidColumnGapError):
             get_gap_size("tiny", "st.columns")
+
+    @parameterized.expand(
+        [
+            (16, 16),
+            ("24px", 24),
+        ]
+    )
+    def test_get_gap_size_custom_pixels(self, gap: int | str, expected_px: int) -> None:
+        """get_gap_size maps integer and pixel string values to custom pixel gaps."""
+
+        gap_config = get_gap_size(gap, "st.columns")
+        assert gap_config.gap_size == GapSize.CUSTOM
+        assert gap_config.custom_gap_px == expected_px
+
+    @parameterized.expand(
+        [
+            (-1,),
+            ("-1px",),
+            (2**32,),
+            (f"{2**32}px",),
+        ]
+    )
+    def test_get_gap_size_custom_pixels_out_of_range(self, gap: int | str) -> None:
+        """get_gap_size raises for negative and out-of-range custom pixel values."""
+
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            get_gap_size(gap, "st.columns")
 
     @parameterized.expand(
         [

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -32,6 +32,9 @@ enum GapSize {
 }
 
 message GapConfig {
-  GapSize gap_size = 1;
-  optional uint32 custom_gap_px = 2;
+  // Exactly one of gap_size or custom_gap_px may be set.
+  oneof gap_value {
+    GapSize gap_size = 1;
+    uint32 custom_gap_px = 2;
+  }
 }

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -28,10 +28,10 @@ enum GapSize {
   XSMALL = 6;
   XLARGE = 7;
   XXLARGE = 8;
+  CUSTOM = 9;
 }
 
 message GapConfig {
-  oneof gap_spec {
-    GapSize gap_size = 1;
-  }
+  GapSize gap_size = 1;
+  optional uint32 custom_gap_px = 2;
 }

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -32,9 +32,6 @@ enum GapSize {
 }
 
 message GapConfig {
-  // Exactly one of gap_size or custom_gap_px may be set.
-  oneof gap_value {
-    GapSize gap_size = 1;
-    uint32 custom_gap_px = 2;
-  }
+  GapSize gap_size = 1;
+  optional uint32 custom_gap_px = 2;
 }


### PR DESCRIPTION
## Summary

This PR implements #13005, allowing users to specify the gap between columns or container elements using integers (representing pixels) or pixel strings (e.g., `"16px"`).

## Changes

- Updated `GapSize.proto` to include a `CUSTOM` gap size and a `custom_gap_px` field
- Updated `st.columns` and `st.container` to accept `int` and `str` (pixels) for the `gap` parameter
- Enhanced the frontend to correctly translate these custom gap values into CSS
- Added comprehensive backend tests for the new gap types
- Updated E2E test coverage

## Example Usage

```python
st.columns(2, gap=16)       # 16px gap
st.columns(2, gap="24px")   # 24px gap
st.container(gap=8)         # 8px gap
```

## Backward Compatibility

Existing behavior for `"small"`, `"medium"`, `"large"`, and `None` is preserved exactly. The protobuf wire format remains compatible with older frontend versions for standard enum values.

Closes #13005