### PR TITLE
[refactor] Throttle useWindowDimensions resize handler

### DIFF
--- a/frontend/app/src/hooks/useViewportSize.test.tsx
+++ b/frontend/app/src/hooks/useViewportSize.test.tsx
@@ -98,7 +98,7 @@ describe("useViewportSize", () => {
     act(() => {
       innerWidthSpy.mockReturnValue(700)
       window.dispatchEvent(new Event("resize"))
-      // Advance timer to flush debounce (100ms)
+      // Advance timer to flush throttle (100ms)
       vi.advanceTimersByTime(100)
     })
 
@@ -108,7 +108,7 @@ describe("useViewportSize", () => {
     act(() => {
       innerWidthSpy.mockReturnValue(1024)
       window.dispatchEvent(new Event("resize"))
-      // Advance timer to flush debounce (100ms)
+      // Advance timer to flush throttle (100ms)
       vi.advanceTimersByTime(100)
     })
 

--- a/frontend/app/src/hooks/useViewportSize.test.tsx
+++ b/frontend/app/src/hooks/useViewportSize.test.tsx
@@ -48,7 +48,12 @@ const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
 )
 
 describe("useViewportSize", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -93,6 +98,8 @@ describe("useViewportSize", () => {
     act(() => {
       innerWidthSpy.mockReturnValue(700)
       window.dispatchEvent(new Event("resize"))
+      // Advance timer to flush debounce (100ms)
+      vi.advanceTimersByTime(100)
     })
 
     expect(result.current.isMobile).toBe(true)
@@ -101,6 +108,8 @@ describe("useViewportSize", () => {
     act(() => {
       innerWidthSpy.mockReturnValue(1024)
       window.dispatchEvent(new Event("resize"))
+      // Advance timer to flush debounce (100ms)
+      vi.advanceTimersByTime(100)
     })
 
     expect(result.current.isMobile).toBe(false)

--- a/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/OverflowTooltip.test.tsx
@@ -17,7 +17,8 @@
 import { render, screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
-import { TestAppWrapper } from "~lib/test_util"
+import ThemeProvider from "~lib/components/core/ThemeProvider"
+import { mockTheme } from "~lib/mocks/mockTheme"
 
 import OverflowTooltip from "./OverflowTooltip"
 import { Placement } from "./Tooltip"
@@ -36,6 +37,24 @@ vi.mock("react", async () => {
     useEffect: useEffectMock,
   }
 })
+
+// Mock useWindowDimensionsContext to avoid WindowDimensionsProvider,
+// which uses hooks that conflict with the global useRef/useEffect mocks.
+vi.mock(
+  "~lib/components/shared/WindowDimensions/useWindowDimensionsContext",
+  () => ({
+    useWindowDimensionsContext: () => ({
+      fullWidth: 1000,
+      fullHeight: 700,
+      innerWidth: 1024,
+      innerHeight: 768,
+    }),
+  })
+)
+
+const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+  <ThemeProvider theme={mockTheme.emotion}>{children}</ThemeProvider>
+)
 
 describe("Tooltip component", () => {
   afterEach(() => {
@@ -60,9 +79,7 @@ describe("Tooltip component", () => {
       >
         the child
       </OverflowTooltip>,
-      {
-        wrapper: ({ children }) => <TestAppWrapper>{children}</TestAppWrapper>,
-      }
+      { wrapper }
     )
 
     const tooltip = screen.getByTestId("stTooltipHoverTarget")
@@ -91,9 +108,7 @@ describe("Tooltip component", () => {
       >
         the child
       </OverflowTooltip>,
-      {
-        wrapper: ({ children }) => <TestAppWrapper>{children}</TestAppWrapper>,
-      }
+      { wrapper }
     )
 
     const tooltip = screen.getByTestId("stTooltipHoverTarget")

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+
+import ThemeProvider from "~lib/components/core/ThemeProvider"
+import { mockTheme } from "~lib/mocks/mockTheme"
+
+import { useWindowDimensions } from "./useWindowDimensions"
+
+const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+  <ThemeProvider theme={mockTheme.emotion}>{children}</ThemeProvider>
+)
+
+describe("useWindowDimensions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      fontSize: "16px",
+    } as CSSStyleDeclaration)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("should return initial dimensions on mount", () => {
+    const { result } = renderHook(() => useWindowDimensions(), { wrapper })
+
+    expect(result.current.innerWidth).toBe(1024)
+    expect(result.current.innerHeight).toBe(768)
+  })
+
+  it("should debounce resize events with 100ms delay", () => {
+    const { result } = renderHook(() => useWindowDimensions(), { wrapper })
+
+    const initialWidth = result.current.innerWidth
+
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 800,
+      })
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    // State should not update immediately
+    expect(result.current.innerWidth).toBe(initialWidth)
+
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+
+    // Still not updated after 50ms
+    expect(result.current.innerWidth).toBe(initialWidth)
+
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+
+    // Updated after 100ms total
+    expect(result.current.innerWidth).toBe(800)
+  })
+
+  it("should coalesce multiple rapid resize events to final value", () => {
+    const { result } = renderHook(() => useWindowDimensions(), { wrapper })
+
+    // Fire multiple resize events in quick succession
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 900,
+      })
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 850,
+      })
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 800,
+      })
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // Only the final value should be applied after debounce
+    expect(result.current.innerWidth).toBe(800)
+  })
+
+  it("should cleanup timeout on unmount", () => {
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout")
+
+    const { unmount } = renderHook(() => useWindowDimensions(), { wrapper })
+
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 800,
+      })
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
@@ -80,6 +80,8 @@ describe("useWindowDimensions", () => {
   it("should coalesce multiple rapid resize events to final value", () => {
     const { result } = renderHook(() => useWindowDimensions(), { wrapper })
 
+    const initialWidth = result.current.innerWidth
+
     // Fire multiple resize events in quick succession
     act(() => {
       Object.defineProperty(window, "innerWidth", {
@@ -90,6 +92,9 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
+    // Intermediate values should not be observed (still at initial)
+    expect(result.current.innerWidth).toBe(initialWidth)
+
     act(() => {
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -99,6 +104,9 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
+    // Still at initial - 850 should not be observed either
+    expect(result.current.innerWidth).toBe(initialWidth)
+
     act(() => {
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -107,6 +115,9 @@ describe("useWindowDimensions", () => {
       })
       window.dispatchEvent(new Event("resize"))
     })
+
+    // Still at initial before debounce completes
+    expect(result.current.innerWidth).toBe(initialWidth)
 
     act(() => {
       vi.advanceTimersByTime(100)

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
@@ -124,8 +124,11 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
+    const callCountBeforeUnmount = clearTimeoutSpy.mock.calls.length
     unmount()
 
-    expect(clearTimeoutSpy).toHaveBeenCalled()
+    expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(
+      callCountBeforeUnmount
+    )
   })
 })

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx
@@ -45,10 +45,8 @@ describe("useWindowDimensions", () => {
     expect(result.current.innerHeight).toBe(768)
   })
 
-  it("should debounce resize events with 100ms delay", () => {
+  it("should update immediately on first resize event (throttle)", () => {
     const { result } = renderHook(() => useWindowDimensions(), { wrapper })
-
-    const initialWidth = result.current.innerWidth
 
     act(() => {
       Object.defineProperty(window, "innerWidth", {
@@ -59,30 +57,14 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
-    // State should not update immediately
-    expect(result.current.innerWidth).toBe(initialWidth)
-
-    act(() => {
-      vi.advanceTimersByTime(50)
-    })
-
-    // Still not updated after 50ms
-    expect(result.current.innerWidth).toBe(initialWidth)
-
-    act(() => {
-      vi.advanceTimersByTime(50)
-    })
-
-    // Updated after 100ms total
+    // Throttle fires immediately on first call
     expect(result.current.innerWidth).toBe(800)
   })
 
-  it("should coalesce multiple rapid resize events to final value", () => {
+  it("should throttle subsequent resize events during cooldown", () => {
     const { result } = renderHook(() => useWindowDimensions(), { wrapper })
 
-    const initialWidth = result.current.innerWidth
-
-    // Fire multiple resize events in quick succession
+    // First resize - fires immediately
     act(() => {
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -92,9 +74,9 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
-    // Intermediate values should not be observed (still at initial)
-    expect(result.current.innerWidth).toBe(initialWidth)
+    expect(result.current.innerWidth).toBe(900)
 
+    // Second resize during cooldown - saved but not applied yet
     act(() => {
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -104,9 +86,10 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
-    // Still at initial - 850 should not be observed either
-    expect(result.current.innerWidth).toBe(initialWidth)
+    // Still at 900 during cooldown
+    expect(result.current.innerWidth).toBe(900)
 
+    // Third resize during cooldown - replaces pending
     act(() => {
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -116,14 +99,14 @@ describe("useWindowDimensions", () => {
       window.dispatchEvent(new Event("resize"))
     })
 
-    // Still at initial before debounce completes
-    expect(result.current.innerWidth).toBe(initialWidth)
+    // Still at 900 during cooldown
+    expect(result.current.innerWidth).toBe(900)
 
+    // After cooldown, the last pending value (800) is applied
     act(() => {
       vi.advanceTimersByTime(100)
     })
 
-    // Only the final value should be applied after debounce
     expect(result.current.innerWidth).toBe(800)
   })
 

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.tsx
@@ -16,6 +16,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useState } from "react"
 
+import { useDebouncedCallback } from "~lib/hooks/useDebouncedCallback"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { convertRemToPx } from "~lib/theme/utils"
 
@@ -54,13 +55,17 @@ export const useWindowDimensions = (): WindowDimensions => {
     setWindowDimensions(getWindowDimensions())
   }, [getWindowDimensions])
 
+  const { debouncedCallback: debouncedResize, cancel: cancelDebounce } =
+    useDebouncedCallback(updateWindowDimensions, 100)
+
   useEffect(() => {
-    window.addEventListener("resize", updateWindowDimensions)
+    window.addEventListener("resize", debouncedResize)
 
     return () => {
-      window.removeEventListener("resize", updateWindowDimensions)
+      window.removeEventListener("resize", debouncedResize)
+      cancelDebounce()
     }
-  }, [updateWindowDimensions])
+  }, [debouncedResize, cancelDebounce])
 
   useLayoutEffect(() => {
     // Measure once on load, let resize handlers take over from there

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.tsx
@@ -16,15 +16,16 @@
 
 import { useCallback, useEffect, useLayoutEffect, useState } from "react"
 
-import { useDebouncedCallback } from "~lib/hooks/useDebouncedCallback"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import { useThrottledCallback } from "~lib/hooks/useThrottledCallback"
 import { convertRemToPx } from "~lib/theme/utils"
 
 /**
- * Debounce delay for window resize events in milliseconds.
- * This prevents excessive re-renders during active window resizing.
+ * Throttle delay for window resize events in milliseconds.
+ * This limits re-renders during active window resizing while still
+ * providing periodic updates.
  */
-const RESIZE_DEBOUNCE_MS = 100
+const RESIZE_THROTTLE_MS = 100
 
 export type WindowDimensions = {
   fullWidth: number
@@ -61,17 +62,17 @@ export const useWindowDimensions = (): WindowDimensions => {
     setWindowDimensions(getWindowDimensions())
   }, [getWindowDimensions])
 
-  const { debouncedCallback: debouncedResize, cancel: cancelDebounce } =
-    useDebouncedCallback(updateWindowDimensions, RESIZE_DEBOUNCE_MS)
+  const { throttledCallback: throttledResize, cancel: cancelThrottle } =
+    useThrottledCallback(updateWindowDimensions, RESIZE_THROTTLE_MS)
 
   useEffect(() => {
-    window.addEventListener("resize", debouncedResize)
+    window.addEventListener("resize", throttledResize)
 
     return () => {
-      window.removeEventListener("resize", debouncedResize)
-      cancelDebounce()
+      window.removeEventListener("resize", throttledResize)
+      cancelThrottle()
     }
-  }, [debouncedResize, cancelDebounce])
+  }, [throttledResize, cancelThrottle])
 
   useLayoutEffect(() => {
     // Measure once on load, let resize handlers take over from there

--- a/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.tsx
+++ b/frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.tsx
@@ -20,6 +20,12 @@ import { useDebouncedCallback } from "~lib/hooks/useDebouncedCallback"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { convertRemToPx } from "~lib/theme/utils"
 
+/**
+ * Debounce delay for window resize events in milliseconds.
+ * This prevents excessive re-renders during active window resizing.
+ */
+const RESIZE_DEBOUNCE_MS = 100
+
 export type WindowDimensions = {
   fullWidth: number
   fullHeight: number
@@ -56,7 +62,7 @@ export const useWindowDimensions = (): WindowDimensions => {
   }, [getWindowDimensions])
 
   const { debouncedCallback: debouncedResize, cancel: cancelDebounce } =
-    useDebouncedCallback(updateWindowDimensions, 100)
+    useDebouncedCallback(updateWindowDimensions, RESIZE_DEBOUNCE_MS)
 
   useEffect(() => {
     window.addEventListener("resize", debouncedResize)

--- a/frontend/lib/src/hooks/useThrottledCallback.test.ts
+++ b/frontend/lib/src/hooks/useThrottledCallback.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+
+import { useThrottledCallback } from "./useThrottledCallback"
+
+describe("useThrottledCallback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("should execute immediately on first call", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useThrottledCallback(callback, 100))
+
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith("first")
+  })
+
+  it("should throttle calls during cooldown period", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useThrottledCallback(callback, 100))
+
+    // First call - executes immediately
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith("first")
+
+    // Second call during cooldown - saved but not executed
+    act(() => {
+      result.current.throttledCallback("second")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Third call during cooldown - replaces pending
+    act(() => {
+      result.current.throttledCallback("third")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // After cooldown, trailing call executes with latest args
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith("third")
+  })
+
+  it("should allow new immediate call after cooldown with no pending", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useThrottledCallback(callback, 100))
+
+    // First call
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Wait for cooldown to end
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // No trailing call since no pending args
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // New call should execute immediately
+    act(() => {
+      result.current.throttledCallback("second")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith("second")
+  })
+
+  it("should cancel pending call when cancel is called", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useThrottledCallback(callback, 100))
+
+    // First call
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    // Second call during cooldown
+    act(() => {
+      result.current.throttledCallback("second")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Cancel pending
+    act(() => {
+      result.current.cancel()
+    })
+
+    // After cooldown, no trailing call
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it("should use latest callback reference", () => {
+    const callback1 = vi.fn()
+    const callback2 = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ cb }) => useThrottledCallback(cb, 100),
+      { initialProps: { cb: callback1 } }
+    )
+
+    // First call with callback1
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    expect(callback1).toHaveBeenCalledTimes(1)
+
+    // Queue a trailing call
+    act(() => {
+      result.current.throttledCallback("second")
+    })
+
+    // Change the callback
+    rerender({ cb: callback2 })
+
+    // After cooldown, trailing call should use the new callback
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(callback1).toHaveBeenCalledTimes(1)
+    expect(callback2).toHaveBeenCalledTimes(1)
+    expect(callback2).toHaveBeenCalledWith("second")
+  })
+})

--- a/frontend/lib/src/hooks/useThrottledCallback.test.ts
+++ b/frontend/lib/src/hooks/useThrottledCallback.test.ts
@@ -163,5 +163,59 @@ describe("useThrottledCallback", () => {
     expect(callback1).toHaveBeenCalledTimes(1)
     expect(callback2).toHaveBeenCalledTimes(1)
     expect(callback2).toHaveBeenCalledWith("second")
+
+    // After the trailing call executes, we're back in cooldown
+    // Wait for cooldown to end
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // Now a new call should execute immediately
+    act(() => {
+      result.current.throttledCallback("third")
+    })
+
+    expect(callback2).toHaveBeenCalledTimes(2)
+    expect(callback2).toHaveBeenLastCalledWith("third")
+  })
+
+  it("should allow immediate execution after trailing call without rerender", () => {
+    // This test verifies that the throttle works correctly even without
+    // a component rerender (e.g., for side-effect-only callbacks)
+    const callback = vi.fn()
+    const { result } = renderHook(() => useThrottledCallback(callback, 100))
+
+    // First call - executes immediately
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Queue a trailing call
+    act(() => {
+      result.current.throttledCallback("second")
+    })
+
+    // After cooldown, trailing call executes
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith("second")
+
+    // Another cooldown - verify immediate execution after trailing call
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // New call should execute immediately
+    act(() => {
+      result.current.throttledCallback("third")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(callback).toHaveBeenLastCalledWith("third")
   })
 })

--- a/frontend/lib/src/hooks/useThrottledCallback.test.ts
+++ b/frontend/lib/src/hooks/useThrottledCallback.test.ts
@@ -131,6 +131,31 @@ describe("useThrottledCallback", () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 
+  it("should allow immediate execution after cancel resets throttle state", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useThrottledCallback(callback, 100))
+
+    // First call - starts throttle
+    act(() => {
+      result.current.throttledCallback("first")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // Cancel should reset isThrottledRef, allowing immediate execution
+    act(() => {
+      result.current.cancel()
+    })
+
+    // Next call should fire immediately (not be throttled)
+    act(() => {
+      result.current.throttledCallback("second")
+    })
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith("second")
+  })
+
   it("should use latest callback reference", () => {
     const callback1 = vi.fn()
     const callback2 = vi.fn()

--- a/frontend/lib/src/hooks/useThrottledCallback.ts
+++ b/frontend/lib/src/hooks/useThrottledCallback.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useRef } from "react"
+
+import useTimeout from "./useTimeout"
+
+interface UseThrottledCallbackReturn<A extends unknown[]> {
+  /** The throttled callback function. */
+  throttledCallback: (...args: A) => void
+  /** Cancel any pending trailing call. */
+  cancel: () => void
+}
+
+/**
+ * A custom hook that provides a throttled callback function.
+ *
+ * The throttled callback executes immediately on the first call, then at most
+ * once per delay period. If called during the cooldown period, the latest args
+ * are saved and executed once the cooldown ends (trailing call).
+ *
+ * @param callback - The function to be throttled.
+ * @param delay - The minimum delay in milliseconds between executions.
+ * @returns An object containing the throttled callback and cancel function.
+ *
+ * @example
+ * const { throttledCallback, cancel } = useThrottledCallback(
+ *   (value) => console.log('Throttled value:', value),
+ *   100
+ * );
+ *
+ * // First call executes immediately
+ * throttledCallback('first');
+ *
+ * // Calls during cooldown are saved; only the last one executes after delay
+ * throttledCallback('second');
+ * throttledCallback('third'); // This one will execute after 100ms
+ */
+export function useThrottledCallback<A extends unknown[]>(
+  callback: (...args: A) => void,
+  delay: number
+): UseThrottledCallbackReturn<A> {
+  const pendingArgsRef = useRef<A | null>(null)
+  const isThrottledRef = useRef(false)
+  const callbackRef = useRef(callback)
+  const shouldRestartRef = useRef(false)
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  const onTimeoutComplete = useCallback(() => {
+    isThrottledRef.current = false
+    if (pendingArgsRef.current !== null) {
+      callbackRef.current(...pendingArgsRef.current)
+      pendingArgsRef.current = null
+      isThrottledRef.current = true
+      shouldRestartRef.current = true
+    }
+  }, [])
+
+  const { clear, restart } = useTimeout(onTimeoutComplete, delay, {
+    autoStart: false,
+  })
+
+  // Handle restart after timeout completes with pending args
+  useEffect(() => {
+    if (shouldRestartRef.current) {
+      shouldRestartRef.current = false
+      restart()
+    }
+  })
+
+  const cancel = useCallback((): void => {
+    clear()
+    pendingArgsRef.current = null
+    isThrottledRef.current = false
+    shouldRestartRef.current = false
+  }, [clear])
+
+  const throttledCallback = useCallback(
+    (...args: A) => {
+      if (!isThrottledRef.current) {
+        callbackRef.current(...args)
+        isThrottledRef.current = true
+        restart()
+      } else {
+        pendingArgsRef.current = args
+      }
+    },
+    [restart]
+  )
+
+  return {
+    throttledCallback,
+    cancel,
+  }
+}

--- a/frontend/lib/src/hooks/useThrottledCallback.ts
+++ b/frontend/lib/src/hooks/useThrottledCallback.ts
@@ -56,6 +56,12 @@ export function useThrottledCallback<A extends unknown[]>(
   const pendingArgsRef = useRef<A | null>(null)
   const isThrottledRef = useRef(false)
   const callbackRef = useRef(callback)
+  /**
+   * Holds the restart function from useTimeout. Populated by the effect below
+   * after the first render. The optional chaining in onTimeoutComplete is
+   * defensive but effectively unreachable since the timer can only fire after
+   * the effect that sets this ref has run.
+   */
   const restartRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
@@ -77,7 +83,7 @@ export function useThrottledCallback<A extends unknown[]>(
     autoStart: false,
   })
 
-  // Keep restart ref in sync
+  /** Keep restart ref in sync with the latest useTimeout reference. */
   useEffect(() => {
     restartRef.current = restart
   }, [restart])

--- a/frontend/lib/src/hooks/useThrottledCallback.ts
+++ b/frontend/lib/src/hooks/useThrottledCallback.ts
@@ -56,7 +56,7 @@ export function useThrottledCallback<A extends unknown[]>(
   const pendingArgsRef = useRef<A | null>(null)
   const isThrottledRef = useRef(false)
   const callbackRef = useRef(callback)
-  const shouldRestartRef = useRef(false)
+  const restartRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     callbackRef.current = callback
@@ -65,10 +65,11 @@ export function useThrottledCallback<A extends unknown[]>(
   const onTimeoutComplete = useCallback(() => {
     isThrottledRef.current = false
     if (pendingArgsRef.current !== null) {
-      callbackRef.current(...pendingArgsRef.current)
+      const args = pendingArgsRef.current
       pendingArgsRef.current = null
+      callbackRef.current(...args)
       isThrottledRef.current = true
-      shouldRestartRef.current = true
+      restartRef.current?.()
     }
   }, [])
 
@@ -76,19 +77,15 @@ export function useThrottledCallback<A extends unknown[]>(
     autoStart: false,
   })
 
-  // Handle restart after timeout completes with pending args
+  // Keep restart ref in sync
   useEffect(() => {
-    if (shouldRestartRef.current) {
-      shouldRestartRef.current = false
-      restart()
-    }
-  })
+    restartRef.current = restart
+  }, [restart])
 
   const cancel = useCallback((): void => {
     clear()
     pendingArgsRef.current = null
     isThrottledRef.current = false
-    shouldRestartRef.current = false
   }, [clear])
 
   const throttledCallback = useCallback(


### PR DESCRIPTION
## Describe your changes

Adds 100ms throttling to the `useWindowDimensions` resize handler to reduce re-renders during window resize operations while still providing periodic updates.

- Uses new `useThrottledCallback` hook (first call fires immediately, then at most once per 100ms)
- Throttling is better than debouncing for resize: updates happen during resize, not just after
- Reduces Main renders significantly during continuous resize

## GitHub Issue Link (if applicable)

N/A - Performance improvement from frontend performance audit

## Testing Plan

- [x] Unit Tests (JS)
  - `frontend/lib/src/hooks/useThrottledCallback.test.ts` — Tests throttle behavior (immediate first call, cooldown, trailing call)
  - `frontend/lib/src/components/shared/WindowDimensions/useWindowDimensions.test.tsx` — Tests throttled resize events

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 3 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->