### PR TITLE
[fix] Keep null CheckboxColumn cells non-interactive in st.data_editor

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.test.ts
@@ -22,7 +22,7 @@ import { mockTheme } from "~lib/mocks/mockTheme"
 import { convertRemToPx } from "~lib/theme/utils"
 
 import CheckboxColumn from "./CheckboxColumn"
-import { isErrorCell } from "./utils"
+import { isErrorCell, isMissingValueCell } from "./utils"
 
 const MOCK_CHECKBOX_COLUMN_PROPS = {
   id: "1",
@@ -108,6 +108,18 @@ describe("CheckboxColumn", () => {
       expect(isErrorCell(cell)).toEqual(true)
     }
   )
+
+  it("uses readonly cells for null values when column is editable (avoids hover checkbox)", () => {
+    const editableProps = { ...MOCK_CHECKBOX_COLUMN_PROPS, isEditable: true }
+    const mockColumn = CheckboxColumn(editableProps, mockTheme.emotion)
+
+    const missingCell = mockColumn.getCell(null) as BooleanCell
+    expect(missingCell.readonly).toEqual(true)
+    expect(isMissingValueCell(missingCell)).toEqual(true)
+
+    expect((mockColumn.getCell(true) as BooleanCell).readonly).toEqual(false)
+    expect((mockColumn.getCell(false) as BooleanCell).readonly).toEqual(false)
+  })
 
   it("applies themeOverride roundingRadius based on theme radii", () => {
     const mockColumn = CheckboxColumn(

--- a/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/CheckboxColumn.ts
@@ -76,12 +76,14 @@ function CheckboxColumn(
         )
       }
 
-      // We are not setting isMissingValue here because the checkbox column
-      // does not work with the missing cell rendering.
+      const isMissing = isNullOrUndefined(cellData)
       return {
         ...cellTemplate,
         data: cellData,
-        isMissingValue: isNullOrUndefined(cellData),
+        isMissingValue: isMissing,
+        // Missing values render as empty; glide-data-grid shows an editable
+        // hover checkbox when readonly is false, so keep those cells readonly.
+        readonly: !props.isEditable || isMissing,
       } as BooleanCell
     },
     getCellValue(cell: BooleanCell): boolean | null {


### PR DESCRIPTION

Fixes #14692

`CheckboxColumn` now sets `readonly: true` on glide-data-grid boolean cells when the value is null/undefined. Editable true/false cells stay togglable; empty cells no longer show a hover checkbox from the grid’s default boolean editor.

## Describe your changes

## Screenshot or video (only for visual changes)

<img width="807" height="698" alt="Screenshot 2026-04-09 at 2 08 18 PM" src="https://github.com/user-attachments/assets/b6c46fdd-f6f7-4d5d-b50f-992dec36a58e" />

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/14692

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

Frontend: `CheckboxColumn.test.ts`. Python `data_editor` suite unchanged in behavior; existing tests pass.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
