### PR TITLE
[perf] Replace MD5 hashing with blake2b for faster performance

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/references/element-identity.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/element-identity.md
@@ -34,7 +34,7 @@ Inputs can include:
 Generated format:
 
 ```text
-$$ID-<md5_hash>-<user_key>
+$$ID-<hash>-<user_key>
 ```
 
 Registration also enforces uniqueness within a run and records the ID/key in the current `ScriptRunContext`.

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -58,7 +58,7 @@ from streamlit.proto.BidiComponent_pb2 import MixedData as MixedDataProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import register_widget
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from streamlit.components.v2.types import (
@@ -147,7 +147,7 @@ class BidiComponentMixin:
         """
 
         canonical = self._canonicalize_json_for_identity(payload)
-        return calc_md5(canonical)
+        return calc_hash(canonical)
 
     def _build_bidi_identity_kwargs(
         self,
@@ -230,7 +230,7 @@ class BidiComponentMixin:
             if data is not None:
                 try:
                     canonical = json.dumps(data, sort_keys=True)
-                    canonical_digest = calc_md5(canonical)
+                    canonical_digest = calc_hash(canonical)
                 except (TypeError, ValueError):
                     # Fallback to existing logic if direct dump fails
                     pass
@@ -242,12 +242,12 @@ class BidiComponentMixin:
         elif data_field == "arrow_data":
             # Hash large payloads instead of shoving raw bytes through the ID
             # hasher for performance.
-            identity["arrow_data"] = calc_md5(proto.arrow_data.data)
+            identity["arrow_data"] = calc_hash(proto.arrow_data.data)
         elif data_field == "bytes":
             # Same story for arbitrary bytes payloads: content-address the data
             # so identity changes track real mutations without re-hashing the
             # whole blob every run.
-            identity["bytes"] = calc_md5(proto.bytes)
+            identity["bytes"] = calc_hash(proto.bytes)
         elif data_field == "mixed":
             mixed: MixedDataProto = proto.mixed
             # Add the JSON content of the MixedData to the identity.
@@ -256,7 +256,7 @@ class BidiComponentMixin:
             )
             # Add the sorted content-addressed ref IDs of the Arrow blobs to the identity.
             # Unlike other data types where we include actual bytes, here we only include
-            # the blob keys. This is sufficient because keys are MD5 hashes of the blob
+            # the blob keys. This is sufficient because keys are content hashes of the blob
             # content (content-addressed), so identical content produces identical keys.
             identity["mixed_arrow_blobs"] = ",".join(sorted(mixed.arrow_blobs.keys()))
         else:

--- a/lib/streamlit/components/v2/bidi_component/serialization.py
+++ b/lib/streamlit/components/v2/bidi_component/serialization.py
@@ -23,7 +23,7 @@ from streamlit.dataframe_util import convert_anything_to_arrow_bytes, is_datafra
 from streamlit.logger import get_logger
 from streamlit.proto.BidiComponent_pb2 import BidiComponent as BidiComponentProto
 from streamlit.proto.BidiComponent_pb2 import MixedData as MixedDataProto
-from streamlit.util import AttributeDictionary, calc_md5
+from streamlit.util import AttributeDictionary, calc_hash
 
 if TYPE_CHECKING:
     from streamlit.components.v2.bidi_component.state import BidiComponentState
@@ -69,7 +69,7 @@ def _extract_dataframes_from_dict(
                 # Use deterministic, content-addressed ref IDs so placeholders
                 # are stable for identical content on each run. This also provides
                 # natural deduplication - identical DataFrames share a single blob.
-                ref_id = calc_md5(arrow_bytes)
+                ref_id = calc_hash(arrow_bytes)
                 arrow_blobs[ref_id] = arrow_bytes
                 processed_data[key] = {ARROW_REF_KEY: ref_id}
             except Exception as e:

--- a/lib/streamlit/components/v2/component_file_watcher.py
+++ b/lib/streamlit/components/v2/component_file_watcher.py
@@ -286,7 +286,7 @@ class ComponentFileWatcher:
             try:
                 cb = self._make_directory_callback(tuple(component_names))
                 # Use a glob pattern that matches all files to let Streamlit's
-                # watcher handle MD5 calculation and change detection
+                # watcher handle hash calculation and change detection
                 watcher = path_watcher_class(
                     directory,
                     cb,

--- a/lib/streamlit/connections/base_connection.py
+++ b/lib/streamlit/connections/base_connection.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, Literal, TypeVar, cast
 
 from streamlit.runtime.secrets import AttrDict, secrets_singleton
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 RawConnectionT = TypeVar("RawConnectionT")
 
@@ -74,7 +74,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         # unlike Python's id() builtin.
         self._connection_instance_id = uuid.uuid4()
 
-        self._config_section_hash = calc_md5(json.dumps(self._secrets.to_dict()))
+        self._config_section_hash = calc_hash(json.dumps(self._secrets.to_dict()))
         secrets_singleton.file_change_listener.connect(self._on_secrets_changed)
 
         self._raw_instance: RawConnectionT | None = self._connect(**kwargs)
@@ -100,7 +100,7 @@ class BaseConnection(ABC, Generic[RawConnectionT]):
         We don't expect either user scripts or connection authors to have to use or
         overwrite this method.
         """
-        new_hash = calc_md5(json.dumps(self._secrets.to_dict()))
+        new_hash = calc_hash(json.dumps(self._secrets.to_dict()))
 
         # Only reset the connection if the secrets file section specific to this
         # connection has changed.

--- a/lib/streamlit/deprecation_util.py
+++ b/lib/streamlit/deprecation_util.py
@@ -21,7 +21,7 @@ from typing import Any, Final, TypeVar, cast
 import streamlit
 from streamlit import config
 from streamlit.logger import get_logger
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -69,7 +69,7 @@ def show_deprecation_warning(
         script run.
     """
     if show_once:
-        message_hash = calc_md5(message)
+        message_hash = calc_hash(message)
         if message_hash in _shown_warnings:
             return
         _shown_warnings.add(message_hash)

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -27,7 +27,7 @@ from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.GraphVizChart_pb2 import GraphVizChart as GraphVizChartProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     import graphviz
@@ -171,7 +171,7 @@ class GraphvizMixin:
 
         # Generate element ID from delta path
         delta_path = self.dg._get_delta_path_str()
-        element_id = calc_md5(delta_path.encode())
+        element_id = calc_hash(delta_path.encode())
 
         graphviz_chart_proto = GraphVizChartProto()
 

--- a/lib/streamlit/elements/lib/subtitle_utils.py
+++ b/lib/streamlit/elements/lib/subtitle_utils.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from streamlit import runtime
 from streamlit.runtime import caching
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 # Regular expression to match the SRT timestamp format
 # It matches the
@@ -161,7 +161,7 @@ def process_subtitle_data(
         raise TypeError(f"Invalid binary data format for subtitle: {type(data)}.")
 
     if runtime.exists():
-        filename = calc_md5(label.encode())
+        filename = calc_hash(label.encode())
         # Save the processed data and return the file URL
         file_url = runtime.get_instance().media_file_mgr.add(
             path_or_data=subtitle_data,

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
@@ -27,7 +26,7 @@ from typing import (
 
 from google.protobuf.message import Message
 
-from streamlit import config
+from streamlit import config, util
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.errors import StreamlitDuplicateElementId, StreamlitDuplicateElementKey
 from streamlit.proto.ChatInput_pb2 import ChatInput
@@ -166,7 +165,7 @@ def _compute_element_id(
     use it to be distinct. The element ID includes an easily identified prefix, and the
     user_key as a suffix, to make it easy to identify it and know if a key maps to it.
     """
-    h = hashlib.new("md5", usedforsecurity=False)
+    h = util.create_fast_hasher()
     h.update(element_type.encode("utf-8"))
     if user_key:
         # Adding this to the hash isn't necessary for uniqueness since the

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -65,7 +65,7 @@ from streamlit.proto.VegaLiteChart_pb2 import (
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import WidgetCallback, register_widget
-from streamlit.util import AttributeDictionary, calc_md5
+from streamlit.util import AttributeDictionary, calc_hash
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -2518,8 +2518,8 @@ def _to_arrow_dataset(data: Any, datasets: dict[str, Any]) -> dict[str, str]:
     # Already serialize the data to be able to create a stable
     # dataset name:
     data_bytes = dataframe_util.convert_anything_to_arrow_bytes(data)
-    # Use the md5 hash of the data as the name:
-    name = calc_md5(str(data_bytes))
+    # Use the content hash of the data as the name:
+    name = calc_hash(str(data_bytes))
 
     datasets[name] = data_bytes
     return {"name": name}

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -73,7 +73,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.type_util import is_list_like, is_type
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -1151,7 +1151,7 @@ class DataEditorMixin:
 
         if dataframe_util.is_pandas_styler(data):
             # Pandas styler will only work for non-editable/disabled columns.
-            # Get first 10 chars of md5 hash of the key or delta path as styler uuid
+            # Get first 10 chars of content hash of the key or delta path as styler uuid
             # and set it as styler uuid.
             # We are only using the first 10 chars to keep the uuid short since
             # it will be used for all the cells in the dataframe. Therefore, this
@@ -1159,7 +1159,7 @@ class DataEditorMixin:
             # should be good enough to avoid  potential collisions in this case.
             # Even on collisions, there should not be a big issue with the
             # rendering in the data editor.
-            styler_uuid = calc_md5(key or self.dg._get_delta_path_str())[:10]
+            styler_uuid = calc_hash(key or self.dg._get_delta_path_str())[:10]
             data.set_uuid(styler_uuid)  # ty: ignore[call-non-callable, unresolved-attribute]
             marshall_styler(proto.arrow_data, data, styler_uuid)
 

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -25,7 +25,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_r
 from streamlit.source_util import page_icon_and_name
 from streamlit.string_util import validate_icon_or_emoji
 from streamlit.url_util import is_url
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 
 def _sanitize_url_path(title: str) -> str:
@@ -495,4 +495,4 @@ class StreamlitPage:
 
     @property
     def _script_hash(self) -> str:
-        return calc_md5(self._url_path)
+        return calc_hash(self._url_path)

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import hashlib
 import inspect
 import threading
 import time
@@ -39,7 +38,7 @@ from typing import (
 
 from typing_extensions import ParamSpec
 
-from streamlit import type_util
+from streamlit import type_util, util
 from streamlit.dataframe_util import is_unevaluated_data_object
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
 from streamlit.errors import StreamlitAPIException
@@ -505,7 +504,7 @@ def _make_value_key(
     # Create the hash from each arg value, except for those args whose name
     # starts with "_". (Underscore-prefixed args are deliberately excluded from
     # hashing.)
-    args_hasher = hashlib.new("md5", usedforsecurity=False)
+    args_hasher = util.create_fast_hasher()
     for arg_name, arg_value in arg_pairs:
         if arg_name is not None and arg_name.startswith("_"):
             _LOGGER.debug("Not hashing %s because it starts with _", arg_name)
@@ -543,7 +542,7 @@ def _make_function_key(cache_type: CacheType, func: Callable[..., Any]) -> str:
     A function's key is stable across reruns of the app, and changes when
     the function's source code changes.
     """
-    func_hasher = hashlib.new("md5", usedforsecurity=False)
+    func_hasher = util.create_fast_hasher()
     func = cast("FunctionType", func)
 
     # Include the function's __module__ and __qualname__ strings in the hash.

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,7 +21,6 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
-import hashlib
 import inspect
 import io
 import os
@@ -352,7 +351,7 @@ class _CacheFuncHasher:
         runs.
         """
 
-        h = hashlib.new("md5", usedforsecurity=False)
+        h = util.create_fast_hasher()
 
         if type_util.is_type(obj, "unittest.mock.Mock") or type_util.is_type(
             obj, "unittest.mock.MagicMock"

--- a/lib/streamlit/runtime/forward_msg_cache.py
+++ b/lib/streamlit/runtime/forward_msg_cache.py
@@ -47,8 +47,8 @@ def populate_hash_if_needed(msg: ForwardMsg) -> None:
         # - Add the type element type and number of bytes to the hash.
         # - Only hash the first N bytes of the message.
 
-        # MD5 is good enough for what we need, which is uniqueness.
-        msg.hash = util.calc_md5(serialized_msg)
+        # The hash is good enough for what we need, which is uniqueness.
+        msg.hash = util.calc_hash(serialized_msg)
 
         # Restore metadata.
         msg.metadata.CopyFrom(metadata)

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -33,7 +33,7 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.time_util import time_to_seconds
 from streamlit.type_util import get_object_name
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -167,7 +167,7 @@ def _fragment(
 
         cursors_snapshot = deepcopy(ctx.cursors)
         dg_stack_snapshot = deepcopy(context_dg_stack.get())
-        fragment_id = calc_md5(
+        fragment_id = calc_hash(
             f"{non_optional_func.__module__}.{get_object_name(non_optional_func)}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}"
         )
 

--- a/lib/streamlit/runtime/pages_manager.py
+++ b/lib/streamlit/runtime/pages_manager.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
@@ -41,7 +41,7 @@ class PagesManager:
         **kwargs: Any,
     ) -> None:
         self._main_script_path = main_script_path
-        self._main_script_hash: PageHash = calc_md5(main_script_path)
+        self._main_script_hash: PageHash = calc_hash(main_script_path)
         self._script_cache = script_cache
         self._intended_page_script_hash: PageHash | None = None
         self._intended_page_name: PageName | None = None

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -90,7 +90,7 @@ from streamlit.testing.v1.element_tree import (
 )
 from streamlit.testing.v1.local_script_runner import LocalScriptRunner
 from streamlit.testing.v1.util import patch_config_options
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
@@ -219,7 +219,7 @@ class AppTest:
         args: tuple[Any, ...] | None = None,
         kwargs: dict[str, Any] | None = None,
     ) -> AppTest:
-        script_name = calc_md5(bytes(script, "utf-8"))
+        script_name = calc_hash(bytes(script, "utf-8"))
 
         path = Path(TMP_DIR.name, script_name)
         aligned_script = textwrap.dedent(script)
@@ -453,7 +453,7 @@ class AppTest:
             )
         page_path_str = str(full_page_path.resolve())
         _, page_name = page_icon_and_name(Path(page_path_str))
-        self._page_hash = calc_md5(page_name)
+        self._page_hash = calc_hash(page_name)
         return self
 
     @property

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -25,6 +25,7 @@ from streamlit.proto.RootContainer_pb2 import RootContainer
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from hashlib import _Hash
 
     from streamlit.delta_generator import DeltaGenerator
 
@@ -65,12 +66,12 @@ def repr_(self: Any) -> str:
     return f"{classname}({field_reprs})"
 
 
-def create_fast_hasher() -> hashlib.blake2b:
+def create_fast_hasher() -> _Hash:
     """Create a fast hasher for incremental hashing.
 
     Uses BLAKE2b which produces 32-character hex digests (16 bytes).
     """
-    return hashlib.blake2b(digest_size=16)
+    return hashlib.blake2b(digest_size=16)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 
 
 def calc_hash(s: bytes | str) -> str:

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -19,23 +19,9 @@ from __future__ import annotations
 import dataclasses
 import functools
 import hashlib
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from streamlit.proto.RootContainer_pb2 import RootContainer
-
-try:
-    import xxhash as _xxhash  # type: ignore[import-not-found]
-except ImportError:  # pragma: no cover - optional dep
-    _xxhash = None
-
-
-class _Hasher(Protocol):
-    """Protocol for hashlib-compatible hasher objects."""
-
-    def update(self, data: bytes) -> None: ...
-    def hexdigest(self) -> str: ...
-    def digest(self) -> bytes: ...
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -79,23 +65,19 @@ def repr_(self: Any) -> str:
     return f"{classname}({field_reprs})"
 
 
-def create_fast_hasher() -> _Hasher:
+def create_fast_hasher() -> hashlib.blake2b:
     """Create a fast hasher for incremental hashing.
 
-    Uses xxhash128 when available, falls back to BLAKE2b.
-    Both produce 32-character hex digests (16 bytes).
+    Uses BLAKE2b which produces 32-character hex digests (16 bytes).
     """
-    if _xxhash is not None:
-        return _xxhash.xxh128()  # type: ignore[no-any-return]
-    return hashlib.blake2b(digest_size=16)  # ty: ignore[invalid-return-type]
+    return hashlib.blake2b(digest_size=16)
 
 
 def calc_hash(s: bytes | str) -> str:
     """Return a fast hash of the given string.
 
-    Uses xxhash128 when available (~10x faster), falls back to BLAKE2b (~2.4x faster
-    than MD5). Both produce 32-character hex digests. This should not be used for
-    security-related purposes.
+    Uses BLAKE2b (~2.4x faster than MD5) and produces 32-character hex digests.
+    This should not be used for security-related purposes.
     """
     b = s.encode("utf-8") if isinstance(s, str) else s
     h = create_fast_hasher()

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover - optional dep
     _xxhash = None
 
 
-class Hasher(Protocol):
+class _Hasher(Protocol):
     """Protocol for hashlib-compatible hasher objects."""
 
     def update(self, data: bytes) -> None: ...
@@ -79,21 +79,23 @@ def repr_(self: Any) -> str:
     return f"{classname}({field_reprs})"
 
 
-def create_fast_hasher() -> Hasher:
+def create_fast_hasher() -> _Hasher:
     """Create a fast hasher for incremental hashing.
 
-    Uses xxhash64 when available, falls back to BLAKE2b.
+    Uses xxhash128 when available, falls back to BLAKE2b.
+    Both produce 32-character hex digests (16 bytes).
     """
     if _xxhash is not None:
-        return _xxhash.xxh64()  # type: ignore[no-any-return]
+        return _xxhash.xxh128()  # type: ignore[no-any-return]
     return hashlib.blake2b(digest_size=16)  # ty: ignore[invalid-return-type]
 
 
 def calc_hash(s: bytes | str) -> str:
     """Return a fast hash of the given string.
 
-    Uses xxhash64 when available (~15x faster), falls back to BLAKE2b (~2.4x faster
-    than MD5). This should not be used for security-related purposes.
+    Uses xxhash128 when available (~10x faster), falls back to BLAKE2b (~2.4x faster
+    than MD5). Both produce 32-character hex digests. This should not be used for
+    security-related purposes.
     """
     b = s.encode("utf-8") if isinstance(s, str) else s
     h = create_fast_hasher()

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -19,9 +19,23 @@ from __future__ import annotations
 import dataclasses
 import functools
 import hashlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from streamlit.proto.RootContainer_pb2 import RootContainer
+
+try:
+    import xxhash as _xxhash  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - optional dep
+    _xxhash = None
+
+
+class Hasher(Protocol):
+    """Protocol for hashlib-compatible hasher objects."""
+
+    def update(self, data: bytes) -> None: ...
+    def hexdigest(self) -> str: ...
+    def digest(self) -> bytes: ...
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -65,16 +79,24 @@ def repr_(self: Any) -> str:
     return f"{classname}({field_reprs})"
 
 
-def calc_md5(s: bytes | str) -> str:
-    """Return the md5 hash of the given string.
+def create_fast_hasher() -> Hasher:
+    """Create a fast hasher for incremental hashing.
 
-    This should not be used for security-related purposes.
+    Uses xxhash64 when available, falls back to BLAKE2b.
     """
-    # Due to security issue in md5 and sha1, usedforsecurity
-    h = hashlib.new("md5", usedforsecurity=False)
+    if _xxhash is not None:
+        return _xxhash.xxh64()  # type: ignore[no-any-return]
+    return hashlib.blake2b(digest_size=16)  # ty: ignore[invalid-return-type]
 
+
+def calc_hash(s: bytes | str) -> str:
+    """Return a fast hash of the given string.
+
+    Uses xxhash64 when available (~15x faster), falls back to BLAKE2b (~2.4x faster
+    than MD5). This should not be used for security-related purposes.
+    """
     b = s.encode("utf-8") if isinstance(s, str) else s
-
+    h = create_fast_hasher()
     h.update(b)
     return h.hexdigest()
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -45,8 +45,8 @@ emit spurious filesystem events caused by:
 - Other background file access
 
 To mitigate false positives from these spurious events, this module:
-1. Checks modification time before calculating MD5 (fast rejection)
-2. Compares MD5 content hash to detect actual changes
+1. Checks modification time before calculating hash (fast rejection)
+2. Compares content hash to detect actual changes
 3. Re-verifies content stability after detecting a change (double-check)
 
 See: https://github.com/streamlit/streamlit/issues/13954
@@ -95,7 +95,7 @@ class EventBasedPathWatcher:
 
     Behavior differs based on whether watching a file or directory:
 
-    **File watching:** Detects content changes via MD5 hash comparison. The
+    **File watching:** Detects content changes via content hash comparison. The
     callback receives the file path and is invoked when content changes. With
     allow_nonexistent=True, also detects file creation.
 
@@ -303,13 +303,13 @@ class WatchedPath:
 
     def __init__(
         self,
-        md5: str,
+        content_hash: str,
         modification_time: float,
         *,  # keyword-only arguments:
         glob_pattern: str | None = None,
         allow_nonexistent: bool = False,
     ) -> None:
-        self.md5 = md5
+        self.content_hash = content_hash
         self.modification_time = modification_time
 
         self.glob_pattern = glob_pattern
@@ -355,7 +355,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             watched_path = self._watched_paths.get(path, None)
             if watched_path is None:
                 try:
-                    md5 = util.calc_md5_with_blocking_retries(
+                    content_hash = util.calc_hash_with_blocking_retries(
                         path,
                         glob_pattern=glob_pattern,
                         allow_nonexistent=allow_nonexistent,
@@ -364,7 +364,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                         path, allow_nonexistent
                     )
                     watched_path = WatchedPath(
-                        md5=md5,
+                        content_hash=content_hash,
                         modification_time=modification_time,
                         glob_pattern=glob_pattern,
                         allow_nonexistent=allow_nonexistent,
@@ -372,7 +372,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                     self._watched_paths[path] = watched_path
                 except StreamlitMaxRetriesError as ex:
                     _LOGGER.debug(
-                        "Failed to calculate MD5 for path %s",
+                        "Failed to calculate hash for path %s",
                         path,
                         exc_info=ex,
                     )
@@ -492,27 +492,27 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 return
 
             changed_path_info.modification_time = modification_time
-            new_md5 = util.calc_md5_with_blocking_retries(
+            new_hash = util.calc_hash_with_blocking_retries(
                 abs_changed_path,
                 glob_pattern=changed_path_info.glob_pattern,
                 allow_nonexistent=changed_path_info.allow_nonexistent,
             )
-            if new_md5 == changed_path_info.md5:
-                _LOGGER.debug("File/dir MD5 did not change: %s", abs_changed_path)
+            if new_hash == changed_path_info.content_hash:
+                _LOGGER.debug("File/dir hash did not change: %s", abs_changed_path)
                 return
 
             # On Windows, background processes (Windows Defender, Search Indexer,
             # OneDrive) can trigger spurious file change events. These processes
             # may temporarily modify file state during their operations, causing
-            # a transient MD5 difference.
+            # a transient hash difference.
             #
             # To mitigate false positives, we perform a stability check: wait
-            # briefly and re-read the file. If the MD5 reverts to the original
+            # briefly and re-read the file. If the hash reverts to the original
             # value, this was likely a spurious event and we should ignore it.
             # See: https://github.com/streamlit/streamlit/issues/13954
             # Import at function level to avoid circular imports and
             # because this code path is rarely executed (only on Windows
-            # after an MD5 change is detected)
+            # after a hash change is detected)
             from streamlit import env_util
 
             if env_util.IS_WINDOWS:
@@ -521,38 +521,38 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 # Brief delay to let transient file operations complete
                 time.sleep(_WINDOWS_STABILITY_DELAY_SECS)
                 try:
-                    verification_md5 = util.calc_md5_with_blocking_retries(
+                    verification_hash = util.calc_hash_with_blocking_retries(
                         abs_changed_path,
                         glob_pattern=changed_path_info.glob_pattern,
                         allow_nonexistent=changed_path_info.allow_nonexistent,
                     )
                 except StreamlitMaxRetriesError as verification_error:
                     # If the stability re-check fails (e.g., due to a transient
-                    # file lock), proceed with the initially computed new_md5
+                    # file lock), proceed with the initially computed new_hash
                     # instead of dropping the change event entirely.
                     _LOGGER.debug(
-                        "Failed to calculate verification MD5 for path %s; "
-                        "proceeding with initial MD5.",
+                        "Failed to calculate verification hash for path %s; "
+                        "proceeding with initial hash.",
                         abs_changed_path,
                         exc_info=verification_error,
                     )
                 else:
-                    if verification_md5 == changed_path_info.md5:
+                    if verification_hash == changed_path_info.content_hash:
                         _LOGGER.debug(
-                            "File/dir MD5 reverted after stability check "
+                            "File/dir hash reverted after stability check "
                             "(likely spurious event): %s",
                             abs_changed_path,
                         )
                         return
-                    # Use the verified MD5 as the new value
-                    new_md5 = verification_md5
+                    # Use the verified hash as the new value
+                    new_hash = verification_hash
 
-            _LOGGER.debug("File/dir MD5 changed: %s", abs_changed_path)
-            changed_path_info.md5 = new_md5
+            _LOGGER.debug("File/dir hash changed: %s", abs_changed_path)
+            changed_path_info.content_hash = new_hash
             changed_path_info.on_changed.send(abs_changed_path)
         except StreamlitMaxRetriesError as ex:
             _LOGGER.debug(
-                "Ignoring file change. Failed to calculate MD5 for path %s",
+                "Ignoring file change. Failed to calculate hash for path %s",
                 abs_changed_path,
                 exc_info=ex,
             )

--- a/lib/streamlit/watcher/path_watcher.py
+++ b/lib/streamlit/watcher/path_watcher.py
@@ -142,7 +142,7 @@ def watch_file(
 ) -> bool:
     """Watch a file for changes.
 
-    The callback is invoked when the file's content changes (detected via MD5).
+    The callback is invoked when the file's content changes (detected via hash).
     If allow_nonexistent is True, the watcher will also detect when the file
     is created.
 

--- a/lib/streamlit/watcher/polling_path_watcher.py
+++ b/lib/streamlit/watcher/polling_path_watcher.py
@@ -75,7 +75,7 @@ class PollingPathWatcher:
         self._modification_time = util.path_modification_time(
             str(self._path), self._allow_nonexistent
         )
-        self._md5 = util.calc_md5_with_blocking_retries(
+        self._content_hash = util.calc_hash_with_blocking_retries(
             str(self._path),
             glob_pattern=self._glob_pattern,
             allow_nonexistent=self._allow_nonexistent,
@@ -110,23 +110,23 @@ class PollingPathWatcher:
 
             self._modification_time = modification_time
 
-            md5 = util.calc_md5_with_blocking_retries(
+            new_hash = util.calc_hash_with_blocking_retries(
                 str(self._path),
                 glob_pattern=self._glob_pattern,
                 allow_nonexistent=self._allow_nonexistent,
             )
-            if md5 == self._md5:
+            if new_hash == self._content_hash:
                 self._schedule()
                 return
         except StreamlitMaxRetriesError as ex:
             _LOGGER.debug(
-                "Ignoring file change. Failed to calculate MD5 for path %s",
+                "Ignoring file change. Failed to calculate hash for path %s",
                 self._path,
                 exc_info=ex,
             )
             return
 
-        self._md5 = md5
+        self._content_hash = new_hash
 
         _LOGGER.debug("Change detected: %s", self._path)
         self._on_changed(str(self._path))

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -26,29 +26,29 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 from streamlit.errors import StreamlitMaxRetriesError
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-# How many times to try to grab the MD5 hash.
+# How many times to try to grab the content hash.
 _MAX_RETRIES = 5
 
 # How long to wait between retries.
 _RETRY_WAIT_SECS = 0.1
 
 
-def calc_md5_with_blocking_retries(
+def calc_hash_with_blocking_retries(
     path: str,
     *,  # keyword-only arguments:
     glob_pattern: str | None = None,
     allow_nonexistent: bool = False,
 ) -> str:
-    """Calculate the MD5 checksum of a given path.
+    """Calculate the hash of a given path.
 
-    For a file, this means calculating the md5 of the file's contents. For a
+    For a file, this means calculating the hash of the file's contents. For a
     directory, we concatenate the directory's path with the names of all the
-    files in it and calculate the md5 of that.
+    files in it and calculate the hash of that.
 
     IMPORTANT: This method calls time.sleep(), which blocks execution. So you
     should only use this outside the main thread.
@@ -77,7 +77,7 @@ def calc_md5_with_blocking_retries(
             else:
                 raise
 
-    return calc_md5(content)
+    return calc_hash(content)
 
 
 def path_modification_time(path: str, allow_nonexistent: bool = False) -> float:

--- a/lib/tests/streamlit/components/v2/test_bidi_component.py
+++ b/lib/tests/streamlit/components/v2/test_bidi_component.py
@@ -44,7 +44,7 @@ from streamlit.runtime.state.session_state import (
     STREAMLIT_INTERNAL_KEY_PREFIX,
     _is_internal_key,
 )
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -1274,7 +1274,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             proto=proto,
         )
 
-        assert identity["mixed_json"] == calc_md5("{}")
+        assert identity["mixed_json"] == calc_hash("{}")
         assert identity["mixed_arrow_blobs"] == "a,b"
 
     def test_identity_kwargs_json_canonicalizes_order(self):
@@ -1292,7 +1292,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
         )
 
         expected = json.dumps({"a": 1, "b": 2}, sort_keys=True)
-        assert identity["json"] == calc_md5(expected)
+        assert identity["json"] == calc_hash(expected)
 
     def test_identity_kwargs_mixed_json_canonicalizes_order(self):
         """MixedData identity must canonicalize JSON portion independently of storage order."""
@@ -1309,7 +1309,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
         )
 
         expected = json.dumps({"a": 1, "b": 2}, sort_keys=True)
-        assert identity["mixed_json"] == calc_md5(expected)
+        assert identity["mixed_json"] == calc_hash(expected)
 
     def test_identity_kwargs_bytes_use_digest(self):
         """Raw byte payloads should contribute content digests, not the full payload."""
@@ -1325,7 +1325,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             proto=proto,
         )
 
-        assert identity["bytes"] == calc_md5(b"bytes payload")
+        assert identity["bytes"] == calc_hash(b"bytes payload")
 
     def test_identity_kwargs_arrow_data_use_digest(self):
         """Arrow payloads should contribute digests to avoid hashing large blobs repeatedly."""
@@ -1341,7 +1341,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             proto=proto,
         )
 
-        assert identity["arrow_data"] == calc_md5(b"\x00\x01")
+        assert identity["arrow_data"] == calc_hash(b"\x00\x01")
 
     def test_unkeyed_id_stable_when_json_key_order_changes(self):
         """Without a user key, changing the insertion order of keys in a JSON dict should NOT change the backend id."""
@@ -1419,7 +1419,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
 
             # Verify the result is correct (sorted keys)
             expected_canonical = json.dumps(data, sort_keys=True)
-            assert identity["json"] == calc_md5(expected_canonical)
+            assert identity["json"] == calc_hash(expected_canonical)
 
             # Verify the slow path was skipped
             mock_digest.assert_not_called()
@@ -1440,7 +1440,7 @@ class BidiComponentIdentityTest(DeltaGeneratorTestCase):
             )
 
             # Verify result is still correct
-            assert identity["json"] == calc_md5(expected_canonical)
+            assert identity["json"] == calc_hash(expected_canonical)
 
             # Verify the slow path WAS called
             mock_digest.assert_called_once()

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1104,7 +1104,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.dataframe
         assert (
             proto.arrow_data.styler.styles
-            == "#T_29028a0632_row1_col2 { background-color: yellow }"
+            == "#T_be55047acf_row1_col2 { background-color: yellow }"
         )
 
         # Check that different delta paths lead to different element ids
@@ -1113,7 +1113,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.dataframe
         assert (
             proto.arrow_data.styler.styles
-            == "#T_e94cd2b42e_row1_col2 { background-color: yellow }"
+            == "#T_f74f894054_row1_col2 { background-color: yellow }"
         )
 
         st.container().container().data_editor(styler, width=100)
@@ -1121,7 +1121,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.dataframe
         assert (
             proto.arrow_data.styler.styles
-            == "#T_9e33af1e69_row1_col2 { background-color: yellow }"
+            == "#T_8b1f1a9d3a_row1_col2 { background-color: yellow }"
         )
 
     def test_duplicate_column_names_raise_exception(self):

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -25,7 +25,7 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 from streamlit.runtime.media_file_storage import MediaFileStorageError
 from streamlit.runtime.memory_media_file_storage import _calculate_file_id
-from streamlit.util import calc_md5
+from streamlit.util import calc_hash
 from streamlit.web.server.server import MEDIA_ENDPOINT
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -151,7 +151,7 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_subtitle_url = _calculate_file_id(
             fake_subtitle_data,
             "text/vtt",
-            filename=f"{calc_md5(b'default')}.vtt",
+            filename=f"{calc_hash(b'default')}.vtt",
         )
         assert expected_subtitle_url in el.video.subtitles[0].url
 
@@ -174,12 +174,12 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_empty_subtitle_url = _calculate_file_id(
             b"",
             "text/vtt",
-            filename=f"{calc_md5(b'')}.vtt",
+            filename=f"{calc_hash(b'')}.vtt",
         )
         expected_english_subtitle_url = _calculate_file_id(
             fake_subtitle_data,
             "text/vtt",
-            filename=f"{calc_md5(b'English')}.vtt",
+            filename=f"{calc_hash(b'English')}.vtt",
         )
         assert expected_empty_subtitle_url in el.video.subtitles[0].url
         assert expected_english_subtitle_url in el.video.subtitles[1].url
@@ -198,7 +198,7 @@ class VideoTest(DeltaGeneratorTestCase):
         expected_english_subtitle_url = _calculate_file_id(
             fake_sub_content,
             "text/vtt",
-            filename=f"{calc_md5(b'default')}.vtt",
+            filename=f"{calc_hash(b'default')}.vtt",
         )
 
         el = self.get_delta_from_queue().new_element

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -1034,7 +1034,7 @@ class ScriptRunnerTest(unittest.TestCase):
         shutdown_data = scriptrunner.event_data[-1]
         assert (
             shutdown_data["client_state"].page_script_hash
-            == "f0b2ab81496648a6f2af976dfd35f4a8"
+            == "74c2683ab3d8427292ef911e1e05a630"
         )
 
     def _assert_no_exceptions(self, scriptrunner: TestScriptRunner) -> None:

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -49,8 +49,41 @@ class UtilTest(unittest.TestCase):
 
         assert hasattr(f, "__wrapped__")
 
-    def test_calc_md5_can_handle_bytes_and_strings(self):
-        assert util.calc_md5("eventually bytes") == util.calc_md5(b"eventually bytes")
+    def test_calc_hash_can_handle_bytes_and_strings(self):
+        assert util.calc_hash("eventually bytes") == util.calc_hash(b"eventually bytes")
+
+    def test_calc_hash_returns_consistent_hex_string(self):
+        """Test that calc_hash returns a consistent hexadecimal string."""
+        result = util.calc_hash("test input")
+        assert isinstance(result, str)
+        assert all(c in "0123456789abcdef" for c in result)
+        assert util.calc_hash("test input") == result
+
+    def test_create_fast_hasher_returns_hasher_protocol(self):
+        """Test that create_fast_hasher returns an object matching Hasher protocol."""
+        hasher = util.create_fast_hasher()
+        assert hasattr(hasher, "update")
+        assert hasattr(hasher, "hexdigest")
+        assert hasattr(hasher, "digest")
+
+    def test_create_fast_hasher_produces_consistent_results(self):
+        """Test that create_fast_hasher produces consistent hash results."""
+        h1 = util.create_fast_hasher()
+        h1.update(b"test data")
+        result1 = h1.hexdigest()
+
+        h2 = util.create_fast_hasher()
+        h2.update(b"test data")
+        result2 = h2.hexdigest()
+
+        assert result1 == result2
+
+    def test_create_fast_hasher_matches_calc_hash(self):
+        """Test that create_fast_hasher produces same result as calc_hash."""
+        data = b"test data"
+        h = util.create_fast_hasher()
+        h.update(data)
+        assert h.hexdigest() == util.calc_hash(data)
 
 
 # Pytest-style tests for ReadOnlyAttributeDictionary

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -67,7 +67,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -79,7 +79,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -94,7 +94,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -106,7 +106,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent(b"/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -121,7 +121,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/dir", cb)
 
@@ -133,7 +133,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/dir")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -150,7 +150,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/dir", cb)
 
@@ -168,7 +168,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher(
             "/this/is/my/dir/file.txt", cb
@@ -188,7 +188,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 0.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "42"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "42"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/dir", cb)
 
@@ -199,7 +199,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_not_called()
 
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "64"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "64"
 
         ev = events.FileSystemEvent("/this/is/my/dir")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -210,9 +210,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-    def test_kwargs_plumbed_to_calc_md5(self):
+    def test_kwargs_plumbed_to_calc_hash(self):
         """Test that we pass the glob_pattern and allow_nonexistent kwargs to
-        calc_md5_with_blocking_retries.
+        calc_hash_with_blocking_retries.
 
         `EventBasedPathWatcher`s can be created with optional kwargs allowing
         the caller to specify what types of files to watch (when watching a
@@ -223,7 +223,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
         ro = event_based_path_watcher.EventBasedPathWatcher(
             "/this/is/my/dir",
@@ -237,19 +237,19 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         folder_handler = fo._observer.schedule.call_args[0][0]
 
-        _, kwargs = self.mock_util.calc_md5_with_blocking_retries.call_args
+        _, kwargs = self.mock_util.calc_hash_with_blocking_retries.call_args
         assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="3")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="3")
 
         ev = events.FileSystemEvent("/this/is/my/dir")
         ev.event_type = events.EVENT_TYPE_MODIFIED
         ev.is_directory = True
         folder_handler.on_modified(ev)
 
-        _, kwargs = self.mock_util.calc_md5_with_blocking_retries.call_args
+        _, kwargs = self.mock_util.calc_hash_with_blocking_retries.call_args
         assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
         cb.assert_called_once()
 
@@ -260,7 +260,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -272,7 +272,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         # Same mtime!
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -283,12 +283,12 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ro.close()
 
-    def test_callback_not_called_if_same_md5(self):
-        """Test that we ignore files with same md5."""
+    def test_callback_not_called_if_same_hash(self):
+        """Test that we ignore files with same content hash."""
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -300,7 +300,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        # Same MD5!
+        # Same hash!
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -316,7 +316,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb = mock.Mock()
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -328,7 +328,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_DELETED  # Wrong type
@@ -348,7 +348,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         def modify_mock_file():
             self.mock_util.path_modification_time = lambda *args: mod_count[0]
-            self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: (
+            self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: (
                 f"{mod_count[0]}"
             )
 
@@ -419,7 +419,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         folder_handler = next(iter(fo._folder_handlers.values()))
 
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         ev = events.FileSystemEvent(file_path)
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -449,8 +449,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         folder_handler = next(iter(fo._folder_handlers.values()))
 
         # Mock fs-related utils to avoid disk access and to ensure
-        # that we always proceed past the mtime/md5 checks.
-        self.mock_util.calc_md5_with_blocking_retries.return_value = "md5"
+        # that we always proceed past the mtime/hash checks.
+        self.mock_util.calc_hash_with_blocking_retries.return_value = "hash"
         mod_time = [1.0]
 
         def mock_mod_time(*args, **kwargs):
@@ -498,9 +498,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb = mock.Mock()
 
-        # Ensure initial md5/mtime allow watcher creation
+        # Ensure initial hash/mtime allow watcher creation
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         ro = event_based_path_watcher.EventBasedPathWatcher(watched_dir, cb)
 
@@ -532,7 +532,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         When watching a directory, file events inside the directory should:
         1. Trigger the callback with the actual file path (not directory path)
-        2. Calculate MD5 on the actual file (to detect content changes)
+        2. Calculate hash on the actual file (to detect content changes)
         """
         watched_dir = "/app/.streamlit"
 
@@ -544,7 +544,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         # Initial setup
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(
             return_value="initial_hash"
         )
 
@@ -562,7 +562,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         # Simulate config.toml being created
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(
             return_value="file_content_hash"
         )
 
@@ -571,9 +571,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         ev.event_type = events.EVENT_TYPE_CREATED
         folder_handler.on_created(ev)
 
-        # Verify calc_md5 was called with the FILE path (not directory)
+        # Verify calc_hash was called with the FILE path (not directory)
         # This ensures file content changes are detected
-        call_args = self.mock_util.calc_md5_with_blocking_retries.call_args
+        call_args = self.mock_util.calc_hash_with_blocking_retries.call_args
         assert call_args[0][0] == config_file_path
 
         # Callback should receive the actual file path (not directory)
@@ -605,9 +605,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb = mock.Mock()
 
-        # Initial MD5 when file doesn't exist (uses path string as content)
+        # Initial hash when file doesn't exist (uses path string as content)
         self.mock_util.path_modification_time = lambda *args: 0.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(
             return_value="nonexistent_hash"
         )
 
@@ -627,8 +627,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         mock_is_dir.return_value = False
 
         self.mock_util.path_modification_time = lambda *args: 101.0
-        # MD5 changes because file now exists with content
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+        # Hash changes because file now exists with content
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(
             return_value="initial_content_hash"
         )
 
@@ -641,8 +641,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         # Step 2: Simulate file being modified
         self.mock_util.path_modification_time = lambda *args: 102.0
-        # MD5 changes because file content changed
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
+        # Hash changes because file content changed
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(
             return_value="modified_content_hash"
         )
 
@@ -666,14 +666,14 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         can temporarily modify files, causing spurious change events. The stability
         check should filter these out by re-reading the file after a brief delay.
 
-        Scenario: MD5 changes initially, but reverts on second read (transient change)
+        Scenario: Hash changes initially, but reverts on second read (transient change)
         Expected: Callback should NOT be triggered
         """
         cb = mock.Mock()
 
         # Initial state
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -683,19 +683,19 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         # Simulate a transient change:
-        # - First read: MD5 = "2" (different from stored "1")
-        # - Second read (after stability delay): MD5 = "1" (reverted to original)
+        # - First read: hash = "2" (different from stored "1")
+        # - Second read (after stability delay): hash = "1" (reverted to original)
         self.mock_util.path_modification_time = lambda *args: 102.0
 
         call_count = [0]
 
-        def transient_md5(*args, **kwargs):
+        def transient_hash(*args, **kwargs):
             call_count[0] += 1
-            # First call returns different MD5, second call returns original
+            # First call returns different hash, second call returns original
             return "2" if call_count[0] == 1 else "1"
 
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(
-            side_effect=transient_md5
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(
+            side_effect=transient_hash
         )
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
@@ -711,8 +711,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
             event_based_path_watcher._WINDOWS_STABILITY_DELAY_SECS
         )
 
-        # Verify calc_md5 was called twice (initial + stability check)
-        assert self.mock_util.calc_md5_with_blocking_retries.call_count == 2
+        # Verify calc_hash was called twice (initial + stability check)
+        assert self.mock_util.calc_hash_with_blocking_retries.call_count == 2
 
         ro.close()
 
@@ -725,14 +725,14 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         The stability check should NOT filter out genuine file modifications.
 
-        Scenario: MD5 changes initially and stays changed on second read
+        Scenario: Hash changes initially and stays changed on second read
         Expected: Callback SHOULD be triggered
         """
         cb = mock.Mock()
 
         # Initial state
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -742,9 +742,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         cb.assert_not_called()
 
         # Simulate a real change:
-        # Both reads return the new MD5 value
+        # Both reads return the new hash value
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="2")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="2")
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -758,8 +758,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
             event_based_path_watcher._WINDOWS_STABILITY_DELAY_SECS
         )
 
-        # Verify calc_md5 was called twice (initial + stability check)
-        assert self.mock_util.calc_md5_with_blocking_retries.call_count == 2
+        # Verify calc_hash was called twice (initial + stability check)
+        assert self.mock_util.calc_hash_with_blocking_retries.call_count == 2
 
         ro.close()
 
@@ -774,7 +774,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         # Initial state
         self.mock_util.path_modification_time = lambda *args: 101.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
         ro = event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
 
@@ -785,7 +785,7 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         # File changes
         self.mock_util.path_modification_time = lambda *args: 102.0
-        self.mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="2")
+        self.mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="2")
 
         ev = events.FileSystemEvent("/this/is/my/file.py")
         ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -794,9 +794,9 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         # Change should trigger callback
         cb.assert_called_once()
 
