### PR TITLE
Fix: Deduplicate JPG and JPEG in the file uploader UI (#11991)

### DIFF
--- a/frontend/lib/src/util/FileHelper.test.ts
+++ b/frontend/lib/src/util/FileHelper.test.ts
@@ -18,6 +18,7 @@ import {
   BYTE_CONVERSION_SIZE,
   FileSize,
   formatTypeForDisplay,
+  formatTypesForDisplay,
   getSizeDisplay,
   isFileTypeAllowed,
   isMimeType,
@@ -133,9 +134,17 @@ describe("formatTypeForDisplay", () => {
 
   it("formats extensions by removing dot and uppercasing", () => {
     expect(formatTypeForDisplay(".jpg")).toEqual("JPG")
+    expect(formatTypeForDisplay(".jpeg")).toEqual("JPG")
     expect(formatTypeForDisplay(".pdf")).toEqual("PDF")
     expect(formatTypeForDisplay(".tar.gz")).toEqual("TAR.GZ")
     expect(formatTypeForDisplay("png")).toEqual("PNG")
+  })
+})
+
+describe("formatTypesForDisplay", () => {
+  it("formats and deduplicates file types", () => {
+    expect(formatTypesForDisplay([".jpg", ".jpeg", "png"])).toEqual("JPG, PNG")
+    expect(formatTypesForDisplay(["image/*", "image/*"])).toEqual("image")
   })
 })
 

--- a/frontend/lib/src/util/FileHelper.ts
+++ b/frontend/lib/src/util/FileHelper.ts
@@ -206,7 +206,8 @@ export const formatTypeForDisplay = (type: string): string => {
   }
 
   // Extension: remove dot and uppercase (e.g., ".jpg" -> "JPG")
-  return type.replace(/^\./, "").toUpperCase()
+  const ext = type.replace(/^\./, "").toUpperCase()
+  return ext === "JPEG" ? "JPG" : ext
 }
 
 /**
@@ -214,7 +215,7 @@ export const formatTypeForDisplay = (type: string): string => {
  * Returns a comma-separated string of formatted types.
  */
 export const formatTypesForDisplay = (types: string[]): string =>
-  types.map(formatTypeForDisplay).join(", ")
+  Array.from(new Set(types.map(formatTypeForDisplay))).join(", ")
 
 /**
  * Return a human-readable message for the given error.


### PR DESCRIPTION
### What
Deduplicates the "JPG" and "JPEG" display string in `st.file_uploader` so that only "JPG" is visually shown to the user, while preserving the backend functionality of accepting aliases.

### Why
Fixes #11991. When a user creates an `st.file_uploader` and passes `"jpg"` or `"jpeg"` to the `type` parameter, the backend expands the allowed extensions to allow both `.jpg` and `.jpeg` (which is correct behavior). However, this previously caused the tooltip to redundantly render `"JPG, JPEG"`. This PR simplifies the UI text by collapsing them into just `"JPG"`, improving the visual aesthetics.

### How
* Handled entirely on the frontend formatting layer (`frontend/lib/src/util/FileHelper.ts`) to avoid modifying backend validation mappings.
* `formatTypeForDisplay` now explicitly maps the string `"JPEG"` to `"JPG"`.
* `formatTypesForDisplay` uses `Set` to deduplicate formats before joining them with a comma.
* Validation logic (`isFileTypeAllowed`) remains completely unchanged, ensuring accurate server-side and client-side file checking functionality is retained.

### Testing
- Added unit tests in `FileHelper.test.ts` to assert that `[.jpg, .jpeg]` accurately collapses to `JPG`.
