### PR TITLE
[chore] Remove deprecated kwargs from `plotly_chart` and `vega_lite_chart`

### DIFF
--- a/e2e_playwright/st_vega_lite_chart.py
+++ b/e2e_playwright/st_vega_lite_chart.py
@@ -87,15 +87,17 @@ st.vega_lite_chart(
     width="stretch",
 )
 
-st.write("Using a top-level `df` and keywords as a spec:")
+st.write("Using a top-level `df` and `spec` dict (another example):")
 
 st.vega_lite_chart(
     df,
-    mark="bar",
-    x_field="a",
-    x_type="ordinal",
-    y_field="b",
-    y_type="quantitative",
+    {
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "a", "type": "ordinal"},
+            "y": {"field": "b", "type": "quantitative"},
+        },
+    },
     width="stretch",
 )
 

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -433,11 +433,9 @@ class PlotlyMixin:
         """Display an interactive Plotly chart.
 
         `Plotly <https://plot.ly/python>`_ is a charting library for Python.
-        The arguments to this function closely follow the ones for Plotly's
-        ``plot()`` function.
 
-        To show Plotly charts in Streamlit, call ``st.plotly_chart`` wherever
-        you would call Plotly's ``py.plot`` or ``py.iplot``.
+        To show Plotly charts in Streamlit, pass a Plotly ``Figure`` or
+        ``Data`` object to ``st.plotly_chart``.
 
         .. Important::
             You must install ``plotly>=4.0.0`` to use this command. Your app's

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -390,7 +390,7 @@ class PlotlyMixin:
             "box",
             "lasso",
         ),
-        **kwargs: Any,
+        config: dict[str, Any] | None = None,
     ) -> DeltaGenerator: ...
 
     @overload
@@ -409,7 +409,7 @@ class PlotlyMixin:
             "box",
             "lasso",
         ),
-        **kwargs: Any,
+        config: dict[str, Any] | None = None,
     ) -> PlotlyState: ...
 
     @gather_metrics("plotly_chart")
@@ -429,7 +429,6 @@ class PlotlyMixin:
             "lasso",
         ),
         config: dict[str, Any] | None = None,
-        **kwargs: Any,
     ) -> DeltaGenerator | PlotlyState:
         """Display an interactive Plotly chart.
 
@@ -572,18 +571,6 @@ class PlotlyMixin:
             configuration options, see Plotly's documentation on `Configuration
             in Python <https://plotly.com/python/configuration-options/>`_.
 
-        **kwargs
-            Additional arguments accepted by Plotly's ``plot()`` function.
-
-            This supports ``config``, a dictionary of Plotly configuration
-            options. For more information about Plotly configuration options,
-            see Plotly's documentation on `Configuration in Python
-            <https://plotly.com/python/configuration-options/>`_.
-
-            .. deprecated::
-               ``**kwargs`` are deprecated and will be removed in a future
-               release. Use ``config`` instead.
-
         Returns
         -------
         element or dict
@@ -673,14 +660,6 @@ class PlotlyMixin:
         # NOTE: "figure_or_data" is the name used in Plotly's .plot() method
         # for their main parameter. I don't like the name, but it's best to
         # keep it in sync with what Plotly calls it.
