### PR TITLE
[chore] Simplify protobuf AGENTS.md documentation

### DIFF
--- a/.cursor/rules/protobuf.mdc
+++ b/.cursor/rules/protobuf.mdc
@@ -10,18 +10,15 @@ alwaysApply: false
 
 Protobuf messages are used for communication between the Streamlit backend and frontend via WebSocket connections.
 
-**Note**: Messages are "released" once shipped in any Streamlit version.
-
 ## Compile Protobuf
 
 Changes requiring compilation:
 
-- Adding a field
-- **Unreleased messages only:** Modifying/removing fields
+- Adding, modifying, or removing fields
 
 Changes not requiring compilation:
 
-- Comments and `[deprecated=true]` notation
+- Comments
 
 Run this command to recompile the protobufs:
 

--- a/.github/instructions/protobuf.instructions.md
+++ b/.github/instructions/protobuf.instructions.md
@@ -8,18 +8,15 @@ applyTo: "**/*.proto"
 
 Protobuf messages are used for communication between the Streamlit backend and frontend via WebSocket connections.
 
-**Note**: Messages are "released" once shipped in any Streamlit version.
-
 ## Compile Protobuf
 
 Changes requiring compilation:
 
-- Adding a field
-- **Unreleased messages only:** Modifying/removing fields
+- Adding, modifying, or removing fields
 
 Changes not requiring compilation:
 
-- Comments and `[deprecated=true]` notation
+- Comments
 
 Run this command to recompile the protobufs:
 

--- a/proto/streamlit/proto/AGENTS.md
+++ b/proto/streamlit/proto/AGENTS.md
@@ -2,18 +2,15 @@
 
 Protobuf messages are used for communication between the Streamlit backend and frontend via WebSocket connections.
 
-**Note**: Messages are "released" once shipped in any Streamlit version.
-
 ## Compile Protobuf
 
 Changes requiring compilation:
 
-- Adding a field
-- **Unreleased messages only:** Modifying/removing fields
+- Adding, modifying, or removing fields
 
 Changes not requiring compilation:
 
-- Comments and `[deprecated=true]` notation
+- Comments
 
 Run this command to recompile the protobufs:
 


### PR DESCRIPTION
## Describe your changes

- Remove obsolete note about message release status
- Combine field modification guidance (adding/modifying/removing) into a single bullet point
- Remove `[deprecated=true]` notation reference from "Changes not requiring compilation"

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Documentation-only change, no tests required

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->