### PR TITLE
Add browser.command config option to specify custom browser executable

### DIFF
--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -57,12 +57,23 @@ def _open_browser_with_webbrowser(url: str) -> None:
     webbrowser.open(url)
 
 
-def _open_browser_with_command(command: str, url: str) -> None:
-    cmd_line = [command, url]
-    with open(os.devnull, "w", encoding="utf-8") as devnull:
-        import subprocess  # noqa: S404
+def _open_browser_with_command(
+    command: str, url: str, extra_args: list[str] | None = None
+) -> None:
+    import subprocess  # noqa: S404
 
-        subprocess.Popen(cmd_line, stdout=devnull, stderr=subprocess.STDOUT)  # noqa: S603
+    cmd_line = [command, *(extra_args or []), url]
+    try:
+        with open(os.devnull, "w", encoding="utf-8") as devnull:
+            subprocess.Popen(cmd_line, stdout=devnull, stderr=subprocess.STDOUT)  # noqa: S603
+    except FileNotFoundError:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Could not find browser command %r. Falling back to default browser.",
+            command,
+        )
+        _open_browser_with_webbrowser(url)
 
 
 def open_browser(url: str) -> None:
@@ -84,7 +95,10 @@ def open_browser(url: str) -> None:
 
     browser_command = config.get_option("browser.command")
     if browser_command:
-        _open_browser_with_command(browser_command, url)
+        if env_util.IS_DARWIN and not os.path.isabs(browser_command):
+            _open_browser_with_command("open", url, extra_args=["-a", browser_command])
+        else:
+            _open_browser_with_command(browser_command, url)
         return
 
     # Treat Windows separately because:

--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -77,6 +77,29 @@ def open_browser(url: str) -> None:
         The URL. Must include the protocol.
 
     """
+    # If the user has configured a specific browser command, use it directly
+    # via subprocess rather than webbrowser.get(), which only accepts
+    # registered browser type names and not arbitrary executable paths.
+    from streamlit import config
+
+    browser_command = config.get_option("browser.command")
+    if browser_command:
+        import subprocess
+        import sys
+
+        if sys.platform == "win32":
+            subprocess.Popen(
+                [browser_command, url],
+                shell=True,
+            )
+        else:
+            subprocess.Popen(
+                [browser_command, url],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        return
+
     # Treat Windows separately because:
     # 1. /dev/null doesn't exist.
     # 2. subprocess.Popen(['start', url]) doesn't actually pop up the

--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -77,27 +77,14 @@ def open_browser(url: str) -> None:
         The URL. Must include the protocol.
 
     """
-    # If the user has configured a specific browser command, use it directly
-    # via subprocess rather than webbrowser.get(), which only accepts
-    # registered browser type names and not arbitrary executable paths.
+    # If the user has configured a specific browser command, launch it via
+    # subprocess. We use subprocess (not webbrowser.get) because webbrowser.get
+    # only accepts registered browser type names, not arbitrary executable paths.
     from streamlit import config
 
     browser_command = config.get_option("browser.command")
     if browser_command:
-        import subprocess
-        import sys
-
-        if sys.platform == "win32":
-            subprocess.Popen(
-                [browser_command, url],
-                shell=True,
-            )
-        else:
-            subprocess.Popen(
-                [browser_command, url],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
+        _open_browser_with_command(browser_command, url)
         return
 
     # Treat Windows separately because:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1131,7 +1131,8 @@ _create_option(
         - Windows: "chrome"
         - WSL: "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
 
-        If not set, Streamlit will use the default browser for the OS.
+        If this is an empty string (default), Streamlit uses the default
+        browser for the OS.
     """,
     default_val="",
     type_=str,

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1120,6 +1120,24 @@ _create_option(
 )
 
 
+_create_option(
+    "browser.command",
+    description="""
+        The browser executable to use when opening URLs. This should be
+        a command name on your PATH or a full path to the browser binary.
+        Examples:
+        - macOS: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        - Linux: "google-chrome" or "firefox"
+        - Windows: "chrome"
+        - WSL: "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+
+        If not set, Streamlit will use the default browser for the OS.
+    """,
+    default_val="",
+    type_=str,
+)
+
+
 @_create_option("browser.serverPort", type_=int)
 def _browser_server_port() -> int:
     """Port where users should point their browsers in order to connect to the

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -30,48 +30,75 @@ class CliUtilTest(unittest.TestCase):
     )
     def test_open_browser(self, os_type, webbrowser_expect, popen_expect):
         """Test web browser opening scenarios."""
