### PR TITLE
Rewrote Pyproject TOML file search loop to reduce cognitive complexity of function.

### DIFF
--- a/lib/streamlit/components/v2/manifest_scanner.py
+++ b/lib/streamlit/components/v2/manifest_scanner.py
@@ -246,57 +246,60 @@ def _find_package_pyproject_toml(dist: importlib.metadata.Distribution) -> Path 
     for finder in (
         _pyproject_via_read_text,
         _pyproject_via_dist_files,
-        lambda d: _pyproject_via_import_spec(d, package_name),
+        _pyproject_via_import_spec,
     ):
-        result = finder(dist)
+        result = finder(dist, package_name)
         if result is not None:
             return result
 
     return None
 
 
-def _pyproject_via_read_text(dist: importlib.metadata.Distribution) -> Path | None:
+def _pyproject_via_read_text(
+    dist: importlib.metadata.Distribution, package_name: str
+) -> Path | None:
     """Locate pyproject.toml using the distribution's read_text + nearby files.
 
     This works for many types of installations including some editable ones.
     """
-    package_name = _normalize_package_name(dist.name)
     try:
-        if hasattr(dist, "read_text"):
-            pyproject_content = dist.read_text("pyproject.toml")
-            if pyproject_content and dist.files:
-                # Found content, now find the actual file path
-                # Look for a reasonable file to get the directory
-                for file in dist.files:
-                    if "__init__.py" in str(file) or ".py" in str(file):
-                        try:
-                            file_path = Path(str(dist.locate_file(file)))
-                            # Check nearby directories for pyproject.toml
-                            current_dir = file_path.parent
-                            # Check current directory and parent
-                            for search_dir in [current_dir, current_dir.parent]:
-                                pyproject_path = search_dir / "pyproject.toml"
-                                if (
-                                    pyproject_path.exists()
-                                    and _validate_pyproject_for_package(
-                                        pyproject_path,
-                                        dist.name,
-                                        package_name,
-                                    )
-                                ):
-                                    return pyproject_path
-                            # Stop after first reasonable file
-                            break
-                        except Exception:  # noqa: S112
-                            continue
+        # Checks to ensure that the given object has the ability to read text, and that the TOML file exists.
+        if not hasattr(dist, "read_text") or not dist.read_text("pyproject.toml"):
+            return None
+        if not dist.files:
+            return None
+
+        # Once the dist is confirmed to have files, find the target directory to search for the TOML
+        # based on where the .py scripts are found.
+        anchor = next(
+            file
+            for file in dist.files
+            if "__init__.py" in str(file) or ".py" in str(file)
+        )
+        if anchor is None:
+            return None
+
+        anchor_dir = Path(str(dist.locate_file(anchor))).parent
+
+        # Now, search for the TOML file in both the current directory and the directory above it,
+        # validate, and if found, return the path to the pyproject.
+        for search_dir in [anchor_dir, anchor_dir.parent]:
+            pyproject_path = search_dir / "pyproject.toml"
+            if pyproject_path.exists() and _validate_pyproject_for_package(
+                pyproject_path,
+                dist.name,
+                package_name,
+            ):
+                return pyproject_path
     except Exception:
         return None
     return None
 
 
-def _pyproject_via_dist_files(dist: importlib.metadata.Distribution) -> Path | None:
+def _pyproject_via_dist_files(
+    dist: importlib.metadata.Distribution, package_name: str
+) -> Path | None:
     """Locate pyproject.toml by scanning the distribution's file list."""
-    package_name = _normalize_package_name(dist.name)
     files = getattr(dist, "files", None)
     if not files:
         return None


### PR DESCRIPTION
## Describe your changes
The manifest_scanner searches for Pyprojects that are TOML files, and the refactoring aimed to reduce the cognitive complexity of the `_pyproject_via_read_text` function, due to the several branches of depth of the conditionals, try statements, and loops. The goal was to extract the logic into a more readable format without disrupting the existing logic. The internal helper functions for finding TOML files: `_pyproject_via_read_text`, `_pyproject_via_dist_files`, and `_pyproject_via_import_spec` were all adjusted with their parameters to make the loop utilizing each function more streamlined, as they all required the same information to be passed in.

## Testing Plan

- The changes were made to private helper functions, and the overall behavior of the module was preserved, so no new test cases were necessary.
- The unit tests were run using `uv run pytest lib/tests/streamlit/components/v2/test_manifest_scanner.py`.
- The linter was run before committing changes using `uv run ruff check lib/streamlit/components/v2/manifest_scanner.py`.
- As this change was a backend exclusive change, no E2E testing was required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