-        # Verify calc_md5 was only called once (no stability re-check)
+        # Verify calc_hash was only called once (no stability re-check)
         # Note: On non-Windows, we don't do the stability check
-        assert self.mock_util.calc_md5_with_blocking_retries.call_count == 1
+        assert self.mock_util.calc_hash_with_blocking_retries.call_count == 1
 
         ro.close()
 
@@ -827,15 +827,15 @@ def ebpw_mocks() -> Generator[tuple[mock.MagicMock, mock.MagicMock], None, None]
 def _folder_handler_after_simulated_change(
     mock_util: mock.MagicMock, watched_path: str
 ) -> tuple[Any, mock.Mock]:
-    """Register a file watcher and set default before/after mtime and MD5 values."""
+    """Register a file watcher and set default before/after mtime and hash values."""
     mock_util.path_modification_time = lambda *args, **kwargs: 101.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "1"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "1"
     cb = mock.Mock()
     event_based_path_watcher.EventBasedPathWatcher(watched_path, cb)
     fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
     folder_handler = fo._observer.schedule.call_args[0][0]
     mock_util.path_modification_time = lambda *args, **kwargs: 102.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "2"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "2"
     return folder_handler, cb
 
 
@@ -845,7 +845,7 @@ def test_event_based_path_watcher_repr(
     """``EventBasedPathWatcher.__repr__`` returns a readable class-based string."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
 
     watcher = event_based_path_watcher.EventBasedPathWatcher(
         "/tmp/watched.py", lambda _p: None
@@ -860,7 +860,7 @@ def test_multi_path_watcher_direct_ctor_raises_when_singleton_exists(
     """Constructing ``_MultiPathWatcher`` directly must fail once the singleton exists."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
 
     event_based_path_watcher._MultiPathWatcher.get_singleton()
     with pytest.raises(RuntimeError, match=r"Use \.get_singleton\(\) instead"):
@@ -873,7 +873,7 @@ def test_multi_path_watcher_repr(
     """``_MultiPathWatcher.__repr__`` identifies the singleton instance."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
 
     fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
     assert "_MultiPathWatcher" in repr(fo)
@@ -885,7 +885,7 @@ def test_event_based_path_watcher_close_all(
     """``EventBasedPathWatcher.close_all`` stops the shared observer."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
 
     event_based_path_watcher.EventBasedPathWatcher("/q/z.py", mock.Mock())
     event_based_path_watcher.EventBasedPathWatcher.close_all()
@@ -906,7 +906,7 @@ def test_watch_path_observer_schedule_failure_skips_registration(
     """If ``Observer.schedule`` fails, the folder handler is not registered."""
     mock_observer_class, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
     mock_observer_class.return_value.schedule.side_effect = schedule_error
 
     cb = mock.Mock()
@@ -922,7 +922,7 @@ def test_stop_watching_path_no_op_when_folder_not_registered(
     """``stop_watching_path`` returns quietly when the folder was never scheduled."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
 
     event_based_path_watcher.EventBasedPathWatcher("/alpha/file.py", mock.Mock())
     fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
@@ -936,7 +936,7 @@ def test_folder_event_handler_repr(
     """``_FolderEventHandler.__repr__`` includes the handler class name."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "h"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "h"
 
     event_based_path_watcher.EventBasedPathWatcher("/x/y.py", mock.Mock())
     fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
@@ -944,13 +944,13 @@ def test_folder_event_handler_repr(
     assert "_FolderEventHandler" in repr(folder_handler)
 
 
-def test_add_path_skipped_when_initial_md5_raises_max_retries(
+def test_add_path_skipped_when_initial_hash_raises_max_retries(
     ebpw_mocks: tuple[mock.MagicMock, mock.MagicMock],
 ) -> None:
-    """If initial MD5 calculation fails, the path is not added and events are ignored."""
+    """If initial hash calculation fails, the path is not added and events are ignored."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = mock.Mock(
+    mock_util.calc_hash_with_blocking_retries = mock.Mock(
         side_effect=StreamlitMaxRetriesError("locked")
     )
 
@@ -961,7 +961,7 @@ def test_add_path_skipped_when_initial_md5_raises_max_retries(
     folder_handler = fo._observer.schedule.call_args[0][0]
     assert folder_handler.is_watching_paths() is False
 
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "2"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "2"
     mock_util.path_modification_time = lambda *args, **kwargs: 2.0
     ev = events.FileSystemEvent("/only/path.py")
     ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -976,7 +976,7 @@ def test_stop_watching_unregistered_path_in_same_folder_is_no_op(
     """Removing a listener for a path that was never registered does nothing."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 1.0
-    mock_util.calc_md5_with_blocking_retries = lambda *args, **kwargs: "1"
+    mock_util.calc_hash_with_blocking_retries = lambda *args, **kwargs: "1"
 
     cb = mock.Mock()
     event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -988,7 +988,7 @@ def test_stop_watching_unregistered_path_in_same_folder_is_no_op(
 def test_moved_event_uses_destination_path(
     ebpw_mocks: tuple[mock.MagicMock, mock.MagicMock],
 ) -> None:
-    """Move events compare MD5 against the destination file path."""
+    """Move events compare hash against the destination file path."""
     _, mock_util = ebpw_mocks
     dest = "/this/is/my/file.py"
     folder_handler, cb = _folder_handler_after_simulated_change(mock_util, dest)
@@ -1017,13 +1017,13 @@ def test_modified_event_ignores_editor_backup_suffix(
 
 @mock.patch("streamlit.env_util.IS_WINDOWS", True)
 @mock.patch("time.sleep", mock.Mock())
-def test_windows_stability_md5_verification_max_retries_keeps_initial_change(
+def test_windows_stability_hash_verification_max_retries_keeps_initial_change(
     ebpw_mocks: tuple[mock.MagicMock, mock.MagicMock],
 ) -> None:
-    """If the stability re-read fails, the first new MD5 is still applied."""
+    """If the stability re-read fails, the first new hash is still applied."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 101.0
-    mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+    mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
     cb = mock.Mock()
     event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -1042,7 +1042,7 @@ def test_windows_stability_md5_verification_max_retries_keeps_initial_change(
             return "2"
         raise StreamlitMaxRetriesError("verification failed")
 
-    mock_util.calc_md5_with_blocking_retries = mock.Mock(side_effect=md5_side_effect)
+    mock_util.calc_hash_with_blocking_retries = mock.Mock(side_effect=md5_side_effect)
 
     ev = events.FileSystemEvent("/this/is/my/file.py")
     ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -1053,13 +1053,13 @@ def test_windows_stability_md5_verification_max_retries_keeps_initial_change(
 
 @mock.patch("streamlit.env_util.IS_WINDOWS", True)
 @mock.patch("time.sleep", mock.Mock())
-def test_windows_stability_uses_post_delay_md5_when_it_differs_from_both(
+def test_windows_stability_uses_post_delay_hash_when_it_differs_from_both(
     ebpw_mocks: tuple[mock.MagicMock, mock.MagicMock],
 ) -> None:
-    """When verification reads a third hash, that value becomes the stored MD5."""
+    """When verification reads a third hash, that value becomes the stored hash."""
     _, mock_util = ebpw_mocks
     mock_util.path_modification_time = lambda *args, **kwargs: 101.0
-    mock_util.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+    mock_util.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
     cb = mock.Mock()
     event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)
@@ -1070,10 +1070,10 @@ def test_windows_stability_uses_post_delay_md5_when_it_differs_from_both(
     mock_util.path_modification_time = lambda *args, **kwargs: 102.0
     sequence = iter(["2", "3"])
 
-    def md5_side_effect(*_args: object, **_kwargs: object) -> str:
+    def hash_side_effect(*_args: object, **_kwargs: object) -> str:
         return next(sequence)
 
-    mock_util.calc_md5_with_blocking_retries = mock.Mock(side_effect=md5_side_effect)
+    mock_util.calc_hash_with_blocking_retries = mock.Mock(side_effect=hash_side_effect)
 
     ev = events.FileSystemEvent("/this/is/my/file.py")
     ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -1103,22 +1103,22 @@ def test_nested_file_event_ignores_unrelated_file_watcher(
     cb.assert_not_called()
 
 
-def test_handle_path_change_ignores_event_when_md5_raises_max_retries(
+def test_handle_path_change_ignores_event_when_hash_raises_max_retries(
     ebpw_mocks: tuple[mock.MagicMock, mock.MagicMock],
 ) -> None:
-    """``StreamlitMaxRetriesError`` during change MD5 calculation drops the event."""
+    """``StreamlitMaxRetriesError`` during change hash calculation drops the event."""
     _, mock_util = ebpw_mocks
-    md5_calls = 0
+    hash_calls = 0
 
-    def md5_fn(*_args: object, **_kwargs: object) -> str:
-        nonlocal md5_calls
-        md5_calls += 1
-        if md5_calls == 1:
+    def hash_fn(*_args: object, **_kwargs: object) -> str:
+        nonlocal hash_calls
+        hash_calls += 1
+        if hash_calls == 1:
             return "1"
         raise StreamlitMaxRetriesError("cannot read")
 
     mock_util.path_modification_time = lambda *args, **kwargs: 101.0
-    mock_util.calc_md5_with_blocking_retries = md5_fn
+    mock_util.calc_hash_with_blocking_retries = hash_fn
 
     cb = mock.Mock()
     event_based_path_watcher.EventBasedPathWatcher("/this/is/my/file.py", cb)

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -1033,16 +1033,16 @@ def test_windows_stability_hash_verification_max_retries_keeps_initial_change(
 
     mock_util.path_modification_time = lambda *args, **kwargs: 102.0
 
-    md5_phase = 0
+    hash_phase = 0
 
-    def md5_side_effect(*_args: object, **_kwargs: object) -> str:
-        nonlocal md5_phase
-        md5_phase += 1
-        if md5_phase == 1:
+    def hash_side_effect(*_args: object, **_kwargs: object) -> str:
+        nonlocal hash_phase
+        hash_phase += 1
+        if hash_phase == 1:
             return "2"
         raise StreamlitMaxRetriesError("verification failed")
 
-    mock_util.calc_hash_with_blocking_retries = mock.Mock(side_effect=md5_side_effect)
+    mock_util.calc_hash_with_blocking_retries = mock.Mock(side_effect=hash_side_effect)
 
     ev = events.FileSystemEvent("/this/is/my/file.py")
     ev.event_type = events.EVENT_TYPE_MODIFIED

--- a/lib/tests/streamlit/watcher/polling_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/polling_path_watcher_test.py
@@ -67,7 +67,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback = mock.Mock()
 
         self.util_mock.path_modification_time = lambda *args: 101.0
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         watcher = polling_path_watcher.PollingPathWatcher(
             "/this/is/my/file.py", callback
@@ -77,7 +77,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback.assert_not_called()
 
         self.util_mock.path_modification_time = lambda *args: 102.0
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         self._run_executor_tasks()
         callback.assert_called_once()
@@ -89,7 +89,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback = mock.Mock()
 
         self.util_mock.path_modification_time = lambda *args: 101.0
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         watcher = polling_path_watcher.PollingPathWatcher(
             "/this/is/my/file.py", callback
@@ -99,7 +99,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback.assert_not_called()
 
         # Same mtime!
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "2"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
 
         # This is the test:
         self._run_executor_tasks()
@@ -112,7 +112,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback = mock.Mock()
 
         self.util_mock.path_modification_time = lambda *args: 0.0
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "11"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "11"
 
         watcher = polling_path_watcher.PollingPathWatcher(
             "/this/is/my/folder/", callback
@@ -122,7 +122,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback.assert_not_called()
 
         # Same mtime!
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "22"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "22"
 
         # This is the test:
         self._run_executor_tasks()
@@ -130,12 +130,12 @@ class PollingPathWatcherTest(unittest.TestCase):
 
         watcher.close()
 
-    def test_callback_not_called_if_same_md5(self):
-        """Test that we ignore files with same md5."""
+    def test_callback_not_called_if_same_hash(self):
+        """Test that we ignore files with same content hash."""
         callback = mock.Mock()
 
         self.util_mock.path_modification_time = lambda *args: 101.0
-        self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: "1"
+        self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
 
         watcher = polling_path_watcher.PollingPathWatcher(
             "/this/is/my/file.py", callback
@@ -145,7 +145,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback.assert_not_called()
 
         self.util_mock.path_modification_time = lambda *args: 102.0
-        # Same MD5
+        # Same hash
 
         # This is the test:
         self._run_executor_tasks()
@@ -153,9 +153,9 @@ class PollingPathWatcherTest(unittest.TestCase):
 
         watcher.close()
 
-    def test_kwargs_plumbed_to_calc_md5(self):
+    def test_kwargs_plumbed_to_calc_hash(self):
         """Test that we pass the glob_pattern and allow_nonexistent kwargs to
-        calc_md5_with_blocking_retries.
+        calc_hash_with_blocking_retries.
 
         `PollingPathWatcher`s can be created with optional kwargs allowing
         the caller to specify what types of files to watch (when watching a
@@ -166,7 +166,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         callback = mock.Mock()
 
         self.util_mock.path_modification_time = lambda *args: 101.0
-        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(return_value="1")
+        self.util_mock.calc_hash_with_blocking_retries = mock.Mock(return_value="1")
 
         watcher = polling_path_watcher.PollingPathWatcher(
             "/this/is/my/dir",
@@ -177,15 +177,15 @@ class PollingPathWatcherTest(unittest.TestCase):
 
         self._run_executor_tasks()
         callback.assert_not_called()
-        _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
+        _, kwargs = self.util_mock.calc_hash_with_blocking_retries.call_args
         assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
 
         self.util_mock.path_modification_time = lambda *args: 102.0
-        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(return_value="2")
+        self.util_mock.calc_hash_with_blocking_retries = mock.Mock(return_value="2")
 
         self._run_executor_tasks()
         callback.assert_called_once()
-        _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
+        _, kwargs = self.util_mock.calc_hash_with_blocking_retries.call_args
         assert kwargs == {"glob_pattern": "*.py", "allow_nonexistent": True}
 
         watcher.close()
@@ -198,7 +198,7 @@ class PollingPathWatcherTest(unittest.TestCase):
 
         def modify_mock_file():
             self.util_mock.path_modification_time = lambda *args: mod_count[0]
-            self.util_mock.calc_md5_with_blocking_retries = lambda _, **kwargs: (
+            self.util_mock.calc_hash_with_blocking_retries = lambda _, **kwargs: (
                 f"{mod_count[0]}"
             )
 
@@ -259,9 +259,9 @@ class PollingPathWatcherTest(unittest.TestCase):
         """
         callback = mock.Mock()
 
-        # Initially file doesn't exist: modification_time=0.0, MD5 based on path
+        # Initially file doesn't exist: modification_time=0.0, hash based on path
         self.util_mock.path_modification_time = mock.Mock(return_value=0.0)
-        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(
+        self.util_mock.calc_hash_with_blocking_retries = mock.Mock(
             return_value="nonexistent_hash"
         )
 
@@ -277,7 +277,7 @@ class PollingPathWatcherTest(unittest.TestCase):
         args = self.util_mock.path_modification_time.call_args[0]
         assert args[1] is True  # allow_nonexistent
 
-        _, kwargs = self.util_mock.calc_md5_with_blocking_retries.call_args
+        _, kwargs = self.util_mock.calc_hash_with_blocking_retries.call_args
         assert kwargs["allow_nonexistent"] is True
 
         self._run_executor_tasks()
@@ -285,7 +285,7 @@ class PollingPathWatcherTest(unittest.TestCase):
 
         # Step 1: Simulate file being created
         self.util_mock.path_modification_time = mock.Mock(return_value=101.0)
-        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(
+        self.util_mock.calc_hash_with_blocking_retries = mock.Mock(
             return_value="initial_content_hash"
         )
 
@@ -296,7 +296,7 @@ class PollingPathWatcherTest(unittest.TestCase):
 
         # Step 2: Simulate file being modified
         self.util_mock.path_modification_time = mock.Mock(return_value=102.0)
-        self.util_mock.calc_md5_with_blocking_retries = mock.Mock(
+        self.util_mock.calc_hash_with_blocking_retries = mock.Mock(
             return_value="modified_content_hash"
         )
 

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -176,8 +176,8 @@ class RaceConditionTests(unittest.TestCase):
             "deleted_file.toml", allow_nonexistent=True
         )
         # Hash of "deleted_file.toml" encoded as UTF-8
-        expected_md5 = util.calc_hash(b"deleted_file.toml")
-        assert result == expected_md5
+        expected_hash = util.calc_hash(b"deleted_file.toml")
+        assert result == expected_hash
 
         # Without allow_nonexistent, should raise
         with pytest.raises(StreamlitMaxRetriesError):

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -25,39 +25,39 @@ from streamlit.watcher import util
 
 
 class UtilTest(unittest.TestCase):
-    def test_md5_calculation_succeeds_with_bytes_input(self):
+    def test_hash_calculation_succeeds_with_bytes_input(self):
         with patch("streamlit.watcher.util.open", mock_open(read_data=b"hello")):
-            md5 = util.calc_md5_with_blocking_retries("foo")
-            assert md5 == "5d41402abc4b2a76b9719d911017c592"
+            result = util.calc_hash_with_blocking_retries("foo")
+            assert result == "46fb7408d4f285228f4af516ea25851b"
 
     @patch("os.path.isdir", MagicMock(return_value=True))
     @patch("streamlit.watcher.util._stable_dir_identifier")
-    def test_md5_calculation_succeeds_with_dir_input(self, mock_stable_dir_identifier):
+    def test_hash_calculation_succeeds_with_dir_input(self, mock_stable_dir_identifier):
         mock_stable_dir_identifier.return_value = "hello"
 
-        md5 = util.calc_md5_with_blocking_retries("foo")
-        assert md5 == "5d41402abc4b2a76b9719d911017c592"
+        result = util.calc_hash_with_blocking_retries("foo")
+        assert result == "46fb7408d4f285228f4af516ea25851b"
         mock_stable_dir_identifier.assert_called_once_with("foo", "*")
 
     @patch("os.path.isdir", MagicMock(return_value=True))
     @patch("streamlit.watcher.util._stable_dir_identifier")
-    def test_md5_calculation_can_pass_glob(self, mock_stable_dir_identifier):
+    def test_hash_calculation_can_pass_glob(self, mock_stable_dir_identifier):
         mock_stable_dir_identifier.return_value = "hello"
 
-        util.calc_md5_with_blocking_retries("foo", glob_pattern="*.py")
+        util.calc_hash_with_blocking_retries("foo", glob_pattern="*.py")
         mock_stable_dir_identifier.assert_called_once_with("foo", "*.py")
 
     @patch("os.path.exists", MagicMock(return_value=False))
-    def test_md5_calculation_allow_nonexistent(self):
-        md5 = util.calc_md5_with_blocking_retries("hello", allow_nonexistent=True)
-        assert md5 == "5d41402abc4b2a76b9719d911017c592"
+    def test_hash_calculation_allow_nonexistent(self):
+        result = util.calc_hash_with_blocking_retries("hello", allow_nonexistent=True)
+        assert result == "46fb7408d4f285228f4af516ea25851b"
 
-    def test_md5_calculation_opens_file_with_rb(self):
+    def test_hash_calculation_opens_file_with_rb(self):
         # This tests implementation :( . But since the issue this is addressing
         # could easily come back to bite us if a distracted coder tweaks the
         # implementation, I'm putting this here anyway.
         with patch("streamlit.watcher.util.open", mock_open(read_data=b"hello")) as m:
-            util.calc_md5_with_blocking_retries("foo")
+            util.calc_hash_with_blocking_retries("foo")
             m.assert_called_once_with("foo", "rb")
 
 
@@ -154,16 +154,16 @@ class RaceConditionTests(unittest.TestCase):
     @patch("streamlit.watcher.util._do_with_retries")
     @patch("streamlit.watcher.util.os.path.isdir")
     @patch("streamlit.watcher.util.os.path.exists")
-    def test_calc_md5_handles_deletion_race_condition(
+    def test_calc_hash_handles_deletion_race_condition(
         self,
         mock_exists: MagicMock,
         mock_isdir: MagicMock,
         mock_do_with_retries: MagicMock,
     ) -> None:
-        """Test that calc_md5_with_blocking_retries handles file deletion gracefully.
+        """Test that calc_hash_with_blocking_retries handles file deletion gracefully.
 
         Scenario: File exists when checked, but is deleted before read() completes.
-        With allow_nonexistent=True, should return MD5 of path string instead of raising.
+        With allow_nonexistent=True, should return hash of path string instead of raising.
         """
         # File exists initially, is not a directory
         mock_exists.return_value = True
@@ -171,16 +171,16 @@ class RaceConditionTests(unittest.TestCase):
         # But read fails because file was deleted (race condition)
         mock_do_with_retries.side_effect = StreamlitMaxRetriesError("File gone")
 
-        # With allow_nonexistent=True, should return MD5 of path (not raise)
-        result = util.calc_md5_with_blocking_retries(
+        # With allow_nonexistent=True, should return hash of path (not raise)
+        result = util.calc_hash_with_blocking_retries(
             "deleted_file.toml", allow_nonexistent=True
         )
-        # MD5 of "deleted_file.toml" encoded as UTF-8
-        expected_md5 = util.calc_md5(b"deleted_file.toml")
+        # Hash of "deleted_file.toml" encoded as UTF-8
+        expected_md5 = util.calc_hash(b"deleted_file.toml")
         assert result == expected_md5
 
         # Without allow_nonexistent, should raise
         with pytest.raises(StreamlitMaxRetriesError):
-            util.calc_md5_with_blocking_retries(
+            util.calc_hash_with_blocking_retries(
                 "deleted_file.toml", allow_nonexistent=False
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,9 +106,8 @@ test = [
   "seaborn>=0.11.2",
   "watchdog>=2.1.5",
   "streamlit-pdf>=1.0.0",
-  # Optional dependencies for better performance:
+  # Optional dependency for better performance:
   "uvloop>=0.15.2; sys_platform != 'win32'",
-  "xxhash>=3.0.0",
   # Optional dependency used for improved exception formatting:
   "rich>=10.14.0",
   # Used by vega-lite / altair e2e tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,9 @@ test = [
   "seaborn>=0.11.2",
   "watchdog>=2.1.5",
   "streamlit-pdf>=1.0.0",
-  # Optional dependency for better performance:
+  # Optional dependencies for better performance:
   "uvloop>=0.15.2; sys_platform != 'win32'",
+  "xxhash>=3.0.0",
   # Optional dependency used for improved exception formatting:
   "rich>=10.14.0",
   # Used by vega-lite / altair e2e tests:


### PR DESCRIPTION
## Summary

Replace internal MD5 hashing with BLAKE2b for non-security-critical operations. BLAKE2b is ~2.4x faster than MD5 and is built into Python's hashlib.

This improves performance for:
- Element ID generation
- Cache key computation  
- File change detection (watchers)
- Content-addressed identifiers

## Changes

- Add `create_fast_hasher()` function to `util.py` returning a blake2b hasher
- Rename `calc_md5` to `calc_hash` across the codebase
- Update caching, element ID, and watcher modules to use fast hasher
- Rename variables/attributes from `md5` to `content_hash`
- Update comments and documentation from MD5 to hash
- Add unit tests for new hashing functions

## Testing Plan

- [x] Unit tests for `create_fast_hasher()` and `calc_hash()`
- [x] Updated existing tests with new hash values
- [x] All `make check` tests pass

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | sharing-pr-agent-artifacts | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 2 |
| subagent | general-purpose | 3 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->