### PR TITLE
[fix] Streaming markdown with color directives shows artifact

### DIFF
--- a/e2e_playwright/st_write_stream.py
+++ b/e2e_playwright/st_write_stream.py
@@ -72,3 +72,16 @@ if button_group.button("Stream data"):
 
 if button_group.button("Stream async data"):
     st.session_state["written_content"] = stream_output.write_stream(async_generator)
+
+
+def stream_color_directives():
+    """Stream text with Streamlit color directives to test issue #14460."""
+    for word in "This is :red[red text] and :blue[blue text] here.".split():
+        yield word + " "
+        time.sleep(0.02)
+
+
+if button_group.button("Stream color directives"):
+    st.session_state["written_content"] = stream_output.write_stream(
+        stream_color_directives
+    )

--- a/e2e_playwright/st_write_stream_test.py
+++ b/e2e_playwright/st_write_stream_test.py
@@ -80,3 +80,20 @@ def test_async_generator(app: Page, assert_snapshot: ImageCompareFunction):
     # Test with the same snapshot name to make sure the output is the same:
     stream_output = get_element_by_key(app, "stream-output")
     assert_snapshot(stream_output, name="st_write_stream-async_generator_output")
+
+
+def test_color_directives_no_artifact(app: Page):
+    """Test that color directives don't show (streamdown:incomplete-link) artifact.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/14460
+    """
+    click_button(app, "Stream color directives")
+
+    stream_output = get_element_by_key(app, "stream-output")
+
+    # Wait for and verify the colored text appears
+    expect(stream_output.get_by_text("red text")).to_be_visible()
+    expect(stream_output.get_by_text("blue text")).to_be_visible()
+
+    # Verify the streamdown artifact does NOT appear (regression check)
+    expect(stream_output.get_by_text("streamdown:incomplete-link")).not_to_be_attached()

--- a/e2e_playwright/st_write_stream_test.py
+++ b/e2e_playwright/st_write_stream_test.py
@@ -91,7 +91,10 @@ def test_color_directives_no_artifact(app: Page):
 
     stream_output = get_element_by_key(app, "stream-output")
 
-    # Wait for and verify the colored text appears
+    # Wait for the full stream to complete (final word "here." visible)
+    expect(stream_output.get_by_text("here.")).to_be_visible()
+
+    # Verify the colored text appears
     expect(stream_output.get_by_text("red text")).to_be_visible()
     expect(stream_output.get_by_text("blue text")).to_be_visible()
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1228,6 +1228,52 @@ describe("CustomPreTag", () => {
       const container = screen.getByTestId("stMarkdownContainer")
       expect(container.querySelector("strong")).toBeNull()
     })
+
+    describe("directive completion during streaming", () => {
+      it.each([
+        // Incomplete directives - should be completed without artifact
+        [":red[incomplete text", "incomplete text"],
+        [":blue[streaming", "streaming"],
+        [":red-background[highlighted", "highlighted"],
+        [":small[small text", "small text"],
+        // Complete directive - should render normally
+        [":red[complete]", "complete"],
+      ])(
+        "renders directive %s without streamdown:incomplete-link artifact",
+        (source, expectedText) => {
+          render(
+            <StreamlitMarkdown
+              source={`This is ${source}`}
+              allowHTML={false}
+              unterminatedParsing={true}
+            />
+          )
+
+          expect(screen.getByText(expectedText)).toBeVisible()
+
+          const container = screen.getByTestId("stMarkdownContainer")
+          expect(container.textContent).not.toContain(
+            "streamdown:incomplete-link"
+          )
+        }
+      )
+
+      it("completes nested incomplete directives", () => {
+        render(
+          <StreamlitMarkdown
+            source=":red-background[:rainbow[nested text"
+            allowHTML={false}
+            unterminatedParsing={true}
+          />
+        )
+
+        const container = screen.getByTestId("stMarkdownContainer")
+        expect(container.textContent).toContain("nested text")
+        expect(container.textContent).not.toContain(
+          "streamdown:incomplete-link"
+        )
+      })
+    })
   })
 })
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1273,6 +1273,29 @@ describe("CustomPreTag", () => {
           "streamdown:incomplete-link"
         )
       })
