### PR TITLE
Docs for chat input height

### DIFF
--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -759,9 +759,9 @@ class ChatMixin:
             - ``"content"`` (default): The widget uses the default single-line
               height and automatically expands based on the text content.
             - ``"stretch"``: The height of the widget stretches to fill the
-              available height of the parent container. Note that the parent
-              container must have a defined height for this to work properly.
-            - An integer specifying the minimum height in pixels. The widget
+              available height of the parent container. The parent container
+              must have a defined height for this to work properly.
+            - An integer specifying the minimum height in pixels: The widget
               has a fixed minimum height but still auto-expands based on text
               content. The minimum recommended height is 68 pixels, which fits
               a single line of text.


### PR DESCRIPTION
## Describe your changes
Small style edits.
* Generally avoid "Note that". If it rises to the level of needing an admonition, use `.. note::`. Otherwise, avoid the extra wordiness.
* Parallelism. Use a colon consistently in the list.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
