### PR TITLE
[chore] Add dependency update cooldown for uv and yarn

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -129,7 +129,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: @emotion/babel-plugin, @emotion/cache, @emotion/hash, @emotion/is-prop-valid, @emotion/memoize, @emotion/react, @emotion/serialize, @emotion/sheet, @emotion/styled, @emotion/unitless, @emotion/utils, @emotion/weak-memoize. A copy of the source code may be downloaded from https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin (@emotion/babel-plugin), https://github.com/emotion-js/emotion/tree/main/packages/cache (@emotion/cache), https://github.com/emotion-js/emotion/tree/main/packages/hash (@emotion/hash), https://github.com/emotion-js/emotion/tree/main/packages/is-prop-valid (@emotion/is-prop-valid), https://github.com/emotion-js/emotion/tree/main/packages/memoize (@emotion/memoize), https://github.com/emotion-js/emotion/tree/main/packages/react (@emotion/react), https://github.com/emotion-js/emotion/tree/main/packages/serialize (@emotion/serialize), https://github.com/emotion-js/emotion/tree/main/packages/sheet (@emotion/sheet), https://github.com/emotion-js/emotion/tree/main/packages/styled (@emotion/styled), https://github.com/emotion-js/emotion/tree/main/packages/unitless (@emotion/unitless), https://github.com/emotion-js/emotion/tree/main/packages/utils (@emotion/utils), https://github.com/emotion-js/emotion/tree/main/packages/weak-memoize (@emotion/weak-memoize). This software contains the following license and notice below:
+The following software may be included in this product: @emotion/babel-plugin, @emotion/cache, @emotion/hash, @emotion/is-prop-valid, @emotion/memoize, @emotion/react, @emotion/serialize, @emotion/sheet, @emotion/styled, @emotion/unitless, @emotion/use-insertion-effect-with-fallbacks, @emotion/utils, @emotion/weak-memoize. A copy of the source code may be downloaded from https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin (@emotion/babel-plugin), https://github.com/emotion-js/emotion/tree/main/packages/cache (@emotion/cache), https://github.com/emotion-js/emotion/tree/main/packages/hash (@emotion/hash), https://github.com/emotion-js/emotion/tree/main/packages/is-prop-valid (@emotion/is-prop-valid), https://github.com/emotion-js/emotion/tree/main/packages/memoize (@emotion/memoize), https://github.com/emotion-js/emotion/tree/main/packages/react (@emotion/react), https://github.com/emotion-js/emotion/tree/main/packages/serialize (@emotion/serialize), https://github.com/emotion-js/emotion/tree/main/packages/sheet (@emotion/sheet), https://github.com/emotion-js/emotion/tree/main/packages/styled (@emotion/styled), https://github.com/emotion-js/emotion/tree/main/packages/unitless (@emotion/unitless), https://github.com/emotion-js/emotion/tree/main/packages/use-insertion-effect-with-fallbacks (@emotion/use-insertion-effect-with-fallbacks), https://github.com/emotion-js/emotion/tree/main/packages/utils (@emotion/utils), https://github.com/emotion-js/emotion/tree/main/packages/weak-memoize (@emotion/weak-memoize). This software contains the following license and notice below:
 
 MIT License
 
@@ -484,7 +484,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: @linaria/core, @linaria/react. A copy of the source code may be downloaded from git@github.com:callstack/linaria.git (@linaria/core), git@github.com:callstack/linaria.git (@linaria/react). This software contains the following license and notice below:
+The following software may be included in this product: @linaria/core. A copy of the source code may be downloaded from git@github.com:callstack/linaria.git. This software contains the following license and notice below:
 
 MIT License
 
