### PR TITLE
[spec] Parallel fragments tech spec

### DIFF
--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -530,10 +530,6 @@ need thread-safe access:
 | `new_fragment_ids` | `set[str]` | Written by any thread executing `@st.fragment`; read after join for cleanup. Needs same per-field lock as the widget sets above. |
 | `fragment_storage` | `FragmentStorage` | Written concurrently when `@st.fragment` definitions register the wrapped function; read after join for `clear()`. `MemoryFragmentStorage` needs a `threading.Lock` around its internal dict — same per-field lock approach as the shared sets. Covered in the thread-safe `ScriptRunContext` shared sets spec. |
 
-#### Loading skeleton
-
-*TODO: needs prototyping and testing before specifying.*
-
 ### Other shared mutable state
 
 `ScriptRunContext` currently mixes per-thread, shared-mutable, shared-immutable, and
@@ -756,18 +752,18 @@ class SharedRunState:
     Single instance shared across main thread and all worker threads."""
     def __init__(self):
         self._lock = threading.Lock()
-        self.widget_ids: set[str] = set()
-        self.widget_user_keys: set[str] = set()
-        self.form_ids: set[str] = set()
-        self.new_fragment_ids: set[str] = set()
-        self.tracked_commands: list[Command] = []
-        self.tracked_commands_counter: Counter[str] = Counter()
+        self._widget_ids: set[str] = set()
+        self._widget_user_keys: set[str] = set()
+        self._form_ids: set[str] = set()
+        self._new_fragment_ids: set[str] = set()
+        self._tracked_commands: list[Command] = []
+        self._tracked_commands_counter: Counter[str] = Counter()
 
     def add_widget_id(self, widget_id: str) -> bool:
         """Add widget ID. Returns True if already present (duplicate)."""
         with self._lock:
-            was_present = widget_id in self.widget_ids
-            self.widget_ids.add(widget_id)
+            was_present = widget_id in self._widget_ids
+            self._widget_ids.add(widget_id)
             return was_present
     # ... similar methods for other fields
 ```

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -68,32 +68,56 @@ def reset(self, ...) -> None:
     if threading.get_ident() != self._main_thread_ident:
         raise RuntimeError("reset() must only be called from the main script thread")
     ...
-    # NEW: create a fresh coordinator for this script run
+    # NEW: create a fresh coordinator (with thread pool) for this script run
     self.parallel_coordinator = ParallelFragmentCoordinator(
         yield_check=self._yield_check,
+        max_workers=config.get_option("runner.parallelMaxWorkers"),
     )
 ```
 
 The coordinator receives a `yield_check` callback from the `ScriptRunner` — this is a
 reference to `_maybe_handle_execution_control_request()`, which checks for pending
-RERUN/STOP requests and raises the appropriate exception:
+RERUN/STOP requests and raises the appropriate exception.
+
+**Thread pool scope and lifecycle:** The coordinator owns a `ThreadPoolExecutor` that
+lives for the duration of a single script run. The pool is created in `ctx.reset()`
+(via the coordinator constructor) and shut down in `drain()` or after `join()` completes.
+No threads outlive the run — this matches the bounded lifecycle of parallel fragments
+(spawned during `exec()`, joined before `scriptFinished`). Features with longer-lived
+threads (e.g., a future `st.background_task()` that survives reruns) would need a
+separate per-session pool with a different lifecycle.
+
+The default `max_workers` follows Python's `ThreadPoolExecutor` default
+(`min(32, os.cpu_count() + 4)`), which works well for the common case of 3-10
+I/O-bound fragments. A Streamlit config option (`[runner] parallelMaxWorkers`) allows
+overriding for constrained environments. When the number of parallel fragments exceeds
+`max_workers`, excess fragments queue in the pool and execute as workers become available.
 
 ```python
 class ParallelFragmentCoordinator:
     def __init__(
         self,
         yield_check: Callable[[], None],
+        max_workers: int | None = None,
         poll_interval: float = 0.1,
     ) -> None:
-        self._threads: list[threading.Thread] = []
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._futures: list[Future] = []
         self._stop_event = threading.Event()
         self._worker_exception: RerunException | StopException | None = None
         self._exception_lock = threading.Lock()
         self._yield_check = yield_check
         self._poll_interval = poll_interval
 
-    def register(self, thread: threading.Thread) -> None:
-        self._threads.append(thread)
+    def submit(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+    ) -> Future:
+        """Submit a fragment to the thread pool."""
+        future = self._executor.submit(fn, *args)
+        self._futures.append(future)
+        return future
 
     def request_stop(self) -> None:
         """A worker called st.stop(). First writer wins."""
@@ -120,24 +144,20 @@ class ParallelFragmentCoordinator:
     def join(self) -> None:
         """Happy-path join. Responsive to external requests (via yield_check)
         and worker-initiated cancellation (via worker_exception)."""
-        while any(t.is_alive() for t in self._threads):
+        while not all(f.done() for f in self._futures):
             self._yield_check()
             if self._worker_exception is not None:
                 raise self._worker_exception
             time.sleep(self._poll_interval)
-        for thread in self._threads:
-            thread.join()
         if self._worker_exception is not None:
             raise self._worker_exception
+        self._executor.shutdown(wait=False)
 
     def drain(self, timeout: float = 5.0) -> None:
         """Cleanup join after cancellation. Signals workers to stop and
-        waits without yield-checking. Safe to call from except blocks."""
+        shuts down the pool. Safe to call from except blocks."""
         self._stop_event.set()
-        deadline = time.monotonic() + timeout
-        for t in self._threads:
-            remaining = max(0, deadline - time.monotonic())
-            t.join(timeout=remaining)
+        self._executor.shutdown(wait=True, cancel_futures=True)
 ```
 
 Three places change:
@@ -160,7 +180,7 @@ else:
 ```
 
 `_dispatch_parallel_fragment` is a new helper in `fragment.py` that copies the current
-context, spawns a thread, and registers it on `ctx` for the join barrier:
+context and submits the fragment to the coordinator's thread pool:
 
 ```python
 def _dispatch_parallel_fragment(
@@ -172,14 +192,16 @@ def _dispatch_parallel_fragment(
     #   - context_dg_stack: the DeltaGenerator/cursor position stack
     #   - in_cached_function: guard preventing widgets inside @st.cache_*
     parent_context = contextvars.copy_context()
-    thread = threading.Thread(
-        target=_run_parallel_fragment,
-        args=(ctx.parallel_coordinator, wrapped_fragment, fragment_id, parent_context),
-        name=f"parallel_fragment_{_short_id(fragment_id)}",
-    )
-    add_script_run_ctx(thread, ctx)
-    ctx.parallel_coordinator.register(thread)
-    thread.start()
+    coordinator = ctx.parallel_coordinator
+
+    def worker() -> None:
+        # Propagate ScriptRunContext to the pool thread (thread-local)
+        add_script_run_ctx(threading.current_thread(), ctx)
+        _run_parallel_fragment(
+            coordinator, wrapped_fragment, fragment_id, parent_context,
+        )
+
+    coordinator.submit(worker)
 ```
 
 `_run_parallel_fragment` is the thread entry point. It runs `wrapped_fragment` inside
@@ -610,6 +632,7 @@ class ScriptRunContext:
         self.thread_state.reset(...)
         self.parallel_coordinator = ParallelFragmentCoordinator(
             yield_check=self._yield_check,
+            max_workers=config.get_option("runner.parallelMaxWorkers"),
         )
 
     def enqueue(self, msg: ForwardMsg) -> None:

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -269,7 +269,7 @@ if rerun_data.fragment_id_queue:
 **When `st.rerun()` or `st.stop()` is called from within a parallel fragment:**
 
 The exception is caught in `_run_parallel_fragment`, which is the thread entry point.
-It runs `wrapped_fragment` inside the copied context and handles three cases:
+It runs `wrapped_fragment` inside the copied context and handles control flow exceptions:
 
 ```python
 def _run_parallel_fragment(
@@ -285,35 +285,39 @@ def _run_parallel_fragment(
             fragment_id=fragment_id,
             is_parallel_worker=True,
         ))
-        while True:
-            try:
-                wrapped_fragment()
-                break
-            except RerunException as e:
-                if e.rerun_data.fragment_id_queue:
-                    # st.rerun(scope="fragment") — re-execute in this thread,
-                    # siblings are unaffected
-                    continue
-                else:
-                    # st.rerun(scope="app") — signal sibling threads to stop
-                    # and preserve the RerunException for the main thread
-                    coordinator.request_rerun(e)
-                    break
-            except StopException:
-                # st.stop() — signal sibling threads to stop
-                coordinator.request_stop()
-                break
-            except FragmentHandledException:
-                break  # error already rendered in the fragment's container
-                       # by wrapped_fragment() — existing behavior
-            except Exception:
-                _LOGGER.exception(
-                    "Parallel fragment %s failed", _short_id(fragment_id)
-                )
-                break
+        try:
+            wrapped_fragment()
+        except RerunException as e:
+            # st.rerun(scope="app") — signal sibling threads to stop
+            # and preserve the RerunException for the main thread.
+            #
+            # Note: st.rerun(scope="fragment") raises StreamlitAPIException
+            # before reaching this point (the existing guard in
+            # _new_fragment_id_queue rejects fragment-scoped reruns during
+            # full-app runs, and parallel fragments only run in threads
+            # during full-app runs). See "Prohibited / error cases" below.
+            coordinator.request_rerun(e)
+        except StopException:
+            # st.stop() — signal sibling threads to stop
+            coordinator.request_stop()
+        except FragmentHandledException:
+            pass  # error already rendered in the fragment's container
+                  # by wrapped_fragment() — existing behavior
+        except Exception:
+            _LOGGER.exception(
+                "Parallel fragment %s failed", _short_id(fragment_id)
+            )
 
     parent_context.run(run_fragment)
 ```
+
+**`st.rerun(scope="fragment")` during the initial full-app run:** The existing guard
+in `_new_fragment_id_queue()` raises `StreamlitAPIException` when
+`fragment_ids_this_run` is empty (which it is during full-app runs). This behavior
+is preserved for parallel fragments — the guard fires before a `RerunException` is
+ever raised, so `_run_parallel_fragment` never sees it. During fragment reruns,
+parallel fragments run sequentially (see above), so the existing while loop in
+`wrapped_fragment()` handles `st.rerun(scope="fragment")` as it does today.
 
 **When an external full-app rerun arrives** (e.g., widget interaction while fragments
 are still running):
