### PR TITLE
[chore] Add typing tests for image, audio, and video

### DIFF
--- a/lib/tests/streamlit/typing/audio_types.py
+++ b/lib/tests/streamlit/typing/audio_types.py
@@ -88,3 +88,16 @@ if TYPE_CHECKING:
         ),
         DeltaGenerator,
     )
+
+    # =====================================================================
+    # Invalid usages - should NOT type check
+    # =====================================================================
+
+    # Invalid width value (not "stretch" or int)
+    audio("audio.wav", width="content")  # type: ignore[arg-type]
+
+    # Passing sample_rate as positional argument (should be keyword-only)
+    audio("audio.wav", "audio/wav", 0, 44100)  # type: ignore[misc]
+
+    # Passing end_time as positional argument (should be keyword-only)
+    audio("audio.wav", "audio/wav", 0, None, 60)  # type: ignore[misc]

--- a/lib/tests/streamlit/typing/audio_types.py
+++ b/lib/tests/streamlit/typing/audio_types.py
@@ -51,7 +51,8 @@ if TYPE_CHECKING:
     assert_type(audio("audio.wav", start_time="1m30s"), DeltaGenerator)
     assert_type(audio("audio.wav", start_time=timedelta(seconds=30)), DeltaGenerator)
 
-    # Audio with sample_rate parameter (for numpy arrays)
+    # Audio with sample_rate parameter (used with numpy arrays; bytes used here as a
+    # stand-in since numpy cannot be imported under TYPE_CHECKING)
     assert_type(audio(b"audio", sample_rate=44100), DeltaGenerator)
     assert_type(audio(b"audio", sample_rate=None), DeltaGenerator)
 
@@ -98,6 +99,3 @@ if TYPE_CHECKING:
 
     # Passing sample_rate as positional argument (should be keyword-only)
     audio("audio.wav", "audio/wav", 0, 44100)  # type: ignore[misc]
-
-    # Passing end_time as positional argument (should be keyword-only)
-    audio("audio.wav", "audio/wav", 0, None, 60)  # type: ignore[misc]

--- a/lib/tests/streamlit/typing/audio_types.py
+++ b/lib/tests/streamlit/typing/audio_types.py
@@ -1,0 +1,90 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from datetime import timedelta
+    from pathlib import Path
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.media import MediaMixin
+
+    audio = MediaMixin().audio
+
+    # =====================================================================
+    # st.audio return type tests
+    # =====================================================================
+
+    # Basic usage - returns DeltaGenerator
+    assert_type(audio("path/to/audio.wav"), DeltaGenerator)
+    assert_type(audio(Path("path/to/audio.wav")), DeltaGenerator)
+    assert_type(audio(b"binary audio data"), DeltaGenerator)
+    assert_type(audio("https://example.com/audio.mp3"), DeltaGenerator)
+    assert_type(audio(None), DeltaGenerator)
+
+    # Audio with format parameter
+    assert_type(audio("audio.wav", format="audio/wav"), DeltaGenerator)
+    assert_type(audio("audio.mp3", format="audio/mpeg"), DeltaGenerator)
+    assert_type(audio("audio.ogg", format="audio/ogg"), DeltaGenerator)
+
+    # Audio with start_time parameter - int, float, timedelta, or str
+    assert_type(audio("audio.wav", start_time=0), DeltaGenerator)
+    assert_type(audio("audio.wav", start_time=30), DeltaGenerator)
+    assert_type(audio("audio.wav", start_time=1.5), DeltaGenerator)
+    assert_type(audio("audio.wav", start_time="10s"), DeltaGenerator)
+    assert_type(audio("audio.wav", start_time="1m30s"), DeltaGenerator)
+    assert_type(audio("audio.wav", start_time=timedelta(seconds=30)), DeltaGenerator)
+
+    # Audio with sample_rate parameter (for numpy arrays)
+    assert_type(audio(b"audio", sample_rate=44100), DeltaGenerator)
+    assert_type(audio(b"audio", sample_rate=None), DeltaGenerator)
+
+    # Audio with end_time parameter - int, float, timedelta, str, or None
+    assert_type(audio("audio.wav", end_time=60), DeltaGenerator)
+    assert_type(audio("audio.wav", end_time=59.5), DeltaGenerator)
+    assert_type(audio("audio.wav", end_time="2m"), DeltaGenerator)
+    assert_type(audio("audio.wav", end_time=timedelta(minutes=2)), DeltaGenerator)
+    assert_type(audio("audio.wav", end_time=None), DeltaGenerator)
+
+    # Audio with loop parameter
+    assert_type(audio("audio.wav", loop=True), DeltaGenerator)
+    assert_type(audio("audio.wav", loop=False), DeltaGenerator)
+
+    # Audio with autoplay parameter
+    assert_type(audio("audio.wav", autoplay=True), DeltaGenerator)
+    assert_type(audio("audio.wav", autoplay=False), DeltaGenerator)
+
+    # Audio with width parameter - "stretch" or int
+    assert_type(audio("audio.wav", width="stretch"), DeltaGenerator)
+    assert_type(audio("audio.wav", width=400), DeltaGenerator)
+
+    # Audio with all parameters combined
+    assert_type(
+        audio(
+            "audio.mp3",
+            format="audio/mpeg",
+            start_time=10,
+            sample_rate=None,
+            end_time=120,
+            loop=True,
+            autoplay=False,
+            width="stretch",
+        ),
+        DeltaGenerator,
+    )

