### PR TITLE
[feature] Add char_count_color to st.text_input and st.text_area

### DIFF
--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.test.tsx
@@ -142,4 +142,27 @@ describe("InputInstructions", () => {
       expect(screen.getByTestId("InputInstructions")).toHaveTextContent("")
     })
   })
+
+  describe("charCountColor", () => {
+    it("applies custom color when charCountColor is provided", () => {
+      const props = getProps({
+        maxLength: 10,
+        charCountColor: "#ff0000",
+      })
+      render(<InputInstructions {...props} />)
+
+      const el = screen.getByTestId("InputInstructions")
+      expect(el).toHaveStyle("color: #ff0000")
+    })
+
+    it("uses default color when charCountColor is not provided", () => {
+      const props = getProps({
+        maxLength: 10,
+      })
+      render(<InputInstructions {...props} />)
+
+      const el = screen.getByTestId("InputInstructions")
+      expect(el).not.toHaveStyle("color: #ff0000")
+    })
+  })
 })

--- a/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
+++ b/frontend/lib/src/components/shared/InputInstructions/InputInstructions.tsx
@@ -29,6 +29,7 @@ export interface Props {
   className?: string
   type?: "multiline" | "single" | "chat"
   allowEnterToSubmit?: boolean
+  charCountColor?: string
 }
 
 const InputInstructions = ({
@@ -39,6 +40,7 @@ const InputInstructions = ({
   className,
   type = "single",
   allowEnterToSubmit = true,
+  charCountColor,
 }: Props): ReactElement => {
   const messages: ReactElement[] = []
   const addMessage = (text: string, shouldBlink = false): void => {
@@ -75,6 +77,7 @@ const InputInstructions = ({
     <StyledWidgetInstructions
       data-testid="InputInstructions"
       className={className}
+      charCountColor={charCountColor}
     >
       {messages}
     </StyledWidgetInstructions>

--- a/frontend/lib/src/components/widgets/BaseWidget/styled-components.ts
+++ b/frontend/lib/src/components/widgets/BaseWidget/styled-components.ts
@@ -15,6 +15,7 @@
  */
 
 import styled from "@emotion/styled"
+import { transparentize } from "color2k"
 
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
@@ -52,15 +53,20 @@ export const StyledWidgetLabelHelp = styled.div({
   flex: 1,
 })
 
-export const StyledWidgetInstructions = styled.div(({ theme }) => ({
-  fontSize: theme.fontSizes.twoSm,
-  color: theme.colors.fadedText60,
-  margin: theme.spacing.none,
-  textAlign: "right",
-  position: "absolute",
-  bottom: theme.spacing.threeXS,
-  right: `calc(${theme.fontSizes.mdLg} * 0.5)`,
-}))
+interface StyledWidgetInstructionsProps {
+  charCountColor?: string
+}
+
+export const StyledWidgetInstructions =
+  styled.div<StyledWidgetInstructionsProps>(({ theme, charCountColor }) => ({
+    fontSize: theme.fontSizes.twoSm,
+    color: charCountColor || transparentize(theme.colors.bodyText, 0.25),
+    margin: theme.spacing.none,
+    textAlign: "right",
+    position: "absolute",
+    bottom: theme.spacing.threeXS,
+    right: `calc(${theme.fontSizes.mdLg} * 0.5)`,
+  }))
 
 /**
  * @deprecated Please utilize `WidgetLabelHelpIconInline` instead of using this

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -34,6 +34,7 @@ import useOnInputChange from "~lib/hooks/useOnInputChange"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import { useTextInputAutoExpand } from "~lib/hooks/useTextInputAutoExpand"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
+import { resolveNamedColor } from "~lib/theme/getColors"
 import { convertRemToPx } from "~lib/theme/utils"
 import { isInForm, labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -299,6 +300,11 @@ const TextArea: FC<Props> = ({
           type={"multiline"}
           inForm={isInForm({ formId })}
           allowEnterToSubmit={allowEnterToSubmit}
+          charCountColor={
+            element.charCountColor
+              ? resolveNamedColor(element.charCountColor, theme)
+              : undefined
+          }
         />
       )}
     </StyledTextAreaContainer>

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.tsx
@@ -37,6 +37,7 @@ import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import useOnInputChange from "~lib/hooks/useOnInputChange"
 import useSubmitFormViaEnterKey from "~lib/hooks/useSubmitFormViaEnterKey"
 import useUpdateUiValue from "~lib/hooks/useUpdateUiValue"
+import { resolveNamedColor } from "~lib/theme/getColors"
 import { convertRemToPx } from "~lib/theme/utils"
 import { isInForm, labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -256,6 +257,11 @@ function TextInput({
           maxLength={maxChars}
           inForm={isInForm({ formId })}
           allowEnterToSubmit={allowEnterToSubmit}
+          charCountColor={
+            element.charCountColor
+              ? resolveNamedColor(element.charCountColor, theme)
+              : undefined
+          }
         />
       )}
     </StyledTextInput>

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -109,6 +109,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
     ) -> str:
         pass
 
@@ -132,6 +133,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
     ) -> str | None:
         pass
 
@@ -155,6 +157,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
     ) -> str | None:
         r"""Display a single-line text input widget.
 
@@ -300,6 +303,12 @@ class TextWidgetsMixin:
             This can't be used with ``type="password"``. An empty
             query parameter (e.g., ``?my_key=``) clears the widget.
 
+        char_count_color : str or None
+            An optional color for the character count text displayed when
+            ``max_chars`` is set. Accepts a named color (e.g., ``"red"``,
+            ``"blue"``, ``"green"``) or a hex color (e.g., ``"#ff0000"``).
+            If ``None`` (default), the theme default color is used.
+
         Returns
         -------
         str or None
@@ -336,6 +345,7 @@ class TextWidgetsMixin:
             icon=icon,
             width=width,
             bind=bind,
+            char_count_color=char_count_color,
             ctx=ctx,
         )
 
@@ -358,6 +368,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
         ctx: ScriptRunContext | None = None,
     ) -> str | None:
         key = to_key(key)
@@ -417,6 +428,9 @@ class TextWidgetsMixin:
 
         if icon is not None:
             text_input_proto.icon = validate_icon_or_emoji(icon)
+
+        if char_count_color is not None:
+            text_input_proto.char_count_color = char_count_color
 
         if type == "default":
             text_input_proto.type = TextInputProto.DEFAULT
@@ -489,6 +503,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
     ) -> str:
         pass
 
@@ -510,6 +525,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
     ) -> str | None:
         pass
 
@@ -531,6 +547,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
     ) -> str | None:
         r"""Display a multi-line text input widget.
 
@@ -665,6 +682,12 @@ class TextWidgetsMixin:
             An empty query parameter (e.g., ``?my_key=``) clears the
             widget.
 
+        char_count_color : str or None
+            An optional color for the character count text displayed when
+            ``max_chars`` is set. Accepts a named color (e.g., ``"red"``,
+            ``"blue"``, ``"green"``) or a hex color (e.g., ``"#ff0000"``).
+            If ``None`` (default), the theme default color is used.
+
         Returns
         -------
         str or None
@@ -707,6 +730,7 @@ class TextWidgetsMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            char_count_color=char_count_color,
             ctx=ctx,
         )
 
@@ -727,6 +751,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        char_count_color: str | None = None,
         ctx: ScriptRunContext | None = None,
     ) -> str | None:
         key = to_key(key)
@@ -780,6 +805,9 @@ class TextWidgetsMixin:
 
         if placeholder is not None:
             text_area_proto.placeholder = str(placeholder)
+
+        if char_count_color is not None:
+            text_area_proto.char_count_color = char_count_color
 
         # Set query param key if bound
         if bind == "query-params" and key is not None:

--- a/lib/tests/streamlit/elements/text_area_test.py
+++ b/lib/tests/streamlit/elements/text_area_test.py
@@ -397,6 +397,27 @@ class TextAreaTest(DeltaGeneratorTestCase):
         assert c.query_param_key == "my_text"
         assert c.max_chars == 5
 
+    def test_char_count_color_hex(self) -> None:
+        """Test that char_count_color is set on the proto when a hex color is provided."""
+        st.text_area("the label", max_chars=50, char_count_color="#ff0000")
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.char_count_color == "#ff0000"
+
+    def test_char_count_color_named(self) -> None:
+        """Test that char_count_color is set on the proto when a named color is provided."""
+        st.text_area("the label", max_chars=50, char_count_color="red")
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.char_count_color == "red"
+
+    def test_char_count_color_default(self) -> None:
+        """Test that char_count_color defaults to empty string when not provided."""
+        st.text_area("the label", max_chars=50)
+
+        c = self.get_delta_from_queue().new_element.text_area
+        assert c.char_count_color == ""
+
 
 class SomeObj:
     pass

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -391,6 +391,27 @@ class TextInputTest(DeltaGeneratorTestCase):
 
         assert "password" in str(exc.value).lower()
 
+    def test_char_count_color_hex(self) -> None:
+        """Test that char_count_color is set on the proto when a hex color is provided."""
+        st.text_input("the label", max_chars=50, char_count_color="#ff0000")
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.char_count_color == "#ff0000"
+
+    def test_char_count_color_named(self) -> None:
+        """Test that char_count_color is set on the proto when a named color is provided."""
+        st.text_input("the label", max_chars=50, char_count_color="red")
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.char_count_color == "red"
+
+    def test_char_count_color_default(self) -> None:
+        """Test that char_count_color defaults to empty string when not provided."""
+        st.text_input("the label", max_chars=50)
+
+        c = self.get_delta_from_queue().new_element.text_input
+        assert c.char_count_color == ""
+
 
 class SomeObj:
     pass

--- a/proto/streamlit/proto/TextArea.proto
+++ b/proto/streamlit/proto/TextArea.proto
@@ -33,6 +33,8 @@ message TextArea {
   LabelVisibility label_visibility = 12;
   // If set, widget value is bound to this query parameter key
   optional string query_param_key = 13;
+  // Custom color for the character count text (e.g. "red", "#ff0000")
+  string char_count_color = 14;
 
   reserved 4;
 }

--- a/proto/streamlit/proto/TextInput.proto
+++ b/proto/streamlit/proto/TextInput.proto
@@ -43,4 +43,6 @@ message TextInput {
   string icon = 14;
   // If set, widget value is bound to this query parameter key
   optional string query_param_key = 15;
+  // Custom color for the character count text (e.g. "red", "#ff0000")
+  string char_count_color = 16;
 }


### PR DESCRIPTION
## Describe your changes

Adds `char_count_color` parameter to `st.text_input()` and `st.text_area()`, allowing users to customize the color of the character count text (e.g. "5/50") displayed when `max_chars` is set. Also improves the default contrast from 60% to 75% opacity of `bodyText` to meet WCAG AA 4.5:1 ratio for small text.

- New `char_count_color` parameter accepts named colors (`"red"`, `"blue"`) or hex values (`"#ff0000"`), following the same pattern as `st.badge(color=...)`
- Named colors resolved via `resolveNamedColor()` on the frontend; defaults to improved high-contrast color when unset

## GitHub Issue Link (if applicable)

Closes #8249

## Testing Plan

- [x] Unit Tests (Python)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.