### PR TITLE
[chore] Update AI review verdict criteria and finalize-pr skill loop

### DIFF
--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -128,6 +128,10 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 **[APPROVED / CHANGES REQUESTED]**: [One sentence summary of the overall assessment.]
 
+Verdict criteria:
+- **APPROVED**: The changes are ready to merge. Use this even if there are minor suggestions or optional improvements — those can be addressed in follow-up PRs.
+- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
+
 ---
 *This is an automated AI review. Please verify the feedback and use your judgment.*
 ```

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -129,7 +129,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 **[APPROVED / CHANGES REQUESTED]**: [One sentence summary of the overall assessment.]
 
 Verdict criteria:
-- **APPROVED**: The changes are ready to merge. Use this even if there are minor suggestions or optional improvements — those can be addressed in follow-up PRs.
+- **APPROVED**: If there are no critical/merge-blocking issues. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
 - **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
 
 ---

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -130,34 +130,21 @@ gh pr edit --add-label "ai-review"
 
 **Checking AI review verdict:**
 
-The AI review posts results as either a PR review or a PR comment (fallback) from the `github-actions` bot. These contain a hidden marker:
+The AI review posts results as a PR review from the `github-actions` bot. These contain a hidden marker:
 
 ```html
 <!-- streamlit-ai-review run_id="..." timestamp="..." -->
 ```
 
-To find the latest AI review and extract the verdict, check both endpoints:
+To find the latest AI review and extract the verdict:
 
 ```bash
 PR_NUM=$(gh pr view --json number -q '.number')
 
-# Check PR reviews first (primary), then PR comments (fallback)
-# The workflow posts via Reviews API but falls back to comments if that fails
-VERDICT=$(
-  gh api --paginate "repos/streamlit/streamlit/pulls/${PR_NUM}/reviews" \
-    | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.submitted_at) | last | .body' \
-    | grep -A2 "## Verdict" 2>/dev/null
-)
-
-if [ -z "$VERDICT" ]; then
-  VERDICT=$(
-    gh api --paginate "repos/streamlit/streamlit/issues/${PR_NUM}/comments" \
-      | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.created_at) | last | .body' \
-      | grep -A2 "## Verdict" 2>/dev/null
-  )
-fi
-
-echo "$VERDICT"
+# Get the verdict from the latest AI review
+gh api --paginate "repos/streamlit/streamlit/pulls/${PR_NUM}/reviews" \
+  | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.submitted_at) | last | .body' \
+  | grep -A2 "## Verdict"
 ```
 
 The verdict section contains a bold keyword indicating the result:

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -130,23 +130,34 @@ gh pr edit --add-label "ai-review"
 
 **Checking AI review verdict:**
 
-The AI review posts results as a PR review from the `github-actions` bot. These reviews contain a hidden marker:
+The AI review posts results as either a PR review or a PR comment (fallback) from the `github-actions` bot. These contain a hidden marker:
 
 ```html
 <!-- streamlit-ai-review run_id="..." timestamp="..." -->
 ```
 
-To find the latest AI review and extract the verdict:
+To find the latest AI review and extract the verdict, check both endpoints:
 
 ```bash
-# Get PR number
 PR_NUM=$(gh pr view --json number -q '.number')
 
-# Get the verdict line from the latest AI review (posted as PR comment, not PR review)
-# Note: Use jq -s to slurp all pages into single array, then sort by created_at to get chronologically latest
-gh api --paginate "repos/streamlit/streamlit/issues/${PR_NUM}/comments" \
-  | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.created_at) | last | .body' \
-  | grep -A2 "## Verdict"
+# Check PR reviews first (primary), then PR comments (fallback)
+# The workflow posts via Reviews API but falls back to comments if that fails
+VERDICT=$(
+  gh api --paginate "repos/streamlit/streamlit/pulls/${PR_NUM}/reviews" \
+    | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.submitted_at) | last | .body' \
+    | grep -A2 "## Verdict" 2>/dev/null
+)
+
+if [ -z "$VERDICT" ]; then
+  VERDICT=$(
+    gh api --paginate "repos/streamlit/streamlit/issues/${PR_NUM}/comments" \
+      | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.created_at) | last | .body' \
+      | grep -A2 "## Verdict" 2>/dev/null
+  )
+fi
+
+echo "$VERDICT"
 ```
 
 The verdict section contains a bold keyword indicating the result:

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -116,7 +116,7 @@ Iterate through AI review and fixes until the review passes (max 5 iterations):
 ```
 for iteration 1 to 5:
     1. Trigger AI review by applying the "ai-review" label