@@ -394,7 +398,7 @@ between blocking operations to improve cancellation responsiveness (see
 | Scenario | Trigger | Calling thread | Siblings + main thread | Outcome |
 |----------|---------|---------------|----------------------|---------|
 | Happy path | — | — | — | All threads complete → `join()` returns → `scriptFinished` |
-| `st.rerun(scope="fragment")` | Thread A | Caught → `continue` → re-executes `wrapped_fragment()` in same thread | Unaffected | Thread A reruns locally |
+| `st.rerun(scope="fragment")` | Thread A | `StreamlitAPIException` — same as sequential fragments during full-app runs | Unaffected | Error rendered in fragment container |
 | `st.stop()` | Thread A | Caught → `request_stop()` → exits | See `should_stop()` at next yield point → `StopException` → exit | Main thread raises `StopException` → run ends |
 | `st.rerun(scope="app")` | Thread A | Caught → `request_rerun(e)` → exits | See `should_stop()` at next yield point → `StopException` → exit | Main thread raises `RerunException` (with rerun data) → `_run_script` restarts |
 | External rerun during `exec()` | Frontend | Main thread: `RerunException` at next `st.*` call → `except` block → `drain()` | See `should_stop()` at next yield point → exit | `_run_script` restarts |
@@ -846,11 +850,11 @@ class SharedRunState:
         self._tracked_commands_counter: Counter[str] = Counter()
 
     def add_widget_id(self, widget_id: str) -> bool:
-        """Add widget ID. Returns True if already present (duplicate)."""
+        """Atomically add widget ID. Returns True if the value was new."""
         with self._lock:
-            was_present = widget_id in self._widget_ids
+            is_new = widget_id not in self._widget_ids
             self._widget_ids.add(widget_id)
-            return was_present
+            return is_new
     # ... similar methods for other fields
 ```
 

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -974,3 +974,72 @@ def switch_page(page: str | Path | StreamlitPage, ...) -> NoReturn:
         _check_not_parallel_worker("st.switch_page")
     # ... existing implementation
 ```
+
+#### External container writes
+
+Non-parallel fragments can write non-widget elements to containers outside the
+fragment's delta path (e.g., a parent-scoped `st.container()` or `st.sidebar`
+entered via `with`). These writes are allowed but accumulate across fragment reruns
+until the next full app rerun — a documented caveat.
+
+During parallel execution, external container writes introduce three problems that
+cannot be solved by the existing cursor ownership model alone:
+
+1. **Cursor races.** External containers share a `RunningCursor` with the main thread
+   (or other workers). `_check_owner()` would crash with `RuntimeError` if a second
+   thread touches the same cursor — a correct safety net, but the error message is
+   opaque and unhelpful to users.
+
+2. **Non-deterministic ordering.** Even if cursor access were serialized (e.g., via a
+   per-cursor lock), the order of elements written by different workers depends on
+   thread scheduling. The UI layout would vary between runs with identical inputs.
+
+3. **Amplified accumulation.** The existing accumulation behavior (elements pile up
+   until a full rerun) is already surprising for sequential fragments. With concurrent
+   writers producing interleaved, duplicated content in unpredictable order, the
+   external container becomes unusable.
+
+**Implementation:** extend the existing `check_fragment_path_policy` pattern to block
+all element writes (not just widgets) when the writer is a parallel worker. Add a
+check in `_enqueue` (`lib/streamlit/delta_generator.py`) that compares the target
+cursor's `delta_path` against `current_fragment_delta_path` when
+`_thread_state.get().is_parallel_worker` is True:
+
+```python
+def _enqueue(self, ...):
+    dg = self._active_dg
+
+    ctx = get_script_run_ctx()
+
+    # Existing sidebar guard (unchanged)
+    if ctx and ctx.current_fragment_id and _writes_directly_to_sidebar(dg):
+        raise StreamlitAPIException(...)
+
+    # Block all external container writes from parallel workers
+    if ctx and _thread_state.get().is_parallel_worker:
+        fragment_path = ctx.current_fragment_delta_path
+        cursor_path = dg._cursor.delta_path if dg._cursor else []
+        if not _is_inside_fragment_path(cursor_path, fragment_path):
+            raise StreamlitAPIException(
+                "Writing to containers outside the fragment is not supported "
+                "during parallel execution. Move the element inside the "
+                "fragment body, or write to the external container during a "
+                "sequential fragment rerun."
+            )
+
+    # ... rest of _enqueue
+```
+
+The `_is_inside_fragment_path` helper applies the same prefix-matching logic as
+`check_fragment_path_policy`: the cursor's delta path must be at least as long as the
+fragment path, and all indices must match at each position.
+
+During sequential fragment reruns (`is_parallel_worker` is False), the existing
+behavior is unchanged: non-widget elements are allowed in external containers, widgets
+are blocked by `check_fragment_path_policy`.
+
+**Follow-up:** if user demand emerges for cross-container output from parallel
+fragments, a dedicated `st.fragment_output()` API could collect results with defined
+ordering semantics (e.g., dispatch order) and render them after the join barrier. This
+would avoid the cursor ownership and ordering problems by design. See project notes
+for alternatives considered.

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -258,6 +258,12 @@ def _run_parallel_fragment(
     parent_context: contextvars.Context,
 ) -> None:
     def run_fragment() -> None:
+        # Set per-thread state inside parent_context.run() so it's
+        # scoped to this context copy, not the pool thread's default
+        _thread_state.set(FragmentThreadState(
+            fragment_id=fragment_id,
+            is_parallel_worker=True,
+        ))
         while True:
             try:
                 wrapped_fragment()
@@ -615,8 +621,8 @@ class ScriptRunContext:
     # 3. Shared mutable run state — new abstraction
     shared: SharedRunState
 
-    # 4. Per-thread fragment state — new abstraction
-    thread_state: FragmentThreadState
+    # 4. Per-thread fragment state — via ContextVar
+    #    See _thread_state ContextVar below.
 
     def __post_init__(self):
         self._main_thread_ident = threading.get_ident()
@@ -629,7 +635,7 @@ class ScriptRunContext:
                 "reset() must only be called from the main script thread"
             )
         self.shared.reset(...)
-        self.thread_state.reset(...)
+        _thread_state.set(FragmentThreadState())
         self.parallel_coordinator = ParallelFragmentCoordinator(
             yield_check=self._yield_check,
             max_workers=config.get_option("runner.parallelMaxWorkers"),
@@ -642,9 +648,9 @@ class ScriptRunContext:
 ```
 
 Adding a new field forces an explicit decision: does it go on `FragmentThreadState`
-(per-thread, no sync needed), `SharedRunState` (shared, sync built-in), one of the
-externally thread-safe objects, or the immutable config? The following sections describe
-each category.
+(per-thread via `ContextVar`, no sync needed), `SharedRunState` (shared, sync built-in),
+one of the externally thread-safe objects, or the immutable config? The following sections
+describe each category.
 
 #### Immutable config
 
@@ -833,11 +839,14 @@ land with the thread-safe shared sets work.
 
 #### `FragmentThreadState` — per-thread fragment state
 
-Bundles per-thread fields into a dataclass. Each worker thread gets a fresh
-instance created by `_dispatch_parallel_fragment`; the main thread reuses a
-single instance across the run.
+Bundles per-thread fields into a dataclass, stored in a `ContextVar` so that each
+thread gets automatic isolation via `copy_context()`:
 
 ```python
+_thread_state: ContextVar[FragmentThreadState] = ContextVar(
+    "thread_state", default=FragmentThreadState(),
+)
+
 @dataclass
 class FragmentThreadState:
     """Per-thread state for a fragment execution."""
@@ -845,15 +854,22 @@ class FragmentThreadState:
     delta_path: tuple[int, ...] | None = None
     in_fragment_callback: bool = False
     active_script_hash: str = ""
+    is_parallel_worker: bool = False
 ```
 
-`in_cached_function` remains a `ContextVar` (it's also used outside fragments). The
-other per-thread fields move here, making `_dispatch_parallel_fragment` explicit:
-create a `FragmentThreadState`, pass it to the worker thread, done.
+This uses the same `ContextVar` + `copy_context()` mechanism already used for
+`context_dg_stack` and `in_cached_function`. When `_dispatch_parallel_fragment`
+calls `contextvars.copy_context()`, the snapshot includes the current
+`_thread_state` binding. The worker then sets a fresh instance via
+`_thread_state.set(FragmentThreadState(...))` inside `parent_context.run()`,
+which is scoped to that thread's context — the main thread's binding is unaffected.
+
+`in_cached_function` remains a separate `ContextVar` (it's also used outside
+fragments and predates this design).
 
 Callers change from bare field access (e.g. `ctx.widget_ids_this_run.add()`,
-`ctx.current_fragment_id`) to the namespaced equivalents (`ctx.shared.add_widget_id()`,
-`ctx.thread_state.fragment_id`).
+`ctx.current_fragment_id`) to `ctx.shared.add_widget_id()` for shared state
+and `_thread_state.get().fragment_id` for per-thread state.
 
 ### API restrictions during parallel execution
 
@@ -868,17 +884,12 @@ that are disruptive or nonsensical during concurrent execution and cannot be add
 by locking alone. All follow the same pattern: **prohibited during the parallel batch**
 (worker threads), **allowed during sequential fragment reruns** (single-threaded).
 
-Detection uses a flag on `FragmentThreadState`, set once by
-`_dispatch_parallel_fragment` at thread creation:
+Detection uses the `is_parallel_worker` flag on `FragmentThreadState`, set in
+`_run_parallel_fragment` when the worker's context is initialized:
 
 ```python
-@dataclass
-class FragmentThreadState:
-    ...
-    is_parallel_worker: bool = False  # True only on worker threads
-
-def _check_not_parallel_worker(ctx: ScriptRunContext, api_name: str) -> None:
-    if ctx.thread_state.is_parallel_worker:
+def _check_not_parallel_worker(api_name: str) -> None:
+    if _thread_state.get().is_parallel_worker:
         raise StreamlitAPIException(
             f"{api_name} cannot be called from a parallel fragment."
         )
@@ -909,7 +920,7 @@ in a dashboard card opens a detail dialog). Blocking this would be overly restri
 def _check_dialog_guard(should_open: bool) -> None:
     ctx = get_script_run_ctx()
     if should_open and ctx:
-        _check_not_parallel_worker(ctx, "@st.dialog")
+        _check_not_parallel_worker("@st.dialog")
         # Existing one-dialog-per-rerun check (unchanged, only runs
         # during sequential execution so no synchronization needed)
         if ctx.has_dialog_opened:
@@ -935,6 +946,6 @@ During a sequential fragment rerun, `st.switch_page` is a valid and common patte
 def switch_page(page: str | Path | StreamlitPage, ...) -> NoReturn:
     ctx = get_script_run_ctx()
     if ctx:
