### PR TITLE
[fix] Programmatically closed popovers/expanders reopening on interaction with another

### DIFF
--- a/e2e_playwright/st_expander.py
+++ b/e2e_playwright/st_expander.py
@@ -266,3 +266,27 @@ if persist_show:
 
 with st.expander("Persist expander", expanded=False, key="persist_expander"):
     st.write("Persist expander content")
+
+# ============================================================================
+# Multiple Stateful Expanders — programmatic close regression test
+# https://github.com/streamlit/streamlit/issues/14943
+# ============================================================================
+
+
+def close_multi_exp_a() -> None:
+    st.session_state.multi_exp_a = False
+
+
+def close_multi_exp_b() -> None:
+    st.session_state.multi_exp_b = False
+
+
+exp_a = st.expander("Multi exp A", key="multi_exp_a", on_change="rerun")
+with exp_a:
+    st.write("Expander A content")
+    st.button("Close A", on_click=close_multi_exp_a, key="close_multi_exp_a_btn")
+
+exp_b = st.expander("Multi exp B", key="multi_exp_b", on_change="rerun")
+with exp_b:
+    st.write("Expander B content")
+    st.button("Close B", on_click=close_multi_exp_b, key="close_multi_exp_b_btn")

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -20,6 +20,7 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
+    click_button,
     click_toggle,
     get_element_by_key,
     get_expander,
