### PR TITLE
fix: resolve undefined tooltip for yearmonth encoding in Altair charts

### DIFF
--- a/frontend/.yarn/patches/vega-lite-npm-6.4.2-2c6c27db4d.patch
+++ b/frontend/.yarn/patches/vega-lite-npm-6.4.2-2c6c27db4d.patch
@@ -1,0 +1,24 @@
+diff --git a/build/index.js b/build/index.js
+index 2e0a4491c0c7fbfe217a15b8b5501989006b02d0..0677b82e14981293df23038229de35f2b8f07e02 100644
+--- a/build/index.js
++++ b/build/index.js
+@@ -9304,6 +9304,7 @@ function tooltipRefForEncoding(encoding, stack, config, { reactiveGeom } = {}) {
+ function addLineBreaksToTooltip(channelDef, config, expr = 'datum') {
+     if (isFieldDef(channelDef) &&
+         isDiscrete$1(channelDef.type) &&
++        !channelDef.timeUnit &&
+         !getFormatMixins(channelDef).format &&
+         !getFormatMixins(channelDef).formatType) {
+         const fieldString = `${expr}["${channelDef.field}"]`;
+diff --git a/src/compile/mark/encode/tooltip.ts b/src/compile/mark/encode/tooltip.ts
+index 8742272c42f090f7c6fcca931ac2a64fd5fa1eb4..61037102204a47df2bc3de1a433e1492de91b8b2 100644
+--- a/src/compile/mark/encode/tooltip.ts
++++ b/src/compile/mark/encode/tooltip.ts
+@@ -178,6 +178,7 @@ function addLineBreaksToTooltip(
+   if (
+     isFieldDef(channelDef) &&
+     isDiscrete(channelDef.type) &&
++    !channelDef.timeUnit &&
+     !getFormatMixins(channelDef).format &&
+     !getFormatMixins(channelDef).formatType
+   ) {

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -119,7 +119,8 @@
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",
     "vega-interpreter": "^2.2.1",
-    "vega-lite": "6.4.2",
+
+    "vega-lite": "patch:vega-lite@npm%3A6.4.2#~/.yarn/patches/vega-lite-npm-6.4.2-2c6c27db4d.patch",
     "wavesurfer.js": "^7.12.2",
     "xxhashjs": "^0.2.2"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3505,7 +3505,7 @@ __metadata:
     vega: "npm:^6.2.0"
     vega-embed: "npm:^7.1.0"
     vega-interpreter: "npm:^2.2.1"
-    vega-lite: "npm:6.4.2"
+    vega-lite: "patch:vega-lite@npm%3A6.4.2#~/.yarn/patches/vega-lite-npm-6.4.2-2c6c27db4d.patch"
     vite: "npm:^8.0.0"
     vite-plugin-dts: "npm:^4.5.4"
     vite-plugin-svgr: "npm:^4.5.0"
@@ -18606,6 +18606,27 @@ __metadata:
     vl2svg: bin/vl2svg
     vl2vg: bin/vl2vg
   checksum: 10c0/e059bbd305e7c355b323e5cc5d1f95551c443c862b88348f6a075d0d537281ac7fc9be693d53a229a70d90201ee71eedc9ce2faac220e059a3b7f987d6898c68
+  languageName: node
+  linkType: hard
+
+"vega-lite@patch:vega-lite@npm%3A6.4.2#~/.yarn/patches/vega-lite-npm-6.4.2-2c6c27db4d.patch":
+  version: 6.4.2
+  resolution: "vega-lite@patch:vega-lite@npm%3A6.4.2#~/.yarn/patches/vega-lite-npm-6.4.2-2c6c27db4d.patch::version=6.4.2&hash=b9b7e7"
+  dependencies:
+    json-stringify-pretty-compact: "npm:~4.0.0"
+    tslib: "npm:~2.8.1"
+    vega-event-selector: "npm:~4.0.0"
+    vega-expression: "npm:~6.1.0"
+    vega-util: "npm:~2.1.0"
+    yargs: "npm:~18.0.0"
+  peerDependencies:
+    vega: ^6.0.0
+  bin:
+    vl2pdf: bin/vl2pdf
+    vl2png: bin/vl2png
+    vl2svg: bin/vl2svg
+    vl2vg: bin/vl2vg
+  checksum: 10c0/dfcf4f80dba9ffcc19f2e42cc511920aca1f64006b4e96ac98193254b01a3970de1f75fd9c307b03c3114171e284df74009fdc3445bc30545dcd38293b9a4c19
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes #14361

- Patches vega-lite 6.4.2 to exclude `timeUnit` fields from the tooltip newline shortcut path in `addLineBreaksToTooltip`
- The shortcut path directly accesses `channelDef.field` (e.g. `datum["date"]`) for discrete fields, but fields with a `timeUnit` transform get renamed by vega-lite's aggregation (e.g. `yearmonth_date`), so the original field no longer exists in the aggregated data and the tooltip renders `"undefined"`
- Adding a `!channelDef.timeUnit` guard forces these fields through `textRef`, which uses `vgField()` to resolve the correct transformed field name and applies proper time formatting

### Root Cause

Introduced by [vega-lite#9678](https://github.com/vega/vega-lite/pull/9678) (tooltip newline support) in vega-lite 6.4.0. The upstream fix is pending at [vega/vega-lite#9782](https://github.com/vega/vega-lite/pull/9782). This PR applies the same one-line fix as a Yarn patch until the upstream release is available.

### Trigger conditions (all must be true)

- Field has a `timeUnit` (e.g. `yearmonth`, `month`, `year`)
- Field type is discrete (`:N` nominal or `:O` ordinal)
- No explicit `format` or `formatType` specified
- Tooltip uses `content: "encoding"` (Streamlit theme default) or mark-level `tooltip: true`

## Test plan

- [ ] Run the reproduction script from #14361 and verify tooltips show the formatted date (e.g. "February 2025") instead of "undefined"
- [ ] Verify tooltips still work correctly for non-temporal discrete fields
- [ ] Verify tooltips still work correctly for temporal fields with explicit `format`
- [ ] Verify tooltips still work correctly for continuous temporal fields (quantitative dates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)