### PR TITLE
[feature] Add pagination widget

### DIFF
--- a/e2e_playwright/st_pagination.py
+++ b/e2e_playwright/st_pagination.py
@@ -1,0 +1,51 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+if "runs" not in st.session_state:
+    st.session_state.runs = 0
+st.session_state.runs += 1
+st.write("Runs:", st.session_state.runs)
+
+with st.container(key="basic_pagination"):
+    page = st.pagination(10, key="basic_page")
+    st.write("basic-page:", page)
+
+with st.container(key="compact_pagination"):
+    compact_page = st.pagination(10, key="compact_page", default=5, max_visible_pages=1)
+    st.write("compact-page:", compact_page)
+
+with st.container(key="disabled_pagination"):
+    if "disabled_page" not in st.session_state:
+        st.session_state.disabled_page = 3
+    disabled_page = st.pagination(10, key="disabled_page", disabled=True)
+    st.write("disabled-page:", disabled_page)
+
+with st.form(key="pagination_form"):
+    form_page = st.pagination(5, key="form_page")
+    st.form_submit_button("Submit")
+st.write("form-page:", form_page)
+
+
+@st.fragment
+def pagination_fragment():
+    fragment_page = st.pagination(5, key="fragment_page")
+    st.write("fragment-page:", fragment_page)
+
+
+pagination_fragment()
+
+st.pagination(10, key="stretch_page", width="stretch")
+st.pagination(10, key="fixed_page", width=300)

