### PR TITLE
[chore] Require uv 0.9.17 for exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = []
 
 [tool.uv]
 # Minimum uv version required for this project
-required-version = ">=0.9.0"
+required-version = ">=0.9.17"
 # Exclude packages published in the last 24 hours to lower risk from supply chain attacks
 exclude-newer = "24 hours"
 # Explicit pandas version constraints by Python version:


### PR DESCRIPTION
## Describe your changes

Requires `uv >= 0.9.17` so the checked-in `exclude-newer = "24 hours"` setting is supported.

- Aligns the declared minimum `uv` version with the dependency cooldown feature already configured in `pyproject.toml`.
- Prevents older `uv` versions from warning during settings discovery and silently ignoring the cooldown.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Explanation of why no additional tests are needed: configuration-only change in `pyproject.toml`; no runtime code path changed.
- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
