### PR TITLE
chore: remove an unnecessary external_test decorator

### DIFF
--- a/e2e_playwright/st_text_test.py
+++ b/e2e_playwright/st_text_test.py
@@ -43,7 +43,6 @@ def test_st_text_doesnt_apply_formatting(
     )
 
 
-@pytest.mark.external_test
 def test_help_tooltip_works(app_target: AppTarget):
     """Test that the help tooltip is displayed on hover."""
     text_with_help = app_target.get_by_test_id("stText").nth(2)


### PR DESCRIPTION
## Describe your changes

- Removes one usage of `@pytest.mark.external_test` since these behaviors are better captured by the Mega Tester app.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- N/A

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
