### PR TITLE
Add border-radius rounding to st.video and st.map

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -23,10 +23,12 @@ interface StyledDeckGlChartProps {
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ isStretchHeight }) => ({
+  ({ theme, isStretchHeight }) => ({
     position: "relative",
     height: "100%",
     width: "100%",
+    borderRadius: theme.radii.default,
+    overflow: "hidden",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.
     ...(isStretchHeight && { minHeight: "6.25rem" }),
   })

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -38,7 +38,7 @@ export interface Subtitle {
   url: string
 }
 
-const VIDEO_STYLE = { width: "100%" }
+
 
 function Video({
   element,
@@ -253,7 +253,7 @@ function Video({
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -261,7 +261,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -277,7 +276,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -23,4 +23,10 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: theme.radii.default,
+}))
+
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: theme.radii.default,
 }))


### PR DESCRIPTION
## Problem

`st.video` and `st.map`/`st.pydeck_chart` are the only elements without rounded corners, making them look inconsistent with the rest of the Streamlit UI.

## Solution

Apply `theme.radii.default` border-radius to:
- **`st.video`**: New `StyledVideo` styled component replaces the inline `style` prop. Also added rounding to the YouTube iframe variant (`StyledVideoIframe`).
- **`st.map` / `st.pydeck_chart`**: Added `borderRadius` and `overflow: hidden` to `StyledDeckGlChart` so the map canvas clips to rounded corners.

### Controls not clipped
- **Video**: Native browser controls naturally respect the element's `border-radius` and remain fully usable.
- **Map**: The zoom/navigation controls are positioned inset from the corners (`right: 2.625rem`, `top: theme.spacing.md`) so `overflow: hidden` does not affect them.
- Custom theming with larger radii still works because controls have sufficient margin from corners.

## Files Changed

| File | Change |
|------|--------|
| `Video/styled-components.ts` | Added `borderRadius` to iframe; new `StyledVideo` component |
| `Video/Video.tsx` | Use `StyledVideo` instead of `<video>` with inline style |
| `DeckGlJsonChart/styled-components.ts` | Added `borderRadius` + `overflow: hidden` |

## Related

Previous PR: #11058

Closes #12806