### PR TITLE
[fix] Prevent cache spinner text from overlapping with progress bar

### DIFF
--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -104,6 +104,7 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
       height: theme.spacing.none,
       overflow: "visible",
       visibility: "visible",
+      // Keep in sync with the cache spinner's paddingBottom in Spinner/styled-components.ts
       marginBottom: `-${theme.spacing.threeXL}`,
       zIndex: theme.zIndices.cacheSpinner,
     },

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -104,7 +104,7 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
       height: theme.spacing.none,
       overflow: "visible",
       visibility: "visible",
-      marginBottom: `-${theme.spacing.lg}`,
+      marginBottom: `-${theme.spacing.threeXL}`,
       zIndex: theme.zIndices.cacheSpinner,
     },
 

--- a/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
@@ -78,7 +78,7 @@ describe("Spinner component", () => {
 
     expect(spinnerContainer).toHaveClass("stSpinner")
     expect(spinnerContainer).toHaveClass("stCacheSpinner")
-    expect(spinnerContainer).toHaveStyle("paddingBottom: 1rem")
+    expect(spinnerContainer).toHaveStyle("paddingBottom: 2rem")
   })
 
   it("shows timer when showTime is true", () => {

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -26,7 +26,9 @@ export const StyledSpinner = styled.div<StyledSpinnerProps>(
       ? {
           // Keep in sync with marginBottom in Block/styled-components.ts
           paddingBottom: theme.spacing.threeXL,
-          background: `linear-gradient(to bottom, ${theme.colors.bgColor} 0%, ${theme.colors.bgColor} 80%, transparent 100%)`,
+          // Top is slightly transparent so the previous element's text descenders
+          // (e.g. the "g" in a progress bar label) are not clipped by this overlay.
+          background: `linear-gradient(to bottom, transparent 0%, ${theme.colors.bgColor} 15%, ${theme.colors.bgColor} 80%, transparent 100%)`,
         }
       : null),
   })

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -24,6 +24,7 @@ export const StyledSpinner = styled.div<StyledSpinnerProps>(
   ({ theme, cache }) => ({
     ...(cache
       ? {
+          // Keep in sync with marginBottom in Block/styled-components.ts
           paddingBottom: theme.spacing.threeXL,
           background: `linear-gradient(to bottom, ${theme.colors.bgColor} 0%, ${theme.colors.bgColor} 80%, transparent 100%)`,
         }

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -24,7 +24,7 @@ export const StyledSpinner = styled.div<StyledSpinnerProps>(
   ({ theme, cache }) => ({
     ...(cache
       ? {
-          paddingBottom: theme.spacing.lg,
+          paddingBottom: theme.spacing.threeXL,
           background: `linear-gradient(to bottom, ${theme.colors.bgColor} 0%, ${theme.colors.bgColor} 80%, transparent 100%)`,
         }
       : null),


### PR DESCRIPTION
## Summary

When using `st.progress` inside a `@st.cache_data` function, the cache spinner text ("Running `foo`...") overlaps with the progress bar's text label.

**Before:** Spinner text and progress bar text overlap, making both unreadable
**After:** Spinner overlay has enough spacing to cleanly separate from content below

## Changes

- Increased `paddingBottom` from `lg` (16px) to `threeXL` (32px) in the cache spinner to extend the opaque background area
- Updated matching `marginBottom` on the container from `-lg` to `-threeXL` to keep layout consistent

Closes https://github.com/streamlit/streamlit/issues/14555


| Condition | Before | After |
|-----------|--------|-------|
| st.progress | <img width="791" height="115" alt="image" src="https://github.com/user-attachments/assets/3f98516c-c97a-4784-a6cb-ce03687b46f7" />| <img width="741" height="96" alt="image" src="https://github.com/user-attachments/assets/6110c3e6-04bf-450c-aec6-81c8750f0a96" /> |
| st.text | <img width="639" height="94" alt="image" src="https://github.com/user-attachments/assets/a4f89ac5-4ef8-402b-a129-8842b8e5c459" /> | <img width="733" height="91" alt="image" src="https://github.com/user-attachments/assets/1502131e-f029-432b-80bc-39b4f49d8c1c" /> |
|st.markdown | <img width="967" height="143" alt="image" src="https://github.com/user-attachments/assets/a5ad0998-3794-425b-a464-cb9f5331842f" /> |  <img width="858" height="126" alt="image" src="https://github.com/user-attachments/assets/ad63c021-4a7d-446a-bb74-72c659a6e5ca" /> |
| st.image | <img width="733" height="190" alt="image" src="https://github.com/user-attachments/assets/c62bf0e9-3792-4934-9fe1-1db0cc112a7e" /> |  <img width="802" height="178" alt="image" src="https://github.com/user-attachments/assets/b913ddb6-89cb-4315-99ef-e25f722519b3" /> |


---

**Generative AI disclosure:** This PR was co-authored with Claude (Anthropic).