### PR TITLE
[fix] Unify switch_page path resolution with st.Page

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import os
 import time
 from collections.abc import Iterable, Mapping
 from itertools import dropwhile
@@ -23,7 +22,7 @@ from typing import TYPE_CHECKING, Literal, NoReturn
 
 import streamlit as st
 from streamlit.errors import NoSessionContext, StreamlitAPIException
-from streamlit.file_util import get_main_script_directory, normalize_path_join
+from streamlit.file_util import get_main_script_directory
 from streamlit.navigation.page import StreamlitPage
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import (
@@ -300,10 +299,10 @@ def switch_page(  # type: ignore[misc]
         if isinstance(page, Path):
             page = str(page)
 
-        main_script_directory = get_main_script_directory(ctx.main_script_path)
-        requested_page = os.path.realpath(
-            normalize_path_join(main_script_directory, page)
-        )
+        # Use Path.resolve() so script_path matching agrees with st.Page registration
+        # (see StreamlitPage.__init__ in navigation/page.py).
+        main_script_directory = Path(get_main_script_directory(ctx.main_script_path))
+        requested_page = str((main_script_directory / page).resolve())
         all_app_pages = ctx.pages_manager.get_pages().values()
 
         matched_pages = [p for p in all_app_pages if p["script_path"] == requested_page]
@@ -311,7 +310,7 @@ def switch_page(  # type: ignore[misc]
         if len(matched_pages) == 0:
             raise StreamlitAPIException(
                 f"Could not find page: `{page}`. Must be the file path relative to the main script, "
-                f"from the directory: `{os.path.basename(main_script_directory)}`. Only the main app file "
+                f"from the directory: `{main_script_directory.name}`. Only the main app file "
                 "and files in the `pages/` directory are supported."
             )
 

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -288,3 +289,55 @@ def test_st_switch_page_raises_for_external_page(patched_get_script_run_ctx):
         switch_page(mock_page)
 
     ctx.script_requests.request_rerun.assert_not_called()
+
+
+@patch("streamlit.commands.execution_control.time.sleep", MagicMock())
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+@pytest.mark.parametrize("page_arg", ["pages/other.py", Path("pages/other.py")])
+def test_st_switch_page_path_resolve_matches_streamlit_page_registration(
+    patched_get_script_run_ctx: MagicMock,
+    tmp_path: Path,
+    page_arg: str | Path,
+) -> None:
+    """Relative paths use Path.resolve() so lookup matches st.Page script_path (#14709)."""
+    main_py = tmp_path / "app.py"
+    main_py.write_text("#", encoding="utf-8")
+    other_py = tmp_path / "pages" / "other.py"
+    other_py.parent.mkdir()
+    other_py.write_text("#", encoding="utf-8")
+
+    main_abs = str(main_py.resolve())
+    # Same resolution as StreamlitPage.__init__: (main_script_parent / page).resolve()
+    registered_script_path = str(
+        (Path(main_abs).parent / "pages" / "other.py").resolve()
+    )
+
+    ctx = MagicMock()
+    ctx.main_script_path = main_abs
+    ctx.script_requests = MagicMock()
+    ctx.query_string = ""
+    ctx.cached_message_hashes = set()
+    ctx.context_info = {}
+    ctx.session_state = MagicMock()
+
+    query_params_cm = MagicMock()
+    mock_query_params = MagicMock()
+    query_params_cm.__enter__.return_value = mock_query_params
+    query_params_cm.__exit__.return_value = False
+    ctx.session_state.query_params.return_value = query_params_cm
+
+    ctx.pages_manager = MagicMock()
+    ctx.pages_manager.get_pages.return_value = {
+        "x": {
+            "script_path": registered_script_path,
+            "page_script_hash": "target_hash",
+        }
+    }
+
+    patched_get_script_run_ctx.return_value = ctx
+
+    switch_page(page_arg)
+
+    ctx.script_requests.request_rerun.assert_called_once()
+    rerun_arg = ctx.script_requests.request_rerun.call_args[0][0]
+    assert rerun_arg.page_script_hash == "target_hash"


### PR DESCRIPTION
## Describe your changes

Resolves string and `pathlib.Path` arguments in `st.switch_page` using `Path(...).resolve()`, the same approach as `StreamlitPage.__init__` when registering pages for `st.navigation`. This replaces `os.path.realpath(normalize_path_join(...))`, which can differ from `Path.resolve()` on Windows (short names, drive-letter casing, junctions, UNC paths).

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

Related: https://github.com/streamlit/streamlit/issues/14709

## Testing Plan

- [x] Unit Tests (Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
