### PR TITLE
feat: integer pixel gap for st.container and st.columns

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -260,6 +260,16 @@ describe("FlexBoxContainer layout props", () => {
       { gapConfig: { gapSize: streamlit.GapSize.NONE } },
       "gap: 0;",
     ],
+    [
+      "gap: pixel value",
+      {
+        gapConfig: streamlit.GapConfig.create({
+          gapPixels: 9,
+          gapSpec: "gapPixels",
+        }),
+      },
+      "gap: 9px;",
+    ],
   ])("should apply %s", (_desc, flexContainer, expectedStyle) => {
     const block: BlockNode = makeVerticalBlock([], {
       flexContainer,

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -59,7 +59,7 @@ import {
   convertKeyToClassName,
   getBorderBackwardsCompatible,
   getClassnamePrefix,
-  getColumnGapSize,
+  getFlexColumnGap,
   getKeyFromId,
   isComponentStale,
   shouldActivateScrollToBottom,
@@ -168,12 +168,25 @@ export const FlexBoxContainer = (
     subElement: getLayoutSubElement(props.node.deltaBlock),
   })
 
+  const flexGapConfig = props.node.deltaBlock.flexContainer?.gapConfig
+  let flexGap: streamlit.GapSize | undefined
+  let flexGapPixels: number | undefined
+  if (flexGapConfig?.gapSpec === "gapPixels") {
+    flexGapPixels = flexGapConfig.gapPixels ?? undefined
+    flexGap = undefined
+  } else {
+    // Backwards compatible with old proto messages since previously
+    // the gap size was defaulted to small.
+    const gs = flexGapConfig?.gapSize
+    flexGap =
+      gs == null || gs === streamlit.GapSize.GAP_UNDEFINED
+        ? streamlit.GapSize.SMALL
+        : gs
+  }
+
   const styles = {
-    gap:
-      // This is backwards compatible with old proto messages since previously
-      // the gap size was defaulted to small.
-      props.node.deltaBlock.flexContainer?.gapConfig?.gapSize ??
-      streamlit.GapSize.SMALL,
+    gap: flexGap,
+    gapPixels: flexGapPixels,
     direction: direction,
     // This is also backwards compatible since previously wrap was not added
     // to the flex container.
@@ -382,10 +395,12 @@ export const BlockNodeRenderer = (
   }
 
   if (node.deltaBlock.column) {
+    const { gapSize, gapPixels } = getFlexColumnGap(node.deltaBlock.column)
     return (
       <StyledColumn
         weight={node.deltaBlock.column.weight ?? 0}
-        gap={getColumnGapSize(node.deltaBlock.column)}
+        gap={gapSize}
+        gapPixels={gapPixels}
         verticalAlignment={
           node.deltaBlock.column.verticalAlignment ?? undefined
         }

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -144,15 +144,18 @@ export const StyledElementContainer = styled.div<StyledElementContainerProps>(
 interface StyledColumnProps {
   weight: number
   gap: streamlit.GapSize | undefined
+  /** When set, fixed CSS gap in pixels (takes precedence over `gap`). */
+  gapPixels?: number | undefined
   showBorder: boolean
   verticalAlignment?: BlockProto.Column.VerticalAlignment
 }
 
 export const StyledColumn = styled.div<StyledColumnProps>(
-  ({ theme, weight, gap, showBorder, verticalAlignment }) => {
+  ({ theme, weight, gap, gapPixels, showBorder, verticalAlignment }) => {
     const { VerticalAlignment } = BlockProto.Column
     const percentage = weight * 100
-    const gapWidth = translateGapWidth(gap, theme)
+    const gapWidth =
+      gapPixels != null ? `${gapPixels}px` : translateGapWidth(gap, theme)
     const width =
       gapWidth === theme.spacing.none
         ? `${percentage}%`
@@ -240,6 +243,8 @@ const getJustifyContent = (
 export interface StyledFlexContainerBlockProps {
   direction: React.CSSProperties["flexDirection"]
   gap?: streamlit.GapSize | undefined
+  /** When set, fixed CSS gap in pixels (takes precedence over `gap`). */
+  gapPixels?: number | undefined
   flex?: React.CSSProperties["flex"]
   // This marks the prop as a transient property so it is
   // not passed to the DOM. It overlaps with a valid attribute
@@ -258,6 +263,7 @@ export const StyledFlexContainerBlock =
       theme,
       direction,
       gap,
+      gapPixels,
       flex,
       $wrap,
       height,
@@ -267,7 +273,9 @@ export const StyledFlexContainerBlock =
       overflow,
     }) => {
       let gapWidth
-      if (gap !== undefined) {
+      if (gapPixels != null) {
+        gapWidth = `${gapPixels}px`
+      } else if (gap !== undefined) {
         gapWidth = translateGapWidth(gap, theme)
       }
 

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -32,7 +32,7 @@ import {
   checkFlexContainerBackwardsCompatibile,
   convertKeyToClassName,
   getBorderBackwardsCompatible,
-  getColumnGapSize,
+  getFlexColumnGap,
   getKeyFromId,
   isElementStale,
   shouldActivateScrollToBottom,
@@ -180,14 +180,17 @@ describe("getKeyFromId", () => {
   })
 })
 
-describe("getColumnGapSize", () => {
+describe("getFlexColumnGap", () => {
   it("returns gapSize when it exists", () => {
     const columnProto = {
       gapConfig: {
         gapSize: streamlit.GapSize.MEDIUM,
       },
     }
-    expect(getColumnGapSize(columnProto)).toBe(streamlit.GapSize.MEDIUM)
+    expect(getFlexColumnGap(columnProto)).toEqual({
+      gapSize: streamlit.GapSize.MEDIUM,
+      gapPixels: undefined,
+    })
   })
 
   it("returns default gapSize when gapSize is undefined", () => {
@@ -196,12 +199,31 @@ describe("getColumnGapSize", () => {
         gapSize: streamlit.GapSize.GAP_UNDEFINED,
       },
     }
-    expect(getColumnGapSize(columnProto)).toBe(streamlit.GapSize.SMALL)
+    expect(getFlexColumnGap(columnProto)).toEqual({
+      gapSize: streamlit.GapSize.SMALL,
+      gapPixels: undefined,
+    })
   })
 
   it("returns GapSize.SMALL when gapConfig does not exist", () => {
     const columnProto = {}
-    expect(getColumnGapSize(columnProto)).toBe(streamlit.GapSize.SMALL)
+    expect(getFlexColumnGap(columnProto)).toEqual({
+      gapSize: streamlit.GapSize.SMALL,
+      gapPixels: undefined,
+    })
+  })
+
+  it("returns gapPixels when gapSpec is gapPixels", () => {
+    const columnProto = {
+      gapConfig: streamlit.GapConfig.create({
+        gapPixels: 11,
+        gapSpec: "gapPixels",
+      }),
+    }
+    expect(getFlexColumnGap(columnProto)).toEqual({
+      gapSize: undefined,
+      gapPixels: 11,
+    })
   })
 })
 

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -184,13 +184,34 @@ export function getKeyFromId(
   return userKey === "None" ? undefined : userKey
 }
 
-export function getColumnGapSize(
-  columnProto: BlockProto.IColumn
-): streamlit.GapSize {
-  if (columnProto.gapConfig?.gapSize) {
-    return columnProto.gapConfig.gapSize
+/** Resolved gap for a column: either a theme gap size or a pixel value. */
+export interface FlexColumnGap {
+  gapSize: streamlit.GapSize | undefined
+  gapPixels: number | undefined
+}
+
+export function getFlexColumnGap(columnProto: BlockProto.IColumn): FlexColumnGap {
+  const gc = columnProto.gapConfig
+  if (gc?.gapSpec === "gapPixels") {
+    return {
+      gapSize: undefined,
+      gapPixels: gc.gapPixels ?? undefined,
+    }
   }
-  return streamlit.GapSize.SMALL
+  const gapSize = gc?.gapSize
+  if (
+    gapSize == null ||
+    gapSize === streamlit.GapSize.GAP_UNDEFINED
+  ) {
+    return {
+      gapSize: streamlit.GapSize.SMALL,
+      gapPixels: undefined,
+    }
+  }
+  return {
+    gapSize,
+    gapPixels: undefined,
+  }
 }
 
 export function checkFlexContainerBackwardsCompatibile(

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -26,8 +26,8 @@ from streamlit.elements.lib.layout_utils import (
     VerticalAlignment,
     Width,
     WidthWithoutContent,
+    build_gap_config,
     get_align,
-    get_gap_size,
     get_height_config,
     get_justify,
     get_width_config,
@@ -45,7 +45,6 @@ from streamlit.errors import (
     StreamlitValueError,
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
-from streamlit.proto.GapSize_pb2 import GapConfig
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.state import register_widget
@@ -112,7 +111,7 @@ class LayoutsMixin:
         horizontal: bool = False,
         horizontal_alignment: HorizontalAlignment = "left",
         vertical_alignment: VerticalAlignment = "top",
-        gap: Gap | None = "small",
+        gap: Gap | int | None = "small",
         autoscroll: bool | None = None,
     ) -> DeltaGenerator:
         """Insert a multi-element container.
@@ -215,7 +214,7 @@ class LayoutsMixin:
               When ``horizontal`` is ``True``, ``"distribute"`` aligns the
               elements the same as ``"top"``.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", int, or None
             The minimum gap size between the elements inside the container.
             This can be one of the following:
 
@@ -226,6 +225,7 @@ class LayoutsMixin:
             - ``"large"``: 4rem gap between the elements.
             - ``"xlarge"``: 6rem gap between the elements.
             - ``"xxlarge"``: 8rem gap between the elements.
+            - A positive ``int``: fixed gap in pixels (e.g. ``8`` for 8px).
             - ``None``: No gap between the elements.
 
             The rem unit is relative to the ``theme.baseFontSize``
@@ -343,8 +343,8 @@ class LayoutsMixin:
         block_proto = BlockProto()
         block_proto.allow_empty = False
         block_proto.flex_container.border = border or False
-        block_proto.flex_container.gap_config.gap_size = get_gap_size(
-            gap, "st.container"
+        block_proto.flex_container.gap_config.CopyFrom(
+            build_gap_config(gap, "st.container")
         )
 
         validate_horizontal_alignment(horizontal_alignment)
@@ -400,7 +400,7 @@ class LayoutsMixin:
         self,
         spec: SpecType,
         *,
-        gap: Gap | None = "small",
+        gap: Gap | int | None = "small",
         vertical_alignment: Literal["top", "center", "bottom"] = "top",
         border: bool = False,
         width: WidthWithoutContent = "stretch",
@@ -431,7 +431,7 @@ class LayoutsMixin:
               Or ``[1, 2, 3]`` creates three columns where the second one is two times
               the width of the first one, and the third one is three times that width.
 
-        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", or None
+        gap : "xxsmall", "xsmall", "small", "medium", "large", "xlarge", "xxlarge", int, or None
             The size of the gap between the columns. This can be one of the
             following:
 
@@ -442,6 +442,7 @@ class LayoutsMixin:
             - ``"large"``: 4rem gap between the columns.
             - ``"xlarge"``: 6rem gap between the columns.
             - ``"xxlarge"``: 8rem gap between the columns.
+            - A positive ``int``: fixed gap in pixels (e.g. ``8`` for 8px).
             - ``None``: No gap between the columns.
 
             The rem unit is relative to the ``theme.baseFontSize``
@@ -595,9 +596,7 @@ class LayoutsMixin:
                 element_type="st.columns",
             )
 
-        gap_size = get_gap_size(gap, "st.columns")
-        gap_config = GapConfig()
-        gap_config.gap_size = gap_size
+        gap_config = build_gap_config(gap, "st.columns")
 
         def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -26,7 +26,7 @@ from streamlit.errors import (
     StreamlitInvalidWidthError,
 )
 from streamlit.proto.Block_pb2 import Block
-from streamlit.proto.GapSize_pb2 import GapSize
+from streamlit.proto.GapSize_pb2 import GapConfig, GapSize
 from streamlit.proto.HeightConfig_pb2 import HeightConfig
 from streamlit.proto.TextAlignmentConfig_pb2 import TextAlignmentConfig
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
@@ -305,6 +305,41 @@ def get_gap_size(gap: str | None, element_type: str) -> GapSize.ValueType:
         return GapSize.NONE
 
     raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+
+
+def build_gap_config(gap: Gap | int | None, element_type: str) -> GapConfig:
+    """Build a ``GapConfig`` from the public ``gap`` API (sizes, ``None``, or pixels).
+
+    Parameters
+    ----------
+    gap
+        A named size key, ``None`` for no gap, or a positive ``int`` for a fixed
+        gap in pixels. Boolean values are rejected (``bool`` is a subclass of
+        ``int``). Floating-point numbers are rejected; use ``int`` only.
+    element_type
+        ``\"st.container\"`` or ``\"st.columns\"`` for error messages.
+
+    Returns
+    -------
+    GapConfig
+        Proto message with either ``gap_size`` or ``gap_pixels`` set.
+    """
+    config = GapConfig()
+    if gap is None:
+        config.gap_size = GapSize.NONE
+        return config
+    if isinstance(gap, bool):
+        raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+    if isinstance(gap, int):
+        if gap <= 0:
+            raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+        config.gap_pixels = gap
+        return config
+    if isinstance(gap, float):
+        raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+
+    config.gap_size = get_gap_size(gap, element_type)
+    return config
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -257,13 +257,13 @@ class StreamlitInvalidVerticalAlignmentError(LocalizableStreamlitException):
 class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
     """Exception raised when an invalid value is specified for gap."""
 
-    def __init__(self, gap: str, element_type: str) -> None:
+    def __init__(self, gap: Any, element_type: str) -> None:
         super().__init__(
             'The `gap` argument to `{element_type}` must be `"xxsmall"`, '
             '`"xsmall"`, `"small"`, `"medium"`, `"large"`, `"xlarge"`, '
-            '`"xxlarge"`, or `"none"`. \n'
+            '`"xxlarge"`, `None`, or a positive integer (gap in pixels). \n'
             "The argument passed was {gap}.",
-            gap=gap,
+            gap=repr(gap),
             element_type=element_type,
         )
 

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -2253,7 +2253,7 @@ class Column(Block):
     type: str = field(repr=False)
     proto: BlockProto.Column = field(repr=False)
     weight: float
-    gap: str | None
+    gap: str | int | None
 
     # Mapping from GapSize enum to string
     _GAP_SIZE_TO_STRING: ClassVar[dict[int, str | None]] = {
@@ -2277,7 +2277,13 @@ class Column(Block):
         self.root = root
         self.type = "column"
         self.weight = proto.weight
-        self.gap = self._GAP_SIZE_TO_STRING.get(proto.gap_config.gap_size)
+        gap_spec = proto.gap_config.WhichOneof("gap_spec")
+        if gap_spec == "gap_pixels":
+            self.gap = proto.gap_config.gap_pixels
+        elif gap_spec == "gap_size":
+            self.gap = self._GAP_SIZE_TO_STRING.get(proto.gap_config.gap_size)
+        else:
+            self.gap = "small"
 
 
 @dataclass(repr=False)

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -265,12 +265,33 @@ class ColumnsTest(DeltaGeneratorTestCase):
             )
             assert col_block.add_block.column.gap_config.gap_size == GapSize.NONE
 
+    def test_columns_with_pixel_gap(self):
+        """Positive integer gap sets gap_pixels on flex container and columns."""
+        st.columns(3, gap=12)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        horizontal_container = all_deltas[0]
+        columns_blocks = all_deltas[1:4]
+
+        assert len(all_deltas) == 4
+        hgc = horizontal_container.add_block.flex_container.gap_config
+        assert hgc.WhichOneof("gap_spec") == "gap_pixels"
+        assert hgc.gap_pixels == 12
+
+        for col_block in columns_blocks:
+            cgc = col_block.add_block.column.gap_config
+            assert cgc.WhichOneof("gap_spec") == "gap_pixels"
+            assert cgc.gap_pixels == 12
+
     @parameterized.expand(
         [
             "invalid",
-            5,
             "5rem",
             "10px",
+            0,
+            -3,
+            3.14,
+            True,
         ]
     )
     def test_columns_with_invalid_gap(self, invalid_gap):
@@ -797,19 +818,25 @@ class ContainerTest(DeltaGeneratorTestCase):
 
     @parameterized.expand(
         [
-            ("small", GapSize.SMALL),
-            ("medium", GapSize.MEDIUM),
-            ("large", GapSize.LARGE),
-            (None, GapSize.NONE),
+            ("small", "gap_size", GapSize.SMALL, None),
+            ("medium", "gap_size", GapSize.MEDIUM, None),
+            ("large", "gap_size", GapSize.LARGE, None),
+            (None, "gap_size", GapSize.NONE, None),
+            (8, "gap_pixels", None, 8),
         ],
     )
-    def test_container_gap(self, gap, expected_gap) -> None:
+    def test_container_gap(
+        self, gap, expected_spec: str, expected_gap_size, expected_pixels
+    ) -> None:
         """Test that st.container sets the gap property correctly."""
         st.container(gap=gap)
         container_block = self.get_delta_from_queue()
-        assert (
-            container_block.add_block.flex_container.gap_config.gap_size == expected_gap
-        )
+        gc = container_block.add_block.flex_container.gap_config
+        assert gc.WhichOneof("gap_spec") == expected_spec
+        if expected_spec == "gap_size":
+            assert gc.gap_size == expected_gap_size
+        else:
+            assert gc.gap_pixels == expected_pixels
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -21,6 +21,7 @@ from parameterized import parameterized
 
 from streamlit.elements.lib.layout_utils import (
     SpaceSize,
+    build_gap_config,
     get_align,
     get_gap_size,
     get_height_config,
@@ -220,6 +221,26 @@ class LayoutUtilsTest(unittest.TestCase):
 
         with pytest.raises(StreamlitInvalidColumnGapError):
             get_gap_size("tiny", "st.columns")
+
+    def test_build_gap_config_pixel_gap(self):
+        """build_gap_config sets gap_pixels for positive int."""
+        config = build_gap_config(7, "st.columns")
+        assert config.WhichOneof("gap_spec") == "gap_pixels"
+        assert config.gap_pixels == 7
+
+    def test_build_gap_config_rejects_non_positive_int(self):
+        """build_gap_config raises for zero or negative pixel gaps."""
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            build_gap_config(0, "st.container")
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            build_gap_config(-2, "st.columns")
+
+    def test_build_gap_config_rejects_bool_and_float(self):
+        """build_gap_config rejects bool and float (API is int or named sizes)."""
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            build_gap_config(True, "st.columns")
+        with pytest.raises(StreamlitInvalidColumnGapError):
+            build_gap_config(1.5, "st.container")
 
     @parameterized.expand(
         [

--- a/proto/streamlit/proto/GapSize.proto
+++ b/proto/streamlit/proto/GapSize.proto
@@ -33,5 +33,6 @@ enum GapSize {
 message GapConfig {
   oneof gap_spec {
     GapSize gap_size = 1;
+    int32 gap_pixels = 2;
   }
 }


### PR DESCRIPTION
## Summary
Implements [#13005](https://github.com/streamlit/streamlit/issues/13005): `gap` on `st.container` and `st.columns` now accepts a positive `int` for a fixed pixel gap, in addition to the existing named sizes and `None`.

## Changes
- **Proto:** `GapConfig` oneof adds `gap_pixels` (field 2). Run `make protobuf` after pull (generated `*_pb2` / frontend protobuf are gitignored).
- **Python:** `build_gap_config()` in `layout_utils.py`; `gap` parameter type `Gap | int | None`. Rejects bool, float, and non-positive integers.
- **Frontend:** `StyledFlexContainerBlock` / `StyledColumn` support `gapPixels`; `getFlexColumnGap()` replaces `getColumnGapSize`.
- **Tests:** Extended `layouts_test`, `layout_utils_test`, `Block.test.tsx`, `utils.test.ts`.

## Verification
- `.venv/bin/python -m pytest lib/tests/streamlit/elements/lib/layout_utils_test.py lib/tests/streamlit/elements/layouts_test.py -q`
- `yarn workspace @streamlit/lib vitest run src/components/core/Block/Block.test.tsx src/components/core/Block/utils.test.ts`

Fixes #13005

Made with [Cursor](https://cursor.com)