### PR TITLE
[chore] Enable 3 more ESLint rules and fix ~40 violations

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -268,9 +268,7 @@ export default defineConfig([
       // We want to enforce display names for context providers for better debugging
       "@eslint-react/no-missing-context-display-name": "error",
       // New rules in @eslint-react v4 — disable until existing violations are addressed
-      "@eslint-react/component-hook-factories": "off",
       "@eslint-react/exhaustive-deps": "off",
-      "@eslint-react/jsx-no-children-prop": "off",
       // TypeScript rules with type-checking
       // We want to use these, but we have far too many instances of these rules
       // for it to be realistic right now. Over time, we should fix these.
@@ -433,7 +431,6 @@ export default defineConfig([
       // New React Compiler rules in react-hooks v7.1 — disable until existing
       // violations are addressed. Only rules-of-hooks and exhaustive-deps were
       // previously enforced.
-      "react-hooks/preserve-manual-memoization": "off",
       "react-hooks/refs": "off",
       "react-hooks/set-state-in-effect": "off",
       // Enforce "You Might Not Need an Effect" pattern - don't derive state in effects

--- a/frontend/lib/src/components/core/Layout/FlexContext.test.tsx
+++ b/frontend/lib/src/components/core/Layout/FlexContext.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, useContext } from "react"
+import { FC, ReactNode, useContext } from "react"
 
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
@@ -22,27 +22,47 @@ import { describe, expect, it } from "vitest"
 import { FlexContext, FlexContextProvider, IFlexContext } from "./FlexContext"
 import { Direction } from "./utils"
 
-describe("FlexContextProvider", () => {
-  // Helper component to consume and display context values
-  const ContextConsumer: FC = () => {
-    const context = useContext(FlexContext)
-    return (
-      <div data-testid="context-consumer">
-        <div data-testid="direction">{context?.direction}</div>
-        <div data-testid="isInHorizontalLayout">
-          {String(context?.isInHorizontalLayout)}
-        </div>
-        <div data-testid="isInRoot">{String(context?.isInRoot)}</div>
-        <div data-testid="parentWidth">
-          {context?.parentWidth ?? "undefined"}
-        </div>
-        <div data-testid="isInContentWidthContainer">
-          {String(context?.isInContentWidthContainer)}
-        </div>
+/** Helper component to consume and display context values. */
+const ContextConsumer: FC = () => {
+  const context = useContext(FlexContext)
+  return (
+    <div data-testid="context-consumer">
+      <div data-testid="direction">{context?.direction}</div>
+      <div data-testid="isInHorizontalLayout">
+        {String(context?.isInHorizontalLayout)}
       </div>
-    )
-  }
+      <div data-testid="isInRoot">{String(context?.isInRoot)}</div>
+      <div data-testid="parentWidth">
+        {context?.parentWidth ?? "undefined"}
+      </div>
+      <div data-testid="isInContentWidthContainer">
+        {String(context?.isInContentWidthContainer)}
+      </div>
+    </div>
+  )
+}
 
+/** Helper component that reads parent context and passes it to a nested provider. */
+const NestedProvider: FC<{
+  direction: Direction
+  hasContentWidth?: boolean
+  hasFixedWidth?: boolean
+  children: ReactNode
+}> = ({ direction, hasContentWidth, hasFixedWidth, children }) => {
+  const parentContext = useContext(FlexContext)
+  return (
+    <FlexContextProvider
+      direction={direction}
+      hasContentWidth={hasContentWidth}
+      hasFixedWidth={hasFixedWidth}
+      parentContext={parentContext}
+    >
+      {children}
+    </FlexContextProvider>
+  )
+}
+
+describe("FlexContextProvider", () => {
   describe("basic context values", () => {
     it("should provide correct values for horizontal layout", () => {
       render(
@@ -238,26 +258,6 @@ describe("FlexContextProvider", () => {
   })
 
   describe("nested contexts", () => {
-    // Helper component that reads parent context and passes it to a nested provider
-    const NestedProvider: FC<{
-      direction: Direction
-      hasContentWidth?: boolean
-      hasFixedWidth?: boolean
-      children: React.ReactNode
-    }> = ({ direction, hasContentWidth, hasFixedWidth, children }) => {
-      const parentContext = useContext(FlexContext)
-      return (
-        <FlexContextProvider
-          direction={direction}
-          hasContentWidth={hasContentWidth}
-          hasFixedWidth={hasFixedWidth}
-          parentContext={parentContext}
-        >
-          {children}
-        </FlexContextProvider>
-      )
-    }
-
     it("should handle multiple levels of nesting with content-width propagation", () => {
       render(
         <FlexContextProvider

--- a/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
+++ b/frontend/lib/src/components/core/Layout/useLayoutStyles.test.tsx
@@ -28,6 +28,7 @@ function withFlexContextProvider(
   direction: Direction,
   isInContentWidthContainer: boolean = false
 ) {
+  // eslint-disable-next-line @eslint-react/component-hook-factories -- Intentional: wrapper factory that creates renderHook wrapper components parameterized by direction
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <FlexContextProvider

--- a/frontend/lib/src/components/core/Layout/withCalculatedWidth.test.tsx
+++ b/frontend/lib/src/components/core/Layout/withCalculatedWidth.test.tsx
@@ -27,13 +27,23 @@ vi.mock("~lib/hooks/useResizeObserver", () => ({
   useResizeObserver: vi.fn(),
 }))
 
+/** Simple test component that displays its width prop. */
+const TestComponent: FC<{ width?: number }> = ({ width }) => (
+  <div data-testid="test-component">Width: {width}</div>
+)
+
+/** Test component that accepts additional props. */
+const ComponentWithProps: FC<{
+  width?: number
+  testProp: string
+}> = ({ width, testProp }) => (
+  <div data-testid="test-component">
+    Width: {width}, TestProp: {testProp}
+  </div>
+)
+
 describe("withCalculatedWidth", () => {
   const mockElementRef = { current: null }
-
-  // Simple test component that displays its width prop
-  const TestComponent: FC<{ width?: number }> = ({ width }) => (
-    <div data-testid="test-component">Width: {width}</div>
-  )
 
   it("should pass width to the wrapped component", () => {
     const mockWidth = 500
@@ -67,16 +77,6 @@ describe("withCalculatedWidth", () => {
       values: [300],
       elementRef: mockElementRef,
     })
-
-    // Create a component that accepts additional props
-    const ComponentWithProps: FC<{
-      width?: number
-      testProp: string
-    }> = ({ width, testProp }) => (
-      <div data-testid="test-component">
-        Width: {width}, TestProp: {testProp}
-      </div>
-    )
 
     const EnhancedComponent = withCalculatedWidth(ComponentWithProps)
     render(<EnhancedComponent testProp="test-value" />)

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx
@@ -37,6 +37,18 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import { useDeckGl, UseDeckGlProps } from "./useDeckGl"
 
+/** Test component that wires useDeckGl to the ElementFullscreenContext expand button. */
+const DeckGlFullscreenTestComponent: FC<UseDeckGlProps> = props => {
+  useDeckGl(props)
+  const { expand } = useRequiredContext(ElementFullscreenContext)
+
+  return (
+    <button type="button" onClick={expand}>
+      Expand
+    </button>
+  )
+}
+
 const mockInitialViewState = {
   bearing: -27.36,
   latitude: 52.2323,
@@ -229,18 +241,8 @@ describe("useDeckGl", () => {
 
     it("should call JSON5.parse when isFullScreen changes", async () => {
       const user = userEvent.setup()
-      const MyComponent: FC<UseDeckGlProps> = props => {
-        useDeckGl(props)
-        const { expand } = useRequiredContext(ElementFullscreenContext)
 
-        return (
-          <button type="button" onClick={expand}>
-            Expand
-          </button>
-        )
-      }
-
-      render(<MyComponent {...getUseDeckGlProps()} />)
+      render(<DeckGlFullscreenTestComponent {...getUseDeckGlProps()} />)
 
       expect(JSON5.parse).toHaveBeenCalledTimes(1)
 

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -24,6 +24,31 @@ import {
   UseDetailsAnimationOptions,
 } from "./useDetailsAnimation"
 
+/** Wrapper component that renders DOM elements wired to the hook's refs. */
+function TestHarness(
+  props: UseDetailsAnimationOptions
+): ReturnType<typeof createElement> {
+  const result = useDetailsAnimation(props)
+  return createElement(
+    "details",
+    { ref: result.detailsRef, "data-testid": "details" },
+    createElement(
+      "summary",
+      {
+        ref: result.summaryRef,
+        "data-testid": "summary",
+        onClick: result.handleToggle,
+      },
+      props.label
+    ),
+    createElement(
+      "div",
+      { ref: result.contentRef, "data-testid": "content" },
+      "Content"
+    )
+  )
+}
+
 describe("useDetailsAnimation", () => {
   describe("initial state", () => {
     it("returns isOpen=true when backendExpanded is true", () => {
@@ -321,31 +346,6 @@ describe("useDetailsAnimation", () => {
     let mockObserve: ReturnType<typeof vi.fn>
     let mockDisconnect: ReturnType<typeof vi.fn>
     const OriginalResizeObserver = globalThis.ResizeObserver
-
-    /** Wrapper component that renders DOM elements wired to the hook's refs. */
-    function TestHarness(
-      props: UseDetailsAnimationOptions
-    ): ReturnType<typeof createElement> {
-      const result = useDetailsAnimation(props)
-      return createElement(
-        "details",
-        { ref: result.detailsRef, "data-testid": "details" },
-        createElement(
-          "summary",
-          {
-            ref: result.summaryRef,
-            "data-testid": "summary",
-            onClick: result.handleToggle,
-          },
-          props.label
-        ),
-        createElement(
-          "div",
-          { ref: result.contentRef, "data-testid": "content" },
-          "Content"
-        )
-      )
-    }
 
     function mockElementHeight(element: Element, height: number): void {
       vi.spyOn(element, "getBoundingClientRect").mockReturnValue({

--- a/frontend/lib/src/components/shared/WindowDimensions/Provider.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/Provider.test.tsx
@@ -24,21 +24,33 @@ import { mockTheme } from "~lib/mocks/mockTheme"
 
 import { useWindowDimensionsContext } from "./useWindowDimensionsContext"
 
+/** Test component that displays window dimensions. */
+const DimensionsConsumer: FC = () => {
+  const dimensions = useWindowDimensionsContext()
+  return <div>{`${dimensions.fullWidth}x${dimensions.fullHeight}`}</div>
+}
+
+/** Test component that nests two WindowDimensionsProviders to verify error. */
+const DoubleProvider: FC = () => (
+  <ThemeProvider theme={mockTheme.emotion}>
+    <WindowDimensionsProvider>
+      <WindowDimensionsProvider>
+        <div>Children content</div>
+      </WindowDimensionsProvider>
+    </WindowDimensionsProvider>
+  </ThemeProvider>
+)
+
 describe("WindowDimensionsProvider", () => {
   it("should provide the width and height of the window and take into account the theme padding", () => {
     vi.spyOn(window, "getComputedStyle").mockReturnValue({
       fontSize: "16px",
     } as CSSStyleDeclaration)
 
-    const MyComponent: FC = () => {
-      const dimensions = useWindowDimensionsContext()
-      return <div>{`${dimensions.fullWidth}x${dimensions.fullHeight}`}</div>
-    }
-
     render(
       <ThemeProvider theme={mockTheme.emotion}>
         <WindowDimensionsProvider>
-          <MyComponent />
+          <DimensionsConsumer />
         </WindowDimensionsProvider>
       </ThemeProvider>
     )
@@ -51,17 +63,7 @@ describe("WindowDimensionsProvider", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {})
 
-    const Provider: FC = () => (
-      <ThemeProvider theme={mockTheme.emotion}>
-        <WindowDimensionsProvider>
-          <WindowDimensionsProvider>
-            <div>Children content</div>
-          </WindowDimensionsProvider>
-        </WindowDimensionsProvider>
-      </ThemeProvider>
-    )
-
-    expect(() => render(<Provider />)).toThrowError(
+    expect(() => render(<DoubleProvider />)).toThrowError(
       "WindowDimensionsProvider should only be used once per app. If you need to read window dimensions, utilize `useWindowDimensionsContext()` instead."
     )
     consoleError.mockRestore()

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -284,8 +284,7 @@ function createOptionChild(
 ): React.FunctionComponent {
   const isSelected = selected.includes(index)
 
-  // we have to use forwardRef here because BasewebButtonGroup passes the ref down to its children
-  // and we see a console.error otherwise
+  // eslint-disable-next-line @eslint-react/component-hook-factories -- Intentional: factory function that returns a forwardRef component per option for BasewebButtonGroup children
   return forwardRef(function BaseButtonGroup(
     // Accept only the props compatible with BaseButton to improve type safety
     props: Partial<BaseButtonProps>,

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -284,7 +284,9 @@ function createOptionChild(
 ): React.FunctionComponent {
   const isSelected = selected.includes(index)
 
-  // eslint-disable-next-line @eslint-react/component-hook-factories -- Intentional: factory function that returns a forwardRef component per option for BasewebButtonGroup children
+  // We have to use forwardRef here because BasewebButtonGroup passes the ref down to
+  // its children and we see a console.error otherwise.
+  // eslint-disable-next-line @eslint-react/component-hook-factories -- Intentional: per-option forwardRef factory required by BasewebButtonGroup
   return forwardRef(function BaseButtonGroup(
     // Accept only the props compatible with BaseButton to improve type safety
     props: Partial<BaseButtonProps>,

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -344,6 +344,7 @@ function ChatInput({
   )
 
   const addFiles = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     (filesToAdd: UploadFileInfo[]): void =>
       setFiles(currentFiles => [...currentFiles, ...filesToAdd]),
     []
@@ -372,6 +373,7 @@ function ChatInput({
   )
 
   const deleteFile = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     (fileId: number): void => {
       setFiles(prevFiles => {
         const file = getFile(fileId, prevFiles)
@@ -400,6 +402,7 @@ function ChatInput({
     ((acceptedFiles: File[], rejectedFiles: never[]) => void) | null
   >(null)
 
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- dropHandlerRef is a ref, setFiles is a stable setter
   const handleRetry = useCallback((fileInfo: UploadFileInfo): void => {
     if (!fileInfo.file || fileInfo.status.type !== "error") {
       return
@@ -526,6 +529,7 @@ function ChatInput({
   })
 
   const submitChatInput = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     (audioInfo?: UploadedFileInfoProto): void => {
       // We want the chat input to always be in focus
       // even if the user clicks the submit button
@@ -582,6 +586,7 @@ function ChatInput({
 
   // Handle audio approval and upload
   const handleAudioApprove = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     async (wav: Blob): Promise<void> => {
       // Convert blob to File
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
@@ -643,6 +648,7 @@ function ChatInput({
 
   // Memoize events to ensure fresh closures when dependencies change
   const controllerEvents = useMemo(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     () => ({
       onApprove: handleAudioApprove,
       onPermissionDenied: () => {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -344,7 +344,7 @@ function ChatInput({
   )
 
   const addFiles = useCallback(
-    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- setFiles is a stable setter
     (filesToAdd: UploadFileInfo[]): void =>
       setFiles(currentFiles => [...currentFiles, ...filesToAdd]),
     []
@@ -373,7 +373,7 @@ function ChatInput({
   )
 
   const deleteFile = useCallback(
-    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- setFiles and setDropzoneResetCounter are stable setters
     (fileId: number): void => {
       setFiles(prevFiles => {
         const file = getFile(fileId, prevFiles)
@@ -529,7 +529,7 @@ function ChatInput({
   })
 
   const submitChatInput = useCallback(
-    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- chatInputRef is a ref; setFiles/setValue/setIsStacked/setDropzoneResetCounter are stable setters
     (audioInfo?: UploadedFileInfoProto): void => {
       // We want the chat input to always be in focus
       // even if the user clicks the submit button
@@ -586,7 +586,7 @@ function ChatInput({
 
   // Handle audio approval and upload
   const handleAudioApprove = useCallback(
-    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- chatInputRef and uploadAbortControllerRef are refs; setAudioUploading and setRecordingError are stable setters
     async (wav: Blob): Promise<void> => {
       // Convert blob to File
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
@@ -648,7 +648,7 @@ function ChatInput({
 
   // Memoize events to ensure fresh closures when dependencies change
   const controllerEvents = useMemo(
-    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- setRecordingError is a stable setter
     () => ({
       onApprove: handleAudioApprove,
       onPermissionDenied: () => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.ts
@@ -137,7 +137,7 @@ function useSelectionHandler(
    * trigger a sync of the state with the widget state
    */
   const processSelectionChange = useCallback(
-    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- setGridSelection is a stable setter
     (
       newSelection: GridSelection,
       options: {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.ts
@@ -137,6 +137,7 @@ function useSelectionHandler(
    * trigger a sync of the state with the widget state
    */
   const processSelectionChange = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
     (
       newSelection: GridSelection,
       options: {

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnVisibilityMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnVisibilityMenu.test.tsx
@@ -121,13 +121,14 @@ const MOCK_COLUMNS: BaseColumn[] = [
 ]
 
 describe("DataFrame ColumnVisibilityMenu", () => {
-  const defaultProps: ColumnVisibilityMenuProps = {
+  const defaultChildren = <button type="button">Toggle Visibility</button>
+
+  const defaultProps: Omit<ColumnVisibilityMenuProps, "children"> = {
     columns: MOCK_COLUMNS,
     columnOrder: [],
     setColumnOrder: vi.fn(),
     hideColumn: vi.fn(),
     showColumn: vi.fn(),
-    children: <button type="button">Toggle Visibility</button>,
     isOpen: true,
     onClose: vi.fn(),
   }
@@ -137,7 +138,11 @@ describe("DataFrame ColumnVisibilityMenu", () => {
   })
 
   it("renders the visibility menu with all columns", async () => {
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...defaultProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     expect(screen.getByTestId("stDataFrameColumnVisibilityMenu")).toBeVisible()
     expect(screen.getByText("Column 1")).toBeVisible()
@@ -147,7 +152,11 @@ describe("DataFrame ColumnVisibilityMenu", () => {
   })
 
   it("shows correct checkbox states based on column visibility", async () => {
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...defaultProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     const checkboxes = screen.getAllByRole("checkbox")
     expect(checkboxes[0]).not.toBeChecked() // Select All (visible but indeterminate)
@@ -157,27 +166,43 @@ describe("DataFrame ColumnVisibilityMenu", () => {
   })
 
   it("calls hideColumn when unchecking a visible column", async () => {
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...defaultProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     await userEvent.click(screen.getByLabelText("Column 1"))
     expect(defaultProps.hideColumn).toHaveBeenCalledWith("_column-1")
   })
 
   it("calls showColumn when checking a hidden column", async () => {
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...defaultProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     await userEvent.click(screen.getByLabelText("Column 2"))
     expect(defaultProps.showColumn).toHaveBeenCalledWith("_column-2")
   })
 
   it("renders children component", async () => {
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...defaultProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     expect(screen.getByText("Toggle Visibility")).toBeInTheDocument()
   })
 
   it("doesn't render menu content when closed", () => {
-    render(<ColumnVisibilityMenu {...defaultProps} isOpen={false} />)
+    render(
+      <ColumnVisibilityMenu {...defaultProps} isOpen={false}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     expect(
       screen.queryByTestId("stDataFrameColumnVisibilityMenu")
@@ -191,7 +216,9 @@ describe("DataFrame ColumnVisibilityMenu", () => {
     }
 
     await renderAndWaitForPopover(
-      <ColumnVisibilityMenu {...propsWithColumnOrder} />
+      <ColumnVisibilityMenu {...propsWithColumnOrder}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
     )
 
     const checkboxes = screen.getAllByRole("checkbox")
@@ -208,7 +235,9 @@ describe("DataFrame ColumnVisibilityMenu", () => {
     }
 
     await renderAndWaitForPopover(
-      <ColumnVisibilityMenu {...propsWithColumnOrder} />
+      <ColumnVisibilityMenu {...propsWithColumnOrder}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
     )
 
     await userEvent.click(screen.getByLabelText("Column 1"))
@@ -223,7 +252,9 @@ describe("DataFrame ColumnVisibilityMenu", () => {
     }
 
     await renderAndWaitForPopover(
-      <ColumnVisibilityMenu {...propsWithColumnOrder} />
+      <ColumnVisibilityMenu {...propsWithColumnOrder}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
     )
 
     await userEvent.click(screen.getByLabelText("Column 2"))
@@ -232,7 +263,11 @@ describe("DataFrame ColumnVisibilityMenu", () => {
   })
 
   it("calls showColumn on all columns when selecting an indeterminate select all", async () => {
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...defaultProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     await userEvent.click(screen.getByLabelText("Select all")) // (Indeterminate, column 2 is hidden)
     expect(defaultProps.showColumn).toHaveBeenCalledWith("index-0")
@@ -246,7 +281,11 @@ describe("DataFrame ColumnVisibilityMenu", () => {
       columns: MOCK_COLUMNS.map(c => ({ ...c, isHidden: true })),
     }
 
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...allHiddenProps} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...allHiddenProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
+    )
 
     await userEvent.click(screen.getByLabelText("Select all"))
     expect(defaultProps.showColumn).toHaveBeenCalledWith("index-0")
@@ -261,7 +300,9 @@ describe("DataFrame ColumnVisibilityMenu", () => {
     }
 
     await renderAndWaitForPopover(
-      <ColumnVisibilityMenu {...allVisibleProps} />
+      <ColumnVisibilityMenu {...allVisibleProps}>
+        {defaultChildren}
+      </ColumnVisibilityMenu>
     )
 
     await userEvent.click(screen.getByLabelText("Select all"))
@@ -277,7 +318,9 @@ describe("DataFrame ColumnVisibilityMenu", () => {
       columnOrder: ["index-0", "_column-1"], // exclude _column-2 via order
     }
 
-    await renderAndWaitForPopover(<ColumnVisibilityMenu {...props} />)
+    await renderAndWaitForPopover(
+      <ColumnVisibilityMenu {...props}>{defaultChildren}</ColumnVisibilityMenu>
+    )
 
     const selectAll = screen.getByLabelText("Select all")
     expect(selectAll).not.toBeChecked()

--- a/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.test.tsx
@@ -150,9 +150,8 @@ describe("DataFrame FormattingMenu", () => {
 
   it("renders children as trigger element", async () => {
     const triggerText = "Custom Trigger"
-    const { children: _, ...propsWithoutChildren } = defaultProps
     await renderAndWaitForPopover(
-      <FormattingMenu {...propsWithoutChildren}>
+      <FormattingMenu {...defaultProps}>
         <div>{triggerText}</div>
       </FormattingMenu>
     )

--- a/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.test.tsx
@@ -41,14 +41,15 @@ async function renderAndWaitForPopover(
 }
 
 describe("DataFrame FormattingMenu", () => {
-  const defaultProps: FormattingMenuProps = {
+  const defaultChildren = <div>Trigger</div>
+
+  const defaultProps: Omit<FormattingMenuProps, "children"> = {
     columnKind: "number",
     isOpen: true,
     onMouseEnter: vi.fn(),
     onMouseLeave: vi.fn(),
     onChangeFormat: vi.fn(),
     onCloseMenu: vi.fn(),
-    children: <div>Trigger</div>,
   }
 
   beforeEach(() => {
@@ -56,7 +57,9 @@ describe("DataFrame FormattingMenu", () => {
   })
 
   it("renders number format options when columnKind is number", async () => {
-    await renderAndWaitForPopover(<FormattingMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <FormattingMenu {...defaultProps}>{defaultChildren}</FormattingMenu>
+    )
 
     // Check for presence of number-specific formats
     expect(screen.getByText("Automatic")).toBeInTheDocument()
@@ -70,7 +73,9 @@ describe("DataFrame FormattingMenu", () => {
 
   it("renders datetime format options when columnKind is datetime", async () => {
     await renderAndWaitForPopover(
-      <FormattingMenu {...defaultProps} columnKind="datetime" />
+      <FormattingMenu {...defaultProps} columnKind="datetime">
+        {defaultChildren}
+      </FormattingMenu>
     )
 
     // Check for presence of datetime-specific formats
@@ -86,7 +91,9 @@ describe("DataFrame FormattingMenu", () => {
 
   it("renders date format options when columnKind is date", async () => {
     await renderAndWaitForPopover(
-      <FormattingMenu {...defaultProps} columnKind="date" />
+      <FormattingMenu {...defaultProps} columnKind="date">
+        {defaultChildren}
+      </FormattingMenu>
     )
 
     // Check for presence of date-specific formats
@@ -100,7 +107,9 @@ describe("DataFrame FormattingMenu", () => {
 
   it("renders time format options when columnKind is time", async () => {
     await renderAndWaitForPopover(
-      <FormattingMenu {...defaultProps} columnKind="time" />
+      <FormattingMenu {...defaultProps} columnKind="time">
+        {defaultChildren}
+      </FormattingMenu>
     )
 
     // Check for presence of time-specific formats
@@ -115,7 +124,11 @@ describe("DataFrame FormattingMenu", () => {
   it("renders no format options for unknown column kind", () => {
     // When columnKind is unknown, the component returns an empty fragment
     // and there's no popover to wait for
-    render(<FormattingMenu {...defaultProps} columnKind="unknown" />)
+    render(
+      <FormattingMenu {...defaultProps} columnKind="unknown">
+        {defaultChildren}
+      </FormattingMenu>
+    )
 
     // Menu should be empty for unknown column types
     expect(screen.queryByText("Automatic")).not.toBeInTheDocument()
@@ -123,7 +136,9 @@ describe("DataFrame FormattingMenu", () => {
   })
 
   it("calls onChangeFormat and onCloseMenu when clicking a format option", async () => {
-    await renderAndWaitForPopover(<FormattingMenu {...defaultProps} />)
+    await renderAndWaitForPopover(
+      <FormattingMenu {...defaultProps}>{defaultChildren}</FormattingMenu>
+    )
 
     // Click the "Dollar" format option
     await userEvent.click(screen.getByText("Dollar"))

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -321,7 +321,7 @@ const Multiselect: FC<Props> = props => {
   // Memoized to prevent BaseWeb from remounting on every render
   const ValueContainer = useMemo(
     () =>
-      // eslint-disable-next-line @eslint-react/no-nested-component-definitions -- Required for baseweb component override with refs
+      // eslint-disable-next-line @eslint-react/no-nested-component-definitions, @eslint-react/component-hook-factories -- Required for baseweb component override with refs
       function ValueContainer(
         props: SharedStylePropsArg & { children: React.ReactNode }
       ): React.ReactElement {

--- a/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
+++ b/frontend/lib/src/hooks/useWidgetManagerElementState.test.tsx
@@ -29,6 +29,42 @@ import useWidgetManagerElementState from "./useWidgetManagerElementState"
 
 const elementId = "elementId"
 
+/** Test component that wires useWidgetManagerElementState to a form input for integration testing. */
+const FormStateTestComponent: FC<{
+  widgetMgr: WidgetStateManager
+  formId: string
+  stateKey: string
+  defaultValue: string
+  testInputAriaLabel: string
+}> = ({ widgetMgr, formId, stateKey, defaultValue, testInputAriaLabel }) => {
+  const [state, setState] = useWidgetManagerElementState<string>({
+    widgetMgr,
+    id: elementId,
+    formId,
+    key: stateKey,
+    defaultValue,
+  })
+
+  return (
+    <RootStyleProvider theme={getDefaultTheme()}>
+      <Form
+        formId={formId}
+        clearOnSubmit={true}
+        enterToSubmit={false}
+        widgetMgr={widgetMgr}
+        border={false}
+      >
+        <input
+          aria-label={testInputAriaLabel}
+          type="text"
+          value={state}
+          onChange={e => setState(e.currentTarget.value)}
+        />
+      </Form>
+    </RootStyleProvider>
+  )
+}
+
 describe("useWidgetManagerElementState hook", () => {
   it("should initialize correctly with initial state", () => {
     const widgetMgr = new WidgetStateManager({
@@ -91,38 +127,18 @@ describe("useWidgetManagerElementState hook", () => {
       sendRerunBackMsg: vi.fn(),
     })
 
-    const TestComponent: FC = () => {
-      const [state, setState] = useWidgetManagerElementState<string>({
-        widgetMgr,
-        id: elementId,
-        formId,
-        key: stateKey,
-        defaultValue,
-      })
-
-      return (
-        <RootStyleProvider theme={getDefaultTheme()}>
-          <Form
-            formId={formId}
-            clearOnSubmit={true}
-            enterToSubmit={false}
-            widgetMgr={widgetMgr}
-            border={false}
-          >
-            <input
-              aria-label={testInputAriaLabel}
-              type="text"
-              value={state}
-              onChange={e => setState(e.currentTarget.value)}
-            />
-          </Form>
-        </RootStyleProvider>
-      )
-    }
-
-    renderWithContexts(<TestComponent />, {
-      formsContext: { formsData: createFormsData() },
-    })
+    renderWithContexts(
+      <FormStateTestComponent
+        widgetMgr={widgetMgr}
+        formId={formId}
+        stateKey={stateKey}
+        defaultValue={defaultValue}
+        testInputAriaLabel={testInputAriaLabel}
+      />,
+      {
+        formsContext: { formsData: createFormsData() },
+      }
+    )
 
     // verify default value
     const inputElement: HTMLInputElement =

--- a/frontend/lib/src/test_util.tsx
+++ b/frontend/lib/src/test_util.tsx
@@ -308,6 +308,7 @@ export const renderWithContexts = (
     ...options.downloadContext,
   }
 
+  // eslint-disable-next-line @eslint-react/component-hook-factories -- Intentional: test utility factory function that creates context wrapper components with closure over mutable context values for rerenderWithContexts
   const Wrapper: FC<PropsWithChildren> = ({ children }) => {
     // Create ref for app root if needed
     const appRootRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary

Enables 3 additional ESLint rules that were disabled in #14890 (ESLint group bump) by fixing existing violations or adding targeted inline suppresses. This is a follow-up to #14998 and can land independently.

- **`@eslint-react/component-hook-factories`** (13 violations): Moved test helper components to module level in 7 test files. Added inline suppresses for 4 intentional factory patterns (BaseUI overrides, test utility wrappers, forwardRef factories).
- **`@eslint-react/jsx-no-children-prop`** (14 violations): Extracted `children` from `defaultProps` in test files and passed via JSX children syntax instead of prop spreading.
- **`react-hooks/preserve-manual-memoization`** (~12 violations): Added inline suppresses alongside existing `exhaustive-deps` suppresses. All cases involve intentionally omitted stable dependencies (React state setters, refs).

### Rules still disabled after this PR and #14998
| Rule | Violations |
|---|---|
| `react-hooks/refs` | 46 |
| `react-hooks/set-state-in-effect` | 28 |
| `@eslint-react/exhaustive-deps` | 33 |

## Test plan
- [x] `make frontend-lint` passes (only pre-existing `import/no-unresolved` errors remain)
- [x] `make frontend-format` passes
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)