### PR TITLE
fix: deduplicate paired extensions in file_uploader (e.g. jpg/jpeg)

### DIFF
--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -108,8 +108,11 @@ def normalize_upload_file_type(file_type: str | Sequence[str]) -> Sequence[str]:
     for x, y in TYPE_PAIRS:
         if x in extensions and y not in extensions:
             extensions.append(y)
-        if y in extensions and x not in extensions:
+        elif y in extensions and x not in extensions:
             extensions.append(x)
+        elif x in extensions and y in extensions:
+            extensions.remove(y)
+
 
     # Combine: MIME types first, then extensions (order for consistent output)
     return mime_types + extensions


### PR DESCRIPTION
## Describe your changes
Fixes #11991

## Problem
When both `.jpg` and `.jpeg` are passed to `st.file_uploader(type=...)`, 
both are shown separately in the UI even though they are the same format.

## Fix
In `normalize_upload_file_type()`, added deduplication logic for paired 
extensions in `file_uploader_utils.py`. When both extensions of a pair 
are already present, the duplicate is removed.

## Testing
- `type=["jpg", "jpeg"]` → now shows only `.jpg`
- `type=["jpg"]` → still auto-adds `.jpeg` (existing behavior preserved)
- `type=["jpeg"]` → still auto-adds `.jpg` (existing behavior preserved)

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
