### PR TITLE
fix: correct compound extension handling in file_uploader_utils.py

### DIFF
--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -155,14 +155,20 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     if not any(
         normalized_filename.endswith(allowed_type) for allowed_type in extension_types
     ):
-        # Report the full compound extension if present (e.g. ".tar.gz" not just ".gz")
-        # so the error message is actually useful to the developer.
-        first_dot = os.path.basename(normalized_filename).find(".")
-        display_ext = (
-            os.path.basename(normalized_filename)[first_dot:]
-            if first_dot != -1
-            else extension
-        )
+        # Report the actual file extension(s), not arbitrary dots from the filename.
+        # Handle common compound extensions first, then fall back to single extensions.
+        basename = os.path.basename(normalized_filename)
+        # Common compound extensions that should be treated as a unit
+        compound_extensions = [".tar.gz", ".tar.bz2", ".tar.xz", ".tar.Z"]
+        display_ext = None
+        for comp_ext in compound_extensions:
+            if basename.lower().endswith(comp_ext.lower()):
+                display_ext = comp_ext
+                break
+        if display_ext is None:
+            # Fall back to single extension using splitext
+            _, single_ext = os.path.splitext(basename)
+            display_ext = single_ext if single_ext else extension
         raise StreamlitAPIException(
             f"Invalid file extension: `{display_ext}`. Allowed: {extension_types}"
         )

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -32,6 +32,9 @@ TYPE_PAIRS = [
     (".mp4", ".mpeg4"),
     (".tif", ".tiff"),
     (".htm", ".html"),
+    (".tar.gz", ".tgz"),    # fix: https://github.com/streamlit/streamlit/issues/11041
+    (".tar.bz2", ".tbz2"),
+    (".tar.xz", ".txz"),
 ]
 
 
@@ -152,6 +155,14 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     if not any(
         normalized_filename.endswith(allowed_type) for allowed_type in extension_types
     ):
+        # Report the full compound extension if present (e.g. ".tar.gz" not just ".gz")
+        # so the error message is actually useful to the developer.
+        first_dot = os.path.basename(normalized_filename).find(".")
+        display_ext = (
+            os.path.basename(normalized_filename)[first_dot:]
+            if first_dot != -1
+            else extension
+        )
         raise StreamlitAPIException(
-            f"Invalid file extension: `{extension}`. Allowed: {extension_types}"
+            f"Invalid file extension: `{display_ext}`. Allowed: {extension_types}"
         )

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -21,6 +21,8 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit import config
+from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction, normalize_upload_file_type
+from streamlit.elements.lib.file_uploader_utils import normalize_upload_file_type
 from streamlit.elements.widgets.file_uploader import (
     FileUploaderSerde,
     _get_upload_files,
@@ -93,6 +95,31 @@ class FileUploaderTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.file_uploader
         assert c.type == [".png", ".jpg", ".jpeg"]
+
+    def test_compound_extension_tar_gz_allowed(self):
+        #Regression: https://github.com/streamlit/streamlit/issues/11041
+        allowed = normalize_upload_file_type(["tar.gz"])
+        enforce_filename_restriction("archive.tar.gz", allowed)  # must not raise
+
+    def test_tgz_paired_with_tar_gz(self):
+        #tgz should be accepted when tar.gz is specified, like jpg/jpeg pairing.
+        allowed = normalize_upload_file_type(["tar.gz"])
+        assert ".tgz" in allowed
+
+    def test_error_message_shows_compound_extension(self):
+        #Error message should say .tar.bz2 not just .bz2
+        allowed = normalize_upload_file_type(["pdf"])
+        with pytest.raises(StreamlitAPIException, match=r"\.tar\.bz2"):
+            enforce_filename_restriction("archive.tar.bz2", allowed)
+
+    def test_single_extension_still_works(self):
+        allowed = normalize_upload_file_type(["pdf"])
+        enforce_filename_restriction("report.pdf", allowed)  # must not raise
+
+    def test_null_byte_rejected(self):
+        allowed = normalize_upload_file_type(["pdf"])
+        with pytest.raises(StreamlitAPIException, match="null bytes"):
+            enforce_filename_restriction("report\0.pdf", allowed)
 
     @patch("streamlit.elements.widgets.file_uploader._get_upload_files")
     def test_not_allowed_file_extension_raise_an_exception(

--- a/lib/tests/streamlit/elements/file_uploader_test.py
+++ b/lib/tests/streamlit/elements/file_uploader_test.py
@@ -22,7 +22,6 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit import config
 from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction, normalize_upload_file_type
-from streamlit.elements.lib.file_uploader_utils import normalize_upload_file_type
 from streamlit.elements.widgets.file_uploader import (
     FileUploaderSerde,
     _get_upload_files,


### PR DESCRIPTION
Two related bugs in enforce_filename_restriction and TYPE_PAIRS:

1. Error message reports os.path.splitext() result (e.g. '.gz') instead of the full compound extension (e.g. '.tar.gz'), making the error misleading and hard to debug for developers.

2. Common archive aliases (.tar.gz / .tgz, .tar.bz2 / .tbz2, .tar.xz / .txz) are missing from TYPE_PAIRS, so specifying 'tar.gz' does not automatically accept '.tgz' files the way '.jpg' accepts '.jpeg'.

Fixes #11041