### PR TITLE
[feature] Deduplicate equivalent file extensions in file uploader display

### DIFF
--- a/e2e_playwright/st_file_uploader.py
+++ b/e2e_playwright/st_file_uploader.py
@@ -311,3 +311,17 @@ st.file_uploader(
     type=["audio", "application/pdf", ".json"],
     key="mixed_types",
 )
+
+# Test extension deduplication (Issue #11991)
+# Backend sends both jpg and jpeg when either is specified
+st.file_uploader(
+    "JPG deduplication test:",
+    type=["jpg"],
+    key="jpg_dedup",
+)
+
+st.file_uploader(
+    "Multiple paired extensions:",
+    type=["jpg", "tif", "pdf"],
+    key="multiple_paired_dedup",
+)

--- a/e2e_playwright/st_file_uploader.py
+++ b/e2e_playwright/st_file_uploader.py
@@ -313,7 +313,7 @@ st.file_uploader(
 )
 
 # Test extension deduplication (Issue #11991)
-# Backend sends both jpg and jpeg when either is specified
+# Backend normalization sends both ".jpg" and ".jpeg" when either "jpg" or "jpeg" is specified
 st.file_uploader(
     "JPG deduplication test:",
     type=["jpg"],

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -1024,8 +1024,8 @@ def test_file_uploader_type_shortcuts(app: Page):
 def test_file_uploader_extension_deduplication(app: Page):
     """Test that equivalent file extensions (e.g., JPG/JPEG) are deduplicated in display.
 
-    Issue #11991: When user specifies 'jpg', backend sends both 'jpg' and 'jpeg',
-    but the UI should only show 'JPG' (the preferred form).
+    Issue #11991: When user specifies ".jpg", backend normalization may produce both
+    ".jpg" and ".jpeg", but the UI should only show "JPG" (the preferred form).
     """
     # Test JPG deduplication
     jpg_uploader = get_element_by_key(app, "jpg_dedup")

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -37,7 +37,7 @@ from e2e_playwright.shared.app_utils import (
     goto_app,
 )
 
-NUM_FILE_UPLOADERS = 19
+NUM_FILE_UPLOADERS = 21
 
 
 def create_temp_directory_with_files(file_data: list[dict[str, Any]]) -> str:
@@ -1019,3 +1019,34 @@ def test_file_uploader_type_shortcuts(app: Page):
     expect(mixed_types_instructions).to_contain_text("JSON")
     # Ensure shortcuts don't show raw MIME wildcard
     expect(mixed_types_instructions).not_to_contain_text("audio/*")
+
+
+def test_file_uploader_extension_deduplication(app: Page):
+    """Test that equivalent file extensions (e.g., JPG/JPEG) are deduplicated in display.
+
+    Issue #11991: When user specifies 'jpg', backend sends both 'jpg' and 'jpeg',
+    but the UI should only show 'JPG' (the preferred form).
+    """
+    # Test JPG deduplication
+    jpg_uploader = get_element_by_key(app, "jpg_dedup")
+    expect(jpg_uploader).to_be_visible()
+
+    jpg_instructions = jpg_uploader.get_by_test_id("stFileUploaderDropzoneInstructions")
+    # Should show "JPG" only, not both "JPG" and "JPEG"
+    expect(jpg_instructions).to_contain_text("JPG")
+    expect(jpg_instructions).not_to_contain_text("JPEG")
+
+    # Test multiple paired extensions
+    multiple_paired_uploader = get_element_by_key(app, "multiple_paired_dedup")
+    expect(multiple_paired_uploader).to_be_visible()
+
+    multiple_paired_instructions = multiple_paired_uploader.get_by_test_id(
+        "stFileUploaderDropzoneInstructions"
+    )
+    # Should show "JPG, TIF, PDF" - each pair deduplicated
+    expect(multiple_paired_instructions).to_contain_text("JPG")
+    expect(multiple_paired_instructions).to_contain_text("TIF")
+    expect(multiple_paired_instructions).to_contain_text("PDF")
+    # Should NOT show the alternate forms
+    expect(multiple_paired_instructions).not_to_contain_text("JPEG")
+    expect(multiple_paired_instructions).not_to_contain_text("TIFF")

--- a/frontend/lib/src/util/FileHelper.test.ts
+++ b/frontend/lib/src/util/FileHelper.test.ts
@@ -319,6 +319,12 @@ describe("formatTypesForDisplay", () => {
     expect(formatTypesForDisplay(["tif", "tiff", "png"])).toBe("TIF, PNG")
   })
 
+  it("deduplicates mixed dotted and dotless extensions", () => {
+    expect(formatTypesForDisplay([".jpg", "jpg"])).toBe("JPG")
+    expect(formatTypesForDisplay(["jpg", ".jpeg"])).toBe("JPG")
+    expect(formatTypesForDisplay([".png", ".jpg", "jpg"])).toBe("PNG, JPG")
+  })
+
   it("handles mixed cases", () => {
     expect(formatTypesForDisplay([".JPG", ".jpeg"])).toBe("JPG")
     expect(formatTypesForDisplay([".JPEG", ".jpg"])).toBe("JPG")

--- a/frontend/lib/src/util/FileHelper.test.ts
+++ b/frontend/lib/src/util/FileHelper.test.ts
@@ -18,6 +18,7 @@ import {
   BYTE_CONVERSION_SIZE,
   FileSize,
   formatTypeForDisplay,
+  formatTypesForDisplay,
   getSizeDisplay,
   isFileTypeAllowed,
   isMimeType,
@@ -276,5 +277,69 @@ describe("isFileTypeAllowed", () => {
       const jpegFile = createFile("photo.jpg", "image/jpeg")
       expect(isFileTypeAllowed(jpegFile, normalizedTypes)).toBe(true)
     })
+  })
+})
+
+describe("formatTypesForDisplay", () => {
+  it("formats a list of types separated by commas", () => {
+    expect(formatTypesForDisplay([".png", ".pdf"])).toBe("PNG, PDF")
+    expect(formatTypesForDisplay(["image/*", ".json"])).toBe("image, JSON")
+  })
+
+  it("deduplicates jpg and jpeg extensions", () => {
+    // Backend sends both when user specifies either
+    expect(formatTypesForDisplay([".jpg", ".jpeg"])).toBe("JPG")
+    expect(formatTypesForDisplay([".jpeg", ".jpg"])).toBe("JPG")
+    // With additional types
+    expect(formatTypesForDisplay([".png", ".jpg", ".jpeg"])).toBe("PNG, JPG")
+  })
+
+  it("deduplicates tif and tiff extensions", () => {
+    expect(formatTypesForDisplay([".tif", ".tiff"])).toBe("TIF")
+    expect(formatTypesForDisplay([".tiff", ".tif"])).toBe("TIF")
+  })
+
+  it("deduplicates htm and html extensions", () => {
+    expect(formatTypesForDisplay([".htm", ".html"])).toBe("HTML")
+    expect(formatTypesForDisplay([".html", ".htm"])).toBe("HTML")
+  })
+
+  it("deduplicates mpg and mpeg extensions", () => {
+    expect(formatTypesForDisplay([".mpg", ".mpeg"])).toBe("MPG")
+    expect(formatTypesForDisplay([".mpeg", ".mpg"])).toBe("MPG")
+  })
+
+  it("deduplicates mp4 and mpeg4 extensions", () => {
+    expect(formatTypesForDisplay([".mp4", ".mpeg4"])).toBe("MP4")
+    expect(formatTypesForDisplay([".mpeg4", ".mp4"])).toBe("MP4")
+  })
+
+  it("handles extensions without dots", () => {
+    expect(formatTypesForDisplay(["jpg", "jpeg"])).toBe("JPG")
+    expect(formatTypesForDisplay(["tif", "tiff", "png"])).toBe("TIF, PNG")
+  })
+
+  it("handles mixed cases", () => {
+    expect(formatTypesForDisplay([".JPG", ".jpeg"])).toBe("JPG")
+    expect(formatTypesForDisplay([".JPEG", ".jpg"])).toBe("JPG")
+  })
+
+  it("preserves MIME types without deduplication", () => {
+    expect(formatTypesForDisplay(["image/jpeg", "image/png"])).toBe(
+      "image/jpeg, image/png"
+    )
+    expect(formatTypesForDisplay(["image/*", ".jpg", ".jpeg"])).toBe(
+      "image, JPG"
+    )
+  })
+
+  it("deduplicates multiple pairs in one list", () => {
+    expect(
+      formatTypesForDisplay([".jpg", ".jpeg", ".tif", ".tiff", ".png"])
+    ).toBe("JPG, TIF, PNG")
+  })
+
+  it("returns empty string for empty array", () => {
+    expect(formatTypesForDisplay([])).toBe("")
   })
 })

