### PR TITLE
[chore] Add versioning-strategy for Python dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -105,6 +105,8 @@ updates:
     # Allow a limited number of update PRs at a time
     # to keep the number of parallel dependency updates manageable.
     open-pull-requests-limit: 3
+    # Only increase version constraints when required for update
+    versioning-strategy: increase-if-necessary
 
     # Use cooldown to avoid updating dependencies too frequently
     # and minimize risk of supply chain attacks.
@@ -132,6 +134,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 3
+    # Only increase version constraints when required for update
+    versioning-strategy: increase-if-necessary
 
     cooldown:
       default-days: 5


### PR DESCRIPTION
## Describe your changes

Adds `versioning-strategy: increase-if-necessary` to both Python (uv) package ecosystems in dependabot.yml. This strategy only increases version constraints in `pyproject.toml` when required for the update, keeping version bounds minimal.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Configuration change only - no code/tests affected