### PR TITLE
[fix] Component template E2E tests failing due to build 1.4.1

### DIFF
--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           python_version: ${{ env.PYTHON_MAX_VERSION }}
 
+      # The component-template repo uses `python -m build` which requires pip.
+      # uv venvs don't include pip by default, and build 1.4.1 has a regression
+      # where it incorrectly detects pip as usable. Install pip to work around this.
+      # See: https://github.com/pypa/build/issues/1004
+      - name: Install pip in venv for build compatibility
+        run: uv pip install pip
+
       - name: Build Package
         timeout-minutes: 120
         run: make package

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -47,11 +47,12 @@ jobs:
           python_version: ${{ env.PYTHON_MAX_VERSION }}
 
       # The component-template repo uses `python -m build` which requires pip.
-      # uv venvs don't include pip by default, and build 1.4.1 has a regression
-      # where it incorrectly detects pip as usable. Install pip to work around this.
+      # uv venvs don't include pip by default, and build 1.4.1+ requires pip
+      # to be available via `python -m pip` for isolated builds.
+      # Use ensurepip to bootstrap pip into the venv (more reliable than uv pip install pip).
       # See: https://github.com/pypa/build/issues/1004
       - name: Install pip in venv for build compatibility
-        run: uv pip install pip
+        run: python -m ensurepip --upgrade
 
       - name: Build Package
         timeout-minutes: 120

--- a/.github/workflows/component-template-e2e-tests.yml
+++ b/.github/workflows/component-template-e2e-tests.yml
@@ -46,14 +46,6 @@ jobs:
         with:
           python_version: ${{ env.PYTHON_MAX_VERSION }}
 
-      # The component-template repo uses `python -m build` which requires pip.
-      # uv venvs don't include pip by default, and build 1.4.1+ requires pip
-      # to be available via `python -m pip` for isolated builds.
-      # Use ensurepip to bootstrap pip into the venv (more reliable than uv pip install pip).
-      # See: https://github.com/pypa/build/issues/1004
-      - name: Install pip in venv for build compatibility
-        run: python -m ensurepip --upgrade
-
       - name: Build Package
         timeout-minutes: 120
         run: make package
@@ -91,6 +83,14 @@ jobs:
           persist-credentials: false
           repository: streamlit/component-template
           path: ./component-template
+
+      # The component-template repo uses `python -m build` which requires pip.
+      # uv venvs don't include pip by default, and build 1.4.1+ requires pip
+      # to be available via `python -m pip` for isolated builds.
+      # This must be placed AFTER `make package` because uv sync removes pip.
+      # See: https://github.com/pypa/build/issues/1004
+      - name: Install pip in venv for build compatibility
+        run: python -m ensurepip --upgrade
 
       - name: Build components wheels
         uses: ./component-template/.github/actions/build_component_wheels


### PR DESCRIPTION
## Describe your changes

Fixes the component template E2E tests that started failing after `build` 1.4.1 was released on March 24, 2026.

**Root cause:** Build 1.4.1 introduced a regression ([pypa/build#1004](https://github.com/pypa/build/issues/1004)) where it incorrectly detects pip as usable in uv-created virtualenvs, then fails when trying to use `python -m pip` because pip isn't actually installed as a module.

**Fix:** Install pip in the venv before running the component-template actions.

## GitHub Issue Link (if applicable)

- Related upstream: https://github.com/pypa/build/issues/1004

## Testing Plan

- CI workflow should pass after this change
- No additional unit/E2E tests needed — this is a CI workflow fix

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->