### PR TITLE
[fix] Skip port retry loop when server.port=0

### DIFF
--- a/lib/streamlit/web/server/server.py
+++ b/lib/streamlit/web/server/server.py
@@ -268,6 +268,10 @@ def start_listening_tcp_socket(http_server: HTTPServer) -> None:
                 if server_port_is_manually_set():
                     _LOGGER.error("Port %s is not available", port)  # noqa: TRY400
                     sys.exit(1)
+                elif port == 0:
+                    # Port 0 means the OS picks an ephemeral port. Retrying
+                    # would try ports 1, 2, 3… (privileged), so just propagate.
+                    raise
                 else:
                     _LOGGER.debug(
                         "Port %s not available, trying to use the next one.", port

--- a/lib/streamlit/web/server/starlette/starlette_server.py
+++ b/lib/streamlit/web/server/starlette/starlette_server.py
@@ -292,6 +292,10 @@ class UvicornServer:
                     if _is_port_manually_set():
                         _LOGGER.error("Port %s is not available", port)  # noqa: TRY400
                         sys.exit(1)
+                    elif port == 0:
+                        # Port 0 means the OS picks an ephemeral port. Retrying
+                        # would try ports 1, 2, 3… (privileged), so just propagate.
+                        raise
                     _LOGGER.debug(
                         "Port %s not available, trying to use the next one.", port
                     )
@@ -480,6 +484,10 @@ class UvicornRunner:
                     if _is_port_manually_set():
                         _LOGGER.error("Port %s is not available", port)  # noqa: TRY400
                         sys.exit(1)
+                    elif port == 0:
+                        # Port 0 means the OS picks an ephemeral port. Retrying
+                        # would try ports 1, 2, 3… (privileged), so just propagate.
+                        raise
                     _LOGGER.debug(
                         "Port %s not available, trying to use the next one.", port
                     )

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -550,28 +550,6 @@ class PortZeroNoRetryTest(unittest.TestCase):
 
         httpserver.listen.assert_called_once_with(0, mock.ANY)
 
-    def test_does_not_increment_to_port_one(self) -> None:
-        """Test that port 0 failure does not fall through to trying port 1."""
-        app = mock.MagicMock()
-        httpserver = mock.MagicMock()
-        httpserver.listen.side_effect = OSError(errno.EADDRINUSE, "test", "asd")
-
-        with (
-            pytest.raises(OSError, match="test"),
-            patch(
-                "streamlit.web.server.server.server_port_is_manually_set",
-                return_value=False,
-            ),
-            patch(
-                "streamlit.web.server.server.HTTPServer",
-                return_value=httpserver,
-            ),
-        ):
-            start_listening(app)
-
-        for call in httpserver.listen.call_args_list:
-            assert call[0][0] != 1, "Should never try port 1 when configured port is 0"
-
 
 class PortPermissionDeniedTest(unittest.TestCase):
     """Tests port retry on permission denied errors (Windows system-reserved ports).

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -517,6 +517,62 @@ class PortRotateOneTest(unittest.TestCase):
             )
 
 
+class PortZeroNoRetryTest(unittest.TestCase):
+    """Tests that port 0 (ephemeral) skips the retry loop entirely."""
+
+    def setUp(self) -> None:
+        self.original_port = config.get_option("server.port")
+        config.set_option("server.port", 0)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        config.set_option("server.port", self.original_port)
+        return super().tearDown()
+
+    def test_does_not_retry_on_failure(self) -> None:
+        """Test that port 0 failure propagates without retrying ports 1, 2, 3…"""
+        app = mock.MagicMock()
+        httpserver = mock.MagicMock()
+        httpserver.listen.side_effect = OSError(errno.EADDRINUSE, "test", "asd")
+
+        with (
+            pytest.raises(OSError, match="test"),
+            patch(
+                "streamlit.web.server.server.server_port_is_manually_set",
+                return_value=False,
+            ),
+            patch(
+                "streamlit.web.server.server.HTTPServer",
+                return_value=httpserver,
+            ),
+        ):
+            start_listening(app)
+
+        httpserver.listen.assert_called_once_with(0, mock.ANY)
+
+    def test_does_not_increment_to_port_one(self) -> None:
+        """Test that port 0 failure does not fall through to trying port 1."""
+        app = mock.MagicMock()
+        httpserver = mock.MagicMock()
+        httpserver.listen.side_effect = OSError(errno.EADDRINUSE, "test", "asd")
+
+        with (
+            pytest.raises(OSError, match="test"),
+            patch(
+                "streamlit.web.server.server.server_port_is_manually_set",
+                return_value=False,
+            ),
+            patch(
+                "streamlit.web.server.server.HTTPServer",
+                return_value=httpserver,
+            ),
+        ):
+            start_listening(app)
+
+        for call in httpserver.listen.call_args_list:
+            assert call[0][0] != 1, "Should never try port 1 when configured port is 0"
+
+
 class PortPermissionDeniedTest(unittest.TestCase):
     """Tests port retry on permission denied errors (Windows system-reserved ports).
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -520,33 +520,20 @@ class PortRotateOneTest(unittest.TestCase):
 class PortZeroNoRetryTest(unittest.TestCase):
     """Tests that port 0 (ephemeral) skips the retry loop entirely."""
 
-    def setUp(self) -> None:
-        self.original_port = config.get_option("server.port")
-        config.set_option("server.port", 0)
-        return super().setUp()
-
-    def tearDown(self) -> None:
-        config.set_option("server.port", self.original_port)
-        return super().tearDown()
-
     def test_does_not_retry_on_failure(self) -> None:
         """Test that port 0 failure propagates without retrying ports 1, 2, 3…"""
-        app = mock.MagicMock()
         httpserver = mock.MagicMock()
         httpserver.listen.side_effect = OSError(errno.EADDRINUSE, "test", "asd")
 
         with (
+            patch_config_options({"server.port": 0}),
             pytest.raises(OSError, match="test"),
             patch(
                 "streamlit.web.server.server.server_port_is_manually_set",
                 return_value=False,
             ),
-            patch(
-                "streamlit.web.server.server.HTTPServer",
-                return_value=httpserver,
-            ),
         ):
-            start_listening(app)
+            streamlit.web.server.server.start_listening_tcp_socket(httpserver)
 
         httpserver.listen.assert_called_once_with(0, mock.ANY)
 

--- a/lib/tests/streamlit/web/server/server_test.py
+++ b/lib/tests/streamlit/web/server/server_test.py
@@ -45,6 +45,7 @@ from streamlit.web.server.server import (
     RetriesExceededError,
     Server,
     start_listening,
+    start_listening_tcp_socket,
 )
 from tests.streamlit.message_mocks import create_dataframe_msg
 from tests.streamlit.web.server.server_test_case import ServerTestCase
@@ -533,7 +534,7 @@ class PortZeroNoRetryTest(unittest.TestCase):
                 return_value=False,
             ),
         ):
