### PR TITLE
feat: add border radius rounding to st.video and st.map

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/styled-components.ts
@@ -23,10 +23,12 @@ interface StyledDeckGlChartProps {
 }
 
 export const StyledDeckGlChart = styled.div<StyledDeckGlChartProps>(
-  ({ isStretchHeight }) => ({
+  ({ isStretchHeight, theme }) => ({
     position: "relative",
     height: "100%",
     width: "100%",
+    borderRadius: `min(${theme.radii.default}, 8px)`,
+    overflow: "hidden",
     // Minimum height is not used when pixel height is provided by user so we don't restrict users from setting small heights.
     ...(isStretchHeight && { minHeight: "6.25rem" }),
   })

--- a/frontend/lib/src/components/elements/Video/Video.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.tsx
@@ -24,7 +24,7 @@ import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
 import { WidgetStateManager as ElementStateManager } from "~lib/WidgetStateManager"
 
-import { StyledVideoIframe } from "./styled-components"
+import { StyledVideo, StyledVideoIframe } from "./styled-components"
 
 const LOG = getLogger("Video")
 export interface VideoProps {
@@ -33,7 +33,6 @@ export interface VideoProps {
   elementMgr: ElementStateManager
 }
 
-const VIDEO_STYLE = { width: "100%" }
 
 function Video({
   element,
@@ -248,7 +247,7 @@ function Video({
 
   return (
     // eslint-disable-next-line jsx-a11y/media-has-caption
-    <video
+    <StyledVideo
       className="stVideo"
       data-testid="stVideo"
       ref={videoRef}
@@ -256,7 +255,6 @@ function Video({
       muted={muted}
       autoPlay={autoplay && !preventAutoplay}
       src={endpoints.buildMediaURL(url)}
-      style={VIDEO_STYLE}
       crossOrigin={crossOrigin}
       onError={handleVideoError}
     >
@@ -272,7 +270,7 @@ function Video({
           data-testid="stVideoSubtitle"
         />
       ))}
-    </video>
+    </StyledVideo>
   )
 }
 

--- a/frontend/lib/src/components/elements/Video/styled-components.ts
+++ b/frontend/lib/src/components/elements/Video/styled-components.ts
@@ -23,4 +23,12 @@ export const StyledVideoIframe = styled.iframe(({ theme }) => ({
   margin: theme.spacing.none,
   width: "100%",
   aspectRatio: "16 / 9",
+  borderRadius: `min(${theme.radii.default}, 8px)`,
+  overflow: "hidden",
+}))
+
+export const StyledVideo = styled.video(({ theme }) => ({
+  width: "100%",
+  borderRadius: `min(${theme.radii.default}, 8px)`,
+  overflow: "hidden",
 }))


### PR DESCRIPTION
## Describe your changes
Adds borderRadius and overflow: hidden to st.video and st.map/st.pydeck_chart components to match the consistent rounded styling of other Streamlit elements. Uses min(theme.radii.default, 8px) to cap the radius and prevent corner controls from being cropped.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)
<img width="748" height="601" alt="Screenshot 2026-04-20 at 9 33 21 PM" src="https://github.com/user-attachments/assets/c42ac14b-f50b-43ab-ac53-63f4140f0d1f" />

## Testing Plan

- Manually tested st.video and st.map locally with the dev server — both display rounded corners correctly
- No new unit tests needed as this is a pure CSS styling change with no logic changes
- No E2E tests needed for the same reason

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