-        with patch.object(env_util, "IS_WINDOWS", os_type == "Windows"), \
-             patch.object(env_util, "IS_DARWIN", os_type == "Darwin"), \
-             patch.object(env_util, "IS_LINUX_OR_BSD", os_type == "Linux"):
-            with patch("streamlit.env_util.is_executable_in_path", return_value=True):
-                with patch("webbrowser.open") as webbrowser_open:
-                    with patch("subprocess.Popen") as subprocess_popen:
-                        open_browser("http://some-url")
-                        assert webbrowser_expect == webbrowser_open.called
-                        assert popen_expect == subprocess_popen.called
+        with (
+            patch.object(env_util, "IS_WINDOWS", os_type == "Windows"),
+            patch.object(env_util, "IS_DARWIN", os_type == "Darwin"),
+            patch.object(env_util, "IS_LINUX_OR_BSD", os_type == "Linux"),
+            patch_config_options({"browser.command": ""}),
+            patch("streamlit.env_util.is_executable_in_path", return_value=True),
+            patch("webbrowser.open") as webbrowser_open,
+            patch("subprocess.Popen") as subprocess_popen,
+        ):
+            open_browser("http://some-url")
+            assert webbrowser_expect == webbrowser_open.called
+            assert popen_expect == subprocess_popen.called
 
     def test_open_browser_linux_no_xdg(self):
-        """Test opening the browser on Linux with no xdg installed"""
-        with patch.object(env_util, "IS_LINUX_OR_BSD", True), \
-             patch.object(env_util, "IS_WINDOWS", False), \
-             patch.object(env_util, "IS_DARWIN", False):
-            with patch("streamlit.env_util.is_executable_in_path", return_value=False):
-                with patch("webbrowser.open") as webbrowser_open:
-                    with patch("subprocess.Popen") as subprocess_popen:
-                        open_browser("http://some-url")
-                        assert webbrowser_open.called
-                        assert not subprocess_popen.called
+        """Test opening the browser on Linux with no xdg installed."""
+        with (
+            patch.object(env_util, "IS_LINUX_OR_BSD", True),
+            patch.object(env_util, "IS_WINDOWS", False),
+            patch.object(env_util, "IS_DARWIN", False),
+            patch_config_options({"browser.command": ""}),
+            patch("streamlit.env_util.is_executable_in_path", return_value=False),
+            patch("webbrowser.open") as webbrowser_open,
+            patch("subprocess.Popen") as subprocess_popen,
+        ):
+            open_browser("http://some-url")
+            assert webbrowser_open.called
+            assert not subprocess_popen.called
 
     def test_open_browser_with_browser_command(self):
         """When browser.command is set, open_browser launches subprocess directly."""
-        with patch_config_options({"browser.command": "/usr/bin/firefox"}):
-            with patch("subprocess.Popen") as subprocess_popen:
-                open_browser("http://some-url")
+        with (
+            patch_config_options({"browser.command": "/usr/bin/firefox"}),
+            patch("subprocess.Popen") as subprocess_popen,
+        ):
+            open_browser("http://some-url")
 
-                subprocess_popen.assert_called_once()
-                args = subprocess_popen.call_args[0][0]
-                assert args == ["/usr/bin/firefox", "http://some-url"]
+            subprocess_popen.assert_called_once()
+            args = subprocess_popen.call_args[0][0]
+            assert args == ["/usr/bin/firefox", "http://some-url"]
+
+    def test_open_browser_with_browser_command_on_windows(self):
+        """browser.command overrides the Windows webbrowser fallback."""
+        with (
+            patch.object(env_util, "IS_WINDOWS", True),
+            patch.object(env_util, "IS_DARWIN", False),
+            patch.object(env_util, "IS_LINUX_OR_BSD", False),
+            patch_config_options({"browser.command": "chrome"}),
+            patch("webbrowser.open") as webbrowser_open,
+            patch("subprocess.Popen") as subprocess_popen,
+        ):
+            open_browser("http://some-url")
+
+            assert not webbrowser_open.called
+            subprocess_popen.assert_called_once()
+            args = subprocess_popen.call_args[0][0]
+            assert args == ["chrome", "http://some-url"]
 
     def test_open_browser_command_not_set_uses_default(self):
         """When browser.command is empty, the OS default mechanism is used."""
