### PR TITLE
fix(caching): chain original exception in UnserializableReturnValueError

### DIFF
--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -409,7 +409,7 @@ class CachedFunc(Generic[P, R]):
                     ) from ex
                 raise UnserializableReturnValueError(
                     return_value=computed_value, func=self._info.func
-                )
+                ) from ex
 
     @overload
     def clear(self) -> None: ...


### PR DESCRIPTION
## Summary

- Add missing `from ex` to `UnserializableReturnValueError` raise in `_handle_cache_miss()`, so the original serialization error (e.g. `PicklingError`) is preserved in the exception chain
- This is consistent with the adjacent `UnevaluatedDataFrameError` which already correctly uses `from ex`

Fixes #14654
Related: #14593

## Details

In `lib/streamlit/runtime/caching/cache_utils.py`, when `cache.write_result()` fails with a `CacheError` or `RuntimeError`, the handler raises `UnserializableReturnValueError` but drops the original exception. This one-line fix adds `from ex` to preserve the exception chain, making it much easier for users to debug serialization failures.

## Test plan

- [x] Verified the change is a single `from ex` addition
- [x] Confirmed adjacent `UnevaluatedDataFrameError` already uses `from ex` (this is just consistency)
- [x] No behavioral change — only exception chaining for better diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)