-        _check_not_parallel_worker(ctx, "st.switch_page")
+        _check_not_parallel_worker("st.switch_page")
     # ... existing implementation
 ```

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -482,7 +482,7 @@ calls `open_block()` (containers). `get_locked_cursor()` is a purely internal AP
 calls `st.container()` before dispatching. This calls `open_block()` on the main
 thread's cursor, which advances it past the fragment's slot and creates a child
 `RunningCursor` for the container. The container delta reaches the frontend
-immediately (enabling the loading skeleton). The child cursor starts with
+immediately. The child cursor starts with
 `_owner_thread = None` — it hasn't been used yet.
 
 **3. Lazy thread ownership.** When the worker thread runs and calls `lock_element()`

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -346,15 +346,17 @@ class RunningCursor(Cursor):
     def __init__(self, ...):
         self._index = 0
         self._owner_ident: int | None = None  # claimed on first use
+        self._owner_lock = threading.Lock()
 
     def _check_owner(self) -> None:
-        current_ident = threading.get_ident()
-        if self._owner_ident is None:
-            self._owner_ident = current_ident
-        elif self._owner_ident != current_ident:
-            raise RuntimeError(
-                "Cursor accessed from a thread that doesn't own it"
-            )
+        with self._owner_lock:
+            current_ident = threading.get_ident()
+            if self._owner_ident is None:
+                self._owner_ident = current_ident
+            elif self._owner_ident != current_ident:
+                raise RuntimeError(
+                    "Cursor accessed from a thread that doesn't own it"
+                )
 
     def _advance(self) -> None:
         self._index += 1
@@ -397,12 +399,14 @@ immediately (enabling the loading skeleton). The child cursor starts with
 
 **3. Lazy thread ownership.** When the worker thread runs and calls `lock_element()`
 on the container's cursor for the first time, `_check_owner()` claims it — setting
-`_owner_ident` to the worker thread's ID via `threading.get_ident()`. From that
-point, any other thread accessing that cursor gets an immediate `RuntimeError`.
-This enforces the invariant without requiring explicit ownership transfer: the main
-thread creates the cursor but never uses it; the worker thread claims it on first
-use. Using `get_ident()` (an int) rather than `current_thread()` (a Thread object)
-avoids the dictionary lookup overhead on every `st.*` call.
+`_owner_ident` to the worker thread's ID via `threading.get_ident()`. The
+check-and-claim is wrapped in a `threading.Lock` to make it atomic, preventing a
+TOCTOU race where two threads could both read `_owner_ident` as `None` and both
+succeed. From that point, any other thread accessing that cursor gets an immediate
+`RuntimeError`. This enforces the invariant without requiring explicit ownership
+transfer: the main thread creates the cursor but never uses it; the worker thread
+claims it on first use. Using `get_ident()` (an int) rather than `current_thread()`
+(a Thread object) avoids the dictionary lookup overhead on every `st.*` call.
 
 #### Element registration
 

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -102,7 +102,8 @@ class ParallelFragmentCoordinator:
         poll_interval: float = 0.1,
     ) -> None:
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
-        self._futures: list[Future] = []
+        self._outstanding = 0  # tracks in-flight work units (inc on submit, dec on completion)
+        self._outstanding_lock = threading.Lock()
         self._stop_event = threading.Event()
         self._worker_exception: RerunException | StopException | None = None
         self._exception_lock = threading.Lock()
@@ -113,11 +114,26 @@ class ParallelFragmentCoordinator:
         self,
         fn: Callable[..., Any],
         *args: Any,
-    ) -> Future:
-        """Submit a fragment to the thread pool."""
-        future = self._executor.submit(fn, *args)
-        self._futures.append(future)
-        return future
+    ) -> None:
+        """Submit a fragment to the thread pool. Can be called from any
+        thread (main thread or worker threads for nested fragments)."""
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+        def tracked() -> None:
+            # Wraps fn so the counter decrements when the work completes.
+            # The decrement is in `finally` so it runs even if fn raises.
+            # For nested fragments, fn's body calls submit() (incrementing
+            # the counter) before returning, so a parent's decrement always
+            # happens after its children's increments — the counter never
+            # hits 0 prematurely.
+            try:
+                fn(*args)
+            finally:
+                with self._outstanding_lock:
+                    self._outstanding -= 1
+
+        self._executor.submit(tracked)
 
     def request_stop(self) -> None:
         """A worker called st.stop(). First writer wins."""
@@ -142,9 +158,14 @@ class ParallelFragmentCoordinator:
         return self._worker_exception
 
     def join(self) -> None:
-        """Happy-path join. Responsive to external requests (via yield_check)
-        and worker-initiated cancellation (via worker_exception)."""
-        while not all(f.done() for f in self._futures):
+        """Happy-path join. Blocks until all submitted work completes,
+        including work submitted by workers (nested parallel fragments).
+        Responsive to external requests (via yield_check) and
+        worker-initiated cancellation (via worker_exception)."""
+        while True:
+            with self._outstanding_lock:
+                if self._outstanding == 0:
+                    break
             self._yield_check()
             if self._worker_exception is not None:
                 raise self._worker_exception

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -303,10 +303,8 @@ def _run_parallel_fragment(
         except FragmentHandledException:
             pass  # error already rendered in the fragment's container
                   # by wrapped_fragment() — existing behavior
-        except Exception:
-            _LOGGER.exception(
-                "Parallel fragment %s failed", _short_id(fragment_id)
-            )
+        except Exception as e:
+            handle_uncaught_app_exception(e)
 
     parent_context.run(run_fragment)
 ```
@@ -1037,9 +1035,3 @@ fragment path, and all indices must match at each position.
 During sequential fragment reruns (`is_parallel_worker` is False), the existing
 behavior is unchanged: non-widget elements are allowed in external containers, widgets
 are blocked by `check_fragment_path_policy`.
