### PR TITLE
[fix] Retain st.radio selection for format_func and custom options

### DIFF
--- a/e2e_playwright/st_radio.py
+++ b/e2e_playwright/st_radio.py
@@ -109,39 +109,6 @@ st.radio(
     options=markdown_options,
 )
 
-
-class Gh14814Option:
-    """Custom option type for gh-14814 (stable __eq__ / __hash__, no __str__)."""
-
-    __slots__ = ("label", "value")
-
-    def __init__(self, label: str, value: int) -> None:
-        self.label = label
-        self.value = value
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Gh14814Option):
-            return False
-        return self.value == other.value
-
-    def __hash__(self) -> int:
-        return hash(self.value)
-
-
-_gh14814_options = [
-    Gh14814Option("Option A", 1),
-    Gh14814Option("Option B", 2),
-    Gh14814Option("Option C", 3),
-]
-
-v15 = st.radio(
-    "radio 15 (custom class format_func, gh-14814)",
-    options=_gh14814_options,
-    format_func=lambda x: x.label,
-    key="radio_gh14814",
-)
-st.write("value 15:", v15.value)
-
 st.header("Radio - width examples")
 
 st.radio(
@@ -235,3 +202,38 @@ v_bound_clear = st.radio(
     bind="query-params",
 )
 st.write("bound radio clear value:", v_bound_clear)
+
+# --- Regression test for gh-14814 ---
+
+
+class Gh14814Option:
+    """Custom option type for gh-14814 (stable __eq__ / __hash__, no __str__)."""
+
+    __slots__ = ("label", "value")
+
+    def __init__(self, label: str, value: int) -> None:
+        self.label = label
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Gh14814Option):
+            return False
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+
+_gh14814_options = [
+    Gh14814Option("Option A", 1),
+    Gh14814Option("Option B", 2),
+    Gh14814Option("Option C", 3),
+]
+
+v15 = st.radio(
+    "radio 15 (custom class format_func, gh-14814)",
+    options=_gh14814_options,
+    format_func=lambda x: x.label,
+    key="radio_gh14814",
+)
+st.write("value 15:", v15.value)

--- a/e2e_playwright/st_radio.py
+++ b/e2e_playwright/st_radio.py
@@ -109,6 +109,39 @@ st.radio(
     options=markdown_options,
 )
 
+
+class Gh14814Option:
+    """Custom option type for gh-14814 (stable __eq__ / __hash__, no __str__)."""
+
+    __slots__ = ("label", "value")
+
+    def __init__(self, label: str, value: int) -> None:
+        self.label = label
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Gh14814Option):
+            return False
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+
+_gh14814_options = [
+    Gh14814Option("Option A", 1),
+    Gh14814Option("Option B", 2),
+    Gh14814Option("Option C", 3),
+]
+
+v15 = st.radio(
+    "radio 15 (custom class format_func, gh-14814)",
+    options=_gh14814_options,
+    format_func=lambda x: x.label,
+    key="radio_gh14814",
+)
+st.write("value 15:", v15.value)
+
 st.header("Radio - width examples")
 
 st.radio(

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
+    rerun_app,
     wait_for_app_loaded,
     wait_for_app_run,
 )
@@ -33,7 +34,7 @@ from e2e_playwright.shared.app_utils import (
     select_radio_option,
 )
 
