### PR TITLE
[docs] Add lightweight writing-spec skill for product/tech specs

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -26,6 +26,7 @@ skills/*
 !skills/understanding-streamlit-architecture/
 !skills/creating-pull-requests/
 !skills/updating-internal-docs/
+!skills/writing-spec/
 !skills/assessing-external-test-risk/
 !skills/fixing-flaky-e2e-tests/
 !skills/implementing-feature/

--- a/.claude/skills/writing-spec/SKILL.md
+++ b/.claude/skills/writing-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-spec
-description: Write product and tech specs for new Streamlit features. Use when designing new API commands, widgets, or significant changes that need team review before implementation.
+description: Writes product and tech specs for new Streamlit features. Use when designing new API commands, widgets, or significant changes that need team review before implementation.
 ---
 
 # Writing product or tech specs

--- a/.claude/skills/writing-spec/SKILL.md
+++ b/.claude/skills/writing-spec/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: writing-spec
+description: Write product and tech specs for new Streamlit features. Use when designing new API commands, widgets, or significant changes that need team review before implementation.
+---
+
+# Writing product or tech specs
+
+Create specs in the `specs/` directory following the instructions in `specs/AGENTS.md`. Use the user's instructions as the basis for the spec.
+
+Quick start:
+
+```bash
+cp -r specs/YYYY-MM-DD-template specs/$(date +%Y-%m-%d)-feature-name
+```
+
+Then fill in `product-spec.md` and/or `tech-spec.md` per the template and guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `creating-pull-requests` | When changes are ready to be submitted as a PR with proper labels and formatting |
 | `addressing-pr-review-comments` | When a PR has reviewer feedback to address, including inline and general PR comments |
 | `updating-internal-docs` | After significant codebase changes to review and update internal documentation |
+| `writing-spec` | When designing new API commands, widgets, or significant changes that need team review before implementation |
 | `finalizing-pr` | When changes are ready to merge — runs quality checks, simplifies code, and creates/updates the PR |
 
 ### Subagents


### PR DESCRIPTION
## Describe your changes

Adds a new `writing-spec` skill to guide AI agents when creating product and tech specs:

- New skill file at `.claude/skills/writing-spec/SKILL.md`
- Skill added to `.claude/.gitignore` allowlist
- Skill documented in `CONTRIBUTING.md` overview table

## Testing Plan

Documentation-only changes, no behavior modifications.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.