### PR TITLE
Add integer/pixel gap support to st.columns and st.container

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -60,6 +60,7 @@ import {
   getBorderBackwardsCompatible,
   getClassnamePrefix,
   getColumnGapSize,
+  getColumnPixelGap,
   getKeyFromId,
   isComponentStale,
   shouldActivateScrollToBottom,
@@ -168,12 +169,13 @@ export const FlexBoxContainer = (
     subElement: getLayoutSubElement(props.node.deltaBlock),
   })
 
+  const gapConfig = props.node.deltaBlock.flexContainer?.gapConfig
   const styles = {
     gap:
       // This is backwards compatible with old proto messages since previously
       // the gap size was defaulted to small.
-      props.node.deltaBlock.flexContainer?.gapConfig?.gapSize ??
-      streamlit.GapSize.SMALL,
+      gapConfig?.gapSize ?? streamlit.GapSize.SMALL,
+    pixelGap: gapConfig?.pixelGap ?? null,
     direction: direction,
     // This is also backwards compatible since previously wrap was not added
     // to the flex container.
@@ -386,6 +388,7 @@ export const BlockNodeRenderer = (
       <StyledColumn
         weight={node.deltaBlock.column.weight ?? 0}
         gap={getColumnGapSize(node.deltaBlock.column)}
+        pixelGap={getColumnPixelGap(node.deltaBlock.column)}
         verticalAlignment={
           node.deltaBlock.column.verticalAlignment ?? undefined
         }

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -144,15 +144,17 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
 interface StyledColumnProps {
   weight: number
   gap: streamlit.GapSize | undefined
+  pixelGap?: number | null
   showBorder: boolean
   verticalAlignment?: BlockProto.Column.VerticalAlignment
 }
 
 export const StyledColumn = styled.div<StyledColumnProps>(
-  ({ theme, weight, gap, showBorder, verticalAlignment }) => {
+  ({ theme, weight, gap, pixelGap, showBorder, verticalAlignment }) => {
     const { VerticalAlignment } = BlockProto.Column
     const percentage = weight * 100
-    const gapWidth = translateGapWidth(gap, theme)
+    const gapWidth =
+      pixelGap != null ? `${pixelGap}px` : translateGapWidth(gap, theme)
     const width =
       gapWidth === theme.spacing.none
         ? `${percentage}%`
@@ -240,6 +242,7 @@ const getJustifyContent = (
 export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
   gap?: streamlit.GapSize | undefined
+  pixelGap?: number | null
   flex?: React.CSSProperties["flex"]
   // This marks the prop as a transient property so it is
   // not passed to the DOM. It overlaps with a valid attribute
@@ -258,6 +261,7 @@ export const StyledFlexContainerBlock =
       theme,
       direction,
       gap,
+      pixelGap,
       flex,
       $wrap,
       height,
@@ -267,7 +271,9 @@ export const StyledFlexContainerBlock =
       overflow,
     }) => {
       let gapWidth
-      if (gap !== undefined) {
+      if (pixelGap != null) {
+        gapWidth = `${pixelGap}px`
+      } else if (gap !== undefined) {
         gapWidth = translateGapWidth(gap, theme)
       }
 

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -28,6 +28,7 @@ import {
   convertKeyToClassName,
   getBorderBackwardsCompatible,
   getColumnGapSize,
+  getColumnPixelGap,
   getKeyFromId,
   isElementStale,
   shouldActivateScrollToBottom,
@@ -187,6 +188,40 @@ describe("getColumnGapSize", () => {
   it("returns GapSize.SMALL when gapConfig does not exist", () => {
     const columnProto = {}
     expect(getColumnGapSize(columnProto)).toBe(streamlit.GapSize.SMALL)
+  })
+})
+
+describe("getColumnPixelGap", () => {
+  it("returns pixelGap when it exists", () => {
+    const columnProto = {
+      gapConfig: {
+        pixelGap: 10,
+      },
+    }
+    expect(getColumnPixelGap(columnProto)).toBe(10)
+  })
+
+  it("returns null when pixelGap is not set", () => {
+    const columnProto = {
+      gapConfig: {
+        gapSize: streamlit.GapSize.MEDIUM,
+      },
+    }
+    expect(getColumnPixelGap(columnProto)).toBeNull()
+  })
+
+  it("returns null when gapConfig does not exist", () => {
+    const columnProto = {}
+    expect(getColumnPixelGap(columnProto)).toBeNull()
+  })
+
+  it("returns 0 when pixelGap is 0", () => {
+    const columnProto = {
+      gapConfig: {
+        pixelGap: 0,
+      },
+    }
+    expect(getColumnPixelGap(columnProto)).toBe(0)
   })
 })
 

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -193,6 +193,15 @@ export function getColumnGapSize(
   return streamlit.GapSize.SMALL
 }
 
+export function getColumnPixelGap(
+  columnProto: BlockProto.IColumn
+): number | null {
+  if (columnProto.gapConfig?.pixelGap != null) {
+    return columnProto.gapConfig.pixelGap
+  }
+  return null
+}
+
 export function checkFlexContainerBackwardsCompatibile(
   blockProto: BlockProto
 ): boolean {

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -27,7 +27,7 @@ from streamlit.elements.lib.layout_utils import (
     Width,
     WidthWithoutContent,
     get_align,
-    get_gap_size,
+    get_gap_config,
     get_height_config,
     get_justify,
     get_width_config,
@@ -45,7 +45,6 @@ from streamlit.errors import (
     StreamlitValueError,
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
-from streamlit.proto.GapSize_pb2 import GapConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import register_widget
@@ -215,7 +214,7 @@ class LayoutsMixin:
               When ``horizontal`` is ``True``, ``"distribute"`` aligns the
               elements the same as ``"top"``.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", int, or None
             The minimum gap size between the elements inside the container.
             This can be one of the following:
 
@@ -226,6 +225,8 @@ class LayoutsMixin:
             - ``"large"``: 4rem gap between the elements.
             - ``"xlarge"``: 6rem gap between the elements.
             - ``"xxlarge"``: 8rem gap between the elements.
+            - An integer: specifies the gap in pixels for pixel-precise
+              control. Must be a non-negative integer.
             - ``None``: No gap between the elements.
 
             The rem unit is relative to the ``theme.baseFontSize``
@@ -343,8 +344,8 @@ class LayoutsMixin:
         block_proto = BlockProto()
         block_proto.allow_empty = False
         block_proto.flex_container.border = border or False
-        block_proto.flex_container.gap_config.gap_size = get_gap_size(
-            gap, "st.container"
+        block_proto.flex_container.gap_config.CopyFrom(
+            get_gap_config(gap, "st.container")
         )
 
         validate_horizontal_alignment(horizontal_alignment)
@@ -431,7 +432,7 @@ class LayoutsMixin:
               Or ``[1, 2, 3]`` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", int, or None
             The size of the gap between the columns. This can be one of the
             following:
 
@@ -442,6 +443,8 @@ class LayoutsMixin:
             - ``"large"``: 4rem gap between the columns.
             - ``"xlarge"``: 6rem gap between the columns.
             - ``"xxlarge"``: 8rem gap between the columns.
+            - An integer: specifies the gap in pixels for pixel-precise
+              control. Must be a non-negative integer.
             - ``None``: No gap between the columns.
 
             The rem unit is relative to the ``theme.baseFontSize``
@@ -595,9 +598,7 @@ class LayoutsMixin:
                 element_type="st.columns",
             )
 
-        gap_size = get_gap_size(gap, "st.columns")
-        gap_config = GapConfig()
-        gap_config.gap_size = gap_size
+        gap_config = get_gap_config(gap, "st.columns")
 
         def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -229,6 +229,9 @@ def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
 
     config = GapConfig()
 
+    if isinstance(gap, bool):
+        raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+
     if isinstance(gap, int):
         if gap < 0:
             raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -26,7 +26,7 @@ from streamlit.errors import (
     StreamlitInvalidWidthError,
 )
 from streamlit.proto.Block_pb2 import Block
-from streamlit.proto.GapSize_pb2 import GapSize
+from streamlit.proto.GapSize_pb2 import GapConfig, GapSize
 from streamlit.proto.HeightConfig_pb2 import HeightConfig
 from streamlit.proto.TextAlignmentConfig_pb2 import TextAlignmentConfig
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
@@ -41,9 +41,10 @@ SpaceSize: TypeAlias = (
         "stretch", "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge"
     ]
 )
-Gap: TypeAlias = Literal[
-    "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge"
-]
+Gap: TypeAlias = (
+    int
+    | Literal["xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge"]
+)
 HorizontalAlignment: TypeAlias = Literal["left", "center", "right", "distribute"]
 VerticalAlignment: TypeAlias = Literal["top", "center", "bottom", "distribute"]
 TextAlignment: TypeAlias = Literal["left", "center", "right", "justify"]
@@ -200,8 +201,22 @@ def get_height_config(height: Height | SpaceSize) -> HeightConfig:
     return height_config
 
 
-def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
-    """Convert a gap string or None to a GapSize proto value."""
+def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
+    """Convert a gap value (string, int, or None) to a GapConfig proto message.
+
+    Parameters
+    ----------
+    gap : str, int, or None
+        The gap value. Can be a size string ("small", "medium", etc.),
+        an integer for pixel-precise gap control, or None for no gap.
+    element_type : str
+        The element type (e.g. "st.container", "st.columns") for error messages.
+
+    Returns
+    -------
+    GapConfig
+        A GapConfig proto message with either gap_size or pixel_gap set.
+    """
     gap_mapping = {
         "xxsmall": GapSize.XXSMALL,
         "xsmall": GapSize.XSMALL,
@@ -212,14 +227,21 @@ def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
         "xxlarge": GapSize.XXLARGE,
     }
 
-    if isinstance(gap, str):
-        gap_size = gap.lower()
-        valid_sizes = gap_mapping.keys()
+    config = GapConfig()
 
-        if gap_size in valid_sizes:
-            return gap_mapping[gap_size]
+    if isinstance(gap, int):
+        if gap < 0:
+            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        config.pixel_gap = gap
+        return config
+    elif isinstance(gap, str):
+        gap_lower = gap.lower()
+        if gap_lower in gap_mapping:
+            config.gap_size = gap_mapping[gap_lower]
+            return config
     elif gap is None:
-        return GapSize.NONE
+        config.gap_size = GapSize.NONE
+        return config
 
     raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -251,11 +251,11 @@ class StreamlitInvalidVerticalAlignmentError(LocalizableStreamlitException):
 class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
     """Exception raised when an invalid value is specified for gap."""
 
-    def __init__(self, gap: str, element_type: str) -> None:
+    def __init__(self, gap: object, element_type: str) -> None:
         super().__init__(
             'The `gap` argument to `{element_type}` must be `"xxsmall"`, '
             '`"xsmall"`, `"small"`, `"medium"`, `"large"`, `"xlarge"`, '
-            '`"xxlarge"`, or `"none"`. \n'
+            '`"xxlarge"`, `"none"`, or a non-negative integer (pixels). \n'
             "The argument passed was {gap}.",
             gap=gap,
             element_type=element_type,

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -2230,7 +2230,7 @@ class Column(Block):
     type: str = field(repr=False)
     proto: BlockProto.Column = field(repr=False)
     weight: float
-    gap: str | None
+    gap: str | int | None
 
     # Mapping from GapSize enum to string
     _GAP_SIZE_TO_STRING: ClassVar[dict[int, str | None]] = {
@@ -2254,7 +2254,10 @@ class Column(Block):
         self.root = root
         self.type = "column"
         self.weight = proto.weight
-        self.gap = self._GAP_SIZE_TO_STRING.get(proto.gap_config.gap_size)
+        if proto.gap_config.HasField("pixel_gap"):
+            self.gap = proto.gap_config.pixel_gap
+        else:
+            self.gap = self._GAP_SIZE_TO_STRING.get(proto.gap_config.gap_size)
 
 
 @dataclass(repr=False)

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from streamlit.elements.lib.layout_utils import (
     SpaceSize,
     get_align,
-    get_gap_size,
+    get_gap_config,
     get_height_config,
     get_justify,
     get_width_config,
@@ -210,16 +210,37 @@ class LayoutUtilsTest(unittest.TestCase):
             (None, GapSize.NONE),
         ]
     )
-    def test_get_gap_size_valid(self, gap: str | None, expected: GapSize.ValueType):
-        """get_gap_size maps valid inputs to GapSize values, None to GapSize.NONE."""
+    def test_get_gap_config_valid_string(
+        self, gap: str | None, expected: GapSize.ValueType
+    ):
+        """get_gap_config maps valid string inputs to GapSize values, None to GapSize.NONE."""
 
-        assert get_gap_size(gap, "st.columns") == expected
+        config = get_gap_config(gap, "st.columns")
+        assert config.gap_size == expected
 
-    def test_get_gap_size_invalid(self):
-        """get_gap_size raises for invalid gap strings."""
+    def test_get_gap_config_valid_int(self):
+        """get_gap_config maps integer inputs to pixel_gap."""
+
+        config = get_gap_config(10, "st.columns")
+        assert config.pixel_gap == 10
+
+    def test_get_gap_config_zero_int(self):
+        """get_gap_config accepts 0 as a valid pixel gap."""
+
+        config = get_gap_config(0, "st.columns")
+        assert config.pixel_gap == 0
+
+    def test_get_gap_config_invalid_string(self):
+        """get_gap_config raises for invalid gap strings."""
 
         with pytest.raises(StreamlitInvalidColumnGapError):
-            get_gap_size("tiny", "st.columns")
+            get_gap_config("tiny", "st.columns")
+
+    def test_get_gap_config_negative_int(self):
+        """get_gap_config raises for negative integer gap values."""
+
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            get_gap_config(-5, "st.columns")
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -242,6 +242,13 @@ class LayoutUtilsTest(unittest.TestCase):
         with pytest.raises(StreamlitInvalidColumnGapError):
             get_gap_config(-5, "st.columns")
 
+    @parameterized.expand([(True,), (False,)])
+    def test_get_gap_config_rejects_bool(self, value: bool):
+        """get_gap_config raises for boolean values (bool is subclass of int)."""
+
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            get_gap_config(value, "st.columns")
+
     @parameterized.expand(
         [
             ("left",),

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -33,5 +33,6 @@ enum GapSize {
 message GapConfig {
   oneof gap_spec {
     GapSize gap_size = 1;
+    uint32 pixel_gap = 2;
   }
 }


### PR DESCRIPTION
## Summary

Closes #13005

Adds support for passing an integer (pixel value) to the `gap` parameter in `st.columns` and `st.container`, in addition to the existing string presets (`"small"`, `"medium"`, `"large"`, etc.).

```python
# Before: only string presets
st.columns(3, gap="medium")

# After: also accepts integers for pixel-precise control
st.columns(3, gap=10)  # 10px gap
st.columns(3, gap=0)   # no gap
```

## Changes

**Proto layer:**
- Added `uint32 pixel_gap` to `GapConfig` as a `oneof gap_spec` alongside the existing `gap_size` enum

**Python backend:**
- Extended `Gap` type alias to `int | Literal[...]`
- Updated `get_gap_config()` to handle integer values (sets `pixel_gap` on the proto)
- Updated docstrings for `st.columns` and `st.container`
- Negative integers raise `StreamlitInvalidColumnGapError`

**Frontend:**
- Added `pixelGap` prop to styled components
- When `pixelGap` is set, uses `{n}px` CSS directly instead of theme spacing lookup
- Full backward compatibility with existing enum-based gaps

**Tests:**
- Python: integer gap, zero gap, negative gap (error case)
- Frontend: `getColumnPixelGap` helper tests

## Approach

Mirrors how `width` and `height` already support integers in Streamlit. The proto `oneof` ensures only one of `gap_size` or `pixel_gap` is set. Fully backward compatible.

## Test plan

- [x] Integer gap values produce correct pixel CSS
- [x] String presets still work as before
- [x] Zero gap produces `0px`
- [x] Negative integers raise error
- [x] Frontend tests pass
- [x] Python tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)