### PR TITLE
Fix #12869: Prevent text area from snapping back after manual resize

### DIFF
--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -117,18 +117,30 @@ const TextArea: FC<Props> = ({
   const [userResized, setUserResized] = useState(false)
   const autoHeightRef = useRef<number>(0)
 
-  // Ref to temporarily blindfold the ResizeObserver during large programatic height shifts
+  // Ref to temporarily blindfold the ResizeObserver during large programmatic height shifts
   const ignoreObserver = useRef(false)
+
+  // Refs for timeouts, to avoid memory leaks
+  const timeout1Ref = useRef<number>()
+  const timeout2Ref = useRef<number>()
+
+  // cleans timeouts if the component unmounts while they're still pending
+  useEffect(() => {
+    return () => {
+      if (timeout1Ref.current) window.clearTimeout(timeout1Ref.current)
+      if (timeout2Ref.current) window.clearTimeout(timeout2Ref.current)
+    }
+  }, [])
 
   // Observe textarea height changes to detect manual user resizing
   useEffect(() => {
     const textarea = textareaRef.current
     if (!textarea) return
 
-    let lastHeight = textarea.offsetHeight
+    let lastHeight = textarea.clientHeight
 
     const observer = new ResizeObserver(entries => {
-      // If we are programatically resetting the height (e.g. huge paste), ignore this event!
+      // If we are programmatically resetting the height (e.g. huge paste), ignore this event!
       if (ignoreObserver.current) return
 
       const newHeight = entries[0].target.clientHeight
@@ -203,8 +215,12 @@ const TextArea: FC<Props> = ({
 
   // Sync the hook's calculated height to our ref for the ResizeObserver to compare against
   useEffect(() => {
-    if (autoExpandHeight) {
-      autoHeightRef.current = parseInt(String(autoExpandHeight), 10) || 0
+    if (autoExpandHeight && textareaRef.current) {
+      requestAnimationFrame(() => {
+        if (textareaRef.current) {
+          autoHeightRef.current = textareaRef.current.clientHeight
+        }
+      })
     }
   }, [autoExpandHeight])
 
@@ -227,9 +243,11 @@ const TextArea: FC<Props> = ({
   const additionalAction = useCallback(() => {
     if (!isAutoHeight) return
 
+    if (timeout1Ref.current) window.clearTimeout(timeout1Ref.current)
+
     // setTimeout ensures the DOM is fully updated with large pastes (Ctrl+V)
     // before we measure scrollHeight to see if the text overflowed the box.
-    setTimeout(() => {
+    timeout1Ref.current = window.setTimeout(() => {
       const el = textareaRef.current
 
       if (userResized && el) {
@@ -240,9 +258,10 @@ const TextArea: FC<Props> = ({
           el.style.height = "" // Clear inline manual height
           setUserResized(false) // Give control back to hook
 
+          if (timeout2Ref.current) window.clearTimeout(timeout2Ref.current)
           // Give the React render cycle and auto-expand hook 150ms to measure and apply
           // the giant text height before we re-enable the manual resize detection.
-          setTimeout(() => {
+          timeout2Ref.current = window.setTimeout(() => {
             ignoreObserver.current = false
           }, 150)
         }
@@ -317,10 +336,11 @@ const TextArea: FC<Props> = ({
               fontWeight: theme.fontWeights.normal,
               lineHeight: theme.lineHeights.inputWidget,
               // The default height of the text area is calculated to perfectly fit 3 lines of text.
-              height:
-                isAutoHeight && !userResized
+              height: isAutoHeight
+                ? !userResized
                   ? autoExpandHeight
-                  : undefined,
+                  : undefined
+                : inputHeight,
               maxHeight: isAutoHeight ? autoExpandMaxHeight : "",
               minHeight: theme.sizes.largestElementHeight,
               resize: isStretchHeight ? "none" : "vertical",

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, memo, useCallback, useId, useRef, useState } from "react"
+import { FC, memo, useCallback, useId, useRef, useState, useEffect } from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 
@@ -113,6 +113,40 @@ const TextArea: FC<Props> = ({
   // Create ref for auto-expansion
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
+  // Track if the user manually resized the textarea
+  const [userResized, setUserResized] = useState(false)
+  const autoHeightRef = useRef<number>(0)
+
+  // Ref to temporarily blindfold the ResizeObserver during large programatic height shifts
+  const ignoreObserver = useRef(false)
+
+  // Observe textarea height changes to detect manual user resizing
+  useEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    let lastHeight = textarea.offsetHeight
+
+    const observer = new ResizeObserver(entries => {
+      // If we are programatically resetting the height (e.g. huge paste), ignore this event!
+      if (ignoreObserver.current) return
+
+      const newHeight = entries[0].target.clientHeight
+      const isAutoExpanding = Math.abs(newHeight - autoHeightRef.current) <= 2
+
+      // If the resize didn't match the auto-expand hook calculation, we assume the user dragged the corner
+      if (!isAutoExpanding && Math.abs(newHeight - lastHeight) > 2) {
+        setUserResized(true)
+      }
+
+      lastHeight = newHeight
+    })
+
+    observer.observe(textarea)
+
+    return () => observer.disconnect()
+  }, [])
+
   /**
    * The value specified by the user via the UI. If the user didn't touch this
    * widget's UI, the default value is used.
@@ -162,8 +196,17 @@ const TextArea: FC<Props> = ({
   } = useTextInputAutoExpand({
     textareaRef,
     // Recalculate height when placeholder or committed value changes
-    dependencies: [element.placeholder, value],
+    // If the user manually resized, we hide the value from dependencies (passing null)
+    // to prevent the hook from shrinking the box back to text-size on every keystroke.
+    dependencies: [element.placeholder, userResized ? null : value],
   })
+
+  // Sync the hook's calculated height to our ref for the ResizeObserver to compare against
+  useEffect(() => {
+    if (autoExpandHeight) {
+      autoHeightRef.current = parseInt(String(autoExpandHeight), 10) || 0
+    }
+  }, [autoExpandHeight])
 
   const commitWidgetValue = useCallback((): void => {
     setDirty(false)
@@ -182,10 +225,32 @@ const TextArea: FC<Props> = ({
   }, [])
 
   const additionalAction = useCallback(() => {
-    if (isAutoHeight) {
-      updateScrollHeight()
-    }
-  }, [isAutoHeight, updateScrollHeight])
+    if (!isAutoHeight) return
+
+    // setTimeout ensures the DOM is fully updated with large pastes (Ctrl+V)
+    // before we measure scrollHeight to see if the text overflowed the box.
+    setTimeout(() => {
+      const el = textareaRef.current
+
+      if (userResized && el) {
+        // If user manually resized, but then types/pastes past the bottom edge,
+        // we clear the manual height and return control to the auto-expand hook.
+        if (el.scrollHeight > el.clientHeight + 2) {
+          ignoreObserver.current = true // Suspend the ResizeObserver temporarily
+          el.style.height = "" // Clear inline manual height
+          setUserResized(false) // Give control back to hook
+
+          // Give the React render cycle and auto-expand hook 150ms to measure and apply
+          // the giant text height before we re-enable the manual resize detection.
+          setTimeout(() => {
+            ignoreObserver.current = false
+          }, 150)
+        }
+      } else {
+        updateScrollHeight()
+      }
+    }, 0)
+  }, [isAutoHeight, userResized, updateScrollHeight])
 
   const onChange = useOnInputChange({
     formId: element.formId,
@@ -252,7 +317,10 @@ const TextArea: FC<Props> = ({
               fontWeight: theme.fontWeights.normal,
               lineHeight: theme.lineHeights.inputWidget,
               // The default height of the text area is calculated to perfectly fit 3 lines of text.
-              height: isAutoHeight ? autoExpandHeight : inputHeight,
+              height:
+                isAutoHeight && !userResized
+                  ? autoExpandHeight
+                  : undefined,
               maxHeight: isAutoHeight ? autoExpandMaxHeight : "",
               minHeight: theme.sizes.largestElementHeight,
               resize: isStretchHeight ? "none" : "vertical",


### PR DESCRIPTION
## Describe your changes

When a st.text_area uses height="content", it automatically adjusts its height. However, if a user manually resized the box by dragging the corner and then typed new text, the box would abruptly snap back to the auto-calculated content height, ignoring the manual resize.

This commit fixes the issue by introducing a ResizeObserver to track manual user resizing. When manual resizing is detected, the text value is temporarily removed from the auto-expand hook dependencies. This stops the component from shrinking back on every keystroke.

Additionally, if the user types or pastes text that exceeds the new manual height, the manual height is cleared and control is returned to the auto-expand logic. The height CSS property is also updated to respect the manually dragged size by returning undefined when needed.

## Screenshot or video (only for visual changes)

https://github.com/user-attachments/assets/5e3753f6-df66-4104-9409-4c63253955f2

## GitHub Issue Link (if applicable)
https://github.com/streamlit/streamlit/issues/12869

## Testing Plan
Video above tested with simple .py file containing:

```python
import streamlit as st
st.text_area("Testing bug 12869", height="content")
```

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