@@ -510,7 +510,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: @loaders.gl/3d-tiles, @loaders.gl/compression, @loaders.gl/core, @loaders.gl/crypto, @loaders.gl/csv, @loaders.gl/gis, @loaders.gl/gltf, @loaders.gl/images, @loaders.gl/math, @loaders.gl/mvt, @loaders.gl/schema, @loaders.gl/terrain, @loaders.gl/textures, @loaders.gl/tiles, @loaders.gl/wms, @loaders.gl/xml, @loaders.gl/zip. A copy of the source code may be downloaded from https://github.com/visgl/loaders.gl (@loaders.gl/3d-tiles), https://github.com/visgl/loaders.gl (@loaders.gl/compression), https://github.com/visgl/loaders.gl (@loaders.gl/core), https://github.com/visgl/loaders.gl (@loaders.gl/crypto), https://github.com/visgl/loaders.gl (@loaders.gl/csv), https://github.com/visgl/loaders.gl (@loaders.gl/gis), https://github.com/visgl/loaders.gl (@loaders.gl/gltf), https://github.com/visgl/loaders.gl (@loaders.gl/images), https://github.com/visgl/loaders.gl (@loaders.gl/math), https://github.com/visgl/loaders.gl (@loaders.gl/mvt), https://github.com/visgl/loaders.gl (@loaders.gl/schema), https://github.com/visgl/loaders.gl (@loaders.gl/terrain), https://github.com/visgl/loaders.gl (@loaders.gl/textures), https://github.com/visgl/loaders.gl (@loaders.gl/tiles), https://github.com/visgl/loaders.gl (@loaders.gl/wms), https://github.com/visgl/loaders.gl (@loaders.gl/xml), https://github.com/visgl/loaders.gl (@loaders.gl/zip). This software contains the following license and notice below:
+The following software may be included in this product: @loaders.gl/3d-tiles, @loaders.gl/compression, @loaders.gl/core, @loaders.gl/crypto, @loaders.gl/csv, @loaders.gl/gis, @loaders.gl/gltf, @loaders.gl/images, @loaders.gl/loader-utils, @loaders.gl/math, @loaders.gl/mvt, @loaders.gl/schema, @loaders.gl/terrain, @loaders.gl/textures, @loaders.gl/tiles, @loaders.gl/wms, @loaders.gl/worker-utils, @loaders.gl/xml, @loaders.gl/zip. A copy of the source code may be downloaded from https://github.com/visgl/loaders.gl (@loaders.gl/3d-tiles), https://github.com/visgl/loaders.gl (@loaders.gl/compression), https://github.com/visgl/loaders.gl (@loaders.gl/core), https://github.com/visgl/loaders.gl (@loaders.gl/crypto), https://github.com/visgl/loaders.gl (@loaders.gl/csv), https://github.com/visgl/loaders.gl (@loaders.gl/gis), https://github.com/visgl/loaders.gl (@loaders.gl/gltf), https://github.com/visgl/loaders.gl (@loaders.gl/images), https://github.com/visgl/loaders.gl (@loaders.gl/loader-utils), https://github.com/visgl/loaders.gl (@loaders.gl/math), https://github.com/visgl/loaders.gl (@loaders.gl/mvt), https://github.com/visgl/loaders.gl (@loaders.gl/schema), https://github.com/visgl/loaders.gl (@loaders.gl/terrain), https://github.com/visgl/loaders.gl (@loaders.gl/textures), https://github.com/visgl/loaders.gl (@loaders.gl/tiles), https://github.com/visgl/loaders.gl (@loaders.gl/wms), https://github.com/visgl/loaders.gl (@loaders.gl/worker-utils), https://github.com/visgl/loaders.gl (@loaders.gl/xml), https://github.com/visgl/loaders.gl (@loaders.gl/zip). This software contains the following license and notice below:
 
 loaders.gl is licensed under the MIT license
 
@@ -555,7 +555,7 @@ See the License for the specific language governing permissions and limitations 
 
 -----
 
-The following software may be included in this product: @luma.gl/constants, @luma.gl/core, @luma.gl/engine, @luma.gl/gltf, @luma.gl/shadertools, @luma.gl/webgl. A copy of the source code may be downloaded from https://github.com/visgl/luma.gl (@luma.gl/constants), https://github.com/visgl/luma.gl (@luma.gl/core), https://github.com/visgl/luma.gl (@luma.gl/engine), https://github.com/visgl/luma.gl (@luma.gl/gltf), https://github.com/visgl/luma.gl (@luma.gl/shadertools), https://github.com/visgl/luma.gl (@luma.gl/webgl). This software contains the following license and notice below:
+The following software may be included in this product: @luma.gl/constants, @luma.gl/core, @luma.gl/engine, @luma.gl/shadertools, @luma.gl/webgl. A copy of the source code may be downloaded from https://github.com/visgl/luma.gl (@luma.gl/constants), https://github.com/visgl/luma.gl (@luma.gl/core), https://github.com/visgl/luma.gl (@luma.gl/engine), https://github.com/visgl/luma.gl (@luma.gl/shadertools), https://github.com/visgl/luma.gl (@luma.gl/webgl). This software contains the following license and notice below:
 
 luma.gl is provided under the MIT license
 
@@ -11725,32 +11725,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
------
-
-The following software may be included in this product: react-number-format. A copy of the source code may be downloaded from https://github.com/s-yadav/react-number-format. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2020-present Sudhanshu Yadav
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 

