### PR TITLE
[fix] Restrict deploy button to localhost only

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1573,6 +1573,34 @@ describe("App", () => {
 
       expect(screen.getByTestId("stAppDeployButton")).toBeInTheDocument()
     })
+
+    it("button should be hidden for non-localhost hostname", () => {
+      // Save original window.location
+      const prevWindowLocation = window.location
+
+      // Mock a non-localhost hostname
+      mockWindowLocation("myapp.streamlit.app")
+
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.DEVELOPER,
+        },
+      })
+
+      // Deploy button should not appear even in DEVELOPER mode when not on localhost
+      expect(screen.queryByTestId("stAppDeployButton")).not.toBeInTheDocument()
+
+      // Restore original window.location
+      Object.defineProperty(window, "location", {
+        value: prevWindowLocation,
+        writable: true,
+        configurable: true,
+      })
+    })
   })
 
   describe("App.onHistoryChange", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1466,6 +1466,20 @@ describe("App", () => {
   })
 
   describe("DeployButton", () => {
+    let prevWindowLocation: Location
+
+    beforeEach(() => {
+      prevWindowLocation = window.location
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        value: prevWindowLocation,
+        writable: true,
+        configurable: true,
+      })
+    })
+
     it("initially button should be hidden", () => {
       renderApp(getProps())
 
@@ -1575,10 +1589,6 @@ describe("App", () => {
     })
 
     it("button should be hidden for non-localhost hostname", () => {
-      // Save original window.location
-      const prevWindowLocation = window.location
-
-      // Mock a non-localhost hostname
       mockWindowLocation("myapp.streamlit.app")
 
       renderApp(getProps())
@@ -1593,13 +1603,6 @@ describe("App", () => {
 
       // Deploy button should not appear even in DEVELOPER mode when not on localhost
       expect(screen.queryByTestId("stAppDeployButton")).not.toBeInTheDocument()
-
-      // Restore original window.location
-      Object.defineProperty(window, "location", {
-        value: prevWindowLocation,
-        writable: true,
-        configurable: true,
-      })
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -5005,27 +5005,6 @@ describe("App", () => {
       expect(screen.queryByTestId("stSidebarNav")).not.toBeInTheDocument()
     })
 
-    it("Deploy button should be hidden for cloud environment", () => {
-      prepareHostCommunicationManager()
-
-      sendForwardMessage("newSession", {
-        ...NEW_SESSION_JSON,
-        config: {
-          ...NEW_SESSION_JSON.config,
-          toolbarMode: Config.ToolbarMode.DEVELOPER,
-        },
-      })
-
-      expect(screen.getByTestId("stAppDeployButton")).toBeInTheDocument()
-
-      fireWindowPostMessage({
-        type: "SET_MENU_ITEMS",
-        items: [{ label: "Host menu item", key: "host-item", type: "text" }],
-      })
-
-      expect(screen.queryByTestId("stAppDeployButton")).not.toBeInTheDocument()
-    })
-
     it("shows toolbar in minimal mode when host menu items exist", () => {
       prepareHostCommunicationManager()
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2228,15 +2228,10 @@ export class App extends PureComponent<Props, State> {
     return "dark"
   }
 
-  isInCloudEnvironment = (): boolean => {
-    const { hostMenuItems } = this.state
-    return hostMenuItems && hostMenuItems?.length > 0
-  }
-
   showDeployButton = (): boolean => {
     return (
+      isLocalhost() &&
       showDevelopmentOptions(this.state.isOwner, this.state.toolbarMode) &&
-      !this.isInCloudEnvironment() &&
       this.sessionInfo.isSet &&
       !this.sessionInfo.isHello
     )


### PR DESCRIPTION
## Describe your changes

- Add `isLocalhost()` check to `showDeployButton()` to ensure the deploy button only shows when the app is running on localhost
- Remove the now-redundant `isInCloudEnvironment()` method since the localhost check makes it unnecessary (cloud environments don't run on localhost)
- Remove obsolete test for cloud environment behavior

This change ensures that even when `toolbarMode === DEVELOPER`, the deploy button will only show on localhost, preventing it from appearing in non-local environments.

## Testing Plan

- [x] Unit Tests - Updated existing deploy button tests, all 6 tests pass
- [x] Verified with `make check` - all checks pass

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->