### PR TITLE
Docs for URL pages and navigation

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -193,17 +193,31 @@ def switch_page(  # type: ignore[misc]
     """Programmatically switch the current page in a multipage app.
 
     When ``st.switch_page`` is called, the current page execution stops and
-    the specified page runs as if the user clicked on it in the sidebar
-    navigation. The specified page must be recognized by Streamlit's multipage
-    architecture (your main Python file or a Python file in a ``pages/``
-    folder). Arbitrary Python scripts cannot be passed to ``st.switch_page``.
+    the specified page runs as if the user clicked on it in the navigation
+    menu. The specified page must be recognized by Streamlit's multipage
+    architecture. Arbitrary Python scripts and URLs can't be passed to
+    ``st.switch_page``.
 
     Parameters
     ----------
-    page : str, Path, or st.Page
-        The file path (relative to the main script) or an st.Page indicating
-        the page to switch to. External URL pages are not supported, including
-        hidden external pages.
+    page : str, Path, or StreamlitPage
+        The page to switch to. This can be one of the following values:
+
+        - Path to a Python file: The path can be a string or ``pathlib.Path``
+          object. It can be absolute or relative to the entrypoint file. The
+          Python file must be the source of a page in ``st.navigation``.
+
+          If you are using the ``pages/`` directory instead of
+          ``st.navigation``, the Python file must be your entrypoint file or
+          a file in the ``pages/`` directory.
+
+        - ``StreamlitPage``: The source of the ``StreamlitPage`` and its
+          ``url_path`` must match a page defined in ``st.navigation``. The
+          ``StreamlitPage`` must be internal and can't be defined by a URL.
+          Use ``st.Page`` to craete a ``StreamlitPage`` object.
+
+        To switch to a page defined by a ``callable``, you must use a
+        ``StreamlitPage`` object.
 
     query_params : dict, list of tuples, or None
         Query parameters to apply when navigating to the target page.

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -214,7 +214,7 @@ def switch_page(  # type: ignore[misc]
         - ``StreamlitPage``: The source of the ``StreamlitPage`` and its
           ``url_path`` must match a page defined in ``st.navigation``. The
           ``StreamlitPage`` must be internal and can't be defined by a URL.
-          Use ``st.Page`` to craete a ``StreamlitPage`` object.
+          Use ``st.Page`` to create a ``StreamlitPage`` object.
 
         To switch to a page defined by a ``callable``, you must use a
         ``StreamlitPage`` object.

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -893,7 +893,7 @@ class ButtonMixin:
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         url : str
-            The url to be opened on user click
+            The URL to open on user click.
 
         key : str, int, or None
             An optional string to use for giving this element a stable
@@ -1105,9 +1105,30 @@ class ButtonMixin:
         Parameters
         ----------
         page : str, Path, or StreamlitPage
-            The file path (relative to the main script) or a ``StreamlitPage``
-            indicating the page to switch to. Alternatively, this can be the
-            URL to an external page (must start with "http://" or "https://").
+            The page to switch to on user click. This can be one of the
+            following values:
+
+            - Path to a Python file: The path can be a string or
+              ``pathlib.Path`` object. It can be absolute or relative to the
+              entrypoint file. The Python file must define a page in
+              ``st.navigation``.
+
+              If you are using the ``pages/`` directory instead of
+              ``st.navigation``, the Python file must be your entrypoint file
+              or a file in the ``pages/`` directory.
+
+            - ``StreamlitPage``: The source of the ``StreamlitPage`` and its
+              ``url_path`` must match a page defined in ``st.navigation``.
+              Use ``st.Page`` to create a ``StreamlitPage`` object.
+
+            - URL: The URL must contain a fully qualified domain name and
+              scheme, like ``"https://docs.streamlit.io"``. When a user clicks
+              a URL-defined page link, the URL opens in a new tab and the app
+              doesn't rerun. If the page link is defined by a URL, then the
+              ``label`` parameter is required.
+
+            To link to a page defined by a ``callable``, you must use a
+            ``StreamlitPage`` object.
 
         label : str
             The label for the page link. Labels are required for external pages.

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1121,9 +1121,9 @@ class ButtonMixin:
               ``url_path`` must match a page defined in ``st.navigation``.
               Use ``st.Page`` to create a ``StreamlitPage`` object.
 
-            - URL: The URL must contain a fully qualified domain name and
-              scheme, like ``"https://docs.streamlit.io"``. When a user clicks
-              a URL-defined page link, the URL opens in a new tab and the app
+            - URL: The URL must contain an HTTP or HTTPS scheme, like
+              ``"https://docs.streamlit.io"``. When a user clicks a
+              URL-defined page link, the URL opens in a new tab and the app
               doesn't rerun. If the page link is defined by a URL, then the
               ``label`` parameter is required.
 

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1110,7 +1110,7 @@ class ButtonMixin:
 
             - Path to a Python file: The path can be a string or
               ``pathlib.Path`` object. It can be absolute or relative to the
-              entrypoint file. The Python file must define a page in
+              entrypoint file. The Python file must be the source of a page in
               ``st.navigation``.
 
               If you are using the ``pages/`` directory instead of

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -84,9 +84,9 @@ def Page(  # noqa: N802
           object. It can be absolute or relative to the entrypoint file.
         - URL: Streamlit opens the URL in a new tab when a user selects it
           in the navigation menu or a page link. In this case, the app doesn't
-          rerun. The URL must be a fully qualified domain name with an HTTP or
-          HTTPS scheme, like ``"https://docs.streamlit.io"``. If the page is
-          defined by a URL, then the ``title`` parameter is required.
+          rerun. The URL must contain an HTTP or HTTPS scheme, like
+          ``"https://docs.streamlit.io"``. If the page is defined by a URL,
+          then the ``title`` parameter is required.
 
     title : str or None
         The title of the page. If this is ``None`` (default), the page title

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -74,14 +74,19 @@ def Page(  # noqa: N802
     Parameters
     ----------
     page : str, Path, or callable
-        The page source as a ``Callable``, path to a Python file, or external
-        URL. If the page source is defined by a Python file, the path can be a
-        string or ``pathlib.Path`` object. Paths can be absolute or relative to
-        the entrypoint file. If the page source is defined by a ``Callable``,
-        the ``Callable`` can't accept arguments. If the page source is an
-        external URL (starting with ``http://`` or ``https://``), clicking the
-        page in the navigation menu will open the URL in a new browser tab.
-        When using an external URL, the ``title`` parameter is required.
+        The source for the internal or external page. This can be one of the
+        following values:
+
+        - ``callable``: Streamlit executes the callable when it runs the page.
+          The ``callable`` can't accept arguments.
+        - Path to a Python file: Streamlit executes the Python script when it
+          runs the page. The path can be a string or ``pathlib.Path``
+          object. It can be absolute or relative to the entrypoint file.
+        - URL: Streamlit opens the URL in a new tab when a user selects it
+          in the navigation menu or a page link. In this case, the app doesn't
+          rerun. The URL must be a fully qualified domain name with an HTTP or
+          HTTPS scheme, like ``"https://docs.streamlit.io"``. If the page is
+          defined by a URL, then the ``title`` parameter is required.
 
     title : str or None
         The title of the page. If this is ``None`` (default), the page title
@@ -155,18 +160,17 @@ def Page(  # noqa: N802
         Whether the page is shown in the navigation menu. If this is
         ``"visible"`` (default), the page appears in the navigation menu. If
         this is ``"hidden"``, the page is excluded from the navigation menu.
-        For internal pages (Python files or callables), hidden pages remain
-        accessible via direct URL, ``st.page_link``, or ``st.switch_page``.
-        For external URL pages, hidden pages can only be opened via
-        ``st.page_link``. Direct URL access and ``st.switch_page`` are not
-        supported for external pages.
+        Hidden pages defined by Python files or callables remain accessible
+        by ``st.page_link`` and ``st.switch_page``. External URLs can always
+        be accessed using ``st.page_link`` regardless of their inclusion or
+        visibility in the navigation menu.
 
         .. note::
 
-           Navigating to a page by URL starts a new session. For a
-           hidden page to be accessible by URL, it must be passed to
+           Navigating to an internal page by URL starts a new session. For
+           any internal page to be accessible by URL, it must be passed to
            ``st.navigation`` during the new session's initial script
-           run.
+           run. The page can be visible or hidden.
 
     Returns
     -------
@@ -175,17 +179,24 @@ def Page(  # noqa: N802
 
     Example
     -------
-    >>> import streamlit as st
-    >>>
-    >>> def page2():
-    >>>     st.title("Second page")
-    >>>
-    >>> pg = st.navigation([
-    >>>     st.Page("page1.py", title="First page", icon="🔥"),
-    >>>     st.Page(page2, title="Second page", icon=":material/favorite:"),
-    >>>     st.Page("https://streamlit.io", title="Streamlit Docs", icon=":material/open_in_new:"),
-    >>> ])
-    >>> pg.run()
+    .. code-block:: python
+        :filename: streamlit_app.py
+
+        import streamlit as st
+
+        def page2():
+            st.title("Second page")
+
+        pg = st.navigation([
+            st.Page("page1.py", title="First page", icon="🔥"),
+            st.Page(page2, title="Second page", icon=":material/favorite:"),
+            st.Page(
+                "https://docs.streamlit.io",
+                title="Streamlit Docs",
+                icon=":material/open_in_new:"
+            ),
+        ])
+        pg.run()
     """
     return StreamlitPage(
         page,


### PR DESCRIPTION
## Describe your changes
* Use bullet list to better distinguish distinct items.
* Clarify limitations of URL pages (hidden or external considerations can be simplified to just: defined by URL or not)

There is a known bug #10572. In actuality, `st.switch_page` and `st.page_link` care more about the `url_path` than the page source. You can switch to the wrong page, or get rerouted to the homepage silently if you get a conflict in the URL pathname. If you use automatic URL paths inherited from the file and callable names, you probably won't notice, but as it stands, matching the `url_path` takes precedence. I just stated that you need to match both the source and path to avoid describing the current (unexpected) behavior of concocting a page with any source as long the the `url_path` matches where you want to go.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
