### PR TITLE
Fix #8607: Make st.switch_page case-insensitive

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -306,7 +306,7 @@ def switch_page(  # type: ignore[misc]
         )
         all_app_pages = ctx.pages_manager.get_pages().values()
 
-        matched_pages = [p for p in all_app_pages if p["script_path"] == requested_page]
+        matched_pages = [p for p in all_app_pages if p["script_path"].lower() == requested_page.lower()]
 
         if len(matched_pages) == 0:
             raise StreamlitAPIException(

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -319,6 +319,7 @@ def test_navigation_resets_pages_manager_state():
     finally:
         PagesManager.uses_pages_directory = original_value
 
+
 def test_switch_page_case_insensitive(tmp_path):
     """Test that st.switch_page ignores case differences in the file path."""
 

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -318,3 +318,27 @@ def test_navigation_resets_pages_manager_state():
         assert "Page content" in at.markdown.values
     finally:
         PagesManager.uses_pages_directory = original_value
+
+def test_switch_page_case_insensitive(tmp_path):
+    """Test that st.switch_page ignores case differences in the file path."""
+
+    main_script = tmp_path / "main.py"
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    page1_script = pages_dir / "page1.py"
+
+    main_script.write_text(
+        "import streamlit as st\n"
+        "st.switch_page('Pages/Page1.py')"
+    )
+
+    page1_script.write_text(
+        "import streamlit as st\n"
+        "st.text('Success')"
+    )
+
+    at = AppTest.from_file(str(main_script)).run()
+
+    assert not at.exception
+
+    assert at.text[0].value == "Success"


### PR DESCRIPTION
The st.switch_page command was failing on macOS and Windows when the requested page case did not match the exact case of the file as initialized by the Streamlit runner. This commit normalizes both the requested page path and the registered script paths to lower case during the comparison, preventing StreamlitAPIException on valid page switches.

## Describe your changes

The `st.switch_page` command was failing on case-insensitive file systems (like macOS and Windows) when the requested page case did not match the exact case of the file initialized by the Streamlit runner (e.g., requesting "app.py" when the file was registered as "App.py"). 

This PR normalizes both the requested page path and the registered script paths to lower case during the comparison in `execution_control.py`, preventing the `StreamlitAPIException` on valid page switches.

## Screenshot or video (only for visual changes)
N/A - Backend logic fix.

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/8607

## Testing Plan
Added a new unit test (`test_st_switch_page_case_insensitive`) in `app_test_test.py` to verify that the case-insensitive resolution works perfectly.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
