### PR TITLE
[spec] Allow interactive resizing of `st.columns`

### DIFF
--- a/specs/2026-04-08-resizable-columns/product-spec.md
+++ b/specs/2026-04-08-resizable-columns/product-spec.md
@@ -188,36 +188,6 @@ st.columns(3, resizable=False)                   # Explicit non-resizable (defau
 st.columns(1, resizable=True)                    # Single column, nothing to resize
 ```
 
-### Implementation Test Requirements
-
-The following test scenarios should be covered in the implementation PR:
-
-**Frontend unit tests (Vitest):**
-
-- Resize handle renders between adjacent columns when `resizable=True`
-- Resize handle does not render when `resizable=False`
-- Drag interaction updates column widths correctly
-- Double-click resets columns to original proportions
-- Minimum width (64px) constraint is enforced
-- Keyboard Arrow Left/Right adjusts widths in 10px increments
-- Cursor changes to `col-resize` on hover
-- ARIA attributes (`role="separator"`, `aria-valuenow`, etc.) are present
-
-**Backend unit tests (pytest):**
-
-- `resizable` parameter is accepted and passed to protobuf
-- Invalid `resizable` values raise appropriate errors
-- Default value is `False`
-
-**E2E tests (Playwright):**
-
-- Drag resize between columns adjusts widths visually
-- Responsive stacking hides resize handles below 640px threshold
-- Widths persist within session (no reset on rerun without config change)
-- Widths reset on page refresh
-- Touch drag works on touch-capable viewports
-- Nested columns resize independently
-
 ## Alternatives Considered
 
 ### Parameter type: `resizable: bool` vs `resize_mode: Literal[...]`

--- a/specs/2026-04-08-resizable-columns/product-spec.md
+++ b/specs/2026-04-08-resizable-columns/product-spec.md
@@ -20,9 +20,9 @@ cannot be adjusted without modifying code and rerunning the app. This creates fr
 **Related issues:**
 
 - [#5003](https://github.com/streamlit/streamlit/issues/5003): Deactivate responsiveness of
-  st.columns (46 upvotes) — users want more control over column layout behavior
+  st.columns — users want more control over column layout behavior
 - [#6592](https://github.com/streamlit/streamlit/issues/6592): Configurable column
-  responsiveness width threshold (19 upvotes) — requests for flexible column sizing
+  responsiveness width threshold — requests for flexible column sizing
 
 **Use cases:**
 

--- a/specs/2026-04-08-resizable-columns/product-spec.md
+++ b/specs/2026-04-08-resizable-columns/product-spec.md
@@ -1,0 +1,199 @@
+---
+author: lukasmasuch
+created: 2026-04-08
+---
+
+# Resizable columns via drag-and-drop
+
+## Summary
+
+Add a `resizable: bool = False` parameter to `st.columns` that allows users to resize columns
+by dragging the border between them. When enabled, a visual border indicator appears on hover
+between adjacent columns, and users can drag to adjust column widths interactively. Resizing
+is purely client-side and does not trigger a script rerun.
+
+## Problem
+
+Column widths in `st.columns` are currently static—once defined via the `spec` parameter, they
+cannot be adjusted without modifying code and rerunning the app. This creates friction for:
+
+**Use cases:**
+
+- **Dashboard customization**: Users want to adjust column widths to better fit their content
+  or screen size without developer intervention
+- **Data exploration**: When comparing data across columns, users may need to temporarily
+  expand one column to see more detail
+- **Responsive layouts**: Allowing users to fine-tune layouts for their specific display
+  configuration
+- **Presentation mode**: Adjusting column proportions during demos or presentations without
+  code changes
+
+**Current workarounds:**
+
+- Provide multiple layout presets via `st.selectbox` (requires code changes, causes rerun)
+- Use CSS hacks with custom components (complex, fragile)
+- Accept fixed layouts (suboptimal UX)
+
+## Proposal
+
+### API
+
+```python
+st.columns(
+    spec,
+    *,
+    gap="small",
+    vertical_alignment="top",
+    border=False,
+    width="stretch",
+    resizable=False,  # NEW
+)
+```
+
+### Parameter
+
+| Parameter   | Type   | Default | Description                                                                                                                                                                                                                                                   |
+| ----------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resizable` | `bool` | `False` | Whether the columns are resizable by dragging. If `False` (default), column widths are fixed based on the `spec` parameter. If `True`, users can resize columns by dragging the border between them on wide viewports where columns are displayed side-by-side. |
+
+### Behavior
+
+**`resizable=False` (default):**
+
+- Standard fixed-width columns based on `spec`
+- No visual resize handles or hover indicators
+- Current behavior preserved
+
+**`resizable=True`:**
+
+- Columns can be resized by dragging the border between adjacent columns
+- **Hover indicator**: A vertical border line appears when hovering over the resize area
+  between columns, signaling that resizing is possible
+- **Drag interaction**: Click and drag the border to resize adjacent column pairs
+- **Double-click to reset**: Double-clicking the resize handle resets the adjacent columns
+  to their original `spec` proportions
+- **Minimum width**: Each column has a minimum width (64px) to prevent columns from
+  collapsing entirely
+- **Keyboard support**: When focused, use Arrow Left/Right keys to resize in 10px increments
+- **Cursor feedback**: The cursor changes to `col-resize` when hovering over the resize handle
+- **Smooth transitions**: The border indicator fades in/out smoothly (150ms transition)
+
+**Width preservation:**
+
+- Resizing adjusts only the two adjacent columns involved in the drag
+- Total row width is preserved—when one column grows, its neighbor shrinks
+- Other columns in the row remain unchanged
+
+**Narrow viewport behavior:**
+
+- On narrow viewports (below the `theme.breakpoints.columns` threshold, typically 576px),
+  columns stack vertically
+- Resize handles are hidden when columns are stacked (resizing not applicable)
+- If the viewport widens again, resize handles reappear
+
+**State persistence:**
+
+- Resized widths persist within a session (maintained in React state)
+- Widths reset to original `spec` proportions on:
+  - Page refresh
+  - Script rerun that changes the column configuration (different `spec` or column count)
+  - Window resize that causes columns to stack and unstack
+
+### Examples
+
+**Basic resizable columns:**
+
+```python
+import streamlit as st
+
+col1, col2, col3 = st.columns(3, resizable=True)
+
+with col1:
+    st.header("Column 1")
+    st.write("Drag the border to resize →")
+
+with col2:
+    st.header("Column 2")
+    st.write("Content here")
+
+with col3:
+    st.header("Column 3")
+    st.write("More content")
+```
+
+**Resizable columns with custom proportions:**
+
+```python
+import streamlit as st
+
+# Start with 70/30 split, user can adjust
+left, right = st.columns([0.7, 0.3], resizable=True)
+
+with left:
+    st.subheader("Main content")
+    st.dataframe(df)
+
+with right:
+    st.subheader("Sidebar")
+    st.write("Filters and controls")
+```
+
+**Resizable columns with borders:**
+
+```python
+import streamlit as st
+
+# Borders help visualize column boundaries
+cols = st.columns(4, resizable=True, border=True)
+
+for i, col in enumerate(cols):
+    with col:
+        st.metric(f"Metric {i+1}", f"{(i+1) * 100}")
+```
+
+### Edge Cases
+
+- **Single column**: `resizable=True` has no effect (nothing to resize between)
+- **Two columns**: One resize handle between them
+- **Many columns**: Resize handles between each adjacent pair; dragging one does not affect
+  non-adjacent columns
+- **Nested columns**: Each `st.columns` call manages its own resize state independently
+  (note: nesting columns is discouraged per Streamlit design guidelines)
+- **Zero gap (`gap=None`)**: Resize handle still appears, positioned at the column boundary
+- **Very narrow columns**: Minimum width of 64px prevents complete collapse
+- **Rapid dragging**: Throttled updates prevent performance issues
+- **Touch devices**: Drag interactions work via touch; hover indicator shows on touch start
+
+### Validation
+
+```python
+# Valid:
+st.columns(3, resizable=True)                    # Equal-width resizable columns
+st.columns([1, 2, 1], resizable=True)            # Custom proportions, resizable
+st.columns(3, resizable=True, border=True)       # With borders
+st.columns(3, resizable=True, gap="large")       # With custom gap
+st.columns(3, resizable=False)                   # Explicit non-resizable (default)
+
+# Valid but no resize effect:
+st.columns(1, resizable=True)                    # Single column, nothing to resize
+```
+
+## Out of Scope (Future Work)
+
+- **Persist widths across sessions**: Store user's preferred widths in local storage or
+  session state
+- **Snap to grid**: Snap widths to predefined percentages (25%, 33%, 50%, etc.)
+- **Resize constraints**: `min_width`/`max_width` parameters per column
+- **Resize callbacks**: `on_resize` callback when widths change
+- **Save/restore layouts**: Named layout presets that users can switch between
+
+## Checklist
+
+| Item                       | ✅ or comment                                                          |
+| -------------------------- | ---------------------------------------------------------------------- |
+| Works on SiS, Cloud, etc?  | ✅ Pure client-side, no server dependencies                            |
+| No breaking API changes    | ✅ New optional parameter with `False` default                         |
+| No new dependencies        | ✅ Uses existing DOM APIs and React state                              |
+| Metrics collected          | ✅ Usage tracked via `gather_metrics("columns")` decorator             |
+| Any security/legal impact? | ✅ No security implications                                            |
+| Any docs changes needed?   | ✅ Document `resizable` parameter with examples in `st.columns` docs   |