-    2. Run the `fixing-pr` subagent to wait for CI, fix failures, and address review comments
+    2. Run the `fixing-pr` subagent in foreground to wait for CI, fix failures, and address review comments
     3. Check AI review verdict in the latest github-actions bot comment
     4. If verdict is "approved" → exit loop
     5. Otherwise → continue to next iteration

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -130,27 +130,28 @@ gh pr edit --add-label "ai-review"
 
 **Checking AI review verdict:**
 
-The AI review posts results as a PR comment from the `github-actions` bot. These comments contain a hidden marker:
+The AI review posts results as a PR review from the `github-actions` bot. These reviews contain a hidden marker:
 
 ```html
 <!-- streamlit-ai-review run_id="..." timestamp="..." -->
 ```
 
-To find the latest AI review comment and extract the verdict:
+To find the latest AI review and extract the verdict:
 
 ```bash
-# Get PR number
+# Get PR number and repo
 PR_NUM=$(gh pr view --json number -q '.number')
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 
-# Get the verdict line from the latest AI review comment
-gh api "repos/streamlit/streamlit/issues/${PR_NUM}/comments" \
+# Get the verdict line from the latest AI review (uses pulls reviews API, not issues comments)
+gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews" \
   --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | last | .body' \
-  | grep -A1 "## Verdict"
+  | grep -A2 "## Verdict"
 ```
 
 The verdict section contains a bold keyword indicating the result:
 - **`**APPROVED**`** → exit loop, PR is ready
-- **`**CHANGES REQUESTED**`** → continue iterating, address the feedback
+- **`**CHANGES_REQUESTED**`** → continue iterating, address the feedback
 
 **Important:** After each `fixing-pr` run, re-check if changes were made. If changes were pushed, the AI review will be stale and needs re-triggering. Continue iterating until the review verdict is "approved" or max iterations reached.
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -144,8 +144,9 @@ PR_NUM=$(gh pr view --json number -q '.number')
 REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 
 # Get the verdict line from the latest AI review (uses pulls reviews API, not issues comments)
+# Note: Use jq -s to slurp all pages into single array, then sort by submitted_at to get chronologically latest
 gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews" \
-  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | last | .body' \
+  | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.submitted_at) | last | .body' \
   | grep -A2 "## Verdict"
 ```
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -143,10 +143,10 @@ To find the latest AI review and extract the verdict:
 PR_NUM=$(gh pr view --json number -q '.number')
 REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 
-# Get the verdict line from the latest AI review (uses pulls reviews API, not issues comments)
-# Note: Use jq -s to slurp all pages into single array, then sort by submitted_at to get chronologically latest
-gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews" \
-  | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.submitted_at) | last | .body' \
+# Get the verdict line from the latest AI review (posted as PR comment, not PR review)
+# Note: Use jq -s to slurp all pages into single array, then sort by created_at to get chronologically latest
+gh api --paginate "repos/${REPO}/issues/${PR_NUM}/comments" \
+  | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.created_at) | last | .body' \
   | grep -A2 "## Verdict"
 ```
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -139,13 +139,12 @@ The AI review posts results as a PR review from the `github-actions` bot. These 
 To find the latest AI review and extract the verdict:
 
 ```bash
-# Get PR number and repo
+# Get PR number
 PR_NUM=$(gh pr view --json number -q '.number')
-REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 
 # Get the verdict line from the latest AI review (posted as PR comment, not PR review)
 # Note: Use jq -s to slurp all pages into single array, then sort by created_at to get chronologically latest
-gh api --paginate "repos/${REPO}/issues/${PR_NUM}/comments" \
+gh api --paginate "repos/streamlit/streamlit/issues/${PR_NUM}/comments" \
   | jq -s '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | sort_by(.created_at) | last | .body' \
   | grep -A2 "## Verdict"
 ```

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -105,34 +105,59 @@ EOF
 
 **If PR exists**, check if description needs updating based on current changes.
 