--- a/e2e_playwright/st_pagination_test.py
+++ b/e2e_playwright/st_pagination_test.py
@@ -1,0 +1,88 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    click_form_button,
+    get_element_by_key,
+)
+
+
+def get_pagination(app: Page, key: str) -> Locator:
+    return get_element_by_key(app, key).get_by_test_id("stPagination")
+
+
+def test_pagination_page_buttons_update_value(app: Page):
+    """Test that clicking page buttons and arrows updates the selected page."""
+    pagination = get_pagination(app, "basic_page")
+
+    pagination.get_by_role("button", name="Page 3").click()
+    wait_for_app_run(app)
+    expect(app.get_by_text("basic-page: 3")).to_be_visible()
+    expect(app.get_by_text("basic-page: 1")).not_to_be_visible()
+
+    pagination = get_pagination(app, "basic_page")
+    pagination.get_by_role("button", name="Next page").click()
+    wait_for_app_run(app)
+    expect(app.get_by_text("basic-page: 4")).to_be_visible()
+
+
+def test_compact_pagination_only_shows_current_page(app: Page):
+    """Test compact pagination with max_visible_pages=1."""
+    pagination = get_pagination(app, "compact_page")
+
+    expect(pagination.get_by_role("button", name="Page 5")).to_be_visible()
+    expect(pagination.get_by_role("button", name="Page 1")).not_to_be_visible()
+
+
+def test_disabled_pagination_cannot_change_value(app: Page):
+    """Test that disabled pagination buttons cannot be interacted with."""
+    pagination = get_pagination(app, "disabled_page")
+
+    expect(pagination.get_by_role("button", name="Page 3")).to_be_disabled()
+    pagination.get_by_role("button", name="Next page").click(force=True)
+    expect(app.get_by_text("disabled-page: 3")).to_be_visible()
+    expect(app.get_by_text("disabled-page: 4")).not_to_be_visible()
+
+
+def test_pagination_works_in_forms(app: Page):
+    """Test that pagination in forms updates when the form is submitted."""
+    pagination = get_pagination(app, "form_page")
+
+    pagination.get_by_role("button", name="Page 2").click()
+    expect(app.get_by_text("form-page: 1")).to_be_visible()
+    click_form_button(app, "Submit")
+    wait_for_app_run(app)
+    expect(app.get_by_text("form-page: 2")).to_be_visible()
+
+
+def test_pagination_works_with_fragments(app: Page):
+    """Test that pagination inside a fragment only reruns the fragment."""
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+
+    pagination = get_pagination(app, "fragment_page")
+    pagination.get_by_role("button", name="Page 2").click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("fragment-page: 2")).to_be_visible()
+    expect(app.get_by_text("Runs: 1")).to_be_visible()
+
+
+def test_custom_css_class_via_key(app: Page):
+    """Test that pagination can have a custom CSS class via the key argument."""
+    expect(get_element_by_key(app, "basic_page")).to_be_visible()

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -51,6 +51,7 @@ import {
   MultiSelect as MultiSelectProto,
   NumberInput as NumberInputProto,
   PageLink as PageLinkProto,
+  Pagination as PaginationProto,
   PlotlyChart as PlotlyChartProto,
   Progress as ProgressProto,
   Radio as RadioProto,
@@ -191,6 +192,9 @@ const MenuButton = lazy(
 )
 const NumberInput = lazy(
   () => import("~lib/components/widgets/NumberInput/NumberInput")
+)
+const Pagination = lazy(
+  () => import("~lib/components/widgets/Pagination/Pagination")
 )
 const Radio = lazy(() => import("~lib/components/widgets/Radio/Radio"))
 const Selectbox = lazy(
@@ -824,6 +828,25 @@ const RawElementNodeRenderer = (
           <Feedback
             key={feedbackProto.id}
             element={feedbackProto}
+            {...widgetProps}
+          />
+        </ElementContainer>
+      )
+    }
+
+    case "pagination": {
+      const paginationProto = node.element.pagination as PaginationProto
+      widgetProps.disabled = widgetProps.disabled || paginationProto.disabled
+
+      return (
+        <ElementContainer
+          node={node}
+          config={ElementContainerConfig.FIT_CONTENT_ELEMENT}
+          isStale={isStale}
+        >
+          <Pagination
+            key={paginationProto.id}
+            element={paginationProto}
             {...widgetProps}
           />
         </ElementContainer>

--- a/frontend/lib/src/components/widgets/Pagination/Pagination.test.tsx
+++ b/frontend/lib/src/components/widgets/Pagination/Pagination.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MutableRefObject } from "react"
+
+import { screen, within } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+
+import { Pagination as PaginationProto } from "@streamlit/protobuf"
+
+import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
+import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import Pagination, { getPaginationItems, Props } from "./Pagination"
+
+const getProps = (
+  elementProps: Partial<PaginationProto> = {},
+  widgetProps: Partial<Props> = {}
+): Props => ({
+  element: PaginationProto.create({
+    id: "pagination-1",
+    numPages: 10,
+    default: 1,
+    disabled: false,
+    maxVisiblePages: 7,
+    ...elementProps,
+  }),
+  disabled: false,
+  widgetMgr: new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  }),
+  widthConfig: {
+    useContent: true,
+  },
+  ...widgetProps,
+})
+
+const getPageButtons = (): HTMLElement[] => {
+  const pagination = screen.getByTestId("stPagination")
+  return within(pagination).getAllByRole("button", { name: /^Page / })
+}
+
+describe("Pagination widget", () => {
+  beforeEach(() => {
+    vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+      values: [],
+      elementRef: { current: null } as MutableRefObject<HTMLDivElement | null>,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe("page item truncation", () => {
+    it("shows all pages when the page count fits", () => {
+      expect(
+        getPaginationItems({
+          currentPage: 1,
+          maxVisiblePages: 5,
+          numPages: 5,
+        })
+      ).toEqual([
+        { type: "page", page: 1 },
+        { type: "page", page: 2 },
+        { type: "page", page: 3 },
+        { type: "page", page: 4 },
+        { type: "page", page: 5 },
+      ])
+    })
+
+    it("keeps first, current, and last page for wider truncation", () => {
+      expect(
+        getPaginationItems({
+          currentPage: 6,
+          maxVisiblePages: 5,
+          numPages: 10,
+        })
+      ).toEqual([
+        { type: "page", page: 1 },
+        { type: "ellipsis", key: "1-5" },
+        { type: "page", page: 5 },
+        { type: "page", page: 6 },
+        { type: "page", page: 7 },
+        { type: "ellipsis", key: "7-10" },
+        { type: "page", page: 10 },
+      ])
+    })
+
+    it("shows only the current page when maxVisiblePages is 1", () => {
+      expect(
+        getPaginationItems({
+          currentPage: 5,
+          maxVisiblePages: 1,
+          numPages: 10,
+        })
+      ).toEqual([{ type: "page", page: 5 }])
+    })
+
+    it("shows no page buttons when maxVisiblePages is 0", () => {
+      expect(
+        getPaginationItems({
+          currentPage: 5,
+          maxVisiblePages: 0,
+          numPages: 10,
+        })
+      ).toEqual([])
+    })
+  })
+
+  describe("rendering", () => {
+    it("renders without crashing", () => {
+      const props = getProps()
+      render(<Pagination {...props} />)
+
+      const pagination = screen.getByTestId("stPagination")
+      expect(pagination).toBeVisible()
+      expect(pagination).toHaveClass("stPagination")
+    })
+
+    it("renders arrows and truncated pages", () => {
+      const props = getProps({ value: 6, setValue: true, maxVisiblePages: 5 })
+      render(<Pagination {...props} />)
+
+      expect(
+        screen.getByRole("button", { name: "Previous page" })
+      ).toBeVisible()
+      expect(screen.getByRole("button", { name: "Next page" })).toBeVisible()
+      expect(screen.getByRole("button", { name: "Page 6" })).toHaveAttribute(
+        "aria-current",
+        "page"
+      )
+      expect(screen.getAllByTestId("stPaginationEllipsis")).toHaveLength(2)
+    })
+
+    it("applies responsive page reduction", () => {
+      vi.spyOn(UseResizeObserver, "useResizeObserver").mockReturnValue({
+        values: [140],
+        elementRef: {
+          current: null,
+        } as MutableRefObject<HTMLDivElement | null>,
+      })
+      const props = getProps({ value: 5, setValue: true, maxVisiblePages: 7 })
+
+      render(<Pagination {...props} />)
+
+      expect(getPageButtons()).toHaveLength(1)
+      expect(screen.getByRole("button", { name: "Page 5" })).toBeVisible()
+      expect(
+        screen.queryByRole("button", { name: "Page 10" })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("interaction", () => {
+    it("sets widget value when a page is clicked", async () => {
+      const user = userEvent.setup()
+      const props = getProps()
+      vi.spyOn(props.widgetMgr, "setIntValue")
+
+      render(<Pagination {...props} />)
+      await user.click(screen.getByRole("button", { name: "Page 3" }))
+
+      expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+        props.element,
+        3,
+        { fromUi: true },
+        undefined
+      )
+    })
+
+    it("moves to the next and previous pages", async () => {
+      const user = userEvent.setup()
+      const props = getProps({ value: 5, setValue: true })
+      vi.spyOn(props.widgetMgr, "setIntValue")
+
+      render(<Pagination {...props} />)
+      await user.click(screen.getByRole("button", { name: "Next page" }))
+      await user.click(screen.getByRole("button", { name: "Previous page" }))
+
+      expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+        props.element,
+        6,
+        { fromUi: true },
+        undefined
+      )
+      expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+        props.element,
+        4,
+        { fromUi: true },
+        undefined
+      )
+    })
+
+    it("disables boundary arrows", () => {
+      const props = getProps({ value: 1, setValue: true })
+      render(<Pagination {...props} />)
+
+      expect(
+        screen.getByRole("button", { name: "Previous page" })
+      ).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Next page" })).toBeEnabled()
+    })
+
+    it("does not update state when disabled", async () => {
+      const user = userEvent.setup()
+      const props = getProps({ disabled: true }, { disabled: true })
+      vi.spyOn(props.widgetMgr, "setIntValue")
+
+      render(<Pagination {...props} />)
+      await user.click(screen.getByRole("button", { name: "Page 3" }))
+
+      expect(props.widgetMgr.setIntValue).not.toHaveBeenCalledWith(
+        props.element,
+        3,
+        { fromUi: true },
+        undefined
+      )
+    })
+
+    it("passes fragmentId to widget state updates", async () => {
+      const user = userEvent.setup()
+      const props = getProps({}, { fragmentId: "myFragmentId" })
+      vi.spyOn(props.widgetMgr, "setIntValue")
+
+      render(<Pagination {...props} />)
+      await user.click(screen.getByRole("button", { name: "Page 2" }))
+
+      expect(props.widgetMgr.setIntValue).toHaveBeenCalledWith(
+        props.element,
+        2,
+        { fromUi: true },
+        "myFragmentId"
+      )
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/Pagination/Pagination.tsx
+++ b/frontend/lib/src/components/widgets/Pagination/Pagination.tsx
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { memo, ReactElement, useCallback, useMemo } from "react"
+
+import { Pagination as PaginationProto, streamlit } from "@streamlit/protobuf"
+
+import { shouldWidthStretch } from "~lib/components/core/Layout/utils"
+import {
+  useBasicWidgetState,
+  ValueWithSource,
+} from "~lib/hooks/useBasicWidgetState"
+import {
+  type DOMRectKeys,
+  useResizeObserver,
+} from "~lib/hooks/useResizeObserver"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import {
+  StyledPaginationButton,
+  StyledPaginationContainer,
+  StyledPaginationControls,
+  StyledPaginationEllipsis,
+} from "./styled-components"
+
+export interface Props {
+  disabled: boolean
+  element: PaginationProto
+  widgetMgr: WidgetStateManager
+  fragmentId?: string
+  widthConfig: streamlit.IWidthConfig | undefined | null
+}
+
+export type PageItem =
+  | {
+      type: "page"
+      page: number
+    }
+  | {
+      type: "ellipsis"
+      key: string
+    }
+
+const RESIZE_OBSERVER_PROPERTIES: DOMRectKeys[] = ["width"]
+const ESTIMATED_PAGE_BUTTON_WIDTH = 48
+const ESTIMATED_ARROW_BUTTONS_WIDTH = 80
+
+function getStateFromWidgetMgr(
+  widgetMgr: WidgetStateManager,
+  element: PaginationProto
+): number | undefined {
+  return widgetMgr.getIntValue(element)
+}
+
+function getDefaultStateFromProto(element: PaginationProto): number {
+  return element.default || 1
+}
+
+function getCurrStateFromProto(element: PaginationProto): number {
+  return element.value || getDefaultStateFromProto(element)
+}
+
+function updateWidgetMgrState(
+  element: PaginationProto,
+  widgetMgr: WidgetStateManager,
+  valueWithSource: ValueWithSource<number>,
+  fragmentId: string | undefined
+): void {
+  widgetMgr.setIntValue(
+    element,
+    valueWithSource.value,
+    { fromUi: valueWithSource.fromUi },
+    fragmentId
+  )
+}
+
+function clampPage(page: number, numPages: number): number {
+  return Math.min(Math.max(page, 1), numPages)
+}
+
+function addEllipses(sortedPages: number[]): PageItem[] {
+  const items: PageItem[] = []
+
+  sortedPages.forEach((page, index) => {
+    const previousPage = sortedPages[index - 1]
+    if (previousPage !== undefined && page - previousPage > 1) {
+      items.push({ type: "ellipsis", key: `${previousPage}-${page}` })
+    }
+    items.push({ type: "page", page })
+  })
+
+  return items
+}
+
+export function getPaginationItems({
+  currentPage,
+  maxVisiblePages,
+  numPages,
+}: {
+  currentPage: number
+  maxVisiblePages: number
+  numPages: number
+}): PageItem[] {
+  if (maxVisiblePages <= 0) {
+    return []
+  }
+
+  if (numPages <= maxVisiblePages) {
+    return Array.from({ length: numPages }, (_, index) => ({
+      type: "page",
+      page: index + 1,
+    }))
+  }
+
+  const pages = new Set<number>()
+  pages.add(clampPage(currentPage, numPages))
+
+  if (maxVisiblePages >= 2) {
+    if (currentPage === numPages) {
+      pages.add(1)
+    } else {
+      pages.add(numPages)
+    }
+  }
+
+  if (maxVisiblePages >= 3) {
+    pages.add(1)
+    pages.add(numPages)
+  }
+
+  let offset = 1
+  while (pages.size < maxVisiblePages) {
+    const leftPage = currentPage - offset
+    const rightPage = currentPage + offset
+    let addedPage = false
+
+    if (leftPage > 1) {
+      pages.add(leftPage)
+      addedPage = true
+    }
+
+    if (pages.size < maxVisiblePages && rightPage < numPages) {
+      pages.add(rightPage)
+      addedPage = true
+    }
+
+    if (!addedPage) {
+      break
+    }
+
+    offset += 1
+  }
+
+  return addEllipses([...pages].sort((a, b) => a - b))
+}
+
+function getResponsiveMaxVisiblePages(
+  width: number | undefined
+): number | undefined {
+  if (width === undefined || width <= 0) {
+    return undefined
+  }
+
+  const availableWidth = width - ESTIMATED_ARROW_BUTTONS_WIDTH
+  if (availableWidth <= 0) {
+    return 0
+  }
+
+  return Math.floor(availableWidth / ESTIMATED_PAGE_BUTTON_WIDTH)
+}
+
+function Pagination(props: Readonly<Props>): ReactElement {
+  const { disabled, element, fragmentId, widgetMgr, widthConfig } = props
+  const numPages = element.numPages || 1
+
+  const [hookValue, setValueWithSource] = useBasicWidgetState<
+    number,
+    PaginationProto
+  >({
+    getStateFromWidgetMgr,
+    getDefaultStateFromProto,
+    getCurrStateFromProto,
+    updateWidgetMgrState,
+    element,
+    widgetMgr,
+    fragmentId,
+    formClearBehavior: "resetValueOnly",
+  })
+
+  const currentPage = clampPage(element.value || hookValue, numPages)
+  const containerWidth = shouldWidthStretch(widthConfig)
+  const { values, elementRef } = useResizeObserver<HTMLDivElement>(
+    RESIZE_OBSERVER_PROPERTIES
+  )
+
+  const maxVisiblePages = useMemo(() => {
+    const explicitMaxVisiblePages = element.maxVisiblePages ?? numPages
+    const responsiveMaxVisiblePages = getResponsiveMaxVisiblePages(values[0])
+    return Math.min(
+      explicitMaxVisiblePages,
+      responsiveMaxVisiblePages ?? explicitMaxVisiblePages
+    )
+  }, [element.maxVisiblePages, numPages, values])
+
+  const pageItems = useMemo(
+    () =>
+      getPaginationItems({
+        currentPage,
+        maxVisiblePages,
+        numPages,
+      }),
+    [currentPage, maxVisiblePages, numPages]
+  )
+
+  const handlePageSelect = useCallback(
+    (page: number): void => {
+      if (disabled || page === currentPage) {
+        return
+      }
+
+      setValueWithSource({ value: page, fromUi: true })
+    },
+    [currentPage, disabled, setValueWithSource]
+  )
+
+  return (
+    <StyledPaginationContainer
+      ref={elementRef}
+      className="stPagination"
+      data-testid="stPagination"
+      containerWidth={containerWidth}
+    >
+      <StyledPaginationControls aria-label="Pagination" role="navigation">
+        <StyledPaginationButton
+          type="button"
+          aria-label="Previous page"
+          disabled={disabled || currentPage === 1}
+          onClick={() => handlePageSelect(currentPage - 1)}
+          data-testid="stPaginationPrevious"
+        >
+          {"<"}
+        </StyledPaginationButton>
+        {pageItems.map(item =>
+          item.type === "ellipsis" ? (
+            <StyledPaginationEllipsis
+              key={item.key}
+              aria-hidden="true"
+              data-testid="stPaginationEllipsis"
+            >
+              ...
+            </StyledPaginationEllipsis>
+          ) : (
+            <StyledPaginationButton
+              key={item.page}
+              type="button"
+              aria-current={item.page === currentPage ? "page" : undefined}
+              aria-label={`Page ${item.page}`}
+              isSelected={item.page === currentPage}
+              disabled={disabled}
+              onClick={() => handlePageSelect(item.page)}
+              data-testid={
+                item.page === currentPage
+                  ? "stPaginationPageActive"
+                  : "stPaginationPage"
+              }
+            >
+              {item.page}
+            </StyledPaginationButton>
+          )
+        )}
+        <StyledPaginationButton
+          type="button"
+          aria-label="Next page"
+          disabled={disabled || currentPage === numPages}
+          onClick={() => handlePageSelect(currentPage + 1)}
+          data-testid="stPaginationNext"
+        >
+          {">"}
+        </StyledPaginationButton>
+      </StyledPaginationControls>
+    </StyledPaginationContainer>
+  )
+}
+
+export default memo(Pagination)

--- a/frontend/lib/src/components/widgets/Pagination/styled-components.ts
+++ b/frontend/lib/src/components/widgets/Pagination/styled-components.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+interface StyledPaginationContainerProps {
+  containerWidth: boolean
+}
+
+export const StyledPaginationContainer =
+  styled.div<StyledPaginationContainerProps>(({ containerWidth }) => ({
+    display: "flex",
+    justifyContent: containerWidth ? "center" : "flex-start",
+    width: containerWidth ? "100%" : "auto",
+    minWidth: 0,
+  }))
+
+export const StyledPaginationControls = styled.div(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  flexWrap: "nowrap",
+  gap: theme.spacing.twoXS,
+  maxWidth: "100%",
+  overflow: "hidden",
+}))
+
+interface StyledPaginationButtonProps {
+  isSelected?: boolean
+}
+
+export const StyledPaginationButton =
+  styled.button<StyledPaginationButtonProps>(({ isSelected, theme }) => ({
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flex: "0 0 auto",
+    minWidth: theme.sizes.minElementHeight,
+    height: theme.sizes.minElementHeight,
+    padding: `${theme.spacing.none} ${theme.spacing.sm}`,
+    margin: theme.spacing.none,
+    borderRadius: theme.radii.button,
+    border: `${theme.sizes.borderWidth} solid ${
+      isSelected ? theme.colors.primary : theme.colors.borderColor
+    }`,
+    backgroundColor: isSelected ? theme.colors.primary : theme.colors.bgColor,
+    color: isSelected ? theme.colors.white : theme.colors.bodyText,
+    cursor: "pointer",
+    userSelect: "none",
+
+    "&:hover:not(:disabled)": {
+      borderColor: theme.colors.primary,
+    },
+    "&:focus": {
+      outline: "none",
+    },
+    "&:focus-visible": {
+      boxShadow: theme.shadows.focusRing,
+    },
+    "&:disabled": {
+      backgroundColor: isSelected
+        ? theme.colors.fadedText10
+        : theme.colors.transparent,
+      borderColor: theme.colors.borderColor,
+      color: isSelected ? theme.colors.fadedText60 : theme.colors.fadedText40,
+      cursor: "not-allowed",
+    },
+  }))
+
+export const StyledPaginationEllipsis = styled.span(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flex: "0 0 auto",
+  minWidth: theme.sizes.minElementHeight,
+  height: theme.sizes.minElementHeight,
+  color: theme.colors.fadedText60,
+  userSelect: "none",
+}))

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -230,6 +230,7 @@ metric = _main.metric
 multiselect = _main.multiselect
 number_input = _main.number_input
 page_link = _main.page_link
+pagination = _main.pagination
 pdf = _main.pdf
 pills = _main.pills
 plotly_chart = _main.plotly_chart

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -97,6 +97,7 @@ from streamlit.elements.widgets.file_uploader import FileUploaderMixin
 from streamlit.elements.widgets.menu_button import MenuButtonMixin
 from streamlit.elements.widgets.multiselect import MultiSelectMixin
 from streamlit.elements.widgets.number_input import NumberInputMixin
+from streamlit.elements.widgets.pagination import PaginationMixin
 from streamlit.elements.widgets.radio import RadioMixin
 from streamlit.elements.widgets.select_slider import SelectSliderMixin
 from streamlit.elements.widgets.selectbox import SelectboxMixin
@@ -209,6 +210,7 @@ class DeltaGenerator(
     MenuButtonMixin,
     MultiSelectMixin,
     NumberInputMixin,
+    PaginationMixin,
     PdfMixin,
     PlotlyMixin,
     ProgressMixin,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -108,7 +108,7 @@ def _normalize_icon_position(
             f'The argument passed was "{icon_position}".'
         )
 
-    return cast("IconPosition", icon_position)  # type: ignore[redundant-cast]
+    return cast("IconPosition", icon_position)
 
 
 def _icon_position_to_proto(

--- a/lib/streamlit/elements/widgets/pagination.py
+++ b/lib/streamlit/elements/widgets/pagination.py
@@ -1,0 +1,232 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from streamlit.elements.lib.form_utils import current_form_id
+from streamlit.elements.lib.layout_utils import (
+    Width,
+    create_layout_config,
+)
+from streamlit.elements.lib.policies import check_widget_policies
+from streamlit.elements.lib.utils import (
+    Key,
+    compute_and_register_element_id,
+    to_key,
+)
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto.Pagination_pb2 import Pagination as PaginationProto
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.runtime.state import get_session_state, register_widget
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.runtime.state import (
+        WidgetArgs,
+        WidgetCallback,
+        WidgetKwargs,
+    )
+
+
+@dataclass
+class PaginationSerde:
+    """Serializer/deserializer for pagination values."""
+
+    default: int
+    num_pages: int
+
+    def serialize(self, value: int) -> int:
+        return int(value)
+
+    def deserialize(self, ui_value: int | None) -> int:
+        if ui_value is None:
+            return self.default
+
+        value = int(ui_value)
+        if value < 1 or value > self.num_pages:
+            return self.default
+
+        return value
+
+
+def _validate_positive_int(name: str, value: int) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise StreamlitAPIException(f"`{name}` must be an integer greater than 0.")
+
+
+class PaginationMixin:
+    @gather_metrics("pagination")
+    def pagination(
+        self,
+        num_pages: int,
+        *,
+        default: int = 1,
+        key: Key | None = None,
+        max_visible_pages: int | None = 7,
+        width: Width = "content",
+        on_change: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        disabled: bool = False,
+    ) -> int:
+        """Display a pagination widget.
+
+        A pagination widget displays page-number buttons with previous and next
+        arrows. It is commonly used to navigate through large datasets, search
+        results, or multi-step content.
+
+        Parameters
+        ----------
+        num_pages : int
+            Total number of pages. This must be at least ``1``.
+        default : int
+            The page selected when the widget first renders. The default is
+            ``1``. This must be between ``1`` and ``num_pages``, inclusive.
+        key : str, int, or None
+            An optional string or integer to use as the unique key for the
+            widget. If this is ``None`` (default), a key will be generated for
+            the widget based on the values of the other parameters.
+
+            A key lets you read or update the widget's value via
+            ``st.session_state[key]``. For more details, see `Widget behavior
+            <https://docs.streamlit.io/develop/concepts/architecture/widget-behavior>`_.
+
+            Additionally, if ``key`` is provided, it will be used as a CSS
+            class name prefixed with ``st-key-``.
+        max_visible_pages : int or None
+            Maximum number of page buttons to display, excluding previous and
+            next arrows. The default is ``7``. If this is ``None``, all pages
+            are eligible to be shown before responsive width reduction is
+            applied. If this is ``0``, only the previous and next arrows are
+            shown.
+        width : "content", "stretch", or int
+            The width of the pagination widget. This can be one of the
+            following:
+
+            - ``"content"`` (default): The width of the widget matches the
+              width of its content, but doesn't exceed the width of the parent
+              container.
+            - ``"stretch"``: The width of the widget matches the width of the
+              parent container.
+            - An integer specifying the width in pixels: The widget has a
+              fixed width. If the specified width is greater than the width of
+              the parent container, the width of the widget matches the width
+              of the parent container.
+        on_change : callable
+            An optional callback invoked when this pagination widget's value
+            changes.
+        args : list or tuple
+            An optional list or tuple of args to pass to the callback.
+        kwargs : dict
+            An optional dict of kwargs to pass to the callback.
+        disabled : bool
+            An optional boolean that disables the pagination widget if set to
+            ``True``. The default is ``False``.
+
+        Returns
+        -------
+        int
+            The currently selected page number, using 1-based indexing.
+
+        Examples
+        --------
+        Display a pagination widget and show content for the selected page:
+
+        >>> import streamlit as st
+        >>>
+        >>> page = st.pagination(num_pages=10)
+        >>> st.write(f"Showing page {page}")
+
+        .. output::
+           https://doc-pagination-basic.streamlit.app/
+           height: 200px
+
+        """
+        _validate_positive_int("num_pages", num_pages)
+        _validate_positive_int("default", default)
+
+        if default > num_pages:
+            raise StreamlitAPIException(
+                "`default` must be between 1 and `num_pages`, inclusive."
+            )
+
+        if max_visible_pages is not None and (
+            not isinstance(max_visible_pages, int)
+            or isinstance(max_visible_pages, bool)
+            or max_visible_pages < 0
+        ):
+            raise StreamlitAPIException(
+                "`max_visible_pages` must be a non-negative integer or None."
+            )
+
+        key = to_key(key)
+        layout_config = create_layout_config(width=width, allow_content_width=True)
+
+        check_widget_policies(self.dg, key, on_change, default_value=default)
+
+        ctx = get_script_run_ctx()
+        element_id = compute_and_register_element_id(
+            "pagination",
+            user_key=key,
+            key_as_main_identity=True,
+            dg=self.dg,
+            num_pages=num_pages,
+            default=default,
+            max_visible_pages=max_visible_pages,
+            width=width,
+        )
+
+        proto = PaginationProto()
+        proto.id = element_id
+        proto.num_pages = num_pages
+        proto.default = default
+        proto.disabled = disabled
+        proto.form_id = current_form_id(self.dg)
+        if max_visible_pages is not None:
+            proto.max_visible_pages = max_visible_pages
+
+        serde = PaginationSerde(default=default, num_pages=num_pages)
+        widget_state = register_widget(
+            proto.id,
+            on_change_handler=on_change,
+            args=args,
+            kwargs=kwargs,
+            deserializer=serde.deserialize,
+            serializer=serde.serialize,
+            ctx=ctx,
+            value_type="int_value",
+        )
+
+        current_value = widget_state.value
+        value_needs_reset = current_value > num_pages
+        if value_needs_reset:
+            current_value = default
+            if key is not None:
+                get_session_state().reset_state_value(key, current_value)
+
+        if value_needs_reset or widget_state.value_changed:
+            proto.value = current_value
+            proto.set_value = True
+
+        self.dg._enqueue("pagination", proto, layout_config=layout_config)
+        return current_value
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """Get our DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -68,6 +68,7 @@ from streamlit.testing.v1.element_tree import (
     Multiselect,
     Node,
     NumberInput,
+    Pagination,
     Radio,
     Selectbox,
     SelectSlider,
@@ -894,6 +895,20 @@ class AppTest:
             ``at.number_input(key="my_key")`` for a widget with a given key.
         """
         return self._tree.number_input
+
+    @property
+    def pagination(self) -> WidgetList[Pagination]:
+        """Sequence of all ``st.pagination`` widgets.
+
+        Returns
+        -------
+        WidgetList of Pagination
+            Sequence of all ``st.pagination`` widgets. Individual widgets can
+            be accessed from a WidgetList by index (order on the page) or key.
+            For example, ``at.pagination[0]`` for the first widget or
+            ``at.pagination(key="my_key")`` for a widget with a given key.
+        """
+        return self._tree.pagination
 
     @property
     def radio(self) -> WidgetList[Radio[Any]]:

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
     from streamlit.proto.Metric_pb2 import Metric as MetricProto
     from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
     from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
+    from streamlit.proto.Pagination_pb2 import Pagination as PaginationProto
     from streamlit.proto.Radio_pb2 import Radio as RadioProto
     from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
     from streamlit.proto.Space_pb2 import Space as SpaceProto
@@ -879,6 +880,43 @@ class Feedback(Widget):
 
     def set_value(self, v: int | None) -> Feedback:
         """Set the value of the feedback widget. (int or None)"""  # noqa: D400
+        self._value = v
+        return self
+
+
+@dataclass(repr=False)
+class Pagination(Widget):
+    """A representation of ``st.pagination``."""
+
+    _value: int | InitialValue
+
+    proto: PaginationProto = field(repr=False)
+    form_id: str
+
+    def __init__(self, proto: PaginationProto, root: ElementTree) -> None:
+        super().__init__(proto, root)
+        self._value = InitialValue()
+        self.type = "pagination"
+
+    @property
+    def _widget_state(self) -> WidgetState:
+        """Protobuf message representing the state of the widget."""
+        ws = WidgetState()
+        ws.id = self.id
+        ws.int_value = self.value
+        return ws
+
+    @property
+    def value(self) -> int:
+        """The currently selected page number. (int)"""  # noqa: D400
+        if not isinstance(self._value, InitialValue):
+            return self._value
+        state = self.root.session_state
+        assert state
+        return cast("int", state[self.id])
+
+    def set_value(self, v: int) -> Pagination:
+        """Set the selected page number. (int)"""  # noqa: D400
         self._value = v
         return self
 
@@ -2071,6 +2109,10 @@ class Block:
         return WidgetList(self.get("number_input"))  # type: ignore
 
     @property
+    def pagination(self) -> WidgetList[Pagination]:
+        return WidgetList(self.get("pagination"))  # type: ignore
+
+    @property
     def radio(self) -> WidgetList[Radio[Any]]:
         return WidgetList(self.get("radio"))  # type: ignore
 
@@ -2528,6 +2570,8 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                 new_node = Multiselect(elt.multiselect, root=root)
             elif ty == "number_input":
                 new_node = NumberInput(elt.number_input, root=root)
+            elif ty == "pagination":
+                new_node = Pagination(elt.pagination, root=root)
             elif ty == "radio":
                 new_node = Radio(elt.radio, root=root)
             elif ty == "selectbox":

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -75,6 +75,7 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("menu_button", lambda: st.menu_button("Menu", ["a", "b", "c"])),
     ("multiselect", lambda: st.multiselect("Show me", ["a", "b", "c"])),
     ("number_input", lambda: st.number_input("Enter a number")),
+    ("pagination", lambda: st.pagination(10)),
     ("radio", lambda: st.radio("Choose me", ["a", "b", "c"])),
     ("slider", lambda: st.slider("Slide me")),
     ("selectbox", lambda: st.selectbox("Select me", ["a", "b", "c"])),

--- a/lib/tests/streamlit/elements/pagination_test.py
+++ b/lib/tests/streamlit/elements/pagination_test.py
@@ -1,0 +1,286 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""st.pagination unit tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import streamlit as st
+from streamlit.elements.widgets.pagination import PaginationSerde
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.state.session_state import get_script_run_ctx
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+from tests.streamlit.elements.layout_test_utils import WidthConfigFields
+
+
+def test_pagination_serde_returns_default_without_ui_value() -> None:
+    """Test that the serde uses the default before UI interaction."""
+    serde = PaginationSerde(default=3, num_pages=10)
+
+    assert serde.deserialize(None) == 3
+
+
+def test_pagination_serde_rejects_out_of_range_ui_value() -> None:
+    """Test that the serde resets invalid UI values to the default."""
+    serde = PaginationSerde(default=2, num_pages=5)
+
+    assert serde.deserialize(8) == 2
+
+
+class TestPaginationCommand(DeltaGeneratorTestCase):
+    """Tests for the st.pagination command."""
+
+    def test_page_count_is_set(self) -> None:
+        """Test that num_pages is set on the proto."""
+        value = st.pagination(10)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert value == 1
+        assert proto.num_pages == 10
+        assert proto.default == 1
+
+    def test_default_value_is_set(self) -> None:
+        """Test that the default value is returned and set on the proto."""
+        value = st.pagination(10, default=4)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert value == 4
+        assert proto.default == 4
+
+    def test_max_visible_pages_is_set(self) -> None:
+        """Test that max_visible_pages is set when provided."""
+        st.pagination(10, max_visible_pages=5)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert proto.max_visible_pages == 5
+
+    def test_max_visible_pages_can_be_none(self) -> None:
+        """Test that max_visible_pages can be omitted from the proto."""
+        st.pagination(10, max_visible_pages=None)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert not proto.HasField("max_visible_pages")
+
+    def test_invalid_num_pages(self) -> None:
+        """Test that invalid num_pages values raise an exception."""
+        for num_pages in [0, -1, True]:
+            with self.subTest(num_pages=num_pages):
+                with pytest.raises(StreamlitAPIException) as e:
+                    st.pagination(num_pages)
+
+                assert "`num_pages` must be an integer greater than 0." in str(e.value)
+
+    def test_invalid_default(self) -> None:
+        """Test that invalid default values raise an exception."""
+        for default in [0, -1, True]:
+            with self.subTest(default=default):
+                with pytest.raises(StreamlitAPIException) as e:
+                    st.pagination(10, default=default)
+
+                assert "`default` must be an integer greater than 0." in str(e.value)
+
+    def test_default_above_num_pages(self) -> None:
+        """Test that default cannot exceed num_pages."""
+        with pytest.raises(StreamlitAPIException) as e:
+            st.pagination(3, default=4)
+
+        assert "`default` must be between 1 and `num_pages`, inclusive." in str(e.value)
+
+    def test_invalid_max_visible_pages(self) -> None:
+        """Test that invalid max_visible_pages values raise an exception."""
+        for max_visible_pages in [-1, True]:
+            with self.subTest(max_visible_pages=max_visible_pages):
+                with pytest.raises(StreamlitAPIException) as e:
+                    st.pagination(10, max_visible_pages=max_visible_pages)
+
+                assert (
+                    "`max_visible_pages` must be a non-negative integer or None."
+                    in str(e.value)
+                )
+
+    def test_disabled_state(self) -> None:
+        """Test that disabled state is set correctly."""
+        st.pagination(10, disabled=True)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert proto.disabled is True
+
+    def test_widget_state_changed_via_session_state(self) -> None:
+        """Test that widget state can be set via session_state."""
+        st.session_state.page = 4
+
+        value = st.pagination(10, key="page")
+
+        assert value == 4
+
+    def test_page_resets_when_num_pages_decreases(self) -> None:
+        """Test that out-of-range state resets to the default page."""
+        st.session_state.page = 8
+
+        value = st.pagination(5, key="page", default=2)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert value == 2
+        assert st.session_state.page == 2
+        assert proto.value == 2
+        assert proto.set_value is True
+
+    def test_on_change_callback_registered(self) -> None:
+        """Test that on_change callback is registered."""
+        st.pagination(10, on_change=lambda: None)
+
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        session_state = ctx.session_state._state
+        widget_id = session_state.get_widget_states()[0].id
+        metadata = session_state._new_widget_state.widget_metadata.get(widget_id)
+        assert metadata is not None
+        assert metadata.callback is not None
+
+    def test_outside_form(self) -> None:
+        """Test that form_id is empty outside of a form."""
+        st.pagination(10)
+
+        proto = self.get_delta_from_queue().new_element.pagination
+        assert proto.form_id == ""
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_inside_form(self) -> None:
+        """Test that form_id is set correctly inside of a form."""
+        with st.form("form"):
+            st.pagination(10)
+
+        assert len(self.get_all_deltas_from_queue()) == 2
+        form_proto = self.get_delta_from_queue(0).add_block
+        proto = self.get_delta_from_queue(1).new_element.pagination
+        assert proto.form_id == form_proto.form.form_id
+
+    def test_stable_id_with_key(self) -> None:
+        """Test that a user key keeps the widget ID stable across parameter changes."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.pagination(
+                10,
+                key="pagination_key",
+                default=1,
+                max_visible_pages=7,
+                disabled=False,
+                width="content",
+            )
+            id1 = self.get_delta_from_queue().new_element.pagination.id
+
+            st.pagination(
+                5,
+                key="pagination_key",
+                default=2,
+                max_visible_pages=3,
+                disabled=True,
+                width="stretch",
+            )
+            id2 = self.get_delta_from_queue().new_element.pagination.id
+
+        assert id1 == id2
+
+    def test_duplicate_element_id_error_message(self) -> None:
+        """Test that duplicate widget ID produces a helpful error message."""
+        with pytest.raises(StreamlitAPIException) as e:
+            st.pagination(10)
+            st.pagination(10)
+
+        assert "pagination" in str(e.value)
+
+
+class TestPaginationWidthConfig(DeltaGeneratorTestCase):
+    """Tests for st.pagination width configuration."""
+
+    def test_default_width_is_content(self) -> None:
+        """Test that default width is content."""
+        st.pagination(10)
+
+        el = self.get_delta_from_queue().new_element
+        assert (
+            el.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_CONTENT.value
+        )
+
+    def test_stretch_width(self) -> None:
+        """Test that stretch width is set correctly."""
+        st.pagination(10, width="stretch")
+
+        el = self.get_delta_from_queue().new_element
+        assert (
+            el.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.USE_STRETCH.value
+        )
+
+    def test_pixel_width(self) -> None:
+        """Test that pixel width is set correctly."""
+        st.pagination(10, width=300)
+
+        el = self.get_delta_from_queue().new_element
+        assert (
+            el.width_config.WhichOneof("width_spec")
+            == WidthConfigFields.PIXEL_WIDTH.value
+        )
+        assert el.width_config.pixel_width == 300
+
+
+def test_apptest_pagination_value_updates() -> None:
+    """Test that AppTest can update pagination values."""
+    from streamlit.testing.v1 import AppTest
+
+    def script() -> None:
+        import streamlit as st
+
+        page = st.pagination(10, key="page")
+        st.write(f"Page: {page}")
+
+    at = AppTest.from_function(script).run()
+    assert at.pagination[0].value == 1
+
+    at = at.pagination[0].set_value(4).run()
+    assert at.pagination[0].value == 4
+    assert at.markdown[0].value == "Page: 4"
+
+
+def test_apptest_pagination_resets_when_ui_value_exceeds_num_pages() -> None:
+    """Test that shrinking num_pages resets stale UI state on the frontend."""
+    from streamlit.testing.v1 import AppTest
+
+    script = """
+import streamlit as st
+
+if "num_pages" not in st.session_state:
+    st.session_state.num_pages = 10
+
+page = st.pagination(st.session_state.num_pages, key="page", default=2)
+st.write(f"Page: {page}")
+"""
+
+    at = AppTest.from_string(script).run()
+    at = at.pagination[0].set_value(8).run()
+    assert at.pagination[0].value == 8
+
+    at.session_state.num_pages = 5
+    at = at.run()
+    assert at.pagination[0].value == 2
+    assert at.pagination[0].proto.set_value is True
+    assert at.pagination[0].proto.value == 2
+    assert at.markdown[0].value == "Page: 2"

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1034,6 +1034,24 @@ def test_feedback_element():
     assert "Feedback" in result
 
 
+def test_pagination_element():
+    """Test Pagination widget used by st.pagination."""
+
+    def script():
+        import streamlit as st
+
+        st.pagination(10, key="page")
+
+    at = AppTest.from_function(script).run()
+    assert at.pagination[0].value == 1
+
+    at.pagination[0].set_value(4).run()
+    assert at.pagination[0].value == 4
+
+    result = repr(at.pagination[0])
+    assert "Pagination" in result
+
+
 def test_unknown_element():
     """Test UnknownElement handles new/unrecognized element types gracefully."""
 

--- a/lib/tests/streamlit/typing/pagination_types.py
+++ b/lib/tests/streamlit/typing/pagination_types.py
@@ -1,0 +1,30 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform some "type checking testing"; mypy should flag any assignments that are incorrect.
+if TYPE_CHECKING:
+    from streamlit.elements.widgets.pagination import PaginationMixin
+
+    pagination = PaginationMixin().pagination
+
+    assert_type(pagination(10), int)
+    assert_type(pagination(10, default=2, key="page"), int)
+    assert_type(pagination(10, max_visible_pages=None), int)
+    assert_type(pagination(10, max_visible_pages=0), int)

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -54,6 +54,7 @@ import "streamlit/proto/Metric.proto";
 import "streamlit/proto/MultiSelect.proto";
 import "streamlit/proto/NumberInput.proto";
 import "streamlit/proto/PageLink.proto";
+import "streamlit/proto/Pagination.proto";
 import "streamlit/proto/PlotlyChart.proto";
 import "streamlit/proto/Progress.proto";
 import "streamlit/proto/Radio.proto";
@@ -137,7 +138,8 @@ message Element {
     Heading heading = 47;
     Code code = 48;
     MenuButton menu_button = 64;
-    // Next ID: 65
+    Pagination pagination = 65;
+    // Next ID: 66
   }
 
   reserved 3, 9, 10, 11, 17;

--- a/proto/streamlit/proto/Pagination.proto
+++ b/proto/streamlit/proto/Pagination.proto
@@ -1,0 +1,35 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+message Pagination {
+  string id = 1;
+  uint32 num_pages = 2;
+  uint32 default = 3;
+  bool disabled = 4;
+  string form_id = 5;
+
+  // Maximum number of page-number buttons to show. If unset, all pages are
+  // eligible to be shown before responsive width reduction is applied.
+  optional uint32 max_visible_pages = 6;
+
+  // Value passed by the backend (selected page).
+  optional uint32 value = 7;
+  bool set_value = 8;
+
+  // next id: 9
+}


### PR DESCRIPTION
## Describe your changes

Adds `st.pagination` for navigating paged content with numbered buttons, prev/next controls, truncation, disabled state, and width handling.

- Wires the widget through protobuf, backend state, AppTest, and frontend rendering.
- Preserves selected-page state across reruns and resets stale pages when `num_pages` shrinks.

## Screenshot or video (only for visual changes)

Not included.

## GitHub Issue Link (if applicable)

- Closes #10785

## Testing Plan

- Unit Tests (JS and/or Python): `lib/tests/streamlit/elements/pagination_test.py`, `lib/tests/streamlit/testing/element_tree_test.py -k pagination`, `frontend/lib/src/components/widgets/Pagination/Pagination.test.tsx`
- E2E Tests: `e2e_playwright/st_pagination_test.py`
- Any manual testing needed? No

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)