### PR TITLE
[chore] Add fast-path optimization to path security middleware

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
@@ -38,7 +38,7 @@ streamlit.path_security : Core path validation functions used by this middleware
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 from starlette.responses import Response
 
@@ -47,27 +47,49 @@ from streamlit.path_security import is_unsafe_path_pattern
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
 
-# Exact paths that are known-safe and can skip the is_unsafe_path_pattern() check.
-# These endpoints have no user-controlled path segments.
+# Route constants for safe endpoints (imported from starlette_routes to stay in sync).
+# These are relative paths without the leading slash.
 #
-# DO NOT add routes that serve user-controlled file paths:
-# - /media/{file_id:path}
-# - /component/{path:path}
-# - /_stcore/bidi-components/{path:path}
-# - /app/static/{path:path}
-_SAFE_EXACT_PATHS: Final[frozenset[str]] = frozenset(
-    {
-        "/_stcore/health",
-        "/_stcore/script-health-check",
-        "/_stcore/metrics",
-        "/_stcore/host-config",
-    }
-)
+# DO NOT add routes that serve user-controlled file paths (media, component,
+# bidi-components, app/static) - those require full is_unsafe_path_pattern validation.
+_SAFE_ROUTE_HEALTH = "_stcore/health"
+_SAFE_ROUTE_SCRIPT_HEALTH = "_stcore/script-health-check"
+_SAFE_ROUTE_METRICS = "_stcore/metrics"
+_SAFE_ROUTE_HOST_CONFIG = "_stcore/host-config"
 
-# Prefix for paths that can skip the is_unsafe_path_pattern() check.
 # The upload_file route uses path params as opaque lookup keys (session_id/file_id),
 # not filesystem paths, so it's safe to skip the pattern check.
-_SAFE_PATH_PREFIX: Final[str] = "/_stcore/upload_file/"
+_SAFE_ROUTE_UPLOAD_PREFIX = "_stcore/upload_file/"
+
+
+def _build_safe_paths(base_url_path: str) -> tuple[frozenset[str], str]:
+    """Build safe exact paths and prefix based on the base URL path.
+
+    Parameters
+    ----------
+    base_url_path
+        The configured server.baseUrlPath (e.g., "/myapp" or "").
+
+    Returns
+    -------
+    tuple[frozenset[str], str]
+        A tuple of (safe_exact_paths, safe_path_prefix) with the base URL prepended.
+    """
+    from streamlit.url_util import make_url_path
+
+    # Build full paths with base URL prefix
+    safe_exact_paths = frozenset(
+        {
+            make_url_path(base_url_path, _SAFE_ROUTE_HEALTH),
+            make_url_path(base_url_path, _SAFE_ROUTE_SCRIPT_HEALTH),
+            make_url_path(base_url_path, _SAFE_ROUTE_METRICS),
+            make_url_path(base_url_path, _SAFE_ROUTE_HOST_CONFIG),
+        }
+    )
+
+    safe_path_prefix = make_url_path(base_url_path, _SAFE_ROUTE_UPLOAD_PREFIX)
+
+    return safe_exact_paths, safe_path_prefix
 
 
 class PathSecurityMiddleware:
@@ -85,6 +107,16 @@ class PathSecurityMiddleware:
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
+
+        # Build safe paths with the configured base URL path.
+        # This is computed at middleware init time (when the app is created),
+        # so config changes after app creation won't affect the safe paths.
+        from streamlit import config
+
+        base_url_path = config.get_option("server.baseUrlPath") or ""
+        self._safe_exact_paths, self._safe_path_prefix = _build_safe_paths(
+            base_url_path
+        )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Process incoming requests and block unsafe paths.
@@ -110,7 +142,7 @@ class PathSecurityMiddleware:
         # Fast-path: Skip validation for known-safe routes that don't serve
         # user-controlled file paths (health checks, metrics, upload endpoints).
         # Use exact match for fixed endpoints to avoid over-matching future routes.
-        if path in _SAFE_EXACT_PATHS or path.startswith(_SAFE_PATH_PREFIX):
+        if path in self._safe_exact_paths or path.startswith(self._safe_path_prefix):
             await self.app(scope, receive, send)
             return
 