--- a/lib/tests/streamlit/typing/image_types.py
+++ b/lib/tests/streamlit/typing/image_types.py
@@ -57,15 +57,24 @@ if TYPE_CHECKING:
     assert_type(image("image.png", channels="RGB"), DeltaGenerator)
     assert_type(image("image.png", channels="BGR"), DeltaGenerator)
 
-    # Image with output_format parameter - "JPEG", "PNG", or "auto"
+    # Image with output_format parameter - "JPEG", "PNG", "GIF", or "auto"
     assert_type(image("image.png", output_format="JPEG"), DeltaGenerator)
     assert_type(image("image.png", output_format="PNG"), DeltaGenerator)
+    assert_type(image("image.png", output_format="GIF"), DeltaGenerator)
     assert_type(image("image.png", output_format="auto"), DeltaGenerator)
 
     # Image with use_container_width parameter (deprecated but still supported)
     assert_type(image("image.png", use_container_width=True), DeltaGenerator)
     assert_type(image("image.png", use_container_width=False), DeltaGenerator)
     assert_type(image("image.png", use_container_width=None), DeltaGenerator)
+
+    # Image with use_column_width parameter (deprecated but still supported)
+    assert_type(image("image.png", use_column_width=True), DeltaGenerator)
+    assert_type(image("image.png", use_column_width=False), DeltaGenerator)
+    assert_type(image("image.png", use_column_width="auto"), DeltaGenerator)
+    assert_type(image("image.png", use_column_width="always"), DeltaGenerator)
+    assert_type(image("image.png", use_column_width="never"), DeltaGenerator)
+    assert_type(image("image.png", use_column_width=None), DeltaGenerator)
 
     # Image with link parameter
     assert_type(image("image.png", link="https://streamlit.io"), DeltaGenerator)

--- a/lib/tests/streamlit/typing/image_types.py
+++ b/lib/tests/streamlit/typing/image_types.py
@@ -86,3 +86,29 @@ if TYPE_CHECKING:
         ),
         DeltaGenerator,
     )
+
+    # =====================================================================
+    # Invalid usages - should NOT type check
+    # =====================================================================
+
+    # Invalid width value (not "content", "stretch", or int)
+    image("image.png", width="invalid")  # type: ignore[arg-type]
+
+    # Invalid channels value (not "RGB" or "BGR")
+    image("image.png", channels="RGBA")  # type: ignore[arg-type]
+
+    # Invalid output_format value (not "JPEG", "PNG", "GIF", or "auto")
+    image("image.png", output_format="WEBP")  # type: ignore[arg-type]
+
+    # Passing link as positional argument (should be keyword-only)
+    image(
+        "image.png",
+        None,
+        "stretch",
+        None,
+        False,
+        "RGB",
+        "auto",
+        None,
+        "https://example.com",
+    )  # type: ignore[misc]

