### PR TITLE
Add OIDC refresh token functionality without redirects

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3390,6 +3390,95 @@ describe("App", () => {
         url: "https://example.com",
       })
     })
+
+    it("performs background token refresh when isBackgroundRefresh is true", async () => {
+      const mockFetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ success: true })))
+
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+
+      sendForwardMessage("authRedirect", {
+        url: "/auth/refresh",
+        isBackgroundRefresh: true,
+      })
+
+      // fetch should be called with the URL as-is
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/auth/refresh",
+          { credentials: "same-origin" }
+        )
+      })
+
+      // Anti-regression: WebSocket should NOT be disconnected or reconnected.
+      // The server already updated the session in-place; the fetch only
+      // updates cookies for future reconnections.
+      expect(connectionManager.disconnect).not.toHaveBeenCalled()
+
+      // Anti-regression: window.location.href should NOT have been set
+      // (background refresh must not redirect the page)
+      expect(window.location.href).not.toBe("/auth/refresh")
+
+      mockFetch.mockRestore()
+    })
+
+    it("does not reconnect WebSocket when background fetch fails", async () => {
+      const mockFetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response("", { status: 500, statusText: "Internal Server Error" })
+        )
+
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+
+      sendForwardMessage("authRedirect", {
+        url: "/auth/refresh",
+        isBackgroundRefresh: true,
+      })
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+      })
+
+      // Anti-regression: WebSocket should NOT be disconnected on failure
+      expect(connectionManager.disconnect).not.toHaveBeenCalled()
+
+      mockFetch.mockRestore()
+    })
+
+    it("does not redirect when isBackgroundRefresh is true", async () => {
+      const mockFetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ success: true })))
+
+      renderApp(getProps())
+
+      // NOTE: The mocking must be done after mounting, but before `handleMessage` is called.
+      // @ts-expect-error
+      delete window.location
+      // @ts-expect-error
+      window.location = { href: "http://localhost:8501" }
+
+      sendForwardMessage("authRedirect", {
+        url: "/auth/refresh",
+        isBackgroundRefresh: true,
+      })
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+      })
+
+      // Anti-regression: must NOT set window.location.href for background requests
+      expect(window.location.href).toBe("http://localhost:8501")
+
+      mockFetch.mockRestore()
+    })
+
   })
 
   describe("Logo handling", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -976,7 +976,9 @@ export class App extends PureComponent<Props, State> {
         navigation: (navigation: Navigation) =>
           this.handleNavigation(navigation),
         authRedirect: (authRedirect: AuthRedirect) => {
-          if (isInChildFrame()) {
+          if (authRedirect.isBackgroundRefresh) {
+            this.handleBackgroundTokenRefresh(authRedirect.url)
+          } else if (isInChildFrame()) {
             this.hostCommunicationMgr.sendMessageToSameOriginHost({
               type: "REDIRECT_TO_URL",
               url: authRedirect.url,
@@ -991,6 +993,25 @@ export class App extends PureComponent<Props, State> {
       LOG.error(err)
       this.showError("Bad message format", { message: err.message })
     }
+  }
+
+  /**
+   * Handle a background token refresh by fetching the refresh URL
+   * without a full browser redirect. The server-side has already
+   * updated the session's user_info in-place, so this fetch only
+   * updates the browser cookies for future page loads/reconnections.
+   * No WebSocket reconnect or script rerun is triggered.
+   */
+  handleBackgroundTokenRefresh = (url: string): void => {
+    fetch(url, { credentials: "same-origin" })
+      .then(response => {
+        if (!response.ok) {
+          LOG.error(`Background token refresh failed: ${response.status}`)
+        }
+      })
+      .catch((err: unknown) => {
+        LOG.error(`Background token refresh error: ${String(err)}`)
+      })
   }
 
   handleLogo = (logo: Logo, metadata: ForwardMsgMetadata): void => {

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -50,6 +50,7 @@ _LOGGER: Final = logger.get_logger(__name__)
 
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
 AUTH_LOGOUT_ENDPOINT: Final = "/auth/logout"
+AUTH_REFRESH_ENDPOINT: Final = "/auth/refresh"
 
 
 @gather_metrics("login")
@@ -701,6 +702,51 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
         """Access exposed tokens via a dict-like object."""
         user_info = _get_user_info()
         return TokensProxy(cast("dict[str, str]", user_info.get("tokens", {})))
+
+    def refresh(self) -> None:
+        """Refresh the current user's access token and user information.
+
+        This method attempts to refresh the user's OAuth access token and update
+        the user information stored in ``st.user``. It uses the refresh token
+        (if available) to obtain a new access token and updated user information
+        from the OAuth provider, then updates the authentication cookies.
+
+        This is meant to be used in the background, like when starting a new session.
+        For that reason, if no refresh token is available or the refresh fails,
+        nothing happens.
+
+        Examples
+        --------
+        **Example: Refresh on each session**
+
+        Refresh the current user's tokens and update user information:
+
+        >>> import streamlit as st
+        >>>
+        >>> if st.user.is_logged_in and not st.session_state.get("fresh_user"):
+        >>>     st.session_state["fresh_user"] = True
+        >>>     st.user.refresh()
+
+        .. Note::
+            - This command requires that the user is already logged in via ``st.login()``.
+            - The OAuth provider must support refresh tokens for this to work properly.
+            - Some providers may not return updated user information on token refresh.
+            - This command will update all tokens, including access tokens and refresh tokens.
+        """
+        context = _get_script_run_ctx()
+        if context is not None:
+            context.user_info.clear()
+            session_id = context.session_id
+
+            if runtime.exists():
+                instance = runtime.get_instance()
+                instance.clear_user_info_for_session(session_id)
+
+            base_path = config.get_option("server.baseUrlPath")
+
+            fwd_msg = ForwardMsg()
+            fwd_msg.auth_redirect.url = make_url_path(base_path, AUTH_REFRESH_ENDPOINT)
+            context.enqueue(fwd_msg)
 
 
 has_shown_experimental_user_warning = False

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -26,6 +26,8 @@ from typing import (
 from streamlit import config, logger, runtime
 from streamlit.auth_util import (
     encode_provider_token,
+    get_expose_tokens_config,
+    get_origin_from_redirect_uri,
     get_secrets_auth_section,
     is_authlib_installed,
     validate_auth_credentials,
@@ -386,7 +388,11 @@ def _get_user_info() -> UserInfoType:
         )
         return {}
 
-    context_user_info = ctx.user_info.copy()
+    # Filter out internal keys (prefixed with "_") so they are never
+    # exposed through st.user / to_dict / iteration.
+    context_user_info: UserInfoType = {
+        k: v for k, v in ctx.user_info.items() if not k.startswith("_")
+    }
 
     auth_section_exists = get_secrets_auth_section()
     if "is_logged_in" not in context_user_info and auth_section_exists:
@@ -711,6 +717,11 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
         (if available) to obtain a new access token and updated user information
         from the OAuth provider, then updates the authentication cookies.
 
+        The token refresh is performed server-side without any browser redirect
+        or page reload. The session's ``user_info`` is updated in-place, and a
+        background request is sent to update the browser cookies so that future
+        page loads or reconnections use the refreshed tokens.
+
         This is meant to be used in the background, like when starting a new session.
         For that reason, if no refresh token is available or the refresh fails,
         nothing happens.
@@ -734,19 +745,89 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
             - This command will update all tokens, including access tokens and refresh tokens.
         """
         context = _get_script_run_ctx()
-        if context is not None:
-            context.user_info.clear()
-            session_id = context.session_id
+        if context is None:
+            return
 
-            if runtime.exists():
-                instance = runtime.get_instance()
-                instance.clear_user_info_for_session(session_id)
+        refresh_token = context.user_info.get("_refresh_token")
+        if not isinstance(refresh_token, str) or not refresh_token:
+            _LOGGER.info("No refresh token available for refresh")
+            return
 
-            base_path = config.get_option("server.baseUrlPath")
+        # Lazy import to avoid circular dependency at module level.
+        from streamlit.web.server.oauth_authlib_routes import refresh_oauth_tokens
 
-            fwd_msg = ForwardMsg()
-            fwd_msg.auth_redirect.url = make_url_path(base_path, AUTH_REFRESH_ENDPOINT)
-            context.enqueue(fwd_msg)
+        result = refresh_oauth_tokens(context.user_info, refresh_token)
+        if result is None:
+            _LOGGER.info("Token refresh returned no result")
+            return
+
+        updated_user_info, updated_tokens = result
+
+        # Update user_info in-place so the current and future script runs
+        # see the refreshed data without a WebSocket reconnect.
+        context.user_info.update(updated_user_info)
+
+        # Update the stored refresh token if the provider returned a new one.
+        new_refresh_token = updated_tokens.get("refresh_token")
+        if new_refresh_token:
+            context.user_info["_refresh_token"] = new_refresh_token
+
+        # Re-apply the expose_tokens filter for the public "tokens" dict.
+        expose_tokens = get_expose_tokens_config()
+        filtered_tokens: dict[str, str] = {}
+        for token_type in expose_tokens:
+            token_key = f"{token_type}_token"
+            if token_key in updated_tokens:
+                filtered_tokens[token_type] = updated_tokens[token_key]
+        context.user_info["tokens"] = filtered_tokens
+
+        # Store the refreshed data in the auth cache under a one-time UUID
+        # so the background fetch endpoint can set cookies without doing
+        # another provider round-trip.  The UUID is consumed on first use.
+        import uuid as _uuid
+
+        from streamlit.web.server.oauth_authlib_routes import auth_cache
+
+        # Build the cookie-ready user_info dict.  The cookie must include
+        # ``origin``, ``is_logged_in`` and ``provider`` – exactly like the
+        # initial OAuth callback does – otherwise the origin validation in
+        # ``_parse_user_cookie()`` will fail on the next page reload and the
+        # user will appear logged-out.
+        cookie_user_info = dict(updated_user_info)
+
+        # ``origin`` is not part of the in-memory user_info (it is removed
+        # by ``_parse_user_cookie`` after validation), so we re-derive it
+        # from the ``redirect_uri`` in secrets – the same source the OAuth
+        # callback handler uses.
+        if "origin" not in cookie_user_info:
+            origin = get_origin_from_redirect_uri()
+            if origin:
+                cookie_user_info["origin"] = origin
+
+        cookie_user_info.setdefault("provider", context.user_info.get("provider"))
+
+        # Remove internal keys that must not be persisted in the cookie.
+        cookie_user_info.pop("_refresh_token", None)
+        cookie_user_info.pop("tokens", None)
+
+        token_id = str(_uuid.uuid4())
+        auth_cache.set(
+            f"_refresh_{token_id}",
+            {
+                "user_info": cookie_user_info,
+                "tokens": updated_tokens,
+            },
+        )
+
+        # Tell the frontend to update the browser cookies via a background
+        # fetch to /auth/refresh.  The frontend will NOT reconnect the
+        # WebSocket or trigger a script rerun.
+        base_path = config.get_option("server.baseUrlPath")
+        refresh_path = make_url_path(base_path, AUTH_REFRESH_ENDPOINT)
+        fwd_msg = ForwardMsg()
+        fwd_msg.auth_redirect.url = f"{refresh_path}?token_id={token_id}"
+        fwd_msg.auth_redirect.is_background_refresh = True
+        context.enqueue(fwd_msg)
 
 
 has_shown_experimental_user_warning = False

--- a/lib/streamlit/web/server/browser_websocket_handler.py
+++ b/lib/streamlit/web/server/browser_websocket_handler.py
@@ -234,6 +234,11 @@ class BrowserWebSocketHandler(WebSocketHandler, SessionClient):
                     if raw_token_cookie_value:
                         all_tokens = json.loads(raw_token_cookie_value)
 
+                        # Store only the refresh token for server-side refresh
+                        # (not exposed to user scripts via _get_user_info)
+                        if "refresh_token" in all_tokens:
+                            user_info["_refresh_token"] = all_tokens["refresh_token"]
+
                         # Filter tokens based on expose_tokens configuration
                         filtered_tokens: dict[str, str] = {}
                         for token_type in self.expose_tokens:

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -17,9 +17,7 @@ import json
 from typing import Any, Final, cast
 from urllib.parse import urlencode, urlparse
 
-import requests
 import tornado.web
-from authlib import jose
 
 from streamlit.auth_util import (
     AuthCache,
@@ -293,7 +291,11 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         user = cast("dict[str, Any]", token.get("userinfo"))
 
         cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
-        tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
+        tokens = {
+            k: token[k]
+            for k in ["id_token", "access_token", "refresh_token"]
+            if k in token
+        }
 
         if user:
             self.set_auth_cookie(cookie_value, tokens)
@@ -344,105 +346,178 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
         return origin_from_redirect_uri
 
 
-class AuthRefreshHandler(AuthHandlerMixin, tornado.web.RequestHandler):
-    def get_new_tokens(
-        self, client: TornadoOAuth2App, refresh_token: str
-    ) -> dict[str, Any] | None:
-        try:
-            metadata = client.load_server_metadata()
-            token_endpoint = metadata.get("token_endpoint")
-            if not token_endpoint:
-                _LOGGER.error("No token endpoint available for refresh")
-                return None
+def _get_new_tokens(
+    client: TornadoOAuth2App, refresh_token: str
+) -> dict[str, Any] | None:
+    """Exchange a refresh token for new tokens at the OIDC provider's token endpoint.
 
-            refresh_data = {
-                "grant_type": "refresh_token",
-                "refresh_token": refresh_token,
-                "client_id": client.client_id,
-                "client_secret": client.client_secret,
-            }
+    Uses the Authlib client's own session so that SSL/TLS settings
+    (e.g. custom CA bundles via ``client_kwargs``) are inherited
+    automatically -- the same configuration that ``st.login`` uses.
 
-            response = requests.post(
+    Parameters
+    ----------
+    client
+        The OAuth client for the provider.
+    refresh_token
+        The refresh token to exchange.
+
+    Returns
+    -------
+    dict or None
+        A dict of new token fields (keys ending in ``_token``), or ``None`` on failure.
+    """
+    try:
+        metadata = client.load_server_metadata()
+        token_endpoint = metadata.get("token_endpoint")
+        if not token_endpoint:
+            _LOGGER.error("No token endpoint available for refresh")
+            return None
+
+        refresh_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client.client_id,
+            "client_secret": client.client_secret,
+        }
+
+        with client.client_cls(**client.client_kwargs) as session:
+            response = session.request(
+                "POST",
                 token_endpoint,
                 data=refresh_data,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 timeout=10,
+                withhold_token=True,
             )
 
-            if response.status_code != 200:
-                _LOGGER.error(
-                    "Token refresh failed with status %i", response.status_code
-                )
-                return None
-
-            new_tokens = response.json()
-            new_tokens = {k: v for k, v in new_tokens.items() if k.endswith("_token")}
-            return new_tokens
-        except Exception:
-            _LOGGER.exception("Token refresh failed")
+        if response.status_code != 200:
+            _LOGGER.error("Token refresh failed with status %i", response.status_code)
             return None
 
-    def decode_id_token(
-        self, client: TornadoOAuth2App, id_token: str
-    ) -> dict[str, Any]:
-        jwks_uri = client.server_metadata.get("jwks_uri")
-        jwks = requests.get(jwks_uri, timeout=10).json()
-        return jose.jwt.decode(id_token, key=jwks)
+        new_tokens = response.json()
+        new_tokens = {k: v for k, v in new_tokens.items() if k.endswith("_token")}
+        return new_tokens
+    except Exception:
+        _LOGGER.exception("Token refresh failed")
+        return None
 
+
+def _decode_id_token(
+    client: TornadoOAuth2App,
+    id_token: str,
+    access_token: str,
+) -> dict[str, Any]:
+    """Decode and validate an OIDC ID token using Authlib's ``parse_id_token``.
+
+    This mirrors the login flow in ``oidc_mixin.py`` -- the same JWKS caching,
+    key-by-kid lookup, and claims validation (issuer, audience, expiry) apply.
+    Since a refresh-token grant does not involve a nonce, nonce validation is
+    explicitly skipped.
+
+    Parameters
+    ----------
+    client
+        The OAuth client for the provider (must have ``server_metadata`` loaded).
+    id_token
+        The raw JWT ID token string.
+    access_token
+        The access token from the same token response.  Authlib uses it to
+        validate the ``at_hash`` claim via ``CodeIDToken``.
+
+    Returns
+    -------
+    dict
+        The decoded and validated token claims.
+    """
+    token: dict[str, Any] = {"id_token": id_token, "access_token": access_token}
+
+    # Skip nonce validation: refresh grants do not carry a nonce.
+    claims_options = {"nonce": {"essential": False}}
+
+    userinfo = client.parse_id_token(token, nonce=None, claims_options=claims_options)
+    return dict(userinfo)
+
+
+def refresh_oauth_tokens(
+    current_user_info: dict[str, Any],
+    refresh_token: str,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Refresh OAuth tokens server-side using the stored refresh token.
+
+    This performs a standard OAuth2 ``refresh_token`` grant against the OIDC
+    provider's token endpoint. If the provider returns a new ``id_token``, the
+    user info is also updated with the decoded claims.
+
+    Parameters
+    ----------
+    current_user_info
+        The current user info dict (must contain ``"provider"``).
+    refresh_token
+        The refresh token string to use for the token refresh.
+
+    Returns
+    -------
+    tuple of (updated_user_info, updated_tokens), or None on failure.
+    """
+    provider = current_user_info.get("provider")
+    if provider is None:
+        _LOGGER.error("Missing or invalid provider for token refresh")
+        return None
+
+    client, _ = create_oauth_client(provider)
+
+    new_tokens = _get_new_tokens(client, refresh_token)
+    if not new_tokens:
+        _LOGGER.info("Refreshing tokens failed")
+        return None
+
+    updated_tokens = dict(new_tokens)
+    updated_user_info = current_user_info.copy()
+
+    if "id_token" in new_tokens:
+        try:
+            new_userinfo = _decode_id_token(
+                client,
+                new_tokens["id_token"],
+                access_token=new_tokens["access_token"],
+            )
+            updated_user_info.update(new_userinfo)
+        except Exception:
+            _LOGGER.exception("Failed to decode id token")
+    else:
+        _LOGGER.info("No id token in new tokens")
+
+    _LOGGER.info("Successfully refreshed user tokens")
+    return updated_user_info, updated_tokens
+
+
+class AuthRefreshHandler(AuthHandlerMixin, tornado.web.RequestHandler):
     def get(self) -> None:
-        """Handle token refresh requests."""
-        try:
-            user_cookie_value = self.get_signed_cookie(AUTH_COOKIE_NAME)
-            tokens_cookie_value = self.get_signed_cookie(TOKENS_COOKIE_NAME)
-        except AttributeError:  # Backward compatibility with Tornado < 6.3.0
-            user_cookie_value = self.get_secure_cookie(AUTH_COOKIE_NAME)
-            tokens_cookie_value = self.get_secure_cookie(TOKENS_COOKIE_NAME)
+        """Handle token refresh requests.
 
-        if not user_cookie_value or not tokens_cookie_value:
-            _LOGGER.error("Missing authentication cookies for token refresh")
+        Expects ``?token_id=<uuid>``.  Retrieves pre-refreshed tokens from the
+        in-memory auth cache and writes them into cookies.  No provider
+        round-trip is performed here – the actual refresh happens server-side
+        inside ``st.user.refresh()`` before this endpoint is hit.
+        """
+        token_id = self.get_argument("token_id", None)
+
+        if not token_id:
+            _LOGGER.warning("Refresh endpoint called without token_id")
             self.redirect_to_base()
             return
 
-        try:
-            current_user_info = json.loads(user_cookie_value)
-            current_tokens = json.loads(tokens_cookie_value)
-        except json.JSONDecodeError:
-            _LOGGER.exception("Invalid authentication cookies for token refresh")
-            self.redirect_to_base()
+        cache_key = f"_refresh_{token_id}"
+        cached = auth_cache.get(cache_key)
+        auth_cache.delete(cache_key)  # One-time use.
+
+        if cached is None:
+            _LOGGER.error("Token ID %s not found in cache", token_id)
+            self.set_header("Content-Type", "application/json")
+            self.write(json.dumps({"success": False}))
             return
 
-        provider = current_user_info.get("provider")
-        if provider is None:
-            _LOGGER.error("Missing or invalid provider for token refresh")
-            self.redirect_to_base()
-            return
-        client, _ = create_oauth_client(provider)
-
-        refresh_token = current_tokens.get("refresh_token")
-        if not refresh_token:
-            _LOGGER.info("No refresh token found")
-            self.redirect_to_base()
-            return
-
-        new_tokens = self.get_new_tokens(client, refresh_token)
-        if not new_tokens:
-            _LOGGER.info("Refreshing tokens failed")
-            self.redirect_to_base()
-            return
-
-        updated_tokens = {**current_tokens, **new_tokens}
-        updated_user_info = current_user_info.copy()
-
-        if "id_token" in new_tokens:
-            try:
-                new_userinfo = self.decode_id_token(client, new_tokens["id_token"])
-                updated_user_info.update(new_userinfo)
-            except Exception:
-                _LOGGER.exception("Failed to decode id token")
-        else:
-            _LOGGER.info("No id token in new tokens")
-
-        self.set_auth_cookie(updated_user_info, updated_tokens)
-        _LOGGER.info("Successfully refreshed user tokens")
-
-        self.redirect_to_base()
+        self.set_auth_cookie(cached["user_info"], cached["tokens"])
+        self.set_header("Content-Type", "application/json")
+        self.write(json.dumps({"success": True}))

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -17,7 +17,9 @@ import json
 from typing import Any, Final, cast
 from urllib.parse import urlencode, urlparse
 
+import requests
 import tornado.web
+from authlib import jose
 
 from streamlit.auth_util import (
     AuthCache,
@@ -340,3 +342,107 @@ class AuthCallbackHandler(AuthHandlerMixin, tornado.web.RequestHandler):
             redirect_uri_parsed.scheme + "://" + redirect_uri_parsed.netloc
         )
         return origin_from_redirect_uri
+
+
+class AuthRefreshHandler(AuthHandlerMixin, tornado.web.RequestHandler):
+    def get_new_tokens(
+        self, client: TornadoOAuth2App, refresh_token: str
+    ) -> dict[str, Any] | None:
+        try:
+            metadata = client.load_server_metadata()
+            token_endpoint = metadata.get("token_endpoint")
+            if not token_endpoint:
+                _LOGGER.error("No token endpoint available for refresh")
+                return None
+
+            refresh_data = {
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client.client_id,
+                "client_secret": client.client_secret,
+            }
+
+            response = requests.post(
+                token_endpoint,
+                data=refresh_data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=10,
+            )
+
+            if response.status_code != 200:
+                _LOGGER.error(
+                    "Token refresh failed with status %i", response.status_code
+                )
+                return None
+
+            new_tokens = response.json()
+            new_tokens = {k: v for k, v in new_tokens.items() if k.endswith("_token")}
+            return new_tokens
+        except Exception:
+            _LOGGER.exception("Token refresh failed")
+            return None
+
+    def decode_id_token(
+        self, client: TornadoOAuth2App, id_token: str
+    ) -> dict[str, Any]:
+        jwks_uri = client.server_metadata.get("jwks_uri")
+        jwks = requests.get(jwks_uri, timeout=10).json()
+        return jose.jwt.decode(id_token, key=jwks)
+
+    def get(self) -> None:
+        """Handle token refresh requests."""
+        try:
+            user_cookie_value = self.get_signed_cookie(AUTH_COOKIE_NAME)
+            tokens_cookie_value = self.get_signed_cookie(TOKENS_COOKIE_NAME)
+        except AttributeError:  # Backward compatibility with Tornado < 6.3.0
+            user_cookie_value = self.get_secure_cookie(AUTH_COOKIE_NAME)
+            tokens_cookie_value = self.get_secure_cookie(TOKENS_COOKIE_NAME)
+
+        if not user_cookie_value or not tokens_cookie_value:
+            _LOGGER.error("Missing authentication cookies for token refresh")
+            self.redirect_to_base()
+            return
+
+        try:
+            current_user_info = json.loads(user_cookie_value)
+            current_tokens = json.loads(tokens_cookie_value)
+        except json.JSONDecodeError:
+            _LOGGER.exception("Invalid authentication cookies for token refresh")
+            self.redirect_to_base()
+            return
+
+        provider = current_user_info.get("provider")
+        if provider is None:
+            _LOGGER.error("Missing or invalid provider for token refresh")
+            self.redirect_to_base()
+            return
+        client, _ = create_oauth_client(provider)
+
+        refresh_token = current_tokens.get("refresh_token")
+        if not refresh_token:
+            _LOGGER.info("No refresh token found")
+            self.redirect_to_base()
+            return
+
+        new_tokens = self.get_new_tokens(client, refresh_token)
+        if not new_tokens:
+            _LOGGER.info("Refreshing tokens failed")
+            self.redirect_to_base()
+            return
+
+        updated_tokens = {**current_tokens, **new_tokens}
+        updated_user_info = current_user_info.copy()
+
+        if "id_token" in new_tokens:
+            try:
+                new_userinfo = self.decode_id_token(client, new_tokens["id_token"])
+                updated_user_info.update(new_userinfo)
+            except Exception:
+                _LOGGER.exception("Failed to decode id token")
+        else:
+            _LOGGER.info("No id token in new tokens")
+
+        self.set_auth_cookie(updated_user_info, updated_tokens)
+        _LOGGER.info("Successfully refreshed user tokens")
+
+        self.redirect_to_base()

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -155,6 +155,7 @@ SCRIPT_HEALTH_CHECK_ENDPOINT: Final = (
 OAUTH2_CALLBACK_ENDPOINT: Final = "/oauth2callback"
 AUTH_LOGIN_ENDPOINT: Final = "/auth/login"
 AUTH_LOGOUT_ENDPOINT: Final = "/auth/logout"
+AUTH_REFRESH_ENDPOINT: Final = "/auth/refresh"
 
 
 class RetriesExceededError(Exception):
@@ -446,6 +447,7 @@ class Server:
                 AuthCallbackHandler,
                 AuthLoginHandler,
                 AuthLogoutHandler,
+                AuthRefreshHandler,
             )
 
             routes.extend(
@@ -463,6 +465,11 @@ class Server:
                     (
                         make_url_path_regex(base, AUTH_LOGOUT_ENDPOINT),
                         AuthLogoutHandler,
+                        {"base_url": base},
+                    ),
+                    (
+                        make_url_path_regex(base, AUTH_REFRESH_ENDPOINT),
+                        AuthRefreshHandler,
                         {"base_url": base},
                     ),
                 ]

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -471,8 +471,10 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
 
     response = await _redirect_to_base(base_url)
 
-    cookie_value = dict(user, origin=origin, is_logged_in=True)
-    tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
+    cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
+    tokens = {
+        k: token[k] for k in ["id_token", "access_token", "refresh_token"] if k in token
+    }
     if user:
         await _set_auth_cookie(response, cookie_value, tokens)
     else:  # pragma: no cover - error path

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -435,6 +435,13 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                             if raw_token_cookie:
                                 all_tokens = json.loads(raw_token_cookie)
 
+                                # Store only the refresh token for server-side refresh
+                                # (not exposed to user scripts via _get_user_info)
+                                if "refresh_token" in all_tokens:
+                                    user_info["_refresh_token"] = all_tokens[
+                                        "refresh_token"
+                                    ]
+
                                 filtered_tokens: dict[str, str] = {}
                                 for token_type in expose_tokens:
                                     token_key = f"{token_type}_token"

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -330,16 +330,19 @@ class UserInfoTokensTest(DeltaGeneratorTestCase):
 
     @contextmanager
     def _with_user_context(self, user_info):
-        """Helper to set up user context for testing."""
+        """Helper to set up user context for testing.
+
+        Uses ``self.forward_msg_queue`` so that messages enqueued during the
+        test are retrievable via ``self.get_message_from_queue()``.
+        """
         orig_report_ctx = get_script_run_ctx()
-        forward_msg_queue = ForwardMsgQueue()
 
         try:
             add_script_run_ctx(
                 threading.current_thread(),
                 ScriptRunContext(
                     session_id="test session id",
-                    _enqueue=forward_msg_queue.enqueue,
+                    _enqueue=self.forward_msg_queue.enqueue,
                     query_string="",
                     session_state=SafeSessionState(SessionState(), lambda: None),
                     uploaded_file_mgr=None,
@@ -400,10 +403,153 @@ class UserInfoTokensTest(DeltaGeneratorTestCase):
             assert isinstance(tokens_key, TokensProxy)
             assert tokens_prop.id == tokens_key.id
 
-    def test_user_refresh_method(self):
-        """Test that st.user.refresh() sends correct proto message."""
-        st.user.refresh()
+    def test_refresh_token_not_exposed(self):
+        """Test that internal _refresh_token is not exposed through st.user."""
+        user_info = {
+            "email": "test@example.com",
+            "_refresh_token": "secret",
+            "tokens": {"id": "visible"},
+        }
 
-        c = self.get_message_from_queue().auth_redirect
+        with self._with_user_context(user_info):
+            # _refresh_token must not appear in iteration, to_dict, or key access.
+            assert "_refresh_token" not in dict(st.user)
+            assert "_refresh_token" not in st.user.to_dict()
+            with pytest.raises(KeyError):
+                st.user["_refresh_token"]
 
-        assert c.url.startswith("/auth/refresh")
+    @patch(
+        "streamlit.user_info.get_expose_tokens_config", return_value=["id", "access"]
+    )
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.refresh_oauth_tokens",
+    )
+    def test_user_refresh_method(self, mock_refresh, mock_expose_tokens):
+        """Test that st.user.refresh() updates user_info in-place and sends cookie update."""
+        user_info = {
+            "email": "old@example.com",
+            "provider": "google",
+            "_refresh_token": "old_refresh",
+            "tokens": {"id": "old_id", "access": "old_access"},
+        }
+
+        mock_refresh.return_value = (
+            {"email": "new@example.com", "provider": "google"},
+            {
+                "id_token": "new_id",
+                "access_token": "new_access",
+                "refresh_token": "new_refresh",
+            },
+        )
+
+        with self._with_user_context(user_info):
+            st.user.refresh()
+
+            # Verify user_info was updated in-place.
+            assert user_info["email"] == "new@example.com"
+            assert user_info["_refresh_token"] == "new_refresh"
+            assert user_info["tokens"] == {"id": "new_id", "access": "new_access"}
+
+            # Verify a ForwardMsg is sent for cookie update.
+            c = self.get_message_from_queue().auth_redirect
+            assert c.url.startswith("/auth/refresh")
+            assert c.is_background_refresh is True
+
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.refresh_oauth_tokens",
+        return_value=None,
+    )
+    def test_user_refresh_no_result_does_not_update(self, mock_refresh):
+        """Test that a failed refresh does not modify user_info."""
+        user_info = {
+            "email": "test@example.com",
+            "provider": "google",
+            "_refresh_token": "tok",
+            "tokens": {"id": "old_id"},
+        }
+
+        with self._with_user_context(user_info):
+            st.user.refresh()
+
+            # user_info must remain unchanged.
+            assert user_info["email"] == "test@example.com"
+            assert user_info["tokens"] == {"id": "old_id"}
+
+    def test_user_refresh_no_refresh_token_is_noop(self):
+        """Test that refresh() is a no-op when no refresh token is stored."""
+        user_info = {
+            "email": "test@example.com",
+            "provider": "google",
+            "tokens": {"id": "old_id"},
+        }
+
+        with self._with_user_context(user_info):
+            st.user.refresh()
+
+            # Anti-regression: no ForwardMsg should be enqueued.
+            assert user_info["email"] == "test@example.com"
+
+    @patch(
+        "streamlit.user_info.get_expose_tokens_config", return_value=["id", "access"]
+    )
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.refresh_oauth_tokens",
+    )
+    def test_user_refresh_auth_cache_contains_cookie_metadata(
+        self, mock_refresh, mock_expose_tokens
+    ):
+        """Test that refresh() stores origin, and provider in auth_cache.
+
+        Without these fields the ``_parse_user_cookie()`` origin validation
+        fails on the next page reload and the user appears logged-out
+        (is_logged_in=False).
+        """
+        user_info = {
+            "email": "old@example.com",
+            "provider": "google",
+            "_refresh_token": "old_refresh",
+            "tokens": {"id": "old_id", "access": "old_access"},
+        }
+
+        mock_refresh.return_value = (
+            {"email": "new@example.com", "provider": "google"},
+            {
+                "id_token": "new_id",
+                "access_token": "new_access",
+                "refresh_token": "new_refresh",
+            },
+        )
+
+        with self._with_user_context(user_info):
+            with patch(
+                "streamlit.user_info.get_origin_from_redirect_uri",
+                return_value="http://localhost:8501",
+            ):
+                st.user.refresh()
+
+            # Retrieve what was stored in the auth_cache.
+            from streamlit.web.server.oauth_authlib_routes import auth_cache
+
+            # The ForwardMsg URL contains the token_id as a query parameter.
+            fwd = self.get_message_from_queue().auth_redirect
+            import re
+
+            match = re.search(r"token_id=([^&]+)", fwd.url)
+            assert match is not None, "token_id not found in auth_redirect URL"
+            token_id = match.group(1)
+
+            cached = auth_cache.get(f"_refresh_{token_id}")
+            assert cached is not None, "auth_cache entry missing for refresh"
+
+            cookie_user_info = cached["user_info"]
+
+            # These fields are required for _parse_user_cookie() to succeed.
+            assert cookie_user_info["provider"] == "google"
+            assert cookie_user_info["origin"] == "http://localhost:8501"
+
+            # Internal keys must NOT be persisted in the cookie.
+            assert "_refresh_token" not in cookie_user_info
+            assert "tokens" not in cookie_user_info
+
+            # Clean up the cache entry.
+            auth_cache.delete(f"_refresh_{token_id}")

--- a/lib/tests/streamlit/user_info_test.py
+++ b/lib/tests/streamlit/user_info_test.py
@@ -399,3 +399,11 @@ class UserInfoTokensTest(DeltaGeneratorTestCase):
             assert isinstance(tokens_prop, TokensProxy)
             assert isinstance(tokens_key, TokensProxy)
             assert tokens_prop.id == tokens_key.id
+
+    def test_user_refresh_method(self):
+        """Test that st.user.refresh() sends correct proto message."""
+        st.user.refresh()
+
+        c = self.get_message_from_queue().auth_redirect
+
+        assert c.url.startswith("/auth/refresh")

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -30,8 +30,43 @@ from streamlit.web.server.oauth_authlib_routes import (
     AuthLoginHandler,
     AuthLogoutHandler,
     AuthRefreshHandler,
+    refresh_oauth_tokens,
 )
 from streamlit.web.server.server_util import AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME
+
+
+def _make_mock_client(
+    *,
+    token_endpoint: str = "https://provider.com/token",
+    server_metadata_extra: dict | None = None,
+    session_response: MagicMock | None = None,
+) -> MagicMock:
+    """Build a mock OAuth client whose ``client_cls`` context manager yields a session.
+
+    The returned mock supports ``client.client_cls(**client.client_kwargs)`` as a
+    context manager.  The session's ``request()`` method returns *session_response*.
+    """
+    mock_session = MagicMock()
+    if session_response is not None:
+        mock_session.request.return_value = session_response
+
+    mock_client_cls = MagicMock()
+    mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+    metadata = {"token_endpoint": token_endpoint}
+    if server_metadata_extra:
+        metadata.update(server_metadata_extra)
+
+    client = MagicMock(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        client_cls=mock_client_cls,
+        client_kwargs={},
+        load_server_metadata=MagicMock(return_value=metadata),
+        server_metadata=metadata,
+    )
+    return client
 
 
 class SecretMock(dict):
@@ -400,6 +435,7 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
             {
                 "access_token": "test_access_token",
                 "id_token": "test_id_token",
+                "refresh_token": "test_refresh_token",
             },
         )
 
@@ -452,54 +488,141 @@ class AuthRefreshHandlerTest(tornado.testing.AsyncHTTPTestCase):
             cookie_secret="test_cookie_secret",
         )
 
-    def _create_signed_cookies(
-        self, user_info: dict, tokens: dict
-    ) -> tornado.httputil.HTTPHeaders:
-        """Helper to create signed cookies for testing."""
-        import tornado.httputil
-        from tornado.web import create_signed_value
+    def test_missing_token_id_redirects(self) -> None:
+        """Test that requests without token_id are redirected."""
+        response = self.fetch("/auth/refresh", follow_redirects=False)
 
-        from streamlit.web.server.server_util import (
-            AUTH_COOKIE_NAME,
-            TOKENS_COOKIE_NAME,
-        )
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
 
-        user_cookie = create_signed_value(
-            "test_cookie_secret", AUTH_COOKIE_NAME, json.dumps(user_info)
-        ).decode("utf-8")
+        # Anti-regression: must NOT return JSON body
+        try:
+            body = json.loads(response.body)
+            assert "success" not in body
+        except (json.JSONDecodeError, ValueError):
+            pass  # Expected: body is empty or not JSON for redirect responses
 
-        tokens_cookie = create_signed_value(
-            "test_cookie_secret", TOKENS_COOKIE_NAME, json.dumps(tokens)
-        ).decode("utf-8")
+    # --- Cookie-set-only path tests (token_id) ---
 
-        headers = tornado.httputil.HTTPHeaders()
-        headers.add(
-            "Cookie",
-            f"{AUTH_COOKIE_NAME}={user_cookie}; {TOKENS_COOKIE_NAME}={tokens_cookie}",
-        )
+    def setUp(self) -> None:
+        super().setUp()
+        self._old_cache = oauth_authlib_routes.auth_cache
+        oauth_authlib_routes.auth_cache = AuthCache()
 
-        return headers
+    def tearDown(self) -> None:
+        oauth_authlib_routes.auth_cache = self._old_cache
+        super().tearDown()
 
-    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
-    @patch(
-        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
-        return_value=(
-            MagicMock(
-                client_id="test_client_id",
-                client_secret="test_client_secret",
-                load_server_metadata=MagicMock(
-                    return_value={"token_endpoint": "https://provider.com/token"}
-                ),
-            ),
-            "",
-        ),
-    )
     @patch.object(AuthRefreshHandler, "set_auth_cookie")
-    def test_refresh_success(
-        self, mock_set_auth_cookie, mock_create_oauth_client, mock_requests_post
-    ):
-        """Test successful token refresh."""
-        # Mock successful token refresh response
+    def test_token_id_sets_cookies_from_cache(
+        self, mock_set_auth_cookie: MagicMock
+    ) -> None:
+        """Test cookie-set-only path retrieves cached data and sets cookies."""
+        cached_user_info = {
+            "provider": "google",
+            "email": "cached@example.com",
+            "is_logged_in": True,
+        }
+        cached_tokens = {
+            "access_token": "cached_access",
+            "refresh_token": "cached_refresh",
+        }
+        oauth_authlib_routes.auth_cache.set(
+            "_refresh_test-uuid",
+            {"user_info": cached_user_info, "tokens": cached_tokens},
+        )
+
+        response = self.fetch(
+            "/auth/refresh?token_id=test-uuid", follow_redirects=False
+        )
+
+        assert response.code == 200
+        body = json.loads(response.body)
+        assert body["success"] is True
+
+        # Verify cookies were set from cached data
+        mock_set_auth_cookie.assert_called_once_with(cached_user_info, cached_tokens)
+
+        # Anti-regression: must NOT redirect for cookie-set-only requests
+        assert "Location" not in response.headers
+
+    def test_token_id_invalid_returns_failure(self) -> None:
+        """Test cookie-set-only path returns failure for invalid/unknown token_id."""
+        response = self.fetch(
+            "/auth/refresh?token_id=nonexistent-uuid",
+            follow_redirects=False,
+        )
+
+        assert response.code == 200
+        body = json.loads(response.body)
+        assert body["success"] is False
+
+        # Anti-regression: must NOT redirect
+        assert "Location" not in response.headers
+
+    @patch.object(AuthRefreshHandler, "set_auth_cookie")
+    def test_token_id_is_one_time_use(self, mock_set_auth_cookie: MagicMock) -> None:
+        """Test that a token_id is consumed after first use and cannot be reused."""
+        cached_data = {
+            "user_info": {"provider": "google", "email": "once@example.com"},
+            "tokens": {"access_token": "once_access"},
+        }
+        oauth_authlib_routes.auth_cache.set("_refresh_once-uuid", cached_data)
+
+        # First request should succeed
+        response1 = self.fetch(
+            "/auth/refresh?token_id=once-uuid", follow_redirects=False
+        )
+        body1 = json.loads(response1.body)
+        assert body1["success"] is True
+        mock_set_auth_cookie.assert_called_once()
+
+        # Second request with same token_id should fail
+        mock_set_auth_cookie.reset_mock()
+        response2 = self.fetch(
+            "/auth/refresh?token_id=once-uuid", follow_redirects=False
+        )
+        body2 = json.loads(response2.body)
+        assert body2["success"] is False
+
+        # Anti-regression: set_auth_cookie must NOT be called on the second request
+        mock_set_auth_cookie.assert_not_called()
+
+    @patch.object(AuthRefreshHandler, "set_auth_cookie")
+    def test_token_id_does_not_call_provider(
+        self,
+        mock_set_auth_cookie: MagicMock,
+    ) -> None:
+        """Test cookie-set-only path does NOT make any HTTP calls to the provider."""
+        cached_data = {
+            "user_info": {"provider": "google", "email": "noprovider@example.com"},
+            "tokens": {"access_token": "np_access", "refresh_token": "np_refresh"},
+        }
+        oauth_authlib_routes.auth_cache.set("_refresh_np-uuid", cached_data)
+
+        response = self.fetch("/auth/refresh?token_id=np-uuid", follow_redirects=False)
+
+        body = json.loads(response.body)
+        assert body["success"] is True
+
+
+@patch(
+    "streamlit.auth_util.secrets_singleton",
+    MagicMock(
+        load_if_toml_exists=MagicMock(return_value=True),
+        get=MagicMock(return_value=SECRETS_MOCK),
+    ),
+)
+class RefreshOauthTokensTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests for the refresh_oauth_tokens() standalone function."""
+
+    def get_app(self):
+        # We need a tornado app for the test case but refresh_oauth_tokens
+        # doesn't use one; provide a minimal app.
+        return tornado.web.Application([])
+
+    def test_refresh_oauth_tokens_success(self):
+        """Test successful token refresh via the standalone function."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -507,224 +630,62 @@ class AuthRefreshHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "refresh_token": "new_refresh_token",
             "expires_in": 3600,
         }
-        mock_requests_post.return_value = mock_response
 
-        # Create test cookies
-        user_info = {
-            "provider": "google",
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
-        }
-        tokens = {
-            "access_token": "old_access_token",
-            "refresh_token": "old_refresh_token",
-        }
+        mock_client = _make_mock_client(session_response=mock_response)
 
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+        with patch(
+            "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+            return_value=(mock_client, ""),
+        ):
+            user_info = {
+                "provider": "google",
+                "email": "test@example.com",
+                "is_logged_in": True,
+            }
 
-        # Verify response
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
+            result = refresh_oauth_tokens(user_info, "old_refresh_token")
 
-        # Verify token refresh was called correctly
-        mock_requests_post.assert_called_once()
-        call_args = mock_requests_post.call_args
-        assert call_args[0][0] == "https://provider.com/token"
-        assert call_args[1]["data"]["grant_type"] == "refresh_token"
-        assert call_args[1]["data"]["refresh_token"] == "old_refresh_token"
-        assert call_args[1]["data"]["client_id"] == "test_client_id"
-        assert call_args[1]["data"]["client_secret"] == "test_client_secret"
-
-        # Verify auth cookie was set with updated tokens
-        mock_set_auth_cookie.assert_called_once()
-        updated_user_info, updated_tokens = mock_set_auth_cookie.call_args[0]
-        assert updated_user_info == user_info
+        assert result is not None
+        updated_user_info, updated_tokens = result
         assert updated_tokens["access_token"] == "new_access_token"
         assert updated_tokens["refresh_token"] == "new_refresh_token"
 
-    def test_refresh_missing_cookies(self):
-        """Test refresh handler with missing authentication cookies."""
-        response = self.fetch("/auth/refresh", follow_redirects=False)
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
+        # Anti-regression: old tokens must be replaced, not kept
+        assert updated_tokens["access_token"] != "old_access_token"
 
-    def test_refresh_missing_refresh_token(self):
-        """Test refresh handler with missing refresh token."""
-        user_info = {
-            "provider": "google",
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
-        }
-        tokens = {"access_token": "test_token"}  # Missing refresh_token
+        # User info should be preserved when no id_token is returned
+        assert updated_user_info["email"] == "test@example.com"
+        assert updated_user_info["provider"] == "google"
 
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+    def test_refresh_oauth_tokens_missing_provider(self):
+        """Test refresh_oauth_tokens returns None when provider is missing."""
+        user_info = {"email": "test@example.com", "is_logged_in": True}
 
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
+        result = refresh_oauth_tokens(user_info, "test_refresh")
+        assert result is None
 
-    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
-    @patch(
-        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
-        return_value=(
-            MagicMock(
-                client_id="test_client_id",
-                client_secret="test_client_secret",
-                load_server_metadata=MagicMock(
-                    return_value={"token_endpoint": "https://provider.com/token"}
-                ),
-            ),
-            "",
-        ),
-    )
-    def test_refresh_token_endpoint_error(
-        self, mock_create_oauth_client, mock_requests_post
-    ):
-        """Test refresh handler when token endpoint returns error."""
+    def test_refresh_oauth_tokens_endpoint_failure(self):
+        """Test refresh_oauth_tokens returns None on token endpoint failure."""
         mock_response = MagicMock()
         mock_response.status_code = 400
-        mock_requests_post.return_value = mock_response
 
-        user_info = {
-            "provider": "google",
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
-        }
-        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+        mock_client = _make_mock_client(session_response=mock_response)
 
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+        with patch(
+            "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+            return_value=(mock_client, ""),
+        ):
+            user_info = {"provider": "google", "email": "test@example.com"}
 
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
+            result = refresh_oauth_tokens(user_info, "test_refresh")
+            assert result is None
 
-    def test_refresh_invalid_json_cookies(self):
-        """Test refresh handler with invalid JSON in cookies."""
-        from tornado.web import create_signed_value
-
-        headers = tornado.httputil.HTTPHeaders()
-        invalid_user_cookie = create_signed_value(
-            "test_cookie_secret", AUTH_COOKIE_NAME, "invalid json"
-        ).decode("utf-8")
-        invalid_tokens_cookie = create_signed_value(
-            "test_cookie_secret", TOKENS_COOKIE_NAME, "invalid json"
-        ).decode("utf-8")
-
-        headers.add(
-            "Cookie",
-            f"{AUTH_COOKIE_NAME}={invalid_user_cookie}; {TOKENS_COOKIE_NAME}={invalid_tokens_cookie}",
-        )
-
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
-
-    def test_refresh_missing_provider(self):
-        """Test refresh handler with missing provider in user info."""
-        user_info = {
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
-            # Missing provider field
-        }
-        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
-
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
-
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
-
-    @patch(
-        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
-        return_value=(
-            MagicMock(
-                load_server_metadata=MagicMock(return_value={})  # No token_endpoint
-            ),
-            "",
-        ),
-    )
-    def test_refresh_no_token_endpoint(self, mock_create_oauth_client):
-        """Test refresh handler when provider has no token endpoint."""
-        user_info = {
-            "provider": "google",
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
-        }
-        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
-
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
-
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
-
-    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
-    @patch(
-        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
-        return_value=(
-            MagicMock(
-                client_id="test_client_id",
-                client_secret="test_client_secret",
-                load_server_metadata=MagicMock(
-                    return_value={"token_endpoint": "https://provider.com/token"}
-                ),
-            ),
-            "",
-        ),
-    )
-    def test_refresh_network_exception(
-        self, mock_create_oauth_client, mock_requests_post
-    ):
-        """Test refresh handler when network request raises exception."""
-        mock_requests_post.side_effect = Exception("Network error")
-
-        user_info = {
-            "provider": "google",
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
-        }
-        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
-
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
-
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
-
-    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
-    @patch("streamlit.web.server.oauth_authlib_routes.requests.get")
-    @patch(
-        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
-        return_value=(
-            MagicMock(
-                client_id="test_client_id",
-                client_secret="test_client_secret",
-                load_server_metadata=MagicMock(
-                    return_value={"token_endpoint": "https://provider.com/token"}
-                ),
-                server_metadata={"jwks_uri": "https://provider.com/jwks"},
-            ),
-            "",
-        ),
-    )
-    @patch("streamlit.web.server.oauth_authlib_routes.jose.jwt.decode")
-    @patch.object(AuthRefreshHandler, "set_auth_cookie")
-    def test_refresh_id_token_decode_failure(
+    @patch("streamlit.web.server.oauth_authlib_routes._decode_id_token")
+    def test_refresh_oauth_tokens_updates_user_info_from_id_token(
         self,
-        mock_set_auth_cookie,
-        mock_jwt_decode,
-        mock_create_oauth_client,
-        mock_requests_get,
-        mock_requests_post,
+        mock_decode_id_token,
     ):
-        """Test refresh handler when ID token decoding fails."""
+        """Test refresh_oauth_tokens updates user info when new id_token is returned."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -732,35 +693,99 @@ class AuthRefreshHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "refresh_token": "new_refresh_token",
             "id_token": "new_id_token",
         }
-        mock_requests_post.return_value = mock_response
 
-        mock_jwks_response = MagicMock()
-        mock_jwks_response.json.return_value = {"keys": []}
-        mock_requests_get.return_value = mock_jwks_response
+        mock_client = _make_mock_client(
+            session_response=mock_response,
+            server_metadata_extra={"jwks_uri": "https://provider.com/jwks"},
+        )
 
-        mock_jwt_decode.side_effect = Exception("Invalid token")
-
-        user_info = {
-            "provider": "google",
-            "email": "test@example.com",
-            "origin": "http://localhost:8501",
-            "is_logged_in": True,
+        mock_decode_id_token.return_value = {
+            "email": "updated@example.com",
+            "name": "Updated Name",
         }
-        tokens = {"access_token": "old_token", "refresh_token": "old_refresh"}
 
-        headers = self._create_signed_cookies(user_info, tokens)
-        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+        with patch(
+            "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+            return_value=(mock_client, ""),
+        ):
+            user_info = {
+                "provider": "google",
+                "email": "old@example.com",
+                "is_logged_in": True,
+            }
 
-        # Should still succeed even if ID token decoding fails
-        assert response.code == 302
-        assert response.headers["Location"] == "/"
+            result = refresh_oauth_tokens(user_info, "old_refresh")
 
-        # Verify auth cookie was set with tokens but unchanged user info
-        mock_set_auth_cookie.assert_called_once()
-        updated_user_info, updated_tokens = mock_set_auth_cookie.call_args[0]
-        assert (
-            updated_user_info == user_info
-        )  # Should be unchanged due to decode failure
-        assert updated_tokens["access_token"] == "new_access_token"
-        assert updated_tokens["refresh_token"] == "new_refresh_token"
+        assert result is not None
+        updated_user_info, updated_tokens = result
+
+        # User info should be updated from the decoded id_token
+        assert updated_user_info["email"] == "updated@example.com"
+        assert updated_user_info["name"] == "Updated Name"
+
+        # Provider and is_logged_in should be preserved
+        assert updated_user_info["provider"] == "google"
+        assert updated_user_info["is_logged_in"] is True
+
+        # Tokens should be updated
         assert updated_tokens["id_token"] == "new_id_token"
+        assert updated_tokens["access_token"] == "new_access_token"
+
+    def test_refresh_oauth_tokens_omits_refresh_token_when_not_returned(self):
+        """Test that updated_tokens omits refresh_token when the provider does not return one."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        # Provider does not return a new refresh_token (some providers do this).
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "expires_in": 3600,
+        }
+
+        mock_client = _make_mock_client(session_response=mock_response)
+
+        with patch(
+            "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+            return_value=(mock_client, ""),
+        ):
+            user_info = {"provider": "google", "email": "test@example.com"}
+
+            result = refresh_oauth_tokens(user_info, "old_refresh")
+
+        assert result is not None
+        _, updated_tokens = result
+
+        # New access_token should be present.
+        assert updated_tokens["access_token"] == "new_access_token"
+
+        # refresh_token must NOT appear -- the caller (user_info.py) is
+        # responsible for keeping the old one when the provider omits it.
+        assert "refresh_token" not in updated_tokens
+
+    def test_refresh_oauth_tokens_does_not_mutate_inputs(self):
+        """Test that refresh_oauth_tokens does not mutate the input dict."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "refresh_token": "new_refresh_token",
+        }
+
+        mock_client = _make_mock_client(session_response=mock_response)
+
+        with patch(
+            "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+            return_value=(mock_client, ""),
+        ):
+            user_info = {
+                "provider": "google",
+                "email": "test@example.com",
+                "is_logged_in": True,
+            }
+
+            # Preserve original reference
+            original_user_info = user_info.copy()
+
+            refresh_oauth_tokens(user_info, "old_refresh")
+
+        # Input must not be mutated
+        assert user_info == original_user_info

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -29,6 +29,7 @@ from streamlit.web.server.oauth_authlib_routes import (
     AuthCallbackHandler,
     AuthLoginHandler,
     AuthLogoutHandler,
+    AuthRefreshHandler,
 )
 from streamlit.web.server.server_util import AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME
 
@@ -429,3 +430,337 @@ class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert response.code == 302
         assert response.headers["Location"] == "/"
+
+
+@patch(
+    "streamlit.auth_util.secrets_singleton",
+    MagicMock(
+        load_if_toml_exists=MagicMock(return_value=True),
+        get=MagicMock(return_value=SECRETS_MOCK),
+    ),
+)
+class AuthRefreshHandlerTest(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/auth/refresh",
+                    AuthRefreshHandler,
+                    {"base_url": ""},
+                )
+            ],
+            cookie_secret="test_cookie_secret",
+        )
+
+    def _create_signed_cookies(
+        self, user_info: dict, tokens: dict
+    ) -> tornado.httputil.HTTPHeaders:
+        """Helper to create signed cookies for testing."""
+        import tornado.httputil
+        from tornado.web import create_signed_value
+
+        from streamlit.web.server.server_util import (
+            AUTH_COOKIE_NAME,
+            TOKENS_COOKIE_NAME,
+        )
+
+        user_cookie = create_signed_value(
+            "test_cookie_secret", AUTH_COOKIE_NAME, json.dumps(user_info)
+        ).decode("utf-8")
+
+        tokens_cookie = create_signed_value(
+            "test_cookie_secret", TOKENS_COOKIE_NAME, json.dumps(tokens)
+        ).decode("utf-8")
+
+        headers = tornado.httputil.HTTPHeaders()
+        headers.add(
+            "Cookie",
+            f"{AUTH_COOKIE_NAME}={user_cookie}; {TOKENS_COOKIE_NAME}={tokens_cookie}",
+        )
+
+        return headers
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+            ),
+            "",
+        ),
+    )
+    @patch.object(AuthRefreshHandler, "set_auth_cookie")
+    def test_refresh_success(
+        self, mock_set_auth_cookie, mock_create_oauth_client, mock_requests_post
+    ):
+        """Test successful token refresh."""
+        # Mock successful token refresh response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "refresh_token": "new_refresh_token",
+            "expires_in": 3600,
+        }
+        mock_requests_post.return_value = mock_response
+
+        # Create test cookies
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {
+            "access_token": "old_access_token",
+            "refresh_token": "old_refresh_token",
+        }
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        # Verify response
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+        # Verify token refresh was called correctly
+        mock_requests_post.assert_called_once()
+        call_args = mock_requests_post.call_args
+        assert call_args[0][0] == "https://provider.com/token"
+        assert call_args[1]["data"]["grant_type"] == "refresh_token"
+        assert call_args[1]["data"]["refresh_token"] == "old_refresh_token"
+        assert call_args[1]["data"]["client_id"] == "test_client_id"
+        assert call_args[1]["data"]["client_secret"] == "test_client_secret"
+
+        # Verify auth cookie was set with updated tokens
+        mock_set_auth_cookie.assert_called_once()
+        updated_user_info, updated_tokens = mock_set_auth_cookie.call_args[0]
+        assert updated_user_info == user_info
+        assert updated_tokens["access_token"] == "new_access_token"
+        assert updated_tokens["refresh_token"] == "new_refresh_token"
+
+    def test_refresh_missing_cookies(self):
+        """Test refresh handler with missing authentication cookies."""
+        response = self.fetch("/auth/refresh", follow_redirects=False)
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    def test_refresh_missing_refresh_token(self):
+        """Test refresh handler with missing refresh token."""
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token"}  # Missing refresh_token
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+            ),
+            "",
+        ),
+    )
+    def test_refresh_token_endpoint_error(
+        self, mock_create_oauth_client, mock_requests_post
+    ):
+        """Test refresh handler when token endpoint returns error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_requests_post.return_value = mock_response
+
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    def test_refresh_invalid_json_cookies(self):
+        """Test refresh handler with invalid JSON in cookies."""
+        from tornado.web import create_signed_value
+
+        headers = tornado.httputil.HTTPHeaders()
+        invalid_user_cookie = create_signed_value(
+            "test_cookie_secret", AUTH_COOKIE_NAME, "invalid json"
+        ).decode("utf-8")
+        invalid_tokens_cookie = create_signed_value(
+            "test_cookie_secret", TOKENS_COOKIE_NAME, "invalid json"
+        ).decode("utf-8")
+
+        headers.add(
+            "Cookie",
+            f"{AUTH_COOKIE_NAME}={invalid_user_cookie}; {TOKENS_COOKIE_NAME}={invalid_tokens_cookie}",
+        )
+
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    def test_refresh_missing_provider(self):
+        """Test refresh handler with missing provider in user info."""
+        user_info = {
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+            # Missing provider field
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                load_server_metadata=MagicMock(return_value={})  # No token_endpoint
+            ),
+            "",
+        ),
+    )
+    def test_refresh_no_token_endpoint(self, mock_create_oauth_client):
+        """Test refresh handler when provider has no token endpoint."""
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+            ),
+            "",
+        ),
+    )
+    def test_refresh_network_exception(
+        self, mock_create_oauth_client, mock_requests_post
+    ):
+        """Test refresh handler when network request raises exception."""
+        mock_requests_post.side_effect = Exception("Network error")
+
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "test_token", "refresh_token": "test_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.post")
+    @patch("streamlit.web.server.oauth_authlib_routes.requests.get")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+                load_server_metadata=MagicMock(
+                    return_value={"token_endpoint": "https://provider.com/token"}
+                ),
+                server_metadata={"jwks_uri": "https://provider.com/jwks"},
+            ),
+            "",
+        ),
+    )
+    @patch("streamlit.web.server.oauth_authlib_routes.jose.jwt.decode")
+    @patch.object(AuthRefreshHandler, "set_auth_cookie")
+    def test_refresh_id_token_decode_failure(
+        self,
+        mock_set_auth_cookie,
+        mock_jwt_decode,
+        mock_create_oauth_client,
+        mock_requests_get,
+        mock_requests_post,
+    ):
+        """Test refresh handler when ID token decoding fails."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_access_token",
+            "refresh_token": "new_refresh_token",
+            "id_token": "new_id_token",
+        }
+        mock_requests_post.return_value = mock_response
+
+        mock_jwks_response = MagicMock()
+        mock_jwks_response.json.return_value = {"keys": []}
+        mock_requests_get.return_value = mock_jwks_response
+
+        mock_jwt_decode.side_effect = Exception("Invalid token")
+
+        user_info = {
+            "provider": "google",
+            "email": "test@example.com",
+            "origin": "http://localhost:8501",
+            "is_logged_in": True,
+        }
+        tokens = {"access_token": "old_token", "refresh_token": "old_refresh"}
+
+        headers = self._create_signed_cookies(user_info, tokens)
+        response = self.fetch("/auth/refresh", headers=headers, follow_redirects=False)
+
+        # Should still succeed even if ID token decoding fails
+        assert response.code == 302
+        assert response.headers["Location"] == "/"
+
+        # Verify auth cookie was set with tokens but unchanged user info
+        mock_set_auth_cookie.assert_called_once()
+        updated_user_info, updated_tokens = mock_set_auth_cookie.call_args[0]
+        assert (
+            updated_user_info == user_info
+        )  # Should be unchanged due to decode failure
+        assert updated_tokens["access_token"] == "new_access_token"
+        assert updated_tokens["refresh_token"] == "new_refresh_token"
+        assert updated_tokens["id_token"] == "new_id_token"

--- a/proto/streamlit/proto/AuthRedirect.proto
+++ b/proto/streamlit/proto/AuthRedirect.proto
@@ -21,4 +21,8 @@ option java_outer_classname = "AuthRedirectProto";
 
 message AuthRedirect {
   string url = 1; // URL TO REDIRECT TO
+  // When true, the frontend should perform a background fetch to the URL
+  // instead of a full browser redirect. This is used for token refresh
+  // to update cookies without causing a page reload.
+  bool is_background_refresh = 2;
 }


### PR DESCRIPTION
## Describe your changes

Add a command (st.user.refresh()) to use the refresh token to refresh both the tokens and the user info.

This PR is based on https://github.com/streamlit/streamlit/pull/12696 and extends the refresh without redirects.

We implemented this PR on our private fork, and this feature works as intended for us: Calling `st.user.refresh()` smoothly updates `st.user` and the tokens without reloading the application. There may be a more elegant implementation, but this solution has achieved our goal.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/12043

## Testing Plan

- Unit tests adapted using AI
- Tested in a test environment with SSO integration

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
