### PR TITLE
[fix] st.text_area height='content' sizing on initial load

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -218,7 +218,7 @@ function ChatInput({
   }, [])
 
   // Track if we've done the initial height calculation with a valid width.
-  // This prevents recalculating on every window resize, which would override manual user resizes.
+  // This prevents unnecessary recalculations on every window resize.
   const hasInitializedWithWidthRef = useRef(false)
 
   const autoExpand = useTextInputAutoExpand({

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -228,7 +228,7 @@ function ChatInput({
   const { updateScrollHeight } = autoExpand
 
   // Recalculate height once when width first becomes available (ResizeObserver is async).
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (width > 0 && !hasInitializedWithWidthRef.current) {
       hasInitializedWithWidthRef.current = true
       updateScrollHeight()

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -217,10 +217,23 @@ function ChatInput({
     }
   }, [])
 
+  // Track if we've done the initial height calculation with a valid width.
+  // This prevents recalculating on every window resize, which would override manual user resizes.
+  const hasInitializedWithWidthRef = useRef(false)
+
   const autoExpand = useTextInputAutoExpand({
     textareaRef: chatInputRef,
     dependencies: [placeholder, isStacked],
   })
+  const { updateScrollHeight } = autoExpand
+
+  // Recalculate height once when width first becomes available (ResizeObserver is async).
+  useEffect(() => {
+    if (width > 0 && !hasInitializedWithWidthRef.current) {
+      hasInitializedWithWidthRef.current = true
+      updateScrollHeight()
+    }
+  }, [width, updateScrollHeight])
 
   // Cache font string and available width for text measurement
   // These values only change on mount or resize, not on every keystroke
@@ -680,7 +693,7 @@ function ChatInput({
     }
 
     setValue(targetValue)
-    autoExpand.updateScrollHeight()
+    updateScrollHeight()
 
     // Clear recording error when user starts typing
     if (recordingError) {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -174,8 +174,12 @@ const TextArea: FC<Props> = ({
   } = useTextInputAutoExpand({
     textareaRef,
     // Recalculate height when placeholder or displayed value changes.
-    // uiValue is used instead of value to ensure height updates during typing and after blur.
-    dependencies: [element.placeholder, uiValue],
+    // When isAutoHeight is true, use uiValue to ensure height updates during typing and after blur.
+    // When isAutoHeight is false, the effect only needs to run when value changes (less frequent).
+    dependencies: [
+      element.placeholder,
+      ...(isAutoHeight ? [uiValue] : [value]),
+    ],
   })
 
   // Recalculate height once when width first becomes available (ResizeObserver is async).

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -18,8 +18,8 @@ import {
   FC,
   memo,
   useCallback,
-  useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react"
@@ -180,12 +180,13 @@ const TextArea: FC<Props> = ({
 
   // Recalculate height once when width first becomes available (ResizeObserver is async).
   // We don't include width in dependencies above to avoid overriding manual user resizes.
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!isAutoHeight) return
     if (width > 0 && !hasInitializedWithWidthRef.current) {
       hasInitializedWithWidthRef.current = true
       updateScrollHeight()
     }
-  }, [width, updateScrollHeight])
+  }, [isAutoHeight, width, updateScrollHeight])
 
   const commitWidgetValue = useCallback((): void => {
     setDirty(false)

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { FC, memo, useCallback, useId, useRef, useState } from "react"
+import {
+  FC,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 
@@ -155,15 +163,29 @@ const TextArea: FC<Props> = ({
 
   const theme = useEmotionTheme()
 
+  // Track if we've done the initial height calculation with a valid width.
+  // This prevents recalculating on every window resize, which would override manual user resizes.
+  const hasInitializedWithWidthRef = useRef(false)
+
   const {
     height: autoExpandHeight,
     maxHeight: autoExpandMaxHeight,
     updateScrollHeight,
   } = useTextInputAutoExpand({
     textareaRef,
-    // Recalculate height when placeholder or committed value changes
-    dependencies: [element.placeholder, value],
+    // Recalculate height when placeholder or displayed value changes.
+    // uiValue is used instead of value to ensure height updates during typing and after blur.
+    dependencies: [element.placeholder, uiValue],
   })
+
+  // Recalculate height once when width first becomes available (ResizeObserver is async).
+  // We don't include width in dependencies above to avoid overriding manual user resizes.
+  useEffect(() => {
+    if (width > 0 && !hasInitializedWithWidthRef.current) {
+      hasInitializedWithWidthRef.current = true
+      updateScrollHeight()
+    }
+  }, [width, updateScrollHeight])
 
   const commitWidgetValue = useCallback((): void => {
     setDirty(false)


### PR DESCRIPTION
## Describe your changes

Fixes `st.text_area(height="content")` auto-expansion behavior:

- **Initial load sizing**: Height now calculates correctly after ResizeObserver provides the actual width (was 0 on first render)
- **Blur height preservation**: Uses `uiValue` instead of `value` in dependencies so height updates during typing and doesn't shrink after blur
- **Manual resize preservation**: Tracks width initialization with a ref to avoid overriding user manual resizes when window resizes

Applies the same fix pattern to `ChatInput` for consistency.

## GitHub Issue Link (if applicable)

- Closes #14876

## Testing Plan

- [x] Existing E2E tests: `test_text_area_content_height_expansion`, `test_text_area_content_height_default_value`
- [x] Unit tests for TextArea and ChatInput components (68 tests passing)
- [x] Manual testing via `make debug` demo app

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | debugging-streamlit | 1 |
| skill | qa-testing-feature | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->