### PR TITLE
Add border-radius rounding to st.video and st.map

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -23,10 +23,12 @@ interface StyledDeckGlChartProps {
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ isStretchHeight }) => ({
+  ({ theme, isStretchHeight }) => ({
     position: "relative",
     height: "100%",
     width: "100%",
+    borderRadius: theme.radii.default,
+    overflow: "hidden",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.
     ...(isStretchHeight && { minHeight: "6.25rem" }),
   })

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -33,7 +33,6 @@ export interface VideoProps {
   elementMgr: ElementStateManager
 }
 
-const VIDEO_STYLE = { width: "100%" }
 
 function Video({
   element,
@@ -248,7 +247,7 @@ function Video({
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -256,7 +255,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -272,7 +270,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -23,4 +23,12 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: theme.radii.default,
+  overflow: "hidden",
+}))
+
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: theme.radii.default,
+  overflow: "hidden",
 }))


### PR DESCRIPTION
## Summary
Adds `borderRadius: theme.radii.default` and `overflow: "hidden"` to `st.video` and `st.map`/`st.pydeck_chart` components to match the rounded styling used by other Streamlit elements.

Closes #12806

## Changes
- **`st.video`**: Created a `StyledVideo` styled component with `borderRadius` and `overflow: "hidden"`, replacing the inline `VIDEO_STYLE` object. Also added `borderRadius` and `overflow` to `StyledVideoIframe`.
- **`st.map`/`st.pydeck_chart`**: Added `borderRadius` and `overflow: "hidden"` to `StyledDeckGlChart`. The `overflow: "hidden"` ensures content is clipped to the rounded corners while the navigation controls (positioned absolutely via `StyledNavigationControlContainer`) remain usable.

## Pattern
Follows the same pattern used by other elements like `ArrowVegaLiteChart`, `Table`, `ChatMessage`, etc. that use `theme.radii.default`.