### PR TITLE
[chore] Bump max tracked commands limit to 400

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -35,7 +35,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_r
 _LOGGER: Final = get_logger(__name__)
 
 # Limit the number of commands to keep the page profile message small
-_MAX_TRACKED_COMMANDS: Final = 200
+_MAX_TRACKED_COMMANDS: Final = 400
 # Only track a maximum of 25 uses per unique command since some apps use
 # commands excessively (e.g. calling add_rows thousands of times in one rerun)
 # making the page profile useless.

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -471,15 +471,20 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
     def test_command_tracking_limits(self):
         """Command tracking limits should be respected.
 
-        Current limits are 25 per unique command and 200 in total.
+        Current limits are _MAX_TRACKED_PER_COMMAND (25) per unique command
+        and _MAX_TRACKED_COMMANDS (400) in total.
         """
         ctx = get_script_run_ctx()
         assert ctx is not None
         ctx.reset()
         ctx.gather_usage_stats = True
 
+        # Create enough unique command names to exceed _MAX_TRACKED_COMMANDS
+        # when each is called _MAX_TRACKED_PER_COMMAND + 1 times.
+        # With 20 commands * 25 per command = 500, which exceeds the 400 limit.
+        num_unique_commands = 20
         funcs = []
-        for i in range(10):
+        for i in range(num_unique_commands):
 
             def test_function() -> str:
                 return "foo"


### PR DESCRIPTION
## Describe your changes

Increases `_MAX_TRACKED_COMMANDS` from 200 to 400.

The original limit of 200 was a legacy limitation based on constraints of the old Segment tracking system, which is no longer in use. With the current telemetry infrastructure, we can safely double this limit to capture more command usage data for apps with many commands.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit tests pass (the test references the constant dynamically)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->