### PR TITLE
fix: deduplicate extension aliases in file_uploader display

### DIFF
--- a/frontend/lib/src/util/FileHelper.test.ts
+++ b/frontend/lib/src/util/FileHelper.test.ts
@@ -18,6 +18,7 @@ import {
   BYTE_CONVERSION_SIZE,
   FileSize,
   formatTypeForDisplay,
+  formatTypesForDisplay,
   getSizeDisplay,
   isFileTypeAllowed,
   isMimeType,
@@ -136,6 +137,32 @@ describe("formatTypeForDisplay", () => {
     expect(formatTypeForDisplay(".pdf")).toEqual("PDF")
     expect(formatTypeForDisplay(".tar.gz")).toEqual("TAR.GZ")
     expect(formatTypeForDisplay("png")).toEqual("PNG")
+  })
+})
+
+describe("formatTypesForDisplay", () => {
+  it("deduplicates JPG and JPEG to show only JPG", () => {
+    expect(formatTypesForDisplay([".jpg", ".jpeg"])).toEqual("JPG")
+  })
+
+  it("deduplicates other extension alias pairs", () => {
+    expect(formatTypesForDisplay([".tif", ".tiff"])).toEqual("TIF")
+    expect(formatTypesForDisplay([".htm", ".html"])).toEqual("HTM")
+    expect(formatTypesForDisplay([".mpg", ".mpeg"])).toEqual("MPG")
+  })
+
+  it("keeps both extensions when only one of a pair is present", () => {
+    expect(formatTypesForDisplay([".jpg", ".png"])).toEqual("JPG, PNG")
+  })
+
+  it("handles mixed MIME types and deduplicated extensions", () => {
+    expect(formatTypesForDisplay(["image/*", ".jpg", ".jpeg", ".png"])).toEqual(
+      "image, JPG, PNG"
+    )
+  })
+
+  it("returns empty string for empty input", () => {
+    expect(formatTypesForDisplay([])).toEqual("")
   })
 })
 

--- a/frontend/lib/src/util/FileHelper.test.ts
+++ b/frontend/lib/src/util/FileHelper.test.ts
@@ -149,6 +149,7 @@ describe("formatTypesForDisplay", () => {
     expect(formatTypesForDisplay([".tif", ".tiff"])).toEqual("TIF")
     expect(formatTypesForDisplay([".htm", ".html"])).toEqual("HTM")
     expect(formatTypesForDisplay([".mpg", ".mpeg"])).toEqual("MPG")
+    expect(formatTypesForDisplay([".mp4", ".mpeg4"])).toEqual("MP4")
   })
 
   it("keeps both extensions when only one of a pair is present", () => {

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -212,6 +212,9 @@ export const formatTypeForDisplay = (type: string): string => {
 /**
  * Extension alias pairs where the shorter form is preferred for display.
  * When both extensions in a pair are present, only the shorter one is shown.
+ *
+ * NOTE: This list mirrors TYPE_PAIRS in lib/streamlit/elements/lib/file_uploader_utils.py.
+ * If pairs are added/removed there, update this list to match.
  */
 const DISPLAY_ALIAS_PAIRS: ReadonlyArray<[string, string]> = [
   [".jpg", ".jpeg"],

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -210,11 +210,42 @@ export const formatTypeForDisplay = (type: string): string => {
 }
 
 /**
+ * Extension alias pairs where the shorter form is preferred for display.
+ * When both extensions in a pair are present, only the shorter one is shown.
+ */
+const DISPLAY_ALIAS_PAIRS: ReadonlyArray<[string, string]> = [
+  [".jpg", ".jpeg"],
+  [".mpg", ".mpeg"],
+  [".mp4", ".mpeg4"],
+  [".tif", ".tiff"],
+  [".htm", ".html"],
+]
+
+/**
+ * Deduplicate extension aliases for display purposes.
+ * When both extensions in an alias pair are present (e.g., .jpg and .jpeg),
+ * only the shorter form is kept to avoid redundant display text.
+ */
+const deduplicateExtensionAliases = (types: string[]): string[] => {
+  const lowered = new Set(types.map(t => t.toLowerCase()))
+  const toRemove = new Set<string>()
+
+  for (const [shorter, longer] of DISPLAY_ALIAS_PAIRS) {
+    if (lowered.has(shorter) && lowered.has(longer)) {
+      toRemove.add(longer)
+    }
+  }
+
+  return types.filter(t => !toRemove.has(t.toLowerCase()))
+}
+
+/**
  * Format a list of file type specifiers for display.
- * Returns a comma-separated string of formatted types.
+ * Deduplicates common extension aliases (e.g., JPG/JPEG) and returns
+ * a comma-separated string of formatted types.
  */
 export const formatTypesForDisplay = (types: string[]): string =>
-  types.map(formatTypeForDisplay).join(", ")
+  deduplicateExtensionAliases(types).map(formatTypeForDisplay).join(", ")
 
 /**
  * Return a human-readable message for the given error.


### PR DESCRIPTION
## Summary

Closes #11991

When `st.file_uploader` is configured with either `.jpg` or `.jpeg`, the backend auto-pairs both extensions for acceptance. However, the frontend displays both redundantly (e.g., "JPG, JPEG").

This PR deduplicates common extension aliases so only the shorter, more common form is shown.

## Changes

- **`frontend/lib/src/util/FileHelper.ts`**:
  - Added `DISPLAY_ALIAS_PAIRS` constant matching the backend `TYPE_PAIRS`
  - Added `deduplicateExtensionAliases()` function
  - Updated `formatTypesForDisplay()` to deduplicate before formatting

- **`frontend/lib/src/util/FileHelper.test.ts`**:
  - Added tests for JPG/JPEG, TIF/TIFF, HTM/HTML, MPG/MPEG deduplication
  - Added test for mixed MIME types and extensions
  - Added test for single extension (no dedup needed)
  - Added empty input test

## Behavior

| Before | After |
|---|---|
| JPG, JPEG | JPG |
| TIF, TIFF, PNG | TIF, PNG |
| image, JPG, JPEG, PNG | image, JPG, PNG |

## Test Plan

- [x] Unit tests added for all alias pairs
- [x] Tests cover edge cases (single extension, mixed MIME/extension, empty)