### PR TITLE
Serve symlinked frontend assets instead of falling through to SPA

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_static_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_static_routes.py
@@ -63,7 +63,13 @@ def create_streamlit_static_handler(
 
     class _StreamlitStaticFiles(StaticFiles):
         def __init__(self, directory: str, base_url: str | None) -> None:
-            super().__init__(directory=directory, html=True)
+            # follow_symlink=True is safe here because we serve our own
+            # package-bundled frontend assets, not user-supplied content.
+            # Without it, installs that symlink the streamlit wheel into the
+            # venv (e.g. uv with cache and venv on different filesystems)
+            # serve the SPA index.html for every /static/js/*.js request,
+            # producing a blank page with no errors.
+            super().__init__(directory=directory, html=True, follow_symlink=True)
             self._base_url = (base_url or "").strip("/")
             self._index_path = os.path.join(directory, "index.html")
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -131,6 +131,36 @@ class TestStreamlitStaticFiles:
         assert response.headers["Cache-Control"] == "no-cache"
 
 
+class TestSymlinkedAssets:
+    """Tests that symlinked bundled assets are served as their real content."""
+
+    def test_symlinked_js_file_is_served(self, tmp_path: Path) -> None:
+        """A JS file reached via symlink should serve its real bytes, not fall
+        back to index.html. Regression for installs (e.g. uv with cache on a
+        different filesystem) that symlink the streamlit wheel into the venv.
+        """
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        (real_dir / "app.abc123.js").write_text("console.log('real')")
+
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+        (static_dir / "app.abc123.js").symlink_to(real_dir / "app.abc123.js")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app) as client:
+            response = client.get("/app.abc123.js")
+
+            assert response.status_code == 200
+            assert response.text == "console.log('real')"
+            assert "<html>" not in response.text
+
+
 class TestReservedPaths:
     """Tests for reserved path handling."""
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -134,6 +135,10 @@ class TestStreamlitStaticFiles:
 class TestSymlinkedAssets:
     """Tests that symlinked bundled assets are served as their real content."""
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Creating symlinks on Windows requires elevated privileges",
+    )
     def test_symlinked_js_file_is_served(self, tmp_path: Path) -> None:
         """A JS file reached via symlink should serve its real bytes, not fall
         back to index.html. Regression for installs (e.g. uv with cache on a


### PR DESCRIPTION
  ## Describe your changes

  Pass `follow_symlink=True` to the `StaticFiles` handler that mounts Streamlit's bundled frontend assets in  `lib/streamlit/web/server/starlette/starlette_static_routes.py`. These assets are package-trusted content shipped with the wheel, not user data, so following symlinks does not widen the trust boundary. The narrower user-app static-serving feature (`server.enableStaticServing`) is a separate code  path and is intentionally left untouched.

  This fixes a silent failure mode where requests for bundled JS assets fall through to the SPA `index.html` fallback when the streamlit wheel is symlinked into the venv (rather than copied). The page renders **blank with no console errors** — the only signal is `/static/js/*.js` returning `200 text/html` in devtools' Network tab. It reproduces reliably with `uv` when its cache and the project `.venv` live on different filesystems: uv falls  back to symlinking across filesystem boundaries, and Starlette's `StaticFiles` defaults to `follow_symlink=False` and 404s on symlinked files (which our handler converts into the SPA fallback).

  Existing workarounds force users to set `UV_LINK_MODE=copy` or relocate their uv cache, paying disk and time cost only to dodge a symlink check on  assets that are always trusted.

  ## Screenshot or video (only for visual changes)

  N/A — server-side fix; visible effect is "blank page in affected installs becomes the actual app."

  ## GitHub Issue Link (if applicable)

  None filed.

  ## Testing Plan

  - **Unit Tests (Python):** Added `TestSymlinkedAssets::test_symlinked_js_file_is_served` in   `lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py`. It creates a JS file outside the static dir, symlinks it in, requests it, and asserts the response body is the real JS bytes rather than the `index.html` fallback. **Verified to fail on `develop` and pass with the fix**  (without the change, the assertion shows `<html>Home</html>` instead of `console.log('real')`). All 32 tests in the file pass with the fix; `ruff  check` and `ruff format --check` clean.
  - **E2E Tests:** Not added. The bug is install-shape-specific (symlinked wheel) and lives entirely in the static-asset handler; reproducing it in Playwright would require manipulating the test environment's site-packages, which the unit test exercises more directly.
  - **Manual testing:** Reproduced the original blank-page symptom with `uv` on a split-filesystem layout against `develop`; with the fix applied the app  loads normally. No behaviour change observed for single-filesystem installs (assets are served the same way; the symlink check just no longer rejects them when present).

  ---

  **Contribution License Agreement**

  By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.