### PR TITLE
refactor(ci): make performance runs an opt-in label for PRs

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -93,7 +93,7 @@ steps:
 | `playwright-custom-components.yml` | Push/PR to `develop` | E2E tests specifically for custom components |
 | `playwright-starlette.yml` | Push to `develop`, labeled PR | E2E tests using experimental Starlette server backend |
 | `cli-regression.yml` | Push/PR to `develop` | CLI regression tests (builds package and runs CLI tests) |
-| `performance.yml` | Push/PR to `develop` | Performance benchmarks (Playwright, Python, Lighthouse) |
+| `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `component-template-e2e-tests.yml` | Push/PR to `develop` | Tests for the streamlit/component-template repo |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -91,7 +91,7 @@ steps:
 | `playwright-custom-components.yml` | Push/PR to `develop` | E2E tests specifically for custom components |
 | `playwright-starlette.yml` | Push to `develop`, labeled PR | E2E tests using experimental Starlette server backend |
 | `cli-regression.yml` | Push/PR to `develop` | CLI regression tests (builds package and runs CLI tests) |
-| `performance.yml` | Push/PR to `develop` | Performance benchmarks (Playwright, Python, Lighthouse) |
+| `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `component-template-e2e-tests.yml` | Push/PR to `develop` | Tests for the streamlit/component-template repo |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -85,7 +85,7 @@ steps:
 | `playwright-custom-components.yml` | Push/PR to `develop` | E2E tests specifically for custom components |
 | `playwright-starlette.yml` | Push to `develop`, labeled PR | E2E tests using experimental Starlette server backend |
 | `cli-regression.yml` | Push/PR to `develop` | CLI regression tests (builds package and runs CLI tests) |
-| `performance.yml` | Push/PR to `develop` | Performance benchmarks (Playwright, Python, Lighthouse) |
+| `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `component-template-e2e-tests.yml` | Push/PR to `develop` | Tests for the streamlit/component-template repo |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 # Avoid duplicate workflows on same branch
 concurrency:
@@ -24,18 +23,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  performance:
+  prepare:
     if: |
       github.event_name == 'workflow_call' ||
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'run-performance')
-    runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 25
-
-    defaults:
-      run:
-        shell: bash
-
+    # Keep label cleanup in a lightweight coordination job before checking out PR code.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      checkout_ref: ${{ steps.compute.outputs.checkout_ref }}
+      sha_short: ${{ steps.compute.outputs.sha_short }}
     steps:
       - name: Remove run-performance label
         if: github.event_name == 'pull_request'
@@ -46,10 +45,50 @@ jobs:
         run: |
           gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels/run-performance" \
             --method DELETE || true
+      - name: Compute checkout inputs
+        id: compute
+        shell: bash
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
+          EVENT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ -n "$INPUT_REF" ]]; then
+            echo "checkout_ref=$INPUT_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            echo "sha_short=${EVENT_PR_HEAD_SHA:0:6}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha_short=${EVENT_SHA:0:6}" >> "$GITHUB_OUTPUT"
+          fi
+
+  performance:
+    needs: prepare
+    if: needs.prepare.result == 'success'
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
       - name: Checkout Streamlit code
+        if: needs.prepare.outputs.checkout_ref != ''
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: 2
+      - name: Checkout Streamlit code
+        if: needs.prepare.outputs.checkout_ref == ''
+        uses: actions/checkout@v6
+        with:
           persist-credentials: false
           submodules: "recursive"
           fetch-depth: 2
@@ -74,21 +113,13 @@ jobs:
         run: make python-performance-tests
       - name: Run make lighthouse-tests
         run: make lighthouse-tests
-      - name: Get short SHA
-        id: short_sha
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "sha_short=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
-          else
-            echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_OUTPUT
-          fi
       - name: Set MY_DATE_TIME env var
         run: echo "MY_DATE_TIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
       - name: Upload failed test results
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
+          name: playwright_test_results_${{ needs.prepare.outputs.sha_short }}
           path: e2e_playwright/test-results
       - name: Upload Performance results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,11 +5,7 @@ on:
     branches:
       - "develop"
   pull_request:
-    types: [opened, synchronize, reopened]
-    paths-ignore:
-      # Don't run CI if changes are only in documentation/spec folders:
-      - "specs/**"
-      - "wiki/**"
+    types: [labeled]
 
   # Allows workflow to be called from other workflows
   workflow_call:
@@ -18,6 +14,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 # Avoid duplicate workflows on same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-performance
@@ -25,6 +25,10 @@ concurrency:
 
 jobs:
   performance:
+    if: |
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'run-performance')
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 25
 
@@ -33,6 +37,15 @@ jobs:
         shell: bash
 
     steps:
+      - name: Remove run-performance label
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api "repos/$REPOSITORY/issues/$PR_NUMBER/labels/run-performance" \
+            --method DELETE || true
       - name: Checkout Streamlit code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Describe your changes

Changed the performance workflow trigger from running on all pull requests to only running when the `run-performance` label is applied. The workflow now automatically removes the label after execution to prevent repeated runs.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Manually tested

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.