### PR TITLE
[chore] Fix typing for types-cachetools 7.0.0+

### DIFF
--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -26,6 +26,7 @@ from typing import (
     Final,
     TypeAlias,
     TypeVar,
+    cast,
     overload,
 )
 
@@ -672,7 +673,8 @@ class ResourceCache(Cache[R]):
 
     @property
     def ttl_seconds(self) -> float:
-        return self._mem_cache.ttl
+        # Cast is needed for types-cachetools 7.0.0+ where .ttl returns Any.
+        return cast("float", self._mem_cache.ttl)
 
     def read_result(self, key: str) -> CachedResult[R]:
         """Read a value and associated messages from the cache.


### PR DESCRIPTION
## Describe your changes

Fixes a typing issue introduced by `types-cachetools 7.0.0+` where `.ttl` returns `Any` instead of `float`.

- Cast `self._mem_cache.ttl` to `float` in `ResourceCache.ttl_seconds` property

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python) — existing tests in `cache_resource_api_test.py` pass

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->