### PR TITLE
Honor baseUrlPath in all cookie Path attributes

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -36,14 +36,30 @@ if TYPE_CHECKING:
 
 
 MAX_COOKIE_BYTES: Final = 4096
-# Cookie attributes added by Tornado: "; Path=/; HttpOnly"
-COOKIE_ATTRIBUTES: Final = "; Path=/; HttpOnly"
-COOKIE_ATTR_SIZE: Final = len(COOKIE_ATTRIBUTES)
 # Safety buffer for signing overhead to account for edge cases, rounding, and potential
 # variations in signing implementations (e.g., longer timestamps after year 2286)
 SIGNING_OVERHEAD_SAFETY_BUFFER: Final = 50
 # Base64 encoding of 1 byte = 4 bytes, so overhead = total - 4
 SINGLE_BYTE_BASE64_SIZE: Final = 4
+# Size of cookie attributes suffix: "; Path=<cookie_path>; HttpOnly"
+_COOKIE_ATTR_TEMPLATE: Final = "; Path={}; HttpOnly"
+
+
+def get_cookie_path() -> str:
+    """Get the cookie path based on server.baseUrlPath configuration.
+
+    Returns "/" when no base path is configured, or "/<baseUrlPath>" when set.
+    """
+    base_path: str | None = config.get_option("server.baseUrlPath")
+    if base_path:
+        # Ensure path starts with "/" and doesn't have trailing slash
+        return "/" + base_path.strip("/")
+    return "/"
+
+
+def _get_cookie_attr_size() -> int:
+    """Get the size of cookie attributes based on the actual cookie path."""
+    return len(_COOKIE_ATTR_TEMPLATE.format(get_cookie_path()))
 
 
 class AuthCache:
@@ -318,8 +334,10 @@ def set_cookie_with_chunks(
     # Calculate actual cookie size using the provided signing function
     signed_value = create_signed_value_fn(cookie_name, serialized_cookie_value)
 
-    # Cookie format: "name=value" + COOKIE_ATTRIBUTES
-    actual_cookie_size = len(cookie_name) + 1 + len(signed_value) + COOKIE_ATTR_SIZE
+    # Cookie format: "name=value" + cookie attributes ("; Path=<path>; HttpOnly")
+    actual_cookie_size = (
+        len(cookie_name) + 1 + len(signed_value) + _get_cookie_attr_size()
+    )
 
     # Check if cookie needs to be split
     if actual_cookie_size > MAX_COOKIE_BYTES:
@@ -385,7 +403,7 @@ def _set_split_cookie(
     # Available space for the signed value:
     # MAX_COOKIE_BYTES - cookie_name - "=" (1 byte) - cookie attributes
     available_for_signed_value = (
-        MAX_COOKIE_BYTES - len(cookie_name) - 1 - COOKIE_ATTR_SIZE
+        MAX_COOKIE_BYTES - len(cookie_name) - 1 - _get_cookie_attr_size()
     )
 
     # Space available for the base64-encoded value (after subtracting signing overhead)

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -24,6 +24,7 @@ from streamlit.auth_util import (
     clear_cookie_and_chunks,
     decode_provider_token,
     generate_default_provider_section,
+    get_cookie_path,
     get_cookie_with_chunks,
     get_origin_from_redirect_uri,
     get_redirect_uri,
@@ -95,7 +96,8 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
         )
 
     def _set_single_cookie(self, cookie_name: str, value: str) -> None:
-        """Set a single cookie."""
+        """Set a single cookie with path matching server.baseUrlPath."""
+        cookie_path = get_cookie_path()
         try:
             # We don't specify Tornado secure flag here because it leads to missing cookie on Safari.
             # The OIDC flow should work only on secure context anyway (localhost or HTTPS),
@@ -104,12 +106,14 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
                 cookie_name,
                 value,
                 httpOnly=True,
+                path=cookie_path,
             )
         except AttributeError:
             self.set_secure_cookie(
                 cookie_name,
                 value,
                 httponly=True,
+                path=cookie_path,
             )
 
     def _create_signed_value(self, cookie_name: str, value: str) -> bytes:
@@ -132,15 +136,24 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
             return None
 
     def clear_auth_cookie(self) -> None:
-        """Clear auth cookies, including any split cookie chunks."""
+        """Clear auth cookies, including any split cookie chunks.
+
+        The path must match the path used when setting the cookie, otherwise
+        the browser won't delete it.
+        """
+        cookie_path = get_cookie_path()
+
+        def clear_single_cookie(cookie_name: str) -> None:
+            self.clear_cookie(cookie_name, path=cookie_path)
+
         clear_cookie_and_chunks(
             self._get_signed_cookie,
-            self.clear_cookie,
+            clear_single_cookie,
             AUTH_COOKIE_NAME,
         )
         clear_cookie_and_chunks(
             self._get_signed_cookie,
-            self.clear_cookie,
+            clear_single_cookie,
             TOKENS_COOKIE_NAME,
         )
 

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -106,7 +106,7 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
             self.set_signed_cookie(
                 cookie_name,
                 value,
-                httpOnly=True,
+                httponly=True,
                 path=cookie_path,
             )
         except AttributeError:
@@ -170,11 +170,23 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
                 days=365
             )
             expires_str = expires.strftime("%a, %d %b %Y %H:%M:%S GMT")
