### PR TITLE
Add block-no-verify hooks to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre_bash_redirect.py",
             "timeout": 10
           }

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -3,6 +3,10 @@
   "hooks": {
     "beforeShellExecution": [
       {
+        "type": "command",
+        "command": "npx block-no-verify@1.1.2"
+      },
+      {
         "type": "prompt",
         "prompt": "Block if the command runs pytest on e2e_playwright tests. These tests should use 'make run-e2e-test <filename>' instead.",
         "matcher": "(uv run )?(python[3]? -m )?pytest.*e2e_playwright"


### PR DESCRIPTION
## Summary

- Adds `block-no-verify@1.1.2` as a Bash `PreToolUse` hook in `.claude/settings.json` (runs before existing `pre_bash_redirect.py`)
- Adds `block-no-verify@1.1.2` as a `beforeShellExecution` command hook in `.cursor/hooks.json` (runs before existing prompt hooks)
- Prevents both Claude Code and Cursor agents from bypassing git hooks via the hook-skip flag

## Details

Streamlit already has excellent quality enforcement — pre-commit autofix, stop checks, and tests. The git hook-bypass flag is the one remaining bypass vector.

`block-no-verify` reads the command from the hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. All existing hooks are preserved unchanged.

Closes #14424

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
