### PR TITLE
[chore] Add unit tests for symlinked skill/agent detection

### DIFF
--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -971,7 +971,12 @@ def test_detect_installed_skills_detects_symlinked_skill_dir(
     # Symlink it into the .claude/skills directory
     skills_dir = app / ".claude" / "skills"
     skills_dir.mkdir(parents=True)
-    (skills_dir / "developing-with-streamlit").symlink_to(real_skill)
+    try:
+        (skills_dir / "developing-with-streamlit").symlink_to(
+            real_skill, target_is_directory=True
+        )
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported in this environment")
 
     monkeypatch.setenv("HOME", str(home))
     tokens = metrics_util._detect_installed_skills(str(app))
@@ -1068,7 +1073,10 @@ def test_detect_installed_agents_detects_symlinked_harness_dir(
     real_claude.mkdir(parents=True)
 
     # Symlink it into the home directory
-    (home / ".claude").symlink_to(real_claude)
+    try:
+        (home / ".claude").symlink_to(real_claude, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symlinks not supported in this environment")
 
     monkeypatch.setenv("HOME", str(home))
     assert metrics_util._detect_installed_agents() == ["claude"]

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -954,6 +954,31 @@ def test_detect_installed_skills_finds_project_skills_when_home_harness_absent(
     ]
 
 
+def test_detect_installed_skills_detects_symlinked_skill_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Symlinked skill directories are detected as if they were real directories."""
+    home = tmp_path / "home"
+    app = tmp_path / "app"
+    home.mkdir()
+    app.mkdir()
+
+    # Create a real skill directory elsewhere
+    real_skill = tmp_path / "external" / "developing-with-streamlit"
+    real_skill.mkdir(parents=True)
+    (real_skill / "SKILL.md").write_text("---\nname: developing-with-streamlit\n---\n")
+
+    # Symlink it into the .claude/skills directory
+    skills_dir = app / ".claude" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "developing-with-streamlit").symlink_to(real_skill)
+
+    monkeypatch.setenv("HOME", str(home))
+    tokens = metrics_util._detect_installed_skills(str(app))
+
+    assert tokens == ["app:claude:developing-with-streamlit"]
+
+
 @pytest.mark.parametrize(
     "detected",
     [[], ["home:claude:developing-with-streamlit"]],
@@ -1029,6 +1054,24 @@ def test_detect_installed_agents_returns_sorted_deduped_tokens(
 
     monkeypatch.setenv("HOME", str(home))
     assert metrics_util._detect_installed_agents() == ["claude", "cursor", "opencode"]
+
+
+def test_detect_installed_agents_detects_symlinked_harness_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Symlinked harness directories are detected as if they were real directories."""
+    home = tmp_path / "home"
+    home.mkdir()
+
+    # Create a real .claude directory elsewhere
+    real_claude = tmp_path / "external" / ".claude"
+    real_claude.mkdir(parents=True)
+
+    # Symlink it into the home directory
+    (home / ".claude").symlink_to(real_claude)
+
+    monkeypatch.setenv("HOME", str(home))
+    assert metrics_util._detect_installed_agents() == ["claude"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Describe your changes

Add unit tests to verify that the metrics tracking for installed agents and skills works correctly when skill folders are symlinked:

- `test_detect_installed_skills_detects_symlinked_skill_dir`: Verifies symlinked skill directories are detected
- `test_detect_installed_agents_detects_symlinked_harness_dir`: Verifies symlinked agent harness directories are detected

Python's `os.path.isdir()` and `os.path.isfile()` follow symlinks by default, so the existing implementation already handles this case correctly. These tests document and verify this behavior.

## Testing Plan

- [x] Unit Tests (Python)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->