### PR TITLE
issue 14573

### DIFF
--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -52,6 +52,7 @@ import {
   isColor,
   isPresetTheme,
   mapCachedThemeSelectionToAvailableTheme,
+  normalizeColor,
   parseFont,
   removeCachedTheme,
   setCachedThemeSelection,
@@ -750,6 +751,72 @@ describe("isColor", () => {
     expect(isColor("cookies are delicious")).toBe(false)
     expect(isColor("")).toBe(false)
     expect(isColor("hsl(120,50,40)")).toBe(false)
+  })
+})
+
+describe("normalizeColor", () => {
+  it("returns standard colors unchanged", () => {
+    expect(normalizeColor("#ff0000")).toBe("#ff0000")
+    expect(normalizeColor("#000000")).toBe("#000000")
+    expect(normalizeColor("rgb(255, 0, 0)")).toBe("rgb(255, 0, 0)")
+    expect(normalizeColor("red")).toBe("red")
+  })
+
+  it("normalizes OKLCH colors via canvas when available", () => {
+    const mockCtx = {
+      fillStyle: "#000000" as string,
+    }
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(mockCtx),
+    }
+    vi.spyOn(document, "createElement").mockReturnValue(
+      mockCanvas as unknown as HTMLElement
+    )
+
+    // Simulate the browser normalizing an OKLCH color to hex
+    const originalFillStyleDescriptor = Object.getOwnPropertyDescriptor(
+      mockCtx,
+      "fillStyle"
+    )
+    let storedFillStyle = "#000000"
+    Object.defineProperty(mockCtx, "fillStyle", {
+      get: () => storedFillStyle,
+      set: (value: string) => {
+        // Simulate browser behavior: normalize OKLCH to hex
+        if (value === "oklch(0.21 0.01 260)") {
+          storedFillStyle = "#2b2d30"
+        } else {
+          storedFillStyle = value
+        }
+      },
+      configurable: true,
+    })
+
+    const result = normalizeColor("oklch(0.21 0.01 260)")
+    expect(result).toBe("#2b2d30")
+
+    vi.restoreAllMocks()
+    if (originalFillStyleDescriptor) {
+      Object.defineProperty(mockCtx, "fillStyle", originalFillStyleDescriptor)
+    }
+  })
+
+  it("returns original color when canvas context is unavailable", () => {
+    const mockCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(null),
+    }
+    vi.spyOn(document, "createElement").mockReturnValue(
+      mockCanvas as unknown as HTMLElement
+    )
+
+    const result = normalizeColor("oklch(0.21 0.01 260)")
+    expect(result).toBe("oklch(0.21 0.01 260)")
+
+    vi.restoreAllMocks()
   })
 })
 

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -169,6 +169,47 @@ export const isColor = (strColor: string): boolean => {
 }
 
 /**
+ * Normalize a CSS color string to a hex format that color2k can parse.
+ * Uses a canvas context to let the browser convert modern CSS color formats
+ * (e.g. oklch, oklab, lch, lab, color()) to a standard rgba() or hex string.
+ * Returns the original color if normalization fails or isn't needed.
+ */
+export const normalizeColor = (color: string): string => {
+  // Quick check: try parsing with color2k first. If it works, no normalization needed.
+  try {
+    parseToRgba(color)
+    return color
+  } catch {
+    // color2k can't parse it — try browser-based normalization below.
+  }
+
+  try {
+    const canvas = document.createElement("canvas")
+    canvas.width = 1
+    canvas.height = 1
+    const ctx = canvas.getContext("2d")
+    if (!ctx) {
+      return color
+    }
+    // Reset to a known color so we can detect if the browser rejects the input.
+    ctx.fillStyle = "#000000"
+    ctx.fillStyle = color
+    // If the browser didn't accept the color, fillStyle stays as "#000000".
+    if (
+      ctx.fillStyle === "#000000" &&
+      color.trim().toLowerCase() !== "#000000" &&
+      color.trim().toLowerCase() !== "black"
+    ) {
+      return color
+    }
+    // The browser normalizes the color — fillStyle returns hex or rgba().
+    return ctx.fillStyle
+  } catch {
+    return color
+  }
+}
+
+/**
  * Helper function that rounds a font size (in rem) to the nearest eighth of a rem
  * This is used to keep configured font sizes to (generally) round values for dialogs.
  * See `convertFontSizes` in `StreamlitMarkdown/styled-components.ts`
@@ -227,12 +268,12 @@ const parseColor = (
 ): string | undefined => {
   // First try the color as-is
   if (isColor(color)) {
-    return color
+    return normalizeColor(color)
   }
 
   // If that fails, try adding a # prefix
   if (isColor(`#${color}`)) {
-    return `#${color}`
+    return normalizeColor(`#${color}`)
   }
 
   // If both fail and this is a color config, log a warning
@@ -1104,7 +1145,7 @@ export const createTheme = (
   // theme's backgroundColor instead of picking them using themeInput.base.
   // This way, things will look good even if a user sets
   // themeInput.base === LIGHT and themeInput.backgroundColor === "black".
-  const bgColor = completedThemeInput.backgroundColor
+  const bgColor = normalizeColor(completedThemeInput.backgroundColor)
   const startingTheme = merge(
     cloneDeep(
       baseThemeConfig
@@ -1529,11 +1570,14 @@ export const createSidebarTheme = (activeTheme: ThemeConfig): ThemeConfig => {
   const { bgColor, secondaryBg } = activeTheme.emotion.colors
 
   // Either use the configured background color or secondary background from main theme:
-  const sidebarBackground = sidebarThemeInput?.backgroundColor || secondaryBg
+  const sidebarBackground = normalizeColor(
+    sidebarThemeInput?.backgroundColor || secondaryBg
+  )
 
   // Either use the configured secondary background color or background from main theme:
-  const secondaryBackgroundColor =
+  const secondaryBackgroundColor = normalizeColor(
     sidebarThemeInput?.secondaryBackgroundColor || bgColor
+  )
 
   // Handle configured vs. default header font sizes for sidebar
   const headingFontSizes = setSidebarHeadingFontSizes(


### PR DESCRIPTION
This pull request introduces a new utility function, `normalizeColor`, to standardize CSS color strings (including modern formats like OKLCH) to a browser-supported format. The function is integrated throughout the theme utilities to ensure consistent color parsing and handling. Comprehensive unit tests for `normalizeColor` are also added to verify its behavior under various scenarios.

**Color normalization improvements:**

* Added the `normalizeColor` function in `utils.ts` to convert modern CSS color formats to a browser-supported format using a canvas context, with fallback to the original string if normalization fails.
* Updated the `parseColor` function to use `normalizeColor` when returning colors, ensuring all parsed colors are normalized.
* Modified theme creation logic (`createTheme` and `createSidebarTheme`) to normalize background and secondary background colors, improving compatibility and consistency for user-supplied or computed color values. [[1]](diffhunk://#diff-56bcae560f1f0c4f6744d3506265d7c2c0c3562a5a9e1294b84bcda37d7bc1e9L1107-R1148) [[2]](diffhunk://#diff-56bcae560f1f0c4f6744d3506265d7c2c0c3562a5a9e1294b84bcda37d7bc1e9L1532-R1580)

**Testing enhancements:**

* Added unit tests for `normalizeColor` in `utils.test.ts`, covering standard colors, OKLCH normalization via canvas, and fallback behavior when the canvas context is unavailable.
* Included `normalizeColor` in the test imports to enable direct testing.