### PR TITLE
[Fix] OpenMetrics compliance for `session_duration` metric

### DIFF
--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Final, NamedTuple, Protocol, runtime_checkable
 
 CACHE_MEMORY_FAMILY: Final = "cache_memory_bytes"
 SESSION_EVENTS_FAMILY: Final = "session_events_total"
-SESSION_DURATION_FAMILY: Final = "session_duration_seconds_total"
+SESSION_DURATION_FAMILY: Final = "session_duration_seconds"
 ACTIVE_SESSIONS_FAMILY: Final = "active_sessions"
 
 if TYPE_CHECKING:
@@ -159,6 +159,8 @@ class CounterStat(NamedTuple):
         The unit of the metric (e.g. '' for unitless).
     help : str
         A description of the metric.
+    sample_name : str | None
+        The emitted sample name when it differs from the metric family name.
     """
 
     family_name: str
@@ -166,16 +168,18 @@ class CounterStat(NamedTuple):
     labels: dict[str, str] | None = None
     unit: str = ""
     help: str = ""
+    sample_name: str | None = None
 
     @property
     def type(self) -> str:
         return "counter"
 
     def to_metric_str(self) -> str:
+        metric_name = self.sample_name or self.family_name
         if self.labels:
             labels_str = ",".join(f'{k}="{v}"' for k, v in sorted(self.labels.items()))
-            return f"{self.family_name}{{{labels_str}}} {self.value}"
-        return f"{self.family_name} {self.value}"
+            return f"{metric_name}{{{labels_str}}} {self.value}"
+        return f"{metric_name} {self.value}"
 
     def marshall_metric_proto(self, metric: MetricProto) -> None:
         """Fill an OpenMetrics `Metric` protobuf object."""

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -285,6 +285,7 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
             result[SESSION_DURATION_FAMILY] = [
                 CounterStat(
                     family_name=SESSION_DURATION_FAMILY,
+                    sample_name=f"{SESSION_DURATION_FAMILY}_total",
                     value=total_duration,
                     unit="seconds",
                     help="Total time spent in active sessions, in seconds.",

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -304,6 +304,7 @@ class CounterStatTest(unittest.TestCase):
         assert stat.help == "A test counter."
         assert stat.value == 42
         assert stat.labels == {"type": "test"}
+        assert stat.sample_name is None
 
     def test_counter_stat_to_metric_str(self) -> None:
         """CounterStat.to_metric_str should format correctly."""
@@ -323,6 +324,29 @@ class CounterStatTest(unittest.TestCase):
             labels={"z_label": "z_val", "a_label": "a_val"},
         )
         expected = 'my_counter{a_label="a_val",z_label="z_val"} 5'
+        assert stat.to_metric_str() == expected
+
+    def test_counter_stat_to_metric_str_with_sample_name(self) -> None:
+        """CounterStat.to_metric_str should support a sample name override."""
+        stat = CounterStat(
+            family_name="session_duration_seconds",
+            sample_name="session_duration_seconds_total",
+            value=42,
+            unit="seconds",
+        )
+        expected = "session_duration_seconds_total 42"
+        assert stat.to_metric_str() == expected
+
+    def test_counter_stat_to_metric_str_with_sample_name_and_labels(self) -> None:
+        """CounterStat.to_metric_str should support sample names with labels."""
+        stat = CounterStat(
+            family_name="session_duration_seconds",
+            sample_name="session_duration_seconds_total",
+            value=42,
+            labels={"region": "us-west"},
+            unit="seconds",
+        )
+        expected = 'session_duration_seconds_total{region="us-west"} 42'
         assert stat.to_metric_str() == expected
 
     def test_counter_stat_to_metric_str_no_labels(self) -> None:

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -362,7 +362,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         assert self._get_stat_value(stats, "session_events_total", "connect") == 0
         assert self._get_stat_value(stats, "session_events_total", "reconnect") == 0
         assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
-        assert self._get_stat_value(stats, "session_duration_seconds_total") == 0
+        assert self._get_stat_value(stats, "session_duration_seconds") == 0
         assert self._get_stat_value(stats, "active_sessions") == 0
 
     def test_new_connection_increments_counter(self) -> None:
@@ -468,7 +468,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
 
         assert len(stats_dict) == 3
         assert "session_events_total" in stats_dict
-        assert "session_duration_seconds_total" in stats_dict
+        assert "session_duration_seconds" in stats_dict
         assert "active_sessions" in stats_dict
 
         # Check session_events_total counters
@@ -481,11 +481,12 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
             assert stat.labels is not None
             assert "type" in stat.labels
 
-        # Check session_duration_seconds_total counter
-        session_duration = stats_dict["session_duration_seconds_total"]
+        # Check session_duration_seconds counter
+        session_duration = stats_dict["session_duration_seconds"]
         assert len(session_duration) == 1
         assert isinstance(session_duration[0], CounterStat)
-        assert session_duration[0].family_name == "session_duration_seconds_total"
+        assert session_duration[0].family_name == "session_duration_seconds"
+        assert session_duration[0].sample_name == "session_duration_seconds_total"
         assert session_duration[0].type == "counter"
         assert session_duration[0].unit == "seconds"
 
@@ -509,7 +510,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.close_session(session_id)
 
         stats = self.session_mgr.get_stats()
-        assert self._get_stat_value(stats, "session_duration_seconds_total") == 10
+        assert self._get_stat_value(stats, "session_duration_seconds") == 10
 
     @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
     @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
@@ -526,7 +527,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.close_session(session_id_2)
 
         stats = self.session_mgr.get_stats()
-        assert self._get_stat_value(stats, "session_duration_seconds_total") == 30
+        assert self._get_stat_value(stats, "session_duration_seconds") == 30
 
     @patch(
         "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
@@ -548,7 +549,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.disconnect_session(session_id)
 
         stats = self.session_mgr.get_stats()
-        assert self._get_stat_value(stats, "session_duration_seconds_total") == 10
+        assert self._get_stat_value(stats, "session_duration_seconds") == 10
 
     @patch(
         "streamlit.runtime.app_session.AppSession.disconnect_file_watchers",
@@ -575,7 +576,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         # Duration from connect (0) to disconnect (5) = 5 seconds
         # The time before the session was closed should not add more duration
         # since no reconnect happened in between.
-        assert self._get_stat_value(stats, "session_duration_seconds_total") == 5
+        assert self._get_stat_value(stats, "session_duration_seconds") == 5
 
     @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
     @patch("streamlit.runtime.websocket_session_manager.time.monotonic")
@@ -592,4 +593,4 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         stats = self.session_mgr.get_stats()
         # Duration from connect (0) to disconnect (5) = 5 seconds
         # Duration from reconnect (6) to close (16) = 10 seconds
-        assert self._get_stat_value(stats, "session_duration_seconds_total") == 15
+        assert self._get_stat_value(stats, "session_duration_seconds") == 15

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -29,6 +29,7 @@ from starlette.testclient import TestClient
 
 from streamlit import file_util
 from streamlit.proto.BackMsg_pb2 import BackMsg
+from streamlit.proto.openmetrics_data_model_pb2 import MetricSet as MetricSetProto
 from streamlit.runtime.media_file_manager import MediaFileManager, MediaFileMetadata
 from streamlit.runtime.media_file_storage import MediaFileKind
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
@@ -61,6 +62,15 @@ class _DummyStatsManager:
                     value=5,
                     labels={"type": "connect"},
                     help="Total count of session events by type.",
+                )
+            ],
+            "session_duration_seconds": [
+                CounterStat(
+                    family_name="session_duration_seconds",
+                    sample_name="session_duration_seconds_total",
+                    value=42,
+                    unit="seconds",
+                    help="Total time spent in active sessions, in seconds.",
                 )
             ],
             "active_sessions": [
@@ -213,6 +223,9 @@ def test_metrics_endpoint(starlette_client: tuple[TestClient, _DummyRuntime]) ->
     assert response.status_code == 200
     assert "cache_memory_bytes" in response.text
     assert "session_events_total" in response.text
+    assert "# TYPE session_duration_seconds counter" in response.text
+    assert "# UNIT session_duration_seconds seconds" in response.text
+    assert "session_duration_seconds_total 42" in response.text
     assert "active_sessions" in response.text
 
 
@@ -266,6 +279,25 @@ def test_metrics_endpoint_protobuf(
     assert response.headers["content-type"] == "application/x-protobuf"
     expected_proto = StatsRequestHandler._stats_to_proto(expected).SerializeToString()
     assert response.content == expected_proto
+
+
+def test_metrics_endpoint_protobuf_uses_canonical_family_name(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """Unitful counters should use the canonical family name in protobuf."""
+    client, _ = starlette_client
+    response = client.get(
+        "/_stcore/metrics",
+        headers={"Accept": "application/x-protobuf"},
+    )
+    assert response.status_code == 200
+
+    metric_set = MetricSetProto()
+    metric_set.ParseFromString(response.content)
+    family_names = {metric_family.name for metric_family in metric_set.metric_families}
+
+    assert "session_duration_seconds" in family_names
+    assert "session_duration_seconds_total" not in family_names
 
 
 def test_media_endpoint_serves_file(

--- a/lib/tests/streamlit/web/server/stats_handler_test.py
+++ b/lib/tests/streamlit/web/server/stats_handler_test.py
@@ -161,6 +161,45 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
         assert expected == MessageToDict(metric_set)
 
+    def test_protobuf_stats_uses_canonical_family_name_for_unitful_counter(self):
+        """Unitful counters should use the canonical family name in protobuf."""
+        self.mock_stats = {
+            "session_duration_seconds": [
+                CounterStat(
+                    family_name="session_duration_seconds",
+                    sample_name="session_duration_seconds_total",
+                    value=42,
+                    unit="seconds",
+                    help="Total time spent in active sessions, in seconds.",
+                )
+            ]
+        }
+
+        response = self.fetch(
+            "/_stcore/metrics",
+            headers=HTTPHeaders({"Accept": "application/x-protobuf"}),
+        )
+        assert response.code == 200
+
+        metric_set = MetricSetProto()
+        metric_set.ParseFromString(response.body)
+
+        expected = {
+            "metricFamilies": [
+                {
+                    "name": "session_duration_seconds",
+                    "type": "COUNTER",
+                    "unit": "seconds",
+                    "help": "Total time spent in active sessions, in seconds.",
+                    "metrics": [
+                        {"metricPoints": [{"counterValue": {"intValue": "42"}}]}
+                    ],
+                }
+            ]
+        }
+
+        assert expected == MessageToDict(metric_set)
+
 
 class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
     """Tests for filtering metrics by family name."""
@@ -180,6 +219,15 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
                     value=5,
                     labels={"type": "connect"},
                     help="Total count of session events by type.",
+                ),
+            ],
+            "session_duration_seconds": [
+                CounterStat(
+                    family_name="session_duration_seconds",
+                    sample_name="session_duration_seconds_total",
+                    value=7,
+                    unit="seconds",
+                    help="Total time spent in active sessions, in seconds.",
                 ),
             ],
             "active_sessions": [
@@ -249,6 +297,16 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
         body = response.body.decode()
         assert "# TYPE session_events_total counter" in body
         assert 'session_events_total{type="connect"} 5' in body
+
+    def test_unitful_counter_stat_format(self):
+        """Unitful counters should use canonical family metadata and sample names."""
+        response = self.fetch("/_stcore/metrics?families=session_duration_seconds")
+        assert response.code == 200
+
+        body = response.body.decode()
+        assert "# TYPE session_duration_seconds counter" in body
+        assert "# UNIT session_duration_seconds seconds" in body
+        assert "session_duration_seconds_total 7" in body
 
     def test_gauge_stat_format(self):
         """GaugeStat without labels should be formatted correctly."""


### PR DESCRIPTION
## Describe your changes

Fixes the Prometheus scraping error:
> Error scraping target: unit "seconds" not a suffix of metrics "session_duration_seconds_total"

The [OpenMetrics spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md) requires the UNIT value to be a suffix of the MetricFamily name. The session duration counter was using `session_duration_seconds_total` as both the family name and the sample name, so the declared unit `seconds` wasn't a valid suffix (it's buried before `_total`).

### What changed
- Renamed the `SESSION_DURATION_FAMILY` constant from `"session_duration_seconds_total"` to `"session_duration_seconds"`.
- Added an optional `sample_name` field to `CounterStat` so counter samples can use a name distinct from the family metadata name. When unset, behavior is unchanged.
- The session duration producer now sets `sample_name="session_duration_seconds_total"` so the emitted sample line keeps the required `_total` suffix while the family metadata uses the canonical name.
- No changes to the serializers — they already separate metadata (`family_name`) from sample rendering (`to_metric_str()`).
### Scope notes
- Only the broken unitful counter (`session_duration`) is renamed. `session_events_total` is technically non-canonical per OpenMetrics but does not cause a Prometheus failure, so it is left unchanged to limit the API-visible break.
- The pre-existing issue of emitting `# UNIT` lines for unitless metrics is tracked separately.


## GitHub Issue Link (if applicable)
Closes #14432 

## Testing Plan
- Unit Tests (JS and/or Python): ✅ Added/Updated
- Manual testing: ✅ 