### PR TITLE
fix: correct Prometheus metric name for session_duration

### DIFF
--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -286,7 +286,6 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
                 CounterStat(
                     family_name=SESSION_DURATION_FAMILY,
                     value=total_duration,
-                    unit="seconds",
                     help="Total time spent in active sessions, in seconds.",
                 ),
             ]

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -77,7 +77,8 @@ class StatsRequestHandler(tornado.web.RequestHandler):
             # our OpenMetrics comments.
             first_stat = stats[0]
             result.append(f"# TYPE {first_stat.family_name} {first_stat.type}")
-            result.append(f"# UNIT {first_stat.family_name} {first_stat.unit}")
+            if first_stat.unit:
+                result.append(f"# UNIT {first_stat.family_name} {first_stat.unit}")
             result.append(f"# HELP {first_stat.help}")
             result.extend(stat.to_metric_str() for stat in stats)
 

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -487,7 +487,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         assert isinstance(session_duration[0], CounterStat)
         assert session_duration[0].family_name == "session_duration_seconds_total"
         assert session_duration[0].type == "counter"
-        assert session_duration[0].unit == "seconds"
+        assert session_duration[0].unit == ""
 
         # Check active_sessions gauge
         active_sessions = stats_dict["active_sessions"]


### PR DESCRIPTION
## Summary

Fixes #14432

Prometheus scraping of `/_stcore/metrics` fails with:
> Error scraping target: unit "seconds" not a suffix of metric "session_duration_seconds_total"

**Root cause**: The `session_duration_seconds_total` CounterStat was created with `unit="seconds"`, causing the OpenMetrics output to include:
```
# UNIT session_duration_seconds_total seconds
```
Per OpenMetrics convention, the unit declared in a `# UNIT` metadata line must be the final suffix of the metric family name. Since the name ends with `_total` (not `_seconds`), Prometheus rejects it.

**Fix**:
- Remove the explicit `unit="seconds"` parameter from the `session_duration_seconds_total` CounterStat. The unit is already encoded in the metric name itself, so the parameter was redundant.
- Fix `_stats_to_text` to skip the `# UNIT` line when the unit is empty, rather than emitting a malformed `# UNIT <name> ` line with a trailing space.

## Test plan

- [x] Existing unit tests updated and passing
- [ ] Verify `/_stcore/metrics` endpoint no longer produces a `# UNIT` line for `session_duration_seconds_total`
- [ ] Verify Prometheus can scrape `/_stcore/metrics` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)