### PR TITLE
[spec] Cookie read/write and local storage APIs

### DIFF
--- a/specs/2026-03-13-cookie-read-write-api/product-spec.md
+++ b/specs/2026-03-13-cookie-read-write-api/product-spec.md
@@ -1,0 +1,172 @@
+---
+author: lukasmasuch
+created: 2026-03-13
+---
+
+# Cookie Read/Write API
+
+## Summary
+
+Add a first-class API for writing browser cookies in Streamlit apps, enabling persistent
+client-side storage that survives page refreshes.
+
+## Problem
+
+Streamlit apps cannot persist state across page refreshes without external infrastructure.
+`st.session_state` is lost on refresh, and `st.context.cookies` is read-only.
+
+**Use cases:**
+
+1. **Session persistence** - Remember users across refreshes without full OAuth
+2. **User preferences** - Store theme, locale, or UI settings
+3. **Draft preservation** - Keep form inputs if user accidentally refreshes
+4. **Custom auth** - Support flows that don't fit `st.login()` (API tokens, simple passwords)
+
+**Current workarounds** (all have significant limitations):
+
+- Third-party packages (`streamlit-cookies-manager`) - require extra reruns, timing issues
+- Custom components with `document.cookie` - can't set HTTP-only cookies
+- ASGI middleware (1.53+) - only works on HTTP requests, not during script execution
+
+Issues: #861 (100+ upvotes), #5105 (localStorage), #8518 (auth-related)
+
+## Proposal
+
+### API Options
+
+**Option 1: New `st.cookies` namespace** ✅ PREFERRED
+
+```python
+st.cookies["theme"] = "dark"
+st.cookies.set("session", token, max_age=86400, httponly=True)
+del st.cookies["draft"]
+```
+
+- Pros: Clean separation, clear that this is mutable, matches `st.session_state` pattern
+- Cons: New top-level namespace
+
+**Option 2: Extend `st.context.cookies`**
+
+```python
+st.context.cookies["theme"] = "dark"
+st.context.cookies.set("session", token, max_age=86400)
+```
+
+- Pros: No new namespace, cookies stay together
+- Cons: `st.context` is conceptually read-only (snapshot of request), breaking type change
+
+**Option 3: Flat functions**
+
+```python
+st.set_cookie("theme", "dark")
+st.delete_cookie("theme")
+```
+
+- Pros: Simple, explicit
+- Cons: Inconsistent with `st.session_state` dict pattern, no iteration support
+
+### Recommended API (Option 1)
+
+```python
+import streamlit as st
+
+# Read (same as st.context.cookies)
+value = st.cookies.get("my_cookie")
+value = st.cookies["my_cookie"]  # KeyError if not found
+
+# Write (available on next rerun)
+st.cookies["my_cookie"] = "value"
+st.cookies.set("my_cookie", "value", max_age=86400, secure=True)
+
+# Delete
+del st.cookies["my_cookie"]
+
+# Check/iterate
+if "my_cookie" in st.cookies: ...
+for name, value in st.cookies.items(): ...
+```
+
+### `st.cookies.set()` Parameters
+
+```python
+def set(
+    name: str,
+    value: str,
+    *,
+    max_age: int | timedelta | None = None,  # None = session cookie
+    expires: datetime | None = None,
+    path: str = "/",
+    domain: str | None = None,
+    secure: bool = True,       # HTTPS-only by default
+    httponly: bool = False,    # JS-accessible by default
+    samesite: Literal["strict", "lax", "none"] = "lax",
+) -> None:
+```
+
+### Behavior
+
+**Timing:** Cookies are queued during script run and sent in the ForwardMsg. They become
+readable on the **next** page load/rerun.
+
+```python
+st.cookies["draft"] = "text"  # Queued
+st.rerun()                    # Sent to browser
+# Next run: st.cookies["draft"] == "text"
+```
+
+**Restrictions:**
+
+- String values only (use `json.dumps()` for complex data)
+- ~4KB limit per cookie (raises `StreamlitAPIException` if exceeded)
+- Names cannot contain `=`, `;`, or whitespace
+
+**Relationship with `st.context.cookies`:** Both read the same cookies. `st.context.cookies`
+remains read-only for backward compatibility. Recommend `st.cookies` for new code.
+
+### Examples
+
+**Remember user preference:**
+
+```python
+theme = st.cookies.get("theme", "light")
+new_theme = st.radio("Theme", ["light", "dark"], index=0 if theme == "light" else 1)
+if new_theme != theme:
+    st.cookies.set("theme", new_theme, max_age=365*24*60*60)
+    st.rerun()
+```
+
+**Simple session token:**
+
+```python
+session_id = st.cookies.get("session")
+if not session_id:
+    session_id = secrets.token_urlsafe(32)
+    st.cookies.set("session", session_id, max_age=7*24*60*60, httponly=True)
+```
+
+### Security & Legal
+
+- `secure=True` default prevents HTTP transmission (except localhost)
+- `samesite="lax"` default prevents CSRF
+- GDPR compliance is developer responsibility (same as Flask, Django, FastAPI)
+- Docs will include consent banner guidance for developers who need it
+
+### Out of Scope (Future Work)
+
+| Feature | Rationale |
+|---------|-----------|
+| `st.local_storage` | Different mechanism; separate feature (#5105) |
+| Cookie consent component | Not required for core API; add based on feedback |
+| Auto JSON serialization | Keep API simple; manual `json.dumps()` is clear |
+| `st.cookies` in `AppTest` | Follow-up work |
+
+## Checklist
+
+| Item                         | Status |
+|------------------------------|--------|
+| Works on SiS, Cloud, etc?    | Needs verification for cookie domain restrictions |
+| No breaking API changes      | ✅ `st.context.cookies` unchanged |
+| No new dependencies          | ✅ Uses existing Tornado/Starlette |
+| Metrics collected            | Track `set`, `delete` calls |
+| Any security/legal impact?   | Secure defaults; GDPR is dev responsibility |
+| Any docs changes needed?     | New guide + `st.context` docs update |

--- a/specs/2026-03-13-cookie-read-write-api/product-spec.md
+++ b/specs/2026-03-13-cookie-read-write-api/product-spec.md
@@ -98,20 +98,23 @@ def set(
     path: str = "/",
     domain: str | None = None,
     secure: bool = True,       # HTTPS-only by default
-    httponly: bool = False,    # JS-accessible by default
     samesite: Literal["strict", "lax", "none"] = "lax",
+    # Note: httponly is NOT supported - JS cannot set HTTP-only cookies.
+    # For HTTP-only cookies, use server-side mechanisms (ASGI middleware).
 ) -> None:
 ```
 
 ### Behavior
 
 **Timing:** Cookies are queued during script run and sent in the ForwardMsg. They become
-readable on the **next** page load/rerun.
+readable on the **next full page load or browser reconnect** (not just `st.rerun()`), because
+`st.context.cookies` reflects cookies from the initial HTTP request/WebSocket handshake.
 
 ```python
 st.cookies["draft"] = "text"  # Queued
-st.rerun()                    # Sent to browser
-# Next run: st.cookies["draft"] == "text"
+st.rerun()                    # Sent to browser, but not yet readable
+# Same session: st.cookies.get("draft") still returns old value
+# After browser refresh: st.cookies["draft"] == "text"
 ```
 
 **Restrictions:**
@@ -141,7 +144,9 @@ if new_theme != theme:
 session_id = st.cookies.get("session")
 if not session_id:
     session_id = secrets.token_urlsafe(32)
-    st.cookies.set("session", session_id, max_age=7*24*60*60, httponly=True)
+    # Note: httponly is NOT supported with st.cookies (JS-based).
+    # For truly HTTP-only session cookies, use ASGI middleware.
+    st.cookies.set("session", session_id, max_age=7*24*60*60, secure=True)
 ```
 
 ### Security & Legal
@@ -162,8 +167,8 @@ if not session_id:
 
 ## Checklist
 
-| Item                         | Status |
-|------------------------------|--------|
+| Item                         | ✅ or comment |
+|------------------------------|---------------|
 | Works on SiS, Cloud, etc?    | Needs verification for cookie domain restrictions |
 | No breaking API changes      | ✅ `st.context.cookies` unchanged |
 | No new dependencies          | ✅ Uses existing Tornado/Starlette |

--- a/specs/2026-03-13-cookie-read-write-api/tech-spec.md
+++ b/specs/2026-03-13-cookie-read-write-api/tech-spec.md
@@ -1,0 +1,123 @@
+---
+author: lukasmasuch
+created: 2026-03-13
+---
+
+# Cookie Read/Write API - Tech Spec
+
+## Architecture
+
+```
+Backend (Python)              Frontend (Browser)
+────────────────────────────     ────────────────────────────
+st.cookies["x"] = "y"    ───▶    document.cookie = "x=y"
+(queue in ScriptRunContext)     (via ForwardMsg.set_cookies)
+
+st.cookies["x"]          ◀───    Cookie header on page load
+(read from ClientContext)       (via HTTP request)
+```
+
+## Implementation
+
+### 1. Proto Changes
+
+`proto/streamlit/proto/ForwardMsg.proto`:
+
+```protobuf
+message SetCookies {
+  repeated Cookie cookies = 1;
+}
+
+message Cookie {
+  string name = 1;
+  string value = 2;
+  bool delete = 3;
+  int32 max_age = 4;
+  string path = 5;
+  string domain = 6;
+  bool secure = 7;
+  bool httponly = 8;
+  string samesite = 9;
+  int64 expires = 10;  // Unix timestamp
+}
+
+message ForwardMsg {
+  // ... existing fields ...
+  SetCookies set_cookies = XX;
+}
+```
+
+### 2. Backend: `StreamlitCookiesProxy`
+
+`lib/streamlit/runtime/cookies.py` (new file):
+
+```python
+class StreamlitCookiesProxy(MutableMapping[str, str]):
+    """Dict-like interface for reading/writing cookies."""
+
+    def __getitem__(self, key: str) -> str:
+        # Read from client context (same as st.context.cookies)
+        ctx = get_script_run_ctx()
+        return ctx.client_context.cookies[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.set(key, value)
+
+    def set(self, name: str, value: str, *, max_age=None, ...) -> None:
+        self._validate(name, value)
+        ctx = get_script_run_ctx()
+        ctx.pending_cookies.append(PendingCookie(name, value, options))
+
+    def delete(self, name: str) -> None:
+        ctx = get_script_run_ctx()
+        ctx.pending_cookies.append(PendingCookie(name, None, CookieOptions(max_age=0)))
+```
+
+### 3. ScriptRunContext Changes
+
+Add `pending_cookies: list[PendingCookie]` to `ScriptRunContext`. Flush to ForwardMsg
+after script completes.
+
+### 4. Frontend Handler
+
+`frontend/lib/src/ForwardMessageHandler.ts`:
+
+```typescript
+function handleSetCookies(setCookies: SetCookies): void {
+  for (const cookie of setCookies.cookies) {
+    if (cookie.delete) {
+      document.cookie = `${cookie.name}=; path=${cookie.path}; max-age=0`;
+    } else {
+      let str = `${encodeURIComponent(cookie.name)}=${encodeURIComponent(cookie.value)}`;
+      if (cookie.maxAge > 0) str += `; max-age=${cookie.maxAge}`;
+      if (cookie.secure) str += `; secure`;
+      str += `; samesite=${cookie.samesite}`;
+      document.cookie = str;
+    }
+  }
+}
+```
+
+**Note on `httponly`:** JavaScript cannot set HTTP-only cookies. If user specifies
+`httponly=True`, log a warning. True HTTP-only cookies require ASGI middleware approach.
+
+### 5. Export
+
+`lib/streamlit/__init__.py`:
+
+```python
+from streamlit.runtime.cookies import StreamlitCookiesProxy
+cookies: StreamlitCookiesProxy = StreamlitCookiesProxy()
+```
+
+## Testing
+
+- **Unit tests:** `StreamlitCookiesProxy` operations, validation, context integration
+- **E2E tests:** Cookie roundtrip (set → reload → read), delete, options verification
+
+## Open Questions
+
+1. **SiS compatibility:** May have cookie domain/path restrictions
+2. **Cookie prefix:** Should we prefix app cookies (e.g., `st_app_*`) to avoid conflicts
+   with internal cookies (`streamlit_user`, `streamlit_tokens`)?
+3. **Starlette migration:** Design should work with both Tornado and Starlette backends

--- a/specs/2026-03-13-cookie-read-write-api/tech-spec.md
+++ b/specs/2026-03-13-cookie-read-write-api/tech-spec.md
@@ -99,7 +99,8 @@ function handleSetCookies(setCookies: SetCookies): void {
 ```
 
 **Note on `httponly`:** JavaScript cannot set HTTP-only cookies. If user specifies
-`httponly=True`, log a warning. True HTTP-only cookies require ASGI middleware approach.
+`httponly=True`, raise a `ValueError` to prevent false security expectations. True HTTP-only
+cookies require server-side mechanisms (e.g., ASGI middleware setting `Set-Cookie` headers).
 
 ### 5. Export
 

--- a/specs/2026-03-15-local-storage-api/product-spec.md
+++ b/specs/2026-03-15-local-storage-api/product-spec.md
@@ -1,0 +1,262 @@
+---
+author: lukasmasuch
+created: 2026-03-15
+---
+
+# Local Storage API (`st.local_storage`)
+
+## Summary
+
+Add a first-class API for reading and writing browser localStorage in Streamlit apps,
+enabling persistent client-side storage for larger data that survives page refreshes and
+browser sessions.
+
+## Problem
+
+Streamlit apps cannot persist client-side state across page refreshes. `st.session_state`
+is server-side and lost on refresh. While cookies work for small data (~4KB), many use
+cases need more storage capacity.
+
+**Use cases:**
+
+1. **User scores/progress** - Track game scores, quiz results, learning progress
+2. **UI state persistence** - Remember filters, settings, view configurations
+3. **Draft preservation** - Store larger form data, chat history, document drafts
+4. **Watchlists/saved items** - User-curated lists without server-side storage
+5. **Offline-first data** - Cache data locally for better performance
+
+**Current workarounds** (all have significant limitations):
+
+- `streamlit_javascript` / `streamlit_js` - Requires extra reruns, timing issues, double-loads
+- Custom components with `localStorage` - Same rerun/timing issues as cookie components
+- `st.cookies` (proposed) - Limited to ~4KB per cookie
+
+**Cookies vs localStorage:**
+
+| Feature | Cookies | localStorage |
+|---------|---------|--------------|
+| Size limit | ~4KB per cookie | ~5-10MB total |
+| Sent to server | Yes (every request) | No (client-only) |
+| Expiration | Configurable | Persistent until cleared |
+| HTTP-only option | Yes | No (always JS-accessible) |
+| Best for | Auth tokens, session IDs | Larger user data, preferences |
+
+Issues: #5105 (50+ upvotes), #13609 (widget binding to localStorage)
+
+## Proposal
+
+### API Options
+
+**Option 1: New `st.local_storage` namespace** ✅ PREFERRED
+
+```python
+st.local_storage["scores"] = {"level1": 100, "level2": 85}
+scores = st.local_storage.get("scores", {})
+del st.local_storage["scores"]
+```
+
+- Pros: Mirrors `st.session_state` pattern, clear separation, supports JSON natively
+- Cons: New top-level namespace
+
+**Option 2: Extend `st.context`**
+
+```python
+st.context.local_storage["scores"] = data
+```
+
+- Pros: Groups browser-side state together
+- Cons: `st.context` is conceptually read-only (request snapshot)
+
+**Option 3: Unified `st.browser_storage`**
+
+```python
+st.browser_storage.local["scores"] = data
+st.browser_storage.session["temp"] = data  # sessionStorage
+```
+
+- Pros: Future-proof for sessionStorage
+- Cons: Extra nesting, sessionStorage rarely needed (we have `st.session_state`)
+
+### Recommended API (Option 1)
+
+```python
+import streamlit as st
+
+# Read (returns None if not found)
+scores = st.local_storage.get("scores")
+scores = st.local_storage["scores"]  # KeyError if not found
+
+# Write (auto-serializes to JSON, available on next rerun)
+st.local_storage["scores"] = {"level1": 100, "level2": 85}
+st.local_storage["theme"] = "dark"
+
+# Write with expiration (optional)
+st.local_storage.set("session_cache", data, expires_in=timedelta(hours=24))
+
+# Delete
+del st.local_storage["theme"]
+st.local_storage.delete("theme")
+
+# Clear all app data
+st.local_storage.clear()
+
+# Check/iterate
+if "scores" in st.local_storage: ...
+for key in st.local_storage: ...
+```
+
+### Why No Other Options?
+
+Unlike cookies, localStorage has no native configuration options:
+
+| Cookies option | localStorage equivalent |
+|----------------|------------------------|
+| `max_age`/`expires` | Not native (we implement via `expires_in`) |
+| `path`/`domain` | Same-origin only (browser-enforced) |
+| `secure`/`httponly`/`samesite` | N/A (data never sent to server) |
+
+### `st.local_storage.set()` Parameters
+
+```python
+def set(
+    key: str,
+    value: Any,  # JSON-serializable
+    *,
+    expires_in: timedelta | None = None,  # Auto-delete after duration
+) -> None:
+```
+
+**Expiration behavior:** If `expires_in` is set, the value is stored with a timestamp.
+On read, if expired, returns `None` (or raises `KeyError`) and queues deletion. This is
+implemented in Python, not a browser feature.
+
+### Behavior
+
+**Timing:** Same as `st.cookies` - values are queued during script run and sent to browser
+via ForwardMsg. Readable on **next** rerun.
+
+```python
+st.local_storage["draft"] = "my text"  # Queued
+st.rerun()                             # Sent to browser
+# Next run: st.local_storage["draft"] == "my text"
+```
+
+**Auto-serialization:** Unlike cookies (string-only), localStorage automatically
+serializes/deserializes JSON:
+
+```python
+st.local_storage["prefs"] = {"theme": "dark", "lang": "en"}  # Auto JSON.stringify
+prefs = st.local_storage["prefs"]  # Auto JSON.parse -> dict
+```
+
+**Namespacing:** Keys are automatically namespaced per-app to prevent cross-app collisions:
+
+```
+st_local_storage_{app_id}_{key}
+```
+
+Where `app_id` is derived from the app's URL path. This prevents one app from reading/
+overwriting another app's data on the same domain.
+
+**Size limits:**
+
+- Individual values: Soft limit ~1MB (warn if exceeded)
+- Total storage: ~5-10MB (browser-dependent)
+- Raises `StreamlitAPIException` on `QuotaExceededError`
+
+### Widget Binding (Related Feature)
+
+The existing query-params binding spec (2026-01-06) includes plans for `bind="local-storage"`:
+
+```python
+st.selectbox("Theme", ["light", "dark"], bind="local-storage", key="theme")
+```
+
+This spec focuses on the **direct API** (`st.local_storage`). Widget binding is a separate
+feature that can be implemented alongside or after the direct API.
+
+| Feature | Direct API (`st.local_storage`) | Widget Binding (`bind="local-storage"`) |
+|---------|--------------------------------|----------------------------------------|
+| Use case | Arbitrary data | Widget state persistence |
+| Data type | Any JSON-serializable | Widget-specific |
+| Scope | Full control | Automatic per-widget |
+
+### Examples
+
+**Track user progress:**
+
+```python
+progress = st.local_storage.get("quiz_progress", {"score": 0, "level": 1})
+
+st.write(f"Level {progress['level']}, Score: {progress['score']}")
+
+if st.button("Complete level"):
+    progress["score"] += 10
+    progress["level"] += 1
+    st.local_storage["quiz_progress"] = progress
+    st.rerun()
+```
+
+**Remember UI settings:**
+
+```python
+settings = st.local_storage.get("settings", {
+    "theme": "light",
+    "columns": 3,
+    "show_advanced": False
+})
+
+theme = st.selectbox("Theme", ["light", "dark"],
+                     index=0 if settings["theme"] == "light" else 1)
+cols = st.slider("Columns", 1, 5, settings["columns"])
+
+if theme != settings["theme"] or cols != settings["columns"]:
+    settings["theme"] = theme
+    settings["columns"] = cols
+    st.local_storage["settings"] = settings
+```
+
+**Draft preservation (larger data):**
+
+```python
+draft = st.local_storage.get("document_draft", "")
+
+content = st.text_area("Document", value=draft, height=400)
+
+# Auto-save on change
+if content != draft:
+    st.local_storage["document_draft"] = content
+
+if st.button("Publish"):
+    publish(content)
+    st.local_storage.delete("document_draft")
+    st.success("Published!")
+```
+
+### Security & Privacy
+
+- **Client-only:** Data never sent to server (unlike cookies)
+- **Same-origin:** Browser enforces same-origin policy
+- **User-controlled:** Users can clear via browser dev tools
+- **No sensitive data:** Docs will warn against storing passwords, tokens (use `st.cookies`
+  with `httponly=True` instead)
+
+### Out of Scope (Future Work)
+
+| Feature | Rationale |
+|---------|-----------|
+| `st.session_storage` | sessionStorage rarely needed; `st.session_state` covers most cases |
+| Widget binding (`bind="local-storage"`) | Separate feature in query-params spec |
+| Encryption helpers | Can add later based on demand |
+| Storage quota management | Let browser handle; document limits |
+
+## Checklist
+
+| Item                         | Status |
+|------------------------------|--------|
+| Works on SiS, Cloud, etc?    | Needs verification for iframe/cross-origin restrictions |
+| No breaking API changes      | ✅ Additive only |
+| No new dependencies          | ✅ Uses browser localStorage API |
+| Metrics collected            | Track `get`, `set`, `delete`, `clear` calls |
+| Any security/legal impact?   | Privacy: client-only, no GDPR concerns for essential use |
+| Any docs changes needed?     | New guide: "Client-Side Storage" covering cookies + localStorage |

--- a/specs/2026-03-15-local-storage-api/product-spec.md
+++ b/specs/2026-03-15-local-storage-api/product-spec.md
@@ -132,13 +132,19 @@ implemented in Python, not a browser feature.
 
 ### Behavior
 
-**Timing:** Same as `st.cookies` - values are queued during script run and sent to browser
-via ForwardMsg. Readable on **next** rerun.
+**Timing:** Values written with `st.local_storage` are queued during the script run and sent
+to the browser via `ForwardMsg` after the run completes. They are **not** readable in the same
+run. With the current design, read-after-write becomes visible only after a **full page reload
+or new browser connection**, when the backend receives a fresh `LocalStorageSnapshot` from
+the browser during session initialization.
 
 ```python
-st.local_storage["draft"] = "my text"  # Queued
-st.rerun()                             # Sent to browser
-# Next run: st.local_storage["draft"] == "my text"
+st.local_storage["draft"] = "my text"  # Queued and sent to browser after this run
+st.rerun()                             # Does not make the new value readable yet
+# Same live session: st.local_storage.get("draft") may still return old value
+
+# After a full browser reload / reconnect:
+# st.local_storage["draft"] == "my text"
 ```
 
 **Auto-serialization:** Unlike cookies (string-only), localStorage automatically
@@ -152,30 +158,31 @@ prefs = st.local_storage["prefs"]  # Auto JSON.parse -> dict
 **Namespacing:** Keys are automatically namespaced per-app to prevent cross-app collisions:
 
 ```
-st_local_storage_{app_id}_{key}
+st_ls_{app_id}_{key}
 ```
 
-Where `app_id` is derived from the app's URL path. This prevents one app from reading/
-overwriting another app's data on the same domain.
+Where `app_id` is derived from the app's URL path (e.g., a hash of the path). This prevents
+one app from reading/overwriting another app's data on the same domain.
 
 **Size limits:**
 
-- Individual values: Soft limit ~1MB (warn if exceeded)
+- Individual values: Hard limit ~1MB per JSON-serialized value (writes raise `StreamlitAPIException` if exceeded)
 - Total storage: ~5-10MB (browser-dependent)
-- Raises `StreamlitAPIException` on `QuotaExceededError`
+- Browser quota failures (`QuotaExceededError` / `DOMException`) are re-raised as-is
 
 ### Widget Binding (Related Feature)
 
-The existing query-params binding spec (2026-01-06) includes plans for `bind="local-storage"`:
+The existing query-params binding spec (2026-01-06) mentions `"localstorage"` as a possible
+future extension for widget binding:
 
 ```python
-st.selectbox("Theme", ["light", "dark"], bind="local-storage", key="theme")
+st.selectbox("Theme", ["light", "dark"], bind="localstorage", key="theme")
 ```
 
 This spec focuses on the **direct API** (`st.local_storage`). Widget binding is a separate
 feature that can be implemented alongside or after the direct API.
 
-| Feature | Direct API (`st.local_storage`) | Widget Binding (`bind="local-storage"`) |
+| Feature | Direct API (`st.local_storage`) | Widget Binding (`bind="localstorage"`) |
 |---------|--------------------------------|----------------------------------------|
 | Use case | Arbitrary data | Widget state persistence |
 | Data type | Any JSON-serializable | Widget-specific |
@@ -235,11 +242,14 @@ if st.button("Publish"):
 
 ### Security & Privacy
 
-- **Client-only:** Data never sent to server (unlike cookies)
+- **Browser-managed storage:** Data is stored in the browser and is not automatically
+  attached to HTTP requests like cookies, but the current design syncs a snapshot to the
+  backend over the Streamlit WebSocket so the Python API can read it
 - **Same-origin:** Browser enforces same-origin policy
 - **User-controlled:** Users can clear via browser dev tools
-- **No sensitive data:** Docs will warn against storing passwords, tokens (use `st.cookies`
-  with `httponly=True` instead)
+- **No sensitive data:** Docs will warn against storing passwords or tokens in localStorage;
+  sensitive values should use server-managed auth/session mechanisms (e.g., server-set
+  `HttpOnly` cookies via ASGI middleware), not client-managed storage
 
 ### Out of Scope (Future Work)
 
@@ -252,8 +262,8 @@ if st.button("Publish"):
 
 ## Checklist
 
-| Item                         | Status |
-|------------------------------|--------|
+| Item                         | ✅ or comment |
+|------------------------------|---------------|
 | Works on SiS, Cloud, etc?    | Needs verification for iframe/cross-origin restrictions |
 | No breaking API changes      | ✅ Additive only |
 | No new dependencies          | ✅ Uses browser localStorage API |

--- a/specs/2026-03-15-local-storage-api/tech-spec.md
+++ b/specs/2026-03-15-local-storage-api/tech-spec.md
@@ -1,0 +1,255 @@
+---
+author: lukasmasuch
+created: 2026-03-15
+---
+
+# Local Storage API - Tech Spec
+
+## Architecture
+
+```
+Backend (Python)              Frontend (Browser)
+────────────────────────────     ────────────────────────────
+st.local_storage["x"] = y    ───▶    localStorage.setItem("x", y)
+(queue in ScriptRunContext)        (via ForwardMsg.set_local_storage)
+
+st.local_storage["x"]        ◀───    BackMsg with localStorage snapshot
+(read from session cache)          (on session connect)
+```
+
+**Key difference from cookies:** localStorage values are not sent with HTTP requests, so
+we need a separate mechanism to sync them to the backend.
+
+## Implementation
+
+### 1. Proto Changes
+
+`proto/streamlit/proto/ForwardMsg.proto`:
+
+```protobuf
+message SetLocalStorage {
+  repeated LocalStorageItem items = 1;
+  bool clear_all = 2;  // Clear all items for this app
+}
+
+message LocalStorageItem {
+  string key = 1;
+  string value = 2;     // JSON-serialized
+  bool delete = 3;
+}
+
+message ForwardMsg {
+  // ... existing fields ...
+  SetLocalStorage set_local_storage = XX;
+}
+```
+
+`proto/streamlit/proto/BackMsg.proto`:
+
+```protobuf
+message LocalStorageSnapshot {
+  repeated LocalStorageItem items = 1;
+}
+
+message BackMsg {
+  // ... existing fields ...
+  LocalStorageSnapshot local_storage_snapshot = XX;
+}
+```
+
+### 2. Frontend: localStorage Sync
+
+**On session connect**, frontend reads localStorage and sends snapshot to backend:
+
+```typescript
+const APP_PREFIX = `st_ls_${getAppId()}_`;
+
+function sendLocalStorageSnapshot(): void {
+  const items: LocalStorageItem[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const fullKey = localStorage.key(i);
+    if (fullKey?.startsWith(APP_PREFIX)) {
+      const key = fullKey.slice(APP_PREFIX.length);
+      items.push({ key, value: localStorage.getItem(fullKey) || "" });
+    }
+  }
+  sendBackMsg({ localStorageSnapshot: { items } });
+}
+```
+
+**On ForwardMsg.set_local_storage**, apply changes:
+
+```typescript
+function handleSetLocalStorage(msg: SetLocalStorage): void {
+  if (msg.clearAll) {
+    // Clear all keys with app prefix
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(APP_PREFIX)) {
+        localStorage.removeItem(key);
+      }
+    }
+  }
+
+  for (const item of msg.items) {
+    const fullKey = APP_PREFIX + item.key;
+    if (item.delete) {
+      localStorage.removeItem(fullKey);
+    } else {
+      try {
+        localStorage.setItem(fullKey, item.value);
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "QuotaExceededError") {
+          console.error(`localStorage quota exceeded for key: ${item.key}`);
+        }
+        throw e;
+      }
+    }
+  }
+}
+```
+
+### 3. Backend: `StreamlitLocalStorageProxy`
+
+`lib/streamlit/runtime/local_storage.py` (new file):
+
+```python
+import json
+from collections.abc import Iterator, MutableMapping
+from typing import Any
+
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+
+
+class StreamlitLocalStorageProxy(MutableMapping[str, Any]):
+    """Dict-like interface for browser localStorage with auto JSON serialization."""
+
+    def __getitem__(self, key: str) -> Any:
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            raise StreamlitAPIException(
+                "st.local_storage can only be used within a Streamlit app"
+            )
+        # Read from cached snapshot (sent via BackMsg on connect)
+        raw = ctx.local_storage_cache.get(key)
+        if raw is None:
+            raise KeyError(key)
+        return json.loads(raw)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._validate_key(key)
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            raise StreamlitAPIException(
+                "st.local_storage can only be used within a Streamlit app"
+            )
+
+        serialized = json.dumps(value, ensure_ascii=False)
+        self._validate_size(key, serialized)
+
+        ctx.pending_local_storage.append(
+            PendingLocalStorageItem(key, serialized, delete=False)
+        )
+
+    def __delitem__(self, key: str) -> None:
+        self.delete(key)
+
+    def __iter__(self) -> Iterator[str]:
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            return iter([])
+        return iter(ctx.local_storage_cache)
+
+    def __len__(self) -> int:
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            return 0
+        return len(ctx.local_storage_cache)
+
+    def delete(self, key: str) -> None:
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            raise StreamlitAPIException(
+                "st.local_storage can only be used within a Streamlit app"
+            )
+        ctx.pending_local_storage.append(
+            PendingLocalStorageItem(key, "", delete=True)
+        )
+
+    def clear(self) -> None:
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            raise StreamlitAPIException(
+                "st.local_storage can only be used within a Streamlit app"
+            )
+        ctx.pending_local_storage_clear = True
+
+    def _validate_key(self, key: str) -> None:
+        if not key or not isinstance(key, str):
+            raise StreamlitAPIException("localStorage key must be a non-empty string")
+
+    def _validate_size(self, key: str, value: str) -> None:
+        if len(value.encode("utf-8")) > 1_000_000:  # 1MB soft limit
+            raise StreamlitAPIException(
+                f"localStorage value for '{key}' exceeds 1MB. "
+                "Consider splitting into smaller chunks."
+            )
+```
+
+### 4. ScriptRunContext Changes
+
+Add to `ScriptRunContext`:
+
+```python
+@dataclass
+class ScriptRunContext:
+    # ... existing fields ...
+    local_storage_cache: dict[str, str] = field(default_factory=dict)
+    pending_local_storage: list[PendingLocalStorageItem] = field(default_factory=list)
+    pending_local_storage_clear: bool = False
+```
+
+### 5. Session Initialization
+
+On BackMsg with `local_storage_snapshot`, populate `local_storage_cache`:
+
+```python
+def handle_local_storage_snapshot(self, snapshot: LocalStorageSnapshot) -> None:
+    self._local_storage_cache = {
+        item.key: item.value for item in snapshot.items
+    }
+```
+
+## Namespacing Strategy
+
+To prevent cross-app collisions on shared domains (e.g., Community Cloud), keys are
+namespaced:
+
+```
+st_ls_{hash(page_url_path)}_{user_key}
+```
+
+Example:
+- App URL: `https://share.streamlit.io/user/myapp/app.py`
+- User key: `scores`
+- Stored key: `st_ls_a1b2c3d4_scores`
+
+## Testing
+
+- **Unit tests:** `StreamlitLocalStorageProxy` operations, JSON serialization, validation
+- **E2E tests:**
+  - Set value → reload → read value (roundtrip)
+  - Clear all → verify empty
+  - Cross-app isolation (two apps don't see each other's data)
+
+## Open Questions
+
+1. **Iframe restrictions:** Some hosting (SiS, embedded apps) may have localStorage
+   restrictions. Need to test and document graceful degradation.
+
+2. **Sync timing:** Should we wait for localStorage snapshot before first script run,
+   or return `None` for keys until snapshot arrives?
+
+3. **Cache invalidation:** If user clears localStorage in dev tools, how do we detect
+   and update `local_storage_cache`?

