### PR TITLE
fix: extend dropdown hover highlight to full width with scrollbar

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/Dropdown/styled-components.ts
@@ -61,10 +61,16 @@ export const ThemedStyledDropdownListItem = styled(StyledDropdownListItem, {
     height: theme.sizes.dropdownItemHeight,
     paddingTop: theme.spacing.none,
     paddingBottom: theme.spacing.none,
-    paddingLeft: theme.sizes.tagMarginInsideBorder,
-    paddingRight: getRightInset(theme),
+    paddingLeft: theme.spacing.none,
+    paddingRight: theme.spacing.none,
     background: "transparent",
     fontWeight: theme.fontWeights.normal,
+
+    // Pass insets to StyledHighlightWrapper via CSS custom properties so the
+    // highlight background extends to the full item width while keeping text
+    // properly inset from the dropdown edges.
+    "--highlight-padding-left": `calc(${theme.sizes.tagMarginInsideBorder} + ${theme.spacing.sm})`,
+    "--highlight-padding-right": `calc(${getRightInset(theme)} + ${theme.spacing.sm})`,
 
     // Override the default itemSize set on the component's JSX
     // on mobile, so we can make list items taller and scrollable

--- a/frontend/lib/src/components/shared/Highlight/styled-components.ts
+++ b/frontend/lib/src/components/shared/Highlight/styled-components.ts
@@ -30,8 +30,10 @@ export const StyledHighlightWrapper = styled.div<StyledHighlightWrapperProps>(
     flexGrow: 1,
     display: "flex",
     alignItems: "center",
-    paddingLeft: theme.spacing.sm,
-    paddingRight: theme.spacing.sm,
+    // Use CSS custom properties for padding so parents can customize the inset.
+    // Falls back to theme.spacing.sm when no custom property is set.
+    paddingLeft: `var(--highlight-padding-left, ${theme.spacing.sm})`,
+    paddingRight: `var(--highlight-padding-right, ${theme.spacing.sm})`,
     // Height matches multiselect tag height
     height: theme.sizes.elementHighlightHeight,
     borderTopLeftRadius: theme.radii.md2,

--- a/frontend/lib/src/components/widgets/TimeInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/TimeInput/styled-components.ts
@@ -27,6 +27,8 @@ export const StyledClearIconContainer = styled.div({
 export const StyledTimeDropdownListItem = styled(StyledDropdownListItem, {
   shouldForwardProp: isPropValid,
 })(({ theme }) => {
+  const rightInset = `max(0px, calc(${theme.sizes.tagMarginInsideBorder} - var(--scrollbar-gutter-size, 0px)))`
+
   return {
     position: "relative",
     display: "flex",
@@ -34,11 +36,13 @@ export const StyledTimeDropdownListItem = styled(StyledDropdownListItem, {
     padding: theme.spacing.none,
     margin: theme.spacing.none,
     height: theme.sizes.dropdownItemHeight,
-    // Inset from edges (xs - borderWidth to account for popover border)
-    marginLeft: theme.sizes.tagMarginInsideBorder,
-    // Right padding also accounts for scrollbar gutter when present
-    marginRight: `max(0px, calc(${theme.sizes.tagMarginInsideBorder} - var(--scrollbar-gutter-size, 0px)))`,
     background: "transparent",
     fontWeight: theme.fontWeights.normal,
+
+    // Pass insets to StyledHighlightWrapper via CSS custom properties so the
+    // highlight background extends to the full item width while keeping text
+    // properly inset from the dropdown edges.
+    "--highlight-padding-left": `calc(${theme.sizes.tagMarginInsideBorder} + ${theme.spacing.sm})`,
+    "--highlight-padding-right": `calc(${rightInset} + ${theme.spacing.sm})`,
   }
 })


### PR DESCRIPTION
Closes #10204

## Summary
- Fixes the visual issue where hover highlight background in `st.selectbox` (and `st.time_input`, `st.multiselect`) doesn't extend to the full width of the dropdown when a scrollbar is present
- Moves horizontal insets from list item padding/margin into the highlight wrapper's padding via CSS custom properties (`--highlight-padding-left`, `--highlight-padding-right`), so the highlight background spans the full item width while keeping text properly inset

## Affected components
- `st.selectbox`
- `st.multiselect`
- `st.time_input`
- `st.date_input` (time picker)

## How it works
Previously, `ThemedStyledDropdownListItem` used `paddingLeft`/`paddingRight` to inset content from the dropdown edges. The `StyledHighlightWrapper` (child) filled the remaining content area via `flexGrow: 1`, so its background stopped at the padding boundary — creating a visible gap between the highlight and the scrollbar.

Now, the list item has zero horizontal padding and instead passes the desired insets to `StyledHighlightWrapper` via CSS custom properties. The wrapper reads these with `var(--highlight-padding-left, ...)` fallbacks, so its background extends to the full item width while text remains properly inset.

The same pattern is applied to `StyledTimeDropdownListItem` (used by `st.time_input` and `st.date_input`), which previously used margins (producing a similar gap).

Other consumers of `StyledHighlightWrapper` (e.g., `MenuButton`) are unaffected — they don't set the custom properties, so the wrapper falls back to `theme.spacing.sm`.

## Test plan
- Verified dropdown hover extends full width with scrollbar present
- Tested in both light and dark modes
- Verified separator lines (select all / creatable) remain correctly inset
- Verified MenuButton dropdowns are unaffected