### PR TITLE
[chore] Remove cursorpyright extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,7 +10,6 @@
     "EditorConfig.EditorConfig",
     "vitest.explorer",
     "tamasfe.even-better-toml",
-    "anysphere.cursorpyright",
     "astral-sh.ty"
   ]
 }


### PR DESCRIPTION
## Describe your changes

Removes `anysphere.cursorpyright` from the recommended VS Code extensions list. This extension is Cursor-specific and not needed for VS Code users.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Manual verification - JSON file is valid

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->