-NUM_RADIO_ELEMENTS = 21
+NUM_RADIO_ELEMENTS = 22
 
 
 def test_radio_widget_rendering(
@@ -129,6 +130,21 @@ def test_radio_has_correct_default_values(app: Page):
     expect_markdown(app, "value 12: male")
     expect_markdown(app, "radio changed: False")
     expect_markdown(app, "value 13: None")
+    expect_markdown(app, "value 15: 1")
+
+
+def test_radio_custom_class_format_func_persists_after_rerun(app: Page):
+    """Regression #14814: non-default radio with format_func must survive rerun."""
+    select_radio_option(
+        app,
+        option="Option B",
+        label="radio 15 (custom class format_func, gh-14814)",
+    )
+    wait_for_app_run(app)
+    expect_markdown(app, "value 15: 2")
+
+    rerun_app(app)
+    expect_markdown(app, "value 15: 2")
 
 
 def test_set_value_correctly_when_click(app: Page):
@@ -193,6 +209,7 @@ def test_set_value_correctly_when_click(app: Page):
     expect_markdown(app, "value 12: male")
     expect_markdown(app, "radio changed: False")
     expect_markdown(app, "value 13: male")
+    expect_markdown(app, "value 15: 1")
 
 
 def test_calls_callback_on_change(app: Page):
@@ -209,6 +226,7 @@ def test_calls_callback_on_change(app: Page):
     expect_markdown(app, "value 1: male")
     expect_markdown(app, "value 12: female")
     expect_markdown(app, "radio changed: False")
+    expect_markdown(app, "value 15: 1")
 
 
 def test_check_top_level_class(app: Page):

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -549,7 +549,7 @@ class RadioMixin:
         # Cast to T | None since radio doesn't support accept_new_options,
         # so string values that aren't in options will be reset to default.
         current_value, value_needs_reset = validate_and_sync_value_with_options(
-            cast("T | None", widget_state.value), opt, index, key
+            cast("T | None", widget_state.value), opt, index, key, format_func
         )
 
         if value_needs_reset or widget_state.value_changed:

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -14,6 +14,7 @@
 
 """radio unit tests."""
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -622,6 +623,57 @@ def test_dynamic_format_func_preserves_value() -> None:
     # Verify it didn't reset to the default "A"
     assert at.radio[0].value != "A"
     assert "Selected: B" in at.text[0].value
+
+
+def test_custom_objects_with_eq_format_func_survives_rerun() -> None:
+    """Regression for #14814: selection must not reset when using format_func.
+
+    ``validate_and_sync_value_with_options`` must receive ``format_func`` so
+    validation compares stable formatted labels, not ``str()`` of instances
+    (which embed object id and changes across reruns).
+    """
+
+    def script():
+        import streamlit as st
+
+        class MyOption:
+            def __init__(self, label: str, value: int) -> None:
+                self.label = label
+                self.value = value
+
+            def __eq__(self, other: object) -> bool:
+                if not isinstance(other, MyOption):
+                    return False
+                return self.value == other.value
+
+            def __hash__(self) -> int:
+                return hash(self.value)
+
+        options = [
+            MyOption("Option A", 1),
+            MyOption("Option B", 2),
+            MyOption("Option C", 3),
+        ]
+        selected = st.radio(
+            "Pick",
+            options=options,
+            format_func=lambda x: x.label,
+            key="bug_radio",
+        )
+        st.text(f"gh14814 value: {selected.value}")
+        st.button("Rerun")
+
+    at = AppTest.from_function(script).run()
+    assert at.radio[0].value.value == 1
+    assert "gh14814 value: 1" in at.text[0].value
+
+    at = at.radio[0].set_value(SimpleNamespace(label="Option B")).run()
+    assert at.radio[0].value.value == 2
+    assert "gh14814 value: 2" in at.text[0].value
+
+    at = at.button[0].click().run()
+    assert at.radio[0].value.value == 2
+    assert "gh14814 value: 2" in at.text[0].value
 
 
 def test_custom_objects_without_eq() -> None:


### PR DESCRIPTION

## Describe your changes

`st.radio` called `validate_and_sync_value_with_options` without `format_func`, so validation used `str()` on option instances. Custom classes without a stable `__str__` then failed the membership check on every rerun and the widget reset to the default index. Pass the user’s `format_func` through, matching `st.selectbox` and `st.select_slider`.

Fixes #14814

## Screenshot or video (only for visual changes)


## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/14814

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests
- [ ] Any manual testing needed?

`make check` (changed files). Added `test_custom_objects_with_eq_format_func_survives_rerun` in `radio_test.py`. Extended `st_radio` e2e with `test_radio_custom_class_format_func_persists_after_rerun` (keyboard rerun after selecting a non-default formatted label).


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