--- a/specs/2026-04-08-resizable-columns/product-spec.md
+++ b/specs/2026-04-08-resizable-columns/product-spec.md
@@ -75,6 +75,9 @@ st.columns(
 - **Minimum width**: Each column has a minimum width (64px) to prevent columns from
   collapsing entirely
 - **Keyboard support**: When focused, use Arrow Left/Right keys to resize in 10px increments
+- **Accessibility**: Resize handles use `role="separator"` with `aria-orientation="vertical"`,
+  `aria-valuenow`/`aria-valuemin`/`aria-valuemax` for screen reader support, and visible
+  focus indicators meeting WCAG 2.1 requirements
 - **Cursor feedback**: The cursor changes to `col-resize` when hovering over the resize handle
 - **Smooth transitions**: The border indicator fades in/out smoothly (150ms transition)
 
@@ -86,7 +89,7 @@ st.columns(
 
 **Narrow viewport behavior:**
 
-- On narrow viewports (below the `theme.breakpoints.columns` threshold, typically 576px),
+- On narrow viewports (below the `theme.breakpoints.columns` threshold, 640px),
   columns stack vertically
 - Resize handles are hidden when columns are stacked (resizing not applicable)
 - If the viewport widens again, resize handles reappear
@@ -157,8 +160,8 @@ for i, col in enumerate(cols):
 - **Two columns**: One resize handle between them
 - **Many columns**: Resize handles between each adjacent pair; dragging one does not affect
   non-adjacent columns
-- **Nested columns**: Each `st.columns` call manages its own resize state independently
-  (note: nesting columns is discouraged per Streamlit design guidelines)
+- **Nested columns**: Nested `st.columns` calls are supported; each call manages its own
+  resize state independently
 - **Zero gap (`gap=None`)**: Resize handle still appears, positioned at the column boundary
 - **Very narrow columns**: Minimum width of 64px prevents complete collapse
 - **Rapid dragging**: Throttled updates prevent performance issues

--- a/specs/2026-04-08-resizable-columns/product-spec.md
+++ b/specs/2026-04-08-resizable-columns/product-spec.md
@@ -17,6 +17,13 @@ is purely client-side and does not trigger a script rerun.
 Column widths in `st.columns` are currently static—once defined via the `spec` parameter, they
 cannot be adjusted without modifying code and rerunning the app. This creates friction for:
 
+**Related issues:**
+
+- [#5003](https://github.com/streamlit/streamlit/issues/5003): Deactivate responsiveness of
+  st.columns (46 upvotes) — users want more control over column layout behavior
+- [#6592](https://github.com/streamlit/streamlit/issues/6592): Configurable column
+  responsiveness width threshold (19 upvotes) — requests for flexible column sizing
+
 **Use cases:**
 
 - **Dashboard customization**: Users want to adjust column widths to better fit their content
@@ -180,6 +187,79 @@ st.columns(3, resizable=False)                   # Explicit non-resizable (defau
 # Valid but no resize effect:
 st.columns(1, resizable=True)                    # Single column, nothing to resize
 ```
+
+### Implementation Test Requirements
+
+The following test scenarios should be covered in the implementation PR:
+
+**Frontend unit tests (Vitest):**
+
+- Resize handle renders between adjacent columns when `resizable=True`
+- Resize handle does not render when `resizable=False`
+- Drag interaction updates column widths correctly
+- Double-click resets columns to original proportions
+- Minimum width (64px) constraint is enforced
+- Keyboard Arrow Left/Right adjusts widths in 10px increments
+- Cursor changes to `col-resize` on hover
+- ARIA attributes (`role="separator"`, `aria-valuenow`, etc.) are present
+
+**Backend unit tests (pytest):**
+
+- `resizable` parameter is accepted and passed to protobuf
+- Invalid `resizable` values raise appropriate errors
+- Default value is `False`
+
+**E2E tests (Playwright):**
+
+- Drag resize between columns adjusts widths visually
+- Responsive stacking hides resize handles below 640px threshold
+- Widths persist within session (no reset on rerun without config change)
+- Widths reset on page refresh
+- Touch drag works on touch-capable viewports
+- Nested columns resize independently
+
+## Alternatives Considered
+
+### Parameter type: `resizable: bool` vs `resize_mode: Literal[...]`
+
+**Option 1: `resizable: bool = False`** (PREFERRED)
+
+```python
+st.columns(3, resizable=True)
+```
+
+- **Pros**: Simple, matches existing `border=True` precedent on the same command, immediately
+  understandable, covers the primary use case
+- **Cons**: If future resize modes are needed (snap-to-grid, constrained), would require
+  additional parameters
+
+**Option 2: `resize_mode: Literal["off", "drag"] | None = None`**
+
+```python
+st.columns(3, resize_mode="drag")
+```
+
+- **Pros**: Follows API Design Principle 16 (Prefer Enums Over Booleans), extensible for
+  future modes like `"snap"` or `"constrained"`
+- **Cons**: More verbose for a binary choice, `None` vs `"off"` distinction is subtle
+
+**Decision**: The boolean approach is preferred because:
+
+1. The `border=True` parameter on `st.columns` establishes a boolean precedent for this command
+2. The feature is fundamentally binary—either columns are resizable or they are not
+3. Future modes (snap-to-grid, constraints) would likely need their own parameters anyway
+   (`snap_to: list[float]`, `min_width: int`) rather than overloading `resize_mode`
+4. Simpler API for the 80% use case aligns with Principle 1 (Simplicity First)
+
+If user feedback indicates strong demand for multiple resize modes, we can deprecate
+`resizable` in favor of `resize_mode` with a clear migration path per Principle 25
+(Graceful Evolution).
+
+### Parameter naming: `resizable` vs `adjustable` vs `flexible`
+
+- `resizable`: Chosen because it directly describes the user action (resize by dragging)
+- `adjustable`: Too generic, could imply programmatic adjustment
+- `flexible`: Conflicts with CSS flexbox terminology, could cause confusion
 
 ## Out of Scope (Future Work)
 


### PR DESCRIPTION
## Describe your changes

Spec renderer: https://issues.streamlit.app/spec_renderer?pr=14687

Adds product spec for the resizable columns feature (`st.columns(..., resizable=True)`).

- Proposes `resizable: bool = False` parameter for `st.columns`
- Enables client-side drag-to-resize between adjacent columns
- Includes behavior details: hover indicators, double-click reset, keyboard support, touch support

## GitHub Issue Link (if applicable)

- Addresses https://github.com/streamlit/streamlit/issues/16661

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | writing-spec | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |

</details>
<!-- agent-metrics-end -->