### PR TITLE
[fix] Selectbox first item hidden when 7 options selected

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.test.tsx
@@ -18,6 +18,7 @@ import { ReactElement } from "react"
 
 import { screen } from "@testing-library/react"
 
+import * as WindowDimensionsContextModule from "~lib/components/shared/WindowDimensions/useWindowDimensionsContext"
 import { mockConvertRemToPx } from "~lib/mocks/mocks"
 import { render } from "~lib/test_util"
 import * as Utils from "~lib/theme/utils"
@@ -26,6 +27,7 @@ import VirtualDropdown from "./VirtualDropdown"
 
 interface OptionProps {
   item?: { value: string; label?: string; isCreatable?: boolean }
+  $isHighlighted?: boolean
 }
 
 function Option(props: OptionProps): ReactElement {
@@ -91,5 +93,47 @@ describe("VirtualDropdown element", () => {
     expect(screen.getAllByTestId("stTooltipHoverTarget")).toHaveLength(2)
     expect(screen.getByText("def", { exact: true })).toBeInTheDocument()
     expect(screen.getByText("Add: abc", { exact: true })).toBeInTheDocument()
+  })
+
+  /**
+   * Regression for https://github.com/streamlit/streamlit/issues/14989:
+   * with exactly 7 items the content height matches the dropdown height,
+   * so scrolling is impossible. Centering on the last item produced an
+   * initialScrollOffset that virtualized away the first item.
+   */
+  it("renders the first item when the last of 7 items is highlighted", () => {
+    // VirtualDropdown only mounts when the dropdown opens, by which point the
+    // window dimensions context already has real values. The test renders
+    // both providers and the dropdown together, so we need to short-circuit
+    // the initial windowHeight=0 state.
+    vi.spyOn(
+      WindowDimensionsContextModule,
+      "useWindowDimensionsContext"
+    ).mockReturnValue({
+      fullWidth: 1024,
+      fullHeight: 768,
+      innerWidth: 1024,
+      innerHeight: 768,
+    })
+
+    const items = Array.from({ length: 7 }, (_, index) => ({
+      value: String(index + 1),
+      label: String(index + 1),
+    }))
+
+    render(
+      <VirtualDropdown>
+        {items.map((item, index) => (
+          <Option
+            key={item.value}
+            item={item}
+            $isHighlighted={index === items.length - 1}
+          />
+        ))}
+      </VirtualDropdown>
+    )
+
+    expect(screen.getByText("1", { exact: true })).toBeVisible()
+    expect(screen.getByText("7", { exact: true })).toBeVisible()
   })
 })

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.test.tsx
@@ -95,45 +95,83 @@ describe("VirtualDropdown element", () => {
     expect(screen.getByText("Add: abc", { exact: true })).toBeInTheDocument()
   })
 
