### PR TITLE
[fix] OAuth MismatchingStateError regression in 1.57.0

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import json
-import time
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from streamlit.auth_util import (
@@ -58,70 +57,6 @@ _LOGGER: Final = get_logger(__name__)
 _ROUTE_AUTH_LOGIN: Final = "auth/login"
 _ROUTE_AUTH_LOGOUT: Final = "auth/logout"
 _ROUTE_OAUTH_CALLBACK: Final = "oauth2callback"
-
-
-class _AsyncAuthCache:
-    """Async cache for Authlib's Starlette integration.
-
-    Authlib's Starlette OAuth client expects an async cache interface.
-    This implementation tracks per-item expiration times to automatically
-    expire OAuth state entries, preventing unbounded memory growth from
-    abandoned auth flows.
-
-    Cache size is expected to be very small: one entry is created per login
-    attempt (not per user/session) and exists only during the OAuth flow—from
-    clicking "Login" until the OAuth callback completes (typically seconds).
-    Each entry is a few hundred bytes. Entries expire after 1 hour (Authlib's
-    default) or are consumed upon successful callback.
-    """
-
-    # Fallback TTL if authlib doesn't provide an expiration time.
-    # This is the same TTL used internally in Authlib (1 hour).
-    _DEFAULT_TTL_SECONDS: Final = 3600
-
-    def __init__(self) -> None:
-        # Cache structure: {key: (value, expiration_timestamp)}
-        # where key is Authlib's state key (e.g., "_state_google_abc123"),
-        # value is the OAuth state data, and expiration_timestamp is a Unix timestamp.
-        self._cache: dict[str, tuple[Any, float]] = {}
-
-    def _evict_expired(self) -> None:
-        """Evict expired items from the cache."""
-        now = time.time()
-        expired_keys = [k for k, (_, exp) in self._cache.items() if exp <= now]
-        for key in expired_keys:
-            del self._cache[key]
-
-    async def get(self, key: str) -> Any:
-        """Get an item from the cache."""
-        self._evict_expired()
-        entry = self._cache.get(key)
-        return entry[0] if entry else None
-
-    async def set(self, key: str, value: Any, expires_in: int | None = None) -> None:
-        """Set an item in the cache."""
-        self._evict_expired()
-        ttl = expires_in if expires_in is not None else self._DEFAULT_TTL_SECONDS
-        self._cache[key] = (value, time.time() + ttl)
-
-    async def delete(self, key: str) -> None:
-        """Delete an item from the cache."""
-        self._cache.pop(key, None)
-
-    def get_dict(self) -> dict[str, Any]:
-        """Get a dictionary of all items in the cache."""
-        self._evict_expired()
-        return {k: v for k, (v, _) in self._cache.items()}
-
-
-# TODO(lukasmasuch): Reevaluate whether we can remove _AsyncAuthCache and rely on Authlib's
-# built-in session storage via SessionMiddleware instead. This would simplify
-# the code but would expose OAuth state data in signed cookies rather than
-# keeping it server-side. See: https://docs.authlib.org/en/latest/client/starlette.html
-#
-# Note: For true multi-tenant support (multiple Streamlit apps in one process),
-# this cache would need to be made per-runtime rather than module-level.
-_STARLETTE_AUTH_CACHE: Final = _AsyncAuthCache()
 
 
 def _normalize_nested_config(value: Any) -> Any:
@@ -330,9 +265,7 @@ def _create_oauth_client(provider: str) -> tuple[Any, str]:
     if "prompt" not in provider_client_kwargs:
         provider_client_kwargs["prompt"] = "select_account"
 
-    oauth = starlette_client.OAuth(
-        config=_AuthlibConfig(config), cache=_STARLETTE_AUTH_CACHE
-    )
+    oauth = starlette_client.OAuth(config=_AuthlibConfig(config))
     oauth.register(provider)
     return oauth.create_client(provider), redirect_uri  # type: ignore[no-untyped-call]
 
@@ -350,15 +283,22 @@ def _parse_provider_token(provider_token: str | None) -> str | None:
     return payload["provider"]
 
 
-def _get_provider_by_state(state_code_from_url: str | None) -> str | None:
-    """Extract the provider from the state code from the URL."""
+def _get_provider_by_state(
+    request: Request, state_code_from_url: str | None
+) -> str | None:
+    """Extract the provider from the session based on the state code.
 
+    Authlib stores OAuth state in the Starlette session using keys in the format
+    "_state_{provider}_{state_code}". This function iterates over session keys
+    to find the provider that matches the given state code.
+    """
     if state_code_from_url is None:
         return None
-    current_cache_keys = list(_STARLETTE_AUTH_CACHE.get_dict().keys())
-    state_provider_mapping = {}
-    for key in current_cache_keys:
-        # Authlib's Starlette integration stores OAuth state in the cache using keys
+
+    session = request.session
+    state_provider_mapping: dict[str, str] = {}
+    for key in list(session.keys()):
+        # Authlib's Starlette integration stores OAuth state in the session using keys
         # in the format: "_state_{provider}_{state_code}".
         # Example: "_state_google_abc123" breaks down as:
         #   - "_state" = fixed prefix used by Authlib
@@ -378,7 +318,7 @@ def _get_provider_by_state(state_code_from_url: str | None) -> str | None:
         try:
             _, _, recorded_provider, code = key.split("_")
         except ValueError:
-            # Skip cache keys that don't match the expected 4-part format.
+            # Skip session keys that don't match the expected 4-part format.
             continue
         state_provider_mapping[code] = recorded_provider
 
@@ -506,7 +446,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
     """Handle the OAuth callback from the authentication provider."""
 
     state = request.query_params.get("state")
-    provider = _get_provider_by_state(state)
+    provider = _get_provider_by_state(request, state)
     origin = _get_origin_from_secrets()
     if origin is None:
         _LOGGER.error(

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -310,13 +310,18 @@ def _get_provider_by_state(
         # We have some unit tests that will fail in case the formats gets changed in
         # an authlib update.
         #
-        # Note: This split assumes no underscores in provider names or state codes.
-        # This is safe because: (1) provider names with underscores are explicitly
-        # blocked in validate_auth_credentials() in auth_util.py, and (2) Authlib's
-        # generate_token() uses only alphanumeric characters (a-zA-Z0-9) for state
-        # codes. See auth_util.py for the underscore validation.
+        # Filter by the "_state_" prefix first to avoid false positives from other
+        # session data that might happen to have 4 underscore-separated parts.
+        if not key.startswith("_state_"):
+            continue
+        #
+        # Note: Using maxsplit=3 makes the parse greedy on the last segment, which is
+        # safer if the state code ever contains underscores. While Authlib's
+        # generate_token() currently uses only alphanumeric characters (a-zA-Z0-9),
+        # this is defensive against upstream changes. Provider names with underscores
+        # are explicitly blocked in validate_auth_credentials() in auth_util.py.
         try:
-            _, _, recorded_provider, code = key.split("_")
+            _, _, recorded_provider, code = key.split("_", 3)
         except ValueError:
             # Skip session keys that don't match the expected 4-part format.
             continue

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from http.cookies import SimpleCookie
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
 from starlette.applications import Starlette
 from starlette.middleware.sessions import SessionMiddleware
@@ -25,7 +26,6 @@ from starlette.testclient import TestClient
 
 from streamlit.web.server.starlette import starlette_app_utils, starlette_auth_routes
 from streamlit.web.server.starlette.starlette_auth_routes import (
-    _STARLETTE_AUTH_CACHE,
     _get_cookie_path,
     _get_origin_from_secrets,
     _get_provider_by_state,
@@ -81,7 +81,7 @@ def test_callback_handles_error_query(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         starlette_auth_routes,
         "_get_provider_by_state",
-        lambda state: "default",
+        lambda request, state: "default",
     )
 
     app = Starlette(routes=create_auth_routes(""))
@@ -104,7 +104,7 @@ def test_callback_missing_provider_redirects(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(
         starlette_auth_routes,
         "_get_provider_by_state",
-        lambda state: None,
+        lambda request, state: None,
     )
 
     app = Starlette(routes=create_auth_routes(""))
@@ -133,7 +133,7 @@ def test_auth_callback_sets_signed_cookie(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         starlette_auth_routes,
         "_get_provider_by_state",
-        lambda state: "default",
+        lambda request, state: "default",
     )
     monkeypatch.setattr(
         starlette_auth_routes,
@@ -200,7 +200,7 @@ def test_callback_missing_origin_redirects(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(
         starlette_auth_routes,
         "_get_provider_by_state",
-        lambda state: "default",
+        lambda request, state: "default",
     )
 
     app = Starlette(routes=create_auth_routes(""))
@@ -265,7 +265,7 @@ class TestAuthCookieFlags:
         monkeypatch.setattr(
             starlette_auth_routes,
             "_get_provider_by_state",
-            lambda state: "default",
+            lambda request, state: "default",
         )
         monkeypatch.setattr(
             starlette_auth_routes,
@@ -321,7 +321,7 @@ class TestAuthCookieFlags:
         monkeypatch.setattr(
             starlette_auth_routes,
             "_get_provider_by_state",
-            lambda state: "default",
+            lambda request, state: "default",
         )
         monkeypatch.setattr(
             starlette_auth_routes,
@@ -404,108 +404,38 @@ class TestGetProviderByState:
 
     def test_returns_none_for_none_state(self) -> None:
         """Test that None state returns None."""
-        assert _get_provider_by_state(None) is None
+
+        mock_request = MagicMock()
+        mock_request.session = {}
+        assert _get_provider_by_state(mock_request, None) is None
 
     def test_returns_none_for_unknown_state(self) -> None:
         """Test that an unknown state code returns None."""
-        # Clear the cache first
-        _STARLETTE_AUTH_CACHE._cache.clear()
-        assert _get_provider_by_state("unknown_state") is None
 
-    def test_extracts_provider_from_cache(self) -> None:
-        """Test that provider is extracted from a matching cache entry."""
-        import time
+        mock_request = MagicMock()
+        mock_request.session = {}
+        assert _get_provider_by_state(mock_request, "unknown_state") is None
 
-        # Clear and populate the cache with a known entry (value, expiration)
-        _STARLETTE_AUTH_CACHE._cache.clear()
-        _STARLETTE_AUTH_CACHE._cache["_state_google_abc123"] = (
-            {"some": "data"},
-            time.time() + 3600,
-        )
+    def test_extracts_provider_from_session(self) -> None:
+        """Test that provider is extracted from a matching session entry."""
+        mock_request = MagicMock()
+        # Session value structure doesn't matter; only the key format is parsed
+        mock_request.session = {"_state_google_abc123": {}}
 
-        assert _get_provider_by_state("abc123") == "google"
+        assert _get_provider_by_state(mock_request, "abc123") == "google"
 
-        # Clean up
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-    def test_handles_malformed_cache_keys(self) -> None:
-        """Test that malformed cache keys are skipped gracefully."""
-        import time
-
-        _STARLETTE_AUTH_CACHE._cache.clear()
-        future_exp = time.time() + 3600
-        # Add a malformed key (not 4 parts)
-        _STARLETTE_AUTH_CACHE._cache["malformed_key"] = ({"some": "data"}, future_exp)
-        # Add a valid key with state code "validstate123"
-        _STARLETTE_AUTH_CACHE._cache["_state_github_validstate123"] = (
-            {"some": "data"},
-            future_exp,
-        )
+    def test_handles_malformed_session_keys(self) -> None:
+        """Test that malformed session keys are skipped gracefully."""
+        mock_request = MagicMock()
+        mock_request.session = {
+            "malformed_key": {},
+            "_state_github_validstate123": {},
+        }
 
         # Should find the valid key when querying with the state code
-        assert _get_provider_by_state("validstate123") == "github"
-        # Should return None for a state code that doesn't exist in the cache
-        assert _get_provider_by_state("nonexistentstate") is None
-
-        # Clean up
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-
-class TestAsyncAuthCacheExpiration:
-    """Tests for _AsyncAuthCache expiration behavior."""
-
-    def test_expired_items_are_evicted_on_get(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that expired items are removed when accessing the cache."""
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-        current_time = 1000.0
-        monkeypatch.setattr(starlette_auth_routes.time, "time", lambda: current_time)
-
-        _STARLETTE_AUTH_CACHE._cache["key1"] = ("value1", 1500.0)
-        _STARLETTE_AUTH_CACHE._cache["key2"] = ("value2", 900.0)
-
-        current_time = 1001.0
-        monkeypatch.setattr(starlette_auth_routes.time, "time", lambda: current_time)
-
-        assert _STARLETTE_AUTH_CACHE.get_dict() == {"key1": "value1"}
-
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-    def test_set_uses_expires_in_parameter(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that set() uses the provided expires_in value."""
-        import asyncio
-
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-        current_time = 1000.0
-        monkeypatch.setattr(starlette_auth_routes.time, "time", lambda: current_time)
-
-        asyncio.run(_STARLETTE_AUTH_CACHE.set("key1", "value1", expires_in=60))
-
-        assert _STARLETTE_AUTH_CACHE._cache["key1"] == ("value1", 1060.0)
-
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-    def test_set_uses_default_ttl_when_expires_in_is_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test that set() uses default TTL when expires_in is not provided."""
-        import asyncio
-
-        _STARLETTE_AUTH_CACHE._cache.clear()
-
-        current_time = 1000.0
-        monkeypatch.setattr(starlette_auth_routes.time, "time", lambda: current_time)
-
-        asyncio.run(_STARLETTE_AUTH_CACHE.set("key1", "value1"))
-
-        assert _STARLETTE_AUTH_CACHE._cache["key1"] == ("value1", 4600.0)
-
-        _STARLETTE_AUTH_CACHE._cache.clear()
+        assert _get_provider_by_state(mock_request, "validstate123") == "github"
+        # Should return None for a state code that doesn't exist in the session
+        assert _get_provider_by_state(mock_request, "nonexistentstate") is None
 
 
 class TestGetOriginFromSecrets:
@@ -550,7 +480,6 @@ class TestGetProviderLogoutUrl:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that None is returned when no user cookie exists."""
-        from unittest.mock import MagicMock
 
         from streamlit.web.server.starlette.starlette_auth_routes import (
             _get_provider_logout_url,
@@ -565,7 +494,6 @@ class TestGetProviderLogoutUrl:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that None is returned when cookie doesn't contain provider."""
-        from unittest.mock import MagicMock
 
         from streamlit.web.server.starlette.starlette_auth_routes import (
             _get_provider_logout_url,
@@ -585,7 +513,6 @@ class TestGetProviderLogoutUrl:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that None is returned when provider has no end_session_endpoint."""
-        from unittest.mock import MagicMock
 
         from streamlit.web.server.starlette.starlette_auth_routes import (
             _get_provider_logout_url,
@@ -619,7 +546,6 @@ class TestGetProviderLogoutUrl:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that logout URL is returned when provider has end_session_endpoint."""
-        from unittest.mock import MagicMock
 
         from streamlit.web.server.starlette.starlette_auth_routes import (
             _get_provider_logout_url,
@@ -679,7 +605,6 @@ class TestGetProviderLogoutUrl:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that None is returned when redirect_uri doesn't end with /oauth2callback."""
-        from unittest.mock import MagicMock
 
         from streamlit.web.server.starlette.starlette_auth_routes import (
             _get_provider_logout_url,

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -403,11 +403,8 @@ class TestGetProviderByState:
     """Tests for _get_provider_by_state function."""
 
     def test_returns_none_for_none_state(self) -> None:
-        """Test that None state returns None."""
-
-        mock_request = MagicMock()
-        mock_request.session = {}
-        assert _get_provider_by_state(mock_request, None) is None
+        """Test that None state returns None (early-return path, no session access)."""
+        assert _get_provider_by_state(MagicMock(), None) is None
 
     def test_returns_none_for_unknown_state(self) -> None:
         """Test that an unknown state code returns None."""

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -437,6 +437,36 @@ class TestGetProviderByState:
         # Should return None for a state code that doesn't exist in the session
         assert _get_provider_by_state(mock_request, "nonexistentstate") is None
 
+    def test_ignores_keys_without_state_prefix(self) -> None:
+        """Test that session keys without '_state_' prefix are ignored."""
+        mock_request = MagicMock()
+        # These keys split into 4 parts but don't have the _state_ prefix
+        mock_request.session = {
+            "user_id_abcd_1234": {},  # Could be mistaken for state key
+            "other_data_xyz_5678": {},  # Another potential false positive
+            "_state_google_realstate123": {},  # Valid Authlib state key
+        }
+
+        # Only the valid _state_ prefixed key should be recognized
+        assert _get_provider_by_state(mock_request, "realstate123") == "google"
+        # The false positives should not be matched
+        assert _get_provider_by_state(mock_request, "1234") is None
+        assert _get_provider_by_state(mock_request, "5678") is None
+
+    def test_handles_state_code_with_underscores(self) -> None:
+        """Test that state codes containing underscores are parsed correctly."""
+        mock_request = MagicMock()
+        # State code contains underscores - maxsplit=3 should keep them together
+        mock_request.session = {
+            "_state_github_complex_state_with_underscores": {},
+        }
+
+        # The entire remainder after the 3rd underscore is the state code
+        assert (
+            _get_provider_by_state(mock_request, "complex_state_with_underscores")
+            == "github"
+        )
+
 
 class TestGetOriginFromSecrets:
     """Tests for _get_origin_from_secrets function."""


### PR DESCRIPTION
## Describe your changes

Fixes the OAuth `MismatchingStateError` regression introduced in 1.57.0 by switching from in-memory cache to session-based OAuth state storage.

- Removes `_AsyncAuthCache` class and `_STARLETTE_AUTH_CACHE` module variable
- Updates `_create_oauth_client()` to use Authlib's built-in session storage
- Updates `_get_provider_by_state()` to read OAuth state from `request.session`

**Root cause**: When Tornado was removed in 1.57.0 (PR #14553), OAuth state storage used an in-memory cache. On Cloud Run (and similar platforms), container restarts between `/auth/login` and `/oauth2callback` caused the cache to be lost, resulting in `MismatchingStateError`. The session cookie marker survived but the state data didn't.

**Solution**: Remove the custom cache and rely on Authlib's default session-based storage via Starlette's `SessionMiddleware`. OAuth state now travels in the signed session cookie, making it stateless and robust to container restarts.

## GitHub Issue Link (if applicable)

- Closes #14991

## Testing Plan

- [x] Unit Tests (Python): Updated `starlette_auth_routes_test.py` — tests `_get_provider_by_state()` with mock sessions, removed obsolete cache expiration tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 2 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->