-            streamlit.web.server.server.start_listening_tcp_socket(httpserver)
+            start_listening_tcp_socket(httpserver)
 
         httpserver.listen.assert_called_once_with(0, mock.ANY)
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
@@ -575,26 +575,6 @@ class TestPortZeroNoRetry:
         bind_socket.assert_called_once()
         assert bind_socket.call_args[0][1] == 0
 
-    def test_uvicorn_server_does_not_try_port_one(self) -> None:
-        """Test that UvicornServer never tries port 1 when configured port is 0."""
-        server = self._create_server()
-
-        with (
-            patch(
-                "streamlit.web.server.starlette.starlette_server._bind_socket",
-                side_effect=OSError(errno.EADDRINUSE, "busy"),
-            ) as bind_socket,
-            patch(
-                "streamlit.web.server.starlette.starlette_server._is_port_manually_set",
-                return_value=False,
-            ),
-            pytest.raises(OSError, match="busy"),
-        ):
-            self._run_async(server._start_starlette())
-
-        for call in bind_socket.call_args_list:
-            assert call[0][1] != 1, "Should never try port 1 when configured port is 0"
-
     def test_uvicorn_runner_calls_once_on_port_zero_failure(self) -> None:
         """Test that UvicornRunner calls uvicorn.run exactly once when port=0."""
         with (
@@ -618,32 +598,6 @@ class TestPortZeroNoRetry:
 
         mock_run.assert_called_once()
         assert mock_run.call_args[1]["port"] == 0
-
-    def test_uvicorn_runner_does_not_try_port_one(self) -> None:
-        """Test that UvicornRunner never tries port 1 when configured port is 0."""
-        with (
-            patch_config_options({"server.address": "127.0.0.1", "server.port": 0}),
-            patch(
-                "streamlit.web.server.starlette.starlette_server._get_uvicorn_config_kwargs",
-                return_value={},
-            ),
-            patch(
-                "streamlit.web.server.starlette.starlette_server._is_port_manually_set",
-                return_value=False,
-            ),
-            patch(
-                "uvicorn.run",
-                side_effect=OSError(errno.EADDRINUSE, "busy"),
-            ) as mock_run,
-            pytest.raises(OSError, match="busy"),
-        ):
-            runner = UvicornRunner("myapp:app")
-            runner.run()
-
-        for call in mock_run.call_args_list:
-            assert call[1]["port"] != 1, (
-                "Should never try port 1 when configured port is 0"
-            )
 
 
 class TestServerLifecycle:

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
@@ -522,6 +522,130 @@ class TestStartStarletteServer:
         assert call_args[0] == "192.168.1.100"
 
 
+class TestPortZeroNoRetry:
+    """Tests that port 0 (ephemeral) skips the retry loop entirely."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        Runtime._instance = None
+        self.original_port = config.get_option("server.port")
+        config.set_option("server.port", 0)
+        self.loop = asyncio.new_event_loop()
+
+    def tearDown(self) -> None:
+        """Tear down test fixtures."""
+        Runtime._instance = None
+        config.set_option("server.port", self.original_port)
+        self.loop.close()
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self) -> None:
+        """Pytest fixture for setup and teardown."""
+        self.setUp()
+        yield
+        self.tearDown()
+
+    def _create_server(self) -> Server:
+        """Create a Server instance for testing."""
+        server = Server("mock/script/path", is_hello=False)
+        server._runtime._eventloop = self.loop
+        return server
+
+    def _run_async(self, coro: Coroutine[Any, Any, None]) -> None:
+        """Run an async coroutine in the test event loop."""
+        self.loop.run_until_complete(coro)
+
+    def test_uvicorn_server_binds_once_on_port_zero_failure(self) -> None:
+        """Test that UvicornServer tries _bind_socket exactly once when port=0."""
+        server = self._create_server()
+
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_server._bind_socket",
+                side_effect=OSError(errno.EADDRINUSE, "busy"),
+            ) as bind_socket,
+            patch(
+                "streamlit.web.server.starlette.starlette_server._is_port_manually_set",
+                return_value=False,
+            ),
+            pytest.raises(OSError, match="busy"),
+        ):
+            self._run_async(server._start_starlette())
+
+        bind_socket.assert_called_once()
+        assert bind_socket.call_args[0][1] == 0
+
+    def test_uvicorn_server_does_not_try_port_one(self) -> None:
+        """Test that UvicornServer never tries port 1 when configured port is 0."""
+        server = self._create_server()
+
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_server._bind_socket",
+                side_effect=OSError(errno.EADDRINUSE, "busy"),
+            ) as bind_socket,
+            patch(
+                "streamlit.web.server.starlette.starlette_server._is_port_manually_set",
+                return_value=False,
+            ),
+            pytest.raises(OSError, match="busy"),
+        ):
+            self._run_async(server._start_starlette())
+
+        for call in bind_socket.call_args_list:
+            assert call[0][1] != 1, "Should never try port 1 when configured port is 0"
+
+    def test_uvicorn_runner_calls_once_on_port_zero_failure(self) -> None:
+        """Test that UvicornRunner calls uvicorn.run exactly once when port=0."""
+        with (
+            patch_config_options({"server.address": "127.0.0.1", "server.port": 0}),
+            patch(
+                "streamlit.web.server.starlette.starlette_server._get_uvicorn_config_kwargs",
+                return_value={},
+            ),
+            patch(
+                "streamlit.web.server.starlette.starlette_server._is_port_manually_set",
+                return_value=False,
+            ),
+            patch(
+                "uvicorn.run",
+                side_effect=OSError(errno.EADDRINUSE, "Address already in use"),
+            ) as mock_run,
+            pytest.raises(OSError, match="Address already in use"),
+        ):
+            runner = UvicornRunner("myapp:app")
+            runner.run()
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args[1]["port"] == 0
+
+    def test_uvicorn_runner_does_not_try_port_one(self) -> None:
+        """Test that UvicornRunner never tries port 1 when configured port is 0."""
+        with (
+            patch_config_options({"server.address": "127.0.0.1", "server.port": 0}),
+            patch(
+                "streamlit.web.server.starlette.starlette_server._get_uvicorn_config_kwargs",
+                return_value={},
+            ),
+            patch(
+                "streamlit.web.server.starlette.starlette_server._is_port_manually_set",
+                return_value=False,
+            ),
+            patch(
+                "uvicorn.run",
+                side_effect=OSError(errno.EADDRINUSE, "busy"),
+            ) as mock_run,
+            pytest.raises(OSError, match="busy"),
+        ):
+            runner = UvicornRunner("myapp:app")
+            runner.run()
+
+        for call in mock_run.call_args_list:
+            assert call[1]["port"] != 1, (
+                "Should never try port 1 when configured port is 0"
+            )
+
+
 class TestServerLifecycle:
     """Tests for server lifecycle behavior required by bootstrap.
 


### PR DESCRIPTION

## Describe your changes

When `server.port=0` (OS-assigned ephemeral port), the port retry loop increments to ports 1, 2, 3… on failure — all privileged ports that will also fail. This skips the retry for all three server startup paths (Tornado, UvicornServer, UvicornRunner) by propagating the error immediately when port is 0.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
