### PR TITLE
Show hex color swatches in Markdown inline code, similar to GitHub

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1119,6 +1119,53 @@ describe("StreamlitMarkdown", () => {
       expect(markdown).not.toHaveClass("stMarkdownColoredBackground")
     })
   })
+
+  describe("hex color swatches in inline code", () => {
+    it.each([
+      ["3-digit hex", "`#f00`", "#f00"],
+      ["4-digit hex with alpha", "`#f008`", "#f008"],
+      ["6-digit hex", "`#ff0000`", "#ff0000"],
+      ["8-digit hex with alpha", "`#ff000080`", "#ff000080"],
+      ["uppercase hex", "`#FF0000`", "#FF0000"],
+      ["mixed-case hex", "`#Ff0000`", "#Ff0000"],
+    ])("renders color swatch for %s", (_label, source, hexColor) => {
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const swatch = document.querySelector(".stMarkdownHexColorSwatch")
+      expect(swatch).toBeInTheDocument()
+      expect(swatch).toHaveStyle({ "background-color": hexColor })
+      expect(swatch).toHaveAttribute("aria-hidden", "true")
+    })
+
+    it.each([
+      ["5-digit hex is invalid", "`#12345`"],
+      ["7-digit hex is invalid", "`#1234567`"],
+      ["non-hex text", "`not-a-color`"],
+      ["named color", "`red`"],
+      ["rgb() color", "`rgb(255,0,0)`"],
+    ])("does not render swatch for %s", (_label, source) => {
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const swatch = document.querySelector(".stMarkdownHexColorSwatch")
+      expect(swatch).not.toBeInTheDocument()
+    })
+
+    it("does not render swatch inside a code block (fenced)", () => {
+      render(
+        <StreamlitMarkdown
+          source={"```\n#ff0000\n```"}
+          allowHTML={false}
+        />
+      )
+      const swatch = document.querySelector(".stMarkdownHexColorSwatch")
+      expect(swatch).not.toBeInTheDocument()
+    })
+
+    it("renders the hex color text alongside the swatch", () => {
+      render(<StreamlitMarkdown source="`#ff0000`" allowHTML={false} />)
+      expect(screen.getByText("#ff0000")).toBeInTheDocument()
+      const swatch = document.querySelector(".stMarkdownHexColorSwatch")
+      expect(swatch).toBeInTheDocument()
+    })
+  })
 })
 
 const getCustomCodeTagProps = (

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -227,6 +227,46 @@ function rehypeSetCodeInlineProperty() {
   }
 }
 
+/** Matches valid CSS hex colors: #RGB, #RGBA, #RRGGBB, or #RRGGBBAA */
+const HEX_COLOR_REGEX =
+  /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/
+
+/**
+ * Rehype plugin that adds a color swatch before inline code elements
+ * containing a valid hex color (e.g., `#0969DA`), similar to GitHub's behavior.
+ */
+function createRehypeHexColorSwatch() {
+  return () => (tree: HastRoot) => {
+    visit(tree, "element", (node: Element, _index, parent) => {
+      if (node.tagName !== "code") return
+      // Skip code blocks (inline code has a non-<pre> parent)
+      if (parent?.type === "element" && (parent as Element).tagName === "pre") {
+        return
+      }
+
+      const textChild = node.children[0]
+      if (!textChild || textChild.type !== "text") return
+
+      const hexColor = textChild.value
+      if (!HEX_COLOR_REGEX.test(hexColor)) return
+
+      // Prepend a small color swatch circle before the hex code text
+      const swatchNode: Element = {
+        type: "element",
+        tagName: "span",
+        properties: {
+          ariaHidden: "true",
+          className: "stMarkdownHexColorSwatch",
+          style: `background-color: ${hexColor};`,
+        },
+        children: [],
+      }
+
+      node.children.unshift(swatchNode)
+    })
+  }
+}
+
 /**
  * Creates a URL-friendly anchor ID from a text string.
  *
@@ -1003,6 +1043,9 @@ const BASE_REMARK_PLUGINS = [
   createRemarkTypographicalSymbols(),
 ]
 
+// Rehype plugin instance for hex color swatches (stateless, created once)
+const rehypeHexColorSwatch = createRehypeHexColorSwatch()
+
 // Sets disallowed markdown for widget labels
 const LABEL_DISALLOWED_ELEMENTS = [
   // Restricts table elements, headings, unordered/ordered lists, task lists, horizontal rules, & blockquotes
@@ -1155,6 +1198,9 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     if (allowHTML && wrappedRawPlugin) {
       plugins.push(wrappedRawPlugin)
     }
+
+    // Show color swatches for hex colors in inline code (e.g. `#0969DA`)
+    plugins.push(rehypeHexColorSwatch)
 
     // This plugin must run last to ensure the inline property is set correctly
     // and not overwritten by other plugins like rehypeRaw

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -356,6 +356,18 @@ export const StyledStreamlitMarkdown =
           border: `${theme.sizes.borderWidth} solid ${theme.colors.dataframeBorderColor}`,
         },
 
+        "span.stMarkdownHexColorSwatch": {
+          display: "inline-block",
+          width: "0.65em",
+          height: "0.65em",
+          borderRadius: "50%",
+          // Inset shadow creates a subtle border that remains visible for light colors
+          boxShadow: "inset 0 0 0 0.0625em rgba(0,0,0,0.25)",
+          verticalAlign: "middle",
+          marginRight: "0.25em",
+          flexShrink: 0,
+        },
+
         "span.stMarkdownColoredBackground": {
           borderRadius: theme.radii.sm,
           padding: `${theme.spacing.threeXS} ${theme.spacing.twoXS}`,


### PR DESCRIPTION
## Summary
  Closes #14564

  Adds hex color swatches in Markdown inline code, similar to GitHub's behavior.
  When a hex color is written in backticks (e.g. `#0969DA`), a small colored
  circle is shown before the code, making it easy to visually identify the color.

  ## Changes
  - Added `createRehypeHexColorSwatch` rehype plugin in `StreamlitMarkdown.tsx`
  - Added `span.stMarkdownHexColorSwatch` styles in `styled-components.ts`
  - Added unit tests for valid/invalid hex colors and code blocks

  ## How to test
  ```python
  import streamlit as st
  st.markdown("Primary color: `#0969DA`, Error: `#cf222e`, Success: `#1a7f37`")