### PR TITLE
feat: add generating-changelog skill

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -30,6 +30,7 @@ skills/*
 !skills/assessing-external-test-risk/
 !skills/fixing-flaky-e2e-tests/
 !skills/implementing-feature/
+!skills/generating-changelog/
 
 # Allow agents
 !agents/

--- a/.claude/skills/generating-changelog/SKILL.md
+++ b/.claude/skills/generating-changelog/SKILL.md
@@ -20,7 +20,11 @@ If only one tag is given, treat it as the new release tag and fetch the previous
   ```bash
   gh api repos/streamlit/streamlit/releases/latest --jq '.tag_name'
   ```
-- Validate both tags exist: `git tag -l <tag>` must produce output for each.
+- Validate both tags exist using exact references (no pattern matching):
+  ```bash
+  git rev-parse -q --verify "refs/tags/<tag>" > /dev/null
+  ```
+  This command must succeed (exit code 0) for each tag.
 - Get the release date from the newer tag:
   ```bash
   git log -1 --format=%ai <new-tag>
@@ -31,17 +35,23 @@ If only one tag is given, treat it as the new release tag and fetch the previous
 Run the fetch script to extract PR numbers from `git log` and batch-fetch metadata via GitHub GraphQL:
 
 ```bash
-uv run python3 scripts/changelog_fetch_prs.py <prev-tag> <new-tag>
+uv run python scripts/changelog_fetch_prs.py <prev-tag> <new-tag>
 ```
 
-This produces `work-tmp/pr-data.json` — a JSON array of `{number, title, labels, author}` objects sorted by PR number.
+This produces `work-tmp/pr-data.json` — a JSON array of `{number, title, labels, author, related_issues, related_issues_truncated}` objects sorted by PR number.
+
+`related_issues` is sourced from the same batched GraphQL query (no per-PR N+1 requests) and includes linked issue numbers plus 👍 counts:
+
+```json
+"related_issues": [{"number": 9836, "thumbs_up": 42}]
+```
 
 ## Step 3 & 4: Filter and categorize
 
 Run the categorization script to exclude noise and categorize PRs by labels:
 
 ```bash
-uv run python3 scripts/changelog_categorize_prs.py
+uv run python scripts/changelog_categorize_prs.py
 ```
 
 This reads `work-tmp/pr-data.json`, applies the following rules, and writes `work-tmp/pr-categorized.json`:
@@ -57,9 +67,11 @@ This reads `work-tmp/pr-data.json`, applies the following rules, and writes `wor
 | `change:breaking`                   | **Breaking Changes** |
 | `change:feature`                    | **New Features**     |
 | `change:bugfix`                     | **Bug Fixes**        |
-| `impact:users` (without `change:*`) | **Other Changes**    |
+| `impact:users` or unrecognized `change:*` labels | **Other Changes**    |
 
 PRs with no `impact:*` or `change:*` labels are flagged as **unlabeled** for user review.
+
+Note: `change:*` labels are typically required by release labeling conventions. The "Other Changes" fallback is a defensive catch-all for `impact:users` PRs and non-standard `change:*` values not covered by `breaking`/`feature`/`bugfix`.
 
 **Important:** These script categories are intermediate groupings for triage. The website changelog does **not** have a "Breaking Changes" or "New Features" section. All entries are mapped into the three website tiers below. Breaking changes, deprecations, and removals fold into Notable Changes or Other Changes with appropriate emojis (see Step 6).
 
@@ -76,8 +88,9 @@ Map into three website tiers:
 1. Total PR count and count per category
 2. List of PRs proposed for "Highlights" tier — allow user to promote/demote
 3. Any unlabeled PRs flagged in Step 3, with suggested classifications
-4. External contributors identified by the script (from the `is_external` field) — verify any edge cases but no need to look up GitHub profiles for `sfc-gh-*` or known internal authors
-5. Ask the user to confirm or adjust before proceeding
+4. For borderline Highlights candidates, consider linked issue 👍 counts from `related_issues` as one prioritization signal (not the only signal)
+5. External contributors identified by the script (from the `is_external` field) — verify any edge cases but no need to look up GitHub profiles for `sfc-gh-*` or known internal authors
+6. Ask the user to confirm or adjust before proceeding
 
 Note: Internal-only feature PRs (e.g., e2e infra, CI workflows, agent skills) are already excluded by the categorize script. You should not need to manually filter these.
 
@@ -173,3 +186,4 @@ After writing the file, print:
 
 - `.github/release.yml` — canonical label-to-category mapping (also used for auto-generated GitHub release notes)
 - Website changelog format reference: `https://docs.streamlit.io/develop/quick-reference/release-notes`
+- Example docs markdown file (style inspiration): `https://raw.githubusercontent.com/streamlit/docs/997b19a5eda68b72ce091d69be9d6921a37e3da0/content/develop/quick-references/release-notes/2026.md`

--- a/.claude/skills/generating-changelog/SKILL.md
+++ b/.claude/skills/generating-changelog/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: generating-changelog
+description: Generates polished website release notes between two git tags for docs.streamlit.io. Use when preparing a new Streamlit release or reviewing changes between versions.
+---
+
+# Generating changelog
+
+Generate publish-ready website changelog (docs.streamlit.io format) between two git tags. Uses PR labels (`impact:users`, `impact:internal`, `change:*`) for categorization and rewrites PR titles into user-friendly descriptions.
+
+The GitHub release changelog is auto-generated from `.github/release.yml` — this skill only produces the website format.
+
+**Usage:** `/generating-changelog <previous-tag> <new-tag>` (e.g., `/generating-changelog 1.44.1 1.45.0`)
+
+If only one tag is given, treat it as the new release tag and fetch the previous tag automatically.
+
+## Step 1: Validate input
+
+- Parse the two tags from user args. First = previous release, second = new release.
+- If only one tag is given, fetch the previous tag:
+  ```bash
+  gh api repos/streamlit/streamlit/releases/latest --jq '.tag_name'
+  ```
+- Validate both tags exist: `git tag -l <tag>` must produce output for each.
+- Get the release date from the newer tag:
+  ```bash
+  git log -1 --format=%ai <new-tag>
+  ```
+
+## Step 2: Fetch PR data
+
+Run the fetch script to extract PR numbers from `git log` and batch-fetch metadata via GitHub GraphQL:
+
+```bash
+uv run python3 scripts/changelog_fetch_prs.py <prev-tag> <new-tag>
+```
+
+This produces `work-tmp/pr-data.json` — a JSON array of `{number, title, labels, author}` objects sorted by PR number.
+
+## Step 3 & 4: Filter and categorize
+
+Run the categorization script to exclude noise and categorize PRs by labels:
+
+```bash
+uv run python3 scripts/changelog_categorize_prs.py
+```
+
+This reads `work-tmp/pr-data.json`, applies the following rules, and writes `work-tmp/pr-categorized.json`:
+
+**Excluded:** bot authors, release/version/docstring PRs, internal-only PRs (`impact:internal` without `impact:users` — this includes internal features with `change:*` labels).
+
+**External contributors:** Each non-excluded PR includes an `is_external` boolean field. Authors matching `sfc-gh-*` or a known internal set are marked `is_external: false`; all others are `is_external: true`. The summary output lists external contributors separately — use this to attribute contributions without needing to look up GitHub profiles.
+
+**Script categories** (by label priority: `breaking` > `feature` > `bugfix` > other):
+
+| Label                               | Script Category      |
+| ----------------------------------- | -------------------- |
+| `change:breaking`                   | **Breaking Changes** |
+| `change:feature`                    | **New Features**     |
+| `change:bugfix`                     | **Bug Fixes**        |
+| `impact:users` (without `change:*`) | **Other Changes**    |
+
+PRs with no `impact:*` or `change:*` labels are flagged as **unlabeled** for user review.
+
+**Important:** These script categories are intermediate groupings for triage. The website changelog does **not** have a "Breaking Changes" or "New Features" section. All entries are mapped into the three website tiers below. Breaking changes, deprecations, and removals fold into Notable Changes or Other Changes with appropriate emojis (see Step 6).
+
+Map into three website tiers:
+
+- **Highlights** (optional — omit entirely when no PRs qualify): Only 0–4 items per release. Reserve for truly major user-facing additions: entirely new capabilities (e.g., a new widget-to-URL-params system, dynamic container control), significant new API parameters that unlock new workflows, or major breaking changes. Incremental improvements, new config options, and additional parameters on existing commands belong in Notable Changes, not Highlights. Some releases (e.g., patch releases) have no Highlights section at all.
+- **Notable Changes**: Remaining features, impactful improvements, new parameters, breaking changes not promoted to Highlights
+- **Other Changes**: Bug fixes, docs, chores, minor improvements
+
+## Step 5: Present classification for review
+
+**Before generating final output**, present a summary to the user:
+
+1. Total PR count and count per category
+2. List of PRs proposed for "Highlights" tier — allow user to promote/demote
+3. Any unlabeled PRs flagged in Step 3, with suggested classifications
+4. External contributors identified by the script (from the `is_external` field) — verify any edge cases but no need to look up GitHub profiles for `sfc-gh-*` or known internal authors
+5. Ask the user to confirm or adjust before proceeding
+
+Note: Internal-only feature PRs (e.g., e2e infra, CI workflows, agent skills) are already excluded by the categorize script. You should not need to manually filter these.
+
+Do NOT proceed to Step 6 until the user confirms.
+
+## Step 6: Rewrite descriptions and generate output
+
+Generate the file in the `work-tmp/` directory: `work-tmp/changelog-website-<new-tag>.md`
+
+### Entry writing style by category
+
+- **Highlights**: Announcing tone — "Introducing...", "Announcing...". PR links may be included or omitted at your discretion.
+- **Features / new parameters** (Notable Changes): User-perspective voice — "You can now...", "`st.foo` has a new `bar` parameter to...", "`st.foo` supports..."
+- **Bug fixes**: Always prefixed with "Bug fix:" — "Bug fix: `st.spinner` avoids a race condition..."
+- **Deprecations/removals**: Plain description with specific emojis (see emoji list below).
+- **Other non-bug entries**: Plain present-tense descriptions, no prefix.
+
+### Formatting rules
+
+- Remove `[fix]`/`[feat]`/`[chore]`/`[docs]` prefixes from PR titles before rewriting
+- **Emojis**:
+  - Bug fixes rotate through these insect/bug emojis: 🐛, 🦋, 🪲, 🐜, 🐝, 🐞, 🕷️, 🪳, 🪰, 🦠, 🦟, 🦂, 🦗, 🕸️, 🐌, 🦎, 🦀, 👽, 👻
+  - Removals use 👻, deprecations use ☠️, under-consideration removals use 💩
+  - Non-bug entries use emojis from this approved palette only (vary them, do not repeat consecutively).
+    - UI/layout/design: 🎨, 📐, 🖼, 🧩, 📏, 💅, 🖌, 🎛, 🎚, 🔲, 🌈, 🪄
+    - Data/charts/tables: 📊, 📈, 📋, 🔢, 🔣, 📒, 📃, 📄
+    - Performance/speed: ⚡, 🚀, ⏱, ⏩, ⏳, 🏎
+    - Security/auth: 🔒, 🔐, 🔏, 🛡, 🔑, 👮, 🥷
+    - Config/settings: ⚙, 🔧, 🛠, ⚒, 🧰, ⛏, 🔩
+    - Links/navigation: 🔗, 🧭, ➡, ⬆, ⬇, 🔝, 🚪, 🛣, ↩
+    - Search/visibility: 🔍, 🔎, 👀, 🕵
+    - Packages/dependencies: 📦, 🔤, 📥, 📤, 💿, 💾, 💽
+    - New features/highlights: ✨, 🎯, 🆕, 🍿, 🎁, 🎈, 🎊, ⭐, 🌟, 🆙
+    - Text/content/docs: ✍, 📝, 📜, 📖, 📘, 📚, ✏, ✒, 🖊, 🖋
+    - Notifications/messaging: 🔔, 📣, 💬, 📨, 📩, 📬, 🛎
+    - State/connection/sync: 💓, 🔀, 🔄, 🔁, 📶, 🔌, ⛓
+    - Media/display: 📷, 📸, 📹, 📺, 🎥, 🎤, 🎵, 🎶, 🎹, 🖥
+    - Files/storage: 📁, 📂, 🗂, 🗃, 🗑, 📌, 📍, 🏷, 🗜
+    - Users/identity: 👤, 👥, 🧑, 👋, 🤝, 👑
+    - Errors/warnings: 🚨, 🚩, ⚠, 🛑, ❌, ❓, 🚧
+    - Testing/science: 🧪, ⚗, 🔭, 🧠
+    - Misc objects: 💡, 💎, 💪, 💯, 💰, 💻, 💼, ⌨, 📱, 📲, 🖨, 🖱, 📞, 🗝, 🖇, ✂, ➕, 🪜, 🪧, 🏗, 🏠, 🏢, 🧱, 🪵
+    - Fun/creative: 🍔, 🍞, 🍪, 🍰, 🎩, 🎫, 🏁, 🏃, 🏄, 🏋, 🏓, 🏹, 🐍, 🐙, 🦊, 🦐, 🤖, 🤹, 🥸, 🧞, 🛸, 🛹, 🪗, 🪆, 🚇, 🚒, 🚣, 🌱, 🌐, 🗺, 🗻
+  - When no palette emoji fits, default to ✨
+- **`st.*` command references**: Use backtick formatting and link to the specific API doc subcategory path: [`st.image`](/develop/api-reference/media/st.image), [`st.dataframe`](/develop/api-reference/data/st.dataframe). Only link the first/primary mention of a command. Links are more common in Notable Changes than Other Changes.
+- **PR and issue links**: Include both PR links and related issue links when applicable. Format: `([#14139](https://github.com/streamlit/streamlit/pull/14139), [#9836](https://github.com/streamlit/streamlit/issues/9836))`. Use `/pull/` for PRs and `/issues/` for issues.
+- **Punctuation**: Every entry ends with a period after the closing parenthesis of PR/issue links.
+- **Contributor attribution**: Attribute external (non-Snowflake) contributors. Use `[username]` (no `@` prefix) in link text, placed after the closing paren and period: `([#NNNNN](https://github.com/streamlit/streamlit/pull/NNNNN)). Thanks, [username](https://github.com/username)!`
+- **Multi-PR grouped entries**: For complex multi-PR features, use a parent bullet with a colon, then indented sub-bullets:
+  ```
+  - 🎨 Main feature description:
+      - Sub-detail or sub-command ([#NNNNN](https://github.com/streamlit/streamlit/pull/NNNNN)).
+      - Another sub-detail ([#MMMMM](https://github.com/streamlit/streamlit/pull/MMMMM)).
+  ```
+
+### Output structure
+
+```markdown
+## **Version <new-tag>**
+
+_Release date: <Month Day, Year>_
+
+**Highlights**
+
+- 🍿 Introducing [`st.new_thing`](/develop/api-reference/widgets/st.new_thing) — a widget that lets you do something amazing ([#14200](https://github.com/streamlit/streamlit/pull/14200)).
+
+**Notable Changes**
+
+- 📊 [`st.dataframe`](/develop/api-reference/data/st.dataframe) has a new `selection_mode` parameter that lets you configure row and column selection behavior ([#14139](https://github.com/streamlit/streamlit/pull/14139), [#9836](https://github.com/streamlit/streamlit/issues/9836)).
+- ☠️ `st.legacy_thing` is deprecated and will be removed in a future version. Use `st.new_thing` instead ([#14050](https://github.com/streamlit/streamlit/pull/14050)).
+- 🔑 App menu redesign:
+  - New "Settings" option in the app menu ([#14100](https://github.com/streamlit/streamlit/pull/14100)).
+  - Reorganized menu items for better discoverability ([#14101](https://github.com/streamlit/streamlit/pull/14101)).
+
+**Other Changes**
+
+- 🐛 Bug fix: `st.spinner` avoids a race condition when used right before a cache miss ([#13849](https://github.com/streamlit/streamlit/pull/13849), [#13634](https://github.com/streamlit/streamlit/issues/13634)).
+- 🦋 Bug fix: `st.number_input` no longer resets to default when the step value changes ([#14125](https://github.com/streamlit/streamlit/pull/14125)). Thanks, [contributor](https://github.com/contributor)!
+- 🪲 Bug fix: Fixed a layout shift in `st.columns` when using `gap="small"` ([#14080](https://github.com/streamlit/streamlit/pull/14080)).
+```
+
+When the release has no Highlights, omit that section entirely (do not include an empty Highlights header).
+
+## Step 7: Final summary
+
+After writing the file, print:
+
+- File path for the generated changelog
+- PR counts per category
+- Reminder to review the file before publishing
+
+## Key references
+
+- `.github/release.yml` — canonical label-to-category mapping (also used for auto-generated GitHub release notes)
+- Website changelog format reference: `https://docs.streamlit.io/develop/quick-reference/release-notes`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `updating-internal-docs` | After significant codebase changes to review and update internal documentation |
 | `writing-spec` | When designing new API commands, widgets, or significant changes that need team review before implementation |
 | `finalizing-pr` | When changes are ready to merge — runs quality checks, simplifies code, and creates/updates the PR |
+| `generating-changelog` | When preparing release notes between two git tags |
 
 ### Subagents
 

--- a/scripts/changelog_categorize_prs.py
+++ b/scripts/changelog_categorize_prs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 """Filter and categorize PR data for changelog generation.
 
 Usage:
-    python3 scripts/changelog_categorize_prs.py [--input path] [--output path]
+    python scripts/changelog_categorize_prs.py [--input path] [--output path]
 
 Reads the PR data JSON produced by changelog_fetch_prs.py, excludes noise
 (bots, release PRs, internal-only), categorizes by labels, and writes

--- a/scripts/changelog_categorize_prs.py
+++ b/scripts/changelog_categorize_prs.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Filter and categorize PR data for changelog generation.
+
+Usage:
+    python3 scripts/changelog_categorize_prs.py [--input path] [--output path]
+
+Reads the PR data JSON produced by changelog_fetch_prs.py, excludes noise
+(bots, release PRs, internal-only), categorizes by labels, and writes
+a categorized JSON file plus a human-readable summary to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any
+
+_BOT_AUTHORS = {
+    "dependabot[bot]",
+    "github-actions",
+    "github-actions[bot]",
+    "dependabot",
+    "snyk-bot",
+    "renovate[bot]",
+    "codecov[bot]",
+}
+
+_KNOWN_INTERNAL_AUTHORS = {
+    "kmcgrady",
+    "lukasmasuch",
+    "mayagbarnes",
+    "raethlein",
+    "vdonato",
+}
+
+_RELEASE_PATTERNS = [
+    re.compile(r"(?i)release/\d+\.\d+"),
+    re.compile(r"(?i)merge.*release"),
+    re.compile(r"(?i)bump version"),
+    re.compile(r"(?i)version bump"),
+    re.compile(r"(?i)docstrings for"),
+]
+
+
+def _is_bot(author: str) -> bool:
+    return author in _BOT_AUTHORS
+
+
+def _is_internal_author(author: str) -> bool:
+    return author.startswith("sfc-gh-") or author in _KNOWN_INTERNAL_AUTHORS
+
+
+def _is_release_noise(title: str) -> bool:
+    return any(p.search(title) for p in _RELEASE_PATTERNS)
+
+
+def categorize_prs(prs: list[dict[str, Any]]) -> dict[str, Any]:
+    categories: dict[str, list[dict[str, Any]]] = {
+        "breaking": [],
+        "features": [],
+        "bugfixes": [],
+        "other_changes": [],
+        "unlabeled": [],
+        "excluded": [],
+    }
+
+    for pr in prs:
+        labels = set(pr.get("labels", []))
+        author = pr.get("author", "")
+        title = pr.get("title", "")
+
+        # Exclude bots
+        if _is_bot(author):
+            categories["excluded"].append({**pr, "exclude_reason": "bot"})
+            continue
+
+        # Exclude release noise
+        if _is_release_noise(title):
+            categories["excluded"].append({**pr, "exclude_reason": "release/version"})
+            continue
+
+        has_change = any(label.startswith("change:") for label in labels)
+        has_impact_users = "impact:users" in labels
+        has_impact_internal = "impact:internal" in labels
+
+        # Exclude internal-only (impact:internal without impact:users)
+        if has_impact_internal and not has_impact_users:
+            categories["excluded"].append({**pr, "exclude_reason": "internal-only"})
+            continue
+
+        # Flag external contributors
+        is_external = not _is_bot(author) and not _is_internal_author(author)
+        pr_entry = {**pr, "is_external": is_external}
+
+        # Categorize by label priority
+        if "change:breaking" in labels:
+            categories["breaking"].append(pr_entry)
+        elif "change:feature" in labels:
+            categories["features"].append(pr_entry)
+        elif "change:bugfix" in labels:
+            categories["bugfixes"].append(pr_entry)
+        elif has_impact_users or has_change:
+            categories["other_changes"].append(pr_entry)
+        else:
+            categories["unlabeled"].append(pr_entry)
+
+    return categories
+
+
+def print_summary(categories: dict[str, Any], total: int) -> None:
+    excluded = categories["excluded"]
+    bot_count = sum(1 for p in excluded if p.get("exclude_reason") == "bot")
+    release_count = sum(
+        1 for p in excluded if p.get("exclude_reason") == "release/version"
+    )
+    internal_count = sum(
+        1 for p in excluded if p.get("exclude_reason") == "internal-only"
+    )
+
+    print(f"\n{'=' * 60}")
+    print(f"Total PRs: {total}")
+    print(
+        f"Excluded: {len(excluded)} "
+        f"(bots: {bot_count}, release/version: {release_count}, internal-only: {internal_count})"
+    )
+    print(f"{'=' * 60}")
+    print(f"Breaking Changes: {len(categories['breaking'])}")
+    print(f"Features:         {len(categories['features'])}")
+    print(f"Bug Fixes:        {len(categories['bugfixes'])}")
+    print(f"Other Changes:    {len(categories['other_changes'])}")
+    print(f"Unlabeled:        {len(categories['unlabeled'])}")
+    print(f"{'=' * 60}\n")
+
+    for cat_name, display_name in [
+        ("breaking", "Breaking Changes"),
+        ("features", "Features"),
+        ("bugfixes", "Bug Fixes"),
+        ("other_changes", "Other Changes"),
+        ("unlabeled", "Unlabeled (needs review)"),
+    ]:
+        items = categories[cat_name]
+        if not items:
+            continue
+        print(f"--- {display_name} ({len(items)}) ---")
+        for pr in items:
+            ext_marker = " [EXTERNAL]" if pr.get("is_external") else ""
+            print(f"  #{pr['number']}: {pr['title']}{ext_marker}")
+        print()
+
+    # Print external contributor summary
+    all_active = []
+    for cat_name in ("breaking", "features", "bugfixes", "other_changes", "unlabeled"):
+        all_active.extend(categories[cat_name])
+    external_authors = sorted(
+        {pr["author"] for pr in all_active if pr.get("is_external")}
+    )
+    if external_authors:
+        print(f"--- External Contributors ({len(external_authors)}) ---")
+        for author in external_authors:
+            print(f"  {author}")
+        print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Categorize PR data for changelog")
+    parser.add_argument(
+        "--input", default="work-tmp/pr-data.json", help="Input JSON path"
+    )
+    parser.add_argument(
+        "--output", default="work-tmp/pr-categorized.json", help="Output JSON path"
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: input file '{args.input}' not found", file=sys.stderr)
+        sys.exit(1)
+
+    with open(args.input, encoding="utf-8") as f:
+        prs = json.load(f)
+
+    categories = categorize_prs(prs)
+    print_summary(categories, len(prs))
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(categories, f, indent=2)
+
+    print(f"Wrote categorized data to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/changelog_fetch_prs.py
+++ b/scripts/changelog_fetch_prs.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fetch PR metadata between two git tags via GitHub GraphQL API.
+
+Usage:
+    python3 scripts/changelog_fetch_prs.py <prev-tag> <new-tag> [--output path]
+
+Extracts PR numbers from `git log`, batches them into GraphQL queries
+(50 per batch), and writes a JSON array of {number, title, labels, author}
+objects sorted by PR number.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import operator
+import os
+import re
+import subprocess
+import sys
+from typing import Any
+
+_BATCH_SIZE = 50
+
+
+def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, **kwargs)
+
+
+def _validate_tag(tag: str) -> None:
+    result = _run(["git", "tag", "-l", tag])
+    if result.returncode != 0:
+        print(f"Error: git tag lookup failed: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    if not result.stdout.strip():
+        print(f"Error: tag '{tag}' not found", file=sys.stderr)
+        sys.exit(1)
+
+
+def _extract_pr_numbers(prev_tag: str, new_tag: str) -> list[int]:
+    result = _run(["git", "log", "--oneline", f"{prev_tag}...{new_tag}"])
+    if result.returncode != 0:
+        print(f"Error running git log: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    numbers = {int(m.group(1)) for m in re.finditer(r"#(\d+)", result.stdout)}
+    return sorted(numbers)
+
+
+def _build_graphql_query(pr_numbers: list[int]) -> str:
+    fields = []
+    for pr in pr_numbers:
+        fields.append(
+            f'pr{pr}: repository(owner:"streamlit",name:"streamlit") '
+            f"{{ pullRequest(number:{pr}) {{ "
+            f"number title labels(first:10) {{ nodes {{ name }} }} "
+            f"author {{ login }} "
+            f"}} }}"
+        )
+    return "query { " + " ".join(fields) + " }"
+
+
+def _parse_graphql_response(stdout: str) -> list[dict[str, Any]]:
+    data = json.loads(stdout).get("data", {})
+    prs = []
+    for _key, repo_data in data.items():
+        if repo_data is None:
+            continue
+        pr_data = repo_data.get("pullRequest")
+        if pr_data is None:
+            continue
+        prs.append(
+            {
+                "number": pr_data["number"],
+                "title": pr_data["title"],
+                "labels": [
+                    n["name"] for n in pr_data.get("labels", {}).get("nodes", [])
+                ],
+                "author": (pr_data.get("author") or {}).get("login", "ghost"),
+            }
+        )
+    return prs
+
+
+def _fetch_batch(pr_numbers: list[int]) -> list[dict[str, Any]]:
+    query = _build_graphql_query(pr_numbers)
+    result = _run(["gh", "api", "graphql", "-f", f"query={query}"])
+
+    # gh returns non-zero when some PRs don't exist (e.g. issue numbers picked
+    # up from commit messages).  The response still contains valid data for the
+    # PRs that *do* exist, so try to parse it regardless of the exit code.
+    if result.stdout.strip():
+        try:
+            prs = _parse_graphql_response(result.stdout)
+            if result.returncode != 0:
+                skipped = len(pr_numbers) - len(prs)
+                if skipped:
+                    print(
+                        f"    {skipped} number(s) were not valid PRs (skipped)",
+                        file=sys.stderr,
+                    )
+            return prs
+        except (json.JSONDecodeError, KeyError):
+            pass  # fall through to individual fetching
+
+    # Total failure (no parseable response). Fall back to fetching one-by-one.
+    print(
+        f"    Batch query failed, retrying individually ({len(pr_numbers)} PRs)...",
+        file=sys.stderr,
+    )
+    prs = []
+    for pr in pr_numbers:
+        single_result = _run(
+            ["gh", "api", "graphql", "-f", f"query={_build_graphql_query([pr])}"]
+        )
+        if single_result.returncode == 0:
+            prs.extend(_parse_graphql_response(single_result.stdout))
+        else:
+            print(f"    Skipping #{pr} (not found or error)", file=sys.stderr)
+    return prs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch PR metadata between two git tags"
+    )
+    parser.add_argument("prev_tag", help="Previous release tag")
+    parser.add_argument("new_tag", help="New release tag")
+    parser.add_argument(
+        "--output", default="work-tmp/pr-data.json", help="Output JSON path"
+    )
+    args = parser.parse_args()
+
+    _validate_tag(args.prev_tag)
+    _validate_tag(args.new_tag)
+
+    print(f"Extracting PR numbers from {args.prev_tag}...{args.new_tag}")
+    pr_numbers = _extract_pr_numbers(args.prev_tag, args.new_tag)
+    print(f"Found {len(pr_numbers)} PRs")
+
+    if not pr_numbers:
+        print("No PRs found between the given tags.")
+        sys.exit(0)
+
+    # Batch into groups of _BATCH_SIZE
+    batches = [
+        pr_numbers[i : i + _BATCH_SIZE] for i in range(0, len(pr_numbers), _BATCH_SIZE)
+    ]
+    print(f"Fetching metadata in {len(batches)} batch(es)...")
+
+    all_prs = []
+    for i, batch in enumerate(batches, 1):
+        print(f"  Batch {i}/{len(batches)} ({len(batch)} PRs)")
+        all_prs.extend(_fetch_batch(batch))
+
+    all_prs.sort(key=operator.itemgetter("number"))
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(all_prs, f, indent=2)
+
+    print(f"Wrote {len(all_prs)} PRs to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/changelog_fetch_prs.py
+++ b/scripts/changelog_fetch_prs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,11 @@
 """Fetch PR metadata between two git tags via GitHub GraphQL API.
 
 Usage:
-    python3 scripts/changelog_fetch_prs.py <prev-tag> <new-tag> [--output path]
+    python scripts/changelog_fetch_prs.py <prev-tag> <new-tag> [--output path]
 
 Extracts PR numbers from `git log`, batches them into GraphQL queries
-(50 per batch), and writes a JSON array of {number, title, labels, author}
+(50 per batch), and writes a JSON array of
+{number, title, labels, author, related_issues, related_issues_truncated}
 objects sorted by PR number.
 """
 
@@ -41,22 +42,25 @@ def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, capture_output=True, text=True, check=False, **kwargs)
 
 
+def _is_pr_not_found_error(stderr: str) -> bool:
+    return "Could not resolve to a PullRequest" in stderr
+
+
 def _validate_tag(tag: str) -> None:
-    result = _run(["git", "tag", "-l", tag])
+    result = _run(["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"])
     if result.returncode != 0:
-        print(f"Error: git tag lookup failed: {result.stderr}", file=sys.stderr)
-        sys.exit(1)
-    if not result.stdout.strip():
-        print(f"Error: tag '{tag}' not found", file=sys.stderr)
+        print(
+            f"Error: tag '{tag}' not found or invalid: {result.stderr}", file=sys.stderr
+        )
         sys.exit(1)
 
 
 def _extract_pr_numbers(prev_tag: str, new_tag: str) -> list[int]:
-    result = _run(["git", "log", "--oneline", f"{prev_tag}...{new_tag}"])
+    result = _run(["git", "log", "--oneline", f"{prev_tag}..{new_tag}"])
     if result.returncode != 0:
         print(f"Error running git log: {result.stderr}", file=sys.stderr)
         sys.exit(1)
-    numbers = {int(m.group(1)) for m in re.finditer(r"#(\d+)", result.stdout)}
+    numbers = {int(m.group(1)) for m in re.finditer(r"\(#(\d+)\)", result.stdout)}
     return sorted(numbers)
 
 
@@ -64,24 +68,42 @@ def _build_graphql_query(pr_numbers: list[int]) -> str:
     fields = []
     for pr in pr_numbers:
         fields.append(
-            f'pr{pr}: repository(owner:"streamlit",name:"streamlit") '
-            f"{{ pullRequest(number:{pr}) {{ "
-            f"number title labels(first:10) {{ nodes {{ name }} }} "
+            f"pr{pr}: pullRequest(number:{pr}) {{ "
+            f"number title labels(first:100) {{ nodes {{ name }} }} "
             f"author {{ login }} "
-            f"}} }}"
+            f"closingIssuesReferences(first:10) {{ "
+            f"nodes {{ number reactions(content:THUMBS_UP) {{ totalCount }} }} "
+            f"pageInfo {{ hasNextPage }} "
+            f"}} "
+            f"}}"
         )
-    return "query { " + " ".join(fields) + " }"
+    return (
+        'query { repository(owner:"streamlit",name:"streamlit") { '
+        + " ".join(fields)
+        + " } }"
+    )
 
 
 def _parse_graphql_response(stdout: str) -> list[dict[str, Any]]:
-    data = json.loads(stdout).get("data", {})
+    data = json.loads(stdout).get("data", {}) or {}
+    repo_data = data.get("repository") or {}
     prs = []
-    for _key, repo_data in data.items():
-        if repo_data is None:
-            continue
-        pr_data = repo_data.get("pullRequest")
+    for _alias, pr_data in repo_data.items():
         if pr_data is None:
             continue
+
+        closing_issues = pr_data.get("closingIssuesReferences") or {}
+        related_issues = []
+        for issue in closing_issues.get("nodes", []):
+            if issue is None:
+                continue
+            related_issues.append(
+                {
+                    "number": issue.get("number"),
+                    "thumbs_up": (issue.get("reactions") or {}).get("totalCount", 0),
+                }
+            )
+
         prs.append(
             {
                 "number": pr_data["number"],
@@ -90,6 +112,18 @@ def _parse_graphql_response(stdout: str) -> list[dict[str, Any]]:
                     n["name"] for n in pr_data.get("labels", {}).get("nodes", [])
                 ],
                 "author": (pr_data.get("author") or {}).get("login", "ghost"),
+                "related_issues": sorted(
+                    [
+                        issue
+                        for issue in related_issues
+                        if issue.get("number") is not None
+                    ],
+                    key=operator.itemgetter("thumbs_up"),
+                    reverse=True,
+                ),
+                "related_issues_truncated": bool(
+                    (closing_issues.get("pageInfo") or {}).get("hasNextPage")
+                ),
             }
         )
     return prs
@@ -99,9 +133,9 @@ def _fetch_batch(pr_numbers: list[int]) -> list[dict[str, Any]]:
     query = _build_graphql_query(pr_numbers)
     result = _run(["gh", "api", "graphql", "-f", f"query={query}"])
 
-    # gh returns non-zero when some PRs don't exist (e.g. issue numbers picked
-    # up from commit messages).  The response still contains valid data for the
-    # PRs that *do* exist, so try to parse it regardless of the exit code.
+    # gh can return non-zero when a queried number is not a valid PR. The
+    # response may still contain valid data for other PRs, so try to parse it
+    # regardless of the exit code.
     if result.stdout.strip():
         try:
             prs = _parse_graphql_response(result.stdout)
@@ -122,14 +156,32 @@ def _fetch_batch(pr_numbers: list[int]) -> list[dict[str, Any]]:
         file=sys.stderr,
     )
     prs = []
+    failures = 0
     for pr in pr_numbers:
         single_result = _run(
             ["gh", "api", "graphql", "-f", f"query={_build_graphql_query([pr])}"]
         )
-        if single_result.returncode == 0:
-            prs.extend(_parse_graphql_response(single_result.stdout))
-        else:
-            print(f"    Skipping #{pr} (not found or error)", file=sys.stderr)
+        if single_result.stdout.strip():
+            try:
+                prs.extend(_parse_graphql_response(single_result.stdout))
+                continue
+            except (json.JSONDecodeError, KeyError):
+                pass
+        if single_result.returncode != 0 and _is_pr_not_found_error(
+            single_result.stderr
+        ):
+            print(f"    Skipping #{pr} (not a valid PR)", file=sys.stderr)
+            continue
+
+        failures += 1
+        print(
+            f"Error: failed to fetch #{pr}: {single_result.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+    if failures and not prs:
+        print("Error: failed to fetch PR metadata from GitHub API.", file=sys.stderr)
+        sys.exit(1)
     return prs
 
 
@@ -147,7 +199,7 @@ def main() -> None:
     _validate_tag(args.prev_tag)
     _validate_tag(args.new_tag)
 
-    print(f"Extracting PR numbers from {args.prev_tag}...{args.new_tag}")
+    print(f"Extracting PR numbers from {args.prev_tag}..{args.new_tag}")
     pr_numbers = _extract_pr_numbers(args.prev_tag, args.new_tag)
     print(f"Found {len(pr_numbers)} PRs")
 


### PR DESCRIPTION
## Describe your changes

This PR adds a new Claude skill for generating polished website changelog entries between git tags. The skill automates the process of creating release notes for docs.streamlit.io by:

- Fetching PR data between two git tags using GitHub's GraphQL API
- Filtering out bot PRs, release noise, and internal-only changes
- Categorizing PRs by labels (`change:breaking`, `change:feature`, `change:bugfix`, etc.)
- Identifying external contributors automatically
- Generating formatted changelog entries with proper emojis, API links, and attribution

The skill includes two Python scripts:
- `changelog_fetch_prs.py` - Extracts PR numbers from git log and batch-fetches metadata via GitHub GraphQL
- `changelog_categorize_prs.py` - Filters noise, categorizes by labels, and identifies external contributors

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Manually tested locally

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.