### PR TITLE
[feature] Add `st.iframe` command

### DIFF
--- a/e2e_playwright/st_iframe.py
+++ b/e2e_playwright/st_iframe.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
 import streamlit as st
 
@@ -74,11 +74,12 @@ st.iframe(html_path)
 st.markdown("### Layout options")
 
 # Stretch height in a container with defined height
+stretch_html = (
+    "<div style='background:lavender;height:100%;margin:0;"
+    "padding:10px;box-sizing:border-box;'>Stretch height</div>"
+)
 with st.container(height=200, key="stretch-container"):
-    st.iframe(
-        "<div style='background:lavender;height:100%;margin:0;padding:10px;box-sizing:border-box;'>Stretch height</div>",
-        height="stretch",
-    )
+    st.iframe(stretch_html, height="stretch")
 
 # --- Tab index ---
 st.markdown("### Tab index")
@@ -100,7 +101,8 @@ st.iframe(
 # --- Scrolling ---
 st.markdown("### Scrolling behavior")
 
-st.iframe(
-    "<div style='height:300px;background:linear-gradient(white,blue);margin:0;padding:10px;'>Tall content that needs scrolling</div>",
-    height=100,
+scroll_html = (
+    "<div style='height:300px;background:linear-gradient(white,blue);"
+    "margin:0;padding:10px;'>Tall content that needs scrolling</div>"
 )
+st.iframe(scroll_html, height=100)

--- a/e2e_playwright/st_iframe.py
+++ b/e2e_playwright/st_iframe.py
@@ -57,8 +57,8 @@ html_content = """<!DOCTYPE html>
 </body>
 </html>"""
 
-tmp_dir = tempfile.mkdtemp()
-html_path = Path(tmp_dir) / "test_page.html"
+_tmp_dir = tempfile.TemporaryDirectory()
+html_path = Path(_tmp_dir.name) / "test_page.html"
 html_path.write_text(html_content, encoding="utf-8")
 
 with st.container(key="local_html_file"):

--- a/e2e_playwright/st_iframe.py
+++ b/e2e_playwright/st_iframe.py
@@ -18,44 +18,37 @@ from pathlib import Path
 import streamlit as st
 
 # --- URL-based iframes ---
-st.markdown("### URL iframes")
+with st.container(key="url_http"):
+    st.iframe("https://example.com", height=200)
 
-# External URL with fixed height
-st.iframe("https://example.com", height=200)
-
-# Data URL
-st.iframe("data:text/html,<h1>Data URL Content</h1>", height=100)
+with st.container(key="url_data"):
+    st.iframe("data:text/html,<h1>Data URL Content</h1>", height=100)
 
 # --- HTML string iframes ---
-st.markdown("### HTML string iframes")
+with st.container(key="html_auto_height"):
+    st.iframe("<p style='margin:0;padding:10px;'>Auto height HTML</p>")
 
-# Simple HTML with auto-height (content mode)
-st.iframe("<p style='margin:0;padding:10px;'>Auto height HTML</p>")
+with st.container(key="html_fixed_height"):
+    st.iframe(
+        "<div style='background:lightblue;padding:20px;margin:0;'>Fixed height content</div>",
+        height=150,
+    )
 
-# HTML with fixed height
-st.iframe(
-    "<div style='background:lightblue;padding:20px;margin:0;'>Fixed height content</div>",
-    height=150,
-)
+with st.container(key="html_stretch_width"):
+    st.iframe(
+        "<div style='background:lightyellow;padding:10px;margin:0;'>Stretch width</div>",
+        width="stretch",
+        height=80,
+    )
 
-# HTML with stretch width
-st.iframe(
-    "<div style='background:lightyellow;padding:10px;margin:0;'>Stretch width</div>",
-    width="stretch",
-    height=80,
-)
-
-# HTML with pixel width
-st.iframe(
-    "<div style='background:lightgreen;padding:10px;margin:0;'>Pixel width</div>",
-    width=300,
-    height=80,
-)
+with st.container(key="html_pixel_width"):
+    st.iframe(
+        "<div style='background:lightgreen;padding:10px;margin:0;'>Pixel width</div>",
+        width=300,
+        height=80,
+    )
 
 # --- Local file iframes ---
-st.markdown("### Local file iframes")
-
-# Create a temporary HTML file
 html_content = """<!DOCTYPE html>
 <html>
 <body style="margin:0;padding:10px;">
@@ -68,41 +61,36 @@ tmp_dir = tempfile.mkdtemp()
 html_path = Path(tmp_dir) / "test_page.html"
 html_path.write_text(html_content, encoding="utf-8")
 
-st.iframe(html_path)
+with st.container(key="local_html_file"):
+    st.iframe(html_path)
 
 # --- Layout options ---
-st.markdown("### Layout options")
-
-# Stretch height in a container with defined height
-stretch_html = (
-    "<div style='background:lavender;height:100%;margin:0;"
-    "padding:10px;box-sizing:border-box;'>Stretch height</div>"
-)
-with st.container(height=200, key="stretch-container"):
+with st.container(height=200, key="stretch_height"):
+    stretch_html = (
+        "<div style='background:lavender;height:100%;margin:0;"
+        "padding:10px;box-sizing:border-box;'>Stretch height</div>"
+    )
     st.iframe(stretch_html, height="stretch")
 
 # --- Tab index ---
-st.markdown("### Tab index")
+with st.container(key="tab_index_0"):
+    st.iframe(
+        "<p style='margin:0;padding:5px;'>Tab index 0</p>",
+        height=40,
+        tab_index=0,
+    )
 
-# With tab_index=0
-st.iframe(
-    "<p style='margin:0;padding:5px;'>Tab index 0</p>",
-    height=40,
-    tab_index=0,
-)
-
-# With tab_index=-1
-st.iframe(
-    "<p style='margin:0;padding:5px;'>Tab index -1</p>",
-    height=40,
-    tab_index=-1,
-)
+with st.container(key="tab_index_neg1"):
+    st.iframe(
+        "<p style='margin:0;padding:5px;'>Tab index -1</p>",
+        height=40,
+        tab_index=-1,
+    )
 
 # --- Scrolling ---
-st.markdown("### Scrolling behavior")
-
-scroll_html = (
-    "<div style='height:300px;background:linear-gradient(white,blue);"
-    "margin:0;padding:10px;'>Tall content that needs scrolling</div>"
-)
-st.iframe(scroll_html, height=100)
+with st.container(key="scrolling"):
+    scroll_html = (
+        "<div style='height:300px;background:linear-gradient(white,blue);"
+        "margin:0;padding:10px;'>Tall content that needs scrolling</div>"
+    )
+    st.iframe(scroll_html, height=100)

--- a/e2e_playwright/st_iframe.py
+++ b/e2e_playwright/st_iframe.py
@@ -1,0 +1,106 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import tempfile
+
+import streamlit as st
+
+# --- URL-based iframes ---
+st.markdown("### URL iframes")
+
+# External URL with fixed height
+st.iframe("https://example.com", height=200)
+
+# Data URL
+st.iframe("data:text/html,<h1>Data URL Content</h1>", height=100)
+
+# --- HTML string iframes ---
+st.markdown("### HTML string iframes")
+
+# Simple HTML with auto-height (content mode)
+st.iframe("<p style='margin:0;padding:10px;'>Auto height HTML</p>")
+
+# HTML with fixed height
+st.iframe(
+    "<div style='background:lightblue;padding:20px;margin:0;'>Fixed height content</div>",
+    height=150,
+)
+
+# HTML with stretch width
+st.iframe(
+    "<div style='background:lightyellow;padding:10px;margin:0;'>Stretch width</div>",
+    width="stretch",
+    height=80,
+)
+
+# HTML with pixel width
+st.iframe(
+    "<div style='background:lightgreen;padding:10px;margin:0;'>Pixel width</div>",
+    width=300,
+    height=80,
+)
+
+# --- Local file iframes ---
+st.markdown("### Local file iframes")
+
+# Create a temporary HTML file
+html_content = """<!DOCTYPE html>
+<html>
+<body style="margin:0;padding:10px;">
+<h2 style="margin:0;">Local HTML File</h2>
+<p style="margin:5px 0 0 0;">Loaded from a local file path.</p>
+</body>
+</html>"""
+
+tmp_dir = tempfile.mkdtemp()
+html_path = Path(tmp_dir) / "test_page.html"
+html_path.write_text(html_content, encoding="utf-8")
+
+st.iframe(html_path)
+
+# --- Layout options ---
+st.markdown("### Layout options")
+
+# Stretch height in a container with defined height
+with st.container(height=200, key="stretch-container"):
+    st.iframe(
+        "<div style='background:lavender;height:100%;margin:0;padding:10px;box-sizing:border-box;'>Stretch height</div>",
+        height="stretch",
+    )
+
+# --- Tab index ---
+st.markdown("### Tab index")
+
+# With tab_index=0
+st.iframe(
+    "<p style='margin:0;padding:5px;'>Tab index 0</p>",
+    height=40,
+    tab_index=0,
+)
+
+# With tab_index=-1
+st.iframe(
+    "<p style='margin:0;padding:5px;'>Tab index -1</p>",
+    height=40,
+    tab_index=-1,
+)
+
+# --- Scrolling ---
+st.markdown("### Scrolling behavior")
+
+st.iframe(
+    "<div style='height:300px;background:linear-gradient(white,blue);margin:0;padding:10px;'>Tall content that needs scrolling</div>",
+    height=100,
+)

--- a/e2e_playwright/st_iframe_test.py
+++ b/e2e_playwright/st_iframe_test.py
@@ -81,3 +81,13 @@ def test_tab_index(app: Page):
     """Test that tab_index is set correctly on iframes."""
     expect(_get_iframe(app, "tab_index_0")).to_have_attribute("tabindex", "0")
     expect(_get_iframe(app, "tab_index_neg1")).to_have_attribute("tabindex", "-1")
+
+
+def test_auto_height_for_srcdoc(app: Page):
+    """Test that srcdoc iframes with height='content' auto-size to their content."""
+    iframe = _get_iframe(app, "html_auto_height")
+    box = iframe.bounding_box()
+    assert box is not None
+    # Auto-height should be > 0 and not the 400px fallback used for URLs
+    assert box["height"] > 0
+    assert box["height"] < 400

--- a/e2e_playwright/st_iframe_test.py
+++ b/e2e_playwright/st_iframe_test.py
@@ -37,7 +37,8 @@ def test_html_string_iframe_has_srcdoc(app: Page):
     expect(html_iframe).to_have_attribute(
         "srcdoc", "<p style='margin:0;padding:10px;'>Auto height HTML</p>"
     )
-    expect(html_iframe).not_to_have_attribute("src")
+    src_val = html_iframe.get_attribute("src")
+    assert src_val is None or src_val == ""
 
 
 def test_html_iframe_fixed_height(app: Page):

--- a/e2e_playwright/st_iframe_test.py
+++ b/e2e_playwright/st_iframe_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.shared.app_utils import get_element_by_key
 
 
-def _get_iframe(app: Page, key: str):
+def _get_iframe(app: Page, key: str) -> Locator:
     """Return the stIFrame locator inside the container with the given key."""
     return get_element_by_key(app, key).get_by_test_id("stIFrame")
 

--- a/e2e_playwright/st_iframe_test.py
+++ b/e2e_playwright/st_iframe_test.py
@@ -1,0 +1,96 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+
+def test_url_iframe_renders(app: Page):
+    """Test that a URL-based iframe renders with correct src attribute."""
+    iframes = app.get_by_test_id("stIFrame")
+    expect(iframes.first).to_be_attached()
+    expect(iframes.first).to_have_attribute("src", "https://example.com")
+
+
+def test_data_url_iframe_renders(app: Page):
+    """Test that a data URL iframe renders correctly."""
+    iframes = app.get_by_test_id("stIFrame")
+    expect(iframes.nth(1)).to_have_attribute(
+        "src", "data:text/html,<h1>Data URL Content</h1>"
+    )
+
+
+def test_html_string_iframe_has_srcdoc(app: Page):
+    """Test that HTML string iframes use srcdoc."""
+    iframes = app.get_by_test_id("stIFrame")
+    html_iframe = iframes.nth(2)
+    expect(html_iframe).to_have_attribute(
+        "srcdoc", "<p style='margin:0;padding:10px;'>Auto height HTML</p>"
+    )
+    expect(html_iframe).not_to_have_attribute("src")
+
+
+def test_html_iframe_fixed_height(app: Page):
+    """Test that fixed-height HTML iframes have the correct rendered height."""
+    iframes = app.get_by_test_id("stIFrame")
+    fixed_height_iframe = iframes.nth(3)
+    box = fixed_height_iframe.bounding_box()
+    assert box is not None
+    assert abs(box["height"] - 150) < 2
+
+
+def test_html_iframe_pixel_width(app: Page):
+    """Test that pixel-width iframes have the correct width."""
+    iframes = app.get_by_test_id("stIFrame")
+    pixel_width_iframe = iframes.nth(5)
+    box = pixel_width_iframe.bounding_box()
+    assert box is not None
+    assert abs(box["width"] - 300) < 2
+
+
+def test_local_html_file_uses_srcdoc(app: Page):
+    """Test that local HTML files are embedded via srcdoc."""
+    iframes = app.get_by_test_id("stIFrame")
+    local_file_iframe = iframes.nth(6)
+    srcdoc = local_file_iframe.get_attribute("srcdoc")
+    assert srcdoc is not None
+    assert "Local HTML File" in srcdoc
+    assert "Loaded from a local file path" in srcdoc
+
+
+def test_scrolling_is_auto(app: Page):
+    """Test that st.iframe always enables scrolling (auto mode)."""
+    iframes = app.get_by_test_id("stIFrame")
+    for i in range(iframes.count()):
+        expect(iframes.nth(i)).to_have_attribute("scrolling", "auto")
+
+
+def test_tab_index_set_correctly(app: Page):
+    """Test that tab_index is set correctly on iframes."""
+    iframes = app.get_by_test_id("stIFrame")
+    tab_index_0_iframe = iframes.nth(8)
+    expect(tab_index_0_iframe).to_have_attribute("tabindex", "0")
+
+    tab_index_neg1_iframe = iframes.nth(9)
+    expect(tab_index_neg1_iframe).to_have_attribute("tabindex", "-1")
+
+
+def test_sandbox_policy(app: Page):
+    """Test that iframes have the correct sandbox policy."""
+    iframes = app.get_by_test_id("stIFrame")
+    first_iframe = iframes.first
+    sandbox = first_iframe.get_attribute("sandbox")
+    assert sandbox is not None
+    assert "allow-scripts" in sandbox
+    assert "allow-same-origin" in sandbox
+    assert "allow-forms" in sandbox

--- a/e2e_playwright/st_iframe_test.py
+++ b/e2e_playwright/st_iframe_test.py
@@ -14,46 +14,41 @@
 
 from playwright.sync_api import Page, expect
 
-
-def test_url_iframe_renders(app: Page):
-    """Test that a URL-based iframe renders with correct src attribute."""
-    iframes = app.get_by_test_id("stIFrame")
-    expect(iframes.first).to_be_attached()
-    expect(iframes.first).to_have_attribute("src", "https://example.com")
+from e2e_playwright.shared.app_utils import get_element_by_key
 
 
-def test_data_url_iframe_renders(app: Page):
-    """Test that a data URL iframe renders correctly."""
-    iframes = app.get_by_test_id("stIFrame")
-    expect(iframes.nth(1)).to_have_attribute(
+def _get_iframe(app: Page, key: str):
+    """Return the stIFrame locator inside the container with the given key."""
+    return get_element_by_key(app, key).get_by_test_id("stIFrame")
+
+
+def test_url_iframes(app: Page):
+    """Test that URL-based iframes render with correct src and no srcdoc."""
+    http_iframe = _get_iframe(app, "url_http")
+    expect(http_iframe).to_be_attached()
+    expect(http_iframe).to_have_attribute("src", "https://example.com")
+
+    data_iframe = _get_iframe(app, "url_data")
+    expect(data_iframe).to_have_attribute(
         "src", "data:text/html,<h1>Data URL Content</h1>"
     )
 
 
-def test_html_string_iframe_has_srcdoc(app: Page):
-    """Test that HTML string iframes use srcdoc."""
-    iframes = app.get_by_test_id("stIFrame")
-    html_iframe = iframes.nth(2)
-    expect(html_iframe).to_have_attribute(
+def test_html_string_iframes(app: Page):
+    """Test that HTML string iframes use srcdoc and respect height settings."""
+    auto_iframe = _get_iframe(app, "html_auto_height")
+    expect(auto_iframe).to_have_attribute(
         "srcdoc", "<p style='margin:0;padding:10px;'>Auto height HTML</p>"
     )
-    src_val = html_iframe.get_attribute("src")
+    src_val = auto_iframe.get_attribute("src")
     assert src_val is None or src_val == ""
 
-
-def test_html_iframe_fixed_height(app: Page):
-    """Test that fixed-height HTML iframes have the correct rendered height."""
-    iframes = app.get_by_test_id("stIFrame")
-    fixed_height_iframe = iframes.nth(3)
-    box = fixed_height_iframe.bounding_box()
+    fixed_iframe = _get_iframe(app, "html_fixed_height")
+    box = fixed_iframe.bounding_box()
     assert box is not None
     assert abs(box["height"] - 150) < 2
 
-
-def test_html_iframe_pixel_width(app: Page):
-    """Test that pixel-width iframes have the correct width."""
-    iframes = app.get_by_test_id("stIFrame")
-    pixel_width_iframe = iframes.nth(5)
+    pixel_width_iframe = _get_iframe(app, "html_pixel_width")
     box = pixel_width_iframe.bounding_box()
     assert box is not None
     assert abs(box["width"] - 300) < 2
@@ -61,37 +56,28 @@ def test_html_iframe_pixel_width(app: Page):
 
 def test_local_html_file_uses_srcdoc(app: Page):
     """Test that local HTML files are embedded via srcdoc."""
-    iframes = app.get_by_test_id("stIFrame")
-    local_file_iframe = iframes.nth(6)
-    srcdoc = local_file_iframe.get_attribute("srcdoc")
+    iframe = _get_iframe(app, "local_html_file")
+    srcdoc = iframe.get_attribute("srcdoc")
     assert srcdoc is not None
     assert "Local HTML File" in srcdoc
     assert "Loaded from a local file path" in srcdoc
 
 
-def test_scrolling_is_auto(app: Page):
-    """Test that st.iframe always enables scrolling (auto mode)."""
+def test_scrolling_and_sandbox(app: Page):
+    """Test that all iframes enable scrolling and use the sandbox policy."""
     iframes = app.get_by_test_id("stIFrame")
     for i in range(iframes.count()):
         expect(iframes.nth(i)).to_have_attribute("scrolling", "auto")
 
-
-def test_tab_index_set_correctly(app: Page):
-    """Test that tab_index is set correctly on iframes."""
-    iframes = app.get_by_test_id("stIFrame")
-    tab_index_0_iframe = iframes.nth(8)
-    expect(tab_index_0_iframe).to_have_attribute("tabindex", "0")
-
-    tab_index_neg1_iframe = iframes.nth(9)
-    expect(tab_index_neg1_iframe).to_have_attribute("tabindex", "-1")
-
-
-def test_sandbox_policy(app: Page):
-    """Test that iframes have the correct sandbox policy."""
-    iframes = app.get_by_test_id("stIFrame")
     first_iframe = iframes.first
     sandbox = first_iframe.get_attribute("sandbox")
     assert sandbox is not None
     assert "allow-scripts" in sandbox
     assert "allow-same-origin" in sandbox
     assert "allow-forms" in sandbox
+
+
+def test_tab_index(app: Page):
+    """Test that tab_index is set correctly on iframes."""
+    expect(_get_iframe(app, "tab_index_0")).to_have_attribute("tabindex", "0")
+    expect(_get_iframe(app, "tab_index_neg1")).to_have_attribute("tabindex", "-1")

--- a/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
@@ -147,4 +147,36 @@ describe("st.iframe", () => {
       expect(screen.getByTestId("stIFrame")).toHaveAttribute("scrolling", "no")
     })
   })
+
+  describe("contentHeight mode", () => {
+    it("should use height: auto when contentHeight is true with srcDoc", () => {
+      const props = getProps({
+        srcdoc: "<p>Auto height content</p>",
+        contentHeight: true,
+      })
+      render(<IFrame {...props} />)
+      const iframe = screen.getByTestId("stIFrame")
+      expect(iframe).toHaveStyle("height: auto")
+    })
+
+    it("should use height: 100% when contentHeight is false", () => {
+      const props = getProps({
+        srcdoc: "<p>Fixed height content</p>",
+        contentHeight: false,
+      })
+      render(<IFrame {...props} />)
+      const iframe = screen.getByTestId("stIFrame")
+      expect(iframe).toHaveStyle("height: 100%")
+    })
+
+    it("should not use content height mode for src iframes", () => {
+      const props = getProps({
+        src: "https://example.com",
+        contentHeight: true,
+      })
+      render(<IFrame {...props} />)
+      const iframe = screen.getByTestId("stIFrame")
+      expect(iframe).toHaveStyle("height: 100%")
+    })
+  })
 })

--- a/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.test.tsx
@@ -37,7 +37,7 @@ describe("st.iframe", () => {
     const props = getProps({})
     render(<IFrame {...props} />)
     const iframeElement = screen.getByTestId("stIFrame")
-    expect(iframeElement).toBeInTheDocument()
+    expect(iframeElement).toBeVisible()
     expect(iframeElement).toHaveClass("stIFrame")
   })
 

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { memo, ReactElement } from "react"
+import { memo, ReactElement, useCallback, useEffect, useRef, useState } from "react"
 
 import { IFrame as IFrameProto } from "@streamlit/protobuf"
 
@@ -47,18 +47,84 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
     ? undefined
     : getNonEmptyString(element.srcdoc)
 
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [contentHeight, setContentHeight] = useState<number | undefined>(
+    undefined
+  )
+
+  const handleIframeLoad = useCallback((): void => {
+    if (!element.contentHeight || !iframeRef.current) {
+      return
+    }
+
+    try {
+      const iframeDoc = iframeRef.current.contentDocument
+      if (!iframeDoc) {
+        return
+      }
+
+      const measureHeight = (): void => {
+        if (!iframeRef.current?.contentDocument) {
+          return
+        }
+        const docEl = iframeRef.current.contentDocument.documentElement
+        const height = Math.max(
+          docEl.scrollHeight,
+          docEl.offsetHeight
+        )
+        if (height > 0) {
+          setContentHeight(height)
+        }
+      }
+
+      measureHeight()
+
+      const observer = new ResizeObserver(() => {
+        measureHeight()
+      })
+      observer.observe(iframeDoc.documentElement)
+
+      // Store cleanup ref so we can disconnect on unmount
+      iframeRef.current.dataset.observerActive = "true"
+      const currentIframe = iframeRef.current
+      const cleanup = (): void => {
+        observer.disconnect()
+        delete currentIframe.dataset.observerActive
+      }
+      currentIframe.addEventListener("st-cleanup", cleanup, { once: true })
+    } catch {
+      // Cross-origin access will fail — that's expected for src iframes
+    }
+  }, [element.contentHeight])
+
+  useEffect(() => {
+    return () => {
+      // Dispatch cleanup event on unmount
+      iframeRef.current?.dispatchEvent(new Event("st-cleanup"))
+    }
+  }, [])
+
+  const useContentHeight = element.contentHeight && notNullOrUndefined(srcDoc)
+  const iframeStyle = useContentHeight && contentHeight !== undefined
+    ? { height: `${contentHeight}px` }
+    : undefined
+
   return (
     <StyledIframe
       className="stIFrame"
       data-testid="stIFrame"
       allow={DEFAULT_IFRAME_FEATURE_POLICY}
+      ref={iframeRef}
       disableScrolling={!element.scrolling}
+      useContentHeight={useContentHeight ?? false}
       src={src}
       srcDoc={srcDoc}
       scrolling={element.scrolling ? "auto" : "no"}
       sandbox={DEFAULT_IFRAME_SANDBOX_POLICY}
       title="st.iframe"
       tabIndex={element.tabIndex ?? undefined}
+      onLoad={handleIframeLoad}
+      style={iframeStyle}
     />
   )
 }

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { memo, ReactElement, useCallback, useEffect, useRef, useState } from "react"
+import {
+  memo,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
 import { IFrame as IFrameProto } from "@streamlit/protobuf"
 
@@ -48,6 +55,7 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
     : getNonEmptyString(element.srcdoc)
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const observerRef = useRef<ResizeObserver | null>(null)
   const [contentHeight, setContentHeight] = useState<number | undefined>(
     undefined
   )
@@ -63,35 +71,18 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
         return
       }
 
-      const measureHeight = (): void => {
-        if (!iframeRef.current?.contentDocument) {
-          return
-        }
-        const docEl = iframeRef.current.contentDocument.documentElement
-        const height = Math.max(
-          docEl.scrollHeight,
-          docEl.offsetHeight
-        )
-        if (height > 0) {
-          setContentHeight(height)
-        }
-      }
+      observerRef.current?.disconnect()
 
-      measureHeight()
-
-      const observer = new ResizeObserver(() => {
-        measureHeight()
+      const observer = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          const height = entry.borderBoxSize?.[0]?.blockSize ?? 0
+          if (height > 0) {
+            setContentHeight(height)
+          }
+        }
       })
       observer.observe(iframeDoc.documentElement)
-
-      // Store cleanup ref so we can disconnect on unmount
-      iframeRef.current.dataset.observerActive = "true"
-      const currentIframe = iframeRef.current
-      const cleanup = (): void => {
-        observer.disconnect()
-        delete currentIframe.dataset.observerActive
-      }
-      currentIframe.addEventListener("st-cleanup", cleanup, { once: true })
+      observerRef.current = observer
     } catch {
       // Cross-origin access will fail — that's expected for src iframes
     }
@@ -99,15 +90,16 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
 
   useEffect(() => {
     return () => {
-      // Dispatch cleanup event on unmount
-      iframeRef.current?.dispatchEvent(new Event("st-cleanup"))
+      observerRef.current?.disconnect()
+      observerRef.current = null
     }
   }, [])
 
   const useContentHeight = element.contentHeight && notNullOrUndefined(srcDoc)
-  const iframeStyle = useContentHeight && contentHeight !== undefined
-    ? { height: `${contentHeight}px` }
-    : undefined
+  const iframeStyle =
+    useContentHeight && contentHeight !== undefined
+      ? { height: `${contentHeight}px` }
+      : undefined
 
   return (
     <StyledIframe

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -96,10 +96,6 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
   }, [])
 
   const useContentHeight = element.contentHeight && notNullOrUndefined(srcDoc)
-  const iframeStyle =
-    useContentHeight && contentHeight !== undefined
-      ? { height: `${contentHeight}px` }
-      : undefined
 
   return (
     <StyledIframe
@@ -109,6 +105,7 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
       ref={iframeRef}
       disableScrolling={!element.scrolling}
       useContentHeight={useContentHeight ?? false}
+      measuredHeight={useContentHeight ? contentHeight : undefined}
       src={src}
       srcDoc={srcDoc}
       scrolling={element.scrolling ? "auto" : "no"}
@@ -116,7 +113,6 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
       title="st.iframe"
       tabIndex={element.tabIndex ?? undefined}
       onLoad={handleIframeLoad}
-      style={iframeStyle}
     />
   )
 }

--- a/frontend/lib/src/components/elements/IFrame/IFrame.tsx
+++ b/frontend/lib/src/components/elements/IFrame/IFrame.tsx
@@ -74,11 +74,12 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
       observerRef.current?.disconnect()
 
       const observer = new ResizeObserver(entries => {
-        for (const entry of entries) {
-          const height = entry.borderBoxSize?.[0]?.blockSize ?? 0
-          if (height > 0) {
-            setContentHeight(height)
-          }
+        if (entries.length === 0) return
+        const entry = entries[0]
+        const height =
+          entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect?.height ?? 0
+        if (height > 0) {
+          setContentHeight(height)
         }
       })
       observer.observe(iframeDoc.documentElement)
@@ -89,11 +90,15 @@ function IFrame({ element }: Readonly<IFrameProps>): ReactElement {
   }, [element.contentHeight])
 
   useEffect(() => {
+    if (!element.contentHeight) {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+    }
     return () => {
       observerRef.current?.disconnect()
       observerRef.current = null
     }
-  }, [])
+  }, [element.contentHeight])
 
   const useContentHeight = element.contentHeight && notNullOrUndefined(srcDoc)
 

--- a/frontend/lib/src/components/elements/IFrame/styled-components.ts
+++ b/frontend/lib/src/components/elements/IFrame/styled-components.ts
@@ -19,12 +19,18 @@ import styled from "@emotion/styled"
 interface StyledIframeProps {
   disableScrolling: boolean
   useContentHeight: boolean
+  measuredHeight?: number
 }
 
 export const StyledIframe = styled.iframe<StyledIframeProps>(
-  ({ theme, disableScrolling, useContentHeight }) => ({
+  ({ theme, disableScrolling, useContentHeight, measuredHeight }) => ({
     width: "100%",
-    height: useContentHeight ? "auto" : "100%",
+    height:
+      measuredHeight !== undefined
+        ? `${measuredHeight}px`
+        : useContentHeight
+          ? "auto"
+          : "100%",
     colorScheme: "normal",
     border: "none",
     padding: theme.spacing.none,

--- a/frontend/lib/src/components/elements/IFrame/styled-components.ts
+++ b/frontend/lib/src/components/elements/IFrame/styled-components.ts
@@ -18,12 +18,13 @@ import styled from "@emotion/styled"
 
 interface StyledIframeProps {
   disableScrolling: boolean
+  useContentHeight: boolean
 }
 
 export const StyledIframe = styled.iframe<StyledIframeProps>(
-  ({ theme, disableScrolling }) => ({
+  ({ theme, disableScrolling, useContentHeight }) => ({
     width: "100%",
-    height: "100%",
+    height: useContentHeight ? "auto" : "100%",
     colorScheme: "normal",
     border: "none",
     padding: theme.spacing.none,

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -199,6 +199,7 @@ graphviz_chart = _main.graphviz_chart
 header = _main.header
 help = _main.help
 html = _main.html
+iframe = _main.iframe
 image = _main.image
 info = _main.info
 json = _main.json

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -14,18 +14,212 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+import mimetypes
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, cast
 
-from streamlit.elements.lib.layout_utils import LayoutConfig
+from streamlit.elements.lib.layout_utils import LayoutConfig, validate_height, validate_width
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
+from streamlit.runtime import caching, runtime
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
+_HTML_EXTENSIONS = {".html", ".htm", ".xhtml"}
+
+_CONTENT_HEIGHT_FALLBACK = 400
+
+
+def _is_url(src: str) -> bool:
+    """Check if the string is a URL (absolute or relative)."""
+    return src.startswith(("http://", "https://", "data:", "/"))
+
+
+def _is_html_file(path: Path) -> bool:
+    """Check if the file path has an HTML extension."""
+    return path.suffix.lower() in _HTML_EXTENSIONS
+
 
 class IframeMixin:
+    @gather_metrics("iframe")
+    def iframe(
+        self,
+        src: str | Path,
+        *,
+        width: int | Literal["stretch", "content"] = "stretch",
+        height: int | Literal["stretch", "content"] = "content",
+        tab_index: int | None = None,
+    ) -> DeltaGenerator:
+        r"""Embed content in an iframe.
+
+        Display a URL, local file, or HTML string inside an iframe element.
+        Streamlit auto-detects the input type and handles it appropriately.
+
+        Parameters
+        ----------
+        src : str or Path
+            Content to embed. Streamlit auto-detects the type:
+
+            - **Absolute URL**: Starts with ``http://``, ``https://``, or
+              ``data:``. Loaded directly in the iframe.
+            - **Relative URL**: Starts with ``/``. Useful for referencing
+              static files served by Streamlit.
+            - **Local file path**: A ``Path`` object or a string that resolves
+              to an existing file. HTML files (``.html``, ``.htm``, ``.xhtml``)
+              are read and embedded via ``srcdoc``. Other files (PDF, images,
+              SVG, etc.) are served through media storage and loaded via
+              ``src``.
+            - **HTML string**: Any other string is treated as inline HTML and
+              embedded via ``srcdoc``.
+
+        width : int, "stretch", or "content"
+            Width of the iframe in CSS pixels, ``"stretch"`` to fill
+            the container width (default), or ``"content"`` to match the
+            content width.
+
+        height : int, "stretch", or "content"
+            Height of the iframe in CSS pixels, ``"stretch"`` to fill the
+            container height, or ``"content"`` (default) to auto-size to
+            the content. For URLs and non-HTML local files, ``"content"``
+            falls back to 400px because cross-origin restrictions prevent
+            content measurement.
+
+        tab_index : int or None
+            Controls sequential focus navigation. See `tabindex
+            <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex>`_
+            documentation on MDN.
+
+            This can be one of the following values:
+
+            - ``None`` (default): Uses the browser's default behavior.
+            - ``-1``: Removes the iframe from sequential navigation, but still
+              allows it to be focused programmatically.
+            - ``0``: Includes the iframe in sequential navigation in the order
+              it appears in the document but after all elements with a positive
+              ``tab_index``.
+            - Positive integer: Includes the iframe in sequential navigation.
+              Elements are navigated in ascending order of their positive
+              ``tab_index``.
+
+        Examples
+        --------
+        Embed an external website:
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+
+            st.iframe("https://docs.streamlit.io", height=600)
+
+        Embed HTML content directly:
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+
+            st.iframe(
+                "<h1>Hello World</h1><p>This is embedded HTML.</p>",
+                height=100,
+            )
+
+        Embed a local HTML file:
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+            from pathlib import Path
+
+            st.iframe(Path("reports/analysis.html"), height=800)
+
+        .. output::
+            https://doc-iframe.streamlit.app/
+
+        """
+        validate_width(width, allow_content=True)
+        validate_height(height, allow_content=True)
+
+        iframe_proto = IFrameProto()
+        is_srcdoc = False
+
+        if isinstance(src, Path):
+            is_srcdoc = self._handle_local_file(src, iframe_proto)
+        elif _is_url(src):
+            iframe_proto.src = src
+        elif os.path.isfile(src):
+            is_srcdoc = self._handle_local_file(Path(src), iframe_proto)
+        else:
+            iframe_proto.srcdoc = src
+            is_srcdoc = True
+
+        iframe_proto.scrolling = True
+
+        if tab_index is not None:
+            if not (
+                isinstance(tab_index, int)
+                and not isinstance(tab_index, bool)
+                and tab_index >= -1
+            ):
+                raise StreamlitAPIException(
+                    "tab_index must be None, -1, or a non-negative integer."
+                )
+            iframe_proto.tab_index = tab_index
+
+        resolved_height = height
+        if height == "content":
+            if is_srcdoc:
+                iframe_proto.content_height = True
+            else:
+                resolved_height = _CONTENT_HEIGHT_FALLBACK
+
+        layout_config = LayoutConfig(
+            width=width,
+            height=resolved_height,
+        )
+        return self.dg._enqueue("iframe", iframe_proto, layout_config=layout_config)
+
+    def _handle_local_file(
+        self,
+        path: Path,
+        proto: IFrameProto,
+    ) -> bool:
+        """Read a local file and populate the proto.
+
+        Returns True if the content was embedded as srcdoc (HTML files),
+        False if served via media storage URL.
+        """
+        if not path.is_file():
+            raise StreamlitAPIException(
+                f"File not found: `{path}`. Make sure the path is correct "
+                f"and the file exists relative to the working directory."
+            )
+
+        if _is_html_file(path):
+            proto.srcdoc = path.read_text(encoding="utf-8")
+            return True
+
+        data = path.read_bytes()
+        mimetype, _ = mimetypes.guess_type(str(path))
+        if mimetype is None:
+            mimetype = "application/octet-stream"
+
+        coordinates = self.dg._get_delta_path_str()
+        if runtime.exists():
+            file_url = runtime.get_instance().media_file_mgr.add(
+                data, mimetype, coordinates
+            )
+            caching.save_media_data(data, mimetype, coordinates)
+        else:
+            file_url = ""
+
+        proto.src = file_url
+        return False
+
     @gather_metrics("_iframe")
     def _iframe(
         self,

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -19,10 +19,15 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
-from streamlit.elements.lib.layout_utils import LayoutConfig, validate_height, validate_width
+from streamlit import runtime
+from streamlit.elements.lib.layout_utils import (
+    LayoutConfig,
+    validate_height,
+    validate_width,
+)
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.IFrame_pb2 import IFrame as IFrameProto
-from streamlit.runtime import caching, runtime
+from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import mimetypes
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Final, Literal, cast
 
 from streamlit import runtime
 from streamlit.elements.lib.layout_utils import (
@@ -33,9 +33,9 @@ from streamlit.runtime.metrics_util import gather_metrics
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
-_HTML_EXTENSIONS = {".html", ".htm", ".xhtml"}
+_HTML_EXTENSIONS: Final = {".html", ".htm", ".xhtml"}
 
-_CONTENT_HEIGHT_FALLBACK = 400
+_CONTENT_HEIGHT_FALLBACK: Final = 400
 
 
 def _is_url(src: str) -> bool:

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -172,6 +172,7 @@ NON_WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("text", lambda: st.text("Hello")),
     ("code", lambda: st.code("Hello")),
     ("html", lambda: st.html("Hello")),
+    ("iframe", lambda: st.iframe("<p>Hello</p>")),
     ("latex", lambda: st.latex("Hello")),
     ("markdown", lambda: st.markdown("Hello")),
     ("write", lambda: st.write("Hello")),

--- a/lib/tests/streamlit/elements/st_iframe_test.py
+++ b/lib/tests/streamlit/elements/st_iframe_test.py
@@ -153,9 +153,7 @@ class TestStIframeLocalFile(DeltaGeneratorTestCase):
         mock_runtime.exists.return_value = True
         mock_runtime.get_instance.return_value = mock_instance
 
-        with tempfile.NamedTemporaryFile(
-            suffix=".pdf", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
             f.write(b"%PDF-1.4 test content")
             f.flush()
             st.iframe(Path(f.name), height=600)
@@ -215,12 +213,12 @@ class TestStIframeLayout(DeltaGeneratorTestCase):
 
     def test_invalid_width_raises(self) -> None:
         """Test that invalid width values raise an error."""
-        with pytest.raises(Exception):
+        with pytest.raises(StreamlitAPIException):
             st.iframe("<p>Test</p>", width="invalid")  # type: ignore[arg-type]
 
     def test_invalid_height_raises(self) -> None:
         """Test that invalid height values raise an error."""
-        with pytest.raises(Exception):
+        with pytest.raises(StreamlitAPIException):
             st.iframe("<p>Test</p>", height="invalid")  # type: ignore[arg-type]
 
 

--- a/lib/tests/streamlit/elements/st_iframe_test.py
+++ b/lib/tests/streamlit/elements/st_iframe_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -120,8 +121,6 @@ class TestStIframeLocalFile(DeltaGeneratorTestCase):
     def test_html_file_with_string_path(self) -> None:
         """Test that HTML files via string paths are read as srcdoc."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            import os
-
             original_cwd = os.getcwd()
             try:
                 os.chdir(tmpdir)
@@ -280,11 +279,3 @@ class TestStIframeInputDetection(DeltaGeneratorTestCase):
         st.iframe("https://example.com", height=100)
         element = self.get_delta_from_queue().new_element
         assert element.iframe.src == "https://example.com"
-
-    def test_gather_metrics_name(self) -> None:
-        """Test that the metrics name is 'iframe' for st.iframe."""
-        # The function should be wrapped with @gather_metrics("iframe")
-        # We just verify it works and enqueues correctly
-        st.iframe("<p>Test</p>", height=100)
-        element = self.get_delta_from_queue().new_element
-        assert element.iframe.srcdoc == "<p>Test</p>"

--- a/lib/tests/streamlit/elements/st_iframe_test.py
+++ b/lib/tests/streamlit/elements/st_iframe_test.py
@@ -111,12 +111,15 @@ class TestStIframeLocalFile(DeltaGeneratorTestCase):
             suffix=".html", mode="w", delete=False, encoding="utf-8"
         ) as f:
             f.write("<h1>Local HTML</h1>")
-            f.flush()
-            st.iframe(Path(f.name))
+            temp_path = Path(f.name)
 
-        element = self.get_delta_from_queue().new_element
-        assert element.iframe.srcdoc == "<h1>Local HTML</h1>"
-        assert element.iframe.content_height is True
+        try:
+            st.iframe(temp_path)
+            element = self.get_delta_from_queue().new_element
+            assert element.iframe.srcdoc == "<h1>Local HTML</h1>"
+            assert element.iframe.content_height is True
+        finally:
+            os.remove(temp_path)
 
     def test_html_file_with_string_path(self) -> None:
         """Test that HTML files via string paths are read as srcdoc."""
@@ -138,11 +141,14 @@ class TestStIframeLocalFile(DeltaGeneratorTestCase):
             suffix=".xhtml", mode="w", delete=False, encoding="utf-8"
         ) as f:
             f.write("<p>XHTML file</p>")
