### PR TITLE
fix(auth): avoid storing access tokens by default

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -299,6 +299,26 @@ def generate_default_provider_section(auth_section: AttrDict) -> dict[str, Any]:
     return default_provider_section
 
 
+def get_tokens_to_store(token_payload: Mapping[str, Any]) -> dict[str, str]:
+    """Select which OAuth tokens should be persisted in auth cookies.
+
+    The ID token is always retained to support RP-initiated logout.
+    The access token is only persisted when explicitly exposed in auth config.
+    """
+    stored_tokens: dict[str, str] = {}
+
+    id_token = token_payload.get("id_token")
+    if isinstance(id_token, str):
+        stored_tokens["id_token"] = id_token
+
+    if "access" in get_expose_tokens_config():
+        access_token = token_payload.get("access_token")
+        if isinstance(access_token, str):
+            stored_tokens["access_token"] = access_token
+
+    return stored_tokens
+
+
 def set_cookie_with_chunks(
     set_single_cookie_fn: Callable[[str, str], None],
     create_signed_value_fn: Callable[[str, str], bytes],

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -31,6 +31,7 @@ from streamlit.auth_util import (
     get_origin_from_redirect_uri,
     get_redirect_uri,
     get_secrets_auth_section,
+    get_tokens_to_store,
     get_validated_redirect_uri,
     set_cookie_with_chunks,
 )
@@ -218,12 +219,13 @@ async def _set_auth_cookie(
         USER_COOKIE_NAME,
         user_info,
     )
-    set_cookie_with_chunks(
-        set_single_cookie,
-        _create_signed_value_wrapper,
-        TOKENS_COOKIE_NAME,
-        tokens,
-    )
+    if tokens:
+        set_cookie_with_chunks(
+            set_single_cookie,
+            _create_signed_value_wrapper,
+            TOKENS_COOKIE_NAME,
+            tokens,
+        )
 
 
 def _set_single_cookie(
@@ -546,7 +548,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
     response = await _redirect_to_base(base_url)
 
     cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
-    tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
+    tokens = get_tokens_to_store(token)
     if user:
         await _set_auth_cookie(response, cookie_value, tokens)
     else:  # pragma: no cover - error path

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -34,6 +34,7 @@ from streamlit.auth_util import (
     get_expose_tokens_config,
     get_redirect_uri,
     get_signing_secret,
+    get_tokens_to_store,
     is_authlib_installed,
     set_cookie_with_chunks,
     validate_auth_credentials,
@@ -233,6 +234,52 @@ class ExposeTokensConfigTest(unittest.TestCase):
                 "Invalid expose_tokens configuration. Only 'id' and 'access' are allowed."
                 in str(exc_info.value)
             )
+
+
+class TokensToStoreTest(unittest.TestCase):
+    """Test token selection for auth cookies."""
+
+    @patch(
+        "streamlit.auth_util.secrets_singleton",
+        MagicMock(
+            load_if_toml_exists=MagicMock(return_value=True),
+            get=MagicMock(
+                return_value={
+                    "redirect_uri": "http://localhost:8501/oauth2callback",
+                    "cookie_secret": "test_cookie_secret",
+                }
+            ),
+        ),
+    )
+    def test_default_configuration_keeps_only_id_token(self):
+        """Test that access tokens are dropped unless explicitly exposed."""
+        result = get_tokens_to_store(
+            {"id_token": "test-id-token", "access_token": "test-access-token"}
+        )
+        assert result == {"id_token": "test-id-token"}
+
+    @patch(
+        "streamlit.auth_util.secrets_singleton",
+        MagicMock(
+            load_if_toml_exists=MagicMock(return_value=True),
+            get=MagicMock(
+                return_value={
+                    "redirect_uri": "http://localhost:8501/oauth2callback",
+                    "cookie_secret": "test_cookie_secret",
+                    "expose_tokens": ["access"],
+                }
+            ),
+        ),
+    )
+    def test_access_token_is_kept_when_explicitly_exposed(self):
+        """Test that access tokens are retained when requested in config."""
+        result = get_tokens_to_store(
+            {"id_token": "test-id-token", "access_token": "test-access-token"}
+        )
+        assert result == {
+            "id_token": "test-id-token",
+            "access_token": "test-access-token",
+        }
 
 
 class CookieChunkingTest(unittest.TestCase):

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -119,7 +119,11 @@ def test_auth_callback_sets_signed_cookie(monkeypatch: pytest.MonkeyPatch) -> No
     """Test that successful OAuth callback sets a signed auth cookie."""
 
     async def _dummy_authorize_access_token(self, request: Any) -> dict[str, Any]:
-        return {"userinfo": {"email": "user@example.com"}}
+        return {
+            "userinfo": {"email": "user@example.com"},
+            "id_token": "test-id-token",
+            "access_token": "test-access-token",
+        }
 
     class _DummyClient:
         async def authorize_access_token(self, request: Any) -> dict[str, Any]:
@@ -147,8 +151,11 @@ def test_auth_callback_sets_signed_cookie(monkeypatch: pytest.MonkeyPatch) -> No
         assert response.status_code == 302
         assert response.headers["location"].endswith("/")
 
+        set_cookie_headers = response.headers.get_list("set-cookie")
+
         cookies = SimpleCookie()
-        cookies.load(response.headers["set-cookie"])
+        for header in set_cookie_headers:
+            cookies.load(header)
         signed_value = cookies["_streamlit_user"].value
         decoded = starlette_app_utils.decode_signed_value(
             "test-secret", "_streamlit_user", signed_value
@@ -157,6 +164,27 @@ def test_auth_callback_sets_signed_cookie(monkeypatch: pytest.MonkeyPatch) -> No
         payload = decoded.decode("utf-8")
         assert "user@example.com" in payload
         assert '"is_logged_in": true' in payload.lower()
+
+        tokens_cookie_header = next(
+            (
+                h
+                for h in set_cookie_headers
+                if h.startswith(f"{TOKENS_COOKIE_NAME}=")
+            ),
+            None,
+        )
+        assert tokens_cookie_header is not None, "Tokens cookie not found"
+
+        cookies = SimpleCookie()
+        cookies.load(tokens_cookie_header)
+        signed_tokens_value = cookies[TOKENS_COOKIE_NAME].value
+        decoded_tokens = starlette_app_utils.decode_signed_value(
+            "test-secret", TOKENS_COOKIE_NAME, signed_tokens_value
+        )
+        assert decoded_tokens is not None
+        tokens_payload = decoded_tokens.decode("utf-8")
+        assert "test-id-token" in tokens_payload
+        assert "test-access-token" not in tokens_payload
 
 
 def test_login_initializes_session(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Entra ID logins were persisting the access token in auth cookies, which can bloat request headers and trigger 400s on later requests. This keeps the ID token for logout support, stores the access token only when `expose_tokens` opts in, and skips the tokens cookie when there's nothing to save. Verified with `uv run pytest lib/tests/streamlit/auth_util_test.py lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py` and `uv run ruff check` on the touched files. Fixes #14960.