-        with patch.object(env_util, "IS_LINUX_OR_BSD", True), \
-             patch.object(env_util, "IS_WINDOWS", False), \
-             patch.object(env_util, "IS_DARWIN", False):
-            with patch_config_options({"browser.command": ""}):
-                with patch("streamlit.env_util.is_executable_in_path", return_value=True):
-                    with patch("subprocess.Popen") as subprocess_popen:
-                        open_browser("http://some-url")
+        with (
+            patch.object(env_util, "IS_LINUX_OR_BSD", True),
+            patch.object(env_util, "IS_WINDOWS", False),
+            patch.object(env_util, "IS_DARWIN", False),
+            patch_config_options({"browser.command": ""}),
+            patch("streamlit.env_util.is_executable_in_path", return_value=True),
+            patch("subprocess.Popen") as subprocess_popen,
+        ):
+            open_browser("http://some-url")
 
-                        subprocess_popen.assert_called_once()
-                        args = subprocess_popen.call_args[0][0]
-                        assert args[0] == "xdg-open"
+            subprocess_popen.assert_called_once()
+            args = subprocess_popen.call_args[0][0]
+            assert args[0] == "xdg-open"

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -19,7 +19,9 @@ from unittest.mock import patch
 
 from parameterized import parameterized
 
+from streamlit import env_util
 from streamlit.cli_util import open_browser
+from streamlit.testing.v1.util import patch_config_options
 
 
 class CliUtilTest(unittest.TestCase):
@@ -28,28 +30,48 @@ class CliUtilTest(unittest.TestCase):
     )
     def test_open_browser(self, os_type, webbrowser_expect, popen_expect):
         """Test web browser opening scenarios."""
-        from streamlit import env_util
-
-        env_util.IS_WINDOWS = os_type == "Windows"
-        env_util.IS_DARWIN = os_type == "Darwin"
-        env_util.IS_LINUX_OR_BSD = os_type == "Linux"
-
-        with patch("streamlit.env_util.is_executable_in_path", return_value=True):
-            with patch("webbrowser.open") as webbrowser_open:
-                with patch("subprocess.Popen") as subprocess_popen:
-                    open_browser("http://some-url")
-                    assert webbrowser_expect == webbrowser_open.called
-                    assert popen_expect == subprocess_popen.called
+        with patch.object(env_util, "IS_WINDOWS", os_type == "Windows"), \
+             patch.object(env_util, "IS_DARWIN", os_type == "Darwin"), \
+             patch.object(env_util, "IS_LINUX_OR_BSD", os_type == "Linux"):
+            with patch("streamlit.env_util.is_executable_in_path", return_value=True):
+                with patch("webbrowser.open") as webbrowser_open:
+                    with patch("subprocess.Popen") as subprocess_popen:
+                        open_browser("http://some-url")
+                        assert webbrowser_expect == webbrowser_open.called
+                        assert popen_expect == subprocess_popen.called
 
     def test_open_browser_linux_no_xdg(self):
         """Test opening the browser on Linux with no xdg installed"""
-        from streamlit import env_util
+        with patch.object(env_util, "IS_LINUX_OR_BSD", True), \
+             patch.object(env_util, "IS_WINDOWS", False), \
+             patch.object(env_util, "IS_DARWIN", False):
+            with patch("streamlit.env_util.is_executable_in_path", return_value=False):
+                with patch("webbrowser.open") as webbrowser_open:
+                    with patch("subprocess.Popen") as subprocess_popen:
+                        open_browser("http://some-url")
+                        assert webbrowser_open.called
+                        assert not subprocess_popen.called
 
-        env_util.IS_LINUX_OR_BSD = True
+    def test_open_browser_with_browser_command(self):
+        """When browser.command is set, open_browser launches subprocess directly."""
+        with patch_config_options({"browser.command": "/usr/bin/firefox"}):
+            with patch("subprocess.Popen") as subprocess_popen:
+                open_browser("http://some-url")
 
