### PR TITLE
[chore] Enforce uv run for git commit/push in agent hooks

### DIFF
--- a/.claude/hooks/pre_bash_redirect.py
+++ b/.claude/hooks/pre_bash_redirect.py
@@ -98,8 +98,8 @@ def main() -> None:
     for cmd_prefix in UV_RUN_COMMANDS:
         if norm == cmd_prefix or norm.startswith(cmd_prefix + " "):
             print(  # noqa: T201
-                f"Policy: Bash('{norm}') is blocked.\n"
-                f"Use 'uv run {norm}' instead of running '{cmd_prefix}' directly.\n",
+                f"Policy: Bash('{cmd}') is blocked.\n"
+                f"Use 'uv run {cmd}' instead of running '{cmd_prefix}' directly.\n",
                 file=sys.stderr,
             )
             sys.exit(2)

--- a/.claude/hooks/pre_bash_redirect.py
+++ b/.claude/hooks/pre_bash_redirect.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 """
-PreToolUse(Bash) hook: enforce uv run for Python commands and block direct pytest on e2e_playwright.
+PreToolUse(Bash) hook: enforce uv run for Python commands and git commands with hooks,
+and block direct pytest on e2e_playwright.
 
 Exit code semantics (as of Claude Code hooks):
 - exit 0: allow tool call
@@ -50,7 +51,18 @@ PYTEST_PATTERN = re.compile(
 )
 
 # Commands that must be run via `uv run`
-UV_RUN_COMMANDS = ("python", "python3", "pytest", "ruff", "mypy", "ty", "streamlit")
+# Includes git commands that trigger pre-commit/pre-push hooks
+UV_RUN_COMMANDS = (
+    "python",
+    "python3",
+    "pytest",
+    "ruff",
+    "mypy",
+    "ty",
+    "streamlit",
+    "git commit",
+    "git push",
+)
 
 
 def main() -> None:
@@ -82,15 +94,15 @@ def main() -> None:
         )
         sys.exit(2)
 
-    # Check if command starts with a Python tool that requires `uv run`
-    first_word = norm.split()[0] if norm else ""
-    if first_word in UV_RUN_COMMANDS:
-        print(  # noqa: T201
-            f"Policy: Bash('{norm}') is blocked.\n"
-            f"Use 'uv run {norm}' instead of running '{first_word}' directly.\n",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    # Check if command starts with a tool/command that requires `uv run`
+    for cmd_prefix in UV_RUN_COMMANDS:
+        if norm == cmd_prefix or norm.startswith(cmd_prefix + " "):
+            print(  # noqa: T201
+                f"Policy: Bash('{norm}') is blocked.\n"
+                f"Use 'uv run {norm}' instead of running '{cmd_prefix}' directly.\n",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
     sys.exit(0)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,9 +29,9 @@
       "Bash(git *)"
     ],
     "ask": [
-      "Bash(git push *)",
-      "Bash(git reset --hard *)",
-      "Bash(git clean *)"
+      "Bash(*git push*)",
+      "Bash(*git reset --hard*)",
+      "Bash(*git clean*)"
     ]
   },
   "hooks": {

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -11,6 +11,11 @@
         "type": "prompt",
         "prompt": "Block if the command starts with a Python tool (python, pytest, ruff, mypy, ty, streamlit) without 'uv run'. Use 'uv run <command> ...' instead.",
         "matcher": "^(python[3]?|pytest|ruff|mypy|ty|streamlit)(\\s|$)"
+      },
+      {
+        "type": "prompt",
+        "prompt": "Block if the command is 'git commit' or 'git push' without 'uv run'. Pre-commit hooks require the uv environment. Use 'uv run git commit ...' or 'uv run git push ...' instead.",
+        "matcher": "^git\\s+(commit|push)(\\s|$)"
       }
     ],
     "afterFileEdit": [

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -41,6 +41,7 @@ alwaysApply: true
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
+- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,7 @@
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
+- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
+- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.


### PR DESCRIPTION
## Describe your changes

Adds `git commit` and `git push` to the list of commands that require `uv run` in agent hooks. Pre-commit hooks need the uv environment to access linters and formatters.

- Added `git commit` and `git push` to `UV_RUN_COMMANDS` in `.claude/hooks/pre_bash_redirect.py`
- Updated check logic to handle multi-word command prefixes
- Added matching hook in `.cursor/hooks.json` for Cursor compatibility

## Testing Plan

- No tests needed - configuration-only changes to agent hooks
- Validated with `make check`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 3 |

</details>
<!-- agent-metrics-end -->