### PR TITLE
chore: enrich PR review skill with conventional comments reference

### DIFF
--- a/.claude/skills/addressing-pr-review-comments/SKILL.md
+++ b/.claude/skills/addressing-pr-review-comments/SKILL.md
@@ -93,26 +93,26 @@ Issue comments (from `issues/{PR_NUMBER}/comments`) do not have a "resolved" fla
 
 Per [conventional comments](https://conventionalcomments.org):
 
-| Label | Action | Priority |
-|-------|--------|----------|
-| `issue` | Fix the problem. Use suggested solution if provided. | High — fix required |
-| `question` | Respond first, then act if needed. Never change code without clarifying. | High — response needed |
-| `suggestion` | Evaluate and implement if beneficial. Check decorations. | Medium — assess intent |
-| `todo` | Complete the small task mentioned. | Medium — complete |
-| `chore` | Complete the process step (run CI, update docs, etc.). | Medium — follow process |
-| `typo` | Fix the typo. Treat like `todo`. | Low — quick fix |
-| `nitpick` | Consider but non-blocking by nature. | Low — optional |
-| `polish` | Improve quality if straightforward. Similar to `suggestion`. | Low — enhancement |
-| `praise` / `thought` / `note` | No action required. | None — skip |
+| Label | Action |
+|-------|--------|
+| `issue` | Fix the problem. Use suggested solution if provided. |
+| `question` | Respond first, then act if needed. Never change code without clarifying. |
+| `suggestion` | Evaluate and implement if beneficial. Check decorations. |
+| `todo` | Complete the small task mentioned. |
+| `chore` | Complete the process step (run CI, update docs, etc.). |
+| `typo` | Fix the typo. |
+| `nitpick` | Apply if trivial. Non-blocking by nature. |
+| `polish` | Improve quality if straightforward. Similar to `suggestion`. |
+| `praise` / `thought` / `note` | Skip — no action required. |
 
 #### Decorations
 
-| Decoration | Meaning | Impact |
-|------------|---------|--------|
-| `(blocking)` | Must resolve before merge | Required |
-| `(non-blocking)` | Should not prevent acceptance | Can defer if minor |
-| `(if-minor)` | Resolve only if changes are trivial | Use judgment on effort |
-| `(security)`, `(ux)`, etc. | Context-specific tags | Informs priority and approach |
+| Decoration | Meaning |
+|------------|---------|
+| `(blocking)` | Must resolve before merge. |
+| `(non-blocking)` | Should not prevent acceptance. |
+| `(if-minor)` | Resolve only if changes are trivial. |
+| `(security)`, `(ux)`, etc. | Context-specific tags — use to inform approach. |
 
 #### Scope assessment
 
@@ -259,13 +259,13 @@ Given these 5 comments on a PR:
 4. `nitpick: Can we use camelCase for consistency?`
 5. `thought: We should probably refactor the entire auth module`
 
-Processing order:
+Handling:
 
-1. **#1 [question]** — Respond first: propose adding `clear_cache()` in the logout handler, await confirmation before changing code.
-2. **#2 [issue]** — Fix immediately (blocking, clear problem).
-3. **#3 [suggestion]** — Evaluate: extraction is straightforward and improves readability → implement.
-4. **#4 [nitpick]** — Apply (trivial, improves consistency).
-5. **#5 [thought]** — Skip (no action required). Acknowledge and propose follow-up PR if the idea has merit.
+- **#1 [question]** — Respond first: propose adding `clear_cache()` in the logout handler, await confirmation before changing code.
+- **#2 [issue]** — Fix: add null check for `user.preferences`.
+- **#3 [suggestion]** — Evaluate: extraction is straightforward and improves readability → implement.
+- **#4 [nitpick]** — Apply (trivial, improves consistency).
+- **#5 [thought]** — Skip. Acknowledge and propose follow-up PR if the idea has merit.
 
 ## Rules
 

--- a/.claude/skills/addressing-pr-review-comments/SKILL.md
+++ b/.claude/skills/addressing-pr-review-comments/SKILL.md
@@ -89,7 +89,39 @@ Issue comments (from `issues/{PR_NUMBER}/comments`) do not have a "resolved" fla
 - **Verify bot comments:** Bot suggestions may be false positives. Always validate the issue exists before acting.
 - **General comments without file/line:** If a comment does not reference a file or line, infer scope from the text (e.g. "add a test" points to a test file, "update the doc" to docs). If scope is unclear, list possible locations when presenting options.
 
-**Action types** (per [conventional comments](https://conventionalcomments.org)): `issue` / `todo` / `chore` (must fix) · `suggestion` (consider) · `nitpick` (optional) · `question` (clarify) · `praise` / `thought` / `note` (skip)
+#### Comment labels
+
+Per [conventional comments](https://conventionalcomments.org):
+
+| Label | Action | Priority |
+|-------|--------|----------|
+| `issue` | Fix the problem. Use suggested solution if provided. | High — fix required |
+| `question` | Respond first, then act if needed. Never change code without clarifying. | High — response needed |
+| `suggestion` | Evaluate and implement if beneficial. Check decorations. | Medium — assess intent |
+| `todo` | Complete the small task mentioned. | Medium — complete |
+| `chore` | Complete the process step (run CI, update docs, etc.). | Medium — follow process |
+| `typo` | Fix the typo. Treat like `todo`. | Low — quick fix |
+| `nitpick` | Consider but non-blocking by nature. | Low — optional |
+| `polish` | Improve quality if straightforward. Similar to `suggestion`. | Low — enhancement |
+| `praise` / `thought` / `note` | No action required. | None — skip |
+
+#### Decorations
+
+| Decoration | Meaning | Impact |
+|------------|---------|--------|
+| `(blocking)` | Must resolve before merge | Required |
+| `(non-blocking)` | Should not prevent acceptance | Can defer if minor |
+| `(if-minor)` | Resolve only if changes are trivial | Use judgment on effort |
+| `(security)`, `(ux)`, etc. | Context-specific tags | Informs priority and approach |
+
+#### Scope assessment
+
+Before implementing feedback, determine if it's in-scope for the current PR:
+
+- **In-scope:** Fixes bugs introduced in this PR · improves code quality of changed files · addresses issues directly related to the PR's purpose · completes small related tasks.
+- **Out-of-scope:** Refactors unrelated code · adds features beyond the PR's goal · fixes pre-existing issues not touched by this PR · architectural changes unrelated to current work.
+
+For out-of-scope feedback: acknowledge the comment, propose a follow-up PR, and get reviewer agreement on deferral before proceeding.
 
 ### 4. Present options
 
@@ -216,6 +248,24 @@ gh api repos/streamlit/streamlit/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies
 gh api repos/streamlit/streamlit/issues/{PR_NUMBER}/comments \
   -f body="@{reviewer} Re: {brief context} - {reply text}"
 ```
+
+## Worked example
+
+Given these 5 comments on a PR:
+
+1. `question (blocking): Should this cache be invalidated on user logout?`
+2. `issue: This function doesn't handle the null case for user.preferences`
+3. `suggestion (non-blocking): Consider extracting this 20-line block into a helper`
+4. `nitpick: Can we use camelCase for consistency?`
+5. `thought: We should probably refactor the entire auth module`
+
+Processing order:
+
+1. **#1 [question]** — Respond first: propose adding `clear_cache()` in the logout handler, await confirmation before changing code.
+2. **#2 [issue]** — Fix immediately (blocking, clear problem).
+3. **#3 [suggestion]** — Evaluate: extraction is straightforward and improves readability → implement.
+4. **#4 [nitpick]** — Apply (trivial, improves consistency).
+5. **#5 [thought]** — Skip (no action required). Acknowledge and propose follow-up PR if the idea has merit.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Merges unique conceptual content from my local feedback guide into the `addressing-pr-review-comments` skill.

### What was added (~50 lines)

- **Conventional comments label table** — Full label reference with action required and priority columns (the skill previously had only a one-line list)
- **Decorations table** — `(blocking)`, `(non-blocking)`, `(if-minor)`, etc. with meaning and impact (previously not covered)
- **Scope assessment framework** — Structured in-scope vs out-of-scope criteria (previously only "minimal fixes" and "flag complexity" mentions)
- **Worked example** — End-to-end example showing how to process 5 different comment types together

### Design decisions

- All new content placed in **Step 3 (Analyze comments)** where agents need to categorize — label/decoration tables and scope assessment sit right before "Present options"
- Worked example placed as its own section before Rules for easy reference
- File stays at **290 lines** (was 240), well under the 500-line skill limit
- No reference files needed — additions are concise enough to remain in SKILL.md

## Test plan

- [x] `make check` passes
- [ ] Review for tone/accuracy — new content should match the skill's concise, operational style
- [ ] Verify no outdated path references remain
- [ ] After merge: delete feedback guide from `agent-knowledge/` stash


Made with [Cursor](https://cursor.com)