### PR TITLE
fix: clear stale main-script blocks at root during fragment run (#14404)

### DIFF
--- a/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts
@@ -71,6 +71,18 @@ export class ClearStaleNodeVisitor implements AppNodeVisitor<
       // Otherwise, we are currently running a fragment, and our behavior
       // depends on the fragmentId of this BlockNode.
 
+      // When at root (no fragmentIdOfBlock), clear main-script blocks from previous runs.
+      // Blocks with fragmentId are from other fragments and should be preserved when we're only
+      // running one fragment. Fixes stale widgets persisting when a spinner runs after conditional
+      // content changes (e.g. radio A->B->A). See #14404.
+      if (
+        !this.fragmentIdOfBlock &&
+        node.scriptRunId !== this.currentScriptRunId &&
+        !node.fragmentId
+      ) {
+        return undefined
+      }
+
       // The parent block was modified but this element wasn't, so it's stale.
       if (
         this.fragmentIdOfBlock &&


### PR DESCRIPTION
## Summary
Fixes #14404

When a spinner (or other fragment) runs after conditional content changes (e.g. radio A->B->A), stale widgets from the previous selection (expander, buttons) were not removed.

## Root cause
`ClearStaleNodeVisitor` did not clear blocks at root level when `fragmentIdOfBlock` was undefined during a fragment run. Blocks from the main script with old `scriptRunId` were preserved instead of being removed.

## Fix
When at root (`!fragmentIdOfBlock`) during a fragment run, clear blocks that have old `scriptRunId` and no `fragmentId` (main-script blocks). Blocks with `fragmentId` (from other fragments) are preserved since they were not re-run.

## Files changed
- `frontend/lib/src/render-tree/visitors/ClearStaleNodeVisitor.ts`

Made with [Cursor](https://cursor.com)