### PR TITLE
Stretch SVG images to container width by default

### DIFF
--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -178,6 +178,61 @@ describe("ImageList Element", () => {
     })
   })
 
+  describe("SVG width behavior", () => {
+    // SVG encoded as a data URI (as the backend produces)
+    const SVG_URL = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgdmlld0JveD0iMCAwIDEwMCAxMDAiLz4="
+
+    it("stretches SVG to container width when no widthConfig is provided", () => {
+      const props = getProps({ imgs: [{ caption: "svg", url: SVG_URL }] })
+      render(<ImageList {...props} />)
+
+      // Container width is 250px (from useResizeObserver mock)
+      const image = screen.getByRole("img")
+      expect(image).toHaveStyle("width: 250px")
+    })
+
+    it("stretches SVG to container width with useContent config", () => {
+      const props = getProps(
+        { imgs: [{ caption: "svg", url: SVG_URL }] },
+        { useContent: true }
+      )
+      render(<ImageList {...props} />)
+
+      const image = screen.getByRole("img")
+      expect(image).toHaveStyle("width: 250px")
+    })
+
+    it("respects explicit pixel width for SVG images", () => {
+      const props = getProps(
+        { imgs: [{ caption: "svg", url: SVG_URL }] },
+        { pixelWidth: 400 }
+      )
+      render(<ImageList {...props} />)
+
+      const image = screen.getByRole("img")
+      expect(image).toHaveStyle("width: 400px")
+      expect(image).not.toHaveStyle("width: 250px")
+    })
+
+    it("stretches SVG images served from .svg URLs", () => {
+      const props = getProps({ imgs: [{ caption: "svg", url: "/media/chart.svg" }] })
+      render(<ImageList {...props} />)
+
+      const image = screen.getByRole("img")
+      expect(image).toHaveStyle("width: 250px")
+    })
+
+    it("does not apply SVG stretch behavior to non-SVG images", () => {
+      const props = getProps({ imgs: [{ url: "/media/mockImage1.jpeg" }] })
+      render(<ImageList {...props} />)
+
+      const image = screen.getByRole("img")
+      // Non-SVG images in content mode get 100% (auto fallback), not containerWidth
+      expect(image).toHaveStyle("width: 100%")
+      expect(image).not.toHaveStyle("width: 250px")
+    })
+  })
+
   describe("Fallback behavior", () => {
     it("defaults to content behavior when no widthConfig is provided", () => {
       const props = getProps()

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -42,6 +42,16 @@ import {
 
 const LOG = getLogger("ImageList")
 
+const SVG_DATA_URI_PREFIX = "data:image/svg+xml"
+
+/** Returns true if the URL refers to an SVG image. */
+function isSvgUrl(url: string | null | undefined): boolean {
+  return (
+    url?.startsWith(SVG_DATA_URI_PREFIX) === true ||
+    url?.endsWith(".svg") === true
+  )
+}
+
 export interface ImageListProps {
   endpoints: StreamlitEndpoints
   element: ImageListProto
@@ -161,9 +171,16 @@ function ImageList({
   // The width of the container element, not necessarily the image.
   const containerWidth = width || 0
 
-  const imageWidth = getImageWidth(widthConfig, containerWidth)
+  const hasSvgImages = element.imgs.some(img => isSvgUrl(img.url))
+  // SVGs with no explicit pixel width may have no intrinsic size (e.g. width="100%")
+  // and collapse to 0×0 in auto-width containers. Apply container-width stretch instead.
+  const svgNeedsStretch = hasSvgImages && !widthConfig?.pixelWidth
 
-  const shouldStretch = widthConfig?.useStretch ?? false
+  const imageWidth = svgNeedsStretch
+    ? containerWidth
+    : getImageWidth(widthConfig, containerWidth)
+
+  const shouldStretch = (widthConfig?.useStretch ?? false) || svgNeedsStretch
 
   const imgStyle: CSSProperties = {}
 


### PR DESCRIPTION
## Summary

  SVG images with relative width (e.g. `width="100%"`) rendered as 0×0 pixels when no explicit `width` was passed to `st.image()`.

  **Root cause:** The image container used `width: auto` (shrink-to-content). An SVG with `width="100%"` has no intrinsic pixel size — it defers to its container,
  which defers to the SVG. The browser resolves this circular dependency as 0×0.

  Fixes #8882.

  ## Changes

  - Detect SVG images by URL prefix (`data:image/svg+xml`, which the backend always produces for local/string SVGs) or `.svg` extension
  - When any image is an SVG and no explicit pixel `width` is set, apply stretch-to-container behavior — giving the SVG a concrete size reference
  - Explicit `width=<int>` is still respected; `width="stretch"` behavior is unchanged

  ## Testing

  - [ ] Locally tested with an SVG using `width="100%"` and `viewBox` — renders correctly without passing `width`
  - [x] Frontend unit tests — 5 new cases added to `ImageList.test.tsx`:
    - SVG data URI with no `widthConfig` → stretches to container width
    - SVG data URI with `useContent` config → still stretches
    - SVG data URI with explicit `pixelWidth` → pixel width respected
    - `.svg` URL extension → stretches
    - Regular JPEG → unchanged (no regression)

  ---
