### PR TITLE
[fix] Evict namespace children when watched sources reload

### DIFF
--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -151,9 +151,27 @@ class LocalSourcesWatcher:
         # However, determining all import paths for a given loaded module is
         # non-trivial, and so as a workaround we simply unload all watched
         # modules.
-        for wm in self._watched_modules.values():
-            if wm.module_name is not None and wm.module_name in sys.modules:
-                del sys.modules[wm.module_name]
+        #
+        # Also evict every sys.modules entry that is a child (name prefix) of an
+        # evicted module. Otherwise PEP 420 namespace packages that span watched
+        # paths and blacklisted paths (e.g. site-packages) leave orphaned children
+        # in sys.modules; re-import then skips binding them on the new parent.
+        modules_to_evict = {
+            wm.module_name
+            for wm in self._watched_modules.values()
+            if wm.module_name is not None and wm.module_name in sys.modules
+        }
+        all_to_evict: set[str] = set()
+        for name in modules_to_evict:
+            all_to_evict.add(name)
+            prefix = f"{name}."
+            for key in list(sys.modules.keys()):
+                if key.startswith(prefix):
+                    all_to_evict.add(key)
+
+        for name in all_to_evict:
+            if name in sys.modules:
+                del sys.modules[name]
 
         for cb in self._on_path_changed:
             cb(filepath)

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -161,17 +161,16 @@ class LocalSourcesWatcher:
             for wm in self._watched_modules.values()
             if wm.module_name is not None and wm.module_name in sys.modules
         }
-        all_to_evict: set[str] = set()
-        for name in modules_to_evict:
-            all_to_evict.add(name)
-            prefix = f"{name}."
+        if modules_to_evict:
+            prefixes = tuple(f"{name}." for name in modules_to_evict)
+            all_to_evict = modules_to_evict.copy()
             for key in list(sys.modules.keys()):
-                if key.startswith(prefix):
+                if key.startswith(prefixes):
                     all_to_evict.add(key)
 
-        for name in all_to_evict:
-            if name in sys.modules:
-                del sys.modules[name]
+            for name in all_to_evict:
+                if name in sys.modules:
+                    del sys.modules[name]
 
         for cb in self._on_path_changed:
             cb(filepath)

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -314,15 +314,23 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             script_real: local_sources_watcher.WatchedModule(MagicMock(), "myns"),
         }
 
+        myns_extra = types.ModuleType("myns_extra")
+
         with patch.dict(
             sys.modules,
-            {"myns": myns, "myns.core": myns_core, "myns.spec": myns_spec},
+            {
+                "myns": myns,
+                "myns.core": myns_core,
+                "myns.spec": myns_spec,
+                "myns_extra": myns_extra,
+            },
         ):
             lsw.on_path_changed(trigger_path)
 
             assert "myns" not in sys.modules
             assert "myns.core" not in sys.modules
             assert "myns.spec" not in sys.modules
+            assert "myns_extra" in sys.modules
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_module_caching(self, _fob):

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
+import types
 import unittest
 from unittest.mock import MagicMock, call, patch
 
@@ -290,6 +291,38 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             assert "pkg" not in sys.modules
 
         del sys.modules["tests.streamlit.watcher.test_data.namespace_package"]
+
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_namespace_partial_eviction_evicts_unwatched_children(self, fob):
+        """Unwatched site-packages children are evicted with the namespace parent.
+
+        When a PEP 420 namespace spans watched local code and blacklisted paths,
+        only watched modules were previously removed from sys.modules; orphaned
+        children broke attribute access on the re-created parent after rerun.
+        """
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        lsw.register_file_change_callback(NOOP_CALLBACK)
+
+        myns = types.ModuleType("myns")
+        myns_core = types.ModuleType("myns.core")
+        myns_spec = types.ModuleType("myns.spec")
+
+        trigger_path = os.path.realpath(NESTED_MODULE_CHILD_FILE)
+        script_real = os.path.realpath(SCRIPT_PATH)
+        lsw._watched_modules = {
+            trigger_path: local_sources_watcher.WatchedModule(MagicMock(), "myns.core"),
+            script_real: local_sources_watcher.WatchedModule(MagicMock(), "myns"),
+        }
+
+        with patch.dict(
+            sys.modules,
+            {"myns": myns, "myns.core": myns_core, "myns.spec": myns_spec},
+        ):
+            lsw.on_path_changed(trigger_path)
+
+            assert "myns" not in sys.modules
+            assert "myns.core" not in sys.modules
+            assert "myns.spec" not in sys.modules
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_module_caching(self, _fob):


### PR DESCRIPTION

## Describe your changes

`LocalSourcesWatcher.on_path_changed` now removes from `sys.modules` every submodule whose name is prefixed by an evicted watched module (e.g. evicting `bioimageio` also evicts `bioimageio.spec`). That keeps PEP 420 namespaces consistent when one portion is watched and another lives under a blacklisted path such as `site-packages`, so Python re-imports children and binds them on the new parent instead of short-circuiting on stale cache entries.

## Screenshot or video (only for visual changes)

N/A (backend-only).

## GitHub Issue Link (if applicable)

Fixes #14704

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

Python: `lib/tests/streamlit/watcher/local_sources_watcher_test.py` (`test_namespace_partial_eviction_evicts_unwatched_children`).

Manual / local repro: `work-tmp/bugfix/gh-14704/repro2/` with `PYTHONPATH=.../local_pkg` and `make debug work-tmp/bugfix/gh-14704/repro2/app.py`; editing the app should rerun without `AttributeError` on `myns.spec`.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
