### PR TITLE
pin axios <=1.14.0

### DIFF
--- a/frontend/connection/package.json
+++ b/frontend/connection/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@streamlit/protobuf": "workspace:^",
     "@streamlit/utils": "workspace:^",
-    "axios": "^1.13.6",
+    "axios": ">=1.13.6 <=1.14.0",
     "lodash-es": "^4.17.23",
     "loglevel": "^1.9.2"
   },

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -63,7 +63,7 @@
     "@streamlit/protobuf": "workspace:^",
     "@streamlit/utils": "workspace:^",
     "apache-arrow": "^21.1.0",
-    "axios": "^1.13.6",
+    "axios": ">=1.13.6 <=1.14.0",
     "baseui": "12.2.0",
     "classnames": "^2.3.2",
     "color2k": "^2.0.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3641,7 +3641,7 @@ __metadata:
     "@streamlit/protobuf": "workspace:^"
     "@streamlit/utils": "workspace:^"
     "@types/lodash-es": "npm:^4.17.12"
-    axios: "npm:^1.13.6"
+    axios: "npm:>=1.13.6 <=1.14.0"
     axios-mock-adapter: "npm:^2.1.0"
     lodash-es: "npm:^4.17.23"
     loglevel: "npm:^1.9.2"
@@ -3711,7 +3711,7 @@ __metadata:
     "@types/xxhashjs": "npm:^0.2.2"
     "@vitejs/plugin-react-swc": "npm:^4.3.0"
     apache-arrow: "npm:^21.1.0"
-    axios: "npm:^1.13.6"
+    axios: "npm:>=1.13.6 <=1.14.0"
     axios-mock-adapter: "npm:^2.1.0"
     baseui: "npm:12.2.0"
     classnames: "npm:^2.3.2"
@@ -6385,7 +6385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.6":
+"axios@npm:>=1.13.6 <=1.14.0":
   version: 1.13.6
   resolution: "axios@npm:1.13.6"
   dependencies:


### PR DESCRIPTION
## Describe your changes

Pins axios to <=1.14.0 to avoid supply chain attack occuring on axios 1.14.1

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/14574

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