-  /**
-   * Regression for https://github.com/streamlit/streamlit/issues/14989:
-   * with exactly 7 items the content height matches the dropdown height,
-   * so scrolling is impossible. Centering on the last item produced an
-   * initialScrollOffset that virtualized away the first item.
-   */
-  it("renders the first item when the last of 7 items is highlighted", () => {
-    // VirtualDropdown only mounts when the dropdown opens, by which point the
-    // window dimensions context already has real values. The test renders
-    // both providers and the dropdown together, so we need to short-circuit
-    // the initial windowHeight=0 state.
-    vi.spyOn(
-      WindowDimensionsContextModule,
-      "useWindowDimensionsContext"
-    ).mockReturnValue({
-      fullWidth: 1024,
-      fullHeight: 768,
-      innerWidth: 1024,
-      innerHeight: 768,
+  describe("initialScrollOffset for highlighted item", () => {
+    beforeEach(() => {
+      // VirtualDropdown only mounts when the dropdown opens, by which point
+      // the window dimensions context already has real values. The test
+      // renders both providers and the dropdown together, so we need to
+      // short-circuit the initial windowHeight=0 state.
+      vi.spyOn(
+        WindowDimensionsContextModule,
+        "useWindowDimensionsContext"
+      ).mockReturnValue({
+        fullWidth: 1024,
+        fullHeight: 768,
+        innerWidth: 1024,
+        innerHeight: 768,
+      })
     })
 
-    const items = Array.from({ length: 7 }, (_, index) => ({
-      value: String(index + 1),
-      label: String(index + 1),
-    }))
+    /**
+     * Regression for https://github.com/streamlit/streamlit/issues/14989:
+     * with exactly 7 items, the content height matches the dropdown height
+     * so scrolling is impossible. Without the fix, centering the last item
+     * produced an initialScrollOffset of 120px that virtualized away items
+     * at the top of the list (item "1" became unreachable).
+     */
+    it("renders all items when the last of 7 fitting items is highlighted", () => {
+      const items = Array.from({ length: 7 }, (_, index) => ({
+        value: String(index + 1),
+        label: String(index + 1),
+      }))
 
-    render(
-      <VirtualDropdown>
-        {items.map((item, index) => (
-          <Option
-            key={item.value}
-            item={item}
-            $isHighlighted={index === items.length - 1}
-          />
-        ))}
-      </VirtualDropdown>
-    )
+      render(
+        <VirtualDropdown>
+          {items.map((item, index) => (
+            <Option
+              key={item.value}
+              item={item}
+              $isHighlighted={index === items.length - 1}
+            />
+          ))}
+        </VirtualDropdown>
+      )
 
-    expect(screen.getByText("1", { exact: true })).toBeVisible()
-    expect(screen.getByText("7", { exact: true })).toBeVisible()
+      // Every item must render — assert the full range, not just endpoints,
+      // so the previously-virtualized-away items in the middle are pinned.
+      for (const { label } of items) {
+        expect(screen.getByText(label, { exact: true })).toBeVisible()
+      }
+    })
+
+    /**
+     * Complement to the regression test: ensure clamping doesn't break the
+     * centering branch for overflowing lists. With 20 items the content
+     * height (800px) exceeds the dropdown's max height (300px), so centering
+     * scrolls past the start; items near the top should be virtualized away
+     * while the highlighted last item remains visible.
+     */
+    it("centers the highlighted item when the list overflows", () => {
+      const items = Array.from({ length: 20 }, (_, index) => ({
+        value: `option-${index + 1}`,
+        label: `option-${index + 1}`,
+      }))
+
+      render(
+        <VirtualDropdown>
+          {items.map((item, index) => (
+            <Option
+              key={item.value}
+              item={item}
+              $isHighlighted={index === items.length - 1}
+            />
+          ))}
+        </VirtualDropdown>
+      )
+
+      expect(screen.getByText("option-20", { exact: true })).toBeVisible()
+      // First item is far above the centered window, so it must not render.
+      expect(screen.queryByText("option-1", { exact: true })).toBeNull()
+    })
   })
 })

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -152,10 +152,20 @@ const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
         (child.props as OptionListProps & { $isHighlighted?: boolean })
           .$isHighlighted
     )
-    // Center the highlighted item in view; stay at top if first or none highlighted
+    // Center the highlighted item in view; stay at top if first or none highlighted.
+    // Clamp to maxScrollOffset so we don't virtualize away items at the top
+    // when the list fits without overflow (offsets past the end are unreachable
+    // because the browser pins scrollTop to 0).
+    const maxScrollOffset = Math.max(0, contentHeight - height)
     const initialScrollOffset =
       highlightedIndex > 0
-        ? Math.max(0, highlightedIndex * itemSize - height / 2 + itemSize / 2)
+        ? Math.min(
+            Math.max(
+              0,
+              highlightedIndex * itemSize - height / 2 + itemSize / 2
+            ),
+            maxScrollOffset
+          )
         : 0
 
     return (


### PR DESCRIPTION

## Describe your changes

Fixes a regression in `st.selectbox` (introduced in #13796, shipped in 1.56) where opening a 7-option dropdown with the last option selected hid the first option. `VirtualDropdown` centers the highlighted item by passing `initialScrollOffset` to react-window, but didn't clamp it to the maximum scrollable distance. When the content height exactly matches the dropdown height, the browser pins `scrollTop` to 0 (no overflow), but react-window still virtualizes items based on the requested offset and skips items at the top. Clamping the offset to `max(0, contentHeight - height)` keeps the centering behavior for overflowing lists and yields 0 for non-overflowing ones, so all items render.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/14989

## Testing Plan

- [x] Unit Tests (JS and/or Python) — added a regression test in `VirtualDropdown.test.tsx` covering the 7-items / last-item-highlighted case.
- [ ] E2E Tests
- [ ] Any manual testing needed?


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
