### PR TITLE
[chore] Update GPT model to gpt-5.4-xhigh in AI PR review

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
         required: false
         type: string
-        default: "gpt-5.5-extra-high,gemini-3.1-pro,claude-opus-4-7-thinking-xhigh"
+        default: "gpt-5.4-xhigh,gemini-3.1-pro,claude-opus-4-7-thinking-xhigh"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'gpt-5.5-extra-high,gemini-3.1-pro,claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ github.event.inputs.model || 'gpt-5.4-xhigh,gemini-3.1-pro,claude-opus-4-7-thinking-xhigh' }}
 
 jobs:
   # Job 1: Parse model list and check for API key


### PR DESCRIPTION
## Describe your changes

- Updates the default GPT model from `gpt-5.5-extra-high` to `gpt-5.4-xhigh` in the AI PR review workflow

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Workflow file validated via `make check`

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->