--- a/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Path security middleware for blocking unsafe path patterns.
+r"""Path security middleware for blocking unsafe path patterns.
 
 This middleware implements the "Swiss Cheese" defense model - it provides
 an additional layer of protection that catches dangerous path patterns even
@@ -30,6 +30,24 @@ Each layer has potential "holes" (ways it could fail):
 - Route handlers: Developer could forget to add checks to new routes
 
 By keeping both layers, an attack only succeeds if BOTH fail simultaneously.
+
+Fast-Path Optimization
+----------------------
+For performance, certain known-safe routes skip the is_unsafe_path_pattern()
+validation. This is a **performance optimization only**, not a security boundary.
+
+IMPORTANT: The check order in __call__ is security-critical:
+1. Double-slash UNC check (//server, \\\\server) runs FIRST on all requests
+2. Fast-path bypass runs SECOND, only after UNC check passes
+3. Full is_unsafe_path_pattern() validation runs on remaining requests
+
+Never reorder these checks - the UNC check must always run before the fast-path.
+
+Why upload_file/ is safe to skip:
+The /_stcore/upload_file/{session_id}/{file_id} route uses session_id and file_id
+as opaque dictionary keys in MemoryUploadedFileManager, never as filesystem paths.
+Even a malicious session_id like "../../../etc/passwd" is just a failed dict lookup,
+not a path traversal - the values are never passed to open() or os.path functions.
 
 See Also
 --------

--- a/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
@@ -43,23 +43,21 @@ from typing import TYPE_CHECKING
 from starlette.responses import Response
 
 from streamlit.path_security import is_unsafe_path_pattern
+from streamlit.web.server.starlette.starlette_routes import (
+    BASE_ROUTE_UPLOAD_FILE,
+    ROUTE_HEALTH,
+    ROUTE_HOST_CONFIG,
+    ROUTE_METRICS,
+    ROUTE_SCRIPT_HEALTH,
+)
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
 
-# Route constants for safe endpoints (imported from starlette_routes to stay in sync).
-# These are relative paths without the leading slash.
-#
-# DO NOT add routes that serve user-controlled file paths (media, component,
-# bidi-components, app/static) - those require full is_unsafe_path_pattern validation.
-_SAFE_ROUTE_HEALTH = "_stcore/health"
-_SAFE_ROUTE_SCRIPT_HEALTH = "_stcore/script-health-check"
-_SAFE_ROUTE_METRICS = "_stcore/metrics"
-_SAFE_ROUTE_HOST_CONFIG = "_stcore/host-config"
-
 # The upload_file route uses path params as opaque lookup keys (session_id/file_id),
 # not filesystem paths, so it's safe to skip the pattern check.
-_SAFE_ROUTE_UPLOAD_PREFIX = "_stcore/upload_file/"
+# Add trailing slash to match only the upload prefix, not other routes.
+_SAFE_ROUTE_UPLOAD_PREFIX = f"{BASE_ROUTE_UPLOAD_FILE}/"
 
 
 def _build_safe_paths(base_url_path: str) -> tuple[frozenset[str], str]:
@@ -80,10 +78,10 @@ def _build_safe_paths(base_url_path: str) -> tuple[frozenset[str], str]:
     # Build full paths with base URL prefix
     safe_exact_paths = frozenset(
         {
-            make_url_path(base_url_path, _SAFE_ROUTE_HEALTH),
-            make_url_path(base_url_path, _SAFE_ROUTE_SCRIPT_HEALTH),
-            make_url_path(base_url_path, _SAFE_ROUTE_METRICS),
-            make_url_path(base_url_path, _SAFE_ROUTE_HOST_CONFIG),
+            make_url_path(base_url_path, ROUTE_HEALTH),
+            make_url_path(base_url_path, ROUTE_SCRIPT_HEALTH),
+            make_url_path(base_url_path, ROUTE_METRICS),
+            make_url_path(base_url_path, ROUTE_HOST_CONFIG),
         }
     )
 

--- a/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
@@ -38,7 +38,7 @@ streamlit.path_security : Core path validation functions used by this middleware
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from starlette.responses import Response
 
@@ -46,6 +46,24 @@ from streamlit.path_security import is_unsafe_path_pattern
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
+
+# Paths that are known-safe and can skip the is_unsafe_path_pattern() check.
+# These endpoints either:
+# 1. Have no user-controlled path segments (health, metrics, host-config), or
+# 2. Use path params as lookup keys, not file paths (upload_file uses session_id/file_id UUIDs)
+#
+# DO NOT add routes that serve user-controlled file paths:
+# - /media/{file_id:path}
+# - /component/{path:path}
+# - /_stcore/bidi-components/{path:path}
+# - /app/static/{path:path}
+_SAFE_PATH_PREFIXES: Final[tuple[str, ...]] = (
+    "/_stcore/health",
+    "/_stcore/script-health-check",
+    "/_stcore/metrics",
+    "/_stcore/host-config",
+    "/_stcore/upload_file/",
+)
 
 
 class PathSecurityMiddleware:
@@ -83,6 +101,12 @@ class PathSecurityMiddleware:
         if path.startswith(("//", "\\\\")):
             response = Response(content="Bad Request", status_code=400)
             await response(scope, receive, send)
+            return
+
+        # Fast-path: Skip validation for known-safe routes that don't serve
+        # user-controlled file paths (health checks, metrics, upload endpoints).
+        if path.startswith(_SAFE_PATH_PREFIXES):
+            await self.app(scope, receive, send)
             return
 
         # Strip leading slash to get the relative path for validation

--- a/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
@@ -47,23 +47,27 @@ from streamlit.path_security import is_unsafe_path_pattern
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
 
-# Paths that are known-safe and can skip the is_unsafe_path_pattern() check.
-# These endpoints either:
-# 1. Have no user-controlled path segments (health, metrics, host-config), or
-# 2. Use path params as lookup keys, not file paths (upload_file uses session_id/file_id UUIDs)
+# Exact paths that are known-safe and can skip the is_unsafe_path_pattern() check.
+# These endpoints have no user-controlled path segments.
 #
 # DO NOT add routes that serve user-controlled file paths:
 # - /media/{file_id:path}
 # - /component/{path:path}
 # - /_stcore/bidi-components/{path:path}
 # - /app/static/{path:path}
-_SAFE_PATH_PREFIXES: Final[tuple[str, ...]] = (
-    "/_stcore/health",
-    "/_stcore/script-health-check",
-    "/_stcore/metrics",
-    "/_stcore/host-config",
-    "/_stcore/upload_file/",
+_SAFE_EXACT_PATHS: Final[frozenset[str]] = frozenset(
+    {
+        "/_stcore/health",
+        "/_stcore/script-health-check",
+        "/_stcore/metrics",
+        "/_stcore/host-config",
+    }
 )
+
+# Prefix for paths that can skip the is_unsafe_path_pattern() check.
+# The upload_file route uses path params as opaque lookup keys (session_id/file_id),
+# not filesystem paths, so it's safe to skip the pattern check.
+_SAFE_PATH_PREFIX: Final[str] = "/_stcore/upload_file/"
 
 
 class PathSecurityMiddleware:
@@ -105,7 +109,8 @@ class PathSecurityMiddleware:
 
         # Fast-path: Skip validation for known-safe routes that don't serve
         # user-controlled file paths (health checks, metrics, upload endpoints).
-        if path.startswith(_SAFE_PATH_PREFIXES):
+        # Use exact match for fixed endpoints to avoid over-matching future routes.
+        if path in _SAFE_EXACT_PATHS or path.startswith(_SAFE_PATH_PREFIX):
             await self.app(scope, receive, send)
             return
 

--- a/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_path_security_middleware.py
@@ -61,6 +61,7 @@ from typing import TYPE_CHECKING
 from starlette.responses import Response
 
 from streamlit.path_security import is_unsafe_path_pattern
+from streamlit.url_util import make_url_path
 from streamlit.web.server.starlette.starlette_routes import (
     BASE_ROUTE_UPLOAD_FILE,
     ROUTE_HEALTH,
@@ -91,7 +92,6 @@ def _build_safe_paths(base_url_path: str) -> tuple[frozenset[str], str]:
     tuple[frozenset[str], str]
         A tuple of (safe_exact_paths, safe_path_prefix) with the base URL prepended.
     """
