### PR TITLE
Add title parameter to status callouts

### DIFF
--- a/e2e_playwright/st_alert.py
+++ b/e2e_playwright/st_alert.py
@@ -127,3 +127,12 @@ st.warning("🔔 This warning has an emoji icon extracted from body")
 
 # Test case with material icon extracted from body
 st.info(":material/lightbulb: This info has a material icon extracted from body")
+
+### Test cases for alert titles ###
+
+st.info("This is an info message with a title", title="Heads up")
+st.success(
+    "This is a success message with a title and icon",
+    title="All set",
+    icon="✅",
+)

--- a/e2e_playwright/st_alert_test.py
+++ b/e2e_playwright/st_alert_test.py
@@ -23,7 +23,7 @@ def test_alerts_rendering_themed(
 ):
     """Test that alerts render correctly with theme-dependent styling."""
     alert_elements = themed_app.get_by_test_id("stAlert")
-    expect(alert_elements).to_have_count(34)
+    expect(alert_elements).to_have_count(36)
 
     # The first 4 alerts are super basic, no need to screenshot test those
     expect(alert_elements.nth(0)).to_have_text("This is an error")
@@ -67,11 +67,29 @@ def test_alerts_rendering_themed(
         material_icon_alert.locator('[data-testid="stMarkdownContainer"]')
     ).to_have_text("This info has a material icon extracted from body")
 
+    titled_info_alert = alert_elements.nth(34)
+    expect(titled_info_alert.get_by_test_id("stAlertTitle")).to_have_text("Heads up")
+    expect(titled_info_alert.get_by_test_id("stAlertDynamicIcon")).to_have_count(0)
+    expect(
+        titled_info_alert.locator('[data-testid="stMarkdownContainer"]')
+    ).to_have_text("This is an info message with a title")
+
+    titled_success_alert = alert_elements.nth(35)
+    expect(titled_success_alert.get_by_test_id("stAlertTitle")).to_have_text(
+        "All set"
+    )
+    expect(titled_success_alert.get_by_test_id("stAlertDynamicIcon")).to_have_text(
+        "✅"
+    )
+    expect(
+        titled_success_alert.locator('[data-testid="stMarkdownContainer"]')
+    ).to_have_text("This is a success message with a title and icon")
+
 
 def test_alerts_rendering_layout(app: Page, assert_snapshot: ImageCompareFunction):
     """Test that alerts layout variations render correctly (theme-independent)."""
     alert_elements = app.get_by_test_id("stAlert")
-    expect(alert_elements).to_have_count(34)
+    expect(alert_elements).to_have_count(36)
 
     # Line wrapping (layout behavior)
     assert_snapshot(alert_elements.nth(8), name="st_alert-error_line_wrapping_1")
@@ -108,7 +126,7 @@ def test_material_symbol_from_latest_font_version_rendering(
 ):
     """Test that icon from latest version material symbols font renders correctly."""
     alert_elements = app.get_by_test_id("stAlert")
-    expect(alert_elements).to_have_count(34)
+    expect(alert_elements).to_have_count(36)
 
     assert_snapshot(
         alert_elements.nth(21),

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -260,6 +260,7 @@ const RawElementNodeRenderer = (
           <AlertElement
             icon={alertProto.icon}
             body={alertProto.body}
+            title={alertProto.title}
             kind={getAlertElementKind(alertProto.format)}
             {...elementProps}
           />

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
@@ -45,7 +45,8 @@ describe("Alert element", () => {
 
     expect(screen.getByTestId("stAlertContentError")).toBeInTheDocument()
     expect(screen.queryByTestId("stAlertDynamicIcon")).not.toBeInTheDocument()
-    expect(screen.getByText("#what in the world?")).toBeInTheDocument()
+    expect(screen.queryByTestId("stAlertTitle")).not.toBeInTheDocument()
+    expect(screen.getByText("#what in the world?")).toBeVisible()
   })
 
   it("renders a WARNING box as expected", () => {
@@ -106,7 +107,8 @@ describe("Alert element", () => {
       body: "It's dangerous to go alone.",
     })
     render(<AlertElement {...props} />)
-    expect(screen.getByTestId("stAlertTitle")).toHaveTextContent("Heads up")
-    expect(screen.getByText("It's dangerous to go alone.")).toBeInTheDocument()
+    expect(screen.getByText("Heads up", { exact: true })).toBeVisible()
+    expect(screen.queryByTestId("stAlertDynamicIcon")).not.toBeInTheDocument()
+    expect(screen.getByText("It's dangerous to go alone.")).toBeVisible()
   })
 })

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.test.tsx
@@ -98,4 +98,15 @@ describe("Alert element", () => {
     expect(screen.getByTestId("stAlertDynamicIcon")).toHaveTextContent("👉🏻")
     expect(screen.getByText("It's dangerous to go alone.")).toBeInTheDocument()
   })
