### PR TITLE
feat: show hex color indicators in inline code, similar to GitHub

### DIFF
--- a/e2e_playwright/st_markdown.py
+++ b/e2e_playwright/st_markdown.py
@@ -537,3 +537,8 @@ Links: [Streamlit](https://streamlit.io) Colors: :red[red] :blue[blue]
 
 Emoji: 🎉 Array: array[index] Dict: dict[key]""",
 )
+
+st.header("Hex Color Indicators")
+st.markdown("The primary color is `#0969DA` and accent is `#FF5733`")
+st.markdown("Short format: `#F00` also works")
+st.markdown("Regular code: `not a color` should not show a dot")

--- a/e2e_playwright/st_markdown_test.py
+++ b/e2e_playwright/st_markdown_test.py
@@ -617,3 +617,24 @@ def test_tooltip_with_complex_markdown_gh_13339(
     assert_snapshot(
         tooltip_content, name="st_markdown-complex_tooltip_with_markdown_formatting"
     )
+
+
+def test_hex_color_indicator(app: Page, assert_snapshot):
+    """Test that hex color codes in inline code show colored dots."""
+    header = app.get_by_role("heading", name="Hex Color Indicators")
+    header.scroll_into_view_if_needed()
+
+    # Get the markdown elements after the header
+    containers = app.get_by_test_id("stMarkdownContainer")
+
+    # Find the container with hex colors
+    hex_container = containers.filter(
+        has_text=re.compile(r"#0969DA")
+    ).first
+    expect(hex_container).to_be_visible()
+
+    # Verify colored dots are rendered
+    color_dots = hex_container.locator('span[aria-hidden="true"]')
+    expect(color_dots).to_have_count(2)
+
+    assert_snapshot(hex_container, name="st_markdown-hex_color_indicators")

--- a/e2e_playwright/st_markdown_test.py
+++ b/e2e_playwright/st_markdown_test.py
@@ -628,9 +628,7 @@ def test_hex_color_indicator(app: Page, assert_snapshot):
     containers = app.get_by_test_id("stMarkdownContainer")
 
     # Find the container with hex colors
-    hex_container = containers.filter(
-        has_text=re.compile(r"#0969DA")
-    ).first
+    hex_container = containers.filter(has_text=re.compile(r"#0969DA")).first
     expect(hex_container).to_be_visible()
 
     # Verify colored dots are rendered

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -845,6 +845,47 @@ describe("StreamlitMarkdown", () => {
     expect(markdownContainer).toHaveStyle("font-size: 0.875rem")
   })
 
+  it("renders hex color indicator for valid 6-digit hex colors in backticks", () => {
+    const source =
+      "The primary color is `#0969DA` and secondary is `#FF5733`"
+    const { container } = render(
+      <StreamlitMarkdown source={source} allowHTML={false} />
+    )
+
+    expect(screen.getByText("#0969DA")).toBeInTheDocument()
+    expect(screen.getByText("#FF5733")).toBeInTheDocument()
+
+    const colorDots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(colorDots.length).toBe(2)
+    expect(colorDots[0]).toHaveStyle({ backgroundColor: "#0969DA" })
+    expect(colorDots[1]).toHaveStyle({ backgroundColor: "#FF5733" })
+  })
+
+  it("renders hex color indicator for 3-digit hex colors", () => {
+    const source = "Short color `#F00` is valid"
+    const { container } = render(
+      <StreamlitMarkdown source={source} allowHTML={false} />
+    )
+
+    expect(screen.getByText("#F00")).toBeInTheDocument()
+
+    const colorDots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(colorDots.length).toBe(1)
+    expect(colorDots[0]).toHaveStyle({ backgroundColor: "#F00" })
+  })
+
+  it("does not render hex color indicator for non-hex code", () => {
+    const source = "This is `regular code` not a color"
+    const { container } = render(
+      <StreamlitMarkdown source={source} allowHTML={false} />
+    )
+
+    expect(screen.getByText("regular code")).toBeInTheDocument()
+
+    const colorDots = container.querySelectorAll('span[aria-hidden="true"]')
+    expect(colorDots.length).toBe(0)
+  })
+
   it("renders regular text sizing when largerLabel is true", () => {
     const source = "Here is some checkbox label text"
     render(

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -846,8 +846,7 @@ describe("StreamlitMarkdown", () => {
   })
 
   it("renders hex color indicator for valid 6-digit hex colors in backticks", () => {
-    const source =
-      "The primary color is `#0969DA` and secondary is `#FF5733`"
+    const source = "The primary color is `#0969DA` and secondary is `#FF5733`"
     const { container } = render(
       <StreamlitMarkdown source={source} allowHTML={false} />
     )

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -462,7 +462,16 @@ export type CustomCodeTagProps = JSX.IntrinsicElements["code"] &
   ReactMarkdownProps & { inline?: boolean }
 
 /**
+ * Detects if a string is a valid hex color code.
+ * Supports both 3-digit (#RGB) and 6-digit (#RRGGBB) formats.
+ */
+function isHexColor(text: string): boolean {
+  return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(text.trim())
+}
+
+/**
  * Renders code tag with highlighting based on requested language.
+ * Also renders a colored dot next to hex color codes in inline code.
  */
 export const CustomCodeTag: FC<CustomCodeTagProps> = ({
   inline,
@@ -477,6 +486,10 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
     .replace(/\n$/, "")
 
   const language = match?.[1] || ""
+
+  // Check if this is an inline code block with a hex color
+  const isHexColorCode = inline && isHexColor(codeText)
+
   return !inline ? (
     <ErrorBoundary>
       <Suspense
@@ -498,6 +511,21 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
     </ErrorBoundary>
   ) : (
     <StyledInlineCode className={className} {...omit(props, "node")}>
+      {isHexColorCode && (
+        <span
+          style={{
+            display: "inline-block",
+            width: "0.75em",
+            height: "0.75em",
+            borderRadius: "50%",
+            backgroundColor: codeText.trim(),
+            marginRight: "0.35em",
+            verticalAlign: "middle",
+            border: "1px solid rgba(0, 0, 0, 0.1)",
+          }}
+          aria-hidden="true"
+        />
+      )}
       {children}
     </StyledInlineCode>
   )


### PR DESCRIPTION
## Describe your changes

Add colored dot next to hex color codes (`#RGB` and `#RRGGBB`) in inline code (backticks), matching GitHub's Markdown behavior.

When users write hex colors like `#0969DA` in markdown, a small circle with that color appears before the text:

```python
st.markdown("The primary color is `#0969DA` and accent is `#FF5733`")
st.markdown("Short format: `#F00` also works")
st.markdown("Regular code: `not a color` should not show a dot")
```

**Implementation:**
- Added `isHexColor()` utility to detect valid 3-digit and 6-digit hex color formats
- Modified `CustomCodeTag` to render a colored dot (`0.75em` circle) for valid hex colors in inline code
- Used `aria-hidden="true"` for accessibility (decorative element)
- Added subtle border for visibility on light backgrounds

**Only applies to inline code (backticks), not code blocks. No impact on non-hex inline code.**

## GitHub Issue Link

Closes #11643

## Testing Plan

- [x] Unit Tests (JS): 3 tests added — 6-digit hex, 3-digit hex, and non-hex negative case
- [x] E2E Tests: Added test fixture and Playwright test for visual regression
- [ ] Any manual testing needed? Render hex colors in `st.markdown` and verify dots appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)