### PR TITLE
docs: fix typo (coersion -> coercion) in options_selector_utils.py

### DIFF
--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -160,7 +160,7 @@ def _coerce_enum(from_enum_value: E1, to_enum_class: type[E2]) -> E1 | E2:
             f"Expected an EnumMeta/Type in the second argument. Got {type(to_enum_class)}"
         )
     if isinstance(from_enum_value, to_enum_class):
-        return from_enum_value  # Enum is already a member, no coersion necessary
+        return from_enum_value  # Enum is already a member, no coercion necessary
 
     coercion_type = config.get_option("runner.enumCoercion")
     if coercion_type not in _ALLOWED_ENUM_COERCION_CONFIG_SETTINGS:


### PR DESCRIPTION
## Description

Fixes a typo in a code comment in `lib/streamlit/elements/lib/options_selector_utils.py`:

> `# Enum is already a member, no coersion necessary`

→

> `# Enum is already a member, no coercion necessary`

The surrounding code already spells "coercion" correctly:
- `runner.enumCoercion` config option
- `coercion_type = config.get_option("runner.enumCoercion")`
- `_ALLOWED_ENUM_COERCION_CONFIG_SETTINGS`

Comment-only change, no behavioral impact.

## Verification

- `uv run ruff check lib/streamlit/elements/lib/options_selector_utils.py` → All checks passed
- `uv run ruff format --check lib/streamlit/elements/lib/options_selector_utils.py` → already formatted
- `uv run pytest lib/tests/streamlit/elements/lib/options_selector_utils_test.py` → 82 passed