--- a/lib/tests/streamlit/typing/image_types.py
+++ b/lib/tests/streamlit/typing/image_types.py
@@ -1,0 +1,88 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.image import ImageMixin
+
+    image = ImageMixin().image
+
+    # =====================================================================
+    # st.image return type tests
+    # =====================================================================
+
+    # Basic usage - returns DeltaGenerator
+    assert_type(image("path/to/image.png"), DeltaGenerator)
+    assert_type(image(Path("path/to/image.png")), DeltaGenerator)
+    assert_type(image(b"binary data"), DeltaGenerator)
+    assert_type(image("https://example.com/image.png"), DeltaGenerator)
+
+    # Image with caption parameter - str or list of str
+    assert_type(image("image.png", caption="My image"), DeltaGenerator)
+    assert_type(image("image.png", caption=None), DeltaGenerator)
+    assert_type(
+        image(["img1.png", "img2.png"], caption=["Caption 1", "Caption 2"]),
+        DeltaGenerator,
+    )
+
+    # Image with width parameter - "content", "stretch", or int
+    assert_type(image("image.png", width="content"), DeltaGenerator)
+    assert_type(image("image.png", width="stretch"), DeltaGenerator)
+    assert_type(image("image.png", width=300), DeltaGenerator)
+
+    # Image with clamp parameter
+    assert_type(image("image.png", clamp=True), DeltaGenerator)
+    assert_type(image("image.png", clamp=False), DeltaGenerator)
+
+    # Image with channels parameter - "RGB" or "BGR"
+    assert_type(image("image.png", channels="RGB"), DeltaGenerator)
+    assert_type(image("image.png", channels="BGR"), DeltaGenerator)
+
+    # Image with output_format parameter - "JPEG", "PNG", or "auto"
+    assert_type(image("image.png", output_format="JPEG"), DeltaGenerator)
+    assert_type(image("image.png", output_format="PNG"), DeltaGenerator)
+    assert_type(image("image.png", output_format="auto"), DeltaGenerator)
+
+    # Image with use_container_width parameter (deprecated but still supported)
+    assert_type(image("image.png", use_container_width=True), DeltaGenerator)
+    assert_type(image("image.png", use_container_width=False), DeltaGenerator)
+    assert_type(image("image.png", use_container_width=None), DeltaGenerator)
+
+    # Image with link parameter
+    assert_type(image("image.png", link="https://streamlit.io"), DeltaGenerator)
+    assert_type(image("image.png", link="/my_page"), DeltaGenerator)
+    assert_type(image("image.png", link=None), DeltaGenerator)
+
+    # Image with all parameters combined
+    assert_type(
+        image(
+            "image.png",
+            caption="Full example",
+            width="stretch",
+            clamp=False,
+            channels="RGB",
+            output_format="auto",
+            use_container_width=None,
+            link="https://streamlit.io",
+        ),
+        DeltaGenerator,
+    )

--- a/lib/tests/streamlit/typing/video_types.py
+++ b/lib/tests/streamlit/typing/video_types.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     assert_type(
         video("video.mp4", subtitles=b"WEBVTT\n\n00:00:01.000..."), DeltaGenerator
     )
-    bytes_io: io.BytesIO = io.BytesIO(b"WEBVTT")
+    bytes_io = io.BytesIO(b"WEBVTT")
     assert_type(video("video.mp4", subtitles=bytes_io), DeltaGenerator)
     assert_type(
         video(
@@ -108,3 +108,13 @@ if TYPE_CHECKING:
         ),
         DeltaGenerator,
     )
+
+    # =====================================================================
+    # Invalid usages - should NOT type check
+    # =====================================================================
+
+    # Invalid width value (not "stretch" or int - "content" is not valid for video)
+    video("video.mp4", width="content")  # type: ignore[arg-type]
+
+    # Passing subtitles as positional argument (should be keyword-only)
+    video("video.mp4", "video/mp4", 0, "subtitles.vtt")  # type: ignore[misc]