-            f.flush()
-            st.iframe(Path(f.name))
+            temp_path = Path(f.name)
 
-        element = self.get_delta_from_queue().new_element
-        assert element.iframe.srcdoc == "<p>XHTML file</p>"
+        try:
+            st.iframe(temp_path)
+            element = self.get_delta_from_queue().new_element
+            assert element.iframe.srcdoc == "<p>XHTML file</p>"
+        finally:
+            os.remove(temp_path)
 
     @patch("streamlit.elements.iframe.runtime")
     def test_non_html_file_uses_media_storage(self, mock_runtime: MagicMock) -> None:
@@ -154,13 +160,16 @@ class TestStIframeLocalFile(DeltaGeneratorTestCase):
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
             f.write(b"%PDF-1.4 test content")
-            f.flush()
-            st.iframe(Path(f.name), height=600)
+            temp_path = Path(f.name)
 
-        element = self.get_delta_from_queue().new_element
-        assert element.iframe.src == "/media/test123"
-        assert element.iframe.content_height is False
-        assert element.height_config.pixel_height == 600
+        try:
+            st.iframe(temp_path, height=600)
+            element = self.get_delta_from_queue().new_element
+            assert element.iframe.src == "/media/test123"
+            assert element.iframe.content_height is False
+            assert element.height_config.pixel_height == 600
+        finally:
+            os.remove(temp_path)
 
     def test_nonexistent_path_object_raises(self) -> None:
         """Test that a Path object pointing to a nonexistent file raises."""
