### PR TITLE
feat(host-comm): add PRINT_APP host-to-guest postMessage type

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4647,6 +4647,18 @@ describe("App", () => {
       })
     })
 
+    it("calls window.print when PRINT_APP window message has been received", () => {
+      const printSpy = vi.spyOn(window, "print").mockImplementation(() => {})
+      prepareHostCommunicationManager()
+
+      fireWindowPostMessage({
+        type: "PRINT_APP",
+      })
+
+      expect(printSpy).toHaveBeenCalledTimes(1)
+      printSpy.mockRestore()
+    })
+
     it("fires appHeartbeat BackMsg when SEND_APP_HEARTBEAT window message has been received", () => {
       prepareHostCommunicationManager()
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4649,14 +4649,17 @@ describe("App", () => {
 
     it("calls window.print when PRINT_APP window message has been received", () => {
       const printSpy = vi.spyOn(window, "print").mockImplementation(() => {})
-      prepareHostCommunicationManager()
+      try {
+        prepareHostCommunicationManager()
 
-      fireWindowPostMessage({
-        type: "PRINT_APP",
-      })
+        fireWindowPostMessage({
+          type: "PRINT_APP",
+        })
 
-      expect(printSpy).toHaveBeenCalledTimes(1)
-      printSpy.mockRestore()
+        expect(printSpy).toHaveBeenCalledTimes(1)
+      } finally {
+        printSpy.mockRestore()
+      }
     })
 
     it("fires appHeartbeat BackMsg when SEND_APP_HEARTBEAT window message has been received", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -428,6 +428,7 @@ export class App extends PureComponent<Props, State> {
         this.connectionManager?.disconnect()
         this.connectionManager = null
       },
+      printApp: this.printCallback,
     })
 
     this.endpoints = new DefaultStreamlitEndpoints({

--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -112,6 +112,7 @@ describe("AppNavigation", () => {
       deployedAppMetadataChanged: () => {},
       restartWebsocketConnection: () => {},
       terminateWebsocketConnection: () => {},
+      printApp: () => {},
       streamlitExecutionStartedAt: 0,
       fileUploadClientConfigChanged: () => {},
     })

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -93,6 +93,7 @@ describe("HostCommunicationManager messaging", () => {
       deployedAppMetadataChanged: vi.fn(),
       restartWebsocketConnection: vi.fn(),
       terminateWebsocketConnection: vi.fn(),
+      printApp: vi.fn(),
     })
 
     originalHash = window.location.hash
@@ -224,6 +225,22 @@ describe("HostCommunicationManager messaging", () => {
 
     // @ts-expect-error - props are private
     expect(hostCommunicationMgr.props.clearCache).toHaveBeenCalled()
+  })
+
+  it("can process a received PRINT_APP message", () => {
+    dispatchEvent(
+      "message",
+      new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "PRINT_APP",
+        },
+        origin: "https://devel.streamlit.test",
+      })
+    )
+
+    // @ts-expect-error - props are private
+    expect(hostCommunicationMgr.props.printApp).toHaveBeenCalled()
   })
 
   it("can process a received REQUEST_PAGE_CHANGE message", () => {
@@ -654,6 +671,7 @@ describe("Test different origins", () => {
       deployedAppMetadataChanged: vi.fn(),
       restartWebsocketConnection: vi.fn(),
       terminateWebsocketConnection: vi.fn(),
+      printApp: vi.fn(),
     })
     ;({ dispatchEvent } = mockEventListeners())
   })
@@ -752,6 +770,7 @@ describe("HostCommunicationManager external auth token handling", () => {
       deployedAppMetadataChanged: vi.fn(),
       restartWebsocketConnection: vi.fn(),
       terminateWebsocketConnection: vi.fn(),
+      printApp: vi.fn(),
     })
   })
 

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -66,6 +66,7 @@ interface HostCommunicationProps {
   ) => void
   readonly restartWebsocketConnection: () => void
   readonly terminateWebsocketConnection: () => void
+  readonly printApp: () => void
 }
 
 /**
@@ -300,6 +301,10 @@ export default class HostCommunicationManager {
 
     if (message.type === "TERMINATE_WEBSOCKET_CONNECTION") {
       this.props.terminateWebsocketConnection()
+    }
+
+    if (message.type === "PRINT_APP") {
+      this.props.printApp()
     }
   }
 }

--- a/frontend/lib/src/hostComm/types.ts
+++ b/frontend/lib/src/hostComm/types.ts
@@ -176,6 +176,9 @@ export type IHostToGuestMessage = {
       prefix: string
       headers: Record<string, string>
     }
+  | {
+      type: "PRINT_APP"
+    }
 )
 
 export type IGuestToHostMessage =


### PR DESCRIPTION
## Describe your changes

Adds a new `PRINT_APP` message to the host-to-guest postMessage protocol, allowing an embedding host frame to programmatically trigger the browser print dialog on the Streamlit app.

When a parent frame sends:
```
  window.parent.postMessage({
    stCommVersion: 1,
    type: "PRINT_APP",
  }, targetOrigin)
```
the app invokes `printCallback`, which waits for the script to finish running (polls at 500ms intervals) then calls `window.print()` — or `iframe.contentWindow.print()` if the app is itself embedded in an iframe.

- types.ts: adds `PRINT_APP` to `IHostToGuestMessage`
- HostCommunicationManager: adds `printApp` prop and dispatches it on receipt of the new message type
- App.tsx: wires `printApp: this.printCallback` into the manager
- Tests: unit test in HostCommunicationManager.test.tsx and integration test in App.test.tsx


## Screenshot or video (only for visual changes)

n/a

## GitHub Issue Link (if applicable)

## Testing Plan

This is hopefully a straight-forward enough that unit testing is sufficient.

- Unit Tests (JS and/or Python)
- Verify once using the outer iframe tester

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