--- a/lib/tests/streamlit/typing/video_types.py
+++ b/lib/tests/streamlit/typing/video_types.py
@@ -1,0 +1,110 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    import io
+    from datetime import timedelta
+    from pathlib import Path
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.media import MediaMixin
+
+    video = MediaMixin().video
+
+    # =====================================================================
+    # st.video return type tests
+    # =====================================================================
+
+    # Basic usage - returns DeltaGenerator
+    assert_type(video("path/to/video.mp4"), DeltaGenerator)
+    assert_type(video(Path("path/to/video.mp4")), DeltaGenerator)
+    assert_type(video(b"binary video data"), DeltaGenerator)
+    assert_type(video("https://example.com/video.mp4"), DeltaGenerator)
+    assert_type(video("https://www.youtube.com/watch?v=abc123"), DeltaGenerator)
+    assert_type(video(None), DeltaGenerator)
+
+    # Video with format parameter
+    assert_type(video("video.mp4", format="video/mp4"), DeltaGenerator)
+    assert_type(video("video.webm", format="video/webm"), DeltaGenerator)
+    assert_type(video("video.ogg", format="video/ogg"), DeltaGenerator)
+
+    # Video with start_time parameter - int, float, timedelta, or str
+    assert_type(video("video.mp4", start_time=0), DeltaGenerator)
+    assert_type(video("video.mp4", start_time=30), DeltaGenerator)
+    assert_type(video("video.mp4", start_time=1.5), DeltaGenerator)
+    assert_type(video("video.mp4", start_time="10s"), DeltaGenerator)
+    assert_type(video("video.mp4", start_time="1m30s"), DeltaGenerator)
+    assert_type(video("video.mp4", start_time=timedelta(seconds=30)), DeltaGenerator)
+
+    # Video with subtitles parameter - str, bytes, Path, BytesIO, or dict
+    assert_type(video("video.mp4", subtitles="subtitles.vtt"), DeltaGenerator)
+    assert_type(video("video.mp4", subtitles=Path("subtitles.srt")), DeltaGenerator)
+    assert_type(
+        video("video.mp4", subtitles=b"WEBVTT\n\n00:00:01.000..."), DeltaGenerator
+    )
+    bytes_io: io.BytesIO = io.BytesIO(b"WEBVTT")
+    assert_type(video("video.mp4", subtitles=bytes_io), DeltaGenerator)
+    assert_type(
+        video(
+            "video.mp4",
+            subtitles={"English": "en.vtt", "French": "fr.vtt"},
+        ),
+        DeltaGenerator,
+    )
+    assert_type(video("video.mp4", subtitles=None), DeltaGenerator)
+
+    # Video with end_time parameter - int, float, timedelta, str, or None
+    assert_type(video("video.mp4", end_time=120), DeltaGenerator)
+    assert_type(video("video.mp4", end_time=119.5), DeltaGenerator)
+    assert_type(video("video.mp4", end_time="5m"), DeltaGenerator)
+    assert_type(video("video.mp4", end_time=timedelta(minutes=5)), DeltaGenerator)
+    assert_type(video("video.mp4", end_time=None), DeltaGenerator)
+
+    # Video with loop parameter
+    assert_type(video("video.mp4", loop=True), DeltaGenerator)
+    assert_type(video("video.mp4", loop=False), DeltaGenerator)
+
+    # Video with autoplay parameter
+    assert_type(video("video.mp4", autoplay=True), DeltaGenerator)
+    assert_type(video("video.mp4", autoplay=False), DeltaGenerator)
+
+    # Video with muted parameter
+    assert_type(video("video.mp4", muted=True), DeltaGenerator)
+    assert_type(video("video.mp4", muted=False), DeltaGenerator)
+
+    # Video with width parameter - "stretch" or int
+    assert_type(video("video.mp4", width="stretch"), DeltaGenerator)
+    assert_type(video("video.mp4", width=640), DeltaGenerator)
+
+    # Video with all parameters combined
+    assert_type(
+        video(
+            "video.mp4",
+            format="video/mp4",
+            start_time=10,
+            subtitles="subtitles.vtt",
+            end_time=300,
+            loop=False,
+            autoplay=True,
+            muted=True,
+            width="stretch",
+        ),
+        DeltaGenerator,
+    )


### PR DESCRIPTION
## Describe your changes

Adds mypy typing tests for `st.image`, `st.audio`, and `st.video` commands to catch typing regressions in the public API.

- `image_types.py` — Tests `st.image` parameters (caption, width, channels, output_format, link, etc.)
- `audio_types.py` — Tests `st.audio` parameters (format, start_time, end_time, loop, autoplay, etc.)
- `video_types.py` — Tests `st.video` parameters (format, start_time, subtitles, end_time, loop, autoplay, muted, etc.)

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Type Tests (mypy)
  - `lib/tests/streamlit/typing/image_types.py`
  - `lib/tests/streamlit/typing/audio_types.py`
  - `lib/tests/streamlit/typing/video_types.py`

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->