### PR TITLE
fix: reset dialog scroll position to top when reopened

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -320,3 +320,15 @@ if st.button("Open Fast Dialog"):
 
 if st.button("Open Slow Dialog"):
     slow_dialog()
+
+
+@st.dialog("Long Dialog")
+def long_dialog() -> None:
+    st.write("First line of content")
+    for i in range(50):
+        st.write(f"Line {i}")
+    st.write("Last line of content")
+
+
+if st.button("Open Long Dialog"):
+    long_dialog()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -776,7 +776,7 @@ def test_long_dialog_starts_scrolled_to_top(app: Page):
     Reproduces issue #12716: When a dialog has enough content to require scrolling,
     reopening the dialog should show the top of the content, not the bottom.
     """
-    for i in range(3):
+    for _ in range(3):
         click_button(app, "Open Long Dialog")
         dialog = app.get_by_test_id(modal_test_id)
         expect(dialog).to_be_visible()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -769,7 +769,7 @@ def test_switching_dialogs_does_not_show_stale_content(app: Page):
     expect(dialog.get_by_test_id("stTextInput")).not_to_be_attached()
 
 
-@pytest.mark.skip_browser("webkit")
+@pytest.mark.skip_browser("webkit")  # viewport assertions are flaky on WebKit
 def test_long_dialog_starts_scrolled_to_top(app: Page):
     """Test that a long dialog starts scrolled to the top when opened and reopened.
 

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -769,13 +769,14 @@ def test_switching_dialogs_does_not_show_stale_content(app: Page):
     expect(dialog.get_by_test_id("stTextInput")).not_to_be_attached()
 
 
+@pytest.mark.skip_browser("webkit")
 def test_long_dialog_starts_scrolled_to_top(app: Page):
     """Test that a long dialog starts scrolled to the top when opened and reopened.
 
     Reproduces issue #12716: When a dialog has enough content to require scrolling,
     reopening the dialog should show the top of the content, not the bottom.
     """
-    for _ in range(3):
+    for i in range(3):
         click_button(app, "Open Long Dialog")
         dialog = app.get_by_test_id(modal_test_id)
         expect(dialog).to_be_visible()
@@ -788,6 +789,11 @@ def test_long_dialog_starts_scrolled_to_top(app: Page):
         # should start scrolled to the top
         last_line = dialog.get_by_text("Last line of content")
         expect(last_line).not_to_be_in_viewport()
+
+        # Scroll to the bottom of the dialog to reproduce the regression scenario
+        # from #12716. On reopen, the dialog should reset to the top.
+        last_line.scroll_into_view_if_needed()
+        expect(last_line).to_be_in_viewport()
 
         # Dismiss the dialog before reopening
         app.keyboard.press("Escape")

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -767,3 +767,28 @@ def test_switching_dialogs_does_not_show_stale_content(app: Page):
     expect(dialog).to_contain_text("Slow dialog content")
     expect(dialog.get_by_text("Fast dialog content")).not_to_be_attached()
     expect(dialog.get_by_test_id("stTextInput")).not_to_be_attached()
+
+
+def test_long_dialog_starts_scrolled_to_top(app: Page):
+    """Test that a long dialog starts scrolled to the top when opened and reopened.
+
+    Reproduces issue #12716: When a dialog has enough content to require scrolling,
+    reopening the dialog should show the top of the content, not the bottom.
+    """
+    for _ in range(3):
+        click_button(app, "Open Long Dialog")
+        dialog = app.get_by_test_id(modal_test_id)
+        expect(dialog).to_be_visible()
+
+        # The first line of content should be visible (in the viewport)
+        first_line = dialog.get_by_text("First line of content")
+        expect(first_line).to_be_in_viewport()
+
+        # The last line of content should NOT be in the viewport since the dialog
+        # should start scrolled to the top
+        last_line = dialog.get_by_text("Last line of content")
+        expect(last_line).not_to_be_in_viewport()
+
+        # Dismiss the dialog before reopening
+        app.keyboard.press("Escape")
+        expect(dialog).not_to_be_attached()

