### PR TITLE
[chore] Refactor implementing-feature skill to use foreground subagents

### DIFF
--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -58,8 +58,8 @@ Progress:
 Run this phase in a **foreground subagent**. The subagent should:
 
 - Search for similar existing features to follow patterns
-- Use the /understanding-streamlit-architecture skill to understand relevant internals
-- **Always write a tech-spec / implementation plan** to `work-tmp/<feature-name>-implementation-plan.md`
+- Use the `/understanding-streamlit-architecture` skill to understand relevant internals
+- **Always write an implementation plan** to `work-tmp/<feature-name>-implementation-plan.md`, where `<feature-name>` is derived from the branch name (e.g., `git branch --show-current | sed 's|.*/||'`) or, if on a detached HEAD, the spec folder basename
 
 The implementation plan must include:
 - Summary of the feature requirements (from spec)
@@ -80,9 +80,8 @@ The subagent should:
 - Do additional research if anything is unclear or missing from the provided context
 - Run `make protobuf` after any protobuf changes
 - Add unit tests (Python in `lib/tests/`, frontend co-located) and E2E tests in `e2e_playwright/`
-- Use the /debugging-streamlit skill to test and debug backend, frontend, and UI
-
-Wait for the subagent to complete before proceeding to verification.
+- Use the `/debugging-streamlit` skill to test and debug backend, frontend, and UI
+- Return a summary of key implementation decisions and any spec divergences
 
 ### Phase 4: Verify against spec
 
@@ -94,13 +93,13 @@ Wait for the subagent to complete before proceeding to verification.
 
 ### Phase 5: Finalize for merge
 
-- Run /finalizing-pr skill to execute quality checks, create the PR, and make it merge-ready
+- Run `/finalizing-pr` skill to execute quality checks, create the PR, and make it merge-ready
 - Follow all steps until the PR is merge-ready
 
 ## Important notes
 
 - **Be fully autonomous** - Do NOT stop or pause to ask for confirmation. You are tasked to go from spec to merge-ready PR without human intervention. Note any open questions or ambiguities in the PR description rather than blocking on them.
-- **Use foreground subagents** - Phases 2 and 3 must run as foreground (blocking) subagents. Wait for each to complete before proceeding. This preserves main context while delegating intensive research and implementation work.
+- **Use foreground subagents** - Phases 2 and 3 run as foreground (blocking) subagents to preserve main context while delegating intensive research and implementation work.
 - **Follow Streamlit patterns** - Check existing similar features for conventions
 - **Reference the spec in PR** - Include spec link in PR description
-- **Test thoroughly** - Use /debugging-streamlit before finalizing
+- **Test thoroughly** - Use `/debugging-streamlit` before finalizing

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -73,16 +73,11 @@ Wait for the subagent to complete and verify the implementation plan exists befo
 
 ### Phase 3: Implement and test
 
-Run this phase in a **foreground subagent**. Provide the subagent with:
-
-- The full spec content (paste the text, not just a path)
-- The full implementation plan content from Phase 2
-- Any relevant API docstrings or interface files identified in the plan
-- Clear instruction to implement the feature end-to-end
+Run this phase in a **foreground subagent**. Provide all relevant context needed to implement the feature, including the full spec content, the implementation plan from Phase 2, and any key API signatures or patterns identified during research.
 
 The subagent should:
-- Read the provided spec and implementation plan
-- Implement the feature based on the plan. Read `wiki/new-feature-guide.md` for tips.
+- Implement the feature based on the spec and plan. Read `wiki/new-feature-guide.md` for tips.
+- Do additional research if anything is unclear or missing from the provided context
 - Run `make protobuf` after any protobuf changes
 - Add unit tests (Python in `lib/tests/`, frontend co-located) and E2E tests in `e2e_playwright/`
 - Use the /debugging-streamlit skill to test and debug backend, frontend, and UI

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -55,7 +55,7 @@ Progress:
 
 ### Phase 2: Research and plan
 
-Run this phase in a **foreground subagent** using the `Agent` tool. The subagent should:
+Run this phase in a **foreground subagent**. The subagent should:
 
 - Search for similar existing features to follow patterns
 - Use the /understanding-streamlit-architecture skill to understand relevant internals
@@ -73,7 +73,7 @@ Wait for the subagent to complete and verify the implementation plan exists befo
 
 ### Phase 3: Implement and test
 
-Run this phase in a **foreground subagent** using the `Agent` tool. Provide the subagent with:
+Run this phase in a **foreground subagent**. Provide the subagent with:
 
 - Path to the original spec (folder, URL, or issue)
 - Path to the implementation plan created in Phase 2

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -75,8 +75,8 @@ Wait for the subagent to complete and verify the implementation plan exists befo
 
 Run this phase in a **foreground subagent**. Provide the subagent with:
 
