### PR TITLE
[chore] Remove Python 3.12 restriction from snowflake extra

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -105,8 +105,8 @@ dependencies = [
 [project.optional-dependencies]
 # Optional dependency required for Snowflake connection:
 snowflake = [
-  "snowflake-snowpark-python[modin]>=1.17.0; python_version<'3.12'",
-  "snowflake-connector-python>=3.3.0; python_version<'3.12'",
+  "snowflake-snowpark-python[modin]>=1.17.0",
+  "snowflake-connector-python>=3.3.0",
 ]
 # Optional dependency required for PDF rendering:
 pdf = ["streamlit-pdf>=1.0.0"]


### PR DESCRIPTION
## Describe your changes

- Removes the `python_version<'3.12'` restrictions from the snowflake optional dependencies
- Enables `snowflake-snowpark-python[modin]` and `snowflake-connector-python` to be installed on Python 3.12+

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [ ] No functional tests needed — this is a dependency constraint change

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->