--- a/frontend/lib/src/components/shared/Modal/Modal.test.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.test.tsx
@@ -68,12 +68,11 @@ describe("Modal component", () => {
       </BaseProvider>
     )
 
-    // Note: In JSDOM, requestAnimationFrame is polyfilled as setTimeout(fn, 0).
-    // The scroll reset effect fires asynchronously, so we verify the container
-    // exists and has the expected test ID. The actual scroll reset behavior
-    // is validated by the E2E test.
+    // The scroll-reset callback ref fires synchronously on mount, so
+    // scrollTop should already be reset to 0 after the reopen rerender.
     const reopenedContainer = screen.getByTestId("stDialogContainer")
     expect(reopenedContainer).toBeVisible()
+    expect(reopenedContainer.scrollTop).toBe(0)
   })
 })
 describe("calculateModalSize", () => {

--- a/frontend/lib/src/components/shared/Modal/Modal.test.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.test.tsx
@@ -35,8 +35,8 @@ describe("Modal component", () => {
     expect(modalElement).toHaveClass("stDialog")
   })
 
-  it("resets scroll position to top when opened", () => {
-    render(
+  it("resets scroll position to top when reopened", () => {
+    const { rerender } = render(
       <BaseProvider theme={LightTheme}>
         <Modal isOpen>
           <div style={{ height: "2000px" }}>Tall content</div>
@@ -44,11 +44,36 @@ describe("Modal component", () => {
       </BaseProvider>
     )
 
-    // The DialogContainer is the scrollable wrapper inside the Modal root.
-    // Verify its scrollTop is 0 when the modal opens.
-    const modalRoot = screen.getByTestId("stDialog")
-    const dialogContainer = modalRoot.firstElementChild as HTMLElement
+    // The DialogContainer should have a data-testid for stable querying.
+    const dialogContainer = screen.getByTestId("stDialogContainer")
     expect(dialogContainer.scrollTop).toBe(0)
+
+    // Simulate scrolling (JSDOM doesn't truly support layout/scrolling,
+    // but we can set scrollTop to verify the reset behavior).
+    dialogContainer.scrollTop = 500
+
+    // Close and reopen the modal
+    rerender(
+      <BaseProvider theme={LightTheme}>
+        <Modal isOpen={false}>
+          <div style={{ height: "2000px" }}>Tall content</div>
+        </Modal>
+      </BaseProvider>
+    )
+    rerender(
+      <BaseProvider theme={LightTheme}>
+        <Modal isOpen>
+          <div style={{ height: "2000px" }}>Tall content</div>
+        </Modal>
+      </BaseProvider>
+    )
+
+    // Note: In JSDOM, requestAnimationFrame is polyfilled as setTimeout(fn, 0).
+    // The scroll reset effect fires asynchronously, so we verify the container
+    // exists and has the expected test ID. The actual scroll reset behavior
+    // is validated by the E2E test.
+    const reopenedContainer = screen.getByTestId("stDialogContainer")
+    expect(reopenedContainer).toBeVisible()
   })
 })
 describe("calculateModalSize", () => {

--- a/frontend/lib/src/components/shared/Modal/Modal.test.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.test.tsx
@@ -34,6 +34,22 @@ describe("Modal component", () => {
     expect(modalElement).toBeInTheDocument()
     expect(modalElement).toHaveClass("stDialog")
   })
+
+  it("resets scroll position to top when opened", () => {
+    render(
+      <BaseProvider theme={LightTheme}>
+        <Modal isOpen>
+          <div style={{ height: "2000px" }}>Tall content</div>
+        </Modal>
+      </BaseProvider>
+    )
+
+    // The DialogContainer is the scrollable wrapper inside the Modal root.
+    // Verify its scrollTop is 0 when the modal opens.
+    const modalRoot = screen.getByTestId("stDialog")
+    const dialogContainer = modalRoot.firstElementChild as HTMLElement
+    expect(dialogContainer.scrollTop).toBe(0)
+  })
 })
 describe("calculateModalSize", () => {
   it("returns the default size when no size is provided", () => {

--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  FunctionComponent,
-  ReactElement,
-  ReactNode,
-  useCallback,
-} from "react"
+import { FunctionComponent, ReactElement, ReactNode, useEffect } from "react"
 
 import {
   type ModalProps,
@@ -181,15 +176,24 @@ function Modal(props: StreamlitModalProps): ReactElement {
   const { spacing, radii, colors, sizes } = useEmotionTheme()
 
   /**
-   * Callback ref that resets the DialogContainer scroll position to the top
-   * when the modal is mounted. Without this, reopening a long dialog may
-   * show the content scrolled to the bottom instead of the top.
+   * Reset the DialogContainer scroll position to the top whenever the modal
+   * opens. Without this, reopening a long dialog may show the content scrolled
+   * to the bottom because baseui's DialogContainer retains its scroll position
+   * across open/close cycles (the DOM element stays alive during close animation).
    */
-  const dialogContainerRef = useCallback((node: HTMLElement | null): void => {
-    if (node) {
-      node.scrollTop = 0
+  useEffect(() => {
+    if (props.isOpen) {
+      const frameId = requestAnimationFrame(() => {
+        const container = document.querySelector<HTMLElement>(
+          '[data-testid="stDialogContainer"]'
+        )
+        if (container) {
+          container.scrollTop = 0
+        }
+      })
+      return () => cancelAnimationFrame(frameId)
     }
-  }, [])
+  }, [props.isOpen])
 
   const defaultOverrides = {
     Root: {
@@ -207,7 +211,7 @@ function Modal(props: StreamlitModalProps): ReactElement {
         paddingTop: spacing.threeXL,
       },
       props: {
-        ref: dialogContainerRef,
+        "data-testid": "stDialogContainer",
       },
     },
     Dialog: {

--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, ReactElement, ReactNode, useEffect } from "react"
+import {
+  forwardRef,
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  useCallback,
+} from "react"
 
 import {
   type ModalProps,
@@ -24,6 +30,8 @@ import {
   ModalFooter as UIModalFooter,
   ModalHeader as UIModalHeader,
 } from "baseui/modal"
+import { DialogContainer as BaseDialogContainer } from "baseui/modal/styled-components"
+import type { SharedStylePropsArg } from "baseui/modal/types"
 import { merge } from "lodash-es"
 
 import BaseButton, {
@@ -172,29 +180,41 @@ export function calculateModalSize(
   return SIZE.default
 }
 
+/**
+ * A component override for baseui's DialogContainer that resets scroll
+ * position to the top on mount. Uses forwardRef to preserve baseui's
+ * internal dialogContainerRef (needed for backdrop-click dismissal).
+ * Passing ref via the override's props field would shadow baseui's ref;
+ * this component override merges both refs instead.
+ */
+const ScrollResetDialogContainer = forwardRef<
+  HTMLDivElement,
+  SharedStylePropsArg & Record<string, unknown>
+>(function ScrollResetDialogContainer(containerProps, forwardedRef) {
+  const mergedRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      if (node) {
+        node.scrollTop = 0
+      }
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node)
+      } else if (forwardedRef) {
+        forwardedRef.current = node
+      }
+    },
+    [forwardedRef]
+  )
+  return (
+    <BaseDialogContainer
+      {...(containerProps as SharedStylePropsArg)}
+      ref={mergedRef}
+      data-testid="stDialogContainer"
+    />
+  )
+})
+
 function Modal(props: StreamlitModalProps): ReactElement {
   const { spacing, radii, colors, sizes } = useEmotionTheme()
-
-  /**
-   * Reset the DialogContainer scroll position to the top whenever the modal
-   * opens. Without this, reopening a long dialog may show the content scrolled
-   * to the bottom because baseui's DialogContainer retains its scroll position
-   * across open/close cycles (the DOM element stays alive during close animation).
-   */
-  useEffect(() => {
-    if (!props.isOpen) {
-      return
-    }
-    const frameId = requestAnimationFrame(() => {
-      const container = document.querySelector<HTMLElement>(
-        '[data-testid="stDialogContainer"]'
-      )
-      if (container) {
-        container.scrollTop = 0
-      }
-    })
-    return () => cancelAnimationFrame(frameId)
-  }, [props.isOpen])
 
   const defaultOverrides = {
     Root: {
@@ -211,9 +231,7 @@ function Modal(props: StreamlitModalProps): ReactElement {
         alignItems: "start",
         paddingTop: spacing.threeXL,
       },
-      props: {
-        "data-testid": "stDialogContainer",
-      },
+      component: ScrollResetDialogContainer,
     },
     Dialog: {
       style: {

--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -182,17 +182,18 @@ function Modal(props: StreamlitModalProps): ReactElement {
    * across open/close cycles (the DOM element stays alive during close animation).
    */
   useEffect(() => {
-    if (props.isOpen) {
-      const frameId = requestAnimationFrame(() => {
-        const container = document.querySelector<HTMLElement>(
-          '[data-testid="stDialogContainer"]'
-        )
-        if (container) {
-          container.scrollTop = 0
-        }
-      })
-      return () => cancelAnimationFrame(frameId)
+    if (!props.isOpen) {
+      return
     }
+    const frameId = requestAnimationFrame(() => {
+      const container = document.querySelector<HTMLElement>(
+        '[data-testid="stDialogContainer"]'
+      )
+      if (container) {
+        container.scrollTop = 0
+      }
+    })
+    return () => cancelAnimationFrame(frameId)
   }, [props.isOpen])
 
   const defaultOverrides = {

--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, ReactElement, ReactNode } from "react"
+import {
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  useCallback,
+} from "react"
 
 import {
   type ModalProps,
@@ -175,6 +180,17 @@ export function calculateModalSize(
 function Modal(props: StreamlitModalProps): ReactElement {
   const { spacing, radii, colors, sizes } = useEmotionTheme()
 
+  /**
+   * Callback ref that resets the DialogContainer scroll position to the top
+   * when the modal is mounted. Without this, reopening a long dialog may
+   * show the content scrolled to the bottom instead of the top.
+   */
+  const dialogContainerRef = useCallback((node: HTMLElement | null): void => {
+    if (node) {
+      node.scrollTop = 0
+    }
+  }, [])
+
   const defaultOverrides = {
     Root: {
       style: {
@@ -189,6 +205,9 @@ function Modal(props: StreamlitModalProps): ReactElement {
       style: {
         alignItems: "start",
         paddingTop: spacing.threeXL,
+      },
+      props: {
+        ref: dialogContainerRef,
       },
     },
     Dialog: {


### PR DESCRIPTION
## Describe your changes

Fixes a bug where reopening a long `st.dialog` would show the content scrolled to the bottom instead of the top. The root cause is that the baseui Modal's `DialogContainer` retains its scroll position between mount/unmount cycles.

The fix adds a callback ref to the `DialogContainer` override in the `Modal` component that resets `scrollTop` to `0` whenever the container is mounted. This ensures the dialog always opens with its content scrolled to the top, regardless of how far the user had scrolled before closing it.

## GitHub Issue Link (if applicable)

Closes #12716

## Testing Plan

- **Unit Tests (JS):** Added a test in `Modal.test.tsx` to verify that the `DialogContainer` `scrollTop` is `0` when the modal opens.
- **E2E Tests:** Added `test_long_dialog_starts_scrolled_to_top` in `st_dialog_test.py` which opens and reopens a long dialog 3 times, asserting that the first line of content is in the viewport and the last line is not, confirming the scroll position resets to top each time.
- **Manual testing:** Open a dialog with enough content to require scrolling, scroll to the bottom, close the dialog, and reopen it. The dialog should start at the top.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.