-        with patch("streamlit.env_util.is_executable_in_path", return_value=False):
-            with patch("webbrowser.open") as webbrowser_open:
-                with patch("subprocess.Popen") as subprocess_popen:
-                    open_browser("http://some-url")
-                    assert webbrowser_open.called
-                    assert not subprocess_popen.called
+                subprocess_popen.assert_called_once()
+                args = subprocess_popen.call_args[0][0]
+                assert args == ["/usr/bin/firefox", "http://some-url"]
+
+    def test_open_browser_command_not_set_uses_default(self):
+        """When browser.command is empty, the OS default mechanism is used."""
+        with patch.object(env_util, "IS_LINUX_OR_BSD", True), \
+             patch.object(env_util, "IS_WINDOWS", False), \
+             patch.object(env_util, "IS_DARWIN", False):
+            with patch_config_options({"browser.command": ""}):
+                with patch("streamlit.env_util.is_executable_in_path", return_value=True):
+                    with patch("subprocess.Popen") as subprocess_popen:
+                        open_browser("http://some-url")
+
+                        subprocess_popen.assert_called_once()
+                        args = subprocess_popen.call_args[0][0]
+                        assert args[0] == "xdg-open"

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -102,3 +102,27 @@ class CliUtilTest(unittest.TestCase):
             subprocess_popen.assert_called_once()
             args = subprocess_popen.call_args[0][0]
             assert args[0] == "xdg-open"
+
+    def test_open_browser_command_not_found_falls_back(self):
+        """When browser.command is invalid, fall back to webbrowser."""
+        with (
+            patch_config_options({"browser.command": "/nonexistent/browser"}),
+            patch.object(env_util, "IS_DARWIN", False),
+            patch("subprocess.Popen", side_effect=FileNotFoundError),
+            patch("webbrowser.open") as webbrowser_open,
+        ):
+            open_browser("http://some-url")
+            assert webbrowser_open.called
+
+    def test_open_browser_command_macos_relative_uses_open(self):
+        """On macOS, a relative browser.command uses 'open -a'."""
+        with (
+            patch.object(env_util, "IS_DARWIN", True),
+            patch_config_options({"browser.command": "Google Chrome"}),
+            patch("subprocess.Popen") as subprocess_popen,
+        ):
+            open_browser("http://some-url")
+
+            subprocess_popen.assert_called_once()
+            args = subprocess_popen.call_args[0][0]
+            assert args == ["open", "-a", "Google Chrome", "http://some-url"]

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -735,6 +735,7 @@ class ConfigTest(unittest.TestCase):
 
         config_options = sorted(
             [
+                "browser.command",
                 "browser.gatherUsageStats",
                 "browser.serverAddress",
                 "browser.serverPort",


### PR DESCRIPTION
## Describe your changes

Adds a `browser.command` configuration option that lets users specify a custom browser executable when Streamlit opens a new tab on startup.

When `browser.command` is set, `open_browser` reuses the existing `_open_browser_with_command` helper (which already wraps `subprocess.Popen` with stdout/stderr suppression and the appropriate security annotations), so the custom-browser branch is portable across platforms and doesn't duplicate logic. Examples of supported values:

- `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` (macOS)
- `google-chrome` (Linux)
- `chrome` (Windows)
- `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` (WSL)

When the option is an empty string (the default), behavior is unchanged — the existing OS-detection logic runs.

The lazy import (`from streamlit import config` inside the function body) avoids the circular import chain that exists between `cli_util`, `config_util`, and `config` at module load time.

## GitHub Issue Link

Closes #637

## Testing Plan

**Unit Tests (Python)**

`lib/tests/streamlit/cli_util_test.py`:

- `test_open_browser_with_browser_command` — verifies `subprocess.Popen` is called with the configured command on the non-Windows default branch
- `test_open_browser_with_browser_command_on_windows` — verifies the custom command overrides the Windows `webbrowser` fallback
- `test_open_browser_command_not_set_uses_default` — verifies that when `browser.command` is `""`, the existing OS-detection logic runs as before
- Existing `test_open_browser` and `test_open_browser_linux_no_xdg` now explicitly patch `browser.command=""` so they don't depend on the real user config.

`lib/tests/streamlit/config_test.py`:

- `test_config_option_keys` updated to include the new `browser.command` key.