+
+      it("does not close non-directive brackets in markdown links", () => {
+        // This tests the fix for the issue where `:red[text] and [link`
+        // would incorrectly close the `[link` bracket too.
+        // The handler should only close directive brackets, not markdown link brackets.
+        render(
+          <StreamlitMarkdown
+            source=":red[red text] and [incomplete link"
+            allowHTML={false}
+            unterminatedParsing={true}
+          />
+        )
+
+        const container = screen.getByTestId("stMarkdownContainer")
+        expect(container.textContent).toContain("red text")
+        // The important thing is that no streamdown artifact appears and no extra ]
+        // is appended that would break the rendering
+        expect(container.textContent).not.toContain(
+          "streamdown:incomplete-link"
+        )
+        // Should not have extra closing brackets added for non-directive [
+        expect(container.textContent).not.toContain("link]")
+      })
     })
   })
 })

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1296,6 +1296,26 @@ describe("CustomPreTag", () => {
         // Should not have extra closing brackets added for non-directive [
         expect(container.textContent).not.toContain("link]")
       })
+
+      it("handles nested brackets inside directives", () => {
+        // This tests the fix for `:red[text [link` where a non-directive `[`
+        // appears inside an open directive. The handler should track nested brackets
+        // to ensure proper balancing.
+        render(
+          <StreamlitMarkdown
+            source=":red[text [link"
+            allowHTML={false}
+            unterminatedParsing={true}
+          />
+        )
+
+        const container = screen.getByTestId("stMarkdownContainer")
+        // The text should be rendered without the artifact
+        expect(container.textContent).toContain("text [link")
+        expect(container.textContent).not.toContain(
+          "streamdown:incomplete-link"
+        )
+      })
     })
   })
 })

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -45,7 +45,7 @@ import ReactMarkdown, {
 import remarkDirective from "remark-directive"
 import remarkGfm from "remark-gfm"
 import remarkMathPlugin from "remark-math"
-import remend from "remend"
+import remend, { type RemendHandler } from "remend"
 import { PluggableList } from "unified"
 import { visit } from "unist-util-visit"
 import xxhash from "xxhashjs"
@@ -923,6 +923,39 @@ function createRemarkTypographicalSymbols() {
   }
 }
 
