### PR TITLE
docs: fix typo in lib/streamlit/runtime/fragment.py

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -384,7 +384,7 @@ def fragment(
         height: 220px
 
     This next example demonstrates how elements both inside and outside of a
-    fragement update with each app or fragment rerun. In this app, clicking
+    fragment update with each app or fragment rerun. In this app, clicking
     "Rerun full app" will increment both counters and update all values
     displayed in the app. In contrast, clicking "Rerun fragment" will only
     increment the counter within the fragment. In this case, the ``st.write``


### PR DESCRIPTION
## Describe your changes

Fixes a typo: `fragement` → `fragment` in `lib/streamlit/runtime/fragment.py`.

## Screenshot or video (only for visual changes)

N/A.

## GitHub Issue Link (if applicable)

N/A — drive-by typo fix.

## Testing Plan

- Explanation of why no additional tests are needed: docs-only single-word change in a docstring.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.