### PR TITLE
Docs for new file uploader types

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -691,11 +691,11 @@ class ChatMixin:
             - ``None`` (default): All file extensions are allowed.
             - A file extension: Only one file extension is allowed. For example,
               to only accept CSV files, use ``"csv"`` or ``".csv"``.
-            - A MIME subtype: Only one MIME subtype is allowed. For example,
+            - A MIME type: Only one MIME type is allowed. For example,
               to accept JPEG images, use ``"image/jpeg"``.
-            - A MIME wildcard: All subtypes within a MIME type are allowed.
+            - A MIME wildcard: All types within a MIME media type are allowed.
               For example, to accept all images, use ``"image/*"``.
-            - A MIME type shorcut: This is a shortcut that is equivalent to a
+            - A MIME media type: This is a shortcut that is equivalent to a
               MIME wildcard. If you use ``"image"``, ``"audio"``, ``"video"``, or
               ``"text"``, Streamlit will internally append ``/*`` to create
               a MIME wildcard.

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -685,15 +685,25 @@ class ChatMixin:
             .. _config.toml: https://docs.streamlit.io/develop/api-reference/configuration/config.toml
 
         file_type : str, Sequence[str], or None
-            The allowed file extension(s) for uploaded files. This can be one
-            of the following types:
+            The allowed file types for uploaded files. This can be one of the
+            following values:
 
             - ``None`` (default): All file extensions are allowed.
-            - A string: A single file extension is allowed. For example, to
-              only accept CSV files, use ``"csv"``.
-            - A sequence of strings: Multiple file extensions are allowed. For
-              example, to only accept JPG/JPEG and PNG files, use
-              ``["jpg", "jpeg", "png"]``.
+            - A file extension: Only one file extension is allowed. For example,
+              to only accept CSV files, use ``"csv"`` or ``".csv"``.
+            - A MIME subtype: Only one MIME subtype is allowed. For example,
+              to accept JPEG images, use ``"image/jpeg"``.
+            - A MIME wildcard: All subtypes within a MIME type are allowed.
+              For example, to accept all images, use ``"image/*"``.
+            - A MIME type shorcut: This is a shortcut that is equivalent to a
+              MIME wildcard. If you use ``"image"``, ``"audio"``, ``"video"``, or
+              ``"text"``, Streamlit will internally append ``/*`` to create
+              a MIME wildcard.
+            - A sequence of strings: Use a combination of the previously listed
+              strings to accept multiple file types.
+
+            For more information about MIME types, see
+            https://www.iana.org/assignments/media-types/media-types.xhtml.
 
             .. note::
                 This is a best-effort check, but doesn't provide a

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -307,11 +307,11 @@ class FileUploaderMixin:
             - ``None`` (default): All file extensions are allowed.
             - A file extension: Only one file extension is allowed. For example,
               to only accept CSV files, use ``"csv"`` or ``".csv"``.
-            - A MIME subtype: Only one MIME subtype is allowed. For example,
+            - A MIME type: Only one MIME type is allowed. For example,
               to accept JPEG images, use ``"image/jpeg"``.
-            - A MIME wildcard: All subtypes within a MIME type are allowed.
+            - A MIME wildcard: All types within a MIME media type are allowed.
               For example, to accept all images, use ``"image/*"``.
-            - A MIME type shorcut: This is a shortcut that is equivalent to a
+            - A MIME media type: This is a shortcut that is equivalent to a
               MIME wildcard. If you use ``"image"``, ``"audio"``, ``"video"``, or
               ``"text"``, Streamlit will internally append ``/*`` to create
               a MIME wildcard.

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -301,15 +301,25 @@ class FileUploaderMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         type : str, list of str, or None
-            The allowed file extension(s) for uploaded files. This can be one
-            of the following types:
+            The allowed file types for uploaded files. This can be one of the
+            following values:
 
             - ``None`` (default): All file extensions are allowed.
-            - A string: A single file extension is allowed. For example, to
-              only accept CSV files, use ``"csv"``.
-            - A sequence of strings: Multiple file extensions are allowed. For
-              example, to only accept JPG/JPEG and PNG files, use
-              ``["jpg", "jpeg", "png"]``.
+            - A file extension: Only one file extension is allowed. For example,
+              to only accept CSV files, use ``"csv"`` or ``".csv"``.
+            - A MIME subtype: Only one MIME subtype is allowed. For example,
+              to accept JPEG images, use ``"image/jpeg"``.
+            - A MIME wildcard: All subtypes within a MIME type are allowed.
+              For example, to accept all images, use ``"image/*"``.
+            - A MIME type shorcut: This is a shortcut that is equivalent to a
+              MIME wildcard. If you use ``"image"``, ``"audio"``, ``"video"``, or
+              ``"text"``, Streamlit will internally append ``/*`` to create
+              a MIME wildcard.
+            - A sequence of strings: Use a combination of the previously listed
+              strings to accept multiple file types.
+
+            For more information about MIME types, see
+            https://www.iana.org/assignments/media-types/media-types.xhtml.
 
             .. note::
                 This is a best-effort check, but doesn't provide a


### PR DESCRIPTION
## Describe your changes
Docs for `st.file_uploader` and `st.chat_input`, which now support additional strings to identify allowed file types for upload.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