-            for cookie_name in (AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME):
+
+            def clear_root_cookie(cookie_name: str) -> None:
                 self.add_header(
                     "Set-Cookie",
                     f'{cookie_name}=""; expires={expires_str}; Path=/',
                 )
+
+            clear_cookie_and_chunks(
+                self._get_signed_cookie,
+                clear_root_cookie,
+                AUTH_COOKIE_NAME,
+            )
+            clear_cookie_and_chunks(
+                self._get_signed_cookie,
+                clear_root_cookie,
+                TOKENS_COOKIE_NAME,
+            )
 
 
 class AuthLoginHandler(AuthHandlerMixin, tornado.web.RequestHandler):

--- a/lib/streamlit/web/server/oauth_authlib_routes.py
+++ b/lib/streamlit/web/server/oauth_authlib_routes.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import datetime
 import json
 from typing import Any, Final, cast
 
@@ -139,7 +140,10 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
         """Clear auth cookies, including any split cookie chunks.
 
         The path must match the path used when setting the cookie, otherwise
-        the browser won't delete it.
+        the browser won't delete it. We also clear at ``path="/"`` to handle
+        legacy cookies set before baseUrlPath was honored (they will linger
+        until expiry otherwise, because browsers require an exact path match
+        for cookie deletion).
         """
         cookie_path = get_cookie_path()
 
@@ -156,6 +160,21 @@ class AuthHandlerMixin(tornado.web.RequestHandler):
             clear_single_cookie,
             TOKENS_COOKIE_NAME,
         )
+
+        # Also clear at root path for backward compatibility with cookies
+        # set before baseUrlPath was respected. Tornado's SimpleCookie is
+        # keyed by name, so calling clear_cookie twice with different paths
+        # overwrites the first. We use add_header directly instead.
+        if cookie_path != "/":
+            expires = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+                days=365
+            )
+            expires_str = expires.strftime("%a, %d %b %Y %H:%M:%S GMT")
+            for cookie_name in (AUTH_COOKIE_NAME, TOKENS_COOKIE_NAME):
+                self.add_header(
+                    "Set-Cookie",
+                    f'{cookie_name}=""; expires={expires_str}; Path=/',
+                )
 
 
 class AuthLoginHandler(AuthHandlerMixin, tornado.web.RequestHandler):

--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -25,7 +25,7 @@ import tornado.web
 from tornado.httpserver import HTTPServer
 
 from streamlit import cli_util, config, file_util, util