-
-        if kwargs:
-            show_deprecation_warning(
-                "Variable keyword arguments for `st.plotly_chart` have been "
-                "deprecated and will be removed in a future release. Use the "
-                "`config` argument instead to specify Plotly configuration "
-                "options."
-            )
 
         if theme not in {"streamlit", None}:
             raise StreamlitAPIException(

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    Final,
     Literal,
     TypeAlias,
     TypedDict,
@@ -40,7 +39,6 @@ from streamlit.deprecation_util import (
     make_deprecated_name_warning,
     show_deprecation_warning,
 )
-from streamlit.elements.lib import dicttools
 from streamlit.elements.lib.built_in_chart_utils import (
     AddRowsMetadata,
     ChartStackType,
@@ -75,36 +73,6 @@ if TYPE_CHECKING:
     from streamlit.dataframe_util import Data
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.elements.lib.color_util import Color
-
-# See https://vega.github.io/vega-lite/docs/encoding.html
-_CHANNELS: Final = {
-    "x",
-    "y",
-    "x2",
-    "y2",
-    "xError",
-    "xError2",
-    "yError",
-    "yError2",
-    "longitude",
-    "latitude",
-    "color",
-    "opacity",
-    "fillOpacity",
-    "strokeOpacity",
-    "strokeWidth",
-    "size",
-    "shape",
-    "text",
-    "tooltip",
-    "href",
-    "key",
-    "order",
-    "detail",
-    "facet",
-    "row",
-    "column",
-}
 
 VegaLiteSpec: TypeAlias = dict[str, Any]
 AltairChart: TypeAlias = Union[
@@ -320,17 +288,9 @@ def _has_nested_composition(spec: VegaLiteSpec) -> bool:
 def _prepare_vega_lite_spec(
     spec: VegaLiteSpec,
     use_container_width: bool,
-    **kwargs: Any,
 ) -> VegaLiteSpec:
-    if kwargs:
-        # Support passing in kwargs.
-        # > marshall(proto, {foo: 'bar'}, baz='boz')
-        # Merge spec with unflattened kwargs, where kwargs take precedence.
-        # This only works for string keys, but kwarg keys are strings anyways.
-        spec = dict(spec, **dicttools.unflatten(kwargs, _CHANNELS))
-    else:
-        # Clone the spec dict, since we may be mutating it.
-        spec = dict(spec)
+    # Clone the spec dict, since we may be mutating it.
+    spec = dict(spec)
 
     if len(spec) == 0:
         raise StreamlitAPIException("Vega-Lite charts require a non-empty spec dict.")
@@ -2030,7 +1990,6 @@ class VegaChartsMixin:
         key: Key | None = None,
         on_select: Literal["ignore"] = "ignore",
         selection_mode: str | Iterable[str] | None = None,
-        **kwargs: Any,
     ) -> DeltaGenerator: ...
 
     # When on_select=rerun, return VegaLiteState.
@@ -2047,7 +2006,6 @@ class VegaChartsMixin:
         key: Key | None = None,
         on_select: Literal["rerun"] | WidgetCallback,
         selection_mode: str | Iterable[str] | None = None,
-        **kwargs: Any,
     ) -> VegaLiteState: ...
 
     @gather_metrics("vega_lite_chart")
@@ -2063,7 +2021,6 @@ class VegaChartsMixin:
         key: Key | None = None,
         on_select: Literal["rerun", "ignore"] | WidgetCallback = "ignore",
         selection_mode: str | Iterable[str] | None = None,
-        **kwargs: Any,
     ) -> DeltaGenerator | VegaLiteState:
         """Display a chart using the Vega-Lite library.
 
@@ -2209,15 +2166,6 @@ class VegaChartsMixin:
 
             Selection parameters are identified by their ``name`` property.
 
-        **kwargs : any
-            The Vega-Lite spec for the chart as keywords. This is an alternative
-            to ``spec``.
-
-            .. deprecated::
-               ``**kwargs`` are deprecated and will be removed in a future
-               release. To specify Vega-Lite configuration options, use the
-               ``spec`` argument instead.
-
         Returns
         -------
         element or dict
@@ -2258,14 +2206,6 @@ class VegaChartsMixin:
         translated to the syntax shown above.
 
         """
