### PR TITLE
[feature] Add `autoscroll` parameter to `st.container`

### DIFF
--- a/e2e_playwright/st_container.py
+++ b/e2e_playwright/st_container.py
@@ -123,3 +123,15 @@ with col2:
         st.write("Inside container 7")
     with st.container(height=100, border=True):
         st.write("Inside container 8")
+
+# Test explicit autoscroll=True - should enable scroll-to-bottom behavior
+with st.container(height=200, autoscroll=True, key="container_with_autoscroll_true"):
+    for i in range(10):
+        st.markdown(f"Item {i}")
+
+# Test explicit autoscroll=False with chat messages - should disable scroll-to-bottom
+with st.container(
+    height=200, autoscroll=False, key="container_with_autoscroll_false_and_chat"
+):
+    for i in range(10):
+        st.chat_message("user").write(f"Message {i}")

--- a/e2e_playwright/st_container_test.py
+++ b/e2e_playwright/st_container_test.py
@@ -200,3 +200,24 @@ def test_containers_in_columns(app: Page, assert_snapshot: ImageCompareFunction)
     columns_container = app.get_by_test_id("stHorizontalBlock").last
     columns_container.scroll_into_view_if_needed()
     assert_snapshot(columns_container, name="st_container-columns")
+
+
+def test_autoscroll_parameter(app: Page):
+    """Test that the autoscroll parameter correctly controls scroll-to-bottom behavior."""
+    # Test autoscroll=True enables scroll-to-bottom without chat messages
+    container_with_autoscroll = get_element_by_key(
+        app, "container_with_autoscroll_true"
+    )
+    expect(container_with_autoscroll).to_have_css("overflow", "auto")
+    expect(container_with_autoscroll).to_have_attribute(
+        "data-test-scroll-behavior", "scroll-to-bottom"
+    )
+
+    # Test autoscroll=False disables scroll-to-bottom even with chat messages
+    container_without_autoscroll = get_element_by_key(
+        app, "container_with_autoscroll_false_and_chat"
+    )
+    expect(container_without_autoscroll).to_have_css("overflow", "auto")
+    expect(container_without_autoscroll).to_have_attribute(
+        "data-test-scroll-behavior", "normal"
+    )

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -360,4 +360,40 @@ describe("shouldActivateScrollToBottom", () => {
 
     expect(shouldActivateScrollToBottom(mockNode)).toBe(false)
   })