-from streamlit.auth_util import is_authlib_installed
+from streamlit.auth_util import get_cookie_path, is_authlib_installed
 from streamlit.config_option import ConfigOption
 from streamlit.logger import get_logger
 from streamlit.runtime import Runtime, RuntimeConfig, RuntimeState
@@ -122,6 +122,7 @@ def get_tornado_settings() -> dict[str, Any]:
         # is timed out.
         "websocket_ping_timeout": ping_timeout,
         "xsrf_cookie_name": "_streamlit_xsrf",
+        "xsrf_cookie_kwargs": {"path": get_cookie_path()},
     }
 
 

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -269,7 +269,10 @@ def _clear_auth_cookie(response: Response, request: Request) -> None:
     """Clear the auth cookies, including any split cookie chunks.
 
     The path must match the path used when setting the cookie, otherwise
-    the browser won't delete it.
+    the browser won't delete it. We also clear at ``path="/"`` to handle
+    legacy cookies set before baseUrlPath was honored (they will linger
+    until expiry otherwise, because browsers require an exact path match
+    for cookie deletion).
     """
     cookie_path = get_cookie_path()
 
@@ -278,6 +281,10 @@ def _clear_auth_cookie(response: Response, request: Request) -> None:
 
     def clear_single_cookie(cookie_name: str) -> None:
         response.delete_cookie(cookie_name, path=cookie_path)