@@ -27,7 +28,7 @@ from e2e_playwright.shared.app_utils import (
 
 EXPANDER_HEADER_IDENTIFIER = "summary"
 
-NUMBER_OF_EXPANDERS: Final = 22
+NUMBER_OF_EXPANDERS: Final = 24
 
 
 def test_expander_displays_correctly(
@@ -407,3 +408,36 @@ def test_keyed_expander_persist_expanded_across_remount(app: Page):
     # Still expanded
     keyed_expander = get_element_by_key(app, "persist_expander")
     expect(keyed_expander.get_by_text("Persist expander content")).to_be_visible()
+
+
+def test_programmatic_close_does_not_reopen_other_expander(app: Page):
+    """Test that programmatically closing one expander does not cause it to
+    reopen when another stateful expander is interacted with.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/14943
+    """
+    exp_a = get_element_by_key(app, "multi_exp_a")
+    exp_b = get_element_by_key(app, "multi_exp_b")
+
+    # Open expander A
+    exp_a.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Verify expander A is open
+    expect(exp_a.get_by_text("Expander A content")).to_be_visible()
+
+    # Programmatically close it via the button inside
+    click_button(app, "Close A")
+
+    # Expander A should be closed
+    expect(exp_a.get_by_text("Expander A content")).not_to_be_visible()
+
+    # Open expander B
+    exp_b.locator("summary").click()
+    wait_for_app_run(app)
+
+    # Expander B should be open
+    expect(exp_b.get_by_text("Expander B content")).to_be_visible()
+
+    # Expander A must NOT have reopened (the bug from #14943)
+    expect(exp_a.get_by_text("Expander A content")).not_to_be_visible()

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -240,3 +240,23 @@ if st.session_state.get("persist_popover_shift"):
 with st.popover("Persist popover", key="persist_popover"):
     st.write("Persist popover content")
     st.checkbox("Shift delta path", key="persist_popover_shift")
+
+# ============================================================================
+# Multiple Stateful Popovers — programmatic close regression test
+# https://github.com/streamlit/streamlit/issues/14943
+# ============================================================================
+
+
+def close_multi_pop_a() -> None:
+    st.session_state.multi_pop_a = False
+
+
+def close_multi_pop_b() -> None:
+    st.session_state.multi_pop_b = False
+
+
+with st.popover("Multi pop A", key="multi_pop_a", on_change="rerun"):
+    st.button("Close A", on_click=close_multi_pop_a, key="close_multi_a_btn")
+
+with st.popover("Multi pop B", key="multi_pop_b", on_change="rerun"):
+    st.button("Close B", on_click=close_multi_pop_b, key="close_multi_b_btn")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -34,7 +34,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(25)
+    expect(popover_elements).to_have_count(27)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -418,3 +418,30 @@ def test_popover_menu_style_icons_hide_chevron(
 
     # Snapshot the container with all three menu-style icon popovers
     assert_snapshot(container, name="st_popover-menu_style_icons")
+
+
+def test_programmatic_close_does_not_reopen_other_popover(app: Page):
+    """Test that programmatically closing one popover does not cause it to
+    reopen when another stateful popover is interacted with.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/14943
+    """
+    # Open popover A
+    open_popover(app, "Multi pop A")
+    expect(app.get_by_text("Close A")).to_be_visible()
+
+    # Programmatically close it via the button inside
+    click_button(app, "Close A")
+
+    # Popover A should be closed — the body should no longer be visible
+    expect(app.get_by_text("Close A")).not_to_be_visible()
+
+    # Open popover B
+    open_popover(app, "Multi pop B")
+
+    # Popover B should be open
+    expect(app.get_by_text("Close B")).to_be_visible()
+
+    # Popover A must NOT have reopened (the bug from #14943).
+    # If it did, "Close A" would be visible in a second popover body.
+    expect(app.get_by_text("Close A")).not_to_be_visible()

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -378,6 +378,92 @@ describe("passive state persistence", () => {
     expect(widgetMgr.getElementState(blockId, "expanded")).toBeUndefined()
   })
 
+  it("syncs widget manager state on programmatic expand change", () => {
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+
+    const widgetId = "expander-123"
+    const fragmentId = "frag-1"
+
+    // Start collapsed
+    const props = getProps(
+      { expanded: false, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    const { rerender } = render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    expect(screen.getByText("test")).not.toBeVisible()
+
+    // Backend programmatically expands (e.g. st.session_state.key = True)
+    const expandedProps = getProps(
+      { expanded: true, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    rerender(
+      <Expander {...expandedProps}>
+        <div>test</div>
+      </Expander>
+    )
+
+    // The widget manager should be updated with fromUi: false so that
+    // subsequent reruns send the correct value back to the backend
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: widgetId },
+      true,
+      { fromUi: false },
+      fragmentId
+    )
+  })
+
+  it("syncs widget manager state on programmatic collapse to prevent stale reopens", () => {
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+
+    const widgetId = "expander-123"
+    const fragmentId = "frag-1"
+
+    // Start expanded
+    const props = getProps(
+      { expanded: true, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    const { rerender } = render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    expect(screen.getByText("test")).toBeVisible()
+
+    // Backend programmatically collapses (e.g. st.session_state.key = False)
+    const collapsedProps = getProps(
+      { expanded: false, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    rerender(
+      <Expander {...collapsedProps}>
+        <div>test</div>
+      </Expander>
+    )
+
+    // The widget manager must be updated with false so that the next rerun
+    // (triggered by e.g. another widget) does not send stale "true" back
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: widgetId },
+      false,
+      { fromUi: false },
+      fragmentId
+    )
+  })
+
   it("uses server state even when elementStates has a stale value (widget mode)", () => {
     const blockId = "$$ID-abc123-my_expander"
     const widgetMgr = createWidgetMgr()

--- a/frontend/lib/src/components/elements/Expander/Expander.test.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.test.tsx
@@ -283,6 +283,92 @@ describe("widget mode (widgetMgr + element.id)", () => {
 
     expect(setBoolValueSpy).not.toHaveBeenCalled()
   })
+
+  it("syncs widget manager state on programmatic expand change", () => {
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+
+    const widgetId = "expander-123"
+    const fragmentId = "frag-1"
+
+    // Start collapsed
+    const props = getProps(
+      { expanded: false, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    const { rerender } = render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    expect(screen.getByText("test")).not.toBeVisible()
+
+    // Backend programmatically expands (e.g. st.session_state.key = True)
+    const expandedProps = getProps(
+      { expanded: true, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    rerender(
+      <Expander {...expandedProps}>
+        <div>test</div>
+      </Expander>
+    )
+
+    // The widget manager should be updated with fromUi: false so that
+    // subsequent reruns send the correct value back to the backend
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: widgetId },
+      true,
+      { fromUi: false },
+      fragmentId
+    )
+  })
+
+  it("syncs widget manager state on programmatic collapse to prevent stale reopens", () => {
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+
+    const widgetId = "expander-123"
+    const fragmentId = "frag-1"
+
+    // Start expanded
+    const props = getProps(
+      { expanded: true, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    const { rerender } = render(
+      <Expander {...props}>
+        <div>test</div>
+      </Expander>
+    )
+
+    expect(screen.getByText("test")).toBeVisible()
+
+    // Backend programmatically collapses (e.g. st.session_state.key = False)
+    const collapsedProps = getProps(
+      { expanded: false, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    rerender(
+      <Expander {...collapsedProps}>
+        <div>test</div>
+      </Expander>
+    )
+
+    // The widget manager must be updated with false so that the next rerun
+    // (triggered by e.g. another widget) does not send stale "true" back
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: widgetId },
+      false,
+      { fromUi: false },
+      fragmentId
+    )
+  })
 })
 
 describe("passive state persistence", () => {
@@ -376,92 +462,6 @@ describe("passive state persistence", () => {
     // Widget mode: persistence should not write expanded state
     // (the hook id is "" so nothing meaningful is stored)
     expect(widgetMgr.getElementState(blockId, "expanded")).toBeUndefined()
-  })
-
-  it("syncs widget manager state on programmatic expand change", () => {
-    const widgetMgr = createWidgetMgr()
-    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
-
-    const widgetId = "expander-123"
-    const fragmentId = "frag-1"
-
-    // Start collapsed
-    const props = getProps(
-      { expanded: false, id: widgetId },
-      { widgetMgr, fragmentId }
-    )
-
-    const { rerender } = render(
-      <Expander {...props}>
-        <div>test</div>
-      </Expander>
-    )
-
-    expect(screen.getByText("test")).not.toBeVisible()
-
-    // Backend programmatically expands (e.g. st.session_state.key = True)
-    const expandedProps = getProps(
-      { expanded: true, id: widgetId },
-      { widgetMgr, fragmentId }
-    )
-
-    rerender(
-      <Expander {...expandedProps}>
-        <div>test</div>
-      </Expander>
-    )
-
-    // The widget manager should be updated with fromUi: false so that
-    // subsequent reruns send the correct value back to the backend
-    expect(setBoolValueSpy).toHaveBeenCalledWith(
-      { id: widgetId },
-      true,
-      { fromUi: false },
-      fragmentId
-    )
-  })
-
-  it("syncs widget manager state on programmatic collapse to prevent stale reopens", () => {
-    const widgetMgr = createWidgetMgr()
-    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
-
-    const widgetId = "expander-123"
-    const fragmentId = "frag-1"
-
-    // Start expanded
-    const props = getProps(
-      { expanded: true, id: widgetId },
-      { widgetMgr, fragmentId }
-    )
-
-    const { rerender } = render(
-      <Expander {...props}>
-        <div>test</div>
-      </Expander>
-    )
-
-    expect(screen.getByText("test")).toBeVisible()
-
-    // Backend programmatically collapses (e.g. st.session_state.key = False)
-    const collapsedProps = getProps(
-      { expanded: false, id: widgetId },
-      { widgetMgr, fragmentId }
-    )
-
-    rerender(
-      <Expander {...collapsedProps}>
-        <div>test</div>
-      </Expander>
-    )
-
-    // The widget manager must be updated with false so that the next rerun
-    // (triggered by e.g. another widget) does not send stale "true" back
-    expect(setBoolValueSpy).toHaveBeenCalledWith(
-      { id: widgetId },
-      false,
-      { fromUi: false },
-      fragmentId
-    )
   })
 
   it("uses server state even when elementStates has a stale value (widget mode)", () => {

--- a/frontend/lib/src/components/elements/Expander/Expander.tsx
+++ b/frontend/lib/src/components/elements/Expander/Expander.tsx
@@ -17,9 +17,11 @@
 import { memo, ReactElement, useCallback, useState } from "react"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
+import { notNullOrUndefined } from "@streamlit/utils"
 
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
+import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
 import useWidgetManagerElementState from "~lib/hooks/useWidgetManagerElementState"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -106,6 +108,22 @@ const Expander: React.FC<React.PropsWithChildren<ExpanderProps>> = ({
     })
 
   const initialExpanded = isPassivelyKeyed ? storedExpanded : element.expanded
+
+  // Sync widget manager state when the backend programmatically changes the
+  // expanded value (e.g. st.session_state.key = False). Without this, the
+  // widget manager retains the stale value and sends it back on the next
+  // rerun, causing the expander to revert to its old state.
+  useExecuteWhenChanged(() => {
+    if (!widgetId || !notNullOrUndefined(element.expanded)) {
+      return
+    }
+    widgetMgr.setBoolValue(
+      { id: widgetId },
+      element.expanded,
+      { fromUi: false },
+      fragmentId
+    )
+  }, [widgetId, element.expanded])
 
   // Callback to notify backend of toggle (only used in widget mode)
   const handleWidgetToggle = useCallback(

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -242,7 +242,11 @@ describe("Dynamic popover (widget mode)", () => {
     const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
 
     const widgetId = "popover-widget-id"
-    const props = getProps({ open: false, id: widgetId }, { widgetMgr })
+    const fragmentId = "frag-1"
+    const props = getProps(
+      { open: false, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
 
     const { rerender } = render(
       <Popover {...props}>
@@ -253,7 +257,10 @@ describe("Dynamic popover (widget mode)", () => {
     const trigger = screen.getByRole("button").closest("[aria-expanded]")
     expect(trigger).toHaveAttribute("aria-expanded", "false")
 
-    const updatedProps = getProps({ open: true, id: widgetId }, { widgetMgr })
+    const updatedProps = getProps(
+      { open: true, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
 
     rerender(
       <Popover {...updatedProps}>
@@ -262,7 +269,60 @@ describe("Dynamic popover (widget mode)", () => {
     )
 
     expect(trigger).toHaveAttribute("aria-expanded", "true")
-    expect(setBoolValueSpy).not.toHaveBeenCalled()
+    // The widget manager state should also be updated (with fromUi: false
+    // to avoid triggering a rerun) so that subsequent reruns send the
+    // correct value back to the backend.
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: widgetId },
+      true,
+      { fromUi: false },
+      fragmentId
+    )
+  })
+
+  it("syncs widget manager state on programmatic close to prevent stale reopens", () => {
+    const widgetMgr = createWidgetMgr()
+    const setBoolValueSpy = vi.spyOn(widgetMgr, "setBoolValue")
+
+    const widgetId = "popover-widget-id"
+    const fragmentId = "frag-1"
+
+    // Start with the popover open (simulating it was opened by the user)
+    const props = getProps(
+      { open: true, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    const { rerender } = render(
+      <Popover {...props}>
+        <div>content</div>
+      </Popover>
+    )
+
+    const trigger = screen.getByRole("button").closest("[aria-expanded]")
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+
+    // Backend programmatically closes the popover (e.g. st.session_state.key = False)
+    const closedProps = getProps(
+      { open: false, id: widgetId },
+      { widgetMgr, fragmentId }
+    )
+
+    rerender(
+      <Popover {...closedProps}>
+        <div>content</div>
+      </Popover>
+    )
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    // The widget manager must be updated with false so that the next rerun
+    // (triggered by e.g. another popover) does not send stale "true" back.
+    expect(setBoolValueSpy).toHaveBeenCalledWith(
+      { id: widgetId },
+      false,
+      { fromUi: false },
+      fragmentId
+    )
   })
 })
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -101,6 +101,16 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       return
     }
     setOpen(element.open)
+    // Also update the widget manager so the frontend sends the correct value
+    // on subsequent reruns. Without this, a programmatic close (e.g.
+    // st.session_state.key = False) would leave a stale "true" in the widget
+    // state, causing the popover to reopen when another widget triggers a rerun.
+    widgetMgr?.setBoolValue(
+      { id: widgetId },
+      element.open,
+      { fromUi: false },
+      fragmentId
+    )
   }, [widgetId, element.open])
 
   // It would be nice to remove this since it uses a resize observer


### PR DESCRIPTION
## Summary

- Fixes #14943 — programmatically closed popovers reopen when interacting with another stateful popover
- When `st.session_state.key = False` closes a popover/expander, the frontend's `WidgetStateManager` was not updated, leaving a stale `true` value that got sent back to the backend on the next rerun
- Added `widgetMgr.setBoolValue(..., { fromUi: false })` to sync the widget manager when the backend overrides the open/expanded state, without triggering an additional rerun
- Applied the same fix to `st.expander` which had the identical latent bug

## Test plan

- [x] Updated Popover unit test ("syncs open state when element.open changes programmatically") to verify widget manager sync
- [x] Added Popover unit test ("syncs widget manager state on programmatic close to prevent stale reopens")
- [x] Added Expander unit test ("syncs widget manager state on programmatic expand change")
- [x] Added Expander unit test ("syncs widget manager state on programmatic collapse to prevent stale reopens")
- [x] Added Popover E2E test (`test_programmatic_close_does_not_reopen_other_popover`)
- [x] Added Expander E2E test (`test_programmatic_close_does_not_reopen_other_expander`)
- [x] All existing Popover/Expander unit tests pass (49/49)
- [x] Both new E2E tests pass
- [x] Verified manually via Playwright against `make debug` that the fix resolves the reported issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
