### PR TITLE
[Fix] Make `_stcore/metrics` OpenMetrics-compliant

### DIFF
--- a/e2e_playwright/web_server_test.py
+++ b/e2e_playwright/web_server_test.py
@@ -155,7 +155,7 @@ def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_base_url
     text = response.text()
     # Should contain cache_memory_bytes metrics (guaranteed by session state in web_server.py)
     assert "cache_memory_bytes" in text
-    # Should NOT contain session_events_total or active_sessions metrics
+    # Should NOT contain session event counter samples or active_sessions metrics
     assert "session_events_total" not in text
     assert "active_sessions" not in text
 
@@ -177,7 +177,7 @@ def test_metrics_endpoint_filters_by_family_session_events(
     assert response.status == 200
 
     text = response.text()
-    # Should contain session_events_total metrics
+    # Should contain session event counter samples
     assert "session_events_total" in text
     # Should NOT contain cache_memory_bytes or active_sessions metrics
     assert "cache_memory_bytes" not in text
@@ -203,7 +203,7 @@ def test_metrics_endpoint_filters_by_family_active_sessions(
     text = response.text()
     # Should contain active_sessions metrics
     assert "active_sessions" in text
-    # Should NOT contain cache_memory_bytes or session_events_total metrics
+    # Should NOT contain cache_memory_bytes or session event counter samples
     assert "cache_memory_bytes" not in text
     assert "session_events_total" not in text
 
@@ -225,7 +225,7 @@ def test_metrics_endpoint_filters_by_multiple_families(app: Page, app_base_url: 
     assert response.status == 200
 
     text = response.text()
-    # Should contain both session_events_total and active_sessions metrics
+    # Should contain both session event counter samples and active_sessions metrics
     assert "session_events_total" in text
     assert "active_sessions" in text
     # Should NOT contain cache_memory_bytes metrics

--- a/e2e_playwright/web_server_test.py
+++ b/e2e_playwright/web_server_test.py
@@ -163,13 +163,13 @@ def test_metrics_endpoint_filters_by_family_cache_memory(app: Page, app_base_url
 def test_metrics_endpoint_filters_by_family_session_events(
     app: Page, app_base_url: str
 ):
-    """Test that metrics endpoint returns session_events_total when requested.
+    """Test that metrics endpoint returns session event samples when requested.
 
     Session events metrics track connections, reconnections, and disconnections.
     """
     response = app.request.get(
         build_app_url(
-            app_base_url, path="/_stcore/metrics", query="families=session_events_total"
+            app_base_url, path="/_stcore/metrics", query="families=session_events"
         )
     )
 
@@ -217,7 +217,7 @@ def test_metrics_endpoint_filters_by_multiple_families(app: Page, app_base_url: 
         build_app_url(
             app_base_url,
             path="/_stcore/metrics",
-            query="families=session_events_total&families=active_sessions",
+            query="families=session_events&families=active_sessions",
         )
     )
 

--- a/e2e_playwright/websocket_reconnects_test.py
+++ b/e2e_playwright/websocket_reconnects_test.py
@@ -42,7 +42,7 @@ def _get_session_event_counts(app: Page, app_base_url: str) -> dict[str, int]:
     """
     response = app.request.get(
         build_app_url(
-            app_base_url, path="/_stcore/metrics", query="families=session_events_total"
+            app_base_url, path="/_stcore/metrics", query="families=session_events"
         )
     )
     text = response.text()
@@ -168,7 +168,7 @@ def test_retain_captured_pictures_when_websocket_connection_drops_and_reconnects
 def test_session_event_metrics_increase_on_disconnect_and_reconnect(
     app: Page, app_base_url: str
 ):
-    """Test that session_events_total metrics increase on disconnect/reconnect.
+    """Test that session event counter samples increase on disconnect/reconnect.
 
     Due to React strict mode, components may mount multiple times, so we only
     verify that metrics increase rather than checking exact values.
@@ -201,7 +201,7 @@ def test_session_event_metrics_increase_on_disconnect_and_reconnect(
 def test_session_event_metrics_increase_after_multiple_disconnects(
     app: Page, app_base_url: str
 ):
-    """Test that session_events_total metrics accumulate over multiple disconnects.
+    """Test that session event counter samples accumulate over multiple disconnects.
 
     Due to React strict mode, components may mount multiple times, so we only
     verify that metrics increase rather than checking exact values.

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -18,7 +18,7 @@ import itertools
 from typing import TYPE_CHECKING, Final, NamedTuple, Protocol, runtime_checkable
 
 CACHE_MEMORY_FAMILY: Final = "cache_memory_bytes"
-SESSION_EVENTS_FAMILY: Final = "session_events_total"
+SESSION_EVENTS_FAMILY: Final = "session_events"
 SESSION_DURATION_FAMILY: Final = "session_duration_seconds"
 ACTIVE_SESSIONS_FAMILY: Final = "active_sessions"
 
@@ -150,7 +150,7 @@ class CounterStat(NamedTuple):
     Properties
     ----------
     family_name : str
-        The name of the metric family (e.g. 'session_events_total').
+        The name of the metric family (e.g. 'session_events').
     value : int
         The current count value.
     labels : dict[str, str] | None
@@ -159,8 +159,6 @@ class CounterStat(NamedTuple):
         The unit of the metric (e.g. '' for unitless).
     help : str
         A description of the metric.
-    sample_name : str | None
-        The emitted sample name when it differs from the metric family name.
     """
 
     family_name: str
@@ -168,14 +166,13 @@ class CounterStat(NamedTuple):
     labels: dict[str, str] | None = None
     unit: str = ""
     help: str = ""
-    sample_name: str | None = None
 
     @property
     def type(self) -> str:
         return "counter"
 
     def to_metric_str(self) -> str:
-        metric_name = self.sample_name or self.family_name
+        metric_name = f"{self.family_name}_total"
         if self.labels:
             labels_str = ",".join(f'{k}="{v}"' for k, v in sorted(self.labels.items()))
             return f"{metric_name}{{{labels_str}}} {self.value}"

--- a/lib/streamlit/runtime/websocket_session_manager.py
+++ b/lib/streamlit/runtime/websocket_session_manager.py
@@ -285,7 +285,6 @@ class WebsocketSessionManager(SessionManager, StatsProvider):
             result[SESSION_DURATION_FAMILY] = [
                 CounterStat(
                     family_name=SESSION_DURATION_FAMILY,
-                    sample_name=f"{SESSION_DURATION_FAMILY}_total",
                     value=total_duration,
                     unit="seconds",
                     help="Total time spent in active sessions, in seconds.",

--- a/lib/streamlit/web/server/stats_request_handler.py
+++ b/lib/streamlit/web/server/stats_request_handler.py
@@ -50,7 +50,7 @@ class StatsRequestHandler(tornado.web.RequestHandler):
 
         # Allow caller to request specific metric families via query parameter.
         # If no families are specified, all metrics are returned.
-        # Example: /_stcore/metrics?families=session_events_total&families=active_sessions
+        # Example: /_stcore/metrics?families=session_events&families=active_sessions
         requested_families = self.get_arguments("families")
         stats = self._manager.get_stats(family_names=requested_families or None)
         # If the request asked for protobuf output, we return a serialized
@@ -77,8 +77,9 @@ class StatsRequestHandler(tornado.web.RequestHandler):
             # our OpenMetrics comments.
             first_stat = stats[0]
             result.append(f"# TYPE {first_stat.family_name} {first_stat.type}")
-            result.append(f"# UNIT {first_stat.family_name} {first_stat.unit}")
-            result.append(f"# HELP {first_stat.help}")
+            if first_stat.unit:
+                result.append(f"# UNIT {first_stat.family_name} {first_stat.unit}")
+            result.append(f"# HELP {first_stat.family_name} {first_stat.help}")
             result.extend(stat.to_metric_str() for stat in stats)
 
         result.append("# EOF\n")

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -304,12 +304,11 @@ class CounterStatTest(unittest.TestCase):
         assert stat.help == "A test counter."
         assert stat.value == 42
         assert stat.labels == {"type": "test"}
-        assert stat.sample_name is None
 
     def test_counter_stat_to_metric_str(self) -> None:
         """CounterStat.to_metric_str should format correctly."""
         stat = CounterStat(
-            family_name="session_events_total",
+            family_name="session_events",
             value=10,
             labels={"type": "connection"},
         )
@@ -323,25 +322,23 @@ class CounterStatTest(unittest.TestCase):
             value=5,
             labels={"z_label": "z_val", "a_label": "a_val"},
         )
-        expected = 'my_counter{a_label="a_val",z_label="z_val"} 5'
+        expected = 'my_counter_total{a_label="a_val",z_label="z_val"} 5'
         assert stat.to_metric_str() == expected
 
-    def test_counter_stat_to_metric_str_with_sample_name(self) -> None:
-        """CounterStat.to_metric_str should support a sample name override."""
+    def test_counter_stat_to_metric_str_with_unit_suffix_family_name(self) -> None:
+        """CounterStat.to_metric_str should append _total to counter family names."""
         stat = CounterStat(
             family_name="session_duration_seconds",
-            sample_name="session_duration_seconds_total",
             value=42,
             unit="seconds",
         )
         expected = "session_duration_seconds_total 42"
         assert stat.to_metric_str() == expected
 
-    def test_counter_stat_to_metric_str_with_sample_name_and_labels(self) -> None:
-        """CounterStat.to_metric_str should support sample names with labels."""
+    def test_counter_stat_to_metric_str_with_labels(self) -> None:
+        """CounterStat.to_metric_str should append _total for labeled counters."""
         stat = CounterStat(
             family_name="session_duration_seconds",
-            sample_name="session_duration_seconds_total",
             value=42,
             labels={"region": "us-west"},
             unit="seconds",
@@ -355,7 +352,7 @@ class CounterStatTest(unittest.TestCase):
             family_name="simple_counter",
             value=7,
         )
-        expected = "simple_counter 7"
+        expected = "simple_counter_total 7"
         assert stat.to_metric_str() == expected
 
 

--- a/lib/tests/streamlit/runtime/websocket_session_manager_test.py
+++ b/lib/tests/streamlit/runtime/websocket_session_manager_test.py
@@ -359,9 +359,9 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         """Stats should all be zero initially."""
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "connect") == 0
-        assert self._get_stat_value(stats, "session_events_total", "reconnect") == 0
-        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+        assert self._get_stat_value(stats, "session_events", "connect") == 0
+        assert self._get_stat_value(stats, "session_events", "reconnect") == 0
+        assert self._get_stat_value(stats, "session_events", "disconnect") == 0
         assert self._get_stat_value(stats, "session_duration_seconds") == 0
         assert self._get_stat_value(stats, "active_sessions") == 0
 
@@ -370,9 +370,9 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.connect_session()
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
-        assert self._get_stat_value(stats, "session_events_total", "reconnect") == 0
-        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+        assert self._get_stat_value(stats, "session_events", "connect") == 1
+        assert self._get_stat_value(stats, "session_events", "reconnect") == 0
+        assert self._get_stat_value(stats, "session_events", "disconnect") == 0
         assert self._get_stat_value(stats, "active_sessions") == 1
 
     def test_multiple_connections(self) -> None:
@@ -382,7 +382,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.connect_session()
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "connect") == 3
+        assert self._get_stat_value(stats, "session_events", "connect") == 3
         assert self._get_stat_value(stats, "active_sessions") == 3
 
     @patch(
@@ -404,8 +404,8 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.connect_session(existing_session_id=session_id)
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
-        assert self._get_stat_value(stats, "session_events_total", "reconnect") == 1
+        assert self._get_stat_value(stats, "session_events", "connect") == 1
+        assert self._get_stat_value(stats, "session_events", "reconnect") == 1
         assert self._get_stat_value(stats, "active_sessions") == 1
 
     def test_disconnect_session_increments_disconnection(self) -> None:
@@ -414,8 +414,8 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.disconnect_session(session_id)
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
-        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 1
+        assert self._get_stat_value(stats, "session_events", "connect") == 1
+        assert self._get_stat_value(stats, "session_events", "disconnect") == 1
         assert self._get_stat_value(stats, "active_sessions") == 0
 
     def test_disconnect_session_on_invalid_session_does_not_increment(self) -> None:
@@ -423,7 +423,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.disconnect_session("nonexistent_session")
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 0
+        assert self._get_stat_value(stats, "session_events", "disconnect") == 0
 
     @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
     def test_close_active_session_increments_disconnection(self) -> None:
@@ -432,8 +432,8 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.close_session(session_id)
         stats = self.session_mgr.get_stats()
 
-        assert self._get_stat_value(stats, "session_events_total", "connect") == 1
-        assert self._get_stat_value(stats, "session_events_total", "disconnect") == 1
+        assert self._get_stat_value(stats, "session_events", "connect") == 1
+        assert self._get_stat_value(stats, "session_events", "disconnect") == 1
         assert self._get_stat_value(stats, "active_sessions") == 0
 
     @patch("streamlit.runtime.app_session.AppSession.shutdown", new=MagicMock())
@@ -447,7 +447,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         self.session_mgr.disconnect_session(session_id)
         stats_after_disconnect = self.session_mgr.get_stats()
         disconnect_count = self._get_stat_value(
-            stats_after_disconnect, "session_events_total", "disconnect"
+            stats_after_disconnect, "session_events", "disconnect"
         )
 
         # Close the stored session - should not increment counter again
@@ -455,9 +455,7 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         stats_after_close = self.session_mgr.get_stats()
 
         assert (
-            self._get_stat_value(
-                stats_after_close, "session_events_total", "disconnect"
-            )
+            self._get_stat_value(stats_after_close, "session_events", "disconnect")
             == disconnect_count
         )
 
@@ -467,28 +465,29 @@ class WebsocketSessionManagerMetricsTests(unittest.TestCase):
         stats_dict = self.session_mgr.get_stats()
 
         assert len(stats_dict) == 3
-        assert "session_events_total" in stats_dict
+        assert "session_events" in stats_dict
         assert "session_duration_seconds" in stats_dict
         assert "active_sessions" in stats_dict
 
-        # Check session_events_total counters
-        session_events = stats_dict["session_events_total"]
+        # Check session_events counters
+        session_events = stats_dict["session_events"]
         assert len(session_events) == 3
         for stat in session_events:
             assert isinstance(stat, CounterStat)
-            assert stat.family_name == "session_events_total"
+            assert stat.family_name == "session_events"
             assert stat.type == "counter"
             assert stat.labels is not None
             assert "type" in stat.labels
+            assert stat.to_metric_str().startswith("session_events_total")
 
         # Check session_duration_seconds counter
         session_duration = stats_dict["session_duration_seconds"]
         assert len(session_duration) == 1
         assert isinstance(session_duration[0], CounterStat)
         assert session_duration[0].family_name == "session_duration_seconds"
-        assert session_duration[0].sample_name == "session_duration_seconds_total"
         assert session_duration[0].type == "counter"
         assert session_duration[0].unit == "seconds"
+        assert session_duration[0].to_metric_str() == "session_duration_seconds_total 0"
 
         # Check active_sessions gauge
         active_sessions = stats_dict["active_sessions"]

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -56,9 +56,9 @@ class _DummyStatsManager:
     def __init__(self) -> None:
         self._stats: dict[str, list[CacheStat | CounterStat | GaugeStat]] = {
             "cache_memory_bytes": [CacheStat("test_cache", "", 1)],
-            "session_events_total": [
+            "session_events": [
                 CounterStat(
-                    family_name="session_events_total",
+                    family_name="session_events",
                     value=5,
                     labels={"type": "connect"},
                     help="Total count of session events by type.",
@@ -67,7 +67,6 @@ class _DummyStatsManager:
             "session_duration_seconds": [
                 CounterStat(
                     family_name="session_duration_seconds",
-                    sample_name="session_duration_seconds_total",
                     value=42,
                     unit="seconds",
                     help="Total time spent in active sessions, in seconds.",
@@ -223,10 +222,21 @@ def test_metrics_endpoint(starlette_client: tuple[TestClient, _DummyRuntime]) ->
     assert response.status_code == 200
     assert "cache_memory_bytes" in response.text
     assert "session_events_total" in response.text
+    assert "# TYPE session_events counter" in response.text
+    assert (
+        "# HELP session_events Total count of session events by type." in response.text
+    )
+    assert "# UNIT session_events " not in response.text
     assert "# TYPE session_duration_seconds counter" in response.text
     assert "# UNIT session_duration_seconds seconds" in response.text
+    assert (
+        "# HELP session_duration_seconds Total time spent in active sessions, in seconds."
+        in response.text
+    )
     assert "session_duration_seconds_total 42" in response.text
     assert "active_sessions" in response.text
+    assert "# HELP active_sessions Current number of active sessions." in response.text
+    assert "# UNIT active_sessions " not in response.text
 
 
 def test_metrics_endpoint_filters_single_family(
@@ -234,7 +244,7 @@ def test_metrics_endpoint_filters_single_family(
 ) -> None:
     """Test that the metrics endpoint filters by a single family."""
     client, _ = starlette_client
-    response = client.get("/_stcore/metrics?families=session_events_total")
+    response = client.get("/_stcore/metrics?families=session_events")
     assert response.status_code == 200
     assert "session_events_total" in response.text
     assert "cache_memory_bytes" not in response.text
@@ -247,7 +257,7 @@ def test_metrics_endpoint_filters_multiple_families(
     """Test that the metrics endpoint filters by multiple families."""
     client, _ = starlette_client
     response = client.get(
-        "/_stcore/metrics?families=session_events_total&families=active_sessions"
+        "/_stcore/metrics?families=session_events&families=active_sessions"
     )
     assert response.status_code == 200
     assert "session_events_total" in response.text

--- a/lib/tests/streamlit/web/server/stats_handler_test.py
+++ b/lib/tests/streamlit/web/server/stats_handler_test.py
@@ -86,7 +86,7 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
         expected_body = (
             b"# TYPE cache_memory_bytes gauge\n"
             b"# UNIT cache_memory_bytes bytes\n"
-            b"# HELP Total memory consumed by a cache.\n"
+            b"# HELP cache_memory_bytes Total memory consumed by a cache.\n"
             b'cache_memory_bytes{cache_type="st.singleton",cache="foo"} 128\n'
             b'cache_memory_bytes{cache_type="st.memo",cache="bar"} 256\n'
             b"# EOF\n"
@@ -167,7 +167,6 @@ class StatsHandlerTest(tornado.testing.AsyncHTTPTestCase):
             "session_duration_seconds": [
                 CounterStat(
                     family_name="session_duration_seconds",
-                    sample_name="session_duration_seconds_total",
                     value=42,
                     unit="seconds",
                     help="Total time spent in active sessions, in seconds.",
@@ -213,9 +212,9 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
                     byte_length=128,
                 )
             ],
-            "session_events_total": [
+            "session_events": [
                 CounterStat(
-                    family_name="session_events_total",
+                    family_name="session_events",
                     value=5,
                     labels={"type": "connect"},
                     help="Total count of session events by type.",
@@ -224,7 +223,6 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
             "session_duration_seconds": [
                 CounterStat(
                     family_name="session_duration_seconds",
-                    sample_name="session_duration_seconds_total",
                     value=7,
                     unit="seconds",
                     help="Total time spent in active sessions, in seconds.",
@@ -265,10 +263,14 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
         assert "cache_memory_bytes" in body
         assert "session_events_total" in body
         assert "active_sessions" in body
+        assert "# TYPE session_events counter" in body
+        assert "# HELP session_events Total count of session events by type." in body
+        assert "# UNIT session_events " not in body
+        assert "# UNIT active_sessions " not in body
 
     def test_filter_single_family(self):
         """Filter should return only the requested family."""
-        response = self.fetch("/_stcore/metrics?families=session_events_total")
+        response = self.fetch("/_stcore/metrics?families=session_events")
         assert response.code == 200
 
         body = response.body.decode()
@@ -280,7 +282,7 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
     def test_filter_multiple_families(self):
         """Filter should support multiple family names."""
         response = self.fetch(
-            "/_stcore/metrics?families=session_events_total&families=active_sessions"
+            "/_stcore/metrics?families=session_events&families=active_sessions"
         )
         assert response.code == 200
 
@@ -291,11 +293,13 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
 
     def test_counter_stat_format(self):
         """CounterStat should be formatted correctly in text output."""
-        response = self.fetch("/_stcore/metrics?families=session_events_total")
+        response = self.fetch("/_stcore/metrics?families=session_events")
         assert response.code == 200
 
         body = response.body.decode()
-        assert "# TYPE session_events_total counter" in body
+        assert "# TYPE session_events counter" in body
+        assert "# HELP session_events Total count of session events by type." in body
+        assert "# UNIT session_events " not in body
         assert 'session_events_total{type="connect"} 5' in body
 
     def test_unitful_counter_stat_format(self):
@@ -306,6 +310,10 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
         body = response.body.decode()
         assert "# TYPE session_duration_seconds counter" in body
         assert "# UNIT session_duration_seconds seconds" in body
+        assert (
+            "# HELP session_duration_seconds Total time spent in active sessions, in seconds."
+            in body
+        )
         assert "session_duration_seconds_total 7" in body
 
     def test_gauge_stat_format(self):
@@ -315,4 +323,6 @@ class StatsHandlerFilterTest(tornado.testing.AsyncHTTPTestCase):
 
         body = response.body.decode()
         assert "# TYPE active_sessions gauge" in body
+        assert "# HELP active_sessions Current number of active sessions." in body
+        assert "# UNIT active_sessions " not in body
         assert "active_sessions 3" in body


### PR DESCRIPTION
## Describe your changes
- Canonicalize counter metric families in `/_stcore/metrics` so metadata uses OpenMetrics-compliant family names while emitted counter samples still use the `_total` suffix.
- Tighten text serialization to omit empty `# UNIT` lines and emit `# HELP <family_name> <help>`.
- Update runtime, server, and e2e metrics tests for the `session_events` family rename and the canonical family/sample split.

Follow-up to #14476 

### API-visible change
- `families=session_events_total` no longer works.
- Consumers should now request `families=session_events`.
- The emitted sample line remains `session_events_total{...}`.

## Testing Plan
- Unit Tests (JS and/or Python)
- E2E Tests