### PR TITLE
fix(caching): data-dependent sample seeds and P-mode PIL palette hashing

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -67,6 +67,66 @@ _CYCLE_PLACEHOLDER: Final = (
 )
 
 
+def _pandas_sample_seed(obj: Any) -> int:
+    """Return a data-dependent seed for pandas sampling, or 0 if unhashable.
+
+    Using 0 matches the legacy fixed seed when ``hash_pandas_object`` cannot run
+    (e.g. unhashable cell values), so the pickle fallback path is unchanged.
+    """
+
+    from pandas.util import hash_pandas_object
+
+    try:
+        hashes = hash_pandas_object(obj)
+        return int(hashes.sum()) & 0xFFFF_FFFF
+    except (TypeError, ValueError):
+        return 0
+
+
+def _numpy_sample_seed(np_obj: Any) -> int:
+    """Return a data-dependent seed for large-array sampling from a short prefix.
+
+    The goal is to avoid a globally fixed sample index set, not cryptographic
+    unpredictability.
+    """
+
+    import numpy as np
+
+    flat = np_obj.flat
+    n = min(64, int(np_obj.size))
+    if n == 0:
+        return 0
+    try:
+        prefix = np.asarray(flat[:n], dtype=np_obj.dtype, order="C")
+        digest = hashlib.md5(prefix.tobytes(), usedforsecurity=False).digest()
+    except (TypeError, ValueError, BufferError):
+        return 0
+    return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
+
+
+def _polars_sample_seed(obj: Any) -> int:
+    """Return a data-dependent seed for Polars sampling, or 0 on failure.
+
+    Uses Polars-native hashing (``hash_rows`` for DataFrames, ``hash`` for
+    Series) to avoid non-determinism that can occur when converting exotic
+    dtypes through NumPy's ``tobytes``.
+    """
+
+    try:
+        head = obj.head(1)
+        # DataFrames expose hash_rows; Series expose hash.
+        if hasattr(head, "hash_rows"):
+            hash_series = head.hash_rows(seed=0)
+        else:
+            hash_series = head.hash(seed=0)
+        digest = hashlib.md5(
+            hash_series.to_numpy().tobytes(), usedforsecurity=False
+        ).digest()
+    except (TypeError, ValueError, BufferError):
+        return 0
+    return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
+
+
 class UserHashError(StreamlitAPIException):
     def __init__(
         self,
@@ -424,7 +484,9 @@ class _CacheFuncHasher:
             self.update(h, series_obj.dtype.name)
 
             if len(series_obj) >= _PANDAS_ROWS_LARGE:
-                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                # Data-dependent seed so sample indices are not globally fixed.
+                rs = _pandas_sample_seed(series_obj.iloc[:1])
+                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=rs)
 
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
@@ -446,7 +508,8 @@ class _CacheFuncHasher:
             self.update(h, df_obj.shape)
 
             if len(df_obj) >= _PANDAS_ROWS_LARGE:
-                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                sample_seed = _pandas_sample_seed(df_obj.iloc[:1])
+                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=sample_seed)
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -466,17 +529,19 @@ class _CacheFuncHasher:
                 return b"%s" % pickle.dumps(df_obj, pickle.HIGHEST_PROTOCOL)
 
         elif type_util.is_type(obj, "polars.series.series.Series"):
-            import polars as pl
-
             obj = cast("pl.Series", obj)
             self.update(h, str(obj.dtype).encode())
             self.update(h, obj.shape)
 
+            sample_seed = 0
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                sample_seed = _polars_sample_seed(obj)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=sample_seed)
 
             try:
-                self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
+                self.update(
+                    h, obj.hash(seed=sample_seed).to_arrow().to_string().encode()
+                )
                 return h.digest()
 
             except TypeError:
@@ -495,15 +560,21 @@ class _CacheFuncHasher:
             obj = cast("pl.DataFrame", obj)
             self.update(h, obj.shape)
 
+            sample_seed = 0
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                sample_seed = _polars_sample_seed(obj)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=sample_seed)
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
                     self.update(h, str(t).encode())
 
                 values_hash_bytes = (
-                    obj.hash_rows(seed=0).hash(seed=0).to_arrow().to_string().encode()
+                    obj.hash_rows(seed=sample_seed)
+                    .hash(seed=sample_seed)
+                    .to_arrow()
+                    .to_string()
+                    .encode()
                 )
 
                 self.update(h, values_hash_bytes)
@@ -527,7 +598,9 @@ class _CacheFuncHasher:
             if np_obj.size >= _NP_SIZE_LARGE:
                 import numpy as np
 
-                state = np.random.RandomState(0)
+                # Data-dependent seed so sample indices are not globally fixed.
+                rs = _numpy_sample_seed(np_obj)
+                state = np.random.RandomState(rs)
                 np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())
