### PR TITLE
[feature] Add st.iframe command

### DIFF
--- a/e2e_playwright/st_iframe.py
+++ b/e2e_playwright/st_iframe.py
@@ -1,0 +1,86 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import streamlit as st
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+INLINE_HTML = """
+<!DOCTYPE html>
+<html lang="en">
+  <body style="margin: 0">
+    <div
+      id="inline-html-content"
+      style="
+        width: 240px;
+        height: 180px;
+        background: lightblue;
+        box-sizing: border-box;
+        padding: 16px;
+      "
+    >
+      Inline iframe HTML
+    </div>
+  </body>
+</html>
+"""
+
+DATA_URL = (
+    "data:text/html,"
+    "<!DOCTYPE html><html lang='en'><body style='margin:0'>"
+    "<div id='data-url-content' style='height:1200px'>Data URL iframe</div>"
+    "</body></html>"
+)
+
+WIDTH_CONTENT_HTML = """
+<!DOCTYPE html>
+<html lang="en">
+  <body style="margin: 0">
+    <div
+      id="width-content-html"
+      style="
+        width: 180px;
+        height: 60px;
+        background: plum;
+        box-sizing: border-box;
+        padding: 12px;
+      "
+    >
+      Width content iframe
+    </div>
+  </body>
+</html>
+"""
+
+st.write("st.iframe test app")
+
+with st.container(key="inline_html_iframe"):
+    st.iframe(INLINE_HTML, tab_index=3)
+
+with st.container(key="local_html_iframe"):
+    st.iframe(STATIC_DIR / "test_iframe.html")
+
+with st.container(key="local_svg_iframe"):
+    st.iframe(STATIC_DIR / "test_iframe.svg")
+
+with st.container(key="data_url_iframe"):
+    st.iframe(DATA_URL)
+
+with st.container(key="static_url_iframe"):
+    st.iframe("/app/static/test_iframe.html")
+
+with st.container(key="content_width_iframe"):
+    st.iframe(WIDTH_CONTENT_HTML, width="content")

--- a/e2e_playwright/st_iframe_test.py
+++ b/e2e_playwright/st_iframe_test.py
@@ -1,0 +1,97 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.shared.app_utils import get_element_by_key
+
+IFRAME_COUNT = 6
+
+
+def get_iframe(app: Page, key: str) -> Locator:
+    """Return the iframe inside the keyed container."""
+    iframe = get_element_by_key(app, key).locator("iframe")
+    expect(iframe).to_be_visible()
+    return iframe
+
+
+def get_iframe_box(iframe: Locator) -> dict[str, float]:
+    """Return the bounding box for an iframe."""
+    box = iframe.bounding_box()
+    if box is None:
+        raise AssertionError("Bounding box is None")
+    return box
+
+
+def test_iframe_srcdoc_sources_auto_size_to_content(app: Page):
+    """Test that srcdoc iframes auto-size to their HTML content."""
+    expect(app.locator("iframe")).to_have_count(IFRAME_COUNT)
+
+    inline_iframe = get_iframe(app, "inline_html_iframe")
+    expect(inline_iframe).to_have_attribute("tabindex", "3")
+    expect(inline_iframe).not_to_have_attribute("src")
+    inline_box = get_iframe_box(inline_iframe)
+    assert 176 <= inline_box["height"] <= 184
+    assert inline_box["height"] < 400
+    expect(
+        app.frame_locator(".st-key-inline_html_iframe iframe").locator(
+            "#inline-html-content"
+        )
+    ).to_contain_text("Inline iframe HTML")
+
+    local_html_iframe = get_iframe(app, "local_html_iframe")
+    expect(local_html_iframe).not_to_have_attribute("src")
+    local_html_box = get_iframe_box(local_html_iframe)
+    assert 136 <= local_html_box["height"] <= 144
+    assert local_html_box["height"] < 400
+    expect(
+        app.frame_locator(".st-key-local_html_iframe iframe").locator(
+            "#local-html-content"
+        )
+    ).to_contain_text("Local HTML iframe content")
+
+    content_width_iframe = get_iframe(app, "content_width_iframe")
+    content_width_box = get_iframe_box(content_width_iframe)
+    assert 176 <= content_width_box["width"] <= 184
+    assert content_width_box["width"] < 400
+    expect(content_width_iframe).not_to_have_attribute("src")
+    expect(
+        app.frame_locator(".st-key-content_width_iframe iframe").locator(
+            "#width-content-html"
+        )
+    ).to_contain_text("Width content iframe")
+
+
+def test_iframe_url_and_non_html_file_sources_use_expected_fallbacks(app: Page):
+    """Test that URL and media-backed iframe sources keep the fallback height."""
+    expect(app.locator("iframe")).to_have_count(IFRAME_COUNT)
+
+    data_url_iframe = get_iframe(app, "data_url_iframe")
+    expect(data_url_iframe).to_have_attribute("src", re.compile(r"^data:text/html,"))
+    expect(data_url_iframe).not_to_have_attribute("srcdoc")
+    assert 398 <= get_iframe_box(data_url_iframe)["height"] <= 402
+
+    static_url_iframe = get_iframe(app, "static_url_iframe")
+    expect(static_url_iframe).to_have_attribute(
+        "src", re.compile(r"/app/static/test_iframe\.html$")
+    )
+    expect(static_url_iframe).not_to_have_attribute("srcdoc")
+    assert 398 <= get_iframe_box(static_url_iframe)["height"] <= 402
+
+    local_svg_iframe = get_iframe(app, "local_svg_iframe")
+    expect(local_svg_iframe).to_have_attribute("src", re.compile(r"/media/.*\.svg$"))
+    expect(local_svg_iframe).not_to_have_attribute("srcdoc")
+    assert 398 <= get_iframe_box(local_svg_iframe)["height"] <= 402