--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -14,8 +14,8 @@
 
 nodeLinker: node-modules
 
-# Exclude packages published in the last 3 days to lower risk from supply chain attacks
-npmMinimalAgeGate: 4320
+# Exclude packages published in the last 2 days to lower risk from supply chain attacks
+npmMinimalAgeGate: 2880
 
 plugins:
   - checksum: 374f735053958b77583ef7b70e56a59540d1d9c681f04b8ab7a600f4325301d2e1fb67c51d34ba75bbbc4e71f8c003fbc52b1f22d7daa30dca655f1a1bf205a1

--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -14,8 +14,8 @@
 
 nodeLinker: node-modules
 
-# Exclude packages published in the last 2 days to lower risk from supply chain attacks
-npmMinimalAgeGate: 2880
+# Exclude packages published in the last 24 hours to lower risk from supply chain attacks
+npmMinimalAgeGate: 1440
 
 plugins:
   - checksum: 374f735053958b77583ef7b70e56a59540d1d9c681f04b8ab7a600f4325301d2e1fb67c51d34ba75bbbc4e71f8c003fbc52b1f22d7daa30dca655f1a1bf205a1

--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -14,6 +14,9 @@
 
 nodeLinker: node-modules
 
+# Exclude packages published in the last 3 days to lower risk from supply chain attacks
+npmMinimalAgeGate: 4320
+
 plugins:
   - checksum: 374f735053958b77583ef7b70e56a59540d1d9c681f04b8ab7a600f4325301d2e1fb67c51d34ba75bbbc4e71f8c003fbc52b1f22d7daa30dca655f1a1bf205a1
     path: .yarn/plugins/@yarnpkg/plugin-licenses.cjs

--- a/frontend/component-lib/package.json
+++ b/frontend/component-lib/package.json
@@ -69,5 +69,5 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0"
   },
-  "packageManager": "yarn@4.5.3"
+  "packageManager": "yarn@4.13.0"
 }

--- a/frontend/component-v2-lib/package.json
+++ b/frontend/component-v2-lib/package.json
@@ -56,5 +56,5 @@
     "url": "https://github.com/streamlit/streamlit/issues"
   },
   "homepage": "https://github.com/streamlit/streamlit#readme",
-  "packageManager": "yarn@4.5.3"
+  "packageManager": "yarn@4.13.0"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "packageManager": "yarn@4.5.3",
+  "packageManager": "yarn@4.13.0",
   "devDependencies": {
     "@bufbuild/buf": "^1.66.1",
     "@eslint-react/eslint-plugin": "^2.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = []
 [tool.uv]
 # Minimum uv version required for this project
 required-version = ">=0.9.0"
-# Exclude packages published in the last 2 days to lower risk from supply chain attacks
-exclude-newer = "2 days"
+# Exclude packages published in the last 24 hours to lower risk from supply chain attacks
+exclude-newer = "24 hours"
 # Explicit pandas version constraints by Python version:
 # - Python 3.10: use pandas 2.x (pandas 3.x requires Python >= 3.11)
 # - Python 3.11+: use pandas 3.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = []
 [tool.uv]
 # Minimum uv version required for this project
 required-version = ">=0.9.0"
-# Exclude packages published in the last 3 days to lower risk from supply chain attacks
-exclude-newer = "3 days"
+# Exclude packages published in the last 2 days to lower risk from supply chain attacks
+exclude-newer = "2 days"
 # Explicit pandas version constraints by Python version:
 # - Python 3.10: use pandas 2.x (pandas 3.x requires Python >= 3.11)
 # - Python 3.11+: use pandas 3.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = []
 [tool.uv]
 # Minimum uv version required for this project
 required-version = ">=0.9.0"
+# Exclude packages published in the last 3 days to lower risk from supply chain attacks
+exclude-newer = "3 days"
 # Explicit pandas version constraints by Python version:
 # - Python 3.10: use pandas 2.x (pandas 3.x requires Python >= 3.11)
 # - Python 3.11+: use pandas 3.x


### PR DESCRIPTION
## Describe your changes

Adds a 24-hour cooldown period for newly published packages to mitigate supply chain attacks:

- **uv (Python)**: Adds `exclude-newer = "24 hours"` to `pyproject.toml`
- **yarn (frontend)**: Adds `npmMinimalAgeGate: 1440` (24 hours in minutes) to `.yarnrc.yml`

Also updates yarn from 4.5.3 to 4.13.0 across all workspaces for `npmMinimalAgeGate` support.

## Testing Plan

- No code changes, only package manager configuration
- Verified `make autofix` and `make check` pass