+
+  it("renders a title separately from the markdown body", () => {
+    const props = getProps({
+      kind: getAlertElementKind(AlertProto.Format.INFO),
+      title: "Heads up",
+      body: "It's dangerous to go alone.",
+    })
+    render(<AlertElement {...props} />)
+    expect(screen.getByTestId("stAlertTitle")).toHaveTextContent("Heads up")
+    expect(screen.getByText("It's dangerous to go alone.")).toBeInTheDocument()
+  })
 })

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
@@ -23,10 +23,16 @@ import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 
-import { StyledAlertContent, StyledAlertIcon } from "./styled-components"
+import {
+  StyledAlertContent,
+  StyledAlertIcon,
+  StyledAlertTextContent,
+  StyledAlertTitle,
+} from "./styled-components"
 
 export interface AlertElementProps {
   body: string
+  title?: string
   icon?: string
   kind: Kind
 }
@@ -37,10 +43,11 @@ export interface AlertElementProps {
 function AlertElement({
   icon,
   body,
+  title,
   kind,
 }: Readonly<AlertElementProps>): ReactElement {
   const theme = useEmotionTheme()
-  const markdownWidth = {
+  const contentWidth = {
     // Fix issue #6394 - Need to account for icon size (iconSizes.lg) + gap when icon present
     width: icon
       ? `calc(100% - (${theme.iconSizes.lg} + ${theme.spacing.sm}))`
@@ -61,11 +68,10 @@ function AlertElement({
             </StyledAlertIcon>
           )}
 
-          <StreamlitMarkdown
-            source={body}
-            allowHTML={false}
-            style={markdownWidth}
-          />
+          <StyledAlertTextContent style={contentWidth}>
+            {title && <StyledAlertTitle data-testid="stAlertTitle">{title}</StyledAlertTitle>}
+            <StreamlitMarkdown source={body} allowHTML={false} style={{ width: "100%" }} />
+          </StyledAlertTextContent>
         </StyledAlertContent>
       </AlertContainer>
     </div>

--- a/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/AlertElement.tsx
@@ -20,12 +20,12 @@ import AlertContainer, {
   Kind,
 } from "~lib/components/shared/AlertContainer/AlertContainer"
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
-import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 
 import {
   StyledAlertContent,
   StyledAlertIcon,
+  StyledAlertMarkdown,
   StyledAlertTextContent,
   StyledAlertTitle,
 } from "./styled-components"
@@ -47,12 +47,10 @@ function AlertElement({
   kind,
 }: Readonly<AlertElementProps>): ReactElement {
   const theme = useEmotionTheme()
-  const contentWidth = {
-    // Fix issue #6394 - Need to account for icon size (iconSizes.lg) + gap when icon present
-    width: icon
-      ? `calc(100% - (${theme.iconSizes.lg} + ${theme.spacing.sm}))`
-      : "100%",
-  }
+  // Fix issue #6394 - Need to account for icon size (iconSizes.lg) + gap when icon present.
+  const contentWidth = icon
+    ? `calc(100% - (${theme.iconSizes.lg} + ${theme.spacing.sm}))`
+    : "100%"
 
   return (
     <div className="stAlert" data-testid="stAlert">
@@ -68,9 +66,13 @@ function AlertElement({
             </StyledAlertIcon>
           )}
 
-          <StyledAlertTextContent style={contentWidth}>
-            {title && <StyledAlertTitle data-testid="stAlertTitle">{title}</StyledAlertTitle>}
-            <StreamlitMarkdown source={body} allowHTML={false} style={{ width: "100%" }} />
+          <StyledAlertTextContent contentWidth={contentWidth}>
+            {title && (
+              <StyledAlertTitle data-testid="stAlertTitle">
+                {title}
+              </StyledAlertTitle>
+            )}
+            <StyledAlertMarkdown source={body} allowHTML={false} />
           </StyledAlertTextContent>
         </StyledAlertContent>
       </AlertContainer>

--- a/frontend/lib/src/components/elements/AlertElement/styled-components.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/styled-components.tsx
@@ -17,6 +17,7 @@
 import styled from "@emotion/styled"
 
 import { StyledCodeBlock } from "~lib/components/elements/CodeBlock/styled-components"
+import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 
 export const StyledAlertContent = styled.div(({ theme }) => ({
   display: "flex",
@@ -33,13 +34,20 @@ export const StyledAlertIcon = styled.div(({ theme }) => ({
   top: theme.spacing.threeXS,
 }))
 
-export const StyledAlertTextContent = styled.div(({ theme }) => ({
-  display: "flex",
-  flexDirection: "column",
-  gap: theme.spacing.twoXS,
-}))
+export const StyledAlertTextContent = styled.div<{ contentWidth: string }>(
+  ({ theme, contentWidth }) => ({
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.spacing.twoXS,
+    width: contentWidth,
+  })
+)
 
 export const StyledAlertTitle = styled.div(({ theme }) => ({
   fontWeight: theme.fontWeights.bold,
   lineHeight: theme.lineHeights.small,
 }))
+
+export const StyledAlertMarkdown = styled(StreamlitMarkdown)({
+  width: "100%",
+})

--- a/frontend/lib/src/components/elements/AlertElement/styled-components.tsx
+++ b/frontend/lib/src/components/elements/AlertElement/styled-components.tsx
@@ -32,3 +32,14 @@ export const StyledAlertIcon = styled.div(({ theme }) => ({
   position: "relative",
   top: theme.spacing.threeXS,
 }))
+
+export const StyledAlertTextContent = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing.twoXS,
+}))
+
+export const StyledAlertTitle = styled.div(({ theme }) => ({
+  fontWeight: theme.fontWeights.bold,
+  lineHeight: theme.lineHeights.small,
+}))

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -55,19 +55,12 @@ def _process_alert_body_and_icon(
     return cleaned_body, ""
 
 
-def _prepend_alert_title(title: SupportsStr | None, body: str) -> str:
-    """Format an optional alert title ahead of the body text."""
+def _clean_alert_title(title: SupportsStr | None) -> str:
+    """Normalize an optional alert title."""
     if title is None:
-        return body
+        return ""
 
-    cleaned_title = clean_text(title)
-    if not cleaned_title:
-        return body
-
-    if not body:
-        return f"**{cleaned_title}**"
-
-    return f"**{cleaned_title}**\n\n{body}"
+    return clean_text(title)
 
 
 def _build_alert_proto(
@@ -82,9 +75,10 @@ def _build_alert_proto(
     alert_proto = AlertProto()
 
     processed_body, processed_icon = _process_alert_body_and_icon(body, icon)
-    alert_proto.body = _prepend_alert_title(title, processed_body)
+    alert_proto.body = processed_body
     alert_proto.icon = processed_icon
     alert_proto.format = format
+    alert_proto.title = _clean_alert_title(title)
 
     validate_width(width)
 
@@ -123,7 +117,7 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display before the body text.
+            An optional plain-text title to display above the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -199,7 +193,7 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display before the body text.
+            An optional plain-text title to display above the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -275,7 +269,7 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display before the body text.
+            An optional plain-text title to display above the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -351,7 +345,7 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display before the body text.
+            An optional plain-text title to display above the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -117,7 +117,8 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display above the body text.
+            An optional plain-text title to display above the body text. If
+            this is ``None`` (default), no title is displayed.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -193,7 +194,8 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display above the body text.
+            An optional plain-text title to display above the body text. If
+            this is ``None`` (default), no title is displayed.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -269,7 +271,8 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display above the body text.
+            An optional plain-text title to display above the body text. If
+            this is ``None`` (default), no title is displayed.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -345,7 +348,8 @@ class AlertMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         title : str or None
-            An optional plain-text title to display above the body text.
+            An optional plain-text title to display above the body text. If
+            this is ``None`` (default), no title is displayed.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -55,12 +55,56 @@ def _process_alert_body_and_icon(
     return cleaned_body, ""
 
 
+def _prepend_alert_title(title: SupportsStr | None, body: str) -> str:
+    """Format an optional alert title ahead of the body text."""
+    if title is None:
+        return body
+
+    cleaned_title = clean_text(title)
+    if not cleaned_title:
+        return body
+
+    if not body:
+        return f"**{cleaned_title}**"
+
+    return f"**{cleaned_title}**\n\n{body}"
+
+
+def _build_alert_proto(
+    *,
+    body: SupportsStr,
+    format: AlertProto.Format.ValueType,
+    title: SupportsStr | None,
+    icon: str | None,
+    width: WidthWithoutContent,
+) -> AlertProto:
+    """Build and validate an alert proto."""
+    alert_proto = AlertProto()
+
+    processed_body, processed_icon = _process_alert_body_and_icon(body, icon)
+    alert_proto.body = _prepend_alert_title(title, processed_body)
+    alert_proto.icon = processed_icon
+    alert_proto.format = format
+
+    validate_width(width)
+
+    width_config = WidthConfig()
+    if isinstance(width, int):
+        width_config.pixel_width = width
+    else:
+        width_config.use_stretch = True
+
+    alert_proto.width_config.CopyFrom(width_config)
+    return alert_proto
+
+
 class AlertMixin:
     @gather_metrics("error")
     def error(
         self,
         body: SupportsStr,
         *,  # keyword-only args:
+        title: SupportsStr | None = None,
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
@@ -77,6 +121,9 @@ class AlertMixin:
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
+        title : str or None
+            An optional plain-text title to display before the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -118,23 +165,13 @@ class AlertMixin:
         >>> st.error('This is an error', icon="🚨")
 
         """
-        alert_proto = AlertProto()
-
-        processed_body, processed_icon = _process_alert_body_and_icon(body, icon)
-        alert_proto.icon = processed_icon
-        alert_proto.body = processed_body
-        alert_proto.format = AlertProto.ERROR
-
-        validate_width(width)
-
-        width_config = WidthConfig()
-
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-
-        alert_proto.width_config.CopyFrom(width_config)
+        alert_proto = _build_alert_proto(
+            body=body,
+            format=AlertProto.ERROR,
+            title=title,
+            icon=icon,
+            width=width,
+        )
 
         return self.dg._enqueue("alert", alert_proto)
 
@@ -143,6 +180,7 @@ class AlertMixin:
         self,
         body: SupportsStr,
         *,  # keyword-only args:
+        title: SupportsStr | None = None,
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
@@ -159,6 +197,9 @@ class AlertMixin:
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
+        title : str or None
+            An optional plain-text title to display before the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -200,22 +241,13 @@ class AlertMixin:
         >>> st.warning('This is a warning', icon="⚠️")
 
         """
-        alert_proto = AlertProto()
-        processed_body, processed_icon = _process_alert_body_and_icon(body, icon)
-        alert_proto.body = processed_body
-        alert_proto.icon = processed_icon
-        alert_proto.format = AlertProto.WARNING
-
-        validate_width(width)
-
-        width_config = WidthConfig()
-
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-
-        alert_proto.width_config.CopyFrom(width_config)
+        alert_proto = _build_alert_proto(
+            body=body,
+            format=AlertProto.WARNING,
+            title=title,
+            icon=icon,
+            width=width,
+        )
 
         return self.dg._enqueue("alert", alert_proto)
 
@@ -224,6 +256,7 @@ class AlertMixin:
         self,
         body: SupportsStr,
         *,  # keyword-only args:
+        title: SupportsStr | None = None,
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
@@ -240,6 +273,9 @@ class AlertMixin:
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
+        title : str or None
+            An optional plain-text title to display before the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -281,23 +317,13 @@ class AlertMixin:
         >>> st.info('This is a purely informational message', icon="ℹ️")
 
         """  # noqa: RUF002
-
-        alert_proto = AlertProto()
-        processed_body, processed_icon = _process_alert_body_and_icon(body, icon)
-        alert_proto.body = processed_body
-        alert_proto.icon = processed_icon
-        alert_proto.format = AlertProto.INFO
-
-        validate_width(width)
-
-        width_config = WidthConfig()
-
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-
-        alert_proto.width_config.CopyFrom(width_config)
+        alert_proto = _build_alert_proto(
+            body=body,
+            format=AlertProto.INFO,
+            title=title,
+            icon=icon,
+            width=width,
+        )
 
         return self.dg._enqueue("alert", alert_proto)
 
@@ -306,6 +332,7 @@ class AlertMixin:
         self,
         body: SupportsStr,
         *,  # keyword-only args:
+        title: SupportsStr | None = None,
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> DeltaGenerator:
@@ -322,6 +349,9 @@ class AlertMixin:
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
+        title : str or None
+            An optional plain-text title to display before the body text.
 
         icon : str, None
             An optional emoji or icon to display next to the alert. If ``icon``
@@ -363,22 +393,13 @@ class AlertMixin:
         >>> st.success('This is a success message!', icon="✅")
 
         """
-        alert_proto = AlertProto()
-        processed_body, processed_icon = _process_alert_body_and_icon(body, icon)
-        alert_proto.body = processed_body
-        alert_proto.icon = processed_icon
-        alert_proto.format = AlertProto.SUCCESS
-
-        validate_width(width)
-
-        width_config = WidthConfig()
-
-        if isinstance(width, int):
-            width_config.pixel_width = width
-        else:
-            width_config.use_stretch = True
-
-        alert_proto.width_config.CopyFrom(width_config)
+        alert_proto = _build_alert_proto(
+            body=body,
+            format=AlertProto.SUCCESS,
+            title=title,
+            icon=icon,
+            width=width,
+        )
 
         return self.dg._enqueue("alert", alert_proto)
 

--- a/lib/tests/streamlit/elements/alert_test.py
+++ b/lib/tests/streamlit/elements/alert_test.py
@@ -51,6 +51,14 @@ class AlertAPITest(DeltaGeneratorTestCase):
             e.value
         )
 
+    @parameterized.expand([(st.error,), (st.warning,), (st.info,), (st.success,)])
+    def test_st_alert_title(self, alert_func):
+        """Test that alert functions prepend an optional title."""
+        alert_func("some alert", title="Heads up")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.alert.body == "**Heads up**\n\nsome alert"
+
 
 class StErrorAPITest(DeltaGeneratorTestCase):
     """Test ability to marshall Alert proto."""
@@ -337,3 +345,12 @@ class AlertIconExtractionTest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         assert el.alert.icon == ":material/warning:"
         assert el.alert.body == "Line 1\nLine 2"
+
+    @parameterized.expand([(st.error,), (st.warning,), (st.info,), (st.success,)])
+    def test_alert_extracts_icon_before_prepending_title(self, alert_func):
+        """Test that title formatting does not block automatic icon extraction."""
+        alert_func("🚨 Something went wrong", title="Heads up")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.alert.icon == "🚨"
+        assert el.alert.body == "**Heads up**\n\nSomething went wrong"

--- a/lib/tests/streamlit/elements/alert_test.py
+++ b/lib/tests/streamlit/elements/alert_test.py
@@ -53,11 +53,12 @@ class AlertAPITest(DeltaGeneratorTestCase):
 
     @parameterized.expand([(st.error,), (st.warning,), (st.info,), (st.success,)])
     def test_st_alert_title(self, alert_func):
-        """Test that alert functions prepend an optional title."""
+        """Test that alert functions populate an optional title."""
         alert_func("some alert", title="Heads up")
 
         el = self.get_delta_from_queue().new_element
-        assert el.alert.body == "**Heads up**\n\nsome alert"
+        assert el.alert.title == "Heads up"
+        assert el.alert.body == "some alert"
 
 
 class StErrorAPITest(DeltaGeneratorTestCase):
@@ -347,10 +348,11 @@ class AlertIconExtractionTest(DeltaGeneratorTestCase):
         assert el.alert.body == "Line 1\nLine 2"
 
     @parameterized.expand([(st.error,), (st.warning,), (st.info,), (st.success,)])
-    def test_alert_extracts_icon_before_prepending_title(self, alert_func):
-        """Test that title formatting does not block automatic icon extraction."""
+    def test_alert_extracts_icon_before_setting_title(self, alert_func):
+        """Test that title handling does not block automatic icon extraction."""
         alert_func("🚨 Something went wrong", title="Heads up")
 
         el = self.get_delta_from_queue().new_element
         assert el.alert.icon == "🚨"
-        assert el.alert.body == "**Heads up**\n\nSomething went wrong"
+        assert el.alert.title == "Heads up"
+        assert el.alert.body == "Something went wrong"

--- a/lib/tests/streamlit/proto_compatibility_test.py
+++ b/lib/tests/streamlit/proto_compatibility_test.py
@@ -252,6 +252,7 @@ def test_alert_proto_stable():
         ("format", FD.LABEL_OPTIONAL, FD.TYPE_ENUM),
         ("icon", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
         ("width_config", FD.LABEL_OPTIONAL, FD.TYPE_MESSAGE),
+        ("title", FD.LABEL_OPTIONAL, FD.TYPE_STRING),
     }
 
 

--- a/lib/tests/streamlit/typing/alert_types.py
+++ b/lib/tests/streamlit/typing/alert_types.py
@@ -1,0 +1,51 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform some "type checking testing"; mypy should flag any assignments that are
+# incorrect.
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.alert import AlertMixin
+
+    alert = AlertMixin()
+
+    assert_type(alert.error("Something went wrong"), DeltaGenerator)
+    assert_type(
+        alert.error("Something went wrong", title="Heads up", icon="🚨"),
+        DeltaGenerator,
+    )
+    assert_type(alert.error("Something went wrong", title=None), DeltaGenerator)
+    assert_type(alert.error("Something went wrong", width="stretch"), DeltaGenerator)
+    assert_type(alert.error("Something went wrong", width=320), DeltaGenerator)
+
+    assert_type(alert.warning("Pay attention"), DeltaGenerator)
+    assert_type(
+        alert.warning("Pay attention", title="Careful", icon="⚠️"),
+        DeltaGenerator,
+    )
+    assert_type(alert.warning("Pay attention", title=None), DeltaGenerator)
+
+    assert_type(alert.info("FYI"), DeltaGenerator)
+    assert_type(alert.info("FYI", title="Heads up", icon="👉🏻"), DeltaGenerator)
+    assert_type(alert.info("FYI", title=None), DeltaGenerator)
+
+    assert_type(alert.success("Done"), DeltaGenerator)
+    assert_type(alert.success("Done", title="All set", icon="✅"), DeltaGenerator)
+    assert_type(alert.success("Done", title=None), DeltaGenerator)

--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -30,6 +30,9 @@ message Alert {
   // Indicates the width setting: "stetch", "content" or a pixel value.
   streamlit.WidthConfig width_config = 4;
 
+  // Optional plain-text title displayed above the body.
+  string title = 5;
+
   // Type of Alert
   enum Format {
     // Plain, fixed width text.

--- a/proto/streamlit/proto/Alert.proto
+++ b/proto/streamlit/proto/Alert.proto
@@ -27,7 +27,7 @@ message Alert {
   Format format = 2;
   string icon = 3;
 
-  // Indicates the width setting: "stetch", "content" or a pixel value.
+  // Indicates the width setting: "stretch", "content" or a pixel value.
   streamlit.WidthConfig width_config = 4;
 
   // Optional plain-text title displayed above the body.


### PR DESCRIPTION
## Summary
- add an optional `title` parameter to `st.error`, `st.warning`, `st.info`, and `st.success`
- prepend the title consistently ahead of the markdown body while preserving existing icon extraction behavior
- add focused tests for title formatting and title + icon interactions

Closes #12417.

## Testing
- `PYTHONPATH=lib .venv/bin/pytest -c lib/pyproject.toml lib/tests/streamlit/elements/alert_test.py`
- `python3 -m py_compile lib/streamlit/elements/alert.py lib/tests/streamlit/elements/alert_test.py`
- `git diff --check`
