### PR TITLE
Add border-radius rounding to st.video and st.map components

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/DeckGlJsonChart.tsx
@@ -40,6 +40,7 @@ import { assertNever } from "~lib/util/assertNever"
 import { MapBoxCss } from "./MapBoxCss"
 import {
   StyledDeckGlChart,
+  StyledMapContent,
   StyledNavigationControlContainer,
 } from "./styled-components"
 import type { DeckGlElementState, DeckGLProps } from "./types"
@@ -233,38 +234,40 @@ export const DeckGlJsonChart: FC<DeckGLProps> = props => {
           />
         )}
       </Toolbar>
-      {/* Only render the DeckGL component if the viewState is not null,
-      or else we'll get a runtime assertion error from deck.gl and the map will not render. */}
-      {viewState && (
-        <DeckGL
-          viewState={viewState}
-          onViewStateChange={onViewStateChange}
-          layers={isInitialized ? deck.layers : EMPTY_LAYERS}
-          getTooltip={createTooltip}
-          // @ts-expect-error There is a type mismatch due to our versions of the libraries
-          ContextProvider={MapContext.Provider}
-          controller
-          onClick={
-            isSelectionModeActivated && !disabled ? handleClick : undefined
-          }
-        >
-          <StaticMap
-            mapStyle={
-              deck.mapStyle &&
-              (typeof deck.mapStyle === "string"
-                ? deck.mapStyle
-                : deck.mapStyle[0])
+      <StyledMapContent>
+        {/* Only render the DeckGL component if the viewState is not null,
+        or else we'll get a runtime assertion error from deck.gl and the map will not render. */}
+        {viewState && (
+          <DeckGL
+            viewState={viewState}
+            onViewStateChange={onViewStateChange}
+            layers={isInitialized ? deck.layers : EMPTY_LAYERS}
+            getTooltip={createTooltip}
+            // @ts-expect-error There is a type mismatch due to our versions of the libraries
+            ContextProvider={MapContext.Provider}
+            controller
+            onClick={
+              isSelectionModeActivated && !disabled ? handleClick : undefined
             }
-            mapboxApiAccessToken={mapboxToken}
-          />
-          <StyledNavigationControlContainer>
-            <NavigationControl
-              data-testid="stDeckGlJsonChartZoomButton"
-              showCompass={false}
+          >
+            <StaticMap
+              mapStyle={
+                deck.mapStyle &&
+                (typeof deck.mapStyle === "string"
+                  ? deck.mapStyle
+                  : deck.mapStyle[0])
+              }
+              mapboxApiAccessToken={mapboxToken}
             />
-          </StyledNavigationControlContainer>
-        </DeckGL>
-      )}
+            <StyledNavigationControlContainer>
+              <NavigationControl
+                data-testid="stDeckGlJsonChartZoomButton"
+                showCompass={false}
+              />
+            </StyledNavigationControlContainer>
+          </DeckGL>
+        )}
+      </StyledMapContent>
     </StyledDeckGlChart>
   )
 }

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -23,10 +23,12 @@ interface StyledDeckGlChartProps {
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ isStretchHeight }) => ({
+  ({ isStretchHeight, theme }) => ({
     position: "relative",
     height: "100%",
     width: "100%",
+    borderRadius: theme.radii.default,
+    overflow: "hidden",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.
     ...(isStretchHeight && { minHeight: "6.25rem" }),
   })

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -33,6 +33,20 @@ export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
   })
 )
 
+/**
+ * Inner wrapper that clips map content at rounded corners via
+ * overflow: hidden. The Toolbar is intentionally kept outside this
+ * wrapper so it can extend above the container boundary without
+ * being clipped.
+ */
+export const StyledMapContent = styled.div(({ theme }) => ({
+  position: "relative",
+  height: "100%",
+  width: "100%",
+  overflow: "hidden",
+  borderRadius: theme.radii.default,
+}))
+
 export const StyledNavigationControlContainer = styled.div(({ theme }) => ({
   position: "absolute",
   right: "2.625rem",

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -28,7 +28,6 @@ export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
     height: "100%",
     width: "100%",
     borderRadius: theme.radii.default,
-    overflow: "hidden",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.
     ...(isStretchHeight && { minHeight: "6.25rem" }),
   })

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -32,8 +32,6 @@ export interface VideoProps {
   element: VideoProto
   elementMgr: ElementStateManager
 }
-
-const VIDEO_STYLE = { width: "100%" }
 
 function Video({
   element,
@@ -248,7 +246,7 @@ function Video({
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -256,7 +254,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -272,7 +269,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -23,4 +23,10 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: theme.radii.default,
+}))
+
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: theme.radii.default,
 }))


### PR DESCRIPTION
## Description

Adds `border-radius` rounding to `st.video` and `st.map`/`st.pydeck_chart` components using `theme.radii.default` for visual consistency with other Streamlit elements.

**Fixes #12806**

## Changes

### Video component (`st.video`)
- **`Video/styled-components.ts`**: Added `borderRadius: theme.radii.default` to `StyledVideoIframe` (for YouTube/Vimeo embeds), and created a new `StyledVideo` styled component with `borderRadius` for native `<video>` elements.
- **`Video/Video.tsx`**: Replaced the plain `<video>` tag with inline `style={{ width: "100%" }}` with the new `StyledVideo` styled component. Removed the now-unused `VIDEO_STYLE` constant.

### Map/PyDeck component (`st.map` / `st.pydeck_chart`)
- **`DeckGlJsonChart/styled-components.ts`**: Added `borderRadius: theme.radii.default` to `StyledDeckGlChart`. Introduced a new `StyledMapContent` inner wrapper with `overflow: "hidden"` and `borderRadius` that wraps the DeckGL canvas. This clips map tiles at the rounded corners while keeping the Toolbar (fullscreen/clear-selection buttons) outside the clipped boundary so it remains accessible.
- **`DeckGlJsonChart/DeckGlJsonChart.tsx`**: Wrapped the DeckGL map content inside `StyledMapContent`. The Toolbar remains a direct child of `StyledDeckGlChart` so its `position: absolute` with `top: -2.65rem` is not clipped by `overflow: hidden`.

## Approach

Used the same `theme.radii.default` pattern already established throughout the Streamlit frontend (e.g., in `StyledAlertContent`, `StyledPlotlyChart`, `StyledArrowTable`, etc.) to ensure visual consistency.

For the map component, a layered approach was needed:
1. `StyledDeckGlChart` — outer container with `position: relative` and `borderRadius` (no overflow clipping, so the Toolbar can extend above)
2. `StyledMapContent` — inner wrapper with `overflow: hidden` and `borderRadius` (clips the map canvas at rounded corners)

This ensures the map tiles are properly clipped at rounded corners while the Toolbar buttons remain fully visible and interactive.

## Testing

- Verified that the styled-component pattern follows the existing codebase conventions
- Changes are CSS-only and use the established theme system, minimizing risk of regressions