@@ -268,11 +277,14 @@ class TestStIframeInputDetection(DeltaGeneratorTestCase):
             suffix=".html", mode="w", delete=False, encoding="utf-8"
         ) as f:
             f.write("<p>File content</p>")
-            f.flush()
-            st.iframe(Path(f.name))
+            temp_path = Path(f.name)
 
-        element = self.get_delta_from_queue().new_element
-        assert element.iframe.srcdoc == "<p>File content</p>"
+        try:
+            st.iframe(temp_path)
+            element = self.get_delta_from_queue().new_element
+            assert element.iframe.srcdoc == "<p>File content</p>"
+        finally:
+            os.remove(temp_path)
 
     def test_url_detected_before_file_check(self) -> None:
         """Test that URLs are detected before checking for files."""

--- a/lib/tests/streamlit/elements/st_iframe_test.py
+++ b/lib/tests/streamlit/elements/st_iframe_test.py
@@ -1,0 +1,292 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.streamlit.elements.layout_test_utils import (
+    HeightConfigFields,
+    WidthConfigFields,
+)
+
+
+class TestStIframeUrl(DeltaGeneratorTestCase):
+    """Tests for st.iframe with URL inputs."""
+
+    def test_absolute_url_http(self) -> None:
+        """Test that http URLs are correctly set as src."""
+        st.iframe("http://example.com", height=500)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.src == "http://example.com"
+        assert element.iframe.WhichOneof("type") == "src"
+        assert element.height_config.pixel_height == 500
+
+    def test_absolute_url_https(self) -> None:
+        """Test that https URLs are correctly set as src."""
+        st.iframe("https://docs.streamlit.io", height=600)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.src == "https://docs.streamlit.io"
+
+    def test_data_url(self) -> None:
+        """Test that data URLs are correctly set as src."""
+        st.iframe("data:text/html,<h1>Hello</h1>", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.src == "data:text/html,<h1>Hello</h1>"
+
+    def test_relative_url(self) -> None:
+        """Test that relative URLs starting with / are set as src."""
+        st.iframe("/app/static/report.html", height=400)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.src == "/app/static/report.html"
+
+    def test_url_with_content_height_falls_back(self) -> None:
+        """Test that height='content' with URL falls back to 400px."""
+        st.iframe("https://example.com")
+        element = self.get_delta_from_queue().new_element
+        assert element.height_config.pixel_height == 400
+        assert element.iframe.content_height is False
+
+
+class TestStIframeHtml(DeltaGeneratorTestCase):
+    """Tests for st.iframe with HTML string inputs."""
+
+    def test_html_string(self) -> None:
+        """Test that plain HTML strings are set as srcdoc."""
+        st.iframe("<h1>Hello World</h1>")
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<h1>Hello World</h1>"
+        assert element.iframe.WhichOneof("type") == "srcdoc"
+
+    def test_html_string_with_content_height(self) -> None:
+        """Test that content_height is set for HTML strings with height='content'."""
+        st.iframe("<p>Auto height</p>")
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.content_height is True
+        assert (
+            element.height_config.WhichOneof("height_spec")
+            == HeightConfigFields.USE_CONTENT.value
+        )
+
+    def test_html_string_with_pixel_height(self) -> None:
+        """Test that pixel height works for HTML strings."""
+        st.iframe("<p>Fixed height</p>", height=200)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<p>Fixed height</p>"
+        assert element.height_config.pixel_height == 200
+        assert element.iframe.content_height is False
+
+    def test_plain_text_treated_as_html(self) -> None:
+        """Test that plain text that isn't a URL or file is treated as HTML."""
+        st.iframe("foo", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "foo"
+
+
+class TestStIframeLocalFile(DeltaGeneratorTestCase):
+    """Tests for st.iframe with local file inputs."""
+
+    def test_html_file_with_path_object(self) -> None:
+        """Test that HTML files via Path objects are read as srcdoc."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".html", mode="w", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("<h1>Local HTML</h1>")
+            f.flush()
+            st.iframe(Path(f.name))
+
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<h1>Local HTML</h1>"
+        assert element.iframe.content_height is True
+
+    def test_html_file_with_string_path(self) -> None:
+        """Test that HTML files via string paths are read as srcdoc."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import os
+
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                Path("test.htm").write_text("<p>HTM file</p>", encoding="utf-8")
+                st.iframe("test.htm")
+            finally:
+                os.chdir(original_cwd)
+
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<p>HTM file</p>"
+
+    def test_xhtml_file(self) -> None:
+        """Test that .xhtml files are read as srcdoc."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".xhtml", mode="w", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("<p>XHTML file</p>")
+            f.flush()
+            st.iframe(Path(f.name))
+
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<p>XHTML file</p>"
+
+    @patch("streamlit.elements.iframe.runtime")
+    def test_non_html_file_uses_media_storage(self, mock_runtime: MagicMock) -> None:
+        """Test that non-HTML files are uploaded to media storage."""
+        mock_instance = MagicMock()
+        mock_instance.media_file_mgr.add.return_value = "/media/test123"
+        mock_runtime.exists.return_value = True
+        mock_runtime.get_instance.return_value = mock_instance
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".pdf", delete=False
+        ) as f:
+            f.write(b"%PDF-1.4 test content")
+            f.flush()
+            st.iframe(Path(f.name), height=600)
+
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.src == "/media/test123"
+        assert element.iframe.content_height is False
+        assert element.height_config.pixel_height == 600
+
+    def test_nonexistent_path_object_raises(self) -> None:
+        """Test that a Path object pointing to a nonexistent file raises."""
+        with pytest.raises(StreamlitAPIException, match="File not found"):
+            st.iframe(Path("/nonexistent/file.html"))
+
+    def test_nonexistent_string_path_treated_as_html(self) -> None:
+        """Test that a string path that doesn't exist is treated as HTML."""
+        st.iframe("nonexistent_file.html", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "nonexistent_file.html"
+
+
+class TestStIframeLayout(DeltaGeneratorTestCase):
+    """Tests for st.iframe width and height configuration."""
+
+    def test_default_width_is_stretch(self) -> None:
+        """Test that default width is 'stretch'."""
+        st.iframe("<p>Test</p>", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert (
+            element.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+
+    def test_pixel_width(self) -> None:
+        """Test that pixel width is set correctly."""
+        st.iframe("<p>Test</p>", width=500, height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.width_config.pixel_width == 500
+
+    def test_content_width(self) -> None:
+        """Test that 'content' width is set correctly."""
+        st.iframe("<p>Test</p>", width="content", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert (
+            element.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_CONTENT.value
+        )
+
+    def test_stretch_height(self) -> None:
+        """Test that 'stretch' height is set correctly."""
+        st.iframe("<p>Test</p>", height="stretch")
+        element = self.get_delta_from_queue().new_element
+        assert (
+            element.height_config.WhichOneof("height_spec")
+            == HeightConfigFields.USE_STRETCH.value
+        )
+
+    def test_invalid_width_raises(self) -> None:
+        """Test that invalid width values raise an error."""
+        with pytest.raises(Exception):
+            st.iframe("<p>Test</p>", width="invalid")  # type: ignore[arg-type]
+
+    def test_invalid_height_raises(self) -> None:
+        """Test that invalid height values raise an error."""
+        with pytest.raises(Exception):
+            st.iframe("<p>Test</p>", height="invalid")  # type: ignore[arg-type]
+
+
+class TestStIframeScrollingAndTabIndex(DeltaGeneratorTestCase):
+    """Tests for st.iframe scrolling and tab_index behavior."""
+
+    def test_scrolling_always_true(self) -> None:
+        """Test that scrolling is always enabled for st.iframe."""
+        st.iframe("<p>Test</p>", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.scrolling is True
+
+    def test_tab_index(self) -> None:
+        """Test that tab_index is set correctly."""
+        st.iframe("<p>Test</p>", height=100, tab_index=0)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.tab_index == 0
+
+    def test_tab_index_negative(self) -> None:
+        """Test that negative tab_index (-1) is accepted."""
+        st.iframe("<p>Test</p>", height=100, tab_index=-1)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.tab_index == -1
+
+    def test_tab_index_none(self) -> None:
+        """Test that tab_index=None doesn't set the field."""
+        st.iframe("<p>Test</p>", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert not element.iframe.HasField("tab_index")
+
+    def test_invalid_tab_index_raises(self) -> None:
+        """Test that invalid tab_index values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.iframe("<p>Test</p>", height=100, tab_index=-2)
+
+    def test_bool_tab_index_raises(self) -> None:
+        """Test that boolean tab_index values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.iframe("<p>Test</p>", height=100, tab_index=True)  # type: ignore[arg-type]
+
+
+class TestStIframeInputDetection(DeltaGeneratorTestCase):
+    """Tests for st.iframe input type detection order."""
+
+    def test_path_object_takes_priority(self) -> None:
+        """Test that Path objects are always treated as file paths."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".html", mode="w", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("<p>File content</p>")
+            f.flush()
+            st.iframe(Path(f.name))
+
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<p>File content</p>"
+
+    def test_url_detected_before_file_check(self) -> None:
+        """Test that URLs are detected before checking for files."""
+        st.iframe("https://example.com", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.src == "https://example.com"
+
+    def test_gather_metrics_name(self) -> None:
+        """Test that the metrics name is 'iframe' for st.iframe."""
+        # The function should be wrapped with @gather_metrics("iframe")
+        # We just verify it works and enqueues correctly
+        st.iframe("<p>Test</p>", height=100)
+        element = self.get_delta_from_queue().new_element
+        assert element.iframe.srcdoc == "<p>Test</p>"

--- a/lib/tests/streamlit/typing/iframe_types.py
+++ b/lib/tests/streamlit/typing/iframe_types.py
@@ -1,0 +1,71 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.iframe import IframeMixin
+
+    iframe = IframeMixin().iframe
+
+    # st.iframe returns DeltaGenerator
+    assert_type(iframe("<p>Hello</p>"), DeltaGenerator)
+
+    # URL source
+    assert_type(iframe("https://example.com", height=600), DeltaGenerator)
+
+    # Data URL
+    assert_type(iframe("data:text/html,<h1>Hi</h1>", height=100), DeltaGenerator)
+
+    # Relative URL
+    assert_type(iframe("/app/static/report.html", height=400), DeltaGenerator)
+
+    # Path object
+    assert_type(iframe(Path("reports/analysis.html"), height=800), DeltaGenerator)
+
+    # Width parameter - int, "stretch", "content"
+    assert_type(iframe("<p>Test</p>", width=300, height=100), DeltaGenerator)
+    assert_type(iframe("<p>Test</p>", width="stretch", height=100), DeltaGenerator)
+    assert_type(iframe("<p>Test</p>", width="content", height=100), DeltaGenerator)
+
+    # Height parameter - int, "stretch", "content"
+    assert_type(iframe("<p>Test</p>", height=200), DeltaGenerator)
+    assert_type(iframe("<p>Test</p>", height="stretch"), DeltaGenerator)
+    assert_type(iframe("<p>Test</p>", height="content"), DeltaGenerator)
+
+    # Default height (content)
+    assert_type(iframe("<p>Test</p>"), DeltaGenerator)
+
+    # tab_index parameter
+    assert_type(iframe("<p>Test</p>", height=100, tab_index=0), DeltaGenerator)
+    assert_type(iframe("<p>Test</p>", height=100, tab_index=-1), DeltaGenerator)
+    assert_type(iframe("<p>Test</p>", height=100, tab_index=None), DeltaGenerator)
+
+    # All parameters combined
+    assert_type(
+        iframe(
+            "<p>Full test</p>",
+            width="stretch",
+            height=500,
+            tab_index=0,
+        ),
+        DeltaGenerator,
+    )

--- a/proto/streamlit/proto/IFrame.proto
+++ b/proto/streamlit/proto/IFrame.proto
@@ -28,5 +28,9 @@ message IFrame {
   bool scrolling = 7;
   optional int32 tab_index = 8;
 
+  // When true, the frontend should auto-measure and set the iframe height
+  // based on the srcdoc content. Only applicable when srcdoc is set.
+  bool content_height = 9;
+
   reserved 3, 4, 5;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Adds `st.iframe` to the main Streamlit namespace, consolidating `st.components.v1.iframe` and `st.components.v1.html` into a single, discoverable command with added support for local files and auto-height.

### Key features

- **Auto-detects input type**: URL, local file path (via `Path` or string), or HTML string
- **Local file support**: HTML files (`.html`, `.htm`, `.xhtml`) embedded via `srcdoc`; other files (PDF, images, SVG) served via media storage
- **Content-based auto-height**: For `srcdoc` content, uses `ResizeObserver` to measure and auto-size the iframe; falls back to 400px for cross-origin URLs
- **Layout modes**: `width` and `height` support `int`, `"stretch"`, and `"content"`
- **Scrolling always enabled**: Uses `scrolling="auto"` for natural scrollbar behavior
- **Same sandbox/permissions policy** as existing `st.components.v1.iframe`

### API

```python
st.iframe(
    src: str | Path,
    *,
    width: int | Literal["stretch", "content"] = "stretch",
    height: int | Literal["stretch", "content"] = "content",
    tab_index: int | None = None,
)
```

### Input detection order

1. `Path` object → local file path
2. Starts with `http://`, `https://`, `data:`, `/` → URL
3. String that exists as a local file → local file path
4. Otherwise → HTML string (embedded via `srcdoc`)

### Changes

- **Proto**: Added `content_height` bool field to `IFrame` message
- **Backend**: Added `iframe()` method to `IframeMixin` with input detection and local file handling
- **Frontend**: Updated `IFrame` component with `ResizeObserver`-based auto-height for `srcdoc` content
- **Export**: Added `st.iframe` to `__init__.py`

## GitHub Issue Link (if applicable)

- Closes #12977

## Testing Plan

- [x] Unit Tests (Python): 29 tests covering URL, HTML string, local file, layout, tab_index, and input detection
- [x] Unit Tests (Frontend): 17 Vitest tests for the IFrame component including `contentHeight` mode
- [x] E2E Tests: 6 Playwright tests for end-to-end validation including auto-height behavior
- [x] Typing Tests: mypy `assert_type` tests for all parameters and return types
- [x] Manual testing via `make debug`
- [x] Backward compatibility: Existing `st_components_v1` E2E tests pass (10/10)

**Spec**: `specs/2026-03-13-st-iframe/product-spec.md`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0440edc-b467-4446-8116-92c4feffda9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0440edc-b467-4446-8116-92c4feffda9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

