### PR TITLE
[chore] Reduce message flush sleep from 10ms to 1ms

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -26,6 +26,7 @@ from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.navigation.page import StreamlitPage
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
 from streamlit.runtime.scriptrunner import (
     RerunData,
     ScriptRunContext,
@@ -320,11 +321,9 @@ def switch_page(  # type: ignore[misc]
     # Reset query params (with exception of embed) and optionally apply overrides.
     with ctx.session_state.query_params() as qp:
         _set_query_params_for_switch(qp, query_params)
-        # Additional safeguard to ensure the query params
-        #  are sent out to the frontend before the new rerun might clear
-        # outstanding messages. This uses the same time that is used as waiting
-        # in our event loop.
-        time.sleep(0.01)
+        # Additional safeguard to ensure the query params are sent out to the
+        # frontend before the new rerun might clear outstanding messages.
+        time.sleep(MESSAGE_FLUSH_INTERVAL_SECS)
 
     ctx.script_requests.request_rerun(
         RerunData(

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -322,10 +322,11 @@ def switch_page(  # type: ignore[misc]
     with ctx.session_state.query_params() as qp:
         _set_query_params_for_switch(qp, query_params)
 
-    # Additional safeguard to ensure the query params are sent out to the
-    # frontend before the new rerun might clear outstanding messages.
-    # Sleep is placed after the with block to release the session state lock first.
-    time.sleep(MESSAGE_FLUSH_INTERVAL_SECS)
+    # Safeguard: sleep longer than the flush interval to ensure at least one
+    # complete flush cycle delivers the query params before the rerun clears
+    # outstanding messages. Sleep is placed after the with block to release
+    # the session state lock first.
+    time.sleep(2 * MESSAGE_FLUSH_INTERVAL_SECS)
 
     ctx.script_requests.request_rerun(
         RerunData(

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -321,9 +321,11 @@ def switch_page(  # type: ignore[misc]
     # Reset query params (with exception of embed) and optionally apply overrides.
     with ctx.session_state.query_params() as qp:
         _set_query_params_for_switch(qp, query_params)
-        # Additional safeguard to ensure the query params are sent out to the
-        # frontend before the new rerun might clear outstanding messages.
-        time.sleep(MESSAGE_FLUSH_INTERVAL_SECS)
+
+    # Additional safeguard to ensure the query params are sent out to the
+    # frontend before the new rerun might clear outstanding messages.
+    # Sleep is placed after the with block to release the session state lock first.
+    time.sleep(MESSAGE_FLUSH_INTERVAL_SECS)
 
     ctx.script_requests.request_rerun(
         RerunData(

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -28,6 +28,7 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
 from streamlit.runtime.scriptrunner_utils.script_run_context import enqueue_message
 
 if TYPE_CHECKING:
@@ -83,11 +84,9 @@ class StatusContainer(DeltaGenerator):
         status_container._current_proto = block_proto
         status_container._current_state = state
 
-        # We need to sleep here for a very short time to prevent issues when
-        # the status is updated too quickly. If an .update() directly follows the
-        # the initialization, sometimes only the latest update is applied.
-        # Adding a short timeout here allows the frontend to render the update before.
-        time.sleep(0.05)
+        # Ensure the initial message is flushed before any immediate .update() call,
+        # so both messages are sent in separate flush cycles.
+        time.sleep(2 * MESSAGE_FLUSH_INTERVAL_SECS)
 
         return status_container
 
@@ -181,12 +180,9 @@ class StatusContainer(DeltaGenerator):
     ) -> Literal[False]:
         # Only update if the current state is running
         if self._current_state == "running":
-            # We need to sleep here for a very short time to prevent issues when
-            # the status is updated too quickly. If an .update() is directly followed
-            # by the exit of the context manager, sometimes only the last update
-            # (to complete) is applied. Adding a short timeout here allows the frontend
-            # to render the update before.
-            time.sleep(0.05)
+            # Ensure any preceding .update() is flushed before the final state change,
+            # so both messages are sent in separate flush cycles.
+            time.sleep(2 * MESSAGE_FLUSH_INTERVAL_SECS)
             if exc_type is not None:
                 # If an exception was raised in the context,
                 # we want to update the status to error.

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -28,7 +28,6 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
-from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
 from streamlit.runtime.scriptrunner_utils.script_run_context import enqueue_message
 
 if TYPE_CHECKING:
@@ -84,9 +83,11 @@ class StatusContainer(DeltaGenerator):
         status_container._current_proto = block_proto
         status_container._current_state = state
 
-        # Ensure the initial message is flushed before any immediate .update() call,
-        # so both messages are sent in separate flush cycles.
-        time.sleep(2 * MESSAGE_FLUSH_INTERVAL_SECS)
+        # We need to sleep here for a very short time to prevent issues when
+        # the status is updated too quickly. If an .update() directly follows the
+        # the initialization, sometimes only the latest update is applied.
+        # Adding a short timeout here allows the frontend to render the update before.
+        time.sleep(0.05)
 
         return status_container
 
@@ -180,9 +181,12 @@ class StatusContainer(DeltaGenerator):
     ) -> Literal[False]:
         # Only update if the current state is running
         if self._current_state == "running":
-            # Ensure any preceding .update() is flushed before the final state change,
-            # so both messages are sent in separate flush cycles.
-            time.sleep(2 * MESSAGE_FLUSH_INTERVAL_SECS)
+            # We need to sleep here for a very short time to prevent issues when
+            # the status is updated too quickly. If an .update() is directly followed
+            # by the exit of the context manager, sometimes only the last update
+            # (to complete) is applied. Adding a short timeout here allows the frontend
+            # to render the update before.
+            time.sleep(0.05)
             if exc_type is not None:
                 # If an exception was raised in the context,
                 # we want to update the status to error.

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -36,6 +36,7 @@ from streamlit.runtime.caching.storage.local_disk_cache_storage import (
 )
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
+from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
 from streamlit.runtime.script_data import ScriptData
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.session_manager import (
@@ -668,9 +669,8 @@ class Runtime:
                             # Yield for a tick after sending a message.
                             await asyncio.sleep(0)
 
-                    # Yield for a few milliseconds between session message
-                    # flushing.
-                    await asyncio.sleep(0.01)
+                    # Yield briefly between session message flushing cycles.
+                    await asyncio.sleep(MESSAGE_FLUSH_INTERVAL_SECS)
                 else:
                     # Break out of the thread loop if we encounter any other state.
                     break

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -29,8 +29,9 @@ _LOGGER: Final = getLogger(__name__)
 
 # The interval (in seconds) between message flush cycles in the runtime event loop.
 # This value is also used by execution_control.py to ensure messages are delivered
-# before triggering a rerun.
-MESSAGE_FLUSH_INTERVAL_SECS: Final = 0.001
+# before triggering a rerun. Note: message batching is enforced at the queue level
+# (flush_browser_queue), not via this sleep interval.
+MESSAGE_FLUSH_INTERVAL_SECS: Final[float] = 0.001
 
 
 class MessageSizeError(MarkdownFormattedException):

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = getLogger(__name__)
 
+# The interval (in seconds) between message flush cycles in the runtime event loop.
+# This value is also used by execution_control.py to ensure messages are delivered
+# before triggering a rerun.
+MESSAGE_FLUSH_INTERVAL_SECS: Final = 0.001
+
 
 class MessageSizeError(MarkdownFormattedException):
     """Exception raised when a websocket message is larger than the configured limit."""

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -28,9 +28,9 @@ if TYPE_CHECKING:
 _LOGGER: Final = getLogger(__name__)
 
 # The interval (in seconds) between message flush cycles in the runtime event loop.
-# This value is also used by execution_control.py to ensure messages are delivered
-# before triggering a rerun. Note: message batching is enforced at the queue level
-# (flush_browser_queue), not via this sleep interval.
+# Also reused by callers that need to wait for outstanding messages to be delivered
+# before requesting a rerun (e.g. `st.switch_page`). Note: message batching is
+# enforced at the queue level (flush_browser_queue), not via this sleep interval.
 MESSAGE_FLUSH_INTERVAL_SECS: Final[float] = 0.001
 
 


### PR DESCRIPTION
## Describe your changes

Reduces the message flush sleep interval from 10ms to 1ms for improved message delivery latency.

- Centralizes the sleep constant as `MESSAGE_FLUSH_INTERVAL_SECS` in `runtime_util.py`
- Updates `runtime.py` event loop to use the centralized constant
- Updates `execution_control.py` (`st.switch_page`) to use the same constant

The 10ms sleep was a legacy "cool-down" period between message flush cycles. Reducing to 1ms improves responsiveness for streaming updates, progress bars, and real-time data without affecting correctness—message batching happens at the queue level, not via this sleep.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit tests pass for `runtime_test.py`, `execution_control_test.py`, and `runtime_util_test.py`
- [x] All existing E2E tests for `st.switch_page` with query params should validate message delivery

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 2 |
| skill | updating-internal-docs | 1 |
| subagent | Explore | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->