+        # Also clear at root path for backward compatibility with
+        # cookies set before baseUrlPath was respected.
+        if cookie_path != "/":
+            response.delete_cookie(cookie_name, path="/")
 
     clear_cookie_and_chunks(
         get_single_cookie,

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -27,6 +27,7 @@ from streamlit.auth_util import (
     clear_cookie_and_chunks,
     decode_provider_token,
     generate_default_provider_section,
+    get_cookie_path,
     get_cookie_with_chunks,
     get_origin_from_redirect_uri,
     get_redirect_uri,
@@ -189,17 +190,6 @@ async def _redirect_to_base(base_url: str) -> RedirectResponse:
     return RedirectResponse(make_url_path(base_url, "/"), status_code=302)
 
 
-def _get_cookie_path() -> str:
-    """Get the cookie path based on server.baseUrlPath configuration."""
-    from streamlit import config
-
-    base_path: str | None = config.get_option("server.baseUrlPath")
-    if base_path:
-        # Ensure path starts with "/" and doesn't have trailing slash
-        return "/" + base_path.strip("/")
-    return "/"
-
-
 async def _set_auth_cookie(
     response: Response, user_info: dict[str, Any], tokens: dict[str, Any]
 ) -> None:
@@ -250,7 +240,7 @@ def _set_single_cookie(
         cookie_payload,
         httponly=True,
         samesite="lax",
-        path=_get_cookie_path(),
+        path=get_cookie_path(),
     )
 
 
@@ -281,7 +271,7 @@ def _clear_auth_cookie(response: Response, request: Request) -> None:
     The path must match the path used when setting the cookie, otherwise
     the browser won't delete it.
     """
-    cookie_path = _get_cookie_path()
+    cookie_path = get_cookie_path()
 
     def get_single_cookie(cookie_name: str) -> bytes | None:
         return _get_signed_cookie_from_request(request, cookie_name)

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Final
 from urllib.parse import quote
 
 from streamlit import config, file_util
+from streamlit.auth_util import get_cookie_path
 from streamlit.logger import get_logger
 from streamlit.runtime.media_file_storage import MediaFileKind, MediaFileStorageError
 from streamlit.runtime.memory_media_file_storage import get_extension_for_mimetype
@@ -201,7 +202,7 @@ def _set_unquoted_cookie(
     If a cookie with the same name already exists, it is replaced.
 
     Cookie flags set:
-    - Path=/: Available to all paths
+    - Path: Matches server.baseUrlPath for proper scoping
     - SameSite=Lax: Protects against CSRF while allowing top-level navigations
     - Secure (conditional): Added when SSL is configured
 
@@ -220,11 +221,12 @@ def _set_unquoted_cookie(
     secure
         Whether to add the Secure flag (should be True when using HTTPS).
     """
+
     # Build the Set-Cookie header value manually to avoid encoding
     header_value = "; ".join(
         [
             f"{cookie_name}={cookie_value}",
-            "Path=/",
+            f"Path={get_cookie_path()}",
             "SameSite=Lax",
             *(["Secure"] if secure else []),
         ]

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -365,11 +365,14 @@ class LogoutHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
         response = self.fetch("/admin/auth/logout", follow_redirects=False)
         assert response.code == 302
 
-        set_cookie_header = response.headers["Set-Cookie"]
-        assert "Path=/admin" in set_cookie_header
+        set_cookie_headers = response.headers.get_list("Set-Cookie")
+        assert any("Path=/admin" in header for header in set_cookie_headers)
         # Also clears at root path for backward compatibility with cookies
         # set before baseUrlPath was honored.
-        assert "Path=/" in set_cookie_header
+        assert any(
+            "Path=/;" in header or header.endswith("Path=/")
+            for header in set_cookie_headers
+        )
 
 
 @patch(

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -367,6 +367,9 @@ class LogoutHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
 
         set_cookie_header = response.headers["Set-Cookie"]
         assert "Path=/admin" in set_cookie_header
+        # Also clears at root path for backward compatibility with cookies
+        # set before baseUrlPath was honored.
+        assert "Path=/" in set_cookie_header
 
 
 @patch(

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -356,26 +356,17 @@ class LogoutHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
             cookie_secret="test_secret",
         )
 
-    @patch("streamlit.auth_util.config.get_option", return_value="admin")
-    def test_logout_clears_cookie_with_base_url_path(self, _mock_config):
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.get_cookie_path",
+        return_value="/admin",
+    )
+    def test_logout_clears_cookie_with_base_url_path(self, _mock_path):
         """Test that logout clears cookies with Path matching baseUrlPath."""
         response = self.fetch("/admin/auth/logout", follow_redirects=False)
         assert response.code == 302
 
         set_cookie_header = response.headers["Set-Cookie"]
         assert "Path=/admin" in set_cookie_header
-
-    @patch("streamlit.auth_util.config.get_option", return_value="admin")
-    @patch.object(AuthLogoutHandler, "set_auth_cookie")
-    def test_set_cookie_includes_base_url_path(self, mock_set_cookie, _mock_config):
-        """Test that _set_single_cookie sets Path matching baseUrlPath."""
-        # We test the _set_single_cookie method indirectly via the callback handler,
-        # but for the Tornado logout handler we can verify the clear path.
-        # The set path is verified by checking the Set-Cookie header in a callback test.
-        response = self.fetch("/admin/auth/logout", follow_redirects=False)
-        assert response.code == 302
-        # Verify cookie clear uses the correct path
-        assert "Path=/admin" in response.headers["Set-Cookie"]
 
 
 @patch(
@@ -409,7 +400,10 @@ class AuthCallbackHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
     def tearDown(self) -> None:
         oauth_authlib_routes.auth_cache = self.old_value
 
-    @patch("streamlit.auth_util.config.get_option", return_value="admin")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.get_cookie_path",
+        return_value="/admin",
+    )
     @patch(
         "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
         return_value=(
@@ -425,7 +419,7 @@ class AuthCallbackHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
             MagicMock(),
         ),
     )
-    def test_callback_sets_cookie_with_base_url_path(self, _mock_client, _mock_config):
+    def test_callback_sets_cookie_with_base_url_path(self, _mock_client, _mock_path):
         """Test that OAuth callback sets auth cookies with Path matching baseUrlPath."""
         response = self.fetch("/admin/oauth2callback?state=123", follow_redirects=False)
         assert response.code == 302

--- a/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
+++ b/lib/tests/streamlit/web/server/oauth_authlib_routes_test.py
@@ -341,6 +341,106 @@ class LogoutHandlerTest(tornado.testing.AsyncHTTPTestCase):
         get=MagicMock(return_value=SECRETS_MOCK),
     ),
 )
+class LogoutHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests that Tornado auth cookies respect server.baseUrlPath."""
+
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/admin/auth/logout",
+                    AuthLogoutHandler,
+                    {"base_url": "/admin"},
+                )
+            ],
+            cookie_secret="test_secret",
+        )
+
+    @patch("streamlit.auth_util.config.get_option", return_value="admin")
+    def test_logout_clears_cookie_with_base_url_path(self, _mock_config):
+        """Test that logout clears cookies with Path matching baseUrlPath."""
+        response = self.fetch("/admin/auth/logout", follow_redirects=False)
+        assert response.code == 302
+
+        set_cookie_header = response.headers["Set-Cookie"]
+        assert "Path=/admin" in set_cookie_header
+
+    @patch("streamlit.auth_util.config.get_option", return_value="admin")
+    @patch.object(AuthLogoutHandler, "set_auth_cookie")
+    def test_set_cookie_includes_base_url_path(self, mock_set_cookie, _mock_config):
+        """Test that _set_single_cookie sets Path matching baseUrlPath."""
+        # We test the _set_single_cookie method indirectly via the callback handler,
+        # but for the Tornado logout handler we can verify the clear path.
+        # The set path is verified by checking the Set-Cookie header in a callback test.
+        response = self.fetch("/admin/auth/logout", follow_redirects=False)
+        assert response.code == 302
+        # Verify cookie clear uses the correct path
+        assert "Path=/admin" in response.headers["Set-Cookie"]
+
+
+@patch(
+    "streamlit.auth_util.secrets_singleton",
+    MagicMock(
+        load_if_toml_exists=MagicMock(return_value=True),
+        get=MagicMock(return_value=SECRETS_MOCK),
+    ),
+)
+class AuthCallbackHandlerCookiePathTest(tornado.testing.AsyncHTTPTestCase):
+    """Tests that auth callback sets cookies with correct Path."""
+
+    def get_app(self):
+        return tornado.web.Application(
+            [
+                (
+                    r"/admin/oauth2callback",
+                    AuthCallbackHandler,
+                    {"base_url": "/admin"},
+                )
+            ],
+            cookie_secret="AAAA",
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.old_value = oauth_authlib_routes.auth_cache
+        oauth_authlib_routes.auth_cache = AuthCache()
+        oauth_authlib_routes.auth_cache.set("a_b_google_123", "AAA", None)
+
+    def tearDown(self) -> None:
+        oauth_authlib_routes.auth_cache = self.old_value
+
+    @patch("streamlit.auth_util.config.get_option", return_value="admin")
+    @patch(
+        "streamlit.web.server.oauth_authlib_routes.create_oauth_client",
+        return_value=(
+            MagicMock(
+                authorize_access_token=MagicMock(
+                    return_value={
+                        "userinfo": {"email": "test@example.com"},
+                        "access_token": "test_access_token",
+                        "id_token": "test_id_token",
+                    }
+                )
+            ),
+            MagicMock(),
+        ),
+    )
+    def test_callback_sets_cookie_with_base_url_path(self, _mock_client, _mock_config):
+        """Test that OAuth callback sets auth cookies with Path matching baseUrlPath."""
+        response = self.fetch("/admin/oauth2callback?state=123", follow_redirects=False)
+        assert response.code == 302
+
+        set_cookie_header = response.headers["Set-Cookie"]
+        assert "Path=/admin" in set_cookie_header
+
+
+@patch(
+    "streamlit.auth_util.secrets_singleton",
+    MagicMock(
+        load_if_toml_exists=MagicMock(return_value=True),
+        get=MagicMock(return_value=SECRETS_MOCK),
+    ),
+)
 class AuthCallbackHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):
         return tornado.web.Application(

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -15,18 +15,19 @@
 from __future__ import annotations
 
 from http.cookies import SimpleCookie
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+import pytest
 from starlette.applications import Starlette
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import PlainTextResponse, RedirectResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from streamlit.auth_util import get_cookie_path
 from streamlit.web.server.starlette import starlette_app_utils, starlette_auth_routes
 from streamlit.web.server.starlette.starlette_auth_routes import (
     _STARLETTE_AUTH_CACHE,
-    _get_cookie_path,
     _get_origin_from_secrets,
     _get_provider_by_state,
     _parse_provider_token,
@@ -37,9 +38,6 @@ from streamlit.web.server.starlette.starlette_server_config import (
     USER_COOKIE_NAME,
 )
 from tests.testutil import patch_config_options
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def _build_app() -> Starlette:
@@ -210,33 +208,21 @@ def test_callback_missing_origin_redirects(monkeypatch: pytest.MonkeyPatch) -> N
         assert response.headers["location"].endswith("/")
 
 
-class TestCookiePath:
-    """Tests for _get_cookie_path function."""
-
-    @patch_config_options({"server.baseUrlPath": ""})
-    def test_returns_root_when_no_base_path(self) -> None:
-        """Test that root path is returned when no base URL is configured."""
-        assert _get_cookie_path() == "/"
-
-    @patch_config_options({"server.baseUrlPath": "myapp"})
-    def test_returns_base_path_with_leading_slash(self) -> None:
-        """Test that base path is returned with leading slash."""
-        assert _get_cookie_path() == "/myapp"
-
-    @patch_config_options({"server.baseUrlPath": "/myapp"})
-    def test_handles_leading_slash_in_config(self) -> None:
-        """Test that leading slash in config is handled correctly."""
-        assert _get_cookie_path() == "/myapp"
-
-    @patch_config_options({"server.baseUrlPath": "myapp/"})
-    def test_removes_trailing_slash(self) -> None:
-        """Test that trailing slash is removed from path."""
-        assert _get_cookie_path() == "/myapp"
-
-    @patch_config_options({"server.baseUrlPath": "/myapp/"})
-    def test_handles_both_leading_and_trailing_slashes(self) -> None:
-        """Test that both leading and trailing slashes are handled."""
-        assert _get_cookie_path() == "/myapp"
+@pytest.mark.parametrize(
+    ("base_url_path", "expected"),
+    [
+        ("", "/"),
+        ("myapp", "/myapp"),
+        ("/myapp", "/myapp"),
+        ("myapp/", "/myapp"),
+        ("/myapp/", "/myapp"),
+    ],
+    ids=["empty", "bare", "leading-slash", "trailing-slash", "both-slashes"],
+)
+def test_get_cookie_path(base_url_path: str, expected: str) -> None:
+    """Test that get_cookie_path normalizes baseUrlPath to a proper cookie path."""
+    with patch_config_options({"server.baseUrlPath": base_url_path}):
+        assert get_cookie_path() == expected
 
 
 class TestAuthCookieFlags:


### PR DESCRIPTION
## Summary
- Consolidates `get_cookie_path()` into `auth_util.py` (previously duplicated in `starlette_auth_routes.py`) so every cookie-setting code path uses the same `server.baseUrlPath`-aware logic
- Applies the correct `Path` attribute to auth cookies (Tornado + Starlette), XSRF cookies, and the unquoted XSRF cookie helper
- Accounts for the dynamic cookie path length when calculating chunk sizes for split auth cookies

This pull request standardizes and centralizes the logic for determining the cookie path used throughout Streamlit's authentication and server modules. By introducing a single `get_cookie_path` utility, it ensures that cookies are consistently set and cleared with the correct path, which is critical for authentication reliability—especially when Streamlit is served under a custom base URL path. Additionally, the pull request updates cookie size calculations to reflect the dynamic path, and refactors related tests for clarity and completeness.

**Cookie Path Handling Improvements:**

* Introduced a new `get_cookie_path` function in `auth_util.py` that computes the cookie path based on the `server.baseUrlPath` configuration, ensuring consistent path normalization across the application.
* Updated all cookie-setting and clearing logic in both Tornado and Starlette-based server routes to use `get_cookie_path`, replacing previous ad hoc or duplicated implementations. [[1]](diffhunk://#diff-587cb642dd396e670b6a247036dc73160582526b7fe019917ac69fe53c04e731R27) [[2]](diffhunk://#diff-587cb642dd396e670b6a247036dc73160582526b7fe019917ac69fe53c04e731L98-R100) [[3]](diffhunk://#diff-587cb642dd396e670b6a247036dc73160582526b7fe019917ac69fe53c04e731R109-R116) [[4]](diffhunk://#diff-587cb642dd396e670b6a247036dc73160582526b7fe019917ac69fe53c04e731L135-R156) [[5]](diffhunk://#diff-33eeef36149c6eaf2d646c3446fbbee0aa1f5e405aab013ba6ed970a142f1b9dR30) [[6]](diffhunk://#diff-33eeef36149c6eaf2d646c3446fbbee0aa1f5e405aab013ba6ed970a142f1b9dL192-L202) [[7]](diffhunk://#diff-33eeef36149c6eaf2d646c3446fbbee0aa1f5e405aab013ba6ed970a142f1b9dL253-R243) [[8]](diffhunk://#diff-33eeef36149c6eaf2d646c3446fbbee0aa1f5e405aab013ba6ed970a142f1b9dL284-R274) [[9]](diffhunk://#diff-643b15348b5a31555537f6f09639411329a56f9e02017e211e87dcd52a2eff88R26) [[10]](diffhunk://#diff-643b15348b5a31555537f6f09639411329a56f9e02017e211e87dcd52a2eff88L204-R205) [[11]](diffhunk://#diff-643b15348b5a31555537f6f09639411329a56f9e02017e211e87dcd52a2eff88R224-R229) [[12]](diffhunk://#diff-3f73cf34a1595773b3b79ea85c5efd0c208e23beec4f812fa05419f87cff597eL28-R28) [[13]](diffhunk://#diff-3f73cf34a1595773b3b79ea85c5efd0c208e23beec4f812fa05419f87cff597eR125)

**Cookie Size Calculation Updates:**

* Refactored cookie size calculation logic in `auth_util.py` to dynamically account for the actual cookie path length, ensuring accurate splitting of large cookies. [[1]](diffhunk://#diff-5d1b0e1dd9e4486c8ddf30a31ac26f41208647f28fd62f8c5fc626d435a8a69dL321-R340) [[2]](diffhunk://#diff-5d1b0e1dd9e4486c8ddf30a31ac26f41208647f28fd62f8c5fc626d435a8a69dL388-R406)

**Testing Improvements:**

* Replaced the old class-based tests for cookie path normalization with a parameterized test for `get_cookie_path`, improving coverage and readability. [[1]](diffhunk://#diff-2a1e9c5e103e71720fbfaedeeb93673b3bbbe3c12ecd65bf9c227dcb565f2be3L18-L29) [[2]](diffhunk://#diff-2a1e9c5e103e71720fbfaedeeb93673b3bbbe3c12ecd65bf9c227dcb565f2be3L41-L43) [[3]](diffhunk://#diff-2a1e9c5e103e71720fbfaedeeb93673b3bbbe3c12ecd65bf9c227dcb565f2be3L213-R225)

These changes collectively make cookie handling more robust and maintainable, especially for deployments using custom base URL paths.


fixes #14488

🤖 Generated with [Claude Code](https://claude.com/claude-code)