--- a/frontend/lib/src/util/FileHelper.test.ts
+++ b/frontend/lib/src/util/FileHelper.test.ts
@@ -286,49 +286,33 @@ describe("formatTypesForDisplay", () => {
     expect(formatTypesForDisplay(["image/*", ".json"])).toBe("image, JSON")
   })
 
-  it("deduplicates jpg and jpeg extensions", () => {
-    // Backend sends both when user specifies either
-    expect(formatTypesForDisplay([".jpg", ".jpeg"])).toBe("JPG")
-    expect(formatTypesForDisplay([".jpeg", ".jpg"])).toBe("JPG")
-    // With additional types
-    expect(formatTypesForDisplay([".png", ".jpg", ".jpeg"])).toBe("PNG, JPG")
-  })
-
-  it("deduplicates tif and tiff extensions", () => {
-    expect(formatTypesForDisplay([".tif", ".tiff"])).toBe("TIF")
-    expect(formatTypesForDisplay([".tiff", ".tif"])).toBe("TIF")
-  })
-
-  it("deduplicates htm and html extensions", () => {
-    expect(formatTypesForDisplay([".htm", ".html"])).toBe("HTML")
-    expect(formatTypesForDisplay([".html", ".htm"])).toBe("HTML")
-  })
-
-  it("deduplicates mpg and mpeg extensions", () => {
-    expect(formatTypesForDisplay([".mpg", ".mpeg"])).toBe("MPG")
-    expect(formatTypesForDisplay([".mpeg", ".mpg"])).toBe("MPG")
-  })
-
-  it("deduplicates mp4 and mpeg4 extensions", () => {
-    expect(formatTypesForDisplay([".mp4", ".mpeg4"])).toBe("MP4")
-    expect(formatTypesForDisplay([".mpeg4", ".mp4"])).toBe("MP4")
-  })
-
-  it("handles extensions without dots", () => {
-    expect(formatTypesForDisplay(["jpg", "jpeg"])).toBe("JPG")
-    expect(formatTypesForDisplay(["tif", "tiff", "png"])).toBe("TIF, PNG")
-  })
-
-  it("deduplicates mixed dotted and dotless extensions", () => {
-    expect(formatTypesForDisplay([".jpg", "jpg"])).toBe("JPG")
-    expect(formatTypesForDisplay(["jpg", ".jpeg"])).toBe("JPG")
-    expect(formatTypesForDisplay([".png", ".jpg", "jpg"])).toBe("PNG, JPG")
-  })
-
-  it("handles mixed cases", () => {
-    expect(formatTypesForDisplay([".JPG", ".jpeg"])).toBe("JPG")
-    expect(formatTypesForDisplay([".JPEG", ".jpg"])).toBe("JPG")
-  })
+  // Backend sends both extensions in each pair when user specifies either
+  it.each([
+    // [input, expected, description]
+    [[".jpg", ".jpeg"], "JPG", "jpg/jpeg pair (dotted)"],
+    [[".jpeg", ".jpg"], "JPG", "jpeg/jpg pair reversed (dotted)"],
+    [[".tif", ".tiff"], "TIF", "tif/tiff pair (dotted)"],
+    [[".tiff", ".tif"], "TIF", "tiff/tif pair reversed (dotted)"],
+    [[".htm", ".html"], "HTML", "htm/html pair (dotted)"],
+    [[".html", ".htm"], "HTML", "html/htm pair reversed (dotted)"],
+    [[".mpg", ".mpeg"], "MPG", "mpg/mpeg pair (dotted)"],
+    [[".mpeg", ".mpg"], "MPG", "mpeg/mpg pair reversed (dotted)"],
+    [[".mp4", ".mpeg4"], "MP4", "mp4/mpeg4 pair (dotted)"],
+    [[".mpeg4", ".mp4"], "MP4", "mpeg4/mp4 pair reversed (dotted)"],
+    [["jpg", "jpeg"], "JPG", "jpg/jpeg pair (dotless)"],
+    [["tif", "tiff", "png"], "TIF, PNG", "tif/tiff pair with extra type"],
+    [[".png", ".jpg", ".jpeg"], "PNG, JPG", "jpg/jpeg pair with leading type"],
+    [[".jpg", "jpg"], "JPG", "mixed dotted/dotless same extension"],
+    [["jpg", ".jpeg"], "JPG", "mixed dotted/dotless equivalent pair"],
+    [[".png", ".jpg", "jpg"], "PNG, JPG", "mixed with leading type"],
+    [[".JPG", ".jpeg"], "JPG", "mixed case uppercase first"],
+    [[".JPEG", ".jpg"], "JPG", "mixed case uppercase alias"],
+  ])(
+    "deduplicates equivalent extensions: %s -> %s (%s)",
+    (input, expected) => {
+      expect(formatTypesForDisplay(input)).toBe(expected)
+    }
+  )
 
   it("preserves MIME types without deduplication", () => {
     expect(formatTypesForDisplay(["image/jpeg", "image/png"])).toBe(

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -191,10 +191,10 @@ export const isFileTypeAllowed = (
 /**
  * Extension pairs that are equivalent for display purposes.
  * The first element is the preferred display form shown to users.
- * Based on backend TYPE_PAIRS (lib/streamlit/elements/file_uploader.py),
+ * Based on backend TYPE_PAIRS (lib/streamlit/elements/lib/file_uploader_utils.py),
  * but with a frontend-specific display preference order.
  */
-const EXTENSION_PAIRS: ReadonlyArray<readonly [string, string]> = [
+const TYPE_PAIRS: ReadonlyArray<readonly [string, string]> = [
   ["jpg", "jpeg"],
   ["tif", "tiff"],
   ["html", "htm"],
@@ -207,7 +207,7 @@ const EXTENSION_PAIRS: ReadonlyArray<readonly [string, string]> = [
  * E.g., "jpeg" -> "jpg", "htm" -> "html"
  */
 const PREFERRED_EXTENSION: ReadonlyMap<string, string> = new Map(
-  EXTENSION_PAIRS.flatMap(([preferred, alternate]) => [
+  TYPE_PAIRS.flatMap(([preferred, alternate]) => [
     [preferred, preferred],
     [alternate, preferred],
   ])

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -189,6 +189,29 @@ export const isFileTypeAllowed = (
 }
 
 /**
+ * Extension pairs that are equivalent (mirrors backend TYPE_PAIRS).
+ * The first element is the preferred display form.
+ */
+const EXTENSION_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ["jpg", "jpeg"],
+  ["tif", "tiff"],
+  ["html", "htm"],
+  ["mpg", "mpeg"],
+  ["mp4", "mpeg4"],
+] as const
+
+/**
+ * Map from any extension to its preferred display form.
+ * E.g., "jpeg" -> "jpg", "htm" -> "html"
+ */
+const PREFERRED_EXTENSION: ReadonlyMap<string, string> = new Map(
+  EXTENSION_PAIRS.flatMap(([preferred, alternate]) => [
+    [preferred, preferred],
+    [alternate, preferred],
+  ])
+)
+
+/**
  * Format a single file type specifier for display.
  * - MIME wildcards (image/*) -> "image"
  * - MIME types (image/jpeg) -> "image/jpeg"
@@ -210,11 +233,44 @@ export const formatTypeForDisplay = (type: string): string => {
 }
 
 /**
+ * Normalize an extension to its preferred form if it has one.
+ * E.g., ".jpeg" -> ".jpg", ".htm" -> ".html"
+ */
+const normalizeExtension = (type: string): string => {
+  // Only normalize extensions, not MIME types
+  if (type.includes("/")) {
+    return type
+  }
+
+  const ext = type.replace(/^\./, "").toLowerCase()
+  const preferred = PREFERRED_EXTENSION.get(ext)
+  if (preferred) {
+    return type.startsWith(".") ? `.${preferred}` : preferred
+  }
+  return type
+}
+
+/**
  * Format a list of file type specifiers for display.
+ * Deduplicates equivalent extensions (e.g., jpg/jpeg) and shows the preferred form.
  * Returns a comma-separated string of formatted types.
  */
-export const formatTypesForDisplay = (types: string[]): string =>
-  types.map(formatTypeForDisplay).join(", ")
+export const formatTypesForDisplay = (types: string[]): string => {
+  // Normalize extensions to preferred form, then deduplicate
+  const seen = new Set<string>()
+  const deduplicated: string[] = []
+
+  for (const type of types) {
+    const normalized = normalizeExtension(type)
+    const key = normalized.toLowerCase()
+    if (!seen.has(key)) {
+      seen.add(key)
+      deduplicated.push(normalized)
+    }
+  }
+
+  return deduplicated.map(formatTypeForDisplay).join(", ")
+}
 
 /**
  * Return a human-readable message for the given error.

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -189,8 +189,10 @@ export const isFileTypeAllowed = (
 }
 
 /**
- * Extension pairs that are equivalent (mirrors backend TYPE_PAIRS).
- * The first element is the preferred display form.
+ * Extension pairs that are equivalent for display purposes.
+ * The first element is the preferred display form shown to users.
+ * Based on backend TYPE_PAIRS (lib/streamlit/elements/file_uploader.py),
+ * but with a frontend-specific display preference order.
  */
 const EXTENSION_PAIRS: ReadonlyArray<readonly [string, string]> = [
   ["jpg", "jpeg"],
@@ -262,7 +264,11 @@ export const formatTypesForDisplay = (types: string[]): string => {
 
   for (const type of types) {
     const normalized = normalizeExtension(type)
-    const key = normalized.toLowerCase()
+    // For deduplication key: strip leading dot and lowercase for extensions,
+    // keep full lowercase for MIME types. This ensures ".jpg" and "jpg" dedupe correctly.
+    const key = normalized.includes("/")
+      ? normalized.toLowerCase()
+      : normalized.replace(/^\./, "").toLowerCase()
     if (!seen.has(key)) {
       seen.add(key)
       deduplicated.push(normalized)


### PR DESCRIPTION
## Summary

When equivalent file extensions (e.g., JPG/JPEG, TIF/TIFF) are present in the accepted types list, `st.file_uploader` redundantly showed both in the UI instruction text. This adds display-level deduplication that always shows the preferred canonical form regardless of input order.

**Before:** `st.file_uploader("Upload", type=["jpeg"])` → displays "JPEG, JPG"
**After:** `st.file_uploader("Upload", type=["jpeg"])` → displays "JPG"

Closes #11991

## Changes

**`frontend/lib/src/util/FileHelper.ts`**
- Add `EXTENSION_PAIRS` array mirroring backend `TYPE_PAIRS`, with the preferred display form listed first
- Add `PREFERRED_EXTENSION` map (bidirectional lookup for canonical forms)
- Add `normalizeExtension()` function to normalize extensions to preferred form
- Update `formatTypesForDisplay()` to deduplicate equivalent extensions before formatting

**`frontend/lib/src/util/FileHelper.test.ts`**
- Add comprehensive tests for `formatTypesForDisplay` deduplication covering all extension pairs

**`e2e_playwright/st_file_uploader.py`**
- Add test cases for JPG deduplication and multiple paired extensions

**`e2e_playwright/st_file_uploader_test.py`**
- Add `test_file_uploader_extension_deduplication` E2E test

## Test plan

- [x] `formatTypesForDisplay([".jpeg", ".jpg"])` → "JPG"
- [x] `formatTypesForDisplay([".tiff", ".tif"])` → "TIF"
- [x] `formatTypesForDisplay([".html", ".htm"])` → "HTML"
- [x] Non-paired extensions unchanged
- [x] MIME types pass through unchanged
- [x] E2E test verifies UI displays correctly
- [x] All 38 unit tests pass
- [x] E2E test passes

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->