-    from streamlit.url_util import make_url_path
 
     # Build full paths with base URL prefix
     safe_exact_paths = frozenset(

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -76,14 +76,14 @@ BASE_ROUTE_COMPONENT: Final = "component"
 BASE_ROUTE_STATIC: Final = "static"
 
 # Health check routes
-_ROUTE_HEALTH: Final = f"{BASE_ROUTE_CORE}/health"
-_ROUTE_SCRIPT_HEALTH: Final = f"{BASE_ROUTE_CORE}/script-health-check"
+ROUTE_HEALTH: Final = f"{BASE_ROUTE_CORE}/health"
+ROUTE_SCRIPT_HEALTH: Final = f"{BASE_ROUTE_CORE}/script-health-check"
 
 # Metrics routes
-_ROUTE_METRICS: Final = f"{BASE_ROUTE_CORE}/metrics"
+ROUTE_METRICS: Final = f"{BASE_ROUTE_CORE}/metrics"
 
 # Host configuration
-_ROUTE_HOST_CONFIG: Final = f"{BASE_ROUTE_CORE}/host-config"
+ROUTE_HOST_CONFIG: Final = f"{BASE_ROUTE_CORE}/host-config"
 
 # Media and file routes
 _ROUTE_MEDIA: Final = f"{BASE_ROUTE_MEDIA}/{{file_id:path}}"
@@ -359,12 +359,12 @@ def create_health_routes(runtime: Runtime, base_url: str | None) -> list[BaseRou
 
     return [
         Route(
-            _with_base(_ROUTE_HEALTH, base_url),
+            _with_base(ROUTE_HEALTH, base_url),
             _health_endpoint,
             methods=["GET", "HEAD"],
         ),
         Route(
-            _with_base(_ROUTE_HEALTH, base_url),
+            _with_base(ROUTE_HEALTH, base_url),
             _health_options,
             methods=["OPTIONS"],
         ),
@@ -395,12 +395,12 @@ def create_script_health_routes(
 
     return [
         Route(
-            _with_base(_ROUTE_SCRIPT_HEALTH, base_url),
+            _with_base(ROUTE_SCRIPT_HEALTH, base_url),
             _script_health_endpoint,
             methods=["GET", "HEAD"],
         ),
         Route(
-            _with_base(_ROUTE_SCRIPT_HEALTH, base_url),
+            _with_base(ROUTE_SCRIPT_HEALTH, base_url),
             _script_health_options,
             methods=["OPTIONS"],
         ),
@@ -436,12 +436,12 @@ def create_metrics_routes(runtime: Runtime, base_url: str | None) -> list[BaseRo
 
     return [
         Route(
-            _with_base(_ROUTE_METRICS, base_url),
+            _with_base(ROUTE_METRICS, base_url),
             _metrics_endpoint,
             methods=["GET"],
         ),
         Route(
-            _with_base(_ROUTE_METRICS, base_url),
+            _with_base(ROUTE_METRICS, base_url),
             _metrics_options,
             methods=["OPTIONS"],
         ),
@@ -478,7 +478,7 @@ def create_host_config_routes(base_url: str | None) -> list[BaseRoute]:
 
     return [
         Route(
-            _with_base(_ROUTE_HOST_CONFIG, base_url),
+            _with_base(ROUTE_HOST_CONFIG, base_url),
             _host_config_endpoint,
             methods=["GET"],
         ),

--- a/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
@@ -363,7 +363,10 @@ class TestSafePathFastPath:
         ],
     )
     def test_safe_prefixes_pass_through(self, safe_path: str) -> None:
-        """Test that known-safe route prefixes pass through without full validation."""
+        """Test that known-safe route prefixes pass through without full validation.
+
+        Smoke test: verifies fast-path doesn't accidentally block these routes.
+        """
         app = _create_test_app()
         client = TestClient(app)
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
@@ -509,3 +509,113 @@ class TestSafePathFastPath:
 
         # These routes should be blocked by the middleware
         assert response.status_code == 400
+
+
+class TestBaseUrlPathCompatibility:
+    """Tests for baseUrlPath compatibility with the safe path fast-path.
+
+    When server.baseUrlPath is configured (e.g., "/myapp"), routes are mounted
+    with that prefix, and scope["path"] includes it (e.g., "/myapp/_stcore/health").
+    The fast-path optimization must account for this prefix.
+    """
+
+    @pytest.mark.parametrize(
+        "safe_route",
+        [
+            "/_stcore/health",
+            "/_stcore/script-health-check",
+            "/_stcore/metrics",
+            "/_stcore/host-config",
+            "/_stcore/upload_file/abc123/file456",
+        ],
+        ids=[
+            "health",
+            "script-health-check",
+            "metrics",
+            "host-config",
+            "upload-file",
+        ],
+    )
+    def test_safe_paths_with_base_url_prefix(
+        self, safe_route: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that safe paths work correctly when server.baseUrlPath is configured.
+
+        The fast-path should work for paths like /myapp/_stcore/health when
+        baseUrlPath is set to /myapp.
+        """
+        from streamlit import config
+
+        base_url = "/myapp"
+        monkeypatch.setattr(
+            config,
+            "get_option",
+            lambda key: base_url if key == "server.baseUrlPath" else None,
+        )
+
+        # Build the expected full path with base URL
+        full_path = f"{base_url}{safe_route}"
+
+        app = _create_test_app()
+        client = TestClient(app)
+
+        response = client.get(full_path)
+
+        # These routes should reach the handler (200), not be blocked (400)
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "safe_route",
+        [
+            "/_stcore/health",
+            "/_stcore/script-health-check",
+            "/_stcore/metrics",
+            "/_stcore/host-config",
+            "/_stcore/upload_file/abc123/file456",
+        ],
+        ids=[
+            "health",
+            "script-health-check",
+            "metrics",
+            "host-config",
+            "upload-file",
+        ],
+    )
+    def test_safe_paths_with_base_url_skip_unsafe_pattern_check(
+        self, safe_route: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that safe paths with baseUrlPath skip the is_unsafe_path_pattern() check.
+
+        This verifies the fast-path optimization works with baseUrlPath by
+        monkeypatching is_unsafe_path_pattern to raise if called.
+        """
+        from streamlit import config
+        from streamlit.web.server.starlette import starlette_path_security_middleware
+
+        base_url = "/myapp"
+        monkeypatch.setattr(
+            config,
+            "get_option",
+            lambda key: base_url if key == "server.baseUrlPath" else None,
+        )
+
+        full_path = f"{base_url}{safe_route}"
+
+        def _raise_if_called(path: str) -> bool:
+            raise AssertionError(
+                f"is_unsafe_path_pattern() was called for {full_path!r} "
+                "but should have been skipped by the fast-path"
+            )
+
+        monkeypatch.setattr(
+            starlette_path_security_middleware,
+            "is_unsafe_path_pattern",
+            _raise_if_called,
+        )
+
+        app = _create_test_app()
+        client = TestClient(app)
+
+        # Should not raise - fast-path should skip is_unsafe_path_pattern
+        response = client.get(full_path)
+        assert response.status_code == 200

--- a/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
@@ -65,6 +65,39 @@ def _create_websocket_app() -> Starlette:
     return app
 
 
+async def _call_asgi_with_path(app: Starlette, path: str) -> tuple[int | None, bytes]:
+    """Call an ASGI app with a raw HTTP scope for the given path.
+
+    This bypasses URL parsing that would interpret // as authority, allowing
+    us to test raw path handling.
+    """
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": b"",
+        "headers": [],
+        "server": ("localhost", 8000),
+        "asgi": {"version": "3.0"},
+    }
+
+    response_status: int | None = None
+    response_body = b""
+
+    async def receive():
+        return {"type": "http.request", "body": b""}
+
+    async def send(message):
+        nonlocal response_status, response_body
+        if message["type"] == "http.response.start":
+            response_status = message["status"]
+        elif message["type"] == "http.response.body":
+            response_body += message.get("body", b"")
+
+    await app(scope, receive, send)
+    return response_status, response_body
+
+
 class TestPathSecurityMiddleware:
     """Tests for PathSecurityMiddleware."""
 
@@ -207,34 +240,9 @@ class TestDoubleSlashBypass:
         We use raw ASGI scope to simulate an attacker sending a malicious request
         directly, bypassing URL parsing that would interpret // as authority.
         """
-        # Build the app with middleware
         app = _create_test_app()
 
-        # Construct a raw ASGI scope with the malicious path
-        scope = {
-            "type": "http",
-            "method": "GET",
-            "path": unc_path,
-            "query_string": b"",
-            "headers": [],
-            "server": ("localhost", 8000),
-            "asgi": {"version": "3.0"},
-        }
-
-        response_status: int | None = None
-        response_body = b""
-
-        async def receive():
-            return {"type": "http.request", "body": b""}
-
-        async def send(message):
-            nonlocal response_status, response_body
-            if message["type"] == "http.response.start":
-                response_status = message["status"]
-            elif message["type"] == "http.response.body":
-                response_body += message.get("body", b"")
-
-        await app(scope, receive, send)
+        response_status, response_body = await _call_asgi_with_path(app, unc_path)
 
         # These MUST be blocked - if they return 200, we have a security bypass
         assert response_status == 400, (
@@ -328,3 +336,77 @@ class TestMiddlewarePosition:
         assert response.status_code == 400
         assert response.text == "Bad Request"
         assert handler_called is False  # Key assertion: handler was never called
+
+
+class TestSafePathFastPath:
+    """Tests for the safe path fast-path optimization.
+
+    These tests verify that known-safe routes skip the is_unsafe_path_pattern()
+    check for performance, while still being protected by the double-slash check.
+    """
+
+    @pytest.mark.parametrize(
+        "safe_path",
+        [
+            "/_stcore/health",
+            "/_stcore/script-health-check",
+            "/_stcore/metrics",
+            "/_stcore/host-config",
+            "/_stcore/upload_file/abc123/file456",
+        ],
+        ids=[
+            "health",
+            "script-health-check",
+            "metrics",
+            "host-config",
+            "upload-file",
+        ],
+    )
+    def test_safe_prefixes_pass_through(self, safe_path: str) -> None:
+        """Test that known-safe route prefixes pass through without full validation."""
+        app = _create_test_app()
+        client = TestClient(app)
+
+        response = client.get(safe_path)
+
+        # These routes should reach the handler (200), not be blocked (400)
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_safe_paths_still_check_double_slash(self) -> None:
+        """Test that safe prefixes still get the double-slash UNC check.
+
+        Even though /_stcore/health is a safe prefix, a request to
+        //_stcore/health (note the double slash) should still be blocked.
+        """
+        app = _create_test_app()
+
+        response_status, _ = await _call_asgi_with_path(app, "//_stcore/health")
+
+        # Double-slash must still be blocked even with safe prefix
+        assert response_status == 400
+
+    @pytest.mark.parametrize(
+        "unsafe_route",
+        [
+            "/media/..\\..\\etc\\passwd",
+            "/component/..\\..\\etc\\passwd",
+            "/_stcore/bidi-components/..\\..\\etc\\passwd",
+            "/app/static/..\\..\\etc\\passwd",
+        ],
+        ids=[
+            "media-traversal",
+            "component-traversal",
+            "bidi-component-traversal",
+            "app-static-traversal",
+        ],
+    )
+    def test_non_safe_routes_still_validated(self, unsafe_route: str) -> None:
+        """Test that routes NOT in the safe prefix list are still validated."""
+        app = _create_test_app()
+        client = TestClient(app)
+
+        response = client.get(unsafe_route)
+
+        # These routes should be blocked by the middleware
+        assert response.status_code == 400

--- a/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py
@@ -372,19 +372,118 @@ class TestSafePathFastPath:
         # These routes should reach the handler (200), not be blocked (400)
         assert response.status_code == 200
 
+    @pytest.mark.parametrize(
+        "safe_path",
+        [
+            "/_stcore/health",
+            "/_stcore/script-health-check",
+            "/_stcore/metrics",
+            "/_stcore/host-config",
+            "/_stcore/upload_file/abc123/file456",
+        ],
+        ids=[
+            "health",
+            "script-health-check",
+            "metrics",
+            "host-config",
+            "upload-file",
+        ],
+    )
+    def test_safe_paths_skip_unsafe_pattern_check(
+        self, safe_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that safe paths skip the is_unsafe_path_pattern() check.
+
+        This verifies the fast-path optimization is actually working by
+        monkeypatching is_unsafe_path_pattern to raise if called.
+        """
+        from streamlit.web.server.starlette import starlette_path_security_middleware
+
+        def _raise_if_called(path: str) -> bool:
+            raise AssertionError(
+                f"is_unsafe_path_pattern() was called for {safe_path!r} "
+                "but should have been skipped by the fast-path"
+            )
+
+        monkeypatch.setattr(
+            starlette_path_security_middleware,
+            "is_unsafe_path_pattern",
+            _raise_if_called,
+        )
+
+        app = _create_test_app()
+        client = TestClient(app)
+
+        # Should not raise - fast-path should skip is_unsafe_path_pattern
+        response = client.get(safe_path)
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "safe_path",
+        [
+            "//_stcore/health",
+            "//_stcore/script-health-check",
+            "//_stcore/metrics",
+            "//_stcore/host-config",
+            "//_stcore/upload_file/abc123/file456",
+        ],
+        ids=[
+            "health",
+            "script-health-check",
+            "metrics",
+            "host-config",
+            "upload-file",
+        ],
+    )
     @pytest.mark.anyio
-    async def test_safe_paths_still_check_double_slash(self) -> None:
+    async def test_safe_paths_still_check_double_slash(self, safe_path: str) -> None:
         """Test that safe prefixes still get the double-slash UNC check.
 
         Even though /_stcore/health is a safe prefix, a request to
         //_stcore/health (note the double slash) should still be blocked.
+        This parametrizes over all safe paths to ensure regression protection.
         """
         app = _create_test_app()
 
-        response_status, _ = await _call_asgi_with_path(app, "//_stcore/health")
+        response_status, _ = await _call_asgi_with_path(app, safe_path)
 
         # Double-slash must still be blocked even with safe prefix
         assert response_status == 400
+
+    @pytest.mark.parametrize(
+        "traversal_path",
+        [
+            "/_stcore/health/..\\..\\etc\\passwd",
+            "/_stcore/metrics/..\\..\\etc\\passwd",
+            "/_stcore/host-config/..\\..\\etc\\passwd",
+        ],
+        ids=[
+            "health-backslash-traversal",
+            "metrics-backslash-traversal",
+            "host-config-backslash-traversal",
+        ],
+    )
+    def test_exact_paths_dont_match_traversal_suffixes(
+        self, traversal_path: str
+    ) -> None:
+        """Test that exact-match safe paths don't match paths with traversal suffixes.
+
+        This documents the defense-in-depth behavior: paths like
+        /_stcore/health/..\\..\\etc\\passwd should NOT match the safe exact path
+        /_stcore/health and should go through full validation.
+
+        Note: Forward-slash traversal (/../..) is normalized by Starlette before
+        reaching the middleware (see TestPathSecurityMiddleware.test_starlette_normalizes_paths),
+        so we only test backslash traversal here.
+        """
+        app = _create_test_app()
+        client = TestClient(app)
+
+        response = client.get(traversal_path)
+
+        # These should be blocked - they don't match exact paths and contain
+        # traversal patterns that fail is_unsafe_path_pattern()
+        assert response.status_code == 400
 
     @pytest.mark.parametrize(
         "unsafe_route",


### PR DESCRIPTION
## Describe your changes

Adds a fast-path optimization to `PathSecurityMiddleware` that skips the `is_unsafe_path_pattern()` validation for known-safe route prefixes, improving request throughput for health checks, metrics, and file uploads.

- Known-safe prefixes: `/_stcore/health`, `/_stcore/script-health-check`, `/_stcore/metrics`, `/_stcore/host-config`, `/_stcore/upload_file/`
- These endpoints either have no user-controlled path segments or use path params as lookup keys, not file paths
- The critical double-slash UNC check is preserved for all requests (runs before the fast-path)

## Testing Plan

- [x] Unit Tests (Python): `lib/tests/streamlit/web/server/starlette/starlette_path_security_middleware_test.py`
  - `TestSafePathFastPath` class tests safe prefixes pass through, double-slash still blocked, non-safe routes still validated

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->