### PR TITLE
Show hex color dot in inline code, similar to GitHub

### DIFF
--- a/e2e_playwright/st_markdown.py
+++ b/e2e_playwright/st_markdown.py
@@ -48,6 +48,7 @@ st.markdown(":rainbow-background[[Link](http://example.com) within rainbow backg
 st.markdown(
     ":green-background[LaTeX math within green background: $ax^2 + bx + c = 0$]"
 )
+st.container(key="inline_hex_color").markdown("GitHub color badge: `#0969DA`")
 
 
 # Headers in markdown tests (originally from the typography-test suite).

--- a/e2e_playwright/st_markdown_test.py
+++ b/e2e_playwright/st_markdown_test.py
@@ -98,6 +98,20 @@ def test_displays_individual_markdowns(app: Page):
     expect(markdown_elements.nth(4).locator("a")).to_have_attribute("href", "href")
 
 
+def test_inline_hex_color_badge_renders_in_themed_app(themed_app: Page):
+    """Test that inline GitHub-style hex colors render a badge in both themes."""
+    markdown_element = get_element_by_key(themed_app, "inline_hex_color").get_by_test_id(
+        "stMarkdown"
+    )
+    code_element = markdown_element.locator("code")
+    dot = code_element.get_by_test_id("stHexColorDot")
+
+    expect(markdown_element).to_be_visible()
+    expect(code_element).to_have_text("#0969DA")
+    expect(dot).to_be_visible()
+    expect(dot).to_have_css("background-color", "rgb(9, 105, 218)")
+
+
 # Headers in markdown tests
 
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -37,6 +37,7 @@ import StreamlitMarkdown, {
   CustomMediaTag,
   CustomPreTag,
   HeadingWithActionElements,
+  isHexColor,
   isValidCssColor,
   LinkWithTargetBlank,
 } from "./StreamlitMarkdown"
@@ -1195,6 +1196,59 @@ describe("CustomCodeTag Element", () => {
     const props = getCustomCodeTagProps({ children })
     render(<CustomCodeTag {...props} />)
     expect(screen.getByTestId("stCode")).toHaveTextContent(expected)
+  })
+})
+
+describe("Hex color badge in inline code", () => {
+  it("renders a color dot for 6-digit hex color", () => {
+    const props = getCustomCodeTagProps({ inline: true, children: "#0969DA" })
+    render(<CustomCodeTag {...props} />)
+
+    const dot = screen.getByTestId("stHexColorDot")
+    expect(dot).toBeInTheDocument()
+    expect(dot).toHaveStyle({ backgroundColor: "#0969DA" })
+  })
+
+  it("renders a color dot for 3-digit hex color", () => {
+    const props = getCustomCodeTagProps({ inline: true, children: "#F00" })
+    render(<CustomCodeTag {...props} />)
+
+    const dot = screen.getByTestId("stHexColorDot")
+    expect(dot).toBeInTheDocument()
+    expect(dot).toHaveStyle({ backgroundColor: "#F00" })
+  })
+
+  it("does not render a color dot for invalid hex (#GGG)", () => {
+    const props = getCustomCodeTagProps({ inline: true, children: "#GGG" })
+    render(<CustomCodeTag {...props} />)
+
+    expect(screen.queryByTestId("stHexColorDot")).not.toBeInTheDocument()
+  })
+
+  it("does not render a color dot for wrong-length hex (#12345)", () => {
+    const props = getCustomCodeTagProps({ inline: true, children: "#12345" })
+    render(<CustomCodeTag {...props} />)
+
+    expect(screen.queryByTestId("stHexColorDot")).not.toBeInTheDocument()
+  })
+
+  it("does not render a color dot for normal inline code", () => {
+    const props = getCustomCodeTagProps({
+      inline: true,
+      children: "some code",
+    })
+    render(<CustomCodeTag {...props} />)
+
+    expect(screen.queryByTestId("stHexColorDot")).not.toBeInTheDocument()
+  })
+
+  it("preserves the hex code text when rendering the dot", () => {
+    const props = getCustomCodeTagProps({ inline: true, children: "#0969DA" })
+    const { container } = render(<CustomCodeTag {...props} />)
+
+    // The code element should contain the hex text
+    const codeEl = container.querySelector("code")
+    expect(codeEl).toHaveTextContent("#0969DA")
   })
 })
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1201,17 +1201,18 @@ describe("CustomCodeTag Element", () => {
 
 describe("isHexColor", () => {
   it.each([
-    ["#F00", true],
     ["#0969DA", true],
-    ["#abc", true],
-    ["#ABCD", true],
-    ["#aabbccdd", true],
+    ["#abcdef", true],
+    ["#ABCDEF", true],
     ["", false],
     ["#", false],
+    ["#F00", false],
+    ["#ABCD", false],
+    ["#aabbccdd", false],
     ["#12345", false],
     ["#GGG", false],
     [" #F00", false],
-    ["#F00 ", false],
+    ["#0969DA ", false],
   ])("isHexColor(%j) === %s", (input, expected) => {
     expect(isHexColor(input)).toBe(expected)
   })
@@ -1225,32 +1226,33 @@ describe("Hex color badge in inline code", () => {
     const dot = screen.getByTestId("stHexColorDot")
     expect(dot).toBeVisible()
     expect(dot).toHaveStyle({ backgroundColor: "#0969DA" })
+    expect(dot).toHaveStyle({
+      border: `${mockTheme.emotion.sizes.borderWidth} solid ${mockTheme.emotion.colors.borderColor}`,
+    })
   })
 
-  it("renders a color dot for 3-digit hex color", () => {
+  it("does not render a color dot for 3-digit hex color", () => {
     const props = getCustomCodeTagProps({ inline: true, children: "#F00" })
     render(<CustomCodeTag {...props} />)
 
-    const dot = screen.getByTestId("stHexColorDot")
-    expect(dot).toBeVisible()
-    expect(dot).toHaveStyle({ backgroundColor: "#F00" })
+    expect(screen.queryByTestId("stHexColorDot")).not.toBeInTheDocument()
   })
 
-  it("renders a color dot for 4-digit hex color", () => {
+  it("does not render a color dot for 4-digit hex color", () => {
     const props = getCustomCodeTagProps({ inline: true, children: "#F00F" })
     render(<CustomCodeTag {...props} />)
 
-    expect(screen.getByTestId("stHexColorDot")).toBeVisible()
+    expect(screen.queryByTestId("stHexColorDot")).not.toBeInTheDocument()
   })
 
-  it("renders a color dot for 8-digit hex color", () => {
+  it("does not render a color dot for 8-digit hex color", () => {
     const props = getCustomCodeTagProps({
       inline: true,
       children: "#0969DA80",
     })
     render(<CustomCodeTag {...props} />)
 
-    expect(screen.getByTestId("stHexColorDot")).toBeVisible()
+    expect(screen.queryByTestId("stHexColorDot")).not.toBeInTheDocument()
   })
 
   it("does not render a color dot for invalid hex (#GGG)", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1199,13 +1199,31 @@ describe("CustomCodeTag Element", () => {
   })
 })
 
+describe("isHexColor", () => {
+  it.each([
+    ["#F00", true],
+    ["#0969DA", true],
+    ["#abc", true],
+    ["#ABCD", true],
+    ["#aabbccdd", true],
+    ["", false],
+    ["#", false],
+    ["#12345", false],
+    ["#GGG", false],
+    [" #F00", false],
+    ["#F00 ", false],
+  ])("isHexColor(%j) === %s", (input, expected) => {
+    expect(isHexColor(input)).toBe(expected)
+  })
+})
+
 describe("Hex color badge in inline code", () => {
   it("renders a color dot for 6-digit hex color", () => {
     const props = getCustomCodeTagProps({ inline: true, children: "#0969DA" })
     render(<CustomCodeTag {...props} />)
 
     const dot = screen.getByTestId("stHexColorDot")
-    expect(dot).toBeInTheDocument()
+    expect(dot).toBeVisible()
     expect(dot).toHaveStyle({ backgroundColor: "#0969DA" })
   })
 
@@ -1214,8 +1232,25 @@ describe("Hex color badge in inline code", () => {
     render(<CustomCodeTag {...props} />)
 
     const dot = screen.getByTestId("stHexColorDot")
-    expect(dot).toBeInTheDocument()
+    expect(dot).toBeVisible()
     expect(dot).toHaveStyle({ backgroundColor: "#F00" })
+  })
+
+  it("renders a color dot for 4-digit hex color", () => {
+    const props = getCustomCodeTagProps({ inline: true, children: "#F00F" })
+    render(<CustomCodeTag {...props} />)
+
+    expect(screen.getByTestId("stHexColorDot")).toBeVisible()
+  })
+
+  it("renders a color dot for 8-digit hex color", () => {
+    const props = getCustomCodeTagProps({
+      inline: true,
+      children: "#0969DA80",
+    })
+    render(<CustomCodeTag {...props} />)
+
+    expect(screen.getByTestId("stHexColorDot")).toBeVisible()
   })
 
   it("does not render a color dot for invalid hex (#GGG)", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -72,6 +72,7 @@ import {
   StyledHeadingActionElements,
   StyledHeadingWithActionElements,
   StyledHelpIconWrapper,
+  StyledHexColorDot,
   StyledLinkIcon,
   StyledPreWrapper,
   StyledStreamlitMarkdown,
@@ -494,18 +495,10 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
   ) : (
     <StyledInlineCode className={className} {...omit(props, "node")}>
       {isHexColor(codeText) && (
-        <span
+        <StyledHexColorDot
           data-testid="stHexColorDot"
-          style={{
-            display: "inline-block",
-            width: "0.65em",
-            height: "0.65em",
-            borderRadius: "50%",
-            backgroundColor: codeText,
-            marginRight: "0.25em",
-            verticalAlign: "middle",
-            border: "1px solid rgba(0,0,0,0.1)",
-          }}
+          aria-hidden="true"
+          color={codeText}
         />
       )}
       {children}
@@ -675,10 +668,11 @@ export function isValidCssColor(color: string): boolean {
   }
 }
 
-const HEX_COLOR_RE = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/
+const HEX_COLOR_RE = /^#([0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/
 
 /**
- * Tests whether a string is a valid 3- or 6-digit hex color (e.g. `#0969DA`, `#F00`).
+ * Tests whether a string is a valid hex color: 3, 4, 6, or 8 digits
+ * (e.g. `#0969DA`, `#F00`, `#F00F`, `#0969DA80`).
  */
 export function isHexColor(value: string): boolean {
   return HEX_COLOR_RE.test(value)

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -668,11 +668,11 @@ export function isValidCssColor(color: string): boolean {
   }
 }
 
-const HEX_COLOR_RE = /^#([0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/
 
 /**
- * Tests whether a string is a valid hex color: 3, 4, 6, or 8 digits
- * (e.g. `#0969DA`, `#F00`, `#F00F`, `#0969DA80`).
+ * Tests whether a string is a valid GitHub-style hex color: 6 digits
+ * (e.g. `#0969DA`).
  */
 export function isHexColor(value: string): boolean {
   return HEX_COLOR_RE.test(value)

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -493,6 +493,21 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
     </ErrorBoundary>
   ) : (
     <StyledInlineCode className={className} {...omit(props, "node")}>
+      {isHexColor(codeText) && (
+        <span
+          data-testid="stHexColorDot"
+          style={{
+            display: "inline-block",
+            width: "0.65em",
+            height: "0.65em",
+            borderRadius: "50%",
+            backgroundColor: codeText,
+            marginRight: "0.25em",
+            verticalAlign: "middle",
+            border: "1px solid rgba(0,0,0,0.1)",
+          }}
+        />
+      )}
       {children}
     </StyledInlineCode>
   )
@@ -658,6 +673,15 @@ export function isValidCssColor(color: string): boolean {
   } catch {
     return false
   }
+}
+
+const HEX_COLOR_RE = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/
+
+/**
+ * Tests whether a string is a valid 3- or 6-digit hex color (e.g. `#0969DA`, `#F00`).
+ */
+export function isHexColor(value: string): boolean {
+  return HEX_COLOR_RE.test(value)
 }
 
 /**

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -532,17 +532,20 @@ export const StyledPreWrapper = styled.div(({ theme }) => ({
   marginBottom: theme.spacing.lg,
 }))
 
-export const StyledHexColorDot = styled.span<{ color: string }>({
-  display: "inline-block",
-  width: "0.65em",
-  height: "0.65em",
-  borderRadius: "50%",
-  marginRight: "0.25em",
-  verticalAlign: "middle",
-  border: "1px solid rgba(0,0,0,0.1)",
-}, ({ color }) => ({
-  backgroundColor: color,
-}))
+export const StyledHexColorDot = styled.span<{ color: string }>(
+  ({ theme }) => ({
+    display: "inline-block",
+    width: "0.65em",
+    height: "0.65em",
+    borderRadius: "50%",
+    marginRight: "0.25em",
+    verticalAlign: "middle",
+    border: `${theme.sizes.borderWidth} solid ${theme.colors.borderColor}`,
+  }),
+  ({ color }) => ({
+    backgroundColor: color,
+  })
+)
 
 export const StyledHelpIconWrapper = styled.span({
   display: "inline-block",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -532,6 +532,18 @@ export const StyledPreWrapper = styled.div(({ theme }) => ({
   marginBottom: theme.spacing.lg,
 }))
 
+export const StyledHexColorDot = styled.span<{ color: string }>({
+  display: "inline-block",
+  width: "0.65em",
+  height: "0.65em",
+  borderRadius: "50%",
+  marginRight: "0.25em",
+  verticalAlign: "middle",
+  border: "1px solid rgba(0,0,0,0.1)",
+}, ({ color }) => ({
+  backgroundColor: color,
+}))
+
 export const StyledHelpIconWrapper = styled.span({
   display: "inline-block",
   verticalAlign: "middle",


### PR DESCRIPTION
## Summary

When a hex color like `#0969DA` is used in backtick inline code within `st.markdown`, a small colored circle is now displayed before the hex text — matching [GitHub's Markdown rendering behavior](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#supported-color-models).

**Before:** `#0969DA` renders as plain inline code
**After:** Shows a colored dot followed by the hex text

## Changes

- Modified `CustomCodeTag` in `StreamlitMarkdown.tsx` to detect valid hex colors (3 or 6 digit) and render a color dot
- Added 6 tests covering valid hex colors, invalid values, and text preservation

Closes #11643

---

**Generative AI disclosure:** This PR was co-authored with Claude (Anthropic).