### PR TITLE
Add browser.preferred config option

### DIFF
--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -57,6 +57,20 @@ def _open_browser_with_webbrowser(url: str) -> None:
     webbrowser.open(url)
 
 
+def _open_browser_with_preferred(url: str, preferred: str) -> bool:
+    """Try to open the URL in the preferred browser.
+
+    Returns True if successful, False if the browser was not found.
+    """
+    import webbrowser
+
+    try:
+        webbrowser.get(preferred).open(url)
+        return True
+    except webbrowser.Error:
+        return False
+
+
 def _open_browser_with_command(command: str, url: str) -> None:
     cmd_line = [command, url]
     with open(os.devnull, "w", encoding="utf-8") as devnull:
@@ -77,6 +91,14 @@ def open_browser(url: str) -> None:
         The URL. Must include the protocol.
 
     """
+    # If a preferred browser is configured, try that first.
+    from streamlit import config
+
+    preferred = config.get_option("browser.preferred")
+    if preferred:
+        if _open_browser_with_preferred(url, preferred):
+            return
+
     # Treat Windows separately because:
     # 1. /dev/null doesn't exist.
     # 2. subprocess.Popen(['start', url]) doesn't actually pop up the

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1133,6 +1133,23 @@ _create_option(
 )
 
 
+_create_option(
+    "browser.preferred",
+    description="""
+        Preferred browser to open when Streamlit starts. When set, Streamlit
+        passes this value to Python's ``webbrowser.get()`` to select a specific
+        browser. If the browser is not found, Streamlit falls back to the
+        system default.
+
+        Examples: "firefox", "chrome", "safari", "windows-default".
+
+        Default: "" (use system default browser)
+    """,
+    default_val="",
+    type_=str,
+)
+
+
 @_create_option("browser.serverPort", type_=int)
 def _browser_server_port() -> int:
     """Port where users should point their browsers in order to connect to the

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import patch
+import webbrowser
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -34,22 +35,54 @@ class CliUtilTest(unittest.TestCase):
         env_util.IS_DARWIN = os_type == "Darwin"
         env_util.IS_LINUX_OR_BSD = os_type == "Linux"
 
-        with patch("streamlit.env_util.is_executable_in_path", return_value=True):
-            with patch("webbrowser.open") as webbrowser_open:
-                with patch("subprocess.Popen") as subprocess_popen:
-                    open_browser("http://some-url")
-                    assert webbrowser_expect == webbrowser_open.called
-                    assert popen_expect == subprocess_popen.called
+        with patch("streamlit.config.get_option", return_value=""):
+            with patch(
+                "streamlit.env_util.is_executable_in_path", return_value=True
+            ):
+                with patch("webbrowser.open") as webbrowser_open:
+                    with patch("subprocess.Popen") as subprocess_popen:
+                        open_browser("http://some-url")
+                        assert webbrowser_expect == webbrowser_open.called
+                        assert popen_expect == subprocess_popen.called
 
     def test_open_browser_linux_no_xdg(self):
-        """Test opening the browser on Linux with no xdg installed"""
+        """Test opening the browser on Linux with no xdg installed."""
         from streamlit import env_util
 
         env_util.IS_LINUX_OR_BSD = True
 
-        with patch("streamlit.env_util.is_executable_in_path", return_value=False):
-            with patch("webbrowser.open") as webbrowser_open:
-                with patch("subprocess.Popen") as subprocess_popen:
+        with patch("streamlit.config.get_option", return_value=""):
+            with patch(
+                "streamlit.env_util.is_executable_in_path", return_value=False
+            ):
+                with patch("webbrowser.open") as webbrowser_open:
+                    with patch("subprocess.Popen") as subprocess_popen:
+                        open_browser("http://some-url")
+                        assert webbrowser_open.called
+                        assert not subprocess_popen.called
+
+    def test_open_browser_preferred(self):
+        """Test that a preferred browser is used when configured."""
+        mock_browser = MagicMock()
+        with patch("streamlit.config.get_option", return_value="firefox"):
+            with patch("webbrowser.get", return_value=mock_browser):
+                open_browser("http://some-url")
+                mock_browser.open.assert_called_once_with("http://some-url")
+
+    def test_open_browser_preferred_fallback(self):
+        """Test fallback to default when the preferred browser is not found."""
+        from streamlit import env_util
+
+        env_util.IS_WINDOWS = True
+        env_util.IS_DARWIN = False
+        env_util.IS_LINUX_OR_BSD = False
+
+        with patch(
+            "streamlit.config.get_option", return_value="nonexistent-browser"
+        ):
+            with patch(
+                "webbrowser.get", side_effect=webbrowser.Error("not found")
+            ):
+                with patch("webbrowser.open") as webbrowser_open:
                     open_browser("http://some-url")
-                    assert webbrowser_open.called
-                    assert not subprocess_popen.called
+                    webbrowser_open.assert_called_once_with("http://some-url")


### PR DESCRIPTION
Fixes #637

## Summary
Adds a `browser.preferred` config option that lets users specify which browser Streamlit opens. Uses Python's `webbrowser.get()` for cross-platform compatibility — no OS-specific special-casing.

## Changes
- `lib/streamlit/config.py` — new `browser.preferred` string config option (defaults to empty)
- `lib/streamlit/cli_util.py` — `open_browser()` checks preferred browser config, falls back to default if not set or browser not found

## Usage
```toml
[browser]
preferred = "firefox"
```

Or via env var: `STREAMLIT_BROWSER_PREFERRED=firefox`

## Design decisions
- Uses `webbrowser.get(name)` which handles platform-specific browser resolution internally
- Graceful fallback: if the preferred browser isn't found, falls back to system default
- Addresses maintainer feedback from #11965 about avoiding OS-specific code