### PR TITLE
[chore] Remove versioning-strategy from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -105,8 +105,6 @@ updates:
     # Allow a limited number of update PRs at a time
     # to keep the number of parallel dependency updates manageable.
     open-pull-requests-limit: 3
-    # Only increase version constraints when required for update
-    versioning-strategy: increase-if-necessary
 
     # Use cooldown to avoid updating dependencies too frequently
     # and minimize risk of supply chain attacks.
@@ -134,8 +132,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 3
-    # Only increase version constraints when required for update
-    versioning-strategy: increase-if-necessary
 
     cooldown:
       default-days: 5


### PR DESCRIPTION
## Describe your changes

Removes the `versioning-strategy: increase-if-necessary` setting from the Python (uv) dependabot configurations.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Configuration change only, no code changes

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->