--- a/specs/2026-03-15-local-storage-api/tech-spec.md
+++ b/specs/2026-03-15-local-storage-api/tech-spec.md
@@ -115,7 +115,9 @@ function handleSetLocalStorage(msg: SetLocalStorage): void {
 
 ```python
 import json
+import time
 from collections.abc import Iterator, MutableMapping
+from datetime import timedelta
 from typing import Any
 
 from streamlit.errors import StreamlitAPIException
@@ -138,6 +140,20 @@ class StreamlitLocalStorageProxy(MutableMapping[str, Any]):
         return json.loads(raw)
 
     def __setitem__(self, key: str, value: Any) -> None:
+        self.set(key, value)
+
+    def set(
+        self,
+        key: str,
+        value: Any,
+        *,
+        expires_in: timedelta | None = None,
+    ) -> None:
+        """Set a value with optional expiration.
+
+        If expires_in is provided, the value is stored with metadata. On read,
+        expired values return None and are queued for deletion.
+        """
         self._validate_key(key)
         ctx = get_script_run_ctx()
         if ctx is None:
@@ -145,12 +161,21 @@ class StreamlitLocalStorageProxy(MutableMapping[str, Any]):
                 "st.local_storage can only be used within a Streamlit app"
             )
 
-        serialized = json.dumps(value, ensure_ascii=False)
+        # If expiration requested, wrap value with metadata
+        if expires_in is not None:
+            expires_at = time.time() + expires_in.total_seconds()
+            wrapped = {"__st_expires_at": expires_at, "value": value}
+            serialized = json.dumps(wrapped, ensure_ascii=False)
+        else:
+            serialized = json.dumps(value, ensure_ascii=False)
+
         self._validate_size(key, serialized)
 
         ctx.pending_local_storage.append(
             PendingLocalStorageItem(key, serialized, delete=False)
         )
+        # Optimistic cache update for immediate read-after-write within same session
+        ctx.local_storage_cache[key] = serialized
 
     def __delitem__(self, key: str) -> None:
         self.delete(key)
@@ -176,6 +201,8 @@ class StreamlitLocalStorageProxy(MutableMapping[str, Any]):
         ctx.pending_local_storage.append(
             PendingLocalStorageItem(key, "", delete=True)
         )
+        # Optimistic cache update
+        ctx.local_storage_cache.pop(key, None)
 
     def clear(self) -> None:
         ctx = get_script_run_ctx()
@@ -184,6 +211,8 @@ class StreamlitLocalStorageProxy(MutableMapping[str, Any]):
                 "st.local_storage can only be used within a Streamlit app"
             )
         ctx.pending_local_storage_clear = True
+        # Optimistic cache update
+        ctx.local_storage_cache.clear()
 
     def _validate_key(self, key: str) -> None:
         if not key or not isinstance(key, str):
@@ -227,13 +256,15 @@ To prevent cross-app collisions on shared domains (e.g., Community Cloud), keys 
 namespaced:
 
 ```
-st_ls_{hash(page_url_path)}_{user_key}
+st_ls_{app_id}_{user_key}
 ```
+
+Where `app_id` is derived from the app's URL path (e.g., a hash of the path).
 
 Example:
 - App URL: `https://share.streamlit.io/user/myapp/app.py`
 - User key: `scores`
-- Stored key: `st_ls_a1b2c3d4_scores`
+- Stored key: `st_ls_a1b2c3d4_scores` (where `a1b2c3d4` is hash of path)
 
 ## Testing
 


### PR DESCRIPTION
## Describe your changes

Adds product and tech specs for two related client-side storage features:

- **Cookie Read/Write API** (`st.cookies`) — First-class API for writing browser cookies, enabling persistent client-side storage that survives page refreshes (~4KB limit per cookie)
- **Local Storage API** (`st.local_storage`) — First-class API for browser localStorage with auto JSON serialization (~5-10MB capacity)

Both specs include:
- Problem statement with linked GitHub issues (#861, #5105, #8518, #13609)
- API options with trade-offs
- Recommended API design with examples
- Technical architecture and implementation details
- Security considerations

## GitHub Issue Link (if applicable)

- Related to #861 (cookie write support, 100+ upvotes)
- Related to #5105 (localStorage support, 50+ upvotes)
- Related to #8518 (auth-related cookie needs)
- Related to #13609 (widget binding to localStorage)

## Testing Plan

- Spec documents only — no code changes

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |

</details>
<!-- agent-metrics-end -->