### PR TITLE
[fix] Restore reactJsonViewCompat shim for local dev server

### DIFF
--- a/frontend/lib/src/components/elements/Json/Json.tsx
+++ b/frontend/lib/src/components/elements/Json/Json.tsx
@@ -16,7 +16,6 @@
 
 import { memo, ReactElement, useCallback } from "react"
 
-import ReactJson, { type OnCopyProps } from "@microlink/react-json-view"
 import JSON5 from "json5"
 
 import { Json as JsonProto } from "@streamlit/protobuf"
@@ -26,6 +25,7 @@ import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { hasLightBackgroundColor } from "~lib/theme/getColors"
 import { ensureError } from "~lib/util/ErrorHandling"
+import ReactJson, { type OnCopyProps } from "~lib/util/reactJsonViewCompat"
 
 import JsonPathTooltip from "./JsonPathTooltip"
 import { StyledJsonWrapper } from "./styled-components"

--- a/frontend/lib/src/components/elements/Json/useJsonTooltip.ts
+++ b/frontend/lib/src/components/elements/Json/useJsonTooltip.ts
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
-import type { OnSelectProps } from "@microlink/react-json-view"
+import type { OnSelectProps } from "~lib/util/reactJsonViewCompat"
 
 /**
  * The state of the JSON tooltip.

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/JsonViewer.tsx
@@ -19,13 +19,13 @@ import {
   type Theme as GlideTheme,
   TextCellEntry,
 } from "@glideapps/glide-data-grid"
-import ReactJson from "@microlink/react-json-view"
 import { getLuminance } from "color2k"
 import JSON5 from "json5"
 
 import { isNullOrUndefined } from "@streamlit/utils"
 
 import { toJsonString } from "~lib/components/widgets/DataFrame/columns/utils"
+import ReactJson from "~lib/util/reactJsonViewCompat"
 
 const StyledJsonWrapper = styled.div(({ theme }) => ({
   overflowY: "auto",

--- a/frontend/lib/src/util/reactJsonViewCompat.ts
+++ b/frontend/lib/src/util/reactJsonViewCompat.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Compatibility shim for `@microlink/react-json-view` under Vite 8.
+ *
+ * Intent:
+ * - Always resolve a callable React component from the imported module, even
+ *   when the dependency is wrapped through nested default exports.
+ *
+ * Why this exists:
+ * - `@microlink/react-json-view` is published as CommonJS, and Vite 8 interop can yield
+ *   different runtime module shapes (`module`, `module.default`,
+ *   `module.default.default`) depending on optimization path.
+ * - Without normalization, Json components can fail with
+ *   "Element type is invalid".
+ * - Direct imports work in CI builds but fail when running locally with the
+ *   hot-reload dev server (e.g., `make debug` or `make frontend-dev`).
+ *
+ * Removal criteria:
+ * - Remove once direct `import ReactJson from "@microlink/react-json-view"` is proven
+ *   stable across both CI builds AND local dev server in this repo.
+ * - Validate by running the debug app and checking
+ *   `work-tmp/debug/latest/frontend.log` for Json render/import failures.
+ *
+ * Vite references:
+ * - https://vite.dev/guide/migration.html
+ * - https://vite.dev/config/dep-optimization-options
+ */
+import * as ReactJsonViewModule from "@microlink/react-json-view"
+
+import { resolveDefaultExport } from "./resolveDefaultExport"
+
+type ReactJsonViewComponent =
+  (typeof import("@microlink/react-json-view"))["default"]
+
+const ReactJsonView = resolveDefaultExport(
+  ReactJsonViewModule
+) as ReactJsonViewComponent
+
+export default ReactJsonView
+export type { OnCopyProps, OnSelectProps } from "@microlink/react-json-view"