-- Path to the original spec (folder, URL, or issue)
-- Path to the implementation plan created in Phase 2
+- The full spec content (paste the text, not just a path)
+- The full implementation plan content from Phase 2
 - Any relevant API docstrings or interface files identified in the plan
 - Clear instruction to implement the feature end-to-end
 

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -55,16 +55,40 @@ Progress:
 
 ### Phase 2: Research and plan
 
+Run this phase in a **foreground subagent** using the `Agent` tool with `subagent_type: "Explore"`. The subagent should:
+
 - Search for similar existing features to follow patterns
 - Use the /understanding-streamlit-architecture skill to understand relevant internals
-- If there is technical complexity, write a tech-spec / implementation plan in `work-tmp/`
+- **Always write a tech-spec / implementation plan** to `work-tmp/<feature-name>-implementation-plan.md`
+
+The implementation plan must include:
+- Summary of the feature requirements (from spec)
+- Relevant existing patterns found in codebase
+- List of files to create or modify (backend, frontend, proto, tests)
+- Implementation steps in order
+- Key decisions and trade-offs
+- Test strategy (unit tests, E2E tests)
+
+Wait for the subagent to complete and verify the implementation plan exists before proceeding.
 
 ### Phase 3: Implement and test
 
-- Implement the feature based on the provided spec. Read `wiki/new-feature-guide.md` for tips.
+Run this phase in a **foreground subagent** using the `Agent` tool with `subagent_type: "general-purpose"`. Provide the subagent with:
+
+- Path to the original spec (folder, URL, or issue)
+- Path to the implementation plan created in Phase 2
+- Any relevant API docstrings or interface files identified in the plan
+- Clear instruction to implement the feature end-to-end
+
+The subagent should:
+- Read the provided spec and implementation plan
+- Implement the feature based on the plan. Read `wiki/new-feature-guide.md` for tips.
 - Run `make protobuf` after any protobuf changes
 - Add unit tests (Python in `lib/tests/`, frontend co-located) and E2E tests in `e2e_playwright/`
 - Use the /debugging-streamlit skill to test and debug backend, frontend, and UI
+- Commit incrementally with logical commits as implementation progresses
+
+Wait for the subagent to complete before proceeding to verification.
 
 ### Phase 4: Verify against spec
 
@@ -82,7 +106,7 @@ Progress:
 ## Important notes
 
 - **Be fully autonomous** - Do NOT stop or pause to ask for confirmation. You are tasked to go from spec to merge-ready PR without human intervention. Note any open questions or ambiguities in the PR description rather than blocking on them.
+- **Use foreground subagents** - Phases 2 and 3 must run as foreground (blocking) subagents. Wait for each to complete before proceeding. This preserves main context while delegating intensive research and implementation work.
 - **Follow Streamlit patterns** - Check existing similar features for conventions
 - **Reference the spec in PR** - Include spec link in PR description
 - **Test thoroughly** - Use /debugging-streamlit before finalizing
-- **Commit incrementally** - Make logical commits as you implement each phase

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -55,7 +55,7 @@ Progress:
 
 ### Phase 2: Research and plan
 
-Run this phase in a **foreground subagent** using the `Agent` tool with `subagent_type: "Explore"`. The subagent should:
+Run this phase in a **foreground subagent** using the `Agent` tool. The subagent should:
 
 - Search for similar existing features to follow patterns
 - Use the /understanding-streamlit-architecture skill to understand relevant internals
@@ -73,7 +73,7 @@ Wait for the subagent to complete and verify the implementation plan exists befo
 
 ### Phase 3: Implement and test
 
-Run this phase in a **foreground subagent** using the `Agent` tool with `subagent_type: "general-purpose"`. Provide the subagent with:
+Run this phase in a **foreground subagent** using the `Agent` tool. Provide the subagent with:
 
 - Path to the original spec (folder, URL, or issue)
 - Path to the implementation plan created in Phase 2

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -86,7 +86,6 @@ The subagent should:
 - Run `make protobuf` after any protobuf changes
 - Add unit tests (Python in `lib/tests/`, frontend co-located) and E2E tests in `e2e_playwright/`
 - Use the /debugging-streamlit skill to test and debug backend, frontend, and UI
-- Commit incrementally with logical commits as implementation progresses
 
 Wait for the subagent to complete before proceeding to verification.
 


### PR DESCRIPTION
## Describe your changes

Updates the `implementing-feature` skill to delegate intensive work to foreground subagents:

- **Phase 2 (Research and plan)**: Now runs in an `Explore` subagent that always writes a tech-spec/implementation plan to `work-tmp/<feature-name>-implementation-plan.md`
- **Phase 3 (Implement and test)**: Now runs in a `general-purpose` subagent that receives the spec, implementation plan, and relevant context

This approach preserves the main agent's context while delegating research and implementation to focused subagents.

## GitHub Issue Link (if applicable)

N/A - Internal skill improvement

## Testing Plan

- [x] Manual verification of skill file syntax
- [x] Pre-commit checks passed

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | general-purpose | 2 |

</details>
<!-- agent-metrics-end -->