### PR TITLE
fix: prevent scroll reset after closing st.dialog with custom components

### DIFF
--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -233,6 +233,30 @@ describe("ComponentInstance", () => {
     expect(iframe).toHaveAttribute("height", "0")
   })
 
+  it("uses visibility:hidden instead of display:none before component is ready", () => {
+    const componentRegistry = getComponentRegistry()
+    renderWithContexts(
+      <ComponentInstance
+        element={createElementProp()}
+        disabled={false}
+        widgetMgr={
+          new WidgetStateManager({
+            sendRerunBackMsg: vi.fn(),
+            formsDataChanged: vi.fn(),
+          })
+        }
+        componentRegistry={componentRegistry}
+      />
+    )
+
+    const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
+    // visibility:hidden keeps layout space, preventing scroll position resets
+    // during reruns (see issue #14917). display:none would remove the element
+    // from layout flow, causing reflows that reset the parent scroll position.
+    expect(iframe).toHaveStyle("visibility: hidden")
+    expect(iframe).not.toHaveStyle("display: none")
+  })
+
   it("will not displays a skeleton when height is explicitly set to 0", () => {
     const componentRegistry = getComponentRegistry()
     renderWithContexts(
@@ -323,6 +347,41 @@ describe("ComponentInstance", () => {
       )
       expect(screen.queryByTestId("stSkeleton")).not.toBeInTheDocument()
       expect(iframe).toHaveAttribute("height", "0")
+    })
+
+    it("sets iframe to visibility:visible after component is ready", () => {
+      const componentRegistry = getComponentRegistry()
+      renderWithContexts(
+        <ComponentInstance
+          element={createElementProp()}
+          disabled={false}
+          widgetMgr={
+            new WidgetStateManager({
+              sendRerunBackMsg: vi.fn(),
+              formsDataChanged: vi.fn(),
+            })
+          }
+          componentRegistry={componentRegistry}
+        />
+      )
+
+      const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
+      expect(iframe).toHaveStyle("visibility: hidden")
+
+      // SET COMPONENT_READY
+      fireEvent(
+        window,
+        new MessageEvent("message", {
+          data: {
+            isStreamlitMessage: true,
+            apiVersion: 1,
+            type: ComponentMessageType.COMPONENT_READY,
+          },
+          // @ts-expect-error
+          source: iframe.contentWindow,
+        })
+      )
+      expect(iframe).toHaveStyle("visibility: visible")
     })
 
     it("prevents RENDER message until component is ready", () => {

--- a/frontend/lib/src/components/widgets/CustomComponent/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CustomComponent/styled-components.ts
@@ -26,6 +26,6 @@ export const StyledComponentIframe = styled.iframe<StyledComponentIframeProps>(
     border: "none",
     padding: theme.spacing.none,
     margin: theme.spacing.none,
-    display: componentReady ? "initial" : "none",
+    visibility: componentReady ? "visible" : "hidden",
   })
 )


### PR DESCRIPTION
## Summary

Closes #14917.

- Replaces `display: none` with `visibility: hidden` on the custom component iframe while waiting for `COMPONENT_READY`
- `display: none` removes the element from layout flow, causing browser reflows that reset the parent `stMain` scroll position when the iframe toggles back to visible during reruns
- `visibility: hidden` preserves layout space, preventing the scroll reset
- This addresses both reported regressions (1.41.0 Firefox-only and 1.53.0 all-browsers) since both funnel through the same `display: none` toggle causing layout reflows

### Root cause

Two commits introduced the regression:

1. **`96241e135e`** (v1.41.0) — Migrated iframe styles from inline `style` to an Emotion styled component. Emotion's CSS class swapping on `display` triggers layout recalculations in Firefox.
2. **`5319def205`** (v1.53.0) — Added dialog identity checking that clears block children on ID mismatch, causing `ComponentInstance` to remount with `isReadyRef = false`, briefly applying `display: none` on both browsers.

### Why the fix is safe

The original `display: none` was added in PR #8179 as a cosmetic improvement to hide the iframe while the loading skeleton displays — it was not a correctness requirement (the iframe previously had no display toggling at all). With `visibility: hidden`:
- The iframe at height 0 (before `setFrameHeight`) takes zero visual space anyway
- The skeleton renders as a sibling and covers the same space regardless
- No pointer events reach the hidden iframe

## Test plan

- Added unit test verifying `visibility: hidden` (not `display: none`) before component is ready
- Added unit test verifying `visibility: visible` after `COMPONENT_READY`
- All 25 existing custom component tests continue to pass
- Manual verification: closing `st.dialog` opened from a custom component should preserve parent page scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)