### PR TITLE
fix: add aria-labels to sidebar collapse and expand buttons

### DIFF
--- a/frontend/app/src/components/Header/Header.test.tsx
+++ b/frontend/app/src/components/Header/Header.test.tsx
@@ -182,10 +182,9 @@ describe("Header", () => {
         <Header {...getProps({ hasSidebar: true, isSidebarOpen: false })} />
       )
 
-      const expandButton = screen.getByTestId("stExpandSidebarButton")
       expect(
-        expandButton.querySelector("button")
-      ).toHaveAttribute("aria-label", "Expand sidebar")
+        screen.getByRole("button", { name: "Expand sidebar" })
+      ).toBeInTheDocument()
     })
   })
 

--- a/frontend/app/src/components/Header/Header.test.tsx
+++ b/frontend/app/src/components/Header/Header.test.tsx
@@ -176,6 +176,17 @@ describe("Header", () => {
 
       expect(onToggleSidebar).toHaveBeenCalled()
     })
+
+    it("has an accessible label on the expand button", () => {
+      render(
+        <Header {...getProps({ hasSidebar: true, isSidebarOpen: false })} />
+      )
+
+      const expandButton = screen.getByTestId("stExpandSidebarButton")
+      expect(
+        expandButton.querySelector("button")
+      ).toHaveAttribute("aria-label", "Expand sidebar")
+    })
   })
 
   describe("Embed mode behavior", () => {

--- a/frontend/app/src/components/Header/Header.tsx
+++ b/frontend/app/src/components/Header/Header.tsx
@@ -92,6 +92,7 @@ const Header = ({
                     kind={BaseButtonKind.HEADER_NO_PADDING}
                     onClick={onToggleSidebar}
                     data-testid="stExpandSidebarButton"
+                    aria-label="Expand sidebar"
                   >
                     <DynamicIcon
                       size="xl"

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -193,9 +193,12 @@ describe("Sidebar Component", () => {
     it("has an accessible label on the collapse button", () => {
       renderSidebar({ isCollapsed: false })
 
+      // The collapse button is hidden with `visibility: hidden` until the
+      // user hovers over the sidebar header (see "Collapse Button Visibility"
+      // tests below), so we need `hidden: true` to query it for attributes.
       const collapseButton = within(
         screen.getByTestId("stSidebarCollapseButton")
-      ).getByRole("button")
+      ).getByRole("button", { hidden: true })
       expect(collapseButton).toHaveAttribute("aria-label", "Collapse sidebar")
     })
   })

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -189,6 +189,15 @@ describe("Sidebar Component", () => {
         expect(mockOnToggleCollapse).toHaveBeenCalledWith(expectedToggleValue)
       }
     )
+
+    it("has an accessible label on the collapse button", () => {
+      renderSidebar({ isCollapsed: false })
+
+      const collapseButton = within(
+        screen.getByTestId("stSidebarCollapseButton")
+      ).getByRole("button")
+      expect(collapseButton).toHaveAttribute("aria-label", "Collapse sidebar")
+    })
   })
 
   describe("Collapse Button Visibility", () => {

--- a/frontend/app/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.tsx
@@ -300,6 +300,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             <BaseButton
               kind={BaseButtonKind.HEADER_NO_PADDING}
               onClick={toggleCollapse}
+              aria-label="Collapse sidebar"
             >
               <DynamicIcon
                 size="xl"


### PR DESCRIPTION
## Summary

- Add `aria-label="Collapse sidebar"` to the sidebar collapse button in `Sidebar.tsx`
- Add `aria-label="Expand sidebar"` to the sidebar expand button in `Header.tsx`
- Add tests verifying both buttons have accessible labels

These icon-only buttons had no accessible text, making them invisible to screen readers.

Partial fix for #8399