### PR TITLE
[chore] Rename opus-4.6-thinking to claude-4.6-opus-high-thinking

### DIFF
--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
         description: "Model to use for flaky test fixing"
         required: false
         type: string
-        default: "opus-4.6-thinking"
+        default: "claude-4.6-opus-high-thinking"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'opus-4.6-thinking' }}
+  MODEL: ${{ inputs.model || 'claude-4.6-opus-high-thinking' }}
   TOP_N: ${{ inputs.top_n || 10 }}
   DAYS: ${{ inputs.days || 4 }}
 

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -153,14 +153,14 @@ jobs:
           [List of up to 3 related issues with links and brief explanations. If no related issues found, state that.]
 
           ---
-          *This is an automated triage comment using \`${{ env.MODEL }}\`. Please verify the suggested labels and related issues.*
+          *This is an automated triage comment using \`$MODEL\`. Please verify the suggested labels and related issues.*
           <output-end>
 
           # Important Notes:
           - Do NOT attempt to post comments, edit issues, or perform any write operations - they will fail.
           - Do NOT run test, lint, or build commands (the dev environment is not setup!).
           - Focus on analysis and generating the output files.
-          " --force --model "${{ env.MODEL }}" --output-format=text
+          " --force --model "$MODEL" --output-format=text
 
       - name: Upload triage artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -14,12 +14,12 @@ on:
         description: "Model to use for the triage"
         required: false
         type: string
-        default: "opus-4.6-thinking"
+        default: "claude-4.6-opus-high-thinking"
 
 # Computed issue number and model for use in jobs
 env:
   ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-  MODEL: ${{ github.event.inputs.model || 'opus-4.6-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'claude-4.6-opus-high-thinking' }}
 
 jobs:
   # Job 1: AI performs the triage analysis with READ-ONLY access

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
         required: false
         type: string
-        default: "gpt-5.3-codex-high,gemini-3.1-pro,opus-4.6-thinking"
+        default: "gpt-5.3-codex-high,gemini-3.1-pro,claude-4.6-opus-high-thinking"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,gemini-3.1-pro,opus-4.6-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,gemini-3.1-pro,claude-4.6-opus-high-thinking' }}
 
 jobs:
   # Job 1: Parse model list and check for API key
@@ -51,7 +51,7 @@ jobs:
           # Guard against empty/whitespace model input
           if [ -z "${MODEL// /}" ]; then
             echo "::error::MODEL is empty or whitespace-only. Using default."
-            MODEL="opus-4.6-thinking"
+            MODEL="claude-4.6-opus-high-thinking"
           fi
 
           # Split comma-separated, trim whitespace, convert to JSON array
@@ -62,7 +62,7 @@ jobs:
           MODEL_COUNT=$(echo "$MODELS_JSON" | jq 'length')
           if [ "$MODEL_COUNT" -eq 0 ]; then
             echo "::error::No valid models found after parsing. Using default."
-            MODELS_JSON='["opus-4.6-thinking"]'
+            MODELS_JSON='["claude-4.6-opus-high-thinking"]'
             MODEL_COUNT=1
           fi
 

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -361,7 +361,7 @@ jobs:
         run: |
           {
             echo "## AI Documentation Update Summary";
-            echo "- Model: ${{ env.MODEL }}";
+            echo "- Model: $MODEL";
             if [ -n "${SOURCE_PR_NUMBER}" ]; then
               echo "- Source PR: #${SOURCE_PR_NUMBER}";
             fi
@@ -387,7 +387,7 @@ jobs:
         run: |
           {
             echo "## AI Documentation Update Summary";
-            echo "- Model: ${{ env.MODEL }}";
+            echo "- Model: $MODEL";
             echo "- Source PR: #${SOURCE_PR_NUMBER}";
             echo "";
             echo "**Skipped:** PR-scoped documentation updates are not supported for fork PRs.";

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -15,7 +15,7 @@ on:
         description: "Model to use for documentation review"
         required: false
         type: string
-        default: "opus-4.6-thinking"
+        default: "claude-4.6-opus-high-thinking"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -23,7 +23,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'opus-4.6-thinking' }}
+  MODEL: ${{ inputs.model || 'claude-4.6-opus-high-thinking' }}
   PR_NUMBER: ${{ inputs.pr_number || '' }}
 
 jobs:


### PR DESCRIPTION
## Describe your changes

Renames the AI model identifier `opus-4.6-thinking` to `claude-4.6-opus-high-thinking` in all AI-assisted CI workflows:

- `.github/workflows/ai-issue-triage.yml`
- `.github/workflows/ai-pr-review.yml`
- `.github/workflows/ai-update-docs.yml`
- `.github/workflows/ai-fix-flaky-e2e-tests.yml`

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [ ] No tests needed (CI workflow configuration change only)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->