+
+  it.each([
+    {
+      description: "autoscroll=true with fixed height",
+      config: { heightConfig: { pixelHeight: 100 }, autoscroll: true },
+      hasChatChild: false,
+      expected: true,
+    },
+    {
+      description: "autoscroll=false overrides chat message presence",
+      config: { heightConfig: { pixelHeight: 100 }, autoscroll: false },
+      hasChatChild: true,
+      expected: false,
+    },
+    {
+      description: "autoscroll=true without fixed height",
+      config: { heightConfig: { useContent: true }, autoscroll: true },
+      hasChatChild: false,
+      expected: false,
+    },
+    {
+      description: "autoscroll=null with chat message uses default (true)",
+      config: { heightConfig: { pixelHeight: 100 }, autoscroll: null },
+      hasChatChild: true,
+      expected: true,
+    },
+    {
+      description: "autoscroll=null without chat message uses default (false)",
+      config: { heightConfig: { pixelHeight: 100 }, autoscroll: null },
+      hasChatChild: false,
+      expected: false,
+    },
+  ])("$description", ({ config, hasChatChild, expected }) => {
+    const mockNode = createBlockNode(config, hasChatChild)
+    expect(shouldActivateScrollToBottom(mockNode)).toBe(expected)
+  })
 })

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -207,19 +207,21 @@ export function checkFlexContainerBackwardsCompatibile(
 }
 
 export function shouldActivateScrollToBottom(blockNode: BlockNode): boolean {
-  // Auto-scroll only activates for containers with a fixed pixel height.
   const hasFixedPixelHeight = blockNode.deltaBlock.heightConfig?.pixelHeight
-  if (
-    hasFixedPixelHeight &&
-    blockNode.children.some(node => {
-      return (
-        node instanceof BlockNode && node.deltaBlock.type === "chatMessage"
-      )
-    })
-  ) {
-    return true
+  if (!hasFixedPixelHeight) {
+    return false
   }
-  return false
+
+  // When autoscroll is explicitly set, use that value directly.
+  const { autoscroll } = blockNode.deltaBlock
+  if (autoscroll !== null && autoscroll !== undefined) {
+    return autoscroll
+  }
+
+  // Default: auto-scroll when container has chat messages.
+  return blockNode.children.some(
+    node => node instanceof BlockNode && node.deltaBlock.type === "chatMessage"
+  )
 }
 
 export function getBorderBackwardsCompatible(blockProto: BlockProto): boolean {

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -245,6 +245,9 @@ class LayoutsMixin:
             auto-scroll is always enabled for containers with fixed height.
             If this is ``False``, auto-scroll is always disabled.
 
+            .. |st.chat_message| replace:: ``st.chat_message``
+            .. _st.chat_message: https://docs.streamlit.io/develop/api-reference/chat/st.chat_message
+
         Examples
         --------
         **Example 1: Inserting elements using ``with`` notation**

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -113,6 +113,7 @@ class LayoutsMixin:
         horizontal_alignment: HorizontalAlignment = "left",
         vertical_alignment: VerticalAlignment = "top",
         gap: Gap | None = "small",
+        autoscroll: bool | None = None,
     ) -> DeltaGenerator:
         """Insert a multi-element container.
 
@@ -234,6 +235,15 @@ class LayoutsMixin:
             between the elements. Elements may have larger gaps in one
             direction if you use a distributed horizontal alignment or fixed
             height.
+
+        autoscroll : bool or None
+            Whether to automatically scroll to the bottom when new content is
+            added. This only has an effect when the container has a fixed
+            height (scrolling enabled). If this is ``None`` (default),
+            auto-scroll is enabled when the container has a fixed height and
+            contains |st.chat_message|_ elements. If this is ``True``,
+            auto-scroll is always enabled for containers with fixed height.
+            If this is ``False``, auto-scroll is always disabled.
 
         Examples
         --------
@@ -376,6 +386,9 @@ class LayoutsMixin:
             block_proto.id = compute_and_register_element_id(
                 "container", user_key=key, dg=None, key_as_main_identity=False
             )
+
+        if autoscroll is not None:
+            block_proto.autoscroll = autoscroll
 
         return self.dg._block(block_proto)
 

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -833,6 +833,36 @@ class ContainerTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitInvalidVerticalAlignmentError):
             st.container(horizontal=True, vertical_alignment=vertical_alignment)
 
+    @parameterized.expand(
+        [
+            ("true_with_height", True, 300, True),
+            ("false_with_height", False, 300, False),
+        ],
+    )
+    def test_autoscroll_sets_proto_field(
+        self,
+        _name: str,
+        autoscroll: bool,
+        height: int,
+        expected_value: bool,
+    ) -> None:
+        """Test that explicit autoscroll values set the proto field."""
+        st.container(height=height, autoscroll=autoscroll)
+        container_block = self.get_delta_from_queue()
+        assert container_block.add_block.autoscroll is expected_value
+
+    def test_autoscroll_none_does_not_set_field(self) -> None:
+        """Test that autoscroll=None (default) does not set the proto field."""
+        st.container(height=300)
+        container_block = self.get_delta_from_queue()
+        assert not container_block.add_block.HasField("autoscroll")
+
+    def test_autoscroll_without_height(self) -> None:
+        """Test that autoscroll can be set without a fixed height."""
+        st.container(autoscroll=True)
+        container_block = self.get_delta_from_queue()
+        assert container_block.add_block.autoscroll is True
+
 
 class PopoverContainerTest(DeltaGeneratorTestCase):
     def test_label_required(self):

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -849,6 +849,7 @@ class ContainerTest(DeltaGeneratorTestCase):
         """Test that explicit autoscroll values set the proto field."""
         st.container(height=height, autoscroll=autoscroll)
         container_block = self.get_delta_from_queue()
+        assert container_block.add_block.HasField("autoscroll")
         assert container_block.add_block.autoscroll is expected_value
 
     def test_autoscroll_none_does_not_set_field(self) -> None:

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -39,6 +39,7 @@ message Block {
   optional string id = 12;
   optional streamlit.HeightConfig height_config = 14;
   optional streamlit.WidthConfig width_config = 15;
+  optional bool autoscroll = 16;
 
   message Vertical {
     bool border = 1;
@@ -175,5 +176,5 @@ message Block {
     AvatarType avatar_type = 3;
   }
 
-  // Next ID: 14
+  // Next ID: 17
 }


### PR DESCRIPTION
## Describe your changes

Add an `autoscroll: bool | None = None` parameter to `st.container()` that allows users to explicitly control the scroll-to-bottom behavior for fixed-height containers.

**Changes:**
- `autoscroll=True`: Force enable auto-scroll for any content (not just chat messages)
- `autoscroll=False`: Force disable auto-scroll even when chat messages are present
- `autoscroll=None` (default): Preserve existing behavior - auto-scroll only when container has chat messages

**Implementation:**
- Backend: Added `autoscroll` parameter to `st.container()` in `layouts.py`
- Protobuf: Added `optional bool autoscroll` field to `Block.proto`
- Frontend: Updated `shouldActivateScrollToBottom()` in `utils.ts` to check explicit autoscroll setting

## GitHub Issue Link (if applicable)

- Closes #8836

## Testing Plan

- [x] Python Unit Tests - Tests proto field serialization for True/False/None
- [x] Frontend Unit Tests - Parameterized tests for all autoscroll scenarios
- [x] E2E Tests - Tests `data-test-scroll-behavior` attribute for both True and False cases

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | finalizing-pr | 1 |
| skill | implementing-feature | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |
| subagent | qa-testing-feature | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->