--- a/frontend/lib/src/util/resolveDefaultExport.test.ts
+++ b/frontend/lib/src/util/resolveDefaultExport.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { resolveDefaultExport } from "./resolveDefaultExport"
+
+describe("resolveDefaultExport", () => {
+  const MockComponent = (): null => null
+
+  describe("module shapes from CommonJS interop", () => {
+    it("returns the component directly when module has no default wrapper", () => {
+      // Case: ESM module or already unwrapped
+      const result = resolveDefaultExport(MockComponent)
+      expect(result).toBe(MockComponent)
+    })
+
+    it("unwraps single default export: { default: Component }", () => {
+      // Case: Standard CommonJS interop
+      const moduleWithDefault = { default: MockComponent }
+      const result = resolveDefaultExport(moduleWithDefault)
+      expect(result).toBe(MockComponent)
+    })
+
+    it("unwraps double nested default: { default: { default: Component } }", () => {
+      // Case: Vite 8 double-wrapped CommonJS interop
+      const doubleNested = { default: { default: MockComponent } }
+      const result = resolveDefaultExport(doubleNested)
+      expect(result).toBe(MockComponent)
+    })
+
+    it("unwraps triple nested default: { default: { default: { default: Component } } }", () => {
+      // Case: Deeply nested (up to maxDepth)
+      const tripleNested = { default: { default: { default: MockComponent } } }
+      const result = resolveDefaultExport(tripleNested)
+      expect(result).toBe(MockComponent)
+    })
+  })
+
+  describe("depth limiting", () => {
+    it("respects maxDepth and stops unwrapping", () => {
+      const tripleNested = { default: { default: { default: MockComponent } } }
+      // With maxDepth=2, should stop at { default: MockComponent }
+      const result = resolveDefaultExport(tripleNested, 2)
+      expect(result).toEqual({ default: MockComponent })
+    })
+
+    it("uses default maxDepth of 3", () => {
+      // 4 levels of nesting - should stop at the 4th wrapper
+      const deeplyNested = {
+        default: { default: { default: { default: MockComponent } } },
+      }
+      const result = resolveDefaultExport(deeplyNested)
+      expect(result).toEqual({ default: MockComponent })
+    })
+
+    it("handles maxDepth of 1", () => {
+      const doubleNested = { default: { default: MockComponent } }
+      const result = resolveDefaultExport(doubleNested, 1)
+      expect(result).toEqual({ default: MockComponent })
+    })
+  })
+
+  describe("edge cases", () => {
+    it("returns null as-is", () => {
+      const result = resolveDefaultExport(null)
+      expect(result).toBeNull()
+    })
+
+    it("returns undefined as-is", () => {
+      const result = resolveDefaultExport(undefined)
+      expect(result).toBeUndefined()
+    })
+
+    it("returns primitives as-is", () => {
+      expect(resolveDefaultExport("string")).toBe("string")
+      expect(resolveDefaultExport(42)).toBe(42)
+      expect(resolveDefaultExport(true)).toBe(true)
+    })
+
+    it("returns arrays as-is (no default property)", () => {
+      const arr = [1, 2, 3]
+      const result = resolveDefaultExport(arr)
+      expect(result).toBe(arr)
+    })
+
+    it("returns objects without default property as-is", () => {
+      const obj = { foo: "bar", baz: 123 }
+      const result = resolveDefaultExport(obj)
+      expect(result).toBe(obj)
+    })
+
+    it("handles object with default set to null", () => {
+      const obj = { default: null }
+      const result = resolveDefaultExport(obj)
+      // After unwrapping, we get null, which stops further iteration
+      expect(result).toBeNull()
+    })
+
+    it("handles object with default set to undefined", () => {
+      const obj = { default: undefined }
+      const result = resolveDefaultExport(obj)
+      expect(result).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Describe your changes

Restores the `reactJsonViewCompat.ts` compatibility shim that was removed in #14380. The direct import from `@microlink/react-json-view` works in CI builds but fails when running locally with the dev server (e.g., `make debug` or `make frontend-dev`).

**Changes:**
- Restored `frontend/lib/src/util/reactJsonViewCompat.ts` with updated imports for `@microlink/react-json-view`
- Updated `Json.tsx`, `useJsonTooltip.ts`, and `JsonViewer.tsx` to import through the compat shim

**Why this is needed:**
- `@microlink/react-json-view` is published as CommonJS
- Vite 8 interop can yield different runtime module shapes (`module`, `module.default`, `module.default.default`) depending on the optimization path
- Without normalization, Json components fail with "Element type is invalid" errors in local dev

## GitHub Issue Link (if applicable)

- Related to #14380

## Testing Plan

- [x] Unit Tests (existing tests pass)
- [x] Manual testing with `make debug` to verify Json elements render correctly

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->