+/**
+ * Completes unclosed Streamlit directive syntax (e.g., `:red[text`) during streaming.
+ *
+ * Runs before remend's link handler (priority 10 < 20) to prevent incomplete directives
+ * from being misinterpreted as markdown links, which produces "(streamdown:incomplete-link)".
+ * See: https://github.com/streamlit/streamlit/issues/14460
+ */
+const directiveCompletionHandler: RemendHandler = {
+  name: "streamlit-directives",
+  priority: 10,
+  handle: (text: string): string => {
+    // Match directive patterns like :red[, :small[, :red-background[
+    const directivePattern = /:[a-z][a-z0-9-]*\[/g
+    const firstMatch = directivePattern.exec(text)
+    if (!firstMatch) {
+      return text
+    }
+
+    // Count unclosed brackets from the first directive onwards
+    const startPos = firstMatch.index + firstMatch[0].length - 1
+    let unclosedCount = 0
+    for (let i = startPos; i < text.length; i++) {
+      if (text[i] === "[") {
+        unclosedCount++
+      } else if (text[i] === "]") {
+        unclosedCount--
+      }
+    }
+
+    return unclosedCount > 0 ? text + "]".repeat(unclosedCount) : text
+  },
+}
+
 // Standard remark plugins that don't depend on theme or props
 // Note: remarkEmoji is lazy-loaded and added conditionally when emoji shortcodes are detected
 const BASE_REMARK_PLUGINS = [
@@ -1130,7 +1163,9 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     // Only apply when unterminatedParsing is enabled (during streaming).
     // Skip for labels (short, complete strings) and HTML content (may interfere).
     if (unterminatedParsing && !isLabel && !allowHTML) {
-      processed = remend(processed)
+      processed = remend(processed, {
+        handlers: [directiveCompletionHandler],
+      })
     }
 
     return processed

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -935,20 +935,26 @@ const directiveCompletionHandler: RemendHandler = {
   priority: 10,
   handle: (text: string): string => {
     // Match directive patterns like :red[, :small[, :red-background[
-    const directivePattern = /:[a-z][a-z0-9-]*\[/g
+    const directivePattern = /:[a-z][a-z0-9-]*\[/
     const firstMatch = directivePattern.exec(text)
     if (!firstMatch) {
       return text
     }
 
-    // Track only directive openings (:<name>[) and close them with ']'.
-    // Non-directive '[' characters (e.g. in markdown links) are ignored so they
-    // do not affect directive completion.
+    // Track directive openings (:<name>[), nested brackets, and close with ']'.
+    // We track all '[' inside directives to handle cases like `:red[text [link]`
+    // where nested brackets need proper balancing.
     let depth = 1
     let i = firstMatch.index + firstMatch[0].length
 
     while (i < text.length) {
       const char = text[i]
+
+      if (char === "[" && depth > 0) {
+        depth += 1
+        i += 1
+        continue
+      }
 
       if (char === "]" && depth > 0) {
         depth -= 1
@@ -958,11 +964,11 @@ const directiveCompletionHandler: RemendHandler = {
 
       if (char === ":") {
         // Attempt to match another directive starting at this position.
-        directivePattern.lastIndex = i
-        const nextMatch = directivePattern.exec(text)
-        if (nextMatch?.index === i) {
+        const remainingText = text.slice(i)
+        const nextMatch = directivePattern.exec(remainingText)
+        if (nextMatch?.index === 0) {
           depth += 1
-          i = nextMatch.index + nextMatch[0].length
+          i += nextMatch[0].length
           continue
         }
       }
@@ -973,6 +979,9 @@ const directiveCompletionHandler: RemendHandler = {
     return depth > 0 ? text + "]".repeat(depth) : text
   },
 }
+
+// Options for remend to use the directive completion handler
+const REMEND_OPTIONS = { handlers: [directiveCompletionHandler] }
 
 // Standard remark plugins that don't depend on theme or props
 // Note: remarkEmoji is lazy-loaded and added conditionally when emoji shortcodes are detected
@@ -1181,9 +1190,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     // Only apply when unterminatedParsing is enabled (during streaming).
     // Skip for labels (short, complete strings) and HTML content (may interfere).
     if (unterminatedParsing && !isLabel && !allowHTML) {
-      processed = remend(processed, {
-        handlers: [directiveCompletionHandler],
-      })
+      processed = remend(processed, REMEND_OPTIONS)
     }
 
     return processed

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -941,18 +941,36 @@ const directiveCompletionHandler: RemendHandler = {
       return text
     }
 
-    // Count unclosed brackets from the first directive onwards
-    const startPos = firstMatch.index + firstMatch[0].length - 1
-    let unclosedCount = 0
-    for (let i = startPos; i < text.length; i++) {
-      if (text[i] === "[") {
-        unclosedCount++
-      } else if (text[i] === "]") {
-        unclosedCount--
+    // Track only directive openings (:<name>[) and close them with ']'.
+    // Non-directive '[' characters (e.g. in markdown links) are ignored so they
+    // do not affect directive completion.
+    let depth = 1
+    let i = firstMatch.index + firstMatch[0].length
+
+    while (i < text.length) {
+      const char = text[i]
+
+      if (char === "]" && depth > 0) {
+        depth -= 1
+        i += 1
+        continue
       }
+
+      if (char === ":") {
+        // Attempt to match another directive starting at this position.
+        directivePattern.lastIndex = i
+        const nextMatch = directivePattern.exec(text)
+        if (nextMatch?.index === i) {
+          depth += 1
+          i = nextMatch.index + nextMatch[0].length
+          continue
+        }
+      }
+
+      i += 1
     }
 
-    return unclosedCount > 0 ? text + "]".repeat(unclosedCount) : text
+    return depth > 0 ? text + "]".repeat(depth) : text
   },
 }
 


### PR DESCRIPTION
## Describe your changes

Fixes streaming markdown completion displaying `(streamdown:incomplete-link)` when using Streamlit's color directives like `:red[text]`, `:small[content]`, etc.

- Adds custom `remend` handler to complete unclosed directive syntax before the link handler runs
- The handler closes directive brackets (e.g., `:red[text` → `:red[text]`) so remark-directive can parse them correctly

## GitHub Issue Link (if applicable)

- Closes #14460

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

**Test files:**
- `frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx` — Tests directive completion during streaming
- `e2e_playwright/st_write_stream_test.py` — E2E test for color directives in `st.write_stream`

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 4 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->