### PR TITLE
Port cortex-code-skills performance.md updates to developing-with-streamlit skill

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -154,9 +154,9 @@ By default, layout containers like `st.tabs`, `st.expander`, and `st.popover` al
 
 `st.tabs` renders ALL tab content on every rerun, even hidden tabs. Two fixes:
 
-**Preferred (Streamlit 1.55+): Dynamic tabs with `on_change="ignore"`**
+**Preferred (Streamlit 1.55+): Dynamic tabs with `on_change="rerun"`**
 
-Keep the tabs UX. Setting `on_change="ignore"` makes tabs lazy — only the visible tab's content renders.
+Keep the tabs UX. Setting `on_change="rerun"` makes tabs dynamic — each tab's `.open` property returns `True` for the selected tab and `False` otherwise, so you can guard expensive work. (With the default `on_change="ignore"`, all tab content runs on every rerun and `.open` is `None` for every tab.)
 
 ```python
 # BAD: Heavy content loads even when tab not visible
@@ -165,11 +165,13 @@ with tab2:
     expensive_chart()  # Always computed!
 
 # GOOD: Dynamic tabs — only visible tab content renders
-tab1, tab2 = st.tabs(["Light", "Heavy"], on_change="ignore")
-with tab1:
-    light_overview()
-with tab2:
-    expensive_chart()  # Only computed when this tab is visible
+tab1, tab2 = st.tabs(["Light", "Heavy"], on_change="rerun")
+if tab1.open:
+    with tab1:
+        light_overview()
+if tab2.open:
+    with tab2:
+        expensive_chart()  # Only computed when this tab is visible
 ```
 
 **Alternative: Replace with `st.segmented_control` + conditional**
@@ -190,6 +192,8 @@ elif view == "Heavy":
 `st.expander` renders content even when collapsed. Two fixes:
 
 **Preferred (Streamlit 1.55+): Dynamic expander with `on_change="rerun"`**
+
+With `on_change="rerun"`, the `.open` property returns `True` when the expander is open and `False` when collapsed, so you can guard expensive work. (Without `on_change`, `.open` is `None` and all content runs regardless.)
 
 ```python
 # BAD: Expander content always loads

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -148,34 +148,68 @@ with st.form("search", border=False):
 
 **This is critical and often missed.**
 
-By default, layout containers like `st.tabs` and `st.expander` render all their content, even when hidden or collapsed. Use `on_change="rerun"` to enable lazy rendering — content only runs when the tab/expander is visible:
+By default, layout containers like `st.tabs`, `st.expander`, and `st.popover` always render all their content, even when hidden or collapsed.
+
+### Tabs with expensive content
+
+`st.tabs` renders ALL tab content on every rerun, even hidden tabs. Two fixes:
+
+**Preferred (Streamlit 1.55+): Dynamic tabs with `on_change="ignore"`**
+
+Keep the tabs UX. Setting `on_change="ignore"` makes tabs lazy — only the visible tab's content renders.
 
 ```python
-# BAD: All tab content loads, even hidden tabs
+# BAD: Heavy content loads even when tab not visible
 tab1, tab2 = st.tabs(["Light", "Heavy"])
 with tab2:
     expensive_chart()  # Always computed!
 
-# GOOD: Only render when tab is active
-tab1, tab2 = st.tabs(["Light", "Heavy"], on_change="rerun")
-if tab2.open:
-    with tab2:
-        expensive_chart()  # Only computed when selected
+# GOOD: Dynamic tabs — only visible tab content renders
+tab1, tab2 = st.tabs(["Light", "Heavy"], on_change="ignore")
+with tab1:
+    light_overview()
+with tab2:
+    expensive_chart()  # Only computed when this tab is visible
 ```
+
+**Alternative: Replace with `st.segmented_control` + conditional**
+
+Swap the tabs widget entirely for a segmented control with explicit if/elif.
+
+```python
+# GOOD: Content only loads when selected
+view = st.segmented_control("View", ["Light", "Heavy"])
+if view == "Light":
+    light_overview()
+elif view == "Heavy":
+    expensive_chart()  # Only computed when selected
+```
+
+### Expanders with expensive content
+
+`st.expander` renders content even when collapsed. Two fixes:
+
+**Preferred (Streamlit 1.55+): Dynamic expander with `on_change="rerun"`**
 
 ```python
 # BAD: Expander content always loads
 with st.expander("Advanced options"):
     heavy_computation()  # Runs even when collapsed!
 
-# GOOD: Only render when expander is open
-details = st.expander("Advanced options", on_change="rerun")
-if details.open:
-    with details:
+# GOOD: Dynamic expander — content only renders when open
+exp = st.expander("Advanced options", on_change="rerun")
+if exp.open:
+    with exp:
         heavy_computation()  # Only runs when expanded
 ```
 
-The `.open` property returns `True` when visible, `False` when hidden, or `None` when `on_change` is not set.
+**Alternative: Replace with `st.toggle` + conditional**
+
+```python
+# GOOD: Toggle controls loading
+if st.toggle("Show advanced options"):
+    heavy_computation()  # Only runs when toggled on
+```
 
 ## Pre-computation
 


### PR DESCRIPTION
## Summary

Mirrors the `references/performance.md` updates from two cortex-code-skills PRs into the `developing-with-streamlit` skill bundled in this repo at `lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md`.

Source PRs:
- snowflake-eng/cortex-code-skills#1528 — *Fix tabs-to-segmented eval: use actual st.tabs anti-pattern as starting point*
- snowflake-eng/cortex-code-skills#1529 — *Fix expander-to-toggle eval: accept on_change="rerun", AST assertions, broken app fix*

## What changed

The *Conditional rendering* section is restructured to match the cortex-code-skills version:

- Split into **Tabs with expensive content** and **Expanders with expensive content** subsections
- Each subsection documents a **Preferred** (`on_change` parameter) and an **Alternative** (`st.segmented_control` or `st.toggle`) fix
- Adds `st.popover` to the list of layout containers that always render
- Notes the Streamlit 1.55+ requirement for the `on_change` patterns

No other sections of `performance.md` were touched by the two source PRs, so the rest of the file is unchanged.

## Test plan

- [x] Skill file renders as valid Markdown
- [x] Diff limited to the Conditional rendering section