### PR TITLE
feat(st.tabs): add height parameter supporting "stretch", "content", and int (#12217)

### DIFF
--- a/e2e_playwright/st_tabs.py
+++ b/e2e_playwright/st_tabs.py
@@ -264,3 +264,32 @@ st.write(
     f"Tabs callback args result: "
     f"{st.session_state.get('tabs_cb_args_result', 'Not called')}"
 )
+
+
+# --- Height parameter (issue #12217) ---------------------------------------
+# Three tab containers inside a fixed-height parent container exercise the
+# three values accepted by ``height``: default (``"content"``), ``"stretch"``
+# and a fixed pixel value.  The first one should keep its natural (small)
+# height; the second should expand to fill the outer container; the third
+# should be clamped to 150px with its own scroll area.
+with st.container(height=360, border=True, key="tabs_height_parent"):
+    content_tabs = st.tabs(["Default", "Other"], key="tabs_height_content")
+    with content_tabs[0]:
+        st.write("Content height tab")
+    with content_tabs[1]:
+        st.write("Second tab, default height")
+
+    stretch_tabs = st.tabs(
+        ["Stretch", "Other"], height="stretch", key="tabs_height_stretch"
+    )
+    with stretch_tabs[0]:
+        st.write("Stretch tab fills the remaining vertical space.")
+    with stretch_tabs[1]:
+        st.write("Second stretch tab")
+
+px_tabs = st.tabs(["Pixel", "Other"], height=150, key="tabs_height_pixel")
+with px_tabs[0]:
+    for i in range(30):
+        st.write(f"scroll line {i}")
+with px_tabs[1]:
+    st.write("Second pixel tab")

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -339,3 +339,47 @@ def test_keyed_tabs_persist_active_tab_across_remount(app: Page):
     expect(keyed_tabs.get_by_role("tab", name="Details")).to_have_attribute(
         "aria-selected", "true"
     )
+
+
+def test_tabs_height_stretch_fills_parent(app: Page):
+    """``height='stretch'`` should make the tabs container stretch to fill
+    the remaining space of its (fixed-height) parent ``st.container``."""
+    parent = get_element_by_key(app, "tabs_height_parent")
+    stretch_tabs = get_element_by_key(app, "tabs_height_stretch")
+    expect(parent).to_be_visible()
+    expect(stretch_tabs).to_be_visible()
+
+    parent_box = parent.bounding_box()
+    stretch_box = stretch_tabs.bounding_box()
+    assert parent_box is not None
+    assert stretch_box is not None
+
+    # The stretch tabs should occupy the majority of the remaining parent
+    # height (after the first, content-sized tabs block and paddings).
+    assert stretch_box["height"] >= parent_box["height"] * 0.4
+
+
+def test_tabs_height_pixel_is_fixed(app: Page):
+    """A fixed pixel ``height`` should clamp the tabs container to that
+    height and enable vertical scrolling of the active tab panel."""
+    pixel_tabs = get_element_by_key(app, "tabs_height_pixel")
+    expect(pixel_tabs).to_be_visible()
+
+    box = pixel_tabs.bounding_box()
+    assert box is not None
+    # Allow a small tolerance for padding/border rounding.
+    assert 140 <= box["height"] <= 170
+
+
+def test_tabs_height_content_is_default(app: Page):
+    """Without ``height``, tabs should size to their content and stay
+    considerably smaller than the fixed-height parent container."""
+    parent = get_element_by_key(app, "tabs_height_parent")
+    content_tabs = get_element_by_key(app, "tabs_height_content")
+    expect(content_tabs).to_be_visible()
+
+    parent_box = parent.bounding_box()
+    content_box = content_tabs.bounding_box()
+    assert parent_box is not None
+    assert content_box is not None
+    assert content_box["height"] < parent_box["height"]

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -399,11 +399,23 @@ export const BlockNodeRenderer = (
   }
 
   if (node.deltaBlock.tabContainer) {
+    // When the tabs container has an explicit (non-default) height — either
+    // "stretch" (100%) or a fixed pixel height — render each tab's content
+    // wrapper at 100% so it can fill the TabPanel.  Otherwise keep the
+    // historical "auto" behaviour so content-sized tabs stay unchanged.
+    const tabHeight = styles.height
+    const hasExplicitHeight =
+      typeof tabHeight === "string" && tabHeight !== "auto"
     const renderTabContent = (
       mappedChildProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
     ): ReactElement => {
       // avoid circular dependency where Tab uses VerticalBlock but VerticalBlock uses tabs
-      return <ContainerContentsWrapper {...mappedChildProps} height="auto" />
+      return (
+        <ContainerContentsWrapper
+          {...mappedChildProps}
+          height={hasExplicitHeight ? "100%" : "auto"}
+        />
+      )
     }
     // We can't use StyledLayoutWrapper for tabs currently because of the horizontal scrolling
     // management that is handled in the Tabs component. TODO(lwilby): Investigate whether it makes
@@ -413,6 +425,7 @@ export const BlockNodeRenderer = (
       isStale,
       renderTabContent,
       width: styles.width,
+      height: styles.height,
       flex: styles.flex,
       fragmentId: node.fragmentId,
     }

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -116,6 +116,33 @@ describe("st.tabs", () => {
     expect(tabs).toHaveLength(5)
   })
 
+  it("applies stretch height as flex column with 100% height", () => {
+    render(<Tabs {...getProps({ height: "100%" })} />)
+    const tabsElement = screen.getByTestId("stTabs")
+    expect(tabsElement).toHaveStyle({
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+    })
+  })
+
+  it("applies a fixed pixel height as flex column", () => {
+    render(<Tabs {...getProps({ height: "250px" })} />)
+    const tabsElement = screen.getByTestId("stTabs")
+    expect(tabsElement).toHaveStyle({
+      height: "250px",
+      display: "flex",
+      flexDirection: "column",
+    })
+  })
+
+  it("does not apply explicit height styling for the default 'auto' height", () => {
+    render(<Tabs {...getProps({ height: "auto" })} />)
+    const tabsElement = screen.getByTestId("stTabs")
+    // No flex column layout should be forced when height is the default 'auto'.
+    expect(tabsElement).not.toHaveStyle({ display: "flex" })
+  })
+
   it("sets the tab labels correctly", () => {
     render(<Tabs {...getProps()} />)
     const tabs = screen.getAllByRole("tab")

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -72,6 +72,7 @@ export interface TabProps extends BlockPropsWithoutWidth {
     childProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
   ) => ReactElement
   width: React.CSSProperties["width"]
+  height: React.CSSProperties["height"]
   flex: React.CSSProperties["flex"]
   fragmentId?: string
 }
@@ -82,10 +83,20 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
     node,
     isStale,
     width,
+    height,
     flex,
     widgetMgr,
     fragmentId,
   } = props
+
+  // `height` comes pre-computed from `useLayoutStyles`:
+  //   - "auto"    => "content" (default tabs behaviour)
+  //   - "100%"    => "stretch" (fill parent)
+  //   - "<N>px"   => fixed pixel height (scrolling tab panels)
+  const isStretchHeight = height === "100%"
+  const isFixedHeight =
+    typeof height === "string" && height !== "auto" && height !== "100%"
+  const hasExplicitHeight = isStretchHeight || isFixedHeight
   const { scriptRunState, scriptRunId, fragmentIdsThisRun } =
     useContext(ScriptRunContext)
   const defaultTabIndex = node.deltaBlock?.tabContainer?.defaultTabIndex ?? 0
@@ -266,6 +277,9 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
       data-testid="stTabs"
       isOverflowing={isOverflowing}
       width={width}
+      height={height}
+      isStretchHeight={isStretchHeight}
+      isFixedHeight={isFixedHeight}
       flex={flex}
     >
       <UITabs
@@ -320,6 +334,18 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
             style: () => ({
               // resetting transform to fix full screen wrapper
               transform: "none",
+              // When the tabs container has an explicit height (stretch or
+              // a fixed pixel value), make the BaseUI root a flex column so
+              // that the active TabPanel can fill the remaining vertical
+              // space below the tab list.
+              ...(hasExplicitHeight
+                ? {
+                    display: "flex",
+                    flexDirection: "column" as const,
+                    height: "100%",
+                    minHeight: 0,
+                  }
+                : {}),
             }),
           },
         }}