@@ -540,7 +613,12 @@ class _CacheFuncHasher:
 
             # we don't just hash the results of obj.tobytes() because we want to use
             # the sampling logic for numpy data
-            np_array = np.frombuffer(pil_obj.tobytes(), dtype="uint8")
+            pixel_bytes = pil_obj.tobytes()
+            if pil_obj.mode == "P":
+                palette_data = pil_obj.getpalette()
+                if palette_data is not None:
+                    pixel_bytes = bytes(palette_data) + pixel_bytes
+            np_array = np.frombuffer(pixel_bytes, dtype="uint8")
             return self.to_bytes(np_array)
 
         elif inspect.isbuiltin(obj):

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -966,3 +966,51 @@ def test_pydantic_model_unhashable_when_model_dump_json_fails() -> None:
         with pytest.raises(UnhashableTypeError) as exc_info:
             get_hash(instance)
     assert "unhashable members" in str(exc_info.value).lower()
+
+
+def test_PIL_pmode_palette_collision_prevention() -> None:
+    """P-mode images with identical index buffers but different palettes must not collide."""
+
+    img_a = Image.new("P", (100, 100), 0)
+    img_b = Image.new("P", (100, 100), 0)
+    palette_a = [0] * 768
+    palette_b = [0] * 768
+    palette_a[0:3] = [0, 0, 0]
+    palette_b[0:3] = [255, 0, 0]
+    img_a.putpalette(palette_a)
+    img_b.putpalette(palette_b)
+
+    assert img_a.tobytes() == img_b.tobytes()
+    assert get_hash(img_a) != get_hash(img_b)
+
+
+def test_numpy_large_array_seed_prefix_change_differs() -> None:
+    """Mutating the seed prefix (first element) produces a different hash for large arrays."""
+
+    total = _NP_SIZE_LARGE + 10_000
+    arr_a = np.zeros(total, dtype=np.float64)
+    arr_b = arr_a.copy()
+    arr_b[0] = 255.0
+
+    assert get_hash(arr_a) != get_hash(arr_b)
+
+
+def test_pandas_large_dataframe_seed_row_change_differs() -> None:
+    """Mutating the seed row (row 0) produces a different hash for large DataFrames."""
+
+    n = _PANDAS_ROWS_LARGE + 5_000
+    df_a = pd.DataFrame({"val": np.zeros(n)})
+    df_b = df_a.copy()
+    df_b.iloc[0, df_b.columns.get_loc("val")] = 99.0
+
+    assert get_hash(df_a) != get_hash(df_b)
+
+
+def test_pandas_large_dataframe_unhashable_payload_uses_pickle_fallback() -> None:
+    """Large frames with unhashable cells must still hash and match when identical."""
+
+    n = _PANDAS_ROWS_LARGE
+    df1 = pd.DataFrame({"x": [[1]] * n})
+    df2 = pd.DataFrame({"x": [[1]] * n})
+
+    assert get_hash(df1) == get_hash(df2)


### PR DESCRIPTION
Fixes hash collisions from fixed sampling seeds for large pandas/polars/numpy inputs and from omitting palette bytes for PIL P-mode images.

Fixes #14622

## Describe your changes

- **Large-object sampling:** Replaced hardcoded `random_state=0` / `seed=0` / `RandomState(0)` with **data-dependent** seeds so sampled rows/values are not globally predictable for large pandas Series/DataFrame, polars Series/DataFrame, and numpy arrays.
- **Safe fallbacks:** Pandas seed derivation uses `hash_pandas_object` inside `try/except TypeError` and falls back to `0` when the first slice is unhashable, preserving the existing pickle fallback behavior for object columns with lists/dicts, etc.
- **Polars:** One derived seed is used consistently for `sample`, `hash` / `hash_rows`, and nested `hash` when the large path is taken; small frames/series still use seed `0` so their cache keys stay unchanged.
- **NumPy:** Seed is derived from an MD5 fingerprint of up to the first 64 elements (with exceptions mapped to `0`), then `RandomState` samples from the flat array as before.
- **PIL P-mode:** When `mode == "P"` and `getpalette()` is not `None`, palette bytes are prepended before hashing pixel `tobytes()`, so different palettes no longer collide when indices match.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/14622

## Testing Plan

- **Unit tests (Python):** Added regressions in `lib/tests/streamlit/runtime/caching/hashing_test.py` for P-mode palette distinction, large numpy/pandas “non-sampled” divergence, and large pandas with unhashable cells (pickle fallback). Ran `uv run pytest lib/tests/streamlit/runtime/caching/hashing_test.py`.
- **E2E tests:** Not required — behavior is internal to cache key computation; no new `st.` API or UI.
- **Manual testing:** Not required beyond the unit tests above.

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
