### PR TITLE
Docs for auto-extracting icons

### DIFF
--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -75,12 +75,12 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
-            If ``icon`` is ``None``, and ``body`` begins with a icon or
-            directive that is a valid value for ``icon``, Streamlit will extract
-            it and display it slightly enlarged, as if it were passed to
-            ``icon``. If ``body`` contains multiple icons, or you want to
-            override this behavior, you can insert a null directive like
-            ``":red[]"`` before your leading icon.
+            If ``icon`` is ``None``, and ``body`` begins with an emoji or
+            Material icon shortcode, Streamlit will extract it and display it
+            slightly enlarged, as if it were passed to ``icon``. If ``body``
+            contains multiple icons, or you want to override this behavior,
+            you can insert a null Markdown directive like ``:red[]`` before
+            your leading icon.
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
@@ -164,12 +164,12 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
-            If ``icon`` is ``None``, and ``body`` begins with a icon or
-            directive that is a valid value for ``icon``, Streamlit will extract
-            it and display it slightly enlarged, as if it were passed to
-            ``icon``. If ``body`` contains multiple icons, or you want to
-            override this behavior, you can insert a null directive like
-            ``":red[]"`` before your leading icon.
+            If ``icon`` is ``None``, and ``body`` begins with an emoji or
+            Material icon shortcode, Streamlit will extract it and display it
+            slightly enlarged, as if it were passed to ``icon``. If ``body``
+            contains multiple icons, or you want to override this behavior,
+            you can insert a null Markdown directive like ``:red[]`` before
+            your leading icon.
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
@@ -252,12 +252,12 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
-            If ``icon`` is ``None``, and ``body`` begins with a icon or
-            directive that is a valid value for ``icon``, Streamlit will extract
-            it and display it slightly enlarged, as if it were passed to
-            ``icon``. If ``body`` contains multiple icons, or you want to
-            override this behavior, you can insert a null directive like
-            ``":red[]"`` before your leading icon.
+            If ``icon`` is ``None``, and ``body`` begins with an emoji or
+            Material icon shortcode, Streamlit will extract it and display it
+            slightly enlarged, as if it were passed to ``icon``. If ``body``
+            contains multiple icons, or you want to override this behavior,
+            you can insert a null Markdown directive like ``:red[]`` before
+            your leading icon.
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
@@ -341,12 +341,12 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
-            If ``icon`` is ``None``, and ``body`` begins with a icon or
-            directive that is a valid value for ``icon``, Streamlit will extract
-            it and display it slightly enlarged, as if it were passed to
-            ``icon``. If ``body`` contains multiple icons, or you want to
-            override this behavior, you can insert a null directive like
-            ``":red[]"`` before your leading icon.
+            If ``icon`` is ``None``, and ``body`` begins with an emoji or
+            Material icon shortcode, Streamlit will extract it and display it
+            slightly enlarged, as if it were passed to ``icon``. If ``body``
+            contains multiple icons, or you want to override this behavior,
+            you can insert a null Markdown directive like ``:red[]`` before
+            your leading icon.
 
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown

--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -75,10 +75,17 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
+            If ``icon`` is ``None``, and ``body`` begins with a icon or
+            directive that is a valid value for ``icon``, Streamlit will extract
+            it and display it slightly enlarged, as if it were passed to
+            ``icon``. If ``body`` contains multiple icons, or you want to
+            override this behavior, you can insert a null directive like
+            ``":red[]"`` before your leading icon.
+
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        icon : str, None
+        icon : str or None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), Streamlit attempts to extract a leading
             emoji or Material icon shortcode from ``body``. If found, the icon
@@ -157,10 +164,17 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
+            If ``icon`` is ``None``, and ``body`` begins with a icon or
+            directive that is a valid value for ``icon``, Streamlit will extract
+            it and display it slightly enlarged, as if it were passed to
+            ``icon``. If ``body`` contains multiple icons, or you want to
+            override this behavior, you can insert a null directive like
+            ``":red[]"`` before your leading icon.
+
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        icon : str, None
+        icon : str or None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), Streamlit attempts to extract a leading
             emoji or Material icon shortcode from ``body``. If found, the icon
@@ -238,10 +252,17 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
+            If ``icon`` is ``None``, and ``body`` begins with a icon or
+            directive that is a valid value for ``icon``, Streamlit will extract
+            it and display it slightly enlarged, as if it were passed to
+            ``icon``. If ``body`` contains multiple icons, or you want to
+            override this behavior, you can insert a null directive like
+            ``":red[]"`` before your leading icon.
+
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        icon : str, None
+        icon : str or None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), Streamlit attempts to extract a leading
             emoji or Material icon shortcode from ``body``. If found, the icon
@@ -320,10 +341,17 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
+            If ``icon`` is ``None``, and ``body`` begins with a icon or
+            directive that is a valid value for ``icon``, Streamlit will extract
+            it and display it slightly enlarged, as if it were passed to
+            ``icon``. If ``body`` contains multiple icons, or you want to
+            override this behavior, you can insert a null directive like
+            ``":red[]"`` before your leading icon.
+
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        icon : str, None
+        icon : str or None
             An optional emoji or icon to display next to the alert. If ``icon``
             is ``None`` (default), Streamlit attempts to extract a leading
             emoji or Material icon shortcode from ``body``. If found, the icon


### PR DESCRIPTION
## Describe your changes
This PR explains the behavior of auto-extracting icons in status elements and how to override it (which might be needed when there are multiple icons in the body/label).

Per testing, this change doesn't seem to apply to toast yet, so that's not included.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
