### PR TITLE
[fix] Resolve server.port=0 for Starlette/UvicornServer path

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_server.py
+++ b/lib/streamlit/web/server/starlette/starlette_server.py
@@ -308,6 +308,7 @@ class UvicornServer:
             # so that config and displayed URLs reflect the real port.
             if port == 0:
                 port = self._socket.getsockname()[1]
+                uvicorn_config.port = port
 
             self._server = uvicorn.Server(uvicorn_config)
             config.set_option("server.port", port, ConfigOption.STREAMLIT_DEFINITION)
@@ -464,9 +465,6 @@ class UvicornRunner:
                 )
 
             # TODO(lukasmasuch): Print the URL with the selected port.
-            # Note: server.port=0 (ephemeral port) won't work here because
-            # uvicorn.run() manages binding internally. Pre-binding the socket
-            # (like UvicornServer.start() does) would be needed to support it.
 
             try:
                 _LOGGER.debug(

--- a/lib/streamlit/web/server/starlette/starlette_server.py
+++ b/lib/streamlit/web/server/starlette/starlette_server.py
@@ -304,6 +304,11 @@ class UvicornServer:
                     continue
                 raise
 
+            # Port 0 means the OS assigns an ephemeral port. Read it back
+            # so that config and displayed URLs reflect the real port.
+            if port == 0:
+                port = self._socket.getsockname()[1]
+
             self._server = uvicorn.Server(uvicorn_config)
             config.set_option("server.port", port, ConfigOption.STREAMLIT_DEFINITION)
             _LOGGER.debug(
@@ -459,6 +464,9 @@ class UvicornRunner:
                 )
 
             # TODO(lukasmasuch): Print the URL with the selected port.
+            # Note: server.port=0 (ephemeral port) won't work here because
+            # uvicorn.run() manages binding internally. Pre-binding the socket
+            # (like UvicornServer.start() does) would be needed to support it.
 
             try:
                 _LOGGER.debug(

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
@@ -522,6 +522,89 @@ class TestStartStarletteServer:
         assert call_args[0] == "192.168.1.100"
 
 
+class TestDynamicPort:
+    """Tests for server.port=0 (ephemeral port) support in UvicornServer."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        Runtime._instance = None
+        self.original_port = config.get_option("server.port")
+        config.set_option("server.port", 0)
+        self.loop = asyncio.new_event_loop()
+
+    def tearDown(self) -> None:
+        """Tear down test fixtures."""
+        Runtime._instance = None
+        config.set_option("server.port", self.original_port)
+        self.loop.close()
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self) -> None:
+        """Pytest fixture for setup and teardown."""
+        self.setUp()
+        yield
+        self.tearDown()
+
+    def _create_server(self) -> Server:
+        """Create a Server instance for testing."""
+        server = Server("mock/script/path", is_hello=False)
+        server._runtime._eventloop = self.loop
+        return server
+
+    def _run_async(self, coro: Coroutine[Any, Any, None]) -> None:
+        """Run an async coroutine in the test event loop."""
+        self.loop.run_until_complete(coro)
+
+    def test_updates_config_port_when_binding_to_zero(self) -> None:
+        """Test that config is updated with the actual port when port=0."""
+        server = self._create_server()
+        mock_socket = mock.MagicMock(spec=socket.socket)
+        mock_socket.getsockname.return_value = ("127.0.0.1", 54321)
+
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_server._bind_socket",
+                return_value=mock_socket,
+            ),
+            patch("uvicorn.Server") as uvicorn_server_cls,
+        ):
+            uvicorn_instance = mock.MagicMock()
+            uvicorn_instance.startup = AsyncMock()
+            uvicorn_instance.main_loop = AsyncMock()
+            uvicorn_instance.shutdown = AsyncMock()
+            uvicorn_instance.should_exit = False
+            uvicorn_server_cls.return_value = uvicorn_instance
+
+            self._run_async(server._start_starlette())
+
+        assert config.get_option("server.port") == 54321
+
+    def test_does_not_call_getsockname_for_nonzero_port(self) -> None:
+        """Test that getsockname is not called when a specific port is configured."""
+        config.set_option("server.port", 8501)
+        server = self._create_server()
+        mock_socket = mock.MagicMock(spec=socket.socket)
+
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_server._bind_socket",
+                return_value=mock_socket,
+            ),
+            patch("uvicorn.Server") as uvicorn_server_cls,
+        ):
+            uvicorn_instance = mock.MagicMock()
+            uvicorn_instance.startup = AsyncMock()
+            uvicorn_instance.main_loop = AsyncMock()
+            uvicorn_instance.shutdown = AsyncMock()
+            uvicorn_instance.should_exit = False
+            uvicorn_server_cls.return_value = uvicorn_instance
+
+            self._run_async(server._start_starlette())
+
+        mock_socket.getsockname.assert_not_called()
+        assert config.get_option("server.port") == 8501
+
+
 class TestServerLifecycle:
     """Tests for server lifecycle behavior required by bootstrap.
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
@@ -578,6 +578,8 @@ class TestDynamicPort:
             self._run_async(server._start_starlette())
 
         assert config.get_option("server.port") == 54321
+        uvicorn_config = uvicorn_server_cls.call_args[0][0]
+        assert uvicorn_config.port == 54321
 
     def test_does_not_call_getsockname_for_nonzero_port(self) -> None:
         """Test that getsockname is not called when a specific port is configured."""


### PR DESCRIPTION

## Describe your changes

When `server.port=0` is configured (requesting an OS-assigned ephemeral port), `UvicornServer.start()` wrote `0` into config instead of the actual bound port, causing URLs like `http://localhost:0` to be displayed.

- After `_bind_socket()` succeeds with port 0, read back the real port via `getsockname()[1]` before writing to config

Companion fix to #14372 (which addresses the same bug on the Tornado path).

## GitHub Issue Link (if applicable)

Related #11308 (Starlette path only; Tornado path addressed in #14372)

## Testing Plan

- [x] Unit Tests (Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

Two new tests in `TestDynamicPort`: verifies config is updated with actual port when binding to 0, and verifies `getsockname` is not called for non-zero ports.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
