### PR TITLE
[fix] Preserve `None` values in `st.data_editor` with pandas 3.0+

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1294,9 +1294,10 @@ def _unify_missing_values(df: DataFrame) -> DataFrame:
     # Replace all recognized nulls (np.nan, pd.NA, NaT) with None.
     result = df.replace([pd.NA, pd.NaT, np.nan], None)  # type: ignore[list-item] # ty: ignore[invalid-argument-type]
 
-    # In pandas 3.0+, infer_objects() converts None back to np.nan, which defeats
-    # the purpose of this function. Only call it for older pandas versions.
-    # See: https://github.com/streamlit/streamlit/issues/14693
+    # infer_objects() improves column type correctness (e.g., int instead of float,
+    # string instead of object). However, in pandas 3.0+ it converts None back to
+    # np.nan, which defeats the purpose of this function. Only call it for older
+    # pandas versions. See: https://github.com/streamlit/streamlit/issues/14693
     if is_pandas_version_less_than("3.0.0"):
         result = result.infer_objects()
 

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1285,16 +1285,22 @@ def _unify_missing_values(df: DataFrame) -> DataFrame:
 
     Pandas uses a variety of values to represent missing values, including np.nan,
     NaT, None, and pd.NA. This function replaces all of these values with None,
-    which is the only missing value type that is supported by all data
+    which is the only missing value type that is supported by all data types
+    when serializing to JSON-compatible formats.
     """
     import numpy as np
     import pandas as pd
 
-    # Replace all recognized nulls (np.nan, pd.NA, NaT) with None
-    # then infer objects without creating a separate copy:
-    # For performance reasons, we could use copy=False here.
-    # However, this is only available in pandas >=2.
-    return df.replace([pd.NA, pd.NaT, np.nan], None).infer_objects()  # type: ignore
+    # Replace all recognized nulls (np.nan, pd.NA, NaT) with None.
+    result = df.replace([pd.NA, pd.NaT, np.nan], None)  # type: ignore[list-item] # ty: ignore[invalid-argument-type]
+
+    # In pandas 3.0+, infer_objects() converts None back to np.nan, which defeats
+    # the purpose of this function. Only call it for older pandas versions.
+    # See: https://github.com/streamlit/streamlit/issues/14693
+    if is_pandas_version_less_than("3.0.0"):
+        result = result.infer_objects()
+
+    return result
 
 
 def _pandas_df_to_series(df: DataFrame) -> Series[Any]:

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -806,6 +806,22 @@ class DataframeUtilTest(unittest.TestCase):
             df, dataframe_util.DataFormat.KEY_VALUE_DICT
         ) == {0: None, 1: None, 2: None, 3: None}
 
+    def test_convert_df_preserves_none_after_row_assignment(self):
+        """Regression test for https://github.com/streamlit/streamlit/issues/14693.
+
+        In pandas 3.0+, infer_objects() converts None back to np.nan. This test
+        verifies that None values assigned via df.loc[] are preserved as None.
+        """
+        # Simulate how data_editor adds new rows
+        df = pd.DataFrame([{"Text": "Row 1"}])
+        df.loc[1] = {"Text": None}
+
+        result = dataframe_util.convert_pandas_df_to_data_format(
+            df, dataframe_util.DataFormat.LIST_OF_RECORDS
+        )
+        # None must be preserved, not converted to np.nan
+        assert result == [{"Text": "Row 1"}, {"Text": None}]
+
     def test_convert_anything_to_sequence_object_is_indexable(self):
         l1 = ["a", "b", "c"]
         l2 = dataframe_util.convert_anything_to_list(l1)


### PR DESCRIPTION
## Describe your changes

Fixes `st.data_editor` returning `NaN` instead of `None` for empty cells in new rows when using pandas 3.0+.

- Skip `infer_objects()` call for pandas 3.0+ in `_unify_missing_values()` since it now converts `None` back to `np.nan`
- Maintain backwards compatibility by keeping `infer_objects()` for pandas < 3.0

## GitHub Issue Link (if applicable)

- Closes #14693

## Testing Plan

- [x] Unit tests added (`test_convert_df_preserves_none_after_row_assignment`)
- [x] Existing tests pass with pandas 3.0.2

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | updating-internal-docs | 1 |
| subagent | Explore | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 4 |
| subagent | reviewing-local-changes | 2 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->