-### 10. Trigger AI review
+### 10. Upload intermediate files
 
-Apply the `ai-review` label to trigger the AI code review:
+If relevant intermediate files exist (specs, plans, implementation notes in `work-tmp/` or untracked in `specs/`), run the `/sharing-pr-agent-artifacts` skill to push them to the wiki and comment on the PR with links.
+
+### 11. AI review and fix loop
+
+Iterate through AI review and fixes until the review passes (max 5 iterations):
+
+```
+for iteration 1 to 5:
+    1. Trigger AI review by applying the "ai-review" label
+    2. Run the `fixing-pr` subagent to wait for CI, fix failures, and address review comments
+    3. Check AI review verdict in the latest github-actions bot comment
+    4. If verdict is "approved" → exit loop
+    5. Otherwise → continue to next iteration
+```
+
+**Triggering AI review:**
 
 ```bash
 gh pr edit --add-label "ai-review"
 ```
 
-### 11. Upload intermediate files
+**Checking AI review verdict:**
 
-If relevant intermediate files exist (specs, plans, implementation notes in `work-tmp/` or untracked in `specs/`), run the `/sharing-pr-agent-artifacts` skill to push them to the wiki and comment on the PR with links.
+The AI review posts results as a PR comment from the `github-actions` bot. These comments contain a hidden marker:
 
-### 12. Fix CI issues and address PR review comments
+```html
+<!-- streamlit-ai-review run_id="..." timestamp="..." -->
+```
 
-Run the `fixing-pr` subagent to automatically wait for CI, fix any failures, address PR review comments, validate changes, and push. Wait for completion before proceeding.
+To find the latest AI review comment and extract the verdict:
 
-### 13. Post agent metrics
+```bash
+# Get PR number
+PR_NUM=$(gh pr view --json number -q '.number')
+
+# Get the verdict line from the latest AI review comment
+gh api "repos/streamlit/streamlit/issues/${PR_NUM}/comments" \
+  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- streamlit-ai-review")))] | last | .body' \
+  | grep -A1 "## Verdict"
+```
+
+The verdict section contains a bold keyword indicating the result:
+- **`**APPROVED**`** → exit loop, PR is ready
+- **`**CHANGES REQUESTED**`** → continue iterating, address the feedback
+
+**Important:** After each `fixing-pr` run, re-check if changes were made. If changes were pushed, the AI review will be stale and needs re-triggering. Continue iterating until the review verdict is "approved" or max iterations reached.
+
+### 12. Post agent metrics
 
 Post the agent metrics to the PR body:
 
 ```bash
 uv run python scripts/log_agent_metrics.py --post
-```
-
-### 14. Trigger final AI review
-
-Apply the `ai-review` label to trigger the final AI code review:
-
-```bash
-gh pr edit --add-label "ai-review"
 ```

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -445,6 +445,12 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
+          # Verify review file exists before modifying
+          if [ ! -f review.md ]; then
+            echo "Error: review.md not found"
+            exit 1
+          fi
+
           # Add hidden marker at the end of the review for programmatic detection
           # Format: <!-- streamlit-ai-review run_id="..." timestamp="..." -->
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -454,12 +460,6 @@ jobs:
           # changes on a PR. The verdict is still written to verdict.txt and used for
           # labeling (e.g. do-not-merge), but the GitHub review event is always COMMENT.
           EVENT="COMMENT"
