### PR TITLE
[fix] Update tests to use Server.start() instead of removed _start_starlette()

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_server.py
+++ b/lib/streamlit/web/server/starlette/starlette_server.py
@@ -230,7 +230,7 @@ class UvicornServer:
 
     Examples
     --------
-    Used internally by Server._start_starlette():
+    Used internally by Server.start():
 
     >>> server = UvicornServer(runtime)
     >>> await server.start()  # Returns when ready

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
@@ -575,7 +575,7 @@ class TestDynamicPort:
             uvicorn_instance.should_exit = False
             uvicorn_server_cls.return_value = uvicorn_instance
 
-            self._run_async(server._start_starlette())
+            self._run_async(server.start())
 
         assert config.get_option("server.port") == 54321
         uvicorn_config = uvicorn_server_cls.call_args[0][0]
@@ -601,7 +601,7 @@ class TestDynamicPort:
             uvicorn_instance.should_exit = False
             uvicorn_server_cls.return_value = uvicorn_instance
 
-            self._run_async(server._start_starlette())
+            self._run_async(server.start())
 
         mock_socket.getsockname.assert_not_called()
         assert config.get_option("server.port") == 8501


### PR DESCRIPTION
## Describe your changes

Fixes two failing tests in `TestDynamicPort` that were calling a removed method `Server._start_starlette()`.

- Updated tests to call `server.start()` instead of `server._start_starlette()`
- Fixed stale docstring reference in `UvicornServer`

The `Server` class was refactored and `_start_starlette()` was removed — `Server.start()` now directly creates and calls `UvicornServer`.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/web/server/starlette/starlette_server_test.py` — 39 tests pass

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->