### PR TITLE
[chore] Improve fixing-pr agent to respond to all review comments

### DIFF
--- a/.claude/agents/fixing-pr.md
+++ b/.claude/agents/fixing-pr.md
@@ -71,7 +71,7 @@ For each review comment:
 2. Implement changes for valid suggestions
 3. Post brief replies **directly on each review comment thread** (not as a combined PR comment) explaining what was done or why feedback was declined
 4. **Respond to ALL unresolved comments**, even those that don't require code changes (e.g., thoughts, observations, questions). Acknowledge these with a brief reply to keep the conversation flowing. Note: This overrides the skill's default exclusion of `thought`/`note` comment types.
-5. **Resolve addressed comment threads** after replying using the GitHub GraphQL API. Do NOT resolve threads that were deferred to human input (per the Exception below) - let the reviewer resolve those once satisfied.
+5. **Resolve addressed bot comment threads** after replying using `gh api`. Only auto-resolve comments from bots (github-actions, copilot, cursor, greptile, graphite). Do NOT auto-resolve human contributor comments - let reviewers resolve those themselves. Also do NOT resolve threads deferred to human input (per the Exception below).
 
 **Exception:** Don't auto-address review comments that require significant product, design, architecture decisions, or significant refactorings. Instead, reply on the comment thread pointing this out and mention that it will need human input.
 

--- a/.claude/agents/fixing-pr.md
+++ b/.claude/agents/fixing-pr.md
@@ -70,8 +70,8 @@ For each review comment:
 1. Evaluate if the feedback is relevant and actionable
 2. Implement changes for valid suggestions
 3. Post brief replies **directly on each review comment thread** (not as a combined PR comment) explaining what was done or why feedback was declined
-4. **Respond to ALL unresolved comments**, even those that don't require code changes (e.g., thoughts, observations, questions). Acknowledge these with a brief reply to keep the conversation flowing.
-5. **Resolve addressed comment threads** after replying. Use `gh api` to resolve conversations once they've been properly addressed.
+4. **Respond to ALL unresolved comments**, even those that don't require code changes (e.g., thoughts, observations, questions). Acknowledge these with a brief reply to keep the conversation flowing. Note: This overrides the skill's default exclusion of `thought`/`note` comment types.
+5. **Resolve addressed comment threads** after replying using the GitHub GraphQL API. Do NOT resolve threads that were deferred to human input (per the Exception below) - let the reviewer resolve those once satisfied.
 
 **Exception:** Don't auto-address review comments that require significant product, design, architecture decisions, or significant refactorings. Instead, reply on the comment thread pointing this out and mention that it will need human input.
 

--- a/.claude/agents/fixing-pr.md
+++ b/.claude/agents/fixing-pr.md
@@ -70,6 +70,8 @@ For each review comment:
 1. Evaluate if the feedback is relevant and actionable
 2. Implement changes for valid suggestions
 3. Post brief replies **directly on each review comment thread** (not as a combined PR comment) explaining what was done or why feedback was declined
+4. **Respond to ALL unresolved comments**, even those that don't require code changes (e.g., thoughts, observations, questions). Acknowledge these with a brief reply to keep the conversation flowing.
+5. **Resolve addressed comment threads** after replying. Use `gh api` to resolve conversations once they've been properly addressed.
 
 **Exception:** Don't auto-address review comments that require significant product, design, architecture decisions, or significant refactorings. Instead, reply on the comment thread pointing this out and mention that it will need human input.
 

--- a/.claude/skills/addressing-pr-review-comments/SKILL.md
+++ b/.claude/skills/addressing-pr-review-comments/SKILL.md
@@ -52,6 +52,7 @@ gh api graphql -f query="
     pullRequest(number: {PR_NUMBER}) {
       reviewThreads(first: 100) {
         nodes {
+          id
           isResolved
           path
           line
@@ -73,7 +74,7 @@ Issue comments (from `issues/{PR_NUMBER}/comments`) do not have a "resolved" fla
 
 **Include:** Unresolved threads (inline), general PR comments from `issues/{PR}/comments`, `issue`/`todo`/`chore` comments, maintainer feedback, `CHANGES_REQUESTED` reviews. Include the PR author's comments when present. They can help clarify the problem space.
 
-**Exclude:** Resolved threads, `praise`/`thought`/`note` comments
+**Exclude:** Resolved threads, `praise`/`thought`/`note` comments (unless the caller explicitly requests responding to ALL comments, in which case acknowledge these with a brief reply)
 
 **Skip status-only automated comments.** Ignore comments that are only status or check notifications with no actionable feedback. Examples: Snyk ("Snyk checks have passed. No issues have been found so far.") and comments from `.github/workflows/pr-preview.yml` that only say the PR is building or the preview is ready.
 
@@ -216,6 +217,14 @@ gh api repos/streamlit/streamlit/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies
 gh api repos/streamlit/streamlit/issues/{PR_NUMBER}/comments \
   -f body="@{reviewer} Re: {brief context} - {reply text}"
 ```
+
+To resolve an inline review thread after addressing it (use the thread `id` from the GraphQL query above):
+
+```bash
+gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: "<THREAD_NODE_ID>" }) { thread { isResolved } } }'
+```
+
+Note: Only inline review threads can be resolved. General PR (issue) comments do not have a resolvable state. Do not resolve threads that were deferred to human input - let the reviewer resolve those once satisfied.
 
 ## Rules
 


### PR DESCRIPTION
## Describe your changes

Updates the `fixing-pr` agent instructions to:
- Respond to ALL unresolved PR review comments, including those that don't require code changes (e.g., thoughts, observations, questions)
- Resolve addressed comment threads after replying using GitHub GraphQL API

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [ ] Documentation-only changes to agent instructions, no code behavior modifications

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->