-        if kwargs:
-            show_deprecation_warning(
-                "Variable keyword arguments for `st.vega_lite_chart` have been "
-                "deprecated and will be removed in a future release. Use the "
-                "`spec` argument instead to specify Vega-Lite configuration "
-                "options."
-            )
-
         return self._vega_lite_chart(
             data=data,
             spec=spec,
@@ -2276,7 +2216,6 @@ class VegaChartsMixin:
             selection_mode=selection_mode,
             width=width,
             height=height,
-            **kwargs,
         )
 
     def _altair_chart(
@@ -2330,7 +2269,6 @@ class VegaChartsMixin:
         add_rows_metadata: AddRowsMetadata | None = None,
         width: Width | None = None,
         height: Height = "content",
-        **kwargs: Any,
     ) -> DeltaGenerator | VegaLiteState:
         """Internal method to enqueue a vega-lite chart element based on a vega-lite spec.
 
@@ -2432,7 +2370,7 @@ class VegaChartsMixin:
             else width == "stretch"
         )
 
-        spec = _prepare_vega_lite_spec(spec, use_container_width_for_spec, **kwargs)
+        spec = _prepare_vega_lite_spec(spec, use_container_width_for_spec)
         _marshall_chart_data(vega_lite_proto, spec, data)
 
         # Prevent the spec from changing across reruns:

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -258,20 +258,6 @@ class PyDeckTest(DeltaGeneratorTestCase):
         assert '"displayModeBar": false' in el.plotly_chart.config
         assert '"responsive": true' in el.plotly_chart.config
 
-    def test_show_deprecation_warning_for_kwargs(self):
-        import plotly.graph_objs as go
-
-        trace0 = go.Scatter(x=[1, 2, 3, 4], y=[10, 15, 13, 17])
-        data = [trace0]
-
-        st.plotly_chart(data, sharing="streamlit")
-        # Get the second to last element, which should be deprecation warning
-        el = self.get_delta_from_queue(-2).new_element
-        assert (
-            "have been deprecated and will be removed in a future release"
-            in el.alert.body
-        )
-
 
 class PlotlyChartWidthTest(DeltaGeneratorTestCase):
     """Test plotly_chart width parameter functionality."""

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -258,6 +258,18 @@ class PyDeckTest(DeltaGeneratorTestCase):
         assert '"displayModeBar": false' in el.plotly_chart.config
         assert '"responsive": true' in el.plotly_chart.config
 
+    def test_kwargs_raises_type_error(self):
+        """Test that passing unexpected kwargs raises TypeError after kwargs removal."""
+        import plotly.graph_objs as go
+
+        trace0 = go.Scatter(x=[1, 2, 3, 4], y=[10, 15, 13, 17])
+        data = [trace0]
+
+        # Passing kwargs that were previously supported (like `sharing`) should now
+        # raise a TypeError since **kwargs support was removed.
+        with pytest.raises(TypeError):
+            st.plotly_chart(data, sharing="streamlit")  # type: ignore[call-overload]
+
 
 class PlotlyChartWidthTest(DeltaGeneratorTestCase):
     """Test plotly_chart width parameter functionality."""

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -1395,6 +1395,13 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
             autosize_spec, {"data": {"name": "foo"}, "mark": "rect"}
         )
 
+    def test_kwargs_raises_type_error(self):
+        """Test that passing unexpected kwargs raises TypeError after kwargs removal."""
+        # Passing spec-as-kwargs that were previously supported should now
+        # raise a TypeError since **kwargs support was removed.
+        with pytest.raises(TypeError):
+            st.vega_lite_chart(df1, x="foo", boink_boop=100)  # type: ignore[call-overload]
+
     def test_pyarrow_table_data(self):
         """Test that you can pass pyarrow.Table as data."""
         table = pa.Table.from_pandas(df1)

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -1395,41 +1395,6 @@ class VegaLiteChartTest(DeltaGeneratorTestCase):
             autosize_spec, {"data": {"name": "foo"}, "mark": "rect"}
         )
 
-    def test_dict_unflatten(self):
-        """Test passing a spec as keywords."""
-        st.vega_lite_chart(df1, x="foo", boink_boop=100, baz={"boz": "booz"})
-
-        proto = self.get_delta_from_queue().new_element.vega_lite_chart
-        pd.testing.assert_frame_equal(
-            convert_arrow_bytes_to_pandas_df(proto.data.data), df1, check_dtype=False
-        )
-        assert json.loads(proto.spec) == merge_dicts(
-            autosize_spec,
-            {
-                "baz": {"boz": "booz"},
-                "boink": {"boop": 100},
-                "encoding": {"x": "foo"},
-            },
-        )
-
-    @patch("streamlit.elements.vega_charts.show_deprecation_warning")
-    def test_kwargs_deprecation_warning(self, mock_warning: Mock):
-        """Test that passing kwargs shows a deprecation warning."""
-        st.vega_lite_chart(df1, x="foo", boink_boop=100)
-
-        mock_warning.assert_called_once()
-        warning_message = mock_warning.call_args[0][0]
-        assert "Variable keyword arguments" in warning_message
-        assert "deprecated" in warning_message
-        assert "spec" in warning_message
-
-    @patch("streamlit.elements.vega_charts.show_deprecation_warning")
-    def test_no_kwargs_no_deprecation_warning(self, mock_warning: Mock):
-        """Test that not passing kwargs does not show a deprecation warning."""
-        st.vega_lite_chart(df1, {"mark": "rect"})
-
-        mock_warning.assert_not_called()
-
     def test_pyarrow_table_data(self):
         """Test that you can pass pyarrow.Table as data."""
         table = pa.Table.from_pandas(df1)


### PR DESCRIPTION
## Describe your changes

Removes the deprecated `**kwargs` parameter from `st.plotly_chart` and `st.vega_lite_chart`:

- `st.plotly_chart`: Users should use the `config` parameter instead
- `st.vega_lite_chart`: Users should use the `spec` parameter instead

**Breaking change**: Users who were still passing kwargs will see a `TypeError`. The deprecation warnings have been in place since before 1.40.

## GitHub Issue Link (if applicable)

N/A - cleanup of previously deprecated API

## Testing Plan

- [x] Unit Tests (Python)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->