-
-          # Verify review file exists
-          if [ ! -f review.md ]; then
-            echo "Error: review.md not found"
-            exit 1
-          fi
 
           # Get head SHA for review API
           HEAD_SHA=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER_ENV" --jq '.head.sha')

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -330,8 +330,8 @@ jobs:
           3. **Resolve conflicts** - use your judgment or own verification to determine the correct assessment when reviewers disagree
           4. **Track missing reviews** - if any expected models are missing from the reviews above, note them as 'failed to complete review'
           5. **Determine final verdict**:
-             - APPROVED: The changes are ready to merge. Use this even if there are minor suggestions or optional improvements — those can be addressed in follow-up PRs.
-             - CHANGES_REQUESTED: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
+             - APPROVED: If the majority of available reviews approve AND there are no critical/merge-blocking issues raised by any reviewer. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
+             - CHANGES_REQUESTED: If majority request changes OR any reviewer raised critical/merge-blocking issues (bugs, security vulnerabilities, breaking changes, missing required tests). Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
 
           __CONSOLIDATION_INSTRUCTIONS__
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -330,8 +330,8 @@ jobs:
           3. **Resolve conflicts** - use your judgment or own verification to determine the correct assessment when reviewers disagree
           4. **Track missing reviews** - if any expected models are missing from the reviews above, note them as 'failed to complete review'
           5. **Determine final verdict**:
-             - APPROVED: Only if the majority of available reviews approve AND there are no critical issues raised by any reviewer
-             - CHANGES_REQUESTED: If majority request changes OR any reviewer raised critical/blocking issues
+             - APPROVED: The changes are ready to merge. Use this even if there are minor suggestions or optional improvements — those can be addressed in follow-up PRs.
+             - CHANGES_REQUESTED: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
 
           __CONSOLIDATION_INSTRUCTIONS__
 
@@ -443,7 +443,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER_ENV: ${{ env.PR_NUMBER }}
           REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
+          # Add hidden marker at the end of the review for programmatic detection
+          # Format: <!-- streamlit-ai-review run_id="..." timestamp="..." -->
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "" >> review.md
+          echo "<!-- streamlit-ai-review run_id=\"$RUN_ID\" timestamp=\"$TIMESTAMP\" -->" >> review.md
           # Always post as COMMENT — the bot should never formally approve or request
           # changes on a PR. The verdict is still written to verdict.txt and used for
           # labeling (e.g. do-not-merge), but the GitHub review event is always COMMENT.

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -74,6 +74,10 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 **[APPROVED / CHANGES REQUESTED]**: [One sentence summary of the overall assessment.]
 
+Verdict criteria:
+- **APPROVED**: The changes are ready to merge. Use this even if there are minor suggestions or optional improvements — those can be addressed in follow-up PRs.
+- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
+
 ---
 *This is an automated AI review. Please verify the feedback and use your judgment.*
 ```

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -75,7 +75,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 **[APPROVED / CHANGES REQUESTED]**: [One sentence summary of the overall assessment.]
 
 Verdict criteria:
-- **APPROVED**: The changes are ready to merge. Use this even if there are minor suggestions or optional improvements — those can be addressed in follow-up PRs.
+- **APPROVED**: If there are no critical/merge-blocking issues. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
 - **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
 
 ---


### PR DESCRIPTION
## Describe your changes

- Updated `finalizing-pr` skill to iterate through AI review and `fixing-pr` up to 5 times until the review verdict is approved
- Added proper API calls to detect AI review verdict from `github-actions[bot]` PR comments containing the `<!-- streamlit-ai-review -->` marker
- Updated verdict criteria in `ai-pr-review.yml` consolidation prompt to only use CHANGES_REQUESTED for merge-blocking issues (bugs, security vulnerabilities, breaking changes, missing required tests)
- Added verdict criteria to `code-review-instructions.md` so individual AI reviewers also follow the same guidance
- Optional improvements and style preferences should no longer result in CHANGES_REQUESTED

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Manual verification that `gh api` calls correctly detect AI review comments and verdicts

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->