### PR TITLE
[fix] respect the Snowflake connection name as an argument

### DIFF
--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -660,7 +660,9 @@ class SnowflakeConnection(BaseSnowflakeConnection):
                 )
                 return snowflake.connector.connect()
 
-            return snowflake.connector.connect(**kwargs)
+            return snowflake.connector.connect(
+                **{"connection_name": self._connection_name, **kwargs}
+            )
         except SnowflakeError:
             if not len(st_secrets) and not kwargs:
                 raise StreamlitAPIException(

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -319,6 +319,45 @@ class TestSnowflakeConnectionClose:
             assert conn._raw_instance is None
 
 
+@pytest.mark.require_integration
+class TestSnowflakeConnectionConnect:
+    """Tests for SnowflakeConnection._connect() (no live Snowflake required)."""
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+        PropertyMock(return_value=AttrDict({})),
+    )
+    @patch("snowflake.connector.connect")
+    def test_passes_connection_name_to_connector(
+        self, patched_connect: MagicMock
+    ) -> None:
+        """Tests that the Streamlit connection name is forwarded to the Snowflake connector.
+
+        When no Streamlit secrets are configured and the connection name is not
+        the reserved ``"snowflake"`` default, ``snowflake.connector.connect()``
+        must receive ``connection_name`` so it can look up the named entry in
+        ``~/.snowflake/connections.toml``.
+        """
+        SnowflakeConnection("my_connection")
+        patched_connect.assert_called_once_with(connection_name="my_connection")
+
+    @patch(
+        "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+        PropertyMock(return_value=AttrDict({})),
+    )
+    @patch("snowflake.connector.connect")
+    def test_kwargs_can_override_connection_name(
+        self, patched_connect: MagicMock
+    ) -> None:
+        """Tests that an explicit connection_name kwarg overrides the default one.
+
+        If the caller supplies ``connection_name`` explicitly via ``st.connection()``,
+        that value should take precedence over the Streamlit connection name.
+        """
+        SnowflakeConnection("my_connection", connection_name="other_connection")
+        patched_connect.assert_called_once_with(connection_name="other_connection")
+
+
 class TestSnowflakeCallersRightsConnection:
     def test_get_connection_params_errors_on_missing_env(self):
         """Tests that _get_connection_params handles missing environment variables."""


### PR DESCRIPTION
Full disclosure: I found this bug on my own, then had Copilot write the code, which I validated. I also used some of its text for the pull request description.

---

The [guide](https://docs.streamlit.io/develop/tutorials/databases/snowflake#write-your-streamlit-app) and [API documentation](https://docs.streamlit.io/develop/api-reference/connections/st.connections.snowflakeconnection) indicate that a connection can be established with

```python
st.connection("my_connection", type="snowflake")
```

Unfortunately, the connection name passed as an argument isn't used.

## Steps to reproduce

1. Remove / comment out the `[connections.snowflake]` section of any `secrets.toml`.
1. Save the following in a Python script.

    ```python
    import snowflake.connector
    import streamlit as st
    
    
    def print_args(*args, **kwargs):
        print("args:", args)
        print("kwargs:", kwargs)
    
    
    snowflake.connector.connect = print_args  # type: ignore
    
    st.connection("my_connection", type="snowflake")
    ```

1. Run the script.
1. It prints:

   ```
   args: ()
   kwargs: {}
   ```

## Describe your changes

(`snowflake_connection.py`): In the named-connection branch of `_connect()`, pass `connection_name=self._connection_name` to `snowflake.connector.connect()`. Dict-merge ordering (`{connection_name: ..., **kwargs}`) ensures an explicit `connection_name` kwarg still takes precedence.

```python
# Before — connection name silently dropped
return snowflake.connector.connect(**kwargs)

# After — name forwarded; kwargs can still override
return snowflake.connector.connect(**{"connection_name": self._connection_name, **kwargs})
```

The `"snowflake"` default-connection path (which intentionally calls `connect()` with no args) is unchanged.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Unit tests** (Python): Two new `@pytest.mark.require_integration` tests in `TestSnowflakeConnectionConnect`:
  - `test_passes_connection_name_to_connector` — asserts `connection_name` is forwarded when using a non-default named connection.
  - `test_kwargs_can_override_connection_name` — asserts an explicit `connection_name` kwarg wins over the Streamlit connection name.
- No E2E tests needed; this is a connector-call argument fix with no UI surface.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.