-
-**Follow-up:** if user demand emerges for cross-container output from parallel
-fragments, a dedicated `st.fragment_output()` API could collect results with defined
-ordering semantics (e.g., dispatch order) and render them after the join barrier. This
-would avoid the cursor ownership and ordering problems by design. See project notes
-for alternatives considered.

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -543,7 +543,7 @@ frontend:
 **`ForwardMsgQueue` — already safe via event loop serialization:** The queue is
 not internally thread-safe (`threading.Lock` was [removed in
 PR #4568](https://github.com/streamlit/streamlit/pull/4568)), but all access
-is serialized through `call_soon_threadsafe` onto the Tornado event loop thread.
+is serialized through `call_soon_threadsafe` onto the server's asyncio event loop thread.
 No changes are needed for parallel fragments.
 
 The enqueue path is the same for both the main script thread and parallel
@@ -562,7 +562,7 @@ st.text("hello")                               (on script thread or worker threa
 
 The key hop is `call_soon_threadsafe`: it pushes a callback onto the event
 loop's queue and returns immediately — the calling thread never blocks. The
-event loop thread (Tornado) processes callbacks one at a time, so
+server's asyncio event loop thread processes callbacks one at a time, so
 `_browser_queue.enqueue()` is only ever called from a single thread.
 
 ```python

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -120,7 +120,7 @@ return wrapped_fragment()
 
 # Proposed:
 if parallel:
-    _dispatch_parallel_fragment(ctx, wrapped_fragment)
+    _dispatch_parallel_fragment(ctx, fragment_id, wrapped_fragment)
     return None
 else:
     return wrapped_fragment()
@@ -141,7 +141,7 @@ def _dispatch_parallel_fragment(
     parent_context = contextvars.copy_context()
     thread = threading.Thread(
         target=_run_parallel_fragment,
-        args=(wrapped_fragment, fragment_id, parent_context),
+        args=(ctx.parallel_coordinator, wrapped_fragment, fragment_id, parent_context),
         name=f"parallel_fragment_{_short_id(fragment_id)}",
     )
     add_script_run_ctx(thread, ctx)

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -86,25 +86,58 @@ class ParallelFragmentCoordinator:
         poll_interval: float = 0.1,
     ) -> None:
         self._threads: list[threading.Thread] = []
-        self._cancel_event = threading.Event()
+        self._stop_event = threading.Event()
+        self._worker_exception: RerunException | StopException | None = None
+        self._exception_lock = threading.Lock()
         self._yield_check = yield_check
         self._poll_interval = poll_interval
 
     def register(self, thread: threading.Thread) -> None:
         self._threads.append(thread)
 
-    def cancel(self) -> None:
-        self._cancel_event.set()
+    def request_stop(self) -> None:
+        """A worker called st.stop(). First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = StopException()
+        self._stop_event.set()
 
-    def is_cancelled(self) -> bool:
-        return self._cancel_event.is_set()
+    def request_rerun(self, exc: RerunException) -> None:
+        """A worker called st.rerun(scope='app'). First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = exc
+        self._stop_event.set()
+
+    def should_stop(self) -> bool:
+        """Check whether this thread should exit."""
+        return self._stop_event.is_set()
+
+    @property
+    def worker_exception(self) -> RerunException | StopException | None:
+        return self._worker_exception
 
     def join(self) -> None:
+        """Happy-path join. Responsive to external requests (via yield_check)
+        and worker-initiated cancellation (via worker_exception)."""
         while any(t.is_alive() for t in self._threads):
             self._yield_check()
+            if self._worker_exception is not None:
+                raise self._worker_exception
             time.sleep(self._poll_interval)
         for thread in self._threads:
             thread.join()
+        if self._worker_exception is not None:
+            raise self._worker_exception
+
+    def drain(self, timeout: float = 5.0) -> None:
+        """Cleanup join after cancellation. Signals workers to stop and
+        waits without yield-checking. Safe to call from except blocks."""
+        self._stop_event.set()
+        deadline = time.monotonic() + timeout
+        for t in self._threads:
+            remaining = max(0, deadline - time.monotonic())
+            t.join(timeout=remaining)
 ```
 
 Three places change:
@@ -213,13 +246,13 @@ def _run_parallel_fragment(
                     # siblings are unaffected
                     continue
                 else:
-                    # st.rerun(scope="app") — signal sibling threads to cancel
-                    # via the coordinator, then exit
-                    coordinator.cancel()
+                    # st.rerun(scope="app") — signal sibling threads to stop
+                    # and preserve the RerunException for the main thread
+                    coordinator.request_rerun(e)
                     break
             except StopException:
-                # st.stop() — signal sibling threads to cancel, then exit
-                coordinator.cancel()
+                # st.stop() — signal sibling threads to stop
+                coordinator.request_stop()
                 break
             except FragmentHandledException:
                 break  # error already rendered in the fragment's container
@@ -241,16 +274,17 @@ This can happen at two points:
 1. **While the main script is still executing.** The existing yield point mechanism
    fires at the next `st.*` call on the script thread, raises `RerunException`, and
    `exec()` exits. This falls into the `except` block below, which calls
-   `coordinator.cancel()` and then `coordinator.join()` to wait for the worker
-   threads to observe the cancellation and terminate.
+   `coordinator.drain()` to signal workers to stop and wait for them to exit.
 
 2. **During the join barrier** (script has finished, waiting for threads). The script
    thread isn't calling `st.*`, so `coordinator.join()` calls `self._yield_check()`
    on each poll interval. If a RERUN/STOP request has arrived, the yield check raises
-   `RerunException` or `StopException`, breaking out of the join loop.
+   `RerunException` or `StopException`, breaking out of the join loop into the
+   `except` block.
 
-In both cases, worker threads must be cancelled before the rerun can proceed. This
-is handled with a try/except in `code_to_exec`:
+In both cases, worker threads must be stopped before the rerun can proceed. The
+`except` block calls `drain()`, which sets the stop event and joins threads directly
+— no yield check loop, so no risk of recursive exceptions:
 
 ```python
 # In code_to_exec():
@@ -259,8 +293,7 @@ try:
     ctx.parallel_coordinator.join()
     self._fragment_storage.clear(new_fragment_ids=ctx.new_fragment_ids)  # existing
 except (RerunException, StopException):
-    ctx.parallel_coordinator.cancel()
-    ctx.parallel_coordinator.join()  # wait for threads to observe cancellation
+    ctx.parallel_coordinator.drain()  # signal workers to stop, wait without yield-checking
     raise  # propagate so _run_script's rerun loop can restart
 ```
 
@@ -270,34 +303,36 @@ Every `st.*` call goes through `_enqueue_forward_msg()` →
 `_maybe_handle_execution_control_request()` in `script_runner.py`. This function acts
 as a yield point — it checks for pending RERUN/STOP requests and raises the appropriate
 exception. Today it guards with `_is_in_script_thread()` and returns early for
-non-script threads. We extend it to also check the coordinator's cancel event for
-worker threads:
+non-script threads. We extend it to check the coordinator's stop event for worker
+threads, and the `worker_exception` for the main thread:
 
 ```python
 def _maybe_handle_execution_control_request(self) -> None:
     if not self._is_in_script_thread():
-        # Worker thread — check coordinator cancel event
+        # Worker thread — check coordinator stop event
         ctx = get_script_run_ctx()
-        if ctx and ctx.parallel_coordinator.is_cancelled():
+        if ctx and ctx.parallel_coordinator.should_stop():
             raise StopException()  # unwinds this thread's call stack
         return
 
     if not self._execing:
         return
 
-    # NEW: also check cancel event on the script thread — a parallel
-    # fragment may have called st.stop() or st.rerun(scope="app")
+    # NEW: check if a worker requested cancellation — propagate with
+    # the correct exception type (StopException or RerunException)
     ctx = self._get_script_run_ctx()
-    if ctx.parallel_coordinator.is_cancelled():
-        raise StopException()
+    exc = ctx.parallel_coordinator.worker_exception
+    if exc is not None:
+        raise exc
 
     # ... existing request checking logic (unchanged) ...
 ```
 
 For worker threads, the `StopException` propagates up into `_run_parallel_fragment`,
 is caught in the `while` loop, and the thread exits. For the main script thread,
-it propagates up through `exec()` into the `except` block in `code_to_exec`,
-which cancels remaining threads and re-raises.
+the worker's original exception (preserving `RerunException` vs `StopException`)
+propagates up through `exec()` into the `except` block in `code_to_exec`,
+which drains remaining threads and re-raises.
 
 A thread blocked on a long I/O call (e.g., a slow database query) will not terminate
 until the call returns and the thread reaches its next yield point. This is inherent to
@@ -311,10 +346,10 @@ between blocking operations to improve cancellation responsiveness (see
 |----------|---------|---------------|----------------------|---------|
 | Happy path | — | — | — | All threads complete → `join()` returns → `scriptFinished` |
 | `st.rerun(scope="fragment")` | Thread A | Caught → `continue` → re-executes `wrapped_fragment()` in same thread | Unaffected | Thread A reruns locally |
-| `st.stop()` | Thread A | Caught → `coordinator.cancel()` → exits | See `is_cancelled()` at next yield point → `StopException` → exit | Run ends |
-| `st.rerun(scope="app")` | Thread A | Caught → `coordinator.cancel()` → exits | Same as `st.stop()` | `_run_script` restarts |
-| External rerun during `exec()` | Frontend | Main thread: `RerunException` at next `st.*` call → `except` block → `cancel()` + `join()` | See `is_cancelled()` at next yield point → exit | `_run_script` restarts |
-| External rerun during `join()` | Frontend | `_yield_check()` raises `RerunException` → `except` block → `cancel()` + `join()` | See `is_cancelled()` at next yield point → exit | `_run_script` restarts |
+| `st.stop()` | Thread A | Caught → `request_stop()` → exits | See `should_stop()` at next yield point → `StopException` → exit | Main thread raises `StopException` → run ends |
+| `st.rerun(scope="app")` | Thread A | Caught → `request_rerun(e)` → exits | See `should_stop()` at next yield point → `StopException` → exit | Main thread raises `RerunException` (with rerun data) → `_run_script` restarts |
+| External rerun during `exec()` | Frontend | Main thread: `RerunException` at next `st.*` call → `except` block → `drain()` | See `should_stop()` at next yield point → exit | `_run_script` restarts |
+| External rerun during `join()` | Frontend | `_yield_check()` raises `RerunException` → `except` block → `drain()` | See `should_stop()` at next yield point → exit | `_run_script` restarts |
 
 ### Content rendering
 

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -153,7 +153,7 @@ class ParallelFragmentCoordinator:
             raise self._worker_exception
         self._executor.shutdown(wait=False)
 
-    def drain(self, timeout: float = 5.0) -> None:
+    def drain(self) -> None:
         """Cleanup join after cancellation. Signals workers to stop and
         shuts down the pool. Safe to call from except blocks."""
         self._stop_event.set()

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -665,11 +665,12 @@ class PagesManager:
 
     def get_pages(self) -> dict[PageHash, PageInfo]:
         """Return a snapshot of the current page registry.
-        No lock needed — the only write to _pages goes through
-        set_pages_and_resolve(), which is already lock-protected."""
-        return dict(self._pages) if self._pages else {
-            self.main_script_hash: { ... }
-        }
+        Lock-protected for free-threaded Python (PEP 703) where
+        iterating a dict during concurrent mutation is unsafe."""
+        with self._lock:
+            return dict(self._pages) if self._pages else {
+                self.main_script_hash: { ... }
+            }
 
     def set_current_page_script_hash(self, h: PageHash) -> None:
         """No lock needed — standalone write, not read by

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -424,45 +424,181 @@ need thread-safe access:
 
 ### Other shared mutable state
 
-The remaining `ScriptRunContext` fields that are affected by parallel execution but
-are not part of the rendering pipeline.
+`ScriptRunContext` currently mixes per-thread, shared-mutable, shared-immutable, and
+externally-managed fields on one flat dataclass. The distinction between what's isolated
+per-thread and what's shared across threads is implicit — you have to know. This is
+fragile: adding a new field requires understanding the concurrency model to choose the
+right category, and nothing prevents accidental unsynchronized access to shared state.
 
-#### Thread-safe fields (no work needed)
+**Proposed design:** restructure `ScriptRunContext` into four explicit categories, each
+with its own abstraction:
 
-| Field | Why safe |
-|-------|----------|
-| `session_state` | `SafeSessionState` wraps all access with an `RLock`. Single-operation atomicity; multi-op sequences are the user's responsibility |
-| `in_cached_function` | `ContextVar` — per-thread by design via `copy_context()` |
-| Immutable scalars (`session_id`, `main_script_path`, `user_info`, `gather_usage_stats`) | Never mutated during execution |
+```python
+@dataclass
+class ScriptRunContext:
+    # 1. Immutable config (enforce via immutability assessment)
+    session_id: str
+    main_script_path: str
+    user_info: UserInfoType
+    gather_usage_stats: bool
 
-#### Per-thread isolated (via `contextvars.copy_context()`)
+    # 2. Shared, externally thread-safe objects
+    session_state: SafeSessionState
+    pages_manager: PagesManager       # with lock added
+    fragment_storage: FragmentStorage  # with lock added
 
-These fields are set per-fragment during execution. `_dispatch_parallel_fragment` uses
-`contextvars.copy_context()` to give each worker thread its own bindings:
+    # 3. Shared mutable run state — new abstraction
+    shared: SharedRunState
 
-| Field | Isolation mechanism |
-|-------|-------------------|
-| `current_fragment_id` | Set per-fragment in `wrap()` — each thread's copy is independent |
-| `current_fragment_delta_path` | Set per-fragment — independent per thread |
-| `in_fragment_callback` | Set during fragment callback — independent per thread |
-| `_active_script_hash` | Set via `run_with_active_hash` context manager — independent per thread |
+    # 4. Per-thread fragment state — new abstraction
+    thread_state: FragmentThreadState
+```
 
-#### Telemetry (need synchronization)
+Adding a new field forces an explicit decision: does it go on `FragmentThreadState`
+(per-thread, no sync needed), `SharedRunState` (shared, sync built-in), one of the
+externally thread-safe objects, or the immutable config? The following sections describe
+each category.
 
-| Field | Type | Mutation pattern |
-|-------|------|------------------|
-| `tracked_commands` | `list[Command]` | Every `st.*` call appends (when usage stats enabled); read after run |
-| `tracked_commands_counter` | `Counter[str]` | Every `st.*` call increments; read after run |
+#### Immutable config
 
-These are append-only during execution and read only after the run completes. They
-need the same per-field lock approach as the widget sets — see the thread-safe
-`ScriptRunContext` shared sets spec.
+`session_id`, `main_script_path`, `user_info`, `gather_usage_stats` — set at
+construction, never mutated during execution. Currently immutable by convention only,
+not enforced. The `ScriptRunContext` immutability assessment should enforce this (e.g.,
+`@property` with read-only access, `types.MappingProxyType` for `user_info`).
 
-#### Dialog guard (`has_dialog_opened`)
+#### Externally thread-safe objects
 
-| Field | Type | Concern |
-|-------|------|---------|
-| `has_dialog_opened` | `bool` | Guards one-dialog-at-a-time |
+These are shared across threads but manage their own locking.
+
+**`SafeSessionState`** wraps all access with an `RLock`. Per-operation atomicity is
+guaranteed — no thread will see a torn read or corrupt the internal data structures.
+However, the lock is **released between operations**, which means compound sequences
+like read-modify-write are not atomic:
+
+```python
+@st.fragment(parallel=True)
+def increment():
+    # Thread A reads counter=5, releases lock
+    val = st.session_state["counter"]
+    # Thread B reads counter=5, releases lock
+    st.session_state["counter"] = val + 1
+    # Both threads write 6 — lost update
+```
+
+**MVP approach: document the limitation.** Most parallel fragment use cases are
+independent — each fragment loads its own data and renders its own UI. Cross-fragment
+shared state writes are uncommon. The product spec scopes cross-fragment communication
+as out of scope for the MVP. Users who need multi-operation atomicity can implement
+their own lock:
+
+```python
+if "lock" not in st.session_state:
+    st.session_state["lock"] = threading.Lock()
+
+@st.fragment(parallel=True)
+def increment():
+    with st.session_state["lock"]:
+        st.session_state["counter"] = st.session_state.get("counter", 0) + 1
+```
+
+The initialization is safe because it runs on the main script thread before parallel
+fragments are dispatched. **Future enhancement:** an atomic update helper or scoped
+lock API could make this more ergonomic (to be filed after parallel fragments ships).
+
+**`PagesManager`** has no internal locking today. `st.navigation` calls `set_pages()`
+then `get_page_script()` — with concurrent callers, Thread A's read can see Thread B's
+page set. `st.switch_page` reads `get_pages()` and mutates
+`set_current_page_script_hash()` via `ctx.set_mpa_v2_page()`. There is no "called
+once" enforcement on `st.navigation` today; repeated calls silently overwrite even in
+synchronous execution. Add `threading.Lock` wrapping `set_pages()`, `get_pages()`,
+`get_page_script()`, and `set_current_page_script_hash()` — the same pattern as
+`SafeSessionState`. The class-level `uses_pages_directory` flag should also be moved
+to an instance attribute (it is currently process-wide, not session-scoped).
+
+**`FragmentStorage`** is written to when `@st.fragment` definitions execute and read
+after join for `clear()`. Add a lock to its internal dict — addressed in the feature
+PR alongside the coordinator integration.
+
+#### `SharedRunState` — shared mutable run state
+
+Bundles the shared mutable fields that are read and written by any thread during
+execution. Encapsulates its own locking — callers use methods like
+`ctx.shared.add_widget_id(id)` instead of bare `ctx.widget_ids_this_run.add(id)`,
+making unsynchronized access impossible by construction.
+
+```python
+class SharedRunState:
+    """Thread-safe shared state for a script run.
+    Single instance shared across main thread and all worker threads."""
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.widget_ids: set[str] = set()
+        self.widget_user_keys: set[str] = set()
+        self.form_ids: set[str] = set()
+        self.new_fragment_ids: set[str] = set()
+        self.tracked_commands: list[Command] = []
+        self.tracked_commands_counter: Counter[str] = Counter()
+
+    def add_widget_id(self, widget_id: str) -> bool:
+        """Add widget ID. Returns True if already present (duplicate)."""
+        with self._lock:
+            was_present = widget_id in self.widget_ids
+            self.widget_ids.add(widget_id)
+            return was_present
+    # ... similar methods for other fields
+```
+
+The thread-safe shared sets spec defines the per-field wrapper APIs (`ThreadSafeStrSet`,
+`ThreadSafeTelemetry`). `SharedRunState` is the container that composes them. This can
+land with the thread-safe shared sets work.
+
+#### `FragmentThreadState` — per-thread fragment state
+
+Bundles per-thread fields into a dataclass created fresh per worker thread by
+`_dispatch_parallel_fragment`. On the main thread, a single instance is reused.
+Replaces the implicit `copy_context()` isolation with explicit per-thread object
+creation.
+
+```python
+@dataclass
+class FragmentThreadState:
+    """Per-thread state for a fragment execution."""
+    fragment_id: str | None = None
+    delta_path: tuple[int, ...] | None = None
+    in_fragment_callback: bool = False
+    active_script_hash: str = ""
+```
+
+`in_cached_function` remains a `ContextVar` (it's also used outside fragments). The
+other per-thread fields move here, making `_dispatch_parallel_fragment` explicit:
+create a `FragmentThreadState`, pass it to the worker thread, done — no reliance on
+`copy_context()` correctly copying the right fields. This can land with the parallel
+fragment coordinator integration.
+
+**Migration path:** callers that access `ctx.widget_ids_this_run` change to
+`ctx.shared.add_widget_id()`. Callers that access `ctx.current_fragment_id` change to
+`ctx.thread_state.fragment_id`. The restructuring can happen incrementally —
+`SharedRunState` and `FragmentThreadState` can land in separate PRs.
+
+### API restrictions during parallel execution
+
+Most Streamlit APIs are safe during parallel execution either inherently (normal
+element rendering via the cursor/delta pipeline) or through synchronization added in
+this feature (shared sets, `ForwardMsgQueue`, `PagesManager`). Execution control
+commands (`st.rerun`, `st.stop`) are handled by the cooperative cancellation mechanism
+(see [Cooperative cancellation](#4-cooperative-cancellation-for-ststop-and-strerun)).
+
+The APIs below require explicit restrictions because they have structural side effects
+that are disruptive or nonsensical during concurrent execution and cannot be addressed
+by locking alone. All follow the same pattern: **prohibited during the parallel batch**
+(worker threads), **allowed during sequential fragment reruns** (single-threaded). The
+implementation can use the same detection mechanism — checking whether the current
+thread is a parallel fragment worker (e.g., via
+`ctx.parallel_coordinator.is_active()` combined with
+`threading.current_thread() != main_thread`, or via a per-thread flag set by
+`_dispatch_parallel_fragment`).
+
+#### Dialogs (`@st.dialog`)
 
 Dialogs require special handling because they need the one-dialog-at-a-time invariant
 but should not be blanket-prohibited for all fragments declared with `parallel=True`.
@@ -481,16 +617,24 @@ opening a dialog from a fragment rerun is a common and valid pattern (e.g., a bu
 in a dashboard card opens a detail dialog). Blocking this would be overly restrictive.
 
 **Implementation:** the dialog guard in `_check_dialog_guard`
-(`lib/streamlit/elements/lib/dialog.py`) should distinguish between these contexts:
+(`lib/streamlit/elements/lib/dialog.py`) should raise `StreamlitAPIException` during
+the parallel batch. During sequential fragment reruns, the existing
+`has_dialog_opened` check (one dialog per rerun) still applies unchanged. No
+synchronization is needed on `has_dialog_opened` itself — it is only read/written
+during sequential execution.
 
-- **During a parallel batch** (current thread is a parallel fragment worker): raise
-  `StreamlitAPIException`. The guard can check whether the current thread is a parallel
-  fragment worker — e.g., via `ctx.parallel_coordinator.is_active()` combined with
-  `threading.current_thread() != main_thread`, or via a per-thread flag set by
-  `_dispatch_parallel_fragment`.
-- **During a sequential fragment rerun**: allow dialogs. The existing
-  `has_dialog_opened` check (one dialog per rerun) still applies unchanged.
+#### Page navigation (`st.switch_page`)
 
-No synchronization is needed on `has_dialog_opened` itself — it is only read/written
-during sequential execution (single-threaded fragment reruns and the main script thread).
-During the parallel batch, dialogs are outright prohibited before the field is accessed.
+`st.switch_page` mutates query params, requests a rerun with a new page hash, and
+forces a yield point — effectively cancelling all parallel threads mid-execution to
+navigate to a different page. During a parallel batch, this is disruptive: even a
+single fragment navigating would abort all other fragments, and multiple fragments
+navigating simultaneously would race on the destination page.
+
+During a sequential fragment rerun, `st.switch_page` is a valid and common pattern
+(e.g., a button in a dashboard card navigates to a detail page).
+
+**Implementation:** add a parallel-batch check in `switch_page`
+(`lib/streamlit/commands/execution_control.py`). No existing guard exists today — the
+function has no fragment awareness. The check should raise `StreamlitAPIException`
+during the parallel batch.

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -1,0 +1,496 @@
+---
+author: sfc-gh-lwilby
+created: 2026-03-13
+---
+
+# Parallel Fragments
+
+## Summary
+
+Add `parallel: bool = False` to `@st.fragment` so that fragment functions run in separate
+threads during full app runs. Today, all fragments execute sequentially on the script runner
+thread — each one blocks until it completes. With `parallel=True`, the fragment's call site
+dispatches its work to a worker thread and returns immediately, allowing independent sections
+to load data and render concurrently.
+
+This spec covers the internal changes needed to support concurrent fragment execution.
+See the [product spec](./product-spec.md) for user-facing API decisions and behavior.
+
+## Problem
+
+Streamlit's execution model assumes a single script thread. Fragments currently execute
+inline on that thread — they share state freely and produce output in a deterministic
+sequential order. Running fragments in parallel threads breaks these assumptions in three
+areas:
+
+1. **Shared mutable state.** The fragment execution path reads and writes fields on a shared
+   `ScriptRunContext` instance (`current_fragment_id`, `widget_ids_this_run`, etc.), enqueues
+   messages through a non-thread-safe `ForwardMsgQueue`, and advances position-tracking
+   cursors that assume single-threaded access.
+
+2. **Execution flow.** Control flow exceptions (`st.rerun()`, `st.stop()`) currently unwind
+   the single script thread. With parallel threads, these exceptions are local to the thread
+   that raises them — sibling threads need to be notified and cancelled. The `scriptFinished`
+   lifecycle signal, which triggers frontend cleanup via `clearStaleNodes`, must be delayed
+   until all threads complete.
+
+3. **Frontend rendering.** Deltas from parallel threads arrive interleaved rather than in
+   top-to-bottom script order. The frontend needs to handle content appearing
+   non-sequentially, show appropriate loading states for not-yet-completed fragments, and
+   ensure `clearStaleNodes` doesn't garbage-collect elements from still-running threads.
+
+## Proposal
+
+### Execution flow
+
+Today, fragments execute inline on the script thread — each one blocks until it completes.
+With `parallel=True`, the fragment is dispatched to a worker thread and the script thread
+continues immediately.
+
+**Proposed flow (parallel):**
+
+1. Script thread hits `my_fragment()`, spawns a worker thread, and continues immediately.
+2. The worker thread runs `wrapped_fragment()` concurrently with the rest of the script.
+3. When `exec()` returns (the script has finished), the script thread waits at a join
+   barrier for all worker threads to complete.
+4. Once all workers are done, `scriptFinished` is sent to the frontend.
+
+Thread lifecycle — registration, joining, and cancellation — is encapsulated in a new
+`ParallelFragmentCoordinator` class. The coordinator is created per-run and stored on
+`ctx`. It receives a `yield_check` callback from the `ScriptRunner` — this is a
+reference to `_maybe_handle_execution_control_request()`, which checks for pending
+RERUN/STOP requests and raises the appropriate exception:
+
+```python
+class ParallelFragmentCoordinator:
+    def __init__(
+        self,
+        yield_check: Callable[[], None],
+        poll_interval: float = 0.1,
+    ) -> None:
+        self._threads: list[threading.Thread] = []
+        self._cancel_event = threading.Event()
+        self._yield_check = yield_check
+        self._poll_interval = poll_interval
+
+    def register(self, thread: threading.Thread) -> None:
+        self._threads.append(thread)
+
+    def cancel(self) -> None:
+        self._cancel_event.set()
+
+    def is_cancelled(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def join(self) -> None:
+        while any(t.is_alive() for t in self._threads):
+            self._yield_check()
+            time.sleep(self._poll_interval)
+        for thread in self._threads:
+            thread.join()
+```
+
+Three places change:
+
+**1. `fragment.py` — dispatch instead of inline execution**
+
+In `wrap()`, a `parallel=True` fragment dispatches `wrapped_fragment` to a worker thread
+instead of calling it directly:
+
+```python
+# Today (fragment.py L267-268):
+return wrapped_fragment()
+
+# Proposed:
+if parallel:
+    _dispatch_parallel_fragment(ctx, wrapped_fragment)
+    return None
+else:
+    return wrapped_fragment()
+```
+
+`_dispatch_parallel_fragment` is a new helper in `fragment.py` that copies the current
+context, spawns a thread, and registers it on `ctx` for the join barrier:
+
+```python
+def _dispatch_parallel_fragment(
+    ctx: ScriptRunContext,
+    fragment_id: str,
+    wrapped_fragment: Callable[[], Any],
+) -> None:
+    # Snapshots all ContextVar values at the call site, including:
+    #   - context_dg_stack: the DeltaGenerator/cursor position stack
+    #   - in_cached_function: guard preventing widgets inside @st.cache_*
+    parent_context = contextvars.copy_context()
+    thread = threading.Thread(
+        target=_run_parallel_fragment,
+        args=(wrapped_fragment, fragment_id, parent_context),
+        name=f"parallel_fragment_{_short_id(fragment_id)}",
+    )
+    add_script_run_ctx(thread, ctx)
+    ctx.parallel_coordinator.register(thread)
+    thread.start()
+```
+
+`_run_parallel_fragment` is the thread entry point. It runs `wrapped_fragment` inside
+the copied context (so each thread gets its own `context_dg_stack` and cursor state).
+Exception handling within this function is covered in the control flow exceptions
+section below.
+
+The script thread does not block. The return value of a parallel fragment is always `None`
+(the user function's return value is discarded — documented in the product spec).
+
+**2. `script_runner.py` — join barrier before scriptFinished**
+
+After `exec()` returns, the script runner must wait for all parallel fragment threads to
+finish before calling `_on_script_finished`. Today, `scriptFinished` triggers
+`clearStaleNodes` on the frontend, which would garbage-collect elements from still-running
+threads if sent too early.
+
+```python
+# In code_to_exec(), after the exec() call (script_runner.py ~L689):
+exec(code, module.__dict__)
+
+# NEW: block until every parallel fragment thread has completed
+ctx.parallel_coordinator.join()
+
+self._fragment_storage.clear(new_fragment_ids=ctx.new_fragment_ids)
+```
+
+**3. Fragment reruns stay sequential (MVP)**
+
+Fragment reruns — triggered by widget interaction or `run_every` — continue to run
+sequentially on the script thread. The existing `fragment_id_queue` loop in `_run_script`
+is unchanged:
+
+```python
+# script_runner.py ~L644-650 — no change for MVP
+if rerun_data.fragment_id_queue:
+    for fragment_id in rerun_data.fragment_id_queue:
+        wrapped_fragment = self._fragment_storage.get(fragment_id)
+        wrapped_fragment()  # still sequential
+```
+
+**4. Cooperative cancellation for `st.stop()` and `st.rerun()`**
+
+**When `st.rerun()` or `st.stop()` is called from within a parallel fragment:**
+
+The exception is caught in `_run_parallel_fragment`, which is the thread entry point.
+It runs `wrapped_fragment` inside the copied context and handles three cases:
+
+```python
+def _run_parallel_fragment(
+    coordinator: ParallelFragmentCoordinator,
+    wrapped_fragment: Callable[[], Any],
+    fragment_id: str,
+    parent_context: contextvars.Context,
+) -> None:
+    def run_fragment() -> None:
+        while True:
+            try:
+                wrapped_fragment()
+                break
+            except RerunException as e:
+                if e.rerun_data.fragment_id_queue:
+                    # st.rerun(scope="fragment") — re-execute in this thread,
+                    # siblings are unaffected
+                    continue
+                else:
+                    # st.rerun(scope="app") — signal sibling threads to cancel
+                    # via the coordinator, then exit
+                    coordinator.cancel()
+                    break
+            except StopException:
+                # st.stop() — signal sibling threads to cancel, then exit
+                coordinator.cancel()
+                break
+            except FragmentHandledException:
+                break  # error already rendered in the fragment's container
+                       # by wrapped_fragment() — existing behavior
+            except Exception:
+                _LOGGER.exception(
+                    "Parallel fragment %s failed", _short_id(fragment_id)
+                )
+                break
+
+    parent_context.run(run_fragment)
+```
+
+**When an external full-app rerun arrives** (e.g., widget interaction while fragments
+are still running):
+
+This can happen at two points:
+
+1. **While the main script is still executing.** The existing yield point mechanism
+   fires at the next `st.*` call on the script thread, raises `RerunException`, and
+   `exec()` exits. This falls into the `except` block below, which calls
+   `coordinator.cancel()` and then `coordinator.join()` to wait for the worker
+   threads to observe the cancellation and terminate.
+
+2. **During the join barrier** (script has finished, waiting for threads). The script
+   thread isn't calling `st.*`, so `coordinator.join()` calls `self._yield_check()`
+   on each poll interval. If a RERUN/STOP request has arrived, the yield check raises
+   `RerunException` or `StopException`, breaking out of the join loop.
+
+In both cases, worker threads must be cancelled before the rerun can proceed. This
+is handled with a try/except in `code_to_exec`:
+
+```python
+# In code_to_exec():
+try:
+    exec(code, module.__dict__)
+    ctx.parallel_coordinator.join()
+    self._fragment_storage.clear(new_fragment_ids=ctx.new_fragment_ids)  # existing
+except (RerunException, StopException):
+    ctx.parallel_coordinator.cancel()
+    ctx.parallel_coordinator.join()  # wait for threads to observe cancellation
+    raise  # propagate so _run_script's rerun loop can restart
+```
+
+**How sibling threads and the main thread observe the cancellation:**
+
+Every `st.*` call goes through `_enqueue_forward_msg()` →
+`_maybe_handle_execution_control_request()` in `script_runner.py`. This function acts
+as a yield point — it checks for pending RERUN/STOP requests and raises the appropriate
+exception. Today it guards with `_is_in_script_thread()` and returns early for
+non-script threads. We extend it to also check the coordinator's cancel event for
+worker threads:
+
+```python
+def _maybe_handle_execution_control_request(self) -> None:
+    if not self._is_in_script_thread():
+        # Worker thread — check coordinator cancel event
+        ctx = get_script_run_ctx()
+        if ctx and ctx.parallel_coordinator.is_cancelled():
+            raise StopException()  # unwinds this thread's call stack
+        return
+
+    if not self._execing:
+        return
+
+    # NEW: also check cancel event on the script thread — a parallel
+    # fragment may have called st.stop() or st.rerun(scope="app")
+    ctx = self._get_script_run_ctx()
+    if ctx.parallel_coordinator.is_cancelled():
+        raise StopException()
+
+    # ... existing request checking logic (unchanged) ...
+```
+
+For worker threads, the `StopException` propagates up into `_run_parallel_fragment`,
+is caught in the `while` loop, and the thread exits. For the main script thread,
+it propagates up through `exec()` into the `except` block in `code_to_exec`,
+which cancels remaining threads and re-raises.
+
+A thread blocked on a long I/O call (e.g., a slow database query) will not terminate
+until the call returns and the thread reaches its next yield point. This is inherent to
+Python threading and should be documented. Users can insert `st.yield_point()` calls
+between blocking operations to improve cancellation responsiveness (see
+[#14523](https://github.com/streamlit/streamlit/issues/14523)).
+
+**Summary of cancellation scenarios:**
+
+| Scenario | Trigger | Calling thread | Siblings + main thread | Outcome |
+|----------|---------|---------------|----------------------|---------|
+| Happy path | — | — | — | All threads complete → `join()` returns → `scriptFinished` |
+| `st.rerun(scope="fragment")` | Thread A | Caught → `continue` → re-executes `wrapped_fragment()` in same thread | Unaffected | Thread A reruns locally |
+| `st.stop()` | Thread A | Caught → `coordinator.cancel()` → exits | See `is_cancelled()` at next yield point → `StopException` → exit | Run ends |
+| `st.rerun(scope="app")` | Thread A | Caught → `coordinator.cancel()` → exits | Same as `st.stop()` | `_run_script` restarts |
+| External rerun during `exec()` | Frontend | Main thread: `RerunException` at next `st.*` call → `except` block → `cancel()` + `join()` | See `is_cancelled()` at next yield point → exit | `_run_script` restarts |
+| External rerun during `join()` | Frontend | `_yield_check()` raises `RerunException` → `except` block → `cancel()` + `join()` | See `is_cancelled()` at next yield point → exit | `_run_script` restarts |
+
+### Content rendering
+
+This section covers the full path from element creation to browser rendering:
+cursor assignment, element registration, message delivery (cached message dedup,
+queuing, yield point check), delta ordering, element cleanup, and loading UX.
+
+#### Cursor ownership and thread-safe rendering
+
+Streamlit's element tree assumes elements along the main trunk arrive in order.
+Content from a parallel thread must be written to a branch — a container on the
+main thread that the worker thread renders into.
+
+Today, `RunningCursor` has no concept of thread ownership. `copy_context()` shallow-
+copies the `context_dg_stack` ContextVar binding, but the DG and cursor objects inside
+are shared by reference. Two threads incrementing the same cursor can produce
+`delta_path` collisions.
+
+The fix has two parts:
+
+**1. Pre-create the container on the main thread.** In `wrap()`, the main thread
+calls `st.container()` before dispatching. This advances the main thread's cursor
+(so subsequent elements don't collide), creates the container delta on the frontend
+immediately (enabling the loading skeleton), and gives the worker thread its own
+container with an independent `RunningCursor`.
+
+**2. Enforce cursor ownership.** Add thread ownership to `RunningCursor` so that
+only the thread that created a cursor can increment it:
+
+```python
+class RunningCursor:
+    def __init__(self, ...):
+        self._index = 0
+        self._owner_thread = threading.current_thread()
+
+    def get_locked_cursor(self, ...):
+        if threading.current_thread() != self._owner_thread:
+            raise RuntimeError(
+                "Cursor accessed from a thread that doesn't own it"
+            )
+        index = self._index
+        self._index += 1
+        return LockedCursor(index=index, ...)
+```
+
+This enforces the invariant: a worker thread must write into a branched container,
+never directly onto the main thread's cursor. If future code accidentally shares a
+cursor across threads, the error surfaces immediately.
+
+#### Element registration
+
+When an `st.*` call creates a widget or form, it registers the element's identity on
+`ScriptRunContext` before building the delta message. These registrations serve as
+cross-thread duplicate detection — for example, two fragments must not define widgets
+with the same user key.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `widget_ids_this_run` | `set[str]` | Every widget adds its computed ID; checked for duplicate detection |
+| `widget_user_keys_this_run` | `set[str]` | Every widget with `key=` adds; checked for duplicate user keys |
+| `form_ids_this_run` | `set[str]` | Every `st.form()` adds; checked for duplicate form IDs |
+
+With parallel threads, these sets are read AND written concurrently — Thread A checks
+for a duplicate while Thread B simultaneously adds a new ID. This is a data race
+without synchronization, and is not safe even under CPython's GIL (which does not
+guarantee atomicity for compound check-then-add operations and is absent in
+free-threaded Python, PEP 703).
+
+The approach is per-field `threading.Lock` wrapping. This is simple, correct, handles
+the cross-thread read requirement (duplicate detection must see IDs from *all*
+threads), and has negligible overhead (O(1) operations behind an uncontended lock at
+expected thread counts). A separate spec covers the implementation details — see the
+thread-safe `ScriptRunContext` shared sets task.
+
+#### Message delivery pipeline
+
+When an `st.*` call produces a delta, it flows through two stages before reaching the
+frontend:
+
+1. **`ScriptRunContext.enqueue()`** — hashes the message, checks `cached_message_hashes`
+   (a `set[str]` on `ctx`) to see if the client already has it cached. If so, sends a
+   lightweight reference instead of the full message. This set is written once at
+   `ctx.reset()` and only read during execution, so it is safe for concurrent access
+   without synchronization. (A separate spec will assess whether `cached_message_hashes`
+   and other `ScriptRunContext` fields should be made formally immutable — see the
+   `ScriptRunContext` immutability assessment task.)
+
+2. **`ScriptRunner._enqueue_forward_msg()`** — calls
+   `_maybe_handle_execution_control_request()` (the yield point check — see
+   [Cooperative cancellation](#4-cooperative-cancellation-for-ststop-and-strerun)), then
+   passes the message to `ForwardMsgQueue`. For user code that doesn't call `st.*`
+   commands in tight loops, `st.yield_point()` provides an explicit yield point without
+   emitting a delta (see [#14523](https://github.com/streamlit/streamlit/issues/14523)).
+
+**`ForwardMsgQueue` thread safety:** The queue is not thread-safe today. Add
+`threading.Lock` around `enqueue()`, `clear()`, and `flush()` so that deltas from
+multiple threads can be enqueued concurrently without corrupting the internal list or
+index map.
+
+#### Delta ordering
+
+Each delta carries an absolute `delta_path`, so interleaved arrival order doesn't
+matter — the frontend places elements by path, not by arrival time.
+
+#### Element cleanup
+
+`scriptFinished` triggers `clearStaleNodes` on the frontend, which garbage-collects
+elements that were not re-rendered. The join barrier (Execution flow §2) delays
+`scriptFinished` until all threads complete, so the cleanup pass never removes elements
+from still-running threads.
+
+After the join, `fragment_storage.clear(new_fragment_ids=ctx.new_fragment_ids)` prunes
+fragment definitions that were not re-registered during this run. Both fields involved
+need thread-safe access:
+
+| Field | Type | Concern |
+|-------|------|---------|
+| `new_fragment_ids` | `set[str]` | Written by any thread executing `@st.fragment`; read after join for cleanup. Needs same per-field lock as the widget sets above. |
+| `fragment_storage` | `FragmentStorage` | Written concurrently when `@st.fragment` definitions register the wrapped function; read after join for `clear()`. `MemoryFragmentStorage` needs a `threading.Lock` around its internal dict — same per-field lock approach as the shared sets. Covered in the thread-safe `ScriptRunContext` shared sets spec. |
+
+#### Loading skeleton
+
+*TODO: needs prototyping and testing before specifying.*
+
+### Other shared mutable state
+
+The remaining `ScriptRunContext` fields that are affected by parallel execution but
+are not part of the rendering pipeline.
+
+#### Thread-safe fields (no work needed)
+
+| Field | Why safe |
+|-------|----------|
+| `session_state` | `SafeSessionState` wraps all access with an `RLock`. Single-operation atomicity; multi-op sequences are the user's responsibility |
+| `in_cached_function` | `ContextVar` — per-thread by design via `copy_context()` |
+| Immutable scalars (`session_id`, `main_script_path`, `user_info`, `gather_usage_stats`) | Never mutated during execution |
+
+#### Per-thread isolated (via `contextvars.copy_context()`)
+
+These fields are set per-fragment during execution. `_dispatch_parallel_fragment` uses
+`contextvars.copy_context()` to give each worker thread its own bindings:
+
+| Field | Isolation mechanism |
+|-------|-------------------|
+| `current_fragment_id` | Set per-fragment in `wrap()` — each thread's copy is independent |
+| `current_fragment_delta_path` | Set per-fragment — independent per thread |
+| `in_fragment_callback` | Set during fragment callback — independent per thread |
+| `_active_script_hash` | Set via `run_with_active_hash` context manager — independent per thread |
+
+#### Telemetry (need synchronization)
+
+| Field | Type | Mutation pattern |
+|-------|------|------------------|
+| `tracked_commands` | `list[Command]` | Every `st.*` call appends (when usage stats enabled); read after run |
+| `tracked_commands_counter` | `Counter[str]` | Every `st.*` call increments; read after run |
+
+These are append-only during execution and read only after the run completes. They
+need the same per-field lock approach as the widget sets — see the thread-safe
+`ScriptRunContext` shared sets spec.
+
+#### Dialog guard (`has_dialog_opened`)
+
+| Field | Type | Concern |
+|-------|------|---------|
+| `has_dialog_opened` | `bool` | Guards one-dialog-at-a-time |
+
+Dialogs require special handling because they need the one-dialog-at-a-time invariant
+but should not be blanket-prohibited for all fragments declared with `parallel=True`.
+
+**Two execution contexts for parallel fragments:**
+
+1. **Initial parallel run** — the fragment body runs concurrently with other parallel
+   fragments on worker threads during the initial script execution. Multiple threads are
+   active; `ctx.parallel_coordinator` is active.
+2. **Fragment rerun** — a UI interaction (button click, row selection, etc.) triggers a
+   rerun of a single fragment. This runs sequentially on the script thread via the
+   existing `fragment_id_queue` loop. No concurrency.
+
+Per [reviewer feedback](https://github.com/streamlit/streamlit/pull/14277#discussion_r2917217279),
+opening a dialog from a fragment rerun is a common and valid pattern (e.g., a button
+in a dashboard card opens a detail dialog). Blocking this would be overly restrictive.
+
+**Implementation:** the dialog guard in `_check_dialog_guard`
+(`lib/streamlit/elements/lib/dialog.py`) should distinguish between these contexts:
+
+- **During a parallel batch** (current thread is a parallel fragment worker): raise
+  `StreamlitAPIException`. The guard can check whether the current thread is a parallel
+  fragment worker — e.g., via `ctx.parallel_coordinator.is_active()` combined with
+  `threading.current_thread() != main_thread`, or via a per-thread flag set by
+  `_dispatch_parallel_fragment`.
+- **During a sequential fragment rerun**: allow dialogs. The existing
+  `has_dialog_opened` check (one dialog per rerun) still applies unchanged.
+
+No synchronization is needed on `has_dialog_opened` itself — it is only read/written
+during sequential execution (single-threaded fragment reruns and the main script thread).
+During the parallel batch, dialogs are outright prohibited before the field is accessed.

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -56,8 +56,25 @@ continues immediately.
 4. Once all workers are done, `scriptFinished` is sent to the frontend.
 
 Thread lifecycle — registration, joining, and cancellation — is encapsulated in a new
-`ParallelFragmentCoordinator` class. The coordinator is created per-run and stored on
-`ctx`. It receives a `yield_check` callback from the `ScriptRunner` — this is a
+`ParallelFragmentCoordinator` class. A fresh coordinator is created in `ctx.reset()`
+at the start of each script run (before `exec()`, so before any worker threads exist)
+and stored on `ctx`. `reset()` is guarded to only run on the main script thread —
+calling it from a worker thread raises `RuntimeError`:
+
+```python
+# In ctx.reset(), called once per script run on the main thread:
+def reset(self, ...) -> None:
+    # NEW: enforce that reset() is only called from the main script thread
+    if threading.get_ident() != self._main_thread_ident:
+        raise RuntimeError("reset() must only be called from the main script thread")
+    ...
+    # NEW: create a fresh coordinator for this script run
+    self.parallel_coordinator = ParallelFragmentCoordinator(
+        yield_check=self._yield_check,
+    )
+```
+
+The coordinator receives a `yield_check` callback from the `ScriptRunner` — this is a
 reference to `_maybe_handle_execution_control_request()`, which checks for pending
 RERUN/STOP requests and raises the appropriate exception:
 
@@ -305,47 +322,87 @@ This section covers the full path from element creation to browser rendering:
 cursor assignment, element registration, message delivery (cached message dedup,
 queuing, yield point check), delta ordering, element cleanup, and loading UX.
 
-#### Cursor ownership and thread-safe rendering
+#### Cursor API and thread-safe rendering
 
 Streamlit's element tree assumes elements along the main trunk arrive in order.
 Content from a parallel thread must be written to a branch — a container on the
 main thread that the worker thread renders into.
 
-Today, `RunningCursor` has no concept of thread ownership. `copy_context()` shallow-
-copies the `context_dg_stack` ContextVar binding, but the DG and cursor objects inside
-are shared by reference. Two threads incrementing the same cursor can produce
-`delta_path` collisions.
+Today, `RunningCursor` has a single method — `get_locked_cursor()` — that serves
+two distinct purposes: reserving a slot for an element (returning a `LockedCursor`
+the caller keeps) and advancing the parent cursor when a block is created (the
+returned `LockedCursor` is discarded). With threading, this conflation becomes a
+problem: `copy_context()` shallow-copies the `context_dg_stack` ContextVar binding,
+so DG and cursor objects are shared by reference. Two threads calling
+`get_locked_cursor()` on the same cursor would race on `_index`.
 
-The fix has two parts:
+The design has three parts:
 
-**1. Pre-create the container on the main thread.** In `wrap()`, the main thread
-calls `st.container()` before dispatching. This advances the main thread's cursor
-(so subsequent elements don't collide), creates the container delta on the frontend
-immediately (enabling the loading skeleton), and gives the worker thread its own
-container with an independent `RunningCursor`.
-
-**2. Enforce cursor ownership.** Add thread ownership to `RunningCursor` so that
-only the thread that created a cursor can increment it:
+**1. Clarify the `RunningCursor` API.** Replace the single `get_locked_cursor()`
+with two methods that match the two use cases, plus shared internal logic:
 
 ```python
-class RunningCursor:
+class RunningCursor(Cursor):
     def __init__(self, ...):
         self._index = 0
-        self._owner_thread = threading.current_thread()
+        self._owner_ident: int | None = None  # claimed on first use
 
-    def get_locked_cursor(self, ...):
-        if threading.current_thread() != self._owner_thread:
+    def _check_owner(self) -> None:
+        current_ident = threading.get_ident()
+        if self._owner_ident is None:
+            self._owner_ident = current_ident
+        elif self._owner_ident != current_ident:
             raise RuntimeError(
                 "Cursor accessed from a thread that doesn't own it"
             )
-        index = self._index
+
+    def _advance(self) -> None:
         self._index += 1
-        return LockedCursor(index=index, ...)
+        self._transient_index = None
+        self._transient_elements = SparseList[Element]()
+
+    def lock_element(self, **props) -> LockedCursor:
+        """Reserve the current position for an element and advance."""
+        self._check_owner()
+        locked = LockedCursor(
+            root_container=self._root_container,
+            parent_path=self._parent_path,
+            index=self._index,
+            **props,
+        )
+        self._advance()
+        return locked
+
+    def open_block(self) -> RunningCursor:
+        """Create a child cursor for a new block and advance."""
+        self._check_owner()
+        child = RunningCursor(
+            root_container=self._root_container,
+            parent_path=(*self._parent_path, self._index),
+        )
+        self._advance()
+        return child
 ```
 
-This enforces the invariant: a worker thread must write into a branched container,
-never directly onto the main thread's cursor. If future code accidentally shares a
-cursor across threads, the error surfaces immediately.
+`DeltaGenerator._enqueue()` calls `lock_element()` (elements); `DeltaGenerator._block()`
+calls `open_block()` (containers). `get_locked_cursor()` is a purely internal API
+(only called in `delta_generator.py`) so it can be replaced directly.
+
+**2. Pre-create the container on the main thread.** In `wrap()`, the main thread
+calls `st.container()` before dispatching. This calls `open_block()` on the main
+thread's cursor, which advances it past the fragment's slot and creates a child
+`RunningCursor` for the container. The container delta reaches the frontend
+immediately (enabling the loading skeleton). The child cursor starts with
+`_owner_thread = None` — it hasn't been used yet.
+
+**3. Lazy thread ownership.** When the worker thread runs and calls `lock_element()`
+on the container's cursor for the first time, `_check_owner()` claims it — setting
+`_owner_ident` to the worker thread's ID via `threading.get_ident()`. From that
+point, any other thread accessing that cursor gets an immediate `RuntimeError`.
+This enforces the invariant without requiring explicit ownership transfer: the main
+thread creates the cursor but never uses it; the worker thread claims it on first
+use. Using `get_ident()` (an int) rather than `current_thread()` (a Thread object)
+avoids the dictionary lookup overhead on every `st.*` call.
 
 #### Element registration
 
@@ -382,8 +439,7 @@ frontend:
    lightweight reference instead of the full message. This set is written once at
    `ctx.reset()` and only read during execution, so it is safe for concurrent access
    without synchronization. (A separate spec will assess whether `cached_message_hashes`
-   and other `ScriptRunContext` fields should be made formally immutable — see the
-   `ScriptRunContext` immutability assessment task.)
+   and other `ScriptRunContext` fields should be made formally immutable.)
 
 2. **`ScriptRunner._enqueue_forward_msg()`** — calls
    `_maybe_handle_execution_control_request()` (the yield point check — see
@@ -392,10 +448,62 @@ frontend:
    commands in tight loops, `st.yield_point()` provides an explicit yield point without
    emitting a delta (see [#14523](https://github.com/streamlit/streamlit/issues/14523)).
 
-**`ForwardMsgQueue` thread safety:** The queue is not thread-safe today. Add
-`threading.Lock` around `enqueue()`, `clear()`, and `flush()` so that deltas from
-multiple threads can be enqueued concurrently without corrupting the internal list or
-index map.
+**`ForwardMsgQueue` — already safe via event loop serialization:** The queue is
+not internally thread-safe (`threading.Lock` was [removed in
+PR #4568](https://github.com/streamlit/streamlit/pull/4568)), but all access
+is serialized through `call_soon_threadsafe` onto the Tornado event loop thread.
+No changes are needed for parallel fragments.
+
+The enqueue path is the same for both the main script thread and parallel
+fragment worker threads:
+
+```
+st.text("hello")                               (on script thread or worker thread)
+  → ctx.enqueue(msg)                           script_run_context.py
+    → ScriptRunner._enqueue_forward_msg(msg)   script_runner.py — yield point check
+      → on_event.send(ENQUEUE_FORWARD_MSG)     blinker signal, fires synchronously
+        → AppSession._on_scriptrunner_event    still on the calling thread
+          → call_soon_threadsafe(callback)     schedules onto event loop, returns immediately
+                                                ──→ event loop thread picks up callback
+                                                    → _browser_queue.enqueue(msg)
+```
+
+The key hop is `call_soon_threadsafe`: it pushes a callback onto the event
+loop's queue and returns immediately — the calling thread never blocks. The
+event loop thread (Tornado) processes callbacks one at a time, so
+`_browser_queue.enqueue()` is only ever called from a single thread.
+
+```python
+# AppSession._on_scriptrunner_event (called on the script/worker thread):
+def _on_scriptrunner_event(self, sender, event, forward_msg=None, ...):
+    """Called from the ScriptRunner's script thread.
+    Forwards to the event loop thread."""
+    self._event_loop.call_soon_threadsafe(
+        lambda: self._handle_scriptrunner_event_on_event_loop(
+            sender, event, forward_msg, ...
+        )
+    )
+
+# _handle_scriptrunner_event_on_event_loop (called on the event loop thread):
+def _handle_scriptrunner_event_on_event_loop(self, sender, event, ...):
+    # ... (checks sender is current ScriptRunner) ...
+    if event == ScriptRunnerEvent.ENQUEUE_FORWARD_MSG:
+        self._enqueue_forward_msg(forward_msg)  # → _browser_queue.enqueue()
+```
+
+This pattern was introduced for fast reruns (where multiple ScriptRunners
+may be active simultaneously, each on its own thread) and extends naturally
+to parallel fragment threads: multiple worker threads calling `ctx.enqueue()`
+each schedule an event loop callback, and the event loop processes them
+sequentially. No lock is needed.
+
+Adding a `threading.Lock` directly to the queue — so that worker threads
+could bypass `call_soon_threadsafe` and enqueue deltas directly — is a
+potential future optimization but is not required for correctness. The
+bottleneck for parallel fragments is I/O and computation (HTTP requests,
+database queries, data processing), not the delta delivery path. The event
+loop serialization adds microseconds of overhead per `st.*` call, which is
+negligible compared to the millisecond-to-second cost of actual fragment work.
 
 #### Delta ordering
 
@@ -452,6 +560,27 @@ class ScriptRunContext:
 
     # 4. Per-thread fragment state — new abstraction
     thread_state: FragmentThreadState
+
+    def __post_init__(self):
+        self._main_thread_ident = threading.get_ident()
+
+    def reset(self, ...) -> None:
+        """Re-initialize mutable state for a new script run.
+        Must only be called from the main script thread."""
+        if threading.get_ident() != self._main_thread_ident:
+            raise RuntimeError(
+                "reset() must only be called from the main script thread"
+            )
+        self.shared.reset(...)
+        self.thread_state.reset(...)
+        self.parallel_coordinator = ParallelFragmentCoordinator(
+            yield_check=self._yield_check,
+        )
+
+    def enqueue(self, msg: ForwardMsg) -> None:
+        """Enqueue a ForwardMsg, substituting a cached ref if possible."""
+        ...
+        self._enqueue(msg_to_send)
 ```
 
 Adding a new field forces an explicit decision: does it go on `FragmentThreadState`
@@ -505,19 +634,110 @@ The initialization is safe because it runs on the main script thread before para
 fragments are dispatched. **Future enhancement:** an atomic update helper or scoped
 lock API could make this more ergonomic (to be filed after parallel fragments ships).
 
-**`PagesManager`** has no internal locking today. `st.navigation` calls `set_pages()`
-then `get_page_script()` — with concurrent callers, Thread A's read can see Thread B's
-page set. `st.switch_page` reads `get_pages()` and mutates
-`set_current_page_script_hash()` via `ctx.set_mpa_v2_page()`. There is no "called
-once" enforcement on `st.navigation` today; repeated calls silently overwrite even in
-synchronous execution. Add `threading.Lock` wrapping `set_pages()`, `get_pages()`,
-`get_page_script()`, and `set_current_page_script_hash()` — the same pattern as
-`SafeSessionState`. The class-level `uses_pages_directory` flag should also be moved
-to an instance attribute (it is currently process-wide, not session-scoped).
+**`PagesManager`** has no internal locking today. `st.navigation` performs a
+compound write-then-read (`set_pages()` followed by `get_page_script()`),
+and `st.switch_page` reads pages then writes the current page hash. With
+concurrent callers these could interleave.
 
-**`FragmentStorage`** is written to when `@st.fragment` definitions execute and read
-after join for `clear()`. Add a lock to its internal dict — addressed in the feature
-PR alongside the coordinator integration.
+Add `threading.Lock` internally and refactor the API to eliminate exposed
+get/set pairs that are unsafe to call independently under concurrency:
+
+```python
+class PagesManager:
+    def __init__(self, ...):
+        self._lock = threading.Lock()
+        self._pages: dict[PageHash, PageInfo] | None = None
+        self._current_page_script_hash: PageHash = ""
+        # Move from class-level to instance attribute
+        self._uses_pages_directory: bool = Path(...).exists()
+        ...
+
+    def set_pages_and_resolve(
+        self,
+        pages: dict[PageHash, PageInfo],
+        fallback_page_hash: PageHash = "",
+    ) -> PageInfo | None:
+        """Atomically set the page registry and resolve the current page.
+        Replaces the separate set_pages() + get_page_script() calls."""
+        with self._lock:
+            self._pages = pages
+            return self._resolve_page_script(fallback_page_hash)
+
+    def get_pages(self) -> dict[PageHash, PageInfo]:
+        """Return a snapshot of the current page registry.
+        No lock needed — the only write to _pages goes through
+        set_pages_and_resolve(), which is already lock-protected."""
+        return dict(self._pages) if self._pages else {
+            self.main_script_hash: { ... }
+        }
+
+    def set_current_page_script_hash(self, h: PageHash) -> None:
+        """No lock needed — standalone write, not read by
+        set_pages_and_resolve() or any compound operation."""
+        self._current_page_script_hash = h
+
+    def _resolve_page_script(self, fallback: PageHash) -> PageInfo | None:
+        """Internal resolver — caller must hold self._lock."""
+        ...  # existing get_page_script() logic
+
+    # set_pages() removed from public API — only used via set_pages_and_resolve()
+    # get_page_script() made private as _resolve_page_script()
+```
+
+Callers change as follows:
+
+```python
+# st.navigation (before):
+ctx.pages_manager.set_pages(pagehash_to_pageinfo)
+found_page = ctx.pages_manager.get_page_script(fallback_page_hash=...)
+
+# st.navigation (after):
+found_page = ctx.pages_manager.set_pages_and_resolve(
+    pagehash_to_pageinfo, fallback_page_hash=...
+)
+
+# st.switch_page — get_pages() is a standalone read, no change needed:
+all_app_pages = ctx.pages_manager.get_pages().values()
+```
+
+The class-level `uses_pages_directory` flag is moved to an instance
+attribute (`self._uses_pages_directory`) since it is session-scoped state,
+not process-wide.
+
+**`FragmentStorage`** (`MemoryFragmentStorage`) wraps a plain `dict` with no
+locking. Rename and lock-protect to clarify intent — these are independent
+operations used in different phases, not a compound get/set pair:
+
+```python
+class MemoryFragmentStorage(FragmentStorage):
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._fragments: dict[str, Fragment] = {}
+
+    def register(self, key: str, fragment: Fragment) -> None:
+        """Store a fragment definition. Called during script execution
+        from the main thread or worker threads (nested fragments).
+        Lock-protected — concurrent registration is the only mutation
+        that can overlap."""
+        with self._lock:
+            self._fragments[key] = fragment
+
+    def lookup(self, key: str) -> Fragment:
+        """Look up a fragment to re-execute. Called during fragment
+        reruns, which are sequential — no concurrent writers."""
+        return self._fragments[key]
+
+    def clear(self, new_fragment_ids: set[str] | None = None) -> None:
+        """Remove orphaned fragments. Lock-protected to guard against
+        a register()/clear() race if ordering invariants change."""
+        with self._lock:
+            ...
+```
+
+`register()` and `clear()` share the lock to protect against concurrent
+dict mutation. `lookup()` doesn't need a lock — the only possible race
+would be a get/set pattern, which doesn't apply here since registration
+and lookup are independent operations in separate phases.
 
 #### `SharedRunState` — shared mutable run state
 
@@ -554,10 +774,9 @@ land with the thread-safe shared sets work.
 
 #### `FragmentThreadState` — per-thread fragment state
 
-Bundles per-thread fields into a dataclass created fresh per worker thread by
-`_dispatch_parallel_fragment`. On the main thread, a single instance is reused.
-Replaces the implicit `copy_context()` isolation with explicit per-thread object
-creation.
+Bundles per-thread fields into a dataclass. Each worker thread gets a fresh
+instance created by `_dispatch_parallel_fragment`; the main thread reuses a
+single instance across the run.
 
 ```python
 @dataclass
@@ -571,14 +790,11 @@ class FragmentThreadState:
 
 `in_cached_function` remains a `ContextVar` (it's also used outside fragments). The
 other per-thread fields move here, making `_dispatch_parallel_fragment` explicit:
-create a `FragmentThreadState`, pass it to the worker thread, done — no reliance on
-`copy_context()` correctly copying the right fields. This can land with the parallel
-fragment coordinator integration.
+create a `FragmentThreadState`, pass it to the worker thread, done.
 
-**Migration path:** callers that access `ctx.widget_ids_this_run` change to
-`ctx.shared.add_widget_id()`. Callers that access `ctx.current_fragment_id` change to
-`ctx.thread_state.fragment_id`. The restructuring can happen incrementally —
-`SharedRunState` and `FragmentThreadState` can land in separate PRs.
+Callers change from bare field access (e.g. `ctx.widget_ids_this_run.add()`,
+`ctx.current_fragment_id`) to the namespaced equivalents (`ctx.shared.add_widget_id()`,
+`ctx.thread_state.fragment_id`).
 
 ### API restrictions during parallel execution
 
@@ -591,12 +807,23 @@ commands (`st.rerun`, `st.stop`) are handled by the cooperative cancellation mec
 The APIs below require explicit restrictions because they have structural side effects
 that are disruptive or nonsensical during concurrent execution and cannot be addressed
 by locking alone. All follow the same pattern: **prohibited during the parallel batch**
-(worker threads), **allowed during sequential fragment reruns** (single-threaded). The
-implementation can use the same detection mechanism — checking whether the current
-thread is a parallel fragment worker (e.g., via
-`ctx.parallel_coordinator.is_active()` combined with
-`threading.current_thread() != main_thread`, or via a per-thread flag set by
-`_dispatch_parallel_fragment`).
+(worker threads), **allowed during sequential fragment reruns** (single-threaded).
+
+Detection uses a flag on `FragmentThreadState`, set once by
+`_dispatch_parallel_fragment` at thread creation:
+
+```python
+@dataclass
+class FragmentThreadState:
+    ...
+    is_parallel_worker: bool = False  # True only on worker threads
+
+def _check_not_parallel_worker(ctx: ScriptRunContext, api_name: str) -> None:
+    if ctx.thread_state.is_parallel_worker:
+        raise StreamlitAPIException(
+            f"{api_name} cannot be called from a parallel fragment."
+        )
+```
 
 #### Dialogs (`@st.dialog`)
 
@@ -616,12 +843,20 @@ Per [reviewer feedback](https://github.com/streamlit/streamlit/pull/14277#discus
 opening a dialog from a fragment rerun is a common and valid pattern (e.g., a button
 in a dashboard card opens a detail dialog). Blocking this would be overly restrictive.
 
-**Implementation:** the dialog guard in `_check_dialog_guard`
-(`lib/streamlit/elements/lib/dialog.py`) should raise `StreamlitAPIException` during
-the parallel batch. During sequential fragment reruns, the existing
-`has_dialog_opened` check (one dialog per rerun) still applies unchanged. No
-synchronization is needed on `has_dialog_opened` itself — it is only read/written
-during sequential execution.
+**Implementation:** add a parallel worker check to `_check_dialog_guard`
+(`lib/streamlit/elements/lib/dialog.py`):
+
+```python
+def _check_dialog_guard(should_open: bool) -> None:
+    ctx = get_script_run_ctx()
+    if should_open and ctx:
+        _check_not_parallel_worker(ctx, "@st.dialog")
+        # Existing one-dialog-per-rerun check (unchanged, only runs
+        # during sequential execution so no synchronization needed)
+        if ctx.has_dialog_opened:
+            raise StreamlitAPIException(...)
+        ctx.has_dialog_opened = True
+```
 
 #### Page navigation (`st.switch_page`)
 
@@ -634,7 +869,13 @@ navigating simultaneously would race on the destination page.
 During a sequential fragment rerun, `st.switch_page` is a valid and common pattern
 (e.g., a button in a dashboard card navigates to a detail page).
 
-**Implementation:** add a parallel-batch check in `switch_page`
-(`lib/streamlit/commands/execution_control.py`). No existing guard exists today — the
-function has no fragment awareness. The check should raise `StreamlitAPIException`
-during the parallel batch.
+**Implementation:** add a parallel worker check at the top of `switch_page`
+(`lib/streamlit/commands/execution_control.py`):
+
+```python
+def switch_page(page: str | Path | StreamlitPage, ...) -> NoReturn:
+    ctx = get_script_run_ctx()
+    if ctx:
+        _check_not_parallel_worker(ctx, "st.switch_page")
+    # ... existing implementation
+```


### PR DESCRIPTION
## Describe your changes

Tech spec for `@st.fragment(parallel=True)` — internal architecture for running fragment
functions in parallel threads during full app runs.

Covers three areas:
- **Execution flow** — thread dispatch, join barrier, cooperative cancellation (coordinator,
  yield points, `st.stop()`/`st.rerun()` scenarios)
- **Content rendering pipeline** — cursor ownership, element registration (thread-safe widget/form
  ID sets), message delivery (cached message dedup, `ForwardMsgQueue` locking), element cleanup
- **Shared mutable state** — full `ScriptRunContext` field catalogue across 4 categories
  (already safe, per-thread isolated, needs synchronization, needs guards)

Companion to the [product spec](https://github.com/streamlit/streamlit/pull/14277) and
[prototype](https://github.com/streamlit/streamlit/pull/14443).

References separate specs for thread-safe shared sets and `st.yield_point()`.

## GitHub Issue Link (if applicable)

Refs #14277

## Testing Plan

- Spec-only PR, no code changes

Made with [Cursor](https://cursor.com)