--- a/e2e_playwright/static/test_iframe.html
+++ b/e2e_playwright/static/test_iframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body style="margin: 0">
+    <div
+      id="local-html-content"
+      style="
+        width: 220px;
+        height: 140px;
+        background: lightgreen;
+        box-sizing: border-box;
+        padding: 16px;
+      "
+    >
+      Local HTML iframe content
+    </div>
+  </body>
+</html>

--- a/e2e_playwright/static/test_iframe.svg
+++ b/e2e_playwright/static/test_iframe.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120">
+  <rect width="200" height="120" fill="lightcoral" />
+  <text x="18" y="68" font-size="20" fill="white">Iframe SVG</text>
+</svg>

--- a/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 
-import { IFrame as IFrameProto } from "@streamlit/protobuf"
+import { IFrame as IFrameProto, streamlit } from "@streamlit/protobuf"
 
 import { render } from "~lib/test_util"
 import {
@@ -26,15 +26,91 @@ import {
 
 import IFrame, { IFrameProps } from "./IFrame"
 
-const getProps = (elementProps: Partial<IFrameProto> = {}): IFrameProps => ({
+let resizeObserverCallback: ResizeObserverCallback | undefined
+
+class MockResizeObserver {
+  observe = vi.fn()
+
+  disconnect = vi.fn()
+
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback
+  }
+}
+
+const getProps = ({
+  elementProps = {},
+  heightConfig,
+  widthConfig,
+}: {
+  elementProps?: Partial<IFrameProto>
+  heightConfig?: streamlit.IHeightConfig | null
+  widthConfig?: streamlit.IWidthConfig | null
+} = {}): IFrameProps => ({
   element: IFrameProto.create({
     ...elementProps,
   }),
+  heightConfig,
+  widthConfig,
 })
 
+const mockIframeDocument = (
+  iframeElement: HTMLElement,
+  {
+    height = 180,
+    width = 320,
+  }: {
+    height?: number
+    width?: number
+  } = {}
+): void => {
+  const documentElement = {
+    clientHeight: height,
+    clientWidth: width,
+    offsetHeight: height,
+    offsetWidth: width,
+    scrollHeight: height,
+    scrollWidth: width,
+  } as unknown as HTMLElement
+
+  const body = {
+    clientHeight: height,
+    clientWidth: width,
+    offsetHeight: height,
+    offsetWidth: width,
+    scrollHeight: height,
+    scrollWidth: width,
+  } as unknown as HTMLBodyElement
+
+  const document = {
+    body,
+    documentElement,
+    readyState: "complete",
+  } as unknown as Document
+
+  Object.defineProperty(iframeElement, "contentDocument", {
+    configurable: true,
+    value: document,
+  })
+  Object.defineProperty(iframeElement, "contentWindow", {
+    configurable: true,
+    value: { document },
+  })
+}
+
 describe("st.iframe", () => {
+  beforeEach(() => {
+    resizeObserverCallback = undefined
+    globalThis.ResizeObserver =
+      MockResizeObserver as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("should render an iframe", () => {
-    const props = getProps({})
+    const props = getProps()
     render(<IFrame {...props} />)
     const iframeElement = screen.getByTestId("stIFrame")
     expect(iframeElement).toBeInTheDocument()
@@ -43,7 +119,7 @@ describe("st.iframe", () => {
 
   describe("tabIndex attribute", () => {
     it("should not have tabIndex attribute when not provided", () => {
-      const props = getProps({})
+      const props = getProps()
       render(<IFrame {...props} />)
       expect(screen.getByTestId("stIFrame")).not.toHaveAttribute("tabindex")
     })
@@ -55,7 +131,11 @@ describe("st.iframe", () => {
     ])(
       "should set tabIndex to $description value when provided",
       ({ value, expected }) => {
-        const props = getProps({ tabIndex: value })
+        const props = getProps({
+          elementProps: {
+            tabIndex: value,
+          },
+        })
         render(<IFrame {...props} />)
         expect(screen.getByTestId("stIFrame")).toHaveAttribute(
           "tabindex",
@@ -67,8 +147,10 @@ describe("st.iframe", () => {
 
   describe("Render iframe with `src` parameter", () => {
     const props = getProps({
-      src: "foo",
-      srcdoc: "bar",
+      elementProps: {
+        src: "foo",
+        srcdoc: "bar",
+      },
     })
 
     it("should set `srcDoc` to undefined if src is defined", () => {
@@ -100,7 +182,9 @@ describe("st.iframe", () => {
 
   describe("Render iframe with `srcDoc` parameter", () => {
     const props = getProps({
-      srcdoc: "bar",
+      elementProps: {
+        srcdoc: "bar",
+      },
     })
 
     it("should set `srcDoc`", () => {
@@ -128,7 +212,9 @@ describe("st.iframe", () => {
   describe("Render iframe with scrolling", () => {
     it("should set scrolling to auto", () => {
       const props = getProps({
-        scrolling: true,
+        elementProps: {
+          scrolling: true,
+        },
       })
       render(<IFrame {...props} />)
       expect(screen.getByTestId("stIFrame")).toHaveAttribute(
@@ -145,6 +231,53 @@ describe("st.iframe", () => {
       render(<IFrame {...props} />)
       expect(screen.getByTestId("stIFrame")).toHaveStyle("overflow: hidden")
       expect(screen.getByTestId("stIFrame")).toHaveAttribute("scrolling", "no")
+    })
+  })
+
+  describe("content sizing", () => {
+    it("measures srcdoc height when height uses content sizing", () => {
+      const props = getProps({
+        elementProps: {
+          srcdoc: "<p>Hello</p>",
+        },
+        heightConfig: new streamlit.HeightConfig({ useContent: true }),
+      })
+
+      render(<IFrame {...props} />)
+
+      const iframeElement = screen.getByTestId("stIFrame")
+      mockIframeDocument(iframeElement, { height: 222 })
+
+      fireEvent.load(iframeElement)
+
+      expect(iframeElement).toHaveStyle("height: 222px")
+      expect(iframeElement).not.toHaveStyle("height: 100%")
+    })
+
+    it("updates measured width and height when iframe content resizes", () => {
+      const props = getProps({
+        elementProps: {
+          srcdoc: "<p>Hello</p>",
+        },
+        heightConfig: new streamlit.HeightConfig({ useContent: true }),
+        widthConfig: new streamlit.WidthConfig({ useContent: true }),
+      })
+
+      render(<IFrame {...props} />)
+
+      const iframeElement = screen.getByTestId("stIFrame")
+      mockIframeDocument(iframeElement, { height: 180, width: 280 })
+      fireEvent.load(iframeElement)
+
+      expect(iframeElement).toHaveStyle("height: 180px")
+      expect(iframeElement).toHaveStyle("width: 280px")
+
+      mockIframeDocument(iframeElement, { height: 360, width: 420 })
+      resizeObserverCallback?.([], {} as ResizeObserver)
+
+      expect(iframeElement).toHaveStyle("height: 360px")
+      expect(iframeElement).toHaveStyle("width: 420px")
+      expect(iframeElement).not.toHaveStyle("width: 100%")
     })
   })
 })

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { memo, ReactElement } from "react"
+import {
+  memo,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
-import { IFrame as IFrameProto } from "@streamlit/protobuf"
+import { IFrame as IFrameProto, streamlit } from "@streamlit/protobuf"
 
 import {
   DEFAULT_IFRAME_FEATURE_POLICY,
@@ -37,28 +44,183 @@ function getNonEmptyString(
 
 export interface IFrameProps {
   element: IFrameProto
+  widthConfig?: streamlit.IWidthConfig | null
+  heightConfig?: streamlit.IHeightConfig | null
 }
 
-function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
+interface ContentDimensions {
+  width?: number
+  height?: number
+}
+
+/**
+ * Return the iframe document when it is accessible.
+ */
+function getIframeDocument(
+  iframe: HTMLIFrameElement | null
+): Document | undefined {
+  if (!iframe?.contentWindow) {
+    return undefined
+  }
+
+  return iframe.contentDocument ?? iframe.contentWindow.document
+}
+
+/**
+ * Measure the content dimensions of an iframe document.
+ */
+function getContentDimensions(document: Document): ContentDimensions {
+  const { body, documentElement } = document
+
+  const height = Math.ceil(
+    Math.max(
+      body?.scrollHeight ?? 0,
+      body?.offsetHeight ?? 0,
+      body?.clientHeight ?? 0,
+      documentElement?.scrollHeight ?? 0,
+      documentElement?.offsetHeight ?? 0,
+      documentElement?.clientHeight ?? 0
+    )
+  )
+
+  const width = Math.ceil(
+    Math.max(
+      body?.scrollWidth ?? 0,
+      body?.offsetWidth ?? 0,
+      body?.clientWidth ?? 0,
+      documentElement?.scrollWidth ?? 0,
+      documentElement?.offsetWidth ?? 0,
+      documentElement?.clientWidth ?? 0
+    )
+  )
+
+  return {
+    height: height > 0 ? height : undefined,
+    width: width > 0 ? width : undefined,
+  }
+}
+
+function IFrame({
+  element,
+  widthConfig,
+  heightConfig,
+}: Readonly<IFrameProps>): ReactElement {
   // Either 'src' or 'srcDoc' will be set in our element. If 'src'
   // is set, we're loading a remote URL in the iframe.
   const src = getNonEmptyString(element.src)
   const srcDoc = notNullOrUndefined(src)
     ? undefined
     : getNonEmptyString(element.srcdoc)
+  const shouldUseContentWidth = widthConfig?.useContent ?? false
+  const shouldUseContentHeight = heightConfig?.useContent ?? false
+  const canMeasureContent =
+    notNullOrUndefined(srcDoc) &&
+    (shouldUseContentWidth || shouldUseContentHeight)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const resizeObserverRef = useRef<ResizeObserver | null>(null)
+  const [contentDimensions, setContentDimensions] =
+    useState<ContentDimensions>({})
+
+  const disconnectResizeObserver = useCallback((): void => {
+    resizeObserverRef.current?.disconnect()
+    resizeObserverRef.current = null
+  }, [])
+
+  const updateContentDimensions = useCallback((): void => {
+    if (!canMeasureContent) {
+      return
+    }
+
+    const document = getIframeDocument(iframeRef.current)
+    if (!document) {
+      return
+    }
+
+    const nextDimensions = getContentDimensions(document)
+    setContentDimensions(prevDimensions => {
+      if (
+        prevDimensions.height === nextDimensions.height &&
+        prevDimensions.width === nextDimensions.width
+      ) {
+        return prevDimensions
+      }
+
+      return nextDimensions
+    })
+  }, [canMeasureContent])
+
+  const observeContentDimensions = useCallback((): void => {
+    disconnectResizeObserver()
+
+    if (!canMeasureContent || typeof ResizeObserver === "undefined") {
+      return
+    }
+
+    const document = getIframeDocument(iframeRef.current)
+    const documentElement = document?.documentElement
+    if (!documentElement) {
+      return
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateContentDimensions()
+    })
+
+    resizeObserver.observe(documentElement)
+    if (document.body && document.body !== documentElement) {
+      resizeObserver.observe(document.body)
+    }
+
+    resizeObserverRef.current = resizeObserver
+  }, [canMeasureContent, disconnectResizeObserver, updateContentDimensions])
+
+  const handleLoad = useCallback((): void => {
+    updateContentDimensions()
+    observeContentDimensions()
+  }, [observeContentDimensions, updateContentDimensions])
+
+  useEffect(() => {
+    if (!canMeasureContent) {
+      disconnectResizeObserver()
+      setContentDimensions({})
+      return undefined
+    }
+
+    const iframe = iframeRef.current
+    if (iframe?.contentDocument?.readyState === "complete") {
+      updateContentDimensions()
+      observeContentDimensions()
+    }
+
+    return () => {
+      disconnectResizeObserver()
+    }
+  }, [
+    canMeasureContent,
+    disconnectResizeObserver,
+    observeContentDimensions,
+    srcDoc,
+    updateContentDimensions,
+  ])
 
   return (
     <StyledIframe
+      ref={iframeRef}
       className="stIFrame"
       data-testid="stIFrame"
       allow={DEFAULT_IFRAME_FEATURE_POLICY}
+      contentHeight={contentDimensions.height}
+      contentWidth={contentDimensions.width}
       disableScrolling={!element.scrolling}
+      onLoad={handleLoad}
       src={src}
       srcDoc={srcDoc}
       scrolling={element.scrolling ? "auto" : "no"}
       sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
       title="st.iframe"
       tabIndex={element.tabIndex ?? undefined}
+      useContentHeight={shouldUseContentHeight}
+      useContentWidth={shouldUseContentWidth}
     />
   )
 }

--- a/frontend/lib/src/components/elements/IFrame/styled-components.ts
+++ b/frontend/lib/src/components/elements/IFrame/styled-components.ts
@@ -17,15 +17,36 @@
 import styled from "@emotion/styled"
 
 interface StyledIframeProps {
+  contentHeight?: number
+  contentWidth?: number
   disableScrolling: boolean
+  useContentHeight: boolean
+  useContentWidth: boolean
 }
 
 export const StyledIframe = styled.iframe<StyledIframeProps>(
-  ({ theme, disableScrolling }) => ({
-    width: "100%",
-    height: "100%",
+  ({
+    theme,
+    contentHeight,
+    contentWidth,
+    disableScrolling,
+    useContentHeight,
+    useContentWidth,
+  }) => ({
+    width: useContentWidth
+      ? contentWidth
+        ? `${contentWidth}px`
+        : "auto"
+      : "100%",
+    height: useContentHeight
+      ? contentHeight
+        ? `${contentHeight}px`
+        : "auto"
+      : "100%",
     colorScheme: "normal",
     border: "none",
+    display: "block",
+    maxWidth: useContentWidth ? "100%" : undefined,
     padding: theme.spacing.none,
     margin: theme.spacing.none,
     overflow: disableScrolling ? "hidden" : undefined,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -199,6 +199,7 @@ graphviz_chart = _main.graphviz_chart
 header = _main.header
 help = _main.help
 html = _main.html
+iframe = _main.iframe
 image = _main.image
 info = _main.info
 json = _main.json

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -14,18 +14,144 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+import mimetypes
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, cast
 
-from streamlit.elements.lib.layout_utils import LayoutConfig
+from streamlit import runtime
+from streamlit.deprecation_util import show_deprecation_warning
+from streamlit.elements.lib.layout_utils import (
+    Height,
+    LayoutConfig,
+    Width,
+    validate_height,
+    validate_width,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
+from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
+_HTML_FILE_EXTENSIONS: Final = {".htm", ".html", ".xhtml"}
+_URL_PREFIXES: Final = ("http://", "https://", "data:", "/")
+_CONTENT_HEIGHT_FALLBACK_PX: Final = 400
+_COMPONENTS_V1_IFRAME_DEPRECATION_WARNING: Final = (
+    "The `st.components.v1.iframe` and `st.components.v1.html` functions are "
+    "deprecated and will be removed in a future release. Use `st.iframe` instead."
+)
+
 
 class IframeMixin:
+    @gather_metrics("iframe")
+    def iframe(
+        self,
+        src: str | Path,
+        *,
+        width: Width = "stretch",
+        height: Height = "content",
+        tab_index: int | None = None,
+    ) -> DeltaGenerator:
+        r"""Embed content in an iframe.
+
+        ``st.iframe`` can embed a URL, a local file, or inline HTML in an
+        iframe. This includes support for local HTML files, PDFs, images, SVGs,
+        and other files that the browser can render natively.
+
+        Unlike ``st.html``, ``st.iframe`` always renders content inside an
+        iframe with Streamlit's default sandbox and permissions policy.
+
+        Parameters
+        ----------
+        src : str or Path
+            The content to embed. Streamlit detects the input type in this
+            order:
+
+            - A ``Path`` object is treated as a local file path.
+            - A string starting with ``http://``, ``https://``, ``data:``, or
+              ``/`` is treated as a URL.
+            - A string that resolves to an existing local file is treated as a
+              local file path.
+            - Any other string is treated as inline HTML and embedded with
+              ``srcdoc``.
+
+        width : "stretch", "content", or int
+            The width of the iframe. This can be one of the following:
+
+            - ``"stretch"`` (default): The iframe matches the width of its
+              parent container.
+            - ``"content"``: The iframe shrinks to fit its content when
+              possible.
+            - An integer specifying the width in pixels: The iframe has a fixed
+              width.
+
+        height : "stretch", "content", or int
+            The height of the iframe. This can be one of the following:
+
+            - ``"content"`` (default): The iframe matches the height of its
+              content when possible. For URLs and non-HTML local files,
+              ``"content"`` falls back to ``400`` pixels because browsers
+              restrict measuring iframe content in those cases.
+            - ``"stretch"``: The iframe fills the available vertical space.
+            - An integer specifying the height in pixels: The iframe has a
+              fixed height.
+
+        tab_index : int or None
+            Specifies how and if the iframe is sequentially focusable.
+            Users typically use the ``Tab`` key for sequential focus
+            navigation.
+
+            This can be one of the following values:
+
+            - ``None`` (default): Uses the browser's default behavior.
+            - ``-1``: Removes the iframe from sequential navigation, but still
+              allows it to be focused programmatically.
+            - ``0``: Includes the iframe in sequential navigation in the order
+              it appears in the document but after all elements with a positive
+              ``tab_index``.
+            - Positive integer: Includes the iframe in sequential navigation.
+              Elements are navigated in ascending order of their positive
+              ``tab_index``.
+
+            For more information, see the `tabindex
+            <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex>`_
+            documentation on MDN.
+
+        Examples
+        --------
+        .. code-block:: python
+           :filename: streamlit_app.py
+
+           import streamlit as st
+           from pathlib import Path
+
+           st.iframe("https://docs.streamlit.io", height=600)
+           st.iframe("<p>Hello from inline HTML.</p>")
+           st.iframe(Path("reports/summary.html"))
+
+        """
+        validate_width(width, allow_content=True)
+        validate_height(height, allow_content=True)
+
+        iframe_proto = IFrameProto()
+        resolved_src, resolved_srcdoc = _resolve_iframe_source(self.dg, src)
+        resolved_height = _resolve_iframe_height(
+            height, is_srcdoc=resolved_srcdoc is not None
+        )
+
+        marshall(
+            iframe_proto,
+            src=resolved_src,
+            srcdoc=resolved_srcdoc,
+            scrolling=True,
+            tab_index=tab_index,
+        )
+        layout_config = LayoutConfig(width=width, height=resolved_height)
+        return self.dg._enqueue("iframe", iframe_proto, layout_config=layout_config)
+
     @gather_metrics("_iframe")
     def _iframe(
         self,
@@ -42,8 +168,8 @@ class IframeMixin:
         module.
 
         .. warning::
-            Using ``st.components.v1.iframe`` directly (instead of importing
-            its module) is deprecated and will be disallowed in a later version.
+            ``st.components.v1.iframe`` is deprecated and will be removed in a
+            future release. Use ``st.iframe`` instead.
 
         Parameters
         ----------
@@ -91,6 +217,7 @@ class IframeMixin:
         >>> components.iframe("https://example.com", height=500)
 
         """
+        show_deprecation_warning(_COMPONENTS_V1_IFRAME_DEPRECATION_WARNING)
         iframe_proto = IFrameProto()
         marshall(
             iframe_proto,
@@ -123,8 +250,8 @@ class IframeMixin:
         ``st.html`` instead.
 
         .. warning::
-            Using ``st.components.v1.html`` directly (instead of importing
-            its module) is deprecated and will be disallowed in a later version.
+            ``st.components.v1.html`` is deprecated and will be removed in a
+            future release. Use ``st.iframe`` instead.
 
         Parameters
         ----------
@@ -174,6 +301,7 @@ class IframeMixin:
         >>> )
 
         """
+        show_deprecation_warning(_COMPONENTS_V1_IFRAME_DEPRECATION_WARNING)
         iframe_proto = IFrameProto()
         marshall(
             iframe_proto,
@@ -241,3 +369,68 @@ def marshall(
             )
 
         proto.tab_index = tab_index
+
+
+def _resolve_iframe_source(
+    dg: DeltaGenerator, src: str | Path
+) -> tuple[str | None, str | None]:
+    if isinstance(src, Path):
+        return _resolve_iframe_file_source(dg, src)
+
+    if _is_url_source(src):
+        return src, None
+
+    if _is_file_path(src):
+        return _resolve_iframe_file_source(dg, Path(src))
+
+    return None, src
+
+
+def _resolve_iframe_file_source(
+    dg: DeltaGenerator, file_path: Path
+) -> tuple[str | None, str | None]:
+    if _is_html_file(file_path):
+        with file_path.open(encoding="utf-8") as file:
+            return None, file.read()
+
+    return _marshall_iframe_media_file(dg, file_path), None
+
+
+def _marshall_iframe_media_file(dg: DeltaGenerator, file_path: Path) -> str:
+    mimetype, _ = mimetypes.guess_type(str(file_path))
+    if mimetype is None:
+        mimetype = "application/octet-stream"
+
+    coordinates = dg._get_delta_path_str()
+    file_path_str = str(file_path)
+
+    if runtime.exists():
+        file_url = runtime.get_instance().media_file_mgr.add(
+            file_path_str, mimetype, coordinates
+        )
+        caching.save_media_data(file_path_str, mimetype, coordinates)
+        return file_url
+
+    return ""
+
+
+def _resolve_iframe_height(height: Height, *, is_srcdoc: bool) -> Height:
+    if height == "content" and not is_srcdoc:
+        return _CONTENT_HEIGHT_FALLBACK_PX
+
+    return height
+
+
+def _is_url_source(src: str) -> bool:
+    return src.startswith(_URL_PREFIXES)
+
+
+def _is_file_path(src: object) -> bool:
+    try:
+        return os.path.isfile(src)
+    except TypeError:
+        return False
+
+
+def _is_html_file(file_path: Path) -> bool:
+    return file_path.suffix.lower() in _HTML_FILE_EXTENSIONS

--- a/lib/tests/streamlit/elements/iframe_test.py
+++ b/lib/tests/streamlit/elements/iframe_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -21,7 +23,10 @@ from streamlit.elements.iframe import marshall
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
-from tests.streamlit.elements.layout_test_utils import WidthConfigFields
+from tests.streamlit.elements.layout_test_utils import (
+    HeightConfigFields,
+    WidthConfigFields,
+)
 
 
 class IFrameTest(unittest.TestCase):
@@ -171,3 +176,77 @@ class IFrameComponentTest(DeltaGeneratorTestCase):
         assert element.height_config.pixel_height == 0
 
         assert element.iframe.srcdoc == "<h1>Test</h1>"
+
+    def test_public_iframe_url_uses_content_fallback_height(self):
+        """Test that st.iframe falls back to 400px for URL content height."""
+        st.iframe("https://example.com")
+
+        element = self.get_delta_from_queue().new_element
+
+        assert (
+            element.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert element.width_config.use_stretch is True
+        assert (
+            element.height_config.WhichOneof("height_spec")
+            == HeightConfigFields.PIXEL_HEIGHT.value
+        )
+        assert element.height_config.pixel_height == 400
+        assert element.iframe.src == "https://example.com"
+        assert element.iframe.scrolling is True
+
+    def test_public_iframe_html_string_uses_srcdoc_and_content_height(self):
+        """Test that st.iframe embeds inline HTML with srcdoc content sizing."""
+        st.iframe("<h1>Test</h1>")
+
+        element = self.get_delta_from_queue().new_element
+
+        assert (
+            element.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+        assert (
+            element.height_config.WhichOneof("height_spec")
+            == HeightConfigFields.USE_CONTENT.value
+        )
+        assert element.height_config.use_content is True
+        assert element.iframe.srcdoc == "<h1>Test</h1>"
+        assert element.iframe.scrolling is True
+
+    def test_public_iframe_local_html_file_uses_srcdoc(self):
+        """Test that st.iframe reads local HTML files into srcdoc."""
+        with TemporaryDirectory() as tmpdir:
+            html_file = Path(tmpdir) / "report.html"
+            html_file.write_text("<p>Local HTML</p>", encoding="utf-8")
+
+            st.iframe(html_file)
+
+            element = self.get_delta_from_queue().new_element
+
+            assert (
+                element.height_config.WhichOneof("height_spec")
+                == HeightConfigFields.USE_CONTENT.value
+            )
+            assert element.iframe.srcdoc == "<p>Local HTML</p>"
+            assert element.iframe.scrolling is True
+
+    def test_public_iframe_local_non_html_file_uses_media_url(self):
+        """Test that st.iframe serves local non-HTML files through media storage."""
+        with TemporaryDirectory() as tmpdir:
+            svg_file = Path(tmpdir) / "chart.svg"
+            svg_file.write_text(
+                "<svg xmlns='http://www.w3.org/2000/svg'></svg>", encoding="utf-8"
+            )
+
+            st.iframe(str(svg_file))
+
+            element = self.get_delta_from_queue().new_element
+
+            assert (
+                element.height_config.WhichOneof("height_spec")
+                == HeightConfigFields.PIXEL_HEIGHT.value
+            )
+            assert element.height_config.pixel_height == 400
+            assert element.iframe.src.startswith("/mock/media/")
+            assert element.iframe.srcdoc == ""

--- a/lib/tests/streamlit/typing/iframe_types.py
+++ b/lib/tests/streamlit/typing/iframe_types.py
@@ -1,0 +1,61 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform some "type checking testing"; mypy should flag any assignments that are
+# incorrect.
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.iframe import IframeMixin
+
+    iframe = IframeMixin().iframe
+
+    # Basic iframe usage
+    assert_type(iframe("https://example.com"), DeltaGenerator)
+    assert_type(iframe("<p>Hello</p>"), DeltaGenerator)
+    assert_type(iframe(Path("report.html")), DeltaGenerator)
+
+    # Width parameter
+    assert_type(iframe("https://example.com", width="stretch"), DeltaGenerator)
+    assert_type(iframe("https://example.com", width="content"), DeltaGenerator)
+    assert_type(iframe("https://example.com", width=320), DeltaGenerator)
+
+    # Height parameter
+    assert_type(iframe("https://example.com", height="content"), DeltaGenerator)
+    assert_type(iframe("https://example.com", height="stretch"), DeltaGenerator)
+    assert_type(iframe("https://example.com", height=480), DeltaGenerator)
+
+    # Tab index parameter
+    assert_type(iframe("https://example.com", tab_index=None), DeltaGenerator)
+    assert_type(iframe("https://example.com", tab_index=-1), DeltaGenerator)
+    assert_type(iframe("https://example.com", tab_index=0), DeltaGenerator)
+    assert_type(iframe("https://example.com", tab_index=3), DeltaGenerator)
+
+    # Combined parameters
+    assert_type(
+        iframe(
+            Path("dashboard.html"),
+            width="stretch",
+            height="content",
+            tab_index=1,
+        ),
+        DeltaGenerator,
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

- Adds top-level `st.iframe` on top of the existing iframe element, with auto-detection for URLs, inline HTML, local HTML files, and local media-backed files.
- Auto-sizes `srcdoc` iframe content for the compact HTML/file cases and falls back to 400px for URL and non-HTML file sources.
- Starts the soft deprecation path for `st.components.v1.iframe` and `st.components.v1.html` while keeping the legacy API behavior intact.
- Implements Python, typing, frontend, and e2e coverage for the new command.

## Screenshot or video (only for visual changes)

- Manual walkthrough completed locally against `make debug e2e_playwright/st_iframe.py`.

## GitHub Issue Link (if applicable)

- Closes #12977
- Spec: `specs/2026-03-13-st-iframe/product-spec.md`

## Testing Plan

- `uv run pytest lib/tests/streamlit/elements/iframe_test.py`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && yarn test lib/src/components/elements/IFrame/IFrame.test.tsx`
- `uv run mypy lib/tests/streamlit/typing/iframe_types.py`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && make frontend-fast`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && make run-e2e-test e2e_playwright/st_iframe_test.py`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && make check`
- `source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null && E2E_CHECK=true make check`
- Manual browser walkthrough on `http://localhost:3004`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82f31224-42ab-4c87-ba60-45acff20ff01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82f31224-42ab-4c87-ba60-45acff20ff01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