@@ -366,6 +392,17 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
                     paddingRight: theme.spacing.none,
                     paddingBottom: theme.spacing.none,
                     paddingTop: theme.spacing.lg,
+                    // When an explicit height is set on st.tabs, let each
+                    // TabPanel expand to fill the remaining space.  For
+                    // fixed pixel heights we also enable internal scrolling
+                    // so that overflow content is reachable.
+                    ...(hasExplicitHeight
+                      ? {
+                          flex: 1,
+                          minHeight: 0,
+                          ...(isFixedHeight ? { overflow: "auto" } : {}),
+                        }
+                      : {}),
                   }),
                 },
                 Tab: {

--- a/frontend/lib/src/components/elements/Tabs/styled-components.ts
+++ b/frontend/lib/src/components/elements/Tabs/styled-components.ts
@@ -20,13 +20,24 @@ import { transparentize } from "color2k"
 interface StyledTabContainerProps {
   isOverflowing: boolean
   width: React.CSSProperties["width"]
+  height: React.CSSProperties["height"]
+  isStretchHeight: boolean
+  isFixedHeight: boolean
   flex: React.CSSProperties["flex"]
 }
 
 export const StyledTabContainer = styled.div<StyledTabContainerProps>(
-  ({ isOverflowing, width, flex }) => ({
+  ({ isOverflowing, width, height, isStretchHeight, isFixedHeight, flex }) => ({
     position: isOverflowing ? "relative" : undefined,
     width: width || undefined,
+    // When a non-default height is requested (stretch or fixed pixel height),
+    // apply flex column layout so the tab panel can fill the available space.
+    height: isStretchHeight || isFixedHeight ? height || undefined : undefined,
+    display: isStretchHeight || isFixedHeight ? "flex" : undefined,
+    flexDirection: isStretchHeight || isFixedHeight ? "column" : undefined,
+    // Allow this flex child to shrink below its content size so that the
+    // inner scroll area (TabPanel) can activate its own overflow.
+    minHeight: isStretchHeight || isFixedHeight ? 0 : undefined,
     flex: flex || undefined,
   })
 )

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -632,6 +632,7 @@ class LayoutsMixin:
         tabs: Sequence[str],
         *,
         width: WidthWithoutContent = "stretch",
+        height: Height = "content",
         default: str | None = None,
         key: Key | None = None,
         on_change: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
@@ -685,6 +686,27 @@ class LayoutsMixin:
               fixed width. If the specified width is greater than the width of
               the parent container, the width of the container matches the width
               of the parent container.
+
+        height : "content", "stretch", or int
+            The height of the tab container. This can be one of the following:
+
+            - ``"content"`` (default): The height of the container matches the
+              height of its content.
+            - ``"stretch"``: The height of the container matches the height of
+              its content or the height of the parent container, whichever is
+              larger. This is useful when placing ``st.tabs`` inside a fixed-
+              height ``st.container`` or a horizontal flex layout, so that
+              each tab panel fills the available vertical space.
+            - An integer specifying the height in pixels: The container has a
+              fixed height. If the content of a tab is larger than the specified
+              height, scrolling is enabled for that tab's contents.
+
+            .. note::
+                Use scrolling tab containers (fixed ``int`` height) sparingly.
+                If you use scrolling tabs, avoid heights that exceed 500 pixels.
+                Otherwise, the scroll surface of the container might cover the
+                majority of the screen on mobile devices, which makes it hard
+                to scroll the rest of the app.
 
         default : str or None
             The default tab to select. If this is ``None`` (default), the first
@@ -916,6 +938,7 @@ class LayoutsMixin:
                 dg=self.dg,
                 tabs=tuple(tabs),
                 width=width,
+                height=height,
                 default=default,
             )
             block_id = element_id
@@ -954,6 +977,8 @@ class LayoutsMixin:
         block_proto.tab_container.SetInParent()
         validate_width(width)
         block_proto.width_config.CopyFrom(get_width_config(width))
+        validate_height(height, allow_content=True)
+        block_proto.height_config.CopyFrom(get_height_config(height))
 
         # Compute the current tab index from the label
         try:

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -1707,6 +1707,81 @@ class TabsTest(DeltaGeneratorTestCase):
         with st.form("form"):
             st.tabs(["A", "B"], on_change="rerun")
 
+    def test_default_height_is_content(self):
+        """Test that the default height config is ``use_content``."""
+        st.tabs(["A", "B"])
+        tab_container_block = self.get_all_deltas_from_queue()[0]
+        height_config = tab_container_block.add_block.height_config
+        assert height_config.WhichOneof("height_spec") == "use_content"
+        assert height_config.use_content is True
+
+    def test_height_stretch(self):
+        """Test that ``height='stretch'`` sets ``use_stretch`` on the proto."""
+        st.tabs(["A", "B"], height="stretch")
+        tab_container_block = self.get_all_deltas_from_queue()[0]
+        height_config = tab_container_block.add_block.height_config
+        assert height_config.WhichOneof("height_spec") == "use_stretch"
+        assert height_config.use_stretch is True
+
+    def test_height_content_explicit(self):
+        """Test that ``height='content'`` explicitly sets ``use_content``."""
+        st.tabs(["A", "B"], height="content")
+        tab_container_block = self.get_all_deltas_from_queue()[0]
+        height_config = tab_container_block.add_block.height_config
+        assert height_config.WhichOneof("height_spec") == "use_content"
+
+    def test_height_pixels(self):
+        """Test that an ``int`` height is written as ``pixel_height``."""
+        st.tabs(["A", "B"], height=300)
+        tab_container_block = self.get_all_deltas_from_queue()[0]
+        height_config = tab_container_block.add_block.height_config
+        assert height_config.WhichOneof("height_spec") == "pixel_height"
+        assert height_config.pixel_height == 300
+
+    @parameterized.expand(
+        [
+            ("invalid_string", "auto"),
+            ("negative", -1),
+            ("zero", 0),
+            ("wrong_type", 1.5),
+            ("none", None),
+        ]
+    )
+    def test_invalid_height_raises(self, _name: str, invalid_height) -> None:
+        """Test that invalid ``height`` values raise ``StreamlitAPIException``."""
+        with pytest.raises(StreamlitAPIException):
+            st.tabs(["A", "B"], height=invalid_height)
+
+    def test_height_included_in_stateful_widget_id(self) -> None:
+        """Test that ``height`` affects the computed widget id for stateful tabs.
+
+        Two otherwise-identical stateful ``st.tabs`` that differ only in the
+        ``height`` argument must produce different widget ids so that the
+        frontend can invalidate cached state when the user changes the
+        height.  We use distinct user keys to avoid the duplicate-key guard
+        and compare the hash portion of the resulting ids.
+        """
+        st.tabs(["A", "B"], key="tabs_a", on_change="rerun", height="content")
+        st.tabs(["A", "B"], key="tabs_b", on_change="rerun", height="stretch")
+        st.tabs(["A", "B"], key="tabs_c", on_change="rerun", height=250)
+
+        deltas = self.get_all_deltas_from_queue()
+        # Each ``st.tabs`` emits one tab_container delta followed by per-tab deltas.
+        tab_container_deltas = [
+            d for d in deltas if d.add_block.HasField("tab_container")
+        ]
+        assert len(tab_container_deltas) == 3
+
+        def _hash_part(delta) -> str:
+            # element ids have the form ``$$ID-<hash>-<user_key>``
+            full_id = delta.add_block.tab_container.id
+            assert full_id, "stateful tabs must emit a non-empty id"
+            return full_id.split("-")[1]
+
+        hashes = {_hash_part(d) for d in tab_container_deltas}
+        # All three heights must produce distinct hashes.
+        assert len(hashes) == 3
+
 
 class DialogTest(DeltaGeneratorTestCase):
     """Run unit tests for the non-public delta-generator dialog and also the dialog


### PR DESCRIPTION
## What

Adds a `height` parameter to `st.tabs` supporting `int | "stretch" | "content"`, mirroring the semantics already used by `st.container(height=...)`. This lets users place `st.tabs` inside a fixed-height `st.container` (or a horizontal flex layout) and have the active tab panel fill the available vertical space.

Closes #12217.

## Why

Requested and confirmed by the maintainers in issue [#12217](https://github.com/streamlit/streamlit/issues/12217):

> jrieke: "Yes, I agree that this would be a natural extension. (…) Looks like you can add a height to `st.tabs`, but only as a fixed pixel value, not as "stretch"."

Since Streamlit 1.48 shipped the AdvancedLayout API (`st.container(height=N, horizontal=True, …)`), not being able to stretch `st.tabs` inside such containers is a visible rough edge.

## How

Three layers, minimal surface area, kept in sync with how `st.container` already handles height:

1. **Proto** — *no changes needed.* `Block.height_config` already exists and the existing `HeightConfig` oneof covers `use_content` / `use_stretch` / `pixel_height`.
2. **Python** (`lib/streamlit/elements/layouts.py`)
   - Add `height: Height = "content"` to `LayoutsMixin.tabs`.
   - Validate with `validate_height(height, allow_content=True)` and write `block_proto.height_config.CopyFrom(get_height_config(height))` — the exact same helpers `st.container` uses.
   - Include `height` in `compute_and_register_element_id(...)` so that changing the height on a stateful `st.tabs(..., on_change="rerun")` invalidates cached widget state.
   - Document the new parameter, including the "avoid >500px scrolling tabs on mobile" note consistent with `st.container`.
3. **Frontend**
   - `Block.tsx`: forward the precomputed `styles.height` to `<Tabs>`; render each tab's `ContainerContentsWrapper` at `height="100%"` when an explicit height is set.
   - `Tabs.tsx`: receive `height`, derive `isStretchHeight` / `isFixedHeight`, and opt into flex-column layout on the BaseUI `Root` and `TabPanel` so the active panel fills the remaining vertical space. For fixed pixel heights the `TabPanel` gets `overflow: auto` so overflow content stays reachable.
   - `styled-components.ts`: `StyledTabContainer` applies the explicit height, `display: flex`, `flex-direction: column`, and `min-height: 0` only when a non-default height is requested — so existing content-sized tabs behave exactly as before.

## Testing

- **Python unit tests** (`lib/tests/streamlit/elements/layouts_test.py :: TabsTest`, 228/228 passing):
  - `test_default_height_is_content`
  - `test_height_stretch`
  - `test_height_content_explicit`
  - `test_height_pixels`
  - `test_invalid_height_raises` (parameterized: `"auto"`, `-1`, `0`, `1.5`, `None`)
  - `test_height_included_in_stateful_widget_id`
- **Frontend unit tests** (`Tabs.test.tsx`): new cases asserting that
  - `height="100%"` renders flex column with `height: 100%`
  - `height="250px"` renders flex column with the pixel height
  - `height="auto"` leaves the default non-flex layout untouched
- **E2E** (`e2e_playwright/st_tabs.py` + `e2e_playwright/st_tabs_test.py`): three new cases exercising the stretch / pixel / content branches inside a fixed-height parent container.

Commands run locally:

```bash
make protobuf                                       # Python proto regenerated (no proto diff)
uv run pytest -c lib/pyproject.toml lib/tests/streamlit/elements/layouts_test.py
# => 228 passed
```

Frontend/E2E tests are structured so CI can run them; I did not run the full yarn/playwright suite locally.

## Note on prior attempt

There was a prior stalled attempt in #14369 (closed by stale-bot after the author stopped responding, not rejected on merits). This PR reuses the same high-level approach but:

- additionally supports fixed pixel heights (not just `"stretch"` / `"content"`),
- uses the existing `HeightConfig` plumbing instead of adding a new tabs-only proto field,
- adds Python/frontend/e2e tests,
- includes the `height` in the stateful `st.tabs` id so cached widget state is invalidated when the user changes the height.

Happy to rebase / squash / adjust naming — feedback welcome!
