### PR TITLE
fix: show tooltip icon when label_visibility="hidden"

### DIFF
--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
@@ -56,9 +56,9 @@ describe("ColorPicker widget", () => {
     })
     render(<BaseColorPicker {...props} />)
 
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -82,9 +82,9 @@ describe("Selectbox widget", () => {
       labelVisibility: LabelVisibilityOptions.Hidden,
     })
     render(<Selectbox {...currProps} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -60,9 +60,9 @@ describe("Radio widget", () => {
     })
     render(<Radio {...props} />)
 
-    const widgetLabel = screen.getByText("Label")
-    expect(widgetLabel).toHaveStyle("visibility: hidden")
-    expect(widgetLabel).not.toBeVisible()
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.test.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.test.tsx
@@ -106,8 +106,36 @@ describe("Widget Label", () => {
     const props = getProps({ labelVisibility: LabelVisibilityOptions.Hidden })
     render(<WidgetLabel {...props} />)
 
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
+    const label = screen.getByTestId("stWidgetLabel")
+    // The container should remain visible so children (e.g. help icon) stay shown
+    expect(label).not.toHaveStyle("visibility: hidden")
+
+    // Only the label text span should be hidden
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
+  })
+
+  it("shows tooltip icon when label_visibility is hidden", () => {
+    render(
+      <ThemeProvider
+        theme={mockTheme.emotion}
+        baseuiTheme={mockTheme.basewebTheme}
+      >
+        <WidgetLabel
+          label="My widget"
+          labelVisibility={LabelVisibilityOptions.Hidden}
+        >
+          <WidgetLabelHelpIconInline
+            content="help text"
+            ariaLabel="Help for My widget"
+          />
+        </WidgetLabel>
+      </ThemeProvider>
     )
+
+    const helpButton = screen.getByRole("button", {
+      name: "Help for My widget",
+    })
+    expect(helpButton).toBeVisible()
   })
 })

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabel.tsx
@@ -47,6 +47,9 @@ export function WidgetLabel({
     return <></>
   }
 
+  const isLabelHidden =
+    labelVisibility === LabelVisibilityOptions.Hidden
+
   return (
     <StyledWidgetLabel
       data-testid="stWidgetLabel"
@@ -59,7 +62,10 @@ export function WidgetLabel({
           and/or aria-labelledby). We hide the visual label text from assistive tech
           to avoid duplicate announcements, while keeping any children (e.g. help
           icons) accessible. */}
-      <span aria-hidden="true">
+      <span
+        aria-hidden="true"
+        style={isLabelHidden ? { visibility: "hidden" } : undefined}
+      >
         <StreamlitMarkdown source={label} allowHTML={false} isLabel />
       </span>
       {children}

--- a/frontend/lib/src/components/widgets/BaseWidget/styled-components.ts
+++ b/frontend/lib/src/components/widgets/BaseWidget/styled-components.ts
@@ -29,8 +29,6 @@ export const StyledWidgetLabel = styled.label<StyledWidgetProps>(
     color: disabled ? theme.colors.fadedText40 : theme.colors.bodyText,
     display:
       labelVisibility === LabelVisibilityOptions.Collapsed ? "none" : "flex",
-    visibility:
-      labelVisibility === LabelVisibilityOptions.Hidden ? "hidden" : "visible",
     marginBottom: theme.spacing.twoXS,
     height: "auto",
     minHeight: theme.fontSizes.xl,

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -393,9 +393,9 @@ describe("ButtonGroup widget", () => {
         },
       })
       render(<ButtonGroup {...props} />)
-      expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-        "visibility: hidden"
-      )
+      const label = screen.getByTestId("stWidgetLabel")
+      const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+      expect(labelTextSpan).toHaveStyle("visibility: hidden")
     })
 
     it("passes labelVisibility prop correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -160,9 +160,9 @@ describe("CameraInput widget", () => {
         },
       })
       render(<CameraInput {...props} />)
-      expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-        "visibility: hidden"
-      )
+      const label = screen.getByTestId("stWidgetLabel")
+      const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+      expect(labelTextSpan).toHaveStyle("visibility: hidden")
     })
 
     it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -90,9 +90,9 @@ describe("Checkbox widget", () => {
     })
 
     render(<Checkbox {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledContent correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -91,9 +91,9 @@ describe("DateInput widget", () => {
       },
     })
     render(<DateInput {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -135,9 +135,9 @@ describe("Multiselect widget", () => {
       },
     })
     render(<Multiselect {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
+++ b/frontend/lib/src/components/widgets/NumberInput/NumberInput.test.tsx
@@ -194,9 +194,9 @@ describe("NumberInput widget", () => {
       },
     })
     render(<NumberInput {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -92,9 +92,9 @@ describe("Slider widget", () => {
       },
     })
     render(<Slider {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.test.tsx
@@ -116,9 +116,9 @@ describe("TextArea widget", () => {
       },
     })
     render(<TextArea {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -79,9 +79,9 @@ describe("TextInput widget", () => {
     })
 
     render(<TextInput {...props} />)
-    expect(screen.getByTestId("stWidgetLabel")).toHaveStyle(
-      "visibility: hidden"
-    )
+    const label = screen.getByTestId("stWidgetLabel")
+    const labelTextSpan = label.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {

--- a/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TimeInput/TimeInput.test.tsx
@@ -70,8 +70,8 @@ describe("TimeInput widget", () => {
     render(<TimeInput {...props} />)
 
     const widgetLabel = screen.getByTestId("stWidgetLabel")
-    expect(widgetLabel).toHaveStyle("visibility: hidden")
-    expect(widgetLabel).not.toBeVisible()
+    const labelTextSpan = widgetLabel.querySelector("span[aria-hidden='true']")
+    expect(labelTextSpan).toHaveStyle("visibility: hidden")
   })
 
   it("pass labelVisibility prop to StyledWidgetLabel correctly when collapsed", () => {


### PR DESCRIPTION
## Describe your changes

When `label_visibility="hidden"` is set on a widget, the tooltip/help icon (passed via the `help` parameter) was also hidden. This happened because `visibility: hidden` was applied to the entire `StyledWidgetLabel` container, which includes both the label text and any children like the tooltip icon.

This fix moves the `visibility: hidden` from the container level to only the label text `<span>` inside `WidgetLabel`, so that:
- The label text is still visually hidden (preserving the current behavior for layout/spacing)
- The tooltip icon remains visible and interactive
- The `collapsed` mode continues to work unchanged (`display: none` on the container)

## Screenshot or video (only for visual changes)

Before: tooltip icon is hidden when `label_visibility="hidden"`
After: tooltip icon is visible and clickable when `label_visibility="hidden"`

## GitHub Issue Link (if applicable)

Fixes #9934

## Testing Plan

- Updated unit tests across all widget test files to verify the new behavior
- Added a dedicated test in `WidgetLabel.test.tsx` confirming the tooltip icon remains visible when `label_visibility` is hidden
- Manual testing: `st.text_input(label="Name", label_visibility="hidden", help="Enter your name")`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.