### PR TITLE
[fix] inconsistent space encoding in query params

### DIFF
--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1726,6 +1726,29 @@ describe("Trigger JSON payloads (aggregated)", () => {
         expect(window.history.replaceState).toHaveBeenCalled()
         expect(mockOnQueryParamsChange).toHaveBeenCalledWith("")
       })
+
+      it("encodes spaces as + in URL, not %20", () => {
+        const widget = { id: "widget1", formId: "" }
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "name",
+          "string_value",
+          "",
+          false
+        )
+
+        widgetMgr.setStringValue(
+          widget,
+          "hello world",
+          { fromUi: true },
+          undefined
+        )
+
+        expect(window.history.replaceState).toHaveBeenCalled()
+        const url = (window.history.replaceState as Mock).mock.calls[0][2]
+        expect(url).toContain("name=hello+world")
+        expect(url).not.toContain("%20")
+      })
     })
 
     describe("URL sync for array values", () => {
@@ -2442,6 +2465,28 @@ describe("Trigger JSON payloads (aggregated)", () => {
         const result = widgetMgr.filterParamsForPageChange("")
         expect(result).toContain("name=test")
         expect(result).toContain("count=42")
+      })
+
+      it("encodes spaces as + in filterParamsForPageChange, not %20", () => {
+        widgetMgr.registerQueryParamBinding(
+          "widget1",
+          "q",
+          "string_value",
+          "",
+          false
+        )
+
+        const widget = { id: "widget1", formId: "" }
+        widgetMgr.setStringValue(
+          widget,
+          "hello world",
+          { fromUi: true },
+          undefined
+        )
+
+        const result = widgetMgr.filterParamsForPageChange("")
+        expect(result).toBe("q=hello+world")
+        expect(result).not.toContain("%20")
       })
     })
   })

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -1221,10 +1221,13 @@ export class WidgetStateManager {
       }
     })
 
-    // Build query string using query-string library
-    const boundParamsStr = queryString.stringify(boundParamsObj, {
-      arrayFormat: "none",
-    })
+    // Build query string using query-string library.
+    // Replace %20 with + to match backend urllib.parse.urlencode encoding.
+    const boundParamsStr = queryString
+      .stringify(boundParamsObj, {
+        arrayFormat: "none",
+      })
+      .replaceAll("%20", "+")
 
     // Combine embed params with bound widget params
     if (!boundParamsStr) {
@@ -1378,13 +1381,16 @@ export class WidgetStateManager {
       currentParams[paramKey] = value
     }
 
-    // Build new URL using query-string
-    // arrayFormat: "none" produces ?key=a&key=b for arrays
-    const newSearch = queryString.stringify(currentParams, {
-      arrayFormat: "none",
-      skipNull: true,
-      skipEmptyString: false,
-    })
+    // Build new URL using query-string.
+    // arrayFormat: "none" produces ?key=a&key=b for arrays.
+    // Replace %20 with + to match backend urllib.parse.urlencode encoding.
+    const newSearch = queryString
+      .stringify(currentParams, {
+        arrayFormat: "none",
+        skipNull: true,
+        skipEmptyString: false,
+      })
+      .replaceAll("%20", "+")
 
     // Skip replaceState if the URL wouldn't actually change
     const currentSearch = window.location.search.replace(/^\?/, "")


### PR DESCRIPTION
## Summary

Fixes #14671

**Root cause:** The frontend `bind="query-params"` path uses `queryString.stringify()` (which internally uses `encodeURIComponent`, encoding spaces as `%20`), while the backend `st.query_params` path uses `urllib.parse.urlencode()` (which uses `quote_plus`, encoding spaces as `+`). When both paths interact, the URL flips between `%20` and `+` encoding.

**Fix:** Post-process the output of `queryString.stringify()` with `.replaceAll("%20", "+")` in both `buildBoundQueryParams()` and `updateUrlParam()` to align with the backend's `+` encoding convention.

### Changes
- `WidgetStateManager.ts`: Replace `%20` with `+` in the output of both `queryString.stringify()` call sites
- `WidgetStateManager.test.ts`: Add 2 tests verifying spaces encode as `+` (not `%20`) in both the URL update and page change filter paths

## Test plan
- [x] New unit tests: "encodes spaces as + in URL, not %20" and "encodes spaces as + in filterParamsForPageChange, not %20"
- [x] All 146 existing WidgetStateManager tests pass


Made with [Cursor](https://cursor.com)