### PR TITLE
Pin pyarrow<24 to fix Python 3.14 CI builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = []
 required-version = ">=0.9.0"
 # Exclude packages published in the last 24 hours to lower risk from supply chain attacks
 exclude-newer = "24 hours"
+# Prevent building pyarrow from source - it always provides pre-built wheels,
+# and source builds require the Arrow C++ library which isn't available in CI.
+no-build-package = ["pyarrow"]
 # Explicit pandas version constraints by Python version:
 # - Python 3.10: use pandas 2.x (pandas 3.x requires Python >= 3.11)
 # - Python 3.11+: use pandas 3.x


### PR DESCRIPTION
## Summary
- Adds `no-build-package = ["pyarrow"]` to uv config to prevent building pyarrow from source
- Fixes CI failure where uv attempts to build pyarrow 24.0.0 from source on Python 3.14, which fails due to missing Arrow C++ library

## Why this approach?
pyarrow always provides pre-built wheels for all supported Python versions and platforms. There's no legitimate reason to build it from source in CI.

This is preferable to pinning pyarrow version because:
- No maintenance burden of tracking pyarrow releases  
- Will fail explicitly if no compatible wheel exists (clear error vs confusing cmake failure)
- Allows users to install newer pyarrow versions

## Root cause investigation
The issue appears to be related to uv's `exclude-newer = "24 hours"` setting combined with newly released pyarrow 24.0.0. Despite cp314 wheels being available, uv falls back to source build. This may be a uv bug worth reporting upstream.

## Test plan
- [ ] CI passes on Python 3.14