### PR TITLE
fix: text_area height=content not working on initial load

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -217,10 +217,23 @@ function ChatInput({
     }
   }, [])
 
+  // Track if we've done the initial height calculation with a valid width.
+  // This prevents recalculating on every window resize, which would override manual user resizes.
+  const hasInitializedWithWidthRef = useRef(false)
+
   const autoExpand = useTextInputAutoExpand({
     textareaRef: chatInputRef,
     dependencies: [placeholder, isStacked],
   })
+  const { updateScrollHeight } = autoExpand
+
+  // Recalculate height once when width first becomes available (ResizeObserver is async).
+  useEffect(() => {
+    if (width > 0 && !hasInitializedWithWidthRef.current) {
+      hasInitializedWithWidthRef.current = true
+      updateScrollHeight()
+    }
+  }, [width, updateScrollHeight])
 
   // Cache font string and available width for text measurement
   // These values only change on mount or resize, not on every keystroke
@@ -680,7 +693,7 @@ function ChatInput({
     }
 
     setValue(targetValue)
-    autoExpand.updateScrollHeight()
+    updateScrollHeight()
 
     // Clear recording error when user starts typing
     if (recordingError) {

--- a/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
+++ b/frontend/lib/src/components/widgets/TextArea/TextArea.tsx
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { FC, memo, useCallback, useId, useRef, useState } from "react"
+import {
+  FC,
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react"
 
 import { Textarea as UITextArea } from "baseui/textarea"
 
@@ -155,15 +163,29 @@ const TextArea: FC<Props> = ({
 
   const theme = useEmotionTheme()
 
+  // Track if we've done the initial height calculation with a valid width.
+  // This prevents recalculating on every window resize, which would override manual user resizes.
+  const hasInitializedWithWidthRef = useRef(false)
+
   const {
     height: autoExpandHeight,
     maxHeight: autoExpandMaxHeight,
     updateScrollHeight,
   } = useTextInputAutoExpand({
     textareaRef,
-    // Recalculate height when placeholder or committed value changes
-    dependencies: [element.placeholder, value],
+    // Recalculate height when placeholder or displayed value changes.
+    // uiValue is used instead of value to ensure height updates during typing and after blur.
+    dependencies: [element.placeholder, uiValue],
   })
+
+  // Recalculate height once when width first becomes available (ResizeObserver is async).
+  // We don't include width in dependencies above to avoid overriding manual user resizes.
+  useEffect(() => {
+    if (width > 0 && !hasInitializedWithWidthRef.current) {
+      hasInitializedWithWidthRef.current = true
+      updateScrollHeight()
+    }
+  }, [width, updateScrollHeight])
 
   const commitWidgetValue = useCallback((): void => {
     setDirty(false)


### PR DESCRIPTION
## Summary
- Fixes `st.text_area` with `height="content"` not rendering correctly on initial load
- Also applies the same fix to `st.chat_input` auto-expansion

## Root Cause
The `ResizeObserver` used by `useCalculatedDimensions` is async - on first render, `width` is -1 (not yet measured). The `useTextInputAutoExpand` hook measures `scrollHeight` during initial layout effects, but at that point the textarea has no valid width, so `scrollHeight` returns an incorrect minimal value.

## Fix
- Add a `useEffect` that recalculates height once when `width` first becomes > 0
- Track initialization with a ref to avoid overriding manual user resizes on subsequent ResizeObserver callbacks
- In `TextArea`, use `uiValue` instead of `value` in auto-expand dependencies so height updates during typing and after blur

## Test plan
- [x] `make check` passes (format, lint, types, unit tests)
- [ ] Manual test: `st.text_area(label="example", value=<long text>, height="content")` renders at correct height on initial load
- [ ] Manual test: switching between `st.text_area` and `cols[0].text_area` still works

Closes #14876

🤖 Generated with [Claude Code](https://claude.com/claude-code)