### PR TITLE
[refactor] Add `React.memo` to seven frontend components

### DIFF
--- a/frontend/lib/src/components/core/Block/ElementContainer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementContainer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, ReactNode, Suspense, useContext } from "react"
+import { memo, ReactElement, ReactNode, Suspense, useContext } from "react"
 
 import classNames from "classnames"
 
@@ -65,12 +65,12 @@ export interface ElementContainerProps {
  * }
  * ```
  */
-export const ElementContainer: FC<ElementContainerProps> = ({
+export const ElementContainer = memo(function ElementContainer({
   node,
   config,
   isStale,
   children,
-}) => {
+}: ElementContainerProps): ReactElement {
   const { isFullScreen } = useContext(ViewStateContext)
 
   const elementType = node.element.type || ""
@@ -106,4 +106,4 @@ export const ElementContainer: FC<ElementContainerProps> = ({
       </ErrorBoundary>
     </StyledElementContainerLayoutWrapper>
   )
-}
+})

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.test.tsx
@@ -50,10 +50,11 @@ import ElementNodeRenderer, {
 
 vi.mock("./ElementContainer", async importOriginal => {
   const mod = await importOriginal<typeof import("./ElementContainer")>()
+  const { createElement } = await import("react")
   return {
     ...mod,
     ElementContainer: vi.fn((props: ElementContainerProps) =>
-      mod.ElementContainer(props)
+      createElement(mod.ElementContainer, props)
     ),
   }
 })

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { lazy, ReactElement, useContext } from "react"
+import { lazy, memo, ReactElement, useContext } from "react"
 
 import {
   Alert as AlertProto,
@@ -224,9 +224,9 @@ function hideIfStale(isStale: boolean, component: ReactElement): ReactElement {
 }
 
 // Render ElementNodes (i.e. leaf nodes).
-const RawElementNodeRenderer = (
+const RawElementNodeRenderer = memo(function RawElementNodeRenderer(
   props: RawElementNodeRendererProps
-): ReactElement => {
+): ReactElement {
   const { node, isStale } = props
   const { isInRoot, isInHorizontalLayout } = useRequiredContext(FlexContext)
 
@@ -1215,7 +1215,7 @@ const RawElementNodeRenderer = (
     default:
       throw new Error(`Unrecognized Element type ${node.element.type}`)
   }
-}
+})
 
 // Render ElementNodes (i.e. leaf nodes) wrapped in Maybe for conditional rendering.
 const ElementNodeRenderer = (

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { lazy, memo, ReactElement, useContext } from "react"
+import { lazy, ReactElement, useContext } from "react"
 
 import {
   Alert as AlertProto,
@@ -224,9 +224,9 @@ function hideIfStale(isStale: boolean, component: ReactElement): ReactElement {
 }
 
 // Render ElementNodes (i.e. leaf nodes).
-const RawElementNodeRenderer = memo(function RawElementNodeRenderer(
+const RawElementNodeRenderer = (
   props: RawElementNodeRendererProps
-): ReactElement {
+): ReactElement => {
   const { node, isStale } = props
   const { isInRoot, isInHorizontalLayout } = useRequiredContext(FlexContext)
 
@@ -1215,7 +1215,7 @@ const RawElementNodeRenderer = memo(function RawElementNodeRenderer(
     default:
       throw new Error(`Unrecognized Element type ${node.element.type}`)
   }
-})
+}
 
 // Render ElementNodes (i.e. leaf nodes) wrapped in Maybe for conditional rendering.
 const ElementNodeRenderer = (

--- a/frontend/lib/src/components/elements/Help/Help.tsx
+++ b/frontend/lib/src/components/elements/Help/Help.tsx
@@ -36,49 +36,11 @@ export interface HelpProps {
   element: HelpProto
 }
 
-/**
- * Functional element representing formatted text.
- */
-function Help({ element }: HelpProps): ReactElement {
-  const { name, type, value, docString, members } = element
-
-  // Put it all together into a nice little html view.
-  return (
-    <StyledDocContainer className="stHelp" data-testid="stHelp">
-      <StyledDocHeader>
-        <StyledDocSummary>
-          {name ? (
-            <StyledDocName data-testid="stHelpName">{name}</StyledDocName>
-          ) : null}
-          {type ? (
-            <StyledDocType data-testid="stHelpType">{type}</StyledDocType>
-          ) : null}
-          {value ? (
-            <StyledDocValue data-testid="stHelpValue">{value}</StyledDocValue>
-          ) : null}
-        </StyledDocSummary>
-      </StyledDocHeader>
-      <StyledDocString data-testid="stHelpDoc">
-        {docString || "No docs available"}
-      </StyledDocString>
-      {members.length > 0 ? (
-        <StyledMembersTable data-testid="stHelpMembersTable">
-          <tbody>
-            {members.map(member => (
-              <Member member={member} key={member.name} />
-            ))}
-          </tbody>
-        </StyledMembersTable>
-      ) : null}
-    </StyledDocContainer>
-  )
-}
-
 interface MemberProps {
   member: IMember
 }
 
-// Exported for tests.
+/** Renders a single member row in the members table. */
 export const Member = memo(function Member({
   member,
 }: MemberProps): ReactElement {
@@ -113,5 +75,40 @@ export const Member = memo(function Member({
     </StyledMembersRow>
   )
 })
+
+/** Functional element representing formatted text. */
+function Help({ element }: HelpProps): ReactElement {
+  const { name, type, value, docString, members } = element
+
+  return (
+    <StyledDocContainer className="stHelp" data-testid="stHelp">
+      <StyledDocHeader>
+        <StyledDocSummary>
+          {name ? (
+            <StyledDocName data-testid="stHelpName">{name}</StyledDocName>
+          ) : null}
+          {type ? (
+            <StyledDocType data-testid="stHelpType">{type}</StyledDocType>
+          ) : null}
+          {value ? (
+            <StyledDocValue data-testid="stHelpValue">{value}</StyledDocValue>
+          ) : null}
+        </StyledDocSummary>
+      </StyledDocHeader>
+      <StyledDocString data-testid="stHelpDoc">
+        {docString || "No docs available"}
+      </StyledDocString>
+      {members.length > 0 ? (
+        <StyledMembersTable data-testid="stHelpMembersTable">
+          <tbody>
+            {members.map(member => (
+              <Member member={member} key={member.name} />
+            ))}
+          </tbody>
+        </StyledMembersTable>
+      ) : null}
+    </StyledDocContainer>
+  )
+}
 
 export default memo(Help)

--- a/frontend/lib/src/components/elements/Help/Help.tsx
+++ b/frontend/lib/src/components/elements/Help/Help.tsx
@@ -79,7 +79,9 @@ interface MemberProps {
 }
 
 // Exported for tests.
-export function Member({ member }: MemberProps): ReactElement {
+export const Member = memo(function Member({
+  member,
+}: MemberProps): ReactElement {
   const { name, type, value, docString } = member
 
   return (
@@ -110,6 +112,6 @@ export function Member({ member }: MemberProps): ReactElement {
       </StyledMembersDetailsCell>
     </StyledMembersRow>
   )
-}
+})
 
 export default memo(Help)

--- a/frontend/lib/src/components/shared/Icon/Icon.tsx
+++ b/frontend/lib/src/components/shared/Icon/Icon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactElement, ReactNode } from "react"
+import { memo, ReactElement, ReactNode } from "react"
 
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
 
@@ -57,21 +57,23 @@ interface IconProps {
   testid?: string
 }
 
-const Icon = ({
+const Icon = memo(function Icon({
   content,
   color,
   size,
   margin,
   padding,
   testid,
-}: IconProps): ReactElement => (
-  <StyledIcon
-    as={content}
-    aria-hidden="true"
-    data-testid={testid}
-    {...getDefaultProps({ size, margin, padding, color })}
-  />
-)
+}: IconProps): ReactElement {
+  return (
+    <StyledIcon
+      as={content}
+      aria-hidden="true"
+      data-testid={testid}
+      {...getDefaultProps({ size, margin, padding, color })}
+    />
+  )
+})
 
 interface EmojiIconProps {
   size?: IconSize
@@ -82,14 +84,14 @@ interface EmojiIconProps {
   color?: string
 }
 
-export const EmojiIcon = ({
+export const EmojiIcon = memo(function EmojiIcon({
   size,
   margin,
   padding,
   children,
   color,
   testid,
-}: EmojiIconProps): ReactElement => {
+}: EmojiIconProps): ReactElement {
   // Handle the case where the emoji is prefixed with emoji:
   if (typeof children === "string") {
     children = children.replace(/^emoji:/, "")
@@ -104,6 +106,6 @@ export const EmojiIcon = ({
       {children}
     </StyledEmojiIcon>
   )
-}
+})
 
 export default Icon

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isValidElement, ReactElement } from "react"
+import { isValidElement, memo, ReactElement } from "react"
 
 import { HelpCircle as HelpCircleIcon } from "react-feather"
 
@@ -73,7 +73,9 @@ type TooltipIconProps =
       children?: never
     })
 
-function TooltipIcon(props: TooltipIconProps): ReactElement {
+const TooltipIcon = memo(function TooltipIcon(
+  props: TooltipIconProps
+): ReactElement {
   const {
     placement = Placement.AUTO,
     isLatex = false,
@@ -150,7 +152,7 @@ function TooltipIcon(props: TooltipIconProps): ReactElement {
       </Tooltip>
     </StyledTooltipIconWrapper>
   )
-}
+})
 
 export function getHelpTooltipAriaLabel(label?: string | null): string {
   // We try to generate a widget-specific accessible name when possible. In some

--- a/frontend/lib/src/components/widgets/BaseWidget/WidgetLabelHelpIcon.tsx
+++ b/frontend/lib/src/components/widgets/BaseWidget/WidgetLabelHelpIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactElement } from "react"
+import { memo, ReactElement } from "react"
 
 import type { Props as StreamlitMarkdownProps } from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip/Tooltip"
@@ -42,7 +42,7 @@ type WidgetLabelHelpIconProps = {
   containerWidth?: boolean
 }
 
-export function WidgetLabelHelpIcon({
+export const WidgetLabelHelpIcon = memo(function WidgetLabelHelpIcon({
   content,
   label,
   ariaLabel,
@@ -65,4 +65,4 @@ export function WidgetLabelHelpIcon({
       />
     </StyledWidgetLabelHelp>
   )
-}
+})

--- a/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
+++ b/frontend/lib/src/components/widgets/Form/FormSubmitButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactElement, useCallback, useEffect } from "react"
+import { memo, ReactElement, useCallback, useEffect } from "react"
 
 import { Button as ButtonProto } from "@streamlit/protobuf"
 
@@ -38,7 +38,9 @@ export interface Props {
   fragmentId?: string
 }
 
-export function FormSubmitButton(props: Props): ReactElement {
+export const FormSubmitButton = memo(function FormSubmitButton(
+  props: Props
+): ReactElement {
   const { disabled, element, widgetMgr, fragmentId } = props
   const { formId } = element
   const shortcut = element.shortcut ? element.shortcut : undefined
@@ -94,4 +96,4 @@ export function FormSubmitButton(props: Props): ReactElement {
       </BaseButtonTooltip>
     </Box>
   )
-}
+})


### PR DESCRIPTION
## Describe your changes

Add `React.memo` wrappers to seven frontend components for performance optimization:

- **`ElementContainer`** (`ElementContainer.tsx`) - Wraps every single element in the app. Prevents re-renders when `node`, `config`, and `isStale` props haven't changed.
- **`Member`** (`Help.tsx`) - List-rendered sub-component in `st.help()` output. Classic `.map()` pattern where memoization prevents all items from re-rendering when only one changes.
- **`WidgetLabelHelpIcon`** (`WidgetLabelHelpIcon.tsx`) - Used in many widget labels with simple, stable props.
- **`FormSubmitButton`** (`FormSubmitButton.tsx`) - Form component that already has stable `useCallback` handlers.
- **`Icon`** (`Icon.tsx`) - Core icon component with primitive props (`content`, `size`, `color`).
- **`EmojiIcon`** (`Icon.tsx`) - Emoji icon component with primitive props.
- **`TooltipIcon`** (`TooltipIcon.tsx`) - Help icon used throughout the UI for widget tooltips.

All implementations use the named function pattern (`memo(function ComponentName(...))`) to preserve component names in React DevTools.

## GitHub Issue Link (if applicable)

N/A - Performance optimization identified in frontend performance analysis

## Testing Plan

- [x] Unit Tests - Existing tests pass, updated `ElementNodeRenderer.test.tsx` mock for memo compatibility
- No new tests needed: `React.memo` is a transparent HOC that doesn't change component behavior, only render scheduling

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.