### PR TITLE
fix(fragment): prevent stale auto-reruns from crashing apps

### DIFF
--- a/e2e_playwright/st_fragment_run_every.py
+++ b/e2e_playwright/st_fragment_run_every.py
@@ -12,14 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Exercise standalone and nested fragment `run_every` cleanup behavior."""
+
 from uuid import uuid4
 
 import streamlit as st
 
 
 @st.fragment(run_every=1.0)
-def my_auto_updating_fragment():
-    st.write(f"uuid in fragment: {uuid4()}")
+def my_auto_updating_fragment() -> None:
+    """Render a standalone auto-updating fragment for baseline coverage."""
+
+    st.write(f"standalone uuid in fragment: {uuid4()}")
+
+
+@st.fragment
+def nested_fragment_parent() -> None:
+    """Conditionally render the nested fragment tree for hide/show testing."""
+
+    if st.toggle("Show nested auto fragment", value=True):
+        nested_fragment_child()
+
+
+@st.fragment
+def nested_fragment_child() -> None:
+    """Add an extra fragment boundary around the nested auto-rerun child."""
+
+    nested_auto_updating_fragment()
+
+
+@st.fragment(run_every=1.0)
+def nested_auto_updating_fragment() -> None:
+    """Render the nested fragment whose timer must be cleaned up when hidden."""
+
+    st.write(f"nested uuid in fragment: {uuid4()}")
 
 
 my_auto_updating_fragment()
+nested_fragment_parent()

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -46,6 +46,9 @@ def test_nested_fragment_run_every_can_disappear_without_crashing(app: Page):
     standalone_fragment = _get_fragment_markdown(app, "standalone uuid in fragment:")
     nested_fragment = _get_fragment_markdown(app, "nested uuid in fragment:")
 
+    expect(standalone_fragment).to_be_visible()
+    expect(nested_fragment).to_be_visible()
+
     standalone_text = standalone_fragment.text_content()
     nested_text = nested_fragment.text_content()
 

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -61,6 +61,7 @@ def test_nested_fragment_run_every_can_disappear_without_crashing(app: Page):
     click_toggle(app, "Show nested auto fragment")
 
     expect(nested_fragment).to_have_count(0)
+    expect(app.get_by_test_id("stException")).to_have_count(0)
 
     # Wait for two standalone ticks: one should be enough in theory, but the
     # extra tick gives slower runners another chance to surface a stale nested

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -52,16 +52,20 @@ def test_nested_fragment_run_every_can_disappear_without_crashing(app: Page):
     assert standalone_text is not None
     assert nested_text is not None
 
+    # Let the nested fragment tick once so its stale timer is live before we hide it.
     expect(nested_fragment).not_to_have_text(nested_text)
 
     click_toggle(app, "Show nested auto fragment")
 
     expect(nested_fragment).to_have_count(0)
 
-    # Wait for the remaining run_every fragment to tick to ensure the hidden
-    # nested fragment's old timer does not crash the app.
-    expect(standalone_fragment).not_to_have_text(standalone_text)
-    expect(app.get_by_test_id("stException")).to_have_count(0)
+    # Wait for multiple standalone ticks so a stale nested timer has enough time
+    # to queue one last rerun and surface the original delta-path crash.
+    for _ in range(2):
+        expect(standalone_fragment).not_to_have_text(standalone_text)
+        standalone_text = standalone_fragment.text_content()
+        assert standalone_text is not None
+        expect(app.get_by_test_id("stException")).to_have_count(0)
 
     click_toggle(app, "Show nested auto fragment")
 

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -59,8 +59,9 @@ def test_nested_fragment_run_every_can_disappear_without_crashing(app: Page):
 
     expect(nested_fragment).to_have_count(0)
 
-    # Wait for multiple standalone ticks so a stale nested timer has enough time
-    # to queue one last rerun and surface the original delta-path crash.
+    # Wait for two standalone ticks: one should be enough in theory, but the
+    # extra tick gives slower runners another chance to surface a stale nested
+    # rerun without stretching the test much longer.
     for _ in range(2):
         expect(standalone_fragment).not_to_have_text(standalone_text)
         standalone_text = standalone_fragment.text_content()

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -12,16 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from playwright.sync_api import Page, expect
+"""End-to-end coverage for fragment `run_every` stability and cleanup."""
+
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.shared.app_utils import click_toggle
+
+
+def _get_fragment_markdown(app: Page, text: str) -> Locator:
+    """Return the markdown node that renders the fragment text prefix."""
+
+    return app.get_by_test_id("stMarkdown").filter(has_text=text)
 
 
 def test_fragment_runs_at_interval(app: Page):
-    fragment_text = app.get_by_test_id("stMarkdown").first.text_content()
+    """Verify a standalone `run_every` fragment keeps updating."""
+
+    fragment = _get_fragment_markdown(app, "standalone uuid in fragment:")
+    fragment_text = fragment.text_content()
 
     assert fragment_text is not None
 
     # Verify that the fragment text updates a few times.
     for _ in range(3):
-        expect(app.get_by_test_id("stMarkdown").first).not_to_have_text(fragment_text)
-        fragment_text = app.get_by_test_id("stMarkdown").first.text_content()
+        expect(fragment).not_to_have_text(fragment_text)
+        fragment_text = fragment.text_content()
         assert fragment_text is not None
+
+
+def test_nested_fragment_run_every_can_disappear_without_crashing(app: Page):
+    """Ensure hiding a nested auto-rerun fragment cleans up its stale timer."""
+
+    standalone_fragment = _get_fragment_markdown(app, "standalone uuid in fragment:")
+    nested_fragment = _get_fragment_markdown(app, "nested uuid in fragment:")
+
+    standalone_text = standalone_fragment.text_content()
+    nested_text = nested_fragment.text_content()
+
+    assert standalone_text is not None
+    assert nested_text is not None
+
+    expect(nested_fragment).not_to_have_text(nested_text)
+
+    click_toggle(app, "Show nested auto fragment")
+
+    expect(nested_fragment).to_have_count(0)
+
+    # Wait for the remaining run_every fragment to tick to ensure the hidden
+    # nested fragment's old timer does not crash the app.
+    expect(standalone_fragment).not_to_have_text(standalone_text)
+    expect(app.get_by_test_id("stException")).to_have_count(0)
+
+    click_toggle(app, "Show nested auto fragment")
+
+    expect(nested_fragment).to_have_count(1)
+    expect(app.get_by_test_id("stException")).to_have_count(0)

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4047,6 +4047,64 @@ describe("App", () => {
       )
     })
 
+    it("does not clear pending reruns on runOnSave-only status updates", () => {
+      renderApp(getProps())
+      const connectionManager = getMockConnectionManager()
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "myFragmentId",
+      })
+
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
+      act(() => {
+        widgetStateManager.sendUpdateWidgetsMessage(undefined)
+      })
+
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: true,
+        scriptIsRunning: false,
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.fragmentId
+      ).toBeUndefined()
+
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: true,
+        scriptIsRunning: true,
+      })
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: true,
+        scriptIsRunning: false,
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[1][0].rerunScript
+      ).toEqual(
+        expect.objectContaining({
+          fragmentId: "myFragmentId",
+          isAutoRerun: true,
+        })
+      )
+    })
+
     it("blocks descendant auto reruns while an auto rerun ancestor is pending", () => {
       withMockedActiveFragmentIds(["parentFragment", "childFragment"], () => {
         withMockedFragmentSubtreeIds(
@@ -4162,6 +4220,8 @@ describe("App", () => {
 
       const previousConnectionManager =
         appInstanceWithPrivateFields.connectionManager
+      // This branch is only reachable by temporarily dropping the mounted App's
+      // private connectionManager before the rerun request is sent.
       appInstanceWithPrivateFields.connectionManager = null
 
       act(() => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -41,6 +41,7 @@ import {
   mockEndpoints,
 } from "@streamlit/connection"
 import {
+  AppRoot,
   CachedTheme,
   CUSTOM_THEME_AUTO_NAME,
   CUSTOM_THEME_DARK_NAME,
@@ -455,6 +456,25 @@ function sendForwardMessage(
 
     getMockConnectionManagerProp("onMessage")(fwMessage)
   })
+}
+
+/**
+ * Mock the fragment IDs reported by `AppRoot.getActiveIds()` so tests can
+ * control which fragment timers survive the latest committed tree update.
+ */
+function mockActiveFragmentIds(fragmentIds: string[]): MockInstance {
+  const getActiveIds = AppRoot.prototype.getActiveIds
+
+  return vi
+    .spyOn(AppRoot.prototype, "getActiveIds")
+    .mockImplementation(function (this: AppRoot) {
+      const activeIds = getActiveIds.call(this)
+
+      return {
+        ...activeIds,
+        fragmentIds: new Set(fragmentIds),
+      }
+    })
 }
 
 async function openCacheModal(): Promise<void> {
@@ -3852,6 +3872,41 @@ describe("App", () => {
       expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 1000)
     })
 
+    it("replaces an existing interval for the same fragment id", () => {
+      renderApp(getProps())
+      const connectionManager = getMockConnectionManager()
+
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "myFragmentId",
+      })
+      sendForwardMessage("autoRerun", {
+        interval: 2.0,
+        fragmentId: "myFragmentId",
+      })
+
+      expect(clearInterval).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(connectionManager.sendMessage).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript
+      ).toEqual(
+        expect.objectContaining({
+          fragmentId: "myFragmentId",
+          isAutoRerun: true,
+        })
+      )
+    })
+
     it("clears intervals on handleNewSession message", () => {
       renderApp(getProps())
       sendForwardMessage("autoRerun", {
@@ -3870,6 +3925,64 @@ describe("App", () => {
 
       expect(clearInterval).toHaveBeenCalled()
       expect(clearInterval).toHaveBeenCalled()
+    })
+
+    it("clears intervals when the app unmounts", () => {
+      const { unmount } = renderApp(getProps())
+
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "myFragmentId",
+      })
+
+      unmount()
+
+      expect(clearInterval).toHaveBeenCalledTimes(1)
+    })
+
+    it("clears only fragment timers removed from the committed tree", () => {
+      const getActiveIdsSpy = mockActiveFragmentIds(["liveFragment"])
+
+      try {
+        renderApp(getProps())
+        const connectionManager = getMockConnectionManager()
+
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "liveFragment",
+        })
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "staleFragment",
+        })
+
+        // @ts-expect-error
+        connectionManager.sendMessage.mockClear()
+
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+        )
+
+        expect(clearInterval).toHaveBeenCalledTimes(1)
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[0][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "liveFragment",
+            isAutoRerun: true,
+          })
+        )
+      } finally {
+        getActiveIdsSpy.mockRestore()
+      }
     })
 
     it("triggers rerunScript with is_auto_rerun set to true", () => {
@@ -4382,7 +4495,7 @@ describe("App", () => {
       expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
     })
 
-    it("requests script rerun if autoReruns is not empty", () => {
+    it("requests script rerun if fragment auto reruns are active", () => {
       vi.useFakeTimers()
       renderApp(getProps())
       const widgetStateManager =
@@ -4431,6 +4544,65 @@ describe("App", () => {
       })
       expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
       vi.useRealTimers()
+    })
+
+    it("does not request script rerun after stale auto reruns are cleaned up", () => {
+      vi.useFakeTimers()
+      const getActiveIdsSpy = mockActiveFragmentIds([])
+
+      try {
+        renderApp(getProps())
+        const widgetStateManager =
+          getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+        act(() => {
+          getMockConnectionManagerProp("connectionStateChanged")(
+            ConnectionState.CONNECTED
+          )
+        })
+
+        sendForwardMessage("newSession", NEW_SESSION_JSON)
+        sendForwardMessage("autoRerun", {
+          interval: 1,
+          fragmentId: "myFragmentId",
+        })
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+        )
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: false,
+        })
+
+        act(() => {
+          getMockConnectionManagerProp("connectionStateChanged")(
+            ConnectionState.DISCONNECTED_FOREVER
+          )
+        })
+
+        const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+        sessionInfo.setCurrent(mockSessionInfoProps())
+        sessionInfo.setCurrent(mockSessionInfoProps())
+        expect(sessionInfo.last).toBeTruthy()
+
+        const sendUpdateWidgetsMessageSpy = vi.spyOn(
+          widgetStateManager,
+          "sendUpdateWidgetsMessage"
+        )
+        sendUpdateWidgetsMessageSpy.mockClear()
+
+        act(() => {
+          getMockConnectionManagerProp("connectionStateChanged")(
+            ConnectionState.CONNECTED
+          )
+        })
+
+        expect(sendUpdateWidgetsMessageSpy).not.toHaveBeenCalled()
+      } finally {
+        getActiveIdsSpy.mockRestore()
+        vi.useRealTimers()
+      }
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -5153,8 +5153,8 @@ describe("App", () => {
       })
 
       // A single tick is enough to prove the interval is active before page
-      // navigation. Additional ticks are now suppressed while that rerun is
-      // pending, which closes the stale nested-fragment race.
+      // navigation. This test focuses on page-change cleanup rather than the
+      // separate pending-rerun suppression path.
       vi.advanceTimersByTime(1000) // in milliseconds
 
       const connectionManager = getMockConnectionManager()

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -477,6 +477,19 @@ function mockActiveFragmentIds(fragmentIds: string[]): MockInstance {
     })
 }
 
+function withMockedActiveFragmentIds(
+  fragmentIds: string[],
+  runTest: () => void
+): void {
+  const getActiveIdsSpy = mockActiveFragmentIds(fragmentIds)
+
+  try {
+    runTest()
+  } finally {
+    getActiveIdsSpy.mockRestore()
+  }
+}
+
 async function openCacheModal(): Promise<void> {
   // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
   fireEvent.keyDown(document.body, {
@@ -3929,21 +3942,82 @@ describe("App", () => {
 
     it("clears intervals when the app unmounts", () => {
       const { unmount } = renderApp(getProps())
+      const connectionManager = getMockConnectionManager()
 
       sendForwardMessage("autoRerun", {
         interval: 1.0,
         fragmentId: "myFragmentId",
       })
 
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
       unmount()
 
       expect(clearInterval).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(connectionManager.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it("does not queue fragment auto reruns while another rerun is pending", () => {
+      renderApp(getProps())
+      const connectionManager = getMockConnectionManager()
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "myFragmentId",
+      })
+
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
+      act(() => {
+        widgetStateManager.sendUpdateWidgetsMessage(undefined)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript.fragmentId
+      ).toBeUndefined()
+
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: false,
+        scriptIsRunning: true,
+      })
+      sendForwardMessage("sessionStatusChanged", {
+        runOnSave: false,
+        scriptIsRunning: false,
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[1][0].rerunScript
+      ).toEqual(
+        expect.objectContaining({
+          fragmentId: "myFragmentId",
+          isAutoRerun: true,
+        })
+      )
     })
 
     it("clears only fragment timers removed from the committed tree", () => {
-      const getActiveIdsSpy = mockActiveFragmentIds(["liveFragment"])
-
-      try {
+      withMockedActiveFragmentIds(["liveFragment"], () => {
         renderApp(getProps())
         const connectionManager = getMockConnectionManager()
 
@@ -3980,9 +4054,7 @@ describe("App", () => {
             isAutoRerun: true,
           })
         )
-      } finally {
-        getActiveIdsSpy.mockRestore()
-      }
+      })
     })
 
     it("triggers rerunScript with is_auto_rerun set to true", () => {
@@ -4548,59 +4620,58 @@ describe("App", () => {
 
     it("does not request script rerun after stale auto reruns are cleaned up", () => {
       vi.useFakeTimers()
-      const getActiveIdsSpy = mockActiveFragmentIds([])
-
       try {
-        renderApp(getProps())
-        const widgetStateManager =
-          getStoredValue<WidgetStateManager>(WidgetStateManager)
+        withMockedActiveFragmentIds([], () => {
+          renderApp(getProps())
+          const widgetStateManager =
+            getStoredValue<WidgetStateManager>(WidgetStateManager)
 
-        act(() => {
-          getMockConnectionManagerProp("connectionStateChanged")(
-            ConnectionState.CONNECTED
+          act(() => {
+            getMockConnectionManagerProp("connectionStateChanged")(
+              ConnectionState.CONNECTED
+            )
+          })
+
+          sendForwardMessage("newSession", NEW_SESSION_JSON)
+          sendForwardMessage("autoRerun", {
+            interval: 1,
+            fragmentId: "myFragmentId",
+          })
+          sendForwardMessage(
+            "scriptFinished",
+            ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
           )
-        })
+          sendForwardMessage("sessionStatusChanged", {
+            runOnSave: false,
+            scriptIsRunning: false,
+          })
 
-        sendForwardMessage("newSession", NEW_SESSION_JSON)
-        sendForwardMessage("autoRerun", {
-          interval: 1,
-          fragmentId: "myFragmentId",
-        })
-        sendForwardMessage(
-          "scriptFinished",
-          ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
-        )
-        sendForwardMessage("sessionStatusChanged", {
-          runOnSave: false,
-          scriptIsRunning: false,
-        })
+          act(() => {
+            getMockConnectionManagerProp("connectionStateChanged")(
+              ConnectionState.DISCONNECTED_FOREVER
+            )
+          })
 
-        act(() => {
-          getMockConnectionManagerProp("connectionStateChanged")(
-            ConnectionState.DISCONNECTED_FOREVER
+          const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
+          sessionInfo.setCurrent(mockSessionInfoProps())
+          sessionInfo.setCurrent(mockSessionInfoProps())
+          expect(sessionInfo.last).toBeTruthy()
+
+          const sendUpdateWidgetsMessageSpy = vi.spyOn(
+            widgetStateManager,
+            "sendUpdateWidgetsMessage"
           )
+          sendUpdateWidgetsMessageSpy.mockClear()
+
+          act(() => {
+            getMockConnectionManagerProp("connectionStateChanged")(
+              ConnectionState.CONNECTED
+            )
+          })
+
+          expect(sendUpdateWidgetsMessageSpy).not.toHaveBeenCalled()
         })
-
-        const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
-        sessionInfo.setCurrent(mockSessionInfoProps())
-        sessionInfo.setCurrent(mockSessionInfoProps())
-        expect(sessionInfo.last).toBeTruthy()
-
-        const sendUpdateWidgetsMessageSpy = vi.spyOn(
-          widgetStateManager,
-          "sendUpdateWidgetsMessage"
-        )
-        sendUpdateWidgetsMessageSpy.mockClear()
-
-        act(() => {
-          getMockConnectionManagerProp("connectionStateChanged")(
-            ConnectionState.CONNECTED
-          )
-        })
-
-        expect(sendUpdateWidgetsMessageSpy).not.toHaveBeenCalled()
       } finally {
-        getActiveIdsSpy.mockRestore()
         vi.useRealTimers()
       }
     })
@@ -5081,26 +5152,22 @@ describe("App", () => {
         fragmentId: "fragmentId",
       })
 
-      // advance timer X times to trigger the interval-function
-      const times = 3
-      for (let i = 0; i < times; i++) {
-        vi.advanceTimersByTime(1000) // in milliseconds
-      }
+      // A single tick is enough to prove the interval is active before page
+      // navigation. Additional ticks are now suppressed while that rerun is
+      // pending, which closes the stale nested-fragment race.
+      vi.advanceTimersByTime(1000) // in milliseconds
 
       const connectionManager = getMockConnectionManager()
-      expect(connectionManager.sendMessage).toBeCalledTimes(times)
-      // ensure that all calls came from the autoRerun by checking the fragment id
-      for (let i = 0; i < times; i++) {
-        expect(
-          // @ts-expect-error
-          connectionManager.sendMessage.mock.calls[i][0].rerunScript
-        ).toEqual(
-          expect.objectContaining({
-            isAutoRerun: true,
-            fragmentId: "fragmentId",
-          })
-        )
-      }
+      expect(connectionManager.sendMessage).toBeCalledTimes(1)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript
+      ).toEqual(
+        expect.objectContaining({
+          isAutoRerun: true,
+          fragmentId: "fragmentId",
+        })
+      )
 
       // trigger a page change. we use a post message instead
       // of triggering a pange change via a newSession message,
@@ -5110,7 +5177,7 @@ describe("App", () => {
         pageScriptHash: "hash1",
       })
 
-      for (let i = 0; i < times; i++) {
+      for (let i = 0; i < 3; i++) {
         vi.advanceTimersByTime(1000) // in milliseconds
       }
 
@@ -5118,10 +5185,7 @@ describe("App", () => {
       // despite advancing the timer. We could check whether clearInterval
       // was called, but this check is more observing the behavior than checking
       // the exact internals.
-      const oldCallCountPlusPageChangeRequest = times + 1
-      expect(connectionManager.sendMessage).toBeCalledTimes(
-        oldCallCountPlusPageChangeRequest
-      )
+      expect(connectionManager.sendMessage).toBeCalledTimes(2)
 
       vi.useRealTimers()
     })

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -490,6 +490,37 @@ function withMockedActiveFragmentIds(
   }
 }
 
+function mockFragmentSubtreeIds(
+  fragmentSubtrees: Record<string, string[]>
+): MockInstance {
+  const getFragmentSubtreeIds = AppRoot.prototype.getFragmentSubtreeIds
+
+  return vi
+    .spyOn(AppRoot.prototype, "getFragmentSubtreeIds")
+    .mockImplementation(function (this: AppRoot, fragmentId: string) {
+      const subtreeIds = fragmentSubtrees[fragmentId]
+
+      if (subtreeIds) {
+        return new Set(subtreeIds)
+      }
+
+      return getFragmentSubtreeIds.call(this, fragmentId)
+    })
+}
+
+function withMockedFragmentSubtreeIds(
+  fragmentSubtrees: Record<string, string[]>,
+  runTest: () => void
+): void {
+  const getFragmentSubtreeIdsSpy = mockFragmentSubtreeIds(fragmentSubtrees)
+
+  try {
+    runTest()
+  } finally {
+    getFragmentSubtreeIdsSpy.mockRestore()
+  }
+}
+
 async function openCacheModal(): Promise<void> {
   // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
   fireEvent.keyDown(document.body, {
@@ -4008,6 +4039,146 @@ describe("App", () => {
       expect(
         // @ts-expect-error
         connectionManager.sendMessage.mock.calls[1][0].rerunScript
+      ).toEqual(
+        expect.objectContaining({
+          fragmentId: "myFragmentId",
+          isAutoRerun: true,
+        })
+      )
+    })
+
+    it("blocks descendant auto reruns while an auto rerun ancestor is pending", () => {
+      withMockedActiveFragmentIds(["parentFragment", "childFragment"], () => {
+        withMockedFragmentSubtreeIds(
+          {
+            parentFragment: ["parentFragment", "childFragment"],
+          },
+          () => {
+            renderApp(getProps())
+            const connectionManager = getMockConnectionManager()
+            const widgetStateManager =
+              getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+            sendForwardMessage("autoRerun", {
+              interval: 1.0,
+              fragmentId: "childFragment",
+            })
+
+            // @ts-expect-error
+            connectionManager.sendMessage.mockClear()
+
+            act(() => {
+              widgetStateManager.sendUpdateWidgetsMessage(
+                "parentFragment",
+                true
+              )
+            })
+
+            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+            expect(
+              // @ts-expect-error
+              connectionManager.sendMessage.mock.calls[0][0].rerunScript
+            ).toEqual(
+              expect.objectContaining({
+                fragmentId: "parentFragment",
+                isAutoRerun: true,
+              })
+            )
+
+            act(() => {
+              vi.advanceTimersByTime(1000)
+            })
+
+            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+
+            sendForwardMessage("sessionStatusChanged", {
+              runOnSave: false,
+              scriptIsRunning: true,
+            })
+            sendForwardMessage(
+              "scriptFinished",
+              ForwardMsg.ScriptFinishedStatus
+                .FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+            )
+            sendForwardMessage("sessionStatusChanged", {
+              runOnSave: false,
+              scriptIsRunning: false,
+            })
+
+            act(() => {
+              vi.advanceTimersByTime(1000)
+            })
+
+            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+            expect(
+              // @ts-expect-error
+              connectionManager.sendMessage.mock.calls[1][0].rerunScript
+            ).toEqual(
+              expect.objectContaining({
+                fragmentId: "childFragment",
+                isAutoRerun: true,
+              })
+            )
+          }
+        )
+      })
+    })
+
+    it("does not leave reruns pending if no connection manager is available", () => {
+      let appInstance: App | null = null
+
+      render(
+        <RootStyleProvider theme={getDefaultTheme()}>
+          <WindowDimensionsProvider>
+            <App
+              ref={instance => {
+                appInstance = instance
+              }}
+              {...getProps()}
+            />
+          </WindowDimensionsProvider>
+        </RootStyleProvider>
+      )
+
+      const connectionManager = getMockConnectionManager()
+      const widgetStateManager =
+        getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "myFragmentId",
+      })
+
+      // @ts-expect-error
+      connectionManager.sendMessage.mockClear()
+
+      if (!appInstance) {
+        throw new Error("Expected App instance ref to be assigned")
+      }
+
+      const appInstanceWithPrivateFields = appInstance as unknown as {
+        connectionManager: ConnectionManager | null
+      }
+
+      const previousConnectionManager =
+        appInstanceWithPrivateFields.connectionManager
+      appInstanceWithPrivateFields.connectionManager = null
+
+      act(() => {
+        widgetStateManager.sendUpdateWidgetsMessage(undefined)
+      })
+
+      appInstanceWithPrivateFields.connectionManager =
+        previousConnectionManager ?? connectionManager
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+      expect(
+        // @ts-expect-error
+        connectionManager.sendMessage.mock.calls[0][0].rerunScript
       ).toEqual(
         expect.objectContaining({
           fragmentId: "myFragmentId",

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4182,6 +4182,79 @@ describe("App", () => {
       })
     })
 
+    it("keeps descendant auto reruns blocked until a fragment rerun commits", () => {
+      withMockedActiveFragmentIds(["parentFragment", "childFragment"], () => {
+        withMockedFragmentSubtreeIds(
+          {
+            parentFragment: ["parentFragment", "childFragment"],
+          },
+          () => {
+            renderApp(getProps())
+            const connectionManager = getMockConnectionManager()
+            const widgetStateManager =
+              getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+            sendForwardMessage("autoRerun", {
+              interval: 1.0,
+              fragmentId: "childFragment",
+            })
+
+            // @ts-expect-error
+            connectionManager.sendMessage.mockClear()
+
+            act(() => {
+              widgetStateManager.sendUpdateWidgetsMessage(
+                "parentFragment",
+                true
+              )
+            })
+
+            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+
+            sendForwardMessage("newSession", {
+              ...NEW_SESSION_JSON,
+              fragmentIdsThisRun: ["parentFragment"],
+            })
+
+            act(() => {
+              vi.advanceTimersByTime(1000)
+            })
+
+            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+
+            sendForwardMessage("sessionStatusChanged", {
+              runOnSave: false,
+              scriptIsRunning: true,
+            })
+            sendForwardMessage(
+              "scriptFinished",
+              ForwardMsg.ScriptFinishedStatus
+                .FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+            )
+            sendForwardMessage("sessionStatusChanged", {
+              runOnSave: false,
+              scriptIsRunning: false,
+            })
+
+            act(() => {
+              vi.advanceTimersByTime(1000)
+            })
+
+            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+            expect(
+              // @ts-expect-error
+              connectionManager.sendMessage.mock.calls[1][0].rerunScript
+            ).toEqual(
+              expect.objectContaining({
+                fragmentId: "childFragment",
+                isAutoRerun: true,
+              })
+            )
+          }
+        )
+      })
+    })
+
     it("does not leave reruns pending if no connection manager is available", () => {
       let appInstance: App | null = null
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -548,6 +548,13 @@ function installMockFragmentTree({
   }
 }
 
+/**
+ * Test helper that artificially clears the mounted App's private
+ * `connectionManager` reference so we can exercise the `!baseUriParts` early
+ * return inside `sendRerunBackMsg`. This branch is otherwise unreachable in
+ * the test harness because the App always has a mock connection manager
+ * attached after mount. The returned function restores the original reference.
+ */
 function temporarilyClearConnectionManager(app: App): () => void {
   const appInstanceWithPrivateFields = app as unknown as {
     connectionManager: ConnectionManager | null
@@ -4372,6 +4379,109 @@ describe("App", () => {
         ).toEqual(
           expect.objectContaining({
             fragmentId: "liveFragment",
+            isAutoRerun: true,
+          })
+        )
+      } finally {
+        cleanupFragmentTree()
+      }
+    })
+
+    it("keeps overlapping auto-rerun blocks scoped per request when one commits", () => {
+      // Regression test for the case where two independent fragment auto-reruns
+      // are in flight at the same time (both sent in the pre-ACK window before
+      // either has reported `scriptIsRunning`). Committing one must not clear
+      // the blocked subtree belonging to the other in-flight request — that
+      // would re-open the stale-descendant-tick window and allow a removed
+      // child fragment to enqueue a rerun before its parent's commit.
+      const cleanupFragmentTree = installMockFragmentTree({
+        activeFragmentIds: ["fragmentA", "fragmentB", "childOfB"],
+        fragmentSubtrees: {
+          fragmentA: ["fragmentA"],
+          fragmentB: ["fragmentB", "childOfB"],
+        },
+      })
+
+      try {
+        renderApp(getProps())
+        const connectionManager = getMockConnectionManager()
+        const widgetStateManager =
+          getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "childOfB",
+        })
+
+        // @ts-expect-error
+        connectionManager.sendMessage.mockClear()
+
+        // Two overlapping in-flight auto-rerun requests, both queued before
+        // either commits.
+        act(() => {
+          widgetStateManager.sendUpdateWidgetsMessage("fragmentA", true)
+        })
+        act(() => {
+          widgetStateManager.sendUpdateWidgetsMessage("fragmentB", true)
+        })
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+
+        // Server commits fragmentA first. Old behavior cleared every blocked
+        // subtree here; the per-request fix must leave fragmentB's block
+        // intact so its descendant timers stay quiescent.
+        sendForwardMessage("newSession", {
+          ...NEW_SESSION_JSON,
+          fragmentIdsThisRun: ["fragmentA"],
+        })
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: true,
+        })
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+        )
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: false,
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+        // childOfB must still be blocked by fragmentB's pending request, so
+        // no extra rerun message has been enqueued yet.
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+
+        // Server commits fragmentB. Now its block is released and the child
+        // auto-rerun can finally fire.
+        sendForwardMessage("newSession", {
+          ...NEW_SESSION_JSON,
+          fragmentIdsThisRun: ["fragmentB"],
+        })
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: true,
+        })
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+        )
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: false,
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(3)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[2][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "childOfB",
             isAutoRerun: true,
           })
         )

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -396,6 +396,29 @@ function renderApp(props: Props): RenderResult {
   )
 }
 
+function renderAppWithRef(props: Props): RenderResult & { app: App } {
+  let app: App | null = null
+
+  const renderResult = render(
+    <RootStyleProvider theme={getDefaultTheme()}>
+      <WindowDimensionsProvider>
+        <App
+          ref={instance => {
+            app = instance
+          }}
+          {...props}
+        />
+      </WindowDimensionsProvider>
+    </RootStyleProvider>
+  )
+
+  if (!app) {
+    throw new Error("Expected App instance ref to be assigned")
+  }
+
+  return { ...renderResult, app }
+}
+
 function getStoredValue<T>(
   // At runtime, vi.mock() adds a `.mock` property to the class constructor.
   // We accept `unknown` and use vi.mocked() internally to access it safely.
@@ -477,19 +500,6 @@ function mockActiveFragmentIds(fragmentIds: string[]): MockInstance {
     })
 }
 
-function withMockedActiveFragmentIds(
-  fragmentIds: string[],
-  runTest: () => void
-): void {
-  const getActiveIdsSpy = mockActiveFragmentIds(fragmentIds)
-
-  try {
-    runTest()
-  } finally {
-    getActiveIdsSpy.mockRestore()
-  }
-}
-
 function mockFragmentSubtreeIds(
   fragmentSubtrees: Record<string, string[]>
 ): MockInstance {
@@ -508,16 +518,46 @@ function mockFragmentSubtreeIds(
     })
 }
 
-function withMockedFragmentSubtreeIds(
-  fragmentSubtrees: Record<string, string[]>,
-  runTest: () => void
-): void {
-  const getFragmentSubtreeIdsSpy = mockFragmentSubtreeIds(fragmentSubtrees)
+function installMockFragmentTree({
+  activeFragmentIds,
+  fragmentSubtrees = {},
+}: {
+  activeFragmentIds?: string[]
+  fragmentSubtrees?: Record<string, string[]>
+}): () => void {
+  const restoreMocks: Array<() => void> = []
 
-  try {
-    runTest()
-  } finally {
-    getFragmentSubtreeIdsSpy.mockRestore()
+  if (activeFragmentIds !== undefined) {
+    const getActiveIdsSpy = mockActiveFragmentIds(activeFragmentIds)
+    restoreMocks.push(() => {
+      getActiveIdsSpy.mockRestore()
+    })
+  }
+
+  if (Object.keys(fragmentSubtrees).length > 0) {
+    const getFragmentSubtreeIdsSpy = mockFragmentSubtreeIds(fragmentSubtrees)
+    restoreMocks.push(() => {
+      getFragmentSubtreeIdsSpy.mockRestore()
+    })
+  }
+
+  return () => {
+    restoreMocks.reverse().forEach(restoreMock => {
+      restoreMock()
+    })
+  }
+}
+
+function temporarilyClearConnectionManager(app: App): () => void {
+  const appInstanceWithPrivateFields = app as unknown as {
+    connectionManager: ConnectionManager | null
+  }
+  const previousConnectionManager =
+    appInstanceWithPrivateFields.connectionManager
+  appInstanceWithPrivateFields.connectionManager = null
+
+  return () => {
+    appInstanceWithPrivateFields.connectionManager = previousConnectionManager
   }
 }
 
@@ -4106,170 +4146,153 @@ describe("App", () => {
     })
 
     it("blocks descendant auto reruns while an auto rerun ancestor is pending", () => {
-      withMockedActiveFragmentIds(["parentFragment", "childFragment"], () => {
-        withMockedFragmentSubtreeIds(
-          {
-            parentFragment: ["parentFragment", "childFragment"],
-          },
-          () => {
-            renderApp(getProps())
-            const connectionManager = getMockConnectionManager()
-            const widgetStateManager =
-              getStoredValue<WidgetStateManager>(WidgetStateManager)
-
-            sendForwardMessage("autoRerun", {
-              interval: 1.0,
-              fragmentId: "childFragment",
-            })
-
-            // @ts-expect-error
-            connectionManager.sendMessage.mockClear()
-
-            act(() => {
-              widgetStateManager.sendUpdateWidgetsMessage(
-                "parentFragment",
-                true
-              )
-            })
-
-            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
-            expect(
-              // @ts-expect-error
-              connectionManager.sendMessage.mock.calls[0][0].rerunScript
-            ).toEqual(
-              expect.objectContaining({
-                fragmentId: "parentFragment",
-                isAutoRerun: true,
-              })
-            )
-
-            act(() => {
-              vi.advanceTimersByTime(1000)
-            })
-
-            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
-
-            sendForwardMessage("sessionStatusChanged", {
-              runOnSave: false,
-              scriptIsRunning: true,
-            })
-            sendForwardMessage(
-              "scriptFinished",
-              ForwardMsg.ScriptFinishedStatus
-                .FINISHED_FRAGMENT_RUN_SUCCESSFULLY
-            )
-            sendForwardMessage("sessionStatusChanged", {
-              runOnSave: false,
-              scriptIsRunning: false,
-            })
-
-            act(() => {
-              vi.advanceTimersByTime(1000)
-            })
-
-            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
-            expect(
-              // @ts-expect-error
-              connectionManager.sendMessage.mock.calls[1][0].rerunScript
-            ).toEqual(
-              expect.objectContaining({
-                fragmentId: "childFragment",
-                isAutoRerun: true,
-              })
-            )
-          }
-        )
+      const cleanupFragmentTree = installMockFragmentTree({
+        activeFragmentIds: ["parentFragment", "childFragment"],
+        fragmentSubtrees: {
+          parentFragment: ["parentFragment", "childFragment"],
+        },
       })
+
+      try {
+        renderApp(getProps())
+        const connectionManager = getMockConnectionManager()
+        const widgetStateManager =
+          getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "childFragment",
+        })
+
+        // @ts-expect-error
+        connectionManager.sendMessage.mockClear()
+
+        act(() => {
+          widgetStateManager.sendUpdateWidgetsMessage("parentFragment", true)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[0][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "parentFragment",
+            isAutoRerun: true,
+          })
+        )
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: true,
+        })
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+        )
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: false,
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[1][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "childFragment",
+            isAutoRerun: true,
+          })
+        )
+      } finally {
+        cleanupFragmentTree()
+      }
     })
 
     it("keeps descendant auto reruns blocked until a fragment rerun commits", () => {
-      withMockedActiveFragmentIds(["parentFragment", "childFragment"], () => {
-        withMockedFragmentSubtreeIds(
-          {
-            parentFragment: ["parentFragment", "childFragment"],
-          },
-          () => {
-            renderApp(getProps())
-            const connectionManager = getMockConnectionManager()
-            const widgetStateManager =
-              getStoredValue<WidgetStateManager>(WidgetStateManager)
-
-            sendForwardMessage("autoRerun", {
-              interval: 1.0,
-              fragmentId: "childFragment",
-            })
-
-            // @ts-expect-error
-            connectionManager.sendMessage.mockClear()
-
-            act(() => {
-              widgetStateManager.sendUpdateWidgetsMessage(
-                "parentFragment",
-                true
-              )
-            })
-
-            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
-
-            sendForwardMessage("newSession", {
-              ...NEW_SESSION_JSON,
-              fragmentIdsThisRun: ["parentFragment"],
-            })
-
-            act(() => {
-              vi.advanceTimersByTime(1000)
-            })
-
-            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
-
-            sendForwardMessage("sessionStatusChanged", {
-              runOnSave: false,
-              scriptIsRunning: true,
-            })
-            sendForwardMessage(
-              "scriptFinished",
-              ForwardMsg.ScriptFinishedStatus
-                .FINISHED_FRAGMENT_RUN_SUCCESSFULLY
-            )
-            sendForwardMessage("sessionStatusChanged", {
-              runOnSave: false,
-              scriptIsRunning: false,
-            })
-
-            act(() => {
-              vi.advanceTimersByTime(1000)
-            })
-
-            expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
-            expect(
-              // @ts-expect-error
-              connectionManager.sendMessage.mock.calls[1][0].rerunScript
-            ).toEqual(
-              expect.objectContaining({
-                fragmentId: "childFragment",
-                isAutoRerun: true,
-              })
-            )
-          }
-        )
+      const cleanupFragmentTree = installMockFragmentTree({
+        activeFragmentIds: ["parentFragment", "childFragment"],
+        fragmentSubtrees: {
+          parentFragment: ["parentFragment", "childFragment"],
+        },
       })
+
+      try {
+        renderApp(getProps())
+        const connectionManager = getMockConnectionManager()
+        const widgetStateManager =
+          getStoredValue<WidgetStateManager>(WidgetStateManager)
+
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "childFragment",
+        })
+
+        // @ts-expect-error
+        connectionManager.sendMessage.mockClear()
+
+        act(() => {
+          widgetStateManager.sendUpdateWidgetsMessage("parentFragment", true)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+
+        sendForwardMessage("newSession", {
+          ...NEW_SESSION_JSON,
+          fragmentIdsThisRun: ["parentFragment"],
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: true,
+        })
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+        )
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: false,
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[1][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "childFragment",
+            isAutoRerun: true,
+          })
+        )
+      } finally {
+        cleanupFragmentTree()
+      }
     })
 
     it("does not leave reruns pending if no connection manager is available", () => {
-      let appInstance: App | null = null
-
-      render(
-        <RootStyleProvider theme={getDefaultTheme()}>
-          <WindowDimensionsProvider>
-            <App
-              ref={instance => {
-                appInstance = instance
-              }}
-              {...getProps()}
-            />
-          </WindowDimensionsProvider>
-        </RootStyleProvider>
-      )
+      const { app } = renderAppWithRef(getProps())
 
       const connectionManager = getMockConnectionManager()
       const widgetStateManager =
@@ -4283,26 +4306,16 @@ describe("App", () => {
       // @ts-expect-error
       connectionManager.sendMessage.mockClear()
 
-      if (!appInstance) {
-        throw new Error("Expected App instance ref to be assigned")
-      }
-
-      const appInstanceWithPrivateFields = appInstance as unknown as {
-        connectionManager: ConnectionManager | null
-      }
-
-      const previousConnectionManager =
-        appInstanceWithPrivateFields.connectionManager
       // This branch is only reachable by temporarily dropping the mounted App's
       // private connectionManager before the rerun request is sent.
-      appInstanceWithPrivateFields.connectionManager = null
-
-      act(() => {
-        widgetStateManager.sendUpdateWidgetsMessage(undefined)
-      })
-
-      appInstanceWithPrivateFields.connectionManager =
-        previousConnectionManager ?? connectionManager
+      const restoreConnectionManager = temporarilyClearConnectionManager(app)
+      try {
+        act(() => {
+          widgetStateManager.sendUpdateWidgetsMessage(undefined)
+        })
+      } finally {
+        restoreConnectionManager()
+      }
 
       act(() => {
         vi.advanceTimersByTime(1000)
@@ -4321,7 +4334,11 @@ describe("App", () => {
     })
 
     it("clears only fragment timers removed from the committed tree", () => {
-      withMockedActiveFragmentIds(["liveFragment"], () => {
+      const cleanupFragmentTree = installMockFragmentTree({
+        activeFragmentIds: ["liveFragment"],
+      })
+
+      try {
         renderApp(getProps())
         const connectionManager = getMockConnectionManager()
 
@@ -4358,7 +4375,9 @@ describe("App", () => {
             isAutoRerun: true,
           })
         )
-      })
+      } finally {
+        cleanupFragmentTree()
+      }
     })
 
     it("triggers rerunScript with is_auto_rerun set to true", () => {
@@ -4925,7 +4944,11 @@ describe("App", () => {
     it("does not request script rerun after stale auto reruns are cleaned up", () => {
       vi.useFakeTimers()
       try {
-        withMockedActiveFragmentIds([], () => {
+        const cleanupFragmentTree = installMockFragmentTree({
+          activeFragmentIds: [],
+        })
+
+        try {
           renderApp(getProps())
           const widgetStateManager =
             getStoredValue<WidgetStateManager>(WidgetStateManager)
@@ -4974,7 +4997,9 @@ describe("App", () => {
           })
 
           expect(sendUpdateWidgetsMessageSpy).not.toHaveBeenCalled()
-        })
+        } finally {
+          cleanupFragmentTree()
+        }
       } finally {
         vi.useRealTimers()
       }

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4490,6 +4490,127 @@ describe("App", () => {
       }
     })
 
+    it("releases the in-flight auto-rerun block even when the server's NewSession and ScriptFinished arrive in a single React batch", () => {
+      // Regression test for a race where multiple WebSocket messages from the
+      // same script run get processed before React commits the
+      // `fragmentIdsThisRun` setState. handleScriptFinished captured
+      // `this.state.fragmentIdsThisRun` synchronously and used it to decide
+      // which auto-rerun blocks to release, so the stale value (from the
+      // previous run) caused the just-completed run's block to leak. With the
+      // block leaked, every subsequent auto-rerun tick for that fragment was
+      // suppressed by isAutoRerunBlocked until the next full-app rerun.
+      const cleanupFragmentTree = installMockFragmentTree({
+        activeFragmentIds: ["fragmentA"],
+        fragmentSubtrees: {
+          fragmentA: ["fragmentA"],
+        },
+      })
+
+      try {
+        renderApp(getProps())
+        const connectionManager = getMockConnectionManager()
+
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "fragmentA",
+        })
+
+        // Seed `state.fragmentIdsThisRun` with a previous run's value that
+        // does NOT include `fragmentA`. After this commits, a stale read of
+        // `this.state.fragmentIdsThisRun` inside handleScriptFinished would
+        // return ["fragmentB"] instead of ["fragmentA"].
+        sendForwardMessage("newSession", {
+          ...NEW_SESSION_JSON,
+          fragmentIdsThisRun: ["fragmentB"],
+        })
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: true,
+        })
+        sendForwardMessage(
+          "scriptFinished",
+          ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+        )
+        sendForwardMessage("sessionStatusChanged", {
+          runOnSave: false,
+          scriptIsRunning: false,
+        })
+
+        // @ts-expect-error
+        connectionManager.sendMessage.mockClear()
+
+        // First tick: fires the in-flight auto-rerun for fragmentA and marks
+        // it as blocked until the rerun commits.
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(1)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[0][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "fragmentA",
+            isAutoRerun: true,
+          })
+        )
+
+        // Server replies for the just-sent fragmentA rerun, but every
+        // ForwardMsg lands inside the same React batch (single act()). React
+        // does not flush `fragmentIdsThisRun` between handlers, so when
+        // handleScriptFinished reads `this.state.fragmentIdsThisRun` it still
+        // sees the previous run's ["fragmentB"].
+        act(() => {
+          const onMessage = getMockConnectionManagerProp("onMessage")
+          const newSessionMsg = new ForwardMsg()
+          newSessionMsg.newSession = cloneDeep({
+            ...NEW_SESSION_JSON,
+            fragmentIdsThisRun: ["fragmentA"],
+          })
+          onMessage(newSessionMsg)
+
+          const startedMsg = new ForwardMsg()
+          startedMsg.sessionStatusChanged = SessionStatus.create({
+            runOnSave: false,
+            scriptIsRunning: true,
+          })
+          onMessage(startedMsg)
+
+          const finishedMsg = new ForwardMsg()
+          finishedMsg.scriptFinished =
+            ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+          onMessage(finishedMsg)
+
+          const stoppedMsg = new ForwardMsg()
+          stoppedMsg.sessionStatusChanged = SessionStatus.create({
+            runOnSave: false,
+            scriptIsRunning: false,
+          })
+          onMessage(stoppedMsg)
+        })
+
+        // Next tick: must fire because the block for fragmentA was released
+        // when its rerun committed. Without the fix, the stale read leaves
+        // the block in place and this tick is dropped.
+        act(() => {
+          vi.advanceTimersByTime(1000)
+        })
+
+        expect(connectionManager.sendMessage).toHaveBeenCalledTimes(2)
+        expect(
+          // @ts-expect-error
+          connectionManager.sendMessage.mock.calls[1][0].rerunScript
+        ).toEqual(
+          expect.objectContaining({
+            fragmentId: "fragmentA",
+            isAutoRerun: true,
+          })
+        )
+      } finally {
+        cleanupFragmentTree()
+      }
+    })
+
     it("triggers rerunScript with is_auto_rerun set to true", () => {
       // Since we mock the isEmbed function, we need to set its return value
       vi.mocked(isEmbed).mockReturnValue(false)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -315,6 +315,19 @@ export class App extends PureComponent<Props, State> {
    */
   private readonly pendingAutoRerunBlocks = new Map<string, Set<string>>()
 
+  /**
+   * Synchronous mirror of `state.fragmentIdsThisRun` that is updated alongside
+   * the corresponding `setState` call so handlers reading it inside the same
+   * React batch see the latest value rather than the previous run's. The
+   * frontend's WebSocket pump can dispatch several ForwardMsgs back-to-back
+   * (e.g. NewSession → SessionStatus → ScriptFinished), and React 18 batches
+   * the resulting `setState`s into one commit. Without this mirror,
+   * `handleScriptFinished` could read the prior run's `fragmentIdsThisRun`
+   * and release the wrong auto-rerun block, leaving the just-completed
+   * fragment permanently blocked from future ticks until a full-app rerun.
+   */
+  private fragmentIdsThisRunSync: readonly string[] = []
+
   public constructor(props: Props) {
     super(props)
 
@@ -1378,6 +1391,10 @@ export class App extends PureComponent<Props, State> {
     // Set this flag to indicate that we have received a NewSession message
     // after the latest rerun request:
     this.hasReceivedNewSession = true
+    // Mirror `fragmentIdsThisRun` synchronously so handlers running inside the
+    // same React batch (NewSession → ... → ScriptFinished) read the value for
+    // the current run instead of the prior run's stale `state` value.
+    this.fragmentIdsThisRunSync = fragmentIdsThisRun
     if (!fragmentIdsThisRun.length) {
       // Full-app reruns can deliver a NewSession without a fresh RUNNING status
       // transition if the app was already running. Fragment reruns keep their
@@ -1642,12 +1659,18 @@ export class App extends PureComponent<Props, State> {
         // leftover elements will be cleared after finished successfully.
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
-        // Capture the fragment IDs that just ran so the setState callback can
-        // release the right auto-rerun blocks without reading `this.state`
-        // (which the lint rules disallow inside setState callbacks). The
-        // value is already correct here because `handleNewSession` set it
-        // earlier in this script run.
-        const committedFragmentIds = this.state.fragmentIdsThisRun
+        // Capture the fragment IDs that just ran from the synchronous mirror.
+        // Reading `this.state.fragmentIdsThisRun` here is unsafe because
+        // React 18 batches the setState calls from the back-to-back
+        // ForwardMsgs that drive a single script run (NewSession →
+        // SessionStatus → ScriptFinished). When that batching kicks in,
+        // `state.fragmentIdsThisRun` still reflects the previous run, so the
+        // setState callback below would release the wrong auto-rerun blocks
+        // and leave the just-completed fragment permanently quiescent until
+        // the next full-app rerun. `fragmentIdsThisRunSync` is updated
+        // alongside `setState` in `handleNewSession`, so it always matches
+        // the run that just finished.
+        const committedFragmentIds = this.fragmentIdsThisRunSync
         this.setState(
           ({ scriptRunId, fragmentIdsThisRun, elements }) => ({
             // Apply any pending elements that haven't been applied.
@@ -1680,7 +1703,7 @@ export class App extends PureComponent<Props, State> {
         status === ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
       ) {
         // The script finished early because another rerun superseded it. The
-        // success path below only releases blocks for fragments that actually
+        // success path above only releases blocks for fragments that actually
         // commit, so without this we would leave the interrupted fragment's
         // entry in `pendingAutoRerunBlocks` indefinitely (until the next
         // full-app rerun), silently dropping all of its future auto-rerun
@@ -1688,8 +1711,10 @@ export class App extends PureComponent<Props, State> {
         // their timers can resume once the superseding run finishes; the
         // `scriptRunState` and `hasPendingRerunRequest` guards in
         // `handleAutoRerunTick` still suppress ticks while another rerun is
-        // in flight.
-        this.state.fragmentIdsThisRun.forEach(interruptedFragmentId => {
+        // in flight. We use the synchronous mirror for the same reason the
+        // success branch does — handlers in the same React batch must not
+        // observe a stale `state.fragmentIdsThisRun`.
+        this.fragmentIdsThisRunSync.forEach(interruptedFragmentId => {
           this.releasePendingAutoRerunBlock(interruptedFragmentId)
         })
       }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1367,6 +1367,7 @@ export class App extends PureComponent<Props, State> {
    */
   handleNewSession = (newSessionProto: NewSession): void => {
     const initialize = newSessionProto.initialize as Initialize
+    const { fragmentIdsThisRun } = newSessionProto
 
     if (this.hasStreamlitVersionChanged(initialize)) {
       window.location.reload()
@@ -1376,8 +1377,13 @@ export class App extends PureComponent<Props, State> {
     // Set this flag to indicate that we have received a NewSession message
     // after the latest rerun request:
     this.hasReceivedNewSession = true
-    this.hasPendingRerunRequest = false
-    this.blockedAutoRerunFragmentIds.clear()
+    if (!fragmentIdsThisRun.length) {
+      // Full-app reruns can deliver a NewSession without a fresh RUNNING status
+      // transition if the app was already running. Fragment reruns keep their
+      // auto-rerun subtree blocked until the committed tree is updated.
+      this.hasPendingRerunRequest = false
+      this.blockedAutoRerunFragmentIds.clear()
+    }
 
     // First, handle initialization logic. Each NewSession message has
     // initialization data. If this is the _first_ time we're receiving
@@ -1393,7 +1399,6 @@ export class App extends PureComponent<Props, State> {
       scriptRunId,
       name: scriptName,
       mainScriptPath,
-      fragmentIdsThisRun,
       pageScriptHash: newPageScriptHash,
       mainScriptHash,
     } = newSessionProto

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1725,6 +1725,9 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Send the fragment-scoped rerun request when a managed auto-rerun interval fires.
+   * `scriptRunState` covers the post-ack window once the server reports RUNNING,
+   * and `hasPendingRerunRequest` covers the pre-ack window after a non-auto
+   * rerun is sent but before that status update arrives.
    */
   private readonly handleAutoRerunTick = (fragmentId: string): void => {
     if (
@@ -2023,7 +2026,8 @@ export class App extends PureComponent<Props, State> {
 
     // Mark non-auto reruns as pending immediately so auto-rerun timers do not
     // enqueue another fragment rerun before the server reports that this one
-    // started. Auto-reruns themselves stay concurrent with other fragments.
+    // started. Auto-reruns themselves stay concurrent with other fragments, so
+    // auto-parent -> auto-child chains still rely on post-commit tree pruning.
     this.hasPendingRerunRequest = isAutoRerun !== true
 
     this.sendBackMsg(

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -308,10 +308,12 @@ export class App extends PureComponent<Props, State> {
   private hasPendingRerunRequest: boolean = false
 
   /**
-   * Fragment IDs whose auto-rerun timers should stay quiescent until the next
-   * committed tree update after an in-flight auto-rerun request.
+   * Fragment subtrees that should be blocked from firing auto-reruns until
+   * their parent auto-rerun request commits. Keyed by the requested fragment
+   * ID (the root of the rerun) so overlapping in-flight requests do not lose
+   * each other's protection when one of them commits first.
    */
-  private readonly blockedAutoRerunFragmentIds = new Set<string>()
+  private readonly pendingAutoRerunBlocks = new Map<string, Set<string>>()
 
   public constructor(props: Props) {
     super(props)
@@ -1640,6 +1642,12 @@ export class App extends PureComponent<Props, State> {
         // leftover elements will be cleared after finished successfully.
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
+        // Capture the fragment IDs that just ran so the setState callback can
+        // release the right auto-rerun blocks without reading `this.state`
+        // (which the lint rules disallow inside setState callbacks). The
+        // value is already correct here because `handleNewSession` set it
+        // earlier in this script run.
+        const committedFragmentIds = this.state.fragmentIdsThisRun
         this.setState(
           ({ scriptRunId, fragmentIdsThisRun, elements }) => ({
             // Apply any pending elements that haven't been applied.
@@ -1652,7 +1660,20 @@ export class App extends PureComponent<Props, State> {
             this.cleanupAfterElementTreeUpdate({
               pruneInactiveAutoReruns: true,
             })
-            this.clearBlockedAutoReruns()
+            // Release auto-rerun blocks scoped to the request(s) that just
+            // committed. For full-app reruns `committedFragmentIds` is empty,
+            // in which case `handleNewSession` has already cleared all blocks
+            // and we still defensively wipe the map. For fragment runs we
+            // only release the blocks belonging to the committed fragment
+            // root(s) so any other in-flight overlapping auto-rerun keeps its
+            // descendant timers blocked until that request also commits.
+            if (committedFragmentIds.length === 0) {
+              this.clearBlockedAutoReruns()
+            } else {
+              committedFragmentIds.forEach(committedFragmentId => {
+                this.releasePendingAutoRerunBlock(committedFragmentId)
+              })
+            }
           }
         )
       }
@@ -1752,7 +1773,28 @@ export class App extends PureComponent<Props, State> {
   }
 
   private clearBlockedAutoReruns(): void {
-    this.blockedAutoRerunFragmentIds.clear()
+    this.pendingAutoRerunBlocks.clear()
+  }
+
+  /**
+   * Release the block scoped to a single committed auto-rerun request without
+   * disturbing other in-flight requests' blocked subtrees.
+   */
+  private releasePendingAutoRerunBlock(fragmentId: string): void {
+    this.pendingAutoRerunBlocks.delete(fragmentId)
+  }
+
+  /**
+   * Returns true if any in-flight auto-rerun request is still blocking the
+   * given fragment ID from queuing additional auto-rerun ticks.
+   */
+  private isAutoRerunBlocked(fragmentId: string): boolean {
+    for (const blockedSet of this.pendingAutoRerunBlocks.values()) {
+      if (blockedSet.has(fragmentId)) {
+        return true
+      }
+    }
+    return false
   }
 
   private resetPendingAutoRerunState(): void {
@@ -1776,7 +1818,7 @@ export class App extends PureComponent<Props, State> {
     if (
       this.state.scriptRunState !== ScriptRunState.NOT_RUNNING ||
       this.hasPendingRerunRequest ||
-      this.blockedAutoRerunFragmentIds.has(fragmentId)
+      this.isAutoRerunBlocked(fragmentId)
     ) {
       return
     }
@@ -1898,16 +1940,25 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Block auto-rerun timers for the in-flight fragment and its live descendants
-   * until the next committed tree update confirms which fragment timers remain.
+   * Block auto-rerun timers for the in-flight fragment and its live
+   * descendants until the next committed tree update confirms which fragment
+   * timers remain. The blocked set is scoped to this rerun request so that
+   * overlapping in-flight requests can release their protection independently
+   * when each commits, instead of one finish wiping every block.
+   *
+   * `getFragmentSubtreeIds` only walks the last committed tree, so any
+   * brand-new auto-rerun child fragment introduced during the in-flight rerun
+   * is not added to the blocked set. In practice that is safe because such a
+   * fragment cannot already have a `run_every` timer scheduled, but callers
+   * should not rely on this set covering the in-flight subtree.
    */
   private markPendingAutoRerun(fragmentId: string): void {
-    // Keep the root fragment blocked even before it appears in the committed
-    // tree, since getFragmentSubtreeIds only sees the last committed snapshot.
-    this.blockedAutoRerunFragmentIds.add(fragmentId)
+    const blockedSet = new Set<string>()
+    blockedSet.add(fragmentId)
     this.state.elements.getFragmentSubtreeIds(fragmentId).forEach(activeId => {
-      this.blockedAutoRerunFragmentIds.add(activeId)
+      blockedSet.add(activeId)
     })
+    this.pendingAutoRerunBlocks.set(fragmentId, blockedSet)
   }
 
   /**
@@ -2207,20 +2258,19 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Sends a message back to the server.
-   *
-   * @returns Whether the message was handed to the connection manager.
+   * Sends a message back to the server. Callers must ensure the connection is
+   * available (e.g. via the `!baseUriParts` early return in
+   * `sendRerunBackMsg`); a missing connection manager is logged and dropped.
    */
-  private readonly sendBackMsg = (msg: BackMsg): boolean => {
+  private readonly sendBackMsg = (msg: BackMsg): void => {
     if (this.connectionManager) {
       LOG.info(msg)
       this.connectionManager.sendMessage(msg)
-      return true
+      return
     }
     LOG.error(
       `Not connected. Cannot send back message: ${msg.type ?? "unknown"}`
     )
-    return false
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -292,19 +292,25 @@ export class App extends PureComponent<Props, State> {
 
   private isInitializingConnectionManager: boolean = true
 
-  // Whether we have received a NewSession message after the latest rerun request.
-  // This is used to ensure that we only increment the message cache run count after
-  // we have received a NewSession message after the latest rerun request.
-  // This will allow us to ignore finished messages from previous script runs.
+  /**
+   * Whether we have received a NewSession message after the latest rerun request.
+   * This is used to ensure that we only increment the message cache run count after
+   * we have received a NewSession message after the latest rerun request.
+   * This allows us to ignore finished messages from previous script runs.
+   */
   private hasReceivedNewSession: boolean = false
 
-  // Whether we've handed a non-auto rerun request to the connection manager
-  // and are still waiting for the server to acknowledge it. This closes the
-  // gap before sessionStatusChanged flips scriptRunState to RUNNING.
+  /**
+   * Whether we've handed a non-auto rerun request to the connection manager
+   * and are still waiting for the server to acknowledge it. This closes the
+   * gap before sessionStatusChanged flips scriptRunState to RUNNING.
+   */
   private hasPendingRerunRequest: boolean = false
 
-  // Fragment IDs whose auto-rerun timers should stay quiescent until the next
-  // committed tree update after an in-flight auto-rerun request.
+  /**
+   * Fragment IDs whose auto-rerun timers should stay quiescent until the next
+   * committed tree update after an in-flight auto-rerun request.
+   */
   private readonly blockedAutoRerunFragmentIds = new Set<string>()
 
   public constructor(props: Props) {
@@ -1222,7 +1228,11 @@ export class App extends PureComponent<Props, State> {
    * @param statusChangeProto a SessionStatus protobuf
    */
   handleSessionStatusChanged = (statusChangeProto: SessionStatus): void => {
-    this.hasPendingRerunRequest = false
+    if (statusChangeProto.scriptIsRunning) {
+      // runOnSave updates also emit sessionStatusChanged while the app stays idle,
+      // so only clear the pending rerun flag once the server reports RUNNING.
+      this.hasPendingRerunRequest = false
+    }
 
     this.setState((prevState: State) => {
       // Determine our new ScriptRunState
@@ -1868,6 +1878,8 @@ export class App extends PureComponent<Props, State> {
    * until the next committed tree update confirms which fragment timers remain.
    */
   private blockPendingAutoRerunSubtree(fragmentId: string): void {
+    // Keep the root fragment blocked even before it appears in the committed
+    // tree, since getFragmentSubtreeIds only sees the last committed snapshot.
     this.blockedAutoRerunFragmentIds.add(fragmentId)
     this.state.elements.getFragmentSubtreeIds(fragmentId).forEach(activeId => {
       this.blockedAutoRerunFragmentIds.add(activeId)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1712,9 +1712,13 @@ export class App extends PureComponent<Props, State> {
    * Remove widget state and fragment timers for items no longer present in the
    * current render tree.
    *
-   * This runs from `setState` callbacks after the new tree has committed, so we
-   * can inspect the live fragment IDs before deciding which fragment-scoped
-   * resources should remain active.
+   * This must only be invoked from a `setState` callback. React runs those
+   * callbacks after the corresponding state update has committed, so reading
+   * `this.state.elements` here is safe even though the surrounding code path
+   * just produced a new value for it: the read returns the freshly committed
+   * tree (rather than racing the in-flight `setState`), which is what lets us
+   * decide accurately which widgets and fragment-scoped timers should remain
+   * active.
    *
    * @param pruneInactiveAutoReruns - When true, remove fragment auto-rerun
    *   timers for fragments that are absent from the committed tree.
@@ -2058,7 +2062,9 @@ export class App extends PureComponent<Props, State> {
     const cachedMessageHashes =
       this.connectionManager?.getCachedMessageHashes() ?? []
 
-    const sent = this.sendBackMsg(
+    // The `!baseUriParts` early return above guarantees `connectionManager`
+    // exists at this point, so `sendBackMsg` will hand the message to it.
+    this.sendBackMsg(
       new BackMsg({
         rerunScript: {
           queryString,
@@ -2073,15 +2079,13 @@ export class App extends PureComponent<Props, State> {
       })
     )
 
-    if (sent) {
-      if (isAutoRerun === true && fragmentId) {
-        this.blockPendingAutoRerunSubtree(fragmentId)
-      } else {
-        // Mark non-auto reruns as pending once the request is handed to the
-        // connection manager so auto-rerun timers do not enqueue another
-        // fragment rerun before the server reports that this one started.
-        this.hasPendingRerunRequest = true
-      }
+    if (isAutoRerun === true && fragmentId) {
+      this.blockPendingAutoRerunSubtree(fragmentId)
+    } else {
+      // Mark non-auto reruns as pending once the request is handed to the
+      // connection manager so auto-rerun timers do not enqueue another
+      // fragment rerun before the server reports that this one started.
+      this.hasPendingRerunRequest = true
     }
     // Reset hasReceivedNewSession to false to ensure that we are aware
     // if a finished message is from a previous script run.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -298,6 +298,11 @@ export class App extends PureComponent<Props, State> {
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
 
+  // Whether we've sent a non-auto rerun request that the server hasn't
+  // acknowledged yet. This closes the gap before sessionStatusChanged flips
+  // scriptRunState to RUNNING, without blocking unrelated auto-rerun fragments.
+  private hasPendingRerunRequest: boolean = false
+
   public constructor(props: Props) {
     super(props)
 
@@ -1213,6 +1218,8 @@ export class App extends PureComponent<Props, State> {
    * @param statusChangeProto a SessionStatus protobuf
    */
   handleSessionStatusChanged = (statusChangeProto: SessionStatus): void => {
+    this.hasPendingRerunRequest = false
+
     this.setState((prevState: State) => {
       // Determine our new ScriptRunState
       let { scriptRunState } = prevState
@@ -1267,6 +1274,7 @@ export class App extends PureComponent<Props, State> {
   handleSessionEvent = (sessionEvent: SessionEvent): void => {
     this.sessionEventDispatcher.handleSessionEventMsg(sessionEvent)
     if (sessionEvent.type === "scriptCompilationException") {
+      this.hasPendingRerunRequest = false
       this.setState({ scriptRunState: ScriptRunState.COMPILATION_ERROR })
       const newDialog: DialogProps = {
         type: DialogType.SCRIPT_COMPILE_ERROR,
@@ -1353,6 +1361,7 @@ export class App extends PureComponent<Props, State> {
     // Set this flag to indicate that we have received a NewSession message
     // after the latest rerun request:
     this.hasReceivedNewSession = true
+    this.hasPendingRerunRequest = false
 
     // First, handle initialization logic. Each NewSession message has
     // initialization data. If this is the _first_ time we're receiving
@@ -1718,6 +1727,13 @@ export class App extends PureComponent<Props, State> {
    * Send the fragment-scoped rerun request when a managed auto-rerun interval fires.
    */
   private readonly handleAutoRerunTick = (fragmentId: string): void => {
+    if (
+      this.state.scriptRunState !== ScriptRunState.NOT_RUNNING ||
+      this.hasPendingRerunRequest
+    ) {
+      return
+    }
+
     this.widgetMgr.sendUpdateWidgetsMessage(fragmentId, true)
   }
 
@@ -2004,6 +2020,11 @@ export class App extends PureComponent<Props, State> {
 
     const cachedMessageHashes =
       this.connectionManager?.getCachedMessageHashes() ?? []
+
+    // Mark non-auto reruns as pending immediately so auto-rerun timers do not
+    // enqueue another fragment rerun before the server reports that this one
+    // started. Auto-reruns themselves stay concurrent with other fragments.
+    this.hasPendingRerunRequest = isAutoRerun !== true
 
     this.sendBackMsg(
       new BackMsg({

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -298,10 +298,14 @@ export class App extends PureComponent<Props, State> {
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
 
-  // Whether we've sent a non-auto rerun request that the server hasn't
-  // acknowledged yet. This closes the gap before sessionStatusChanged flips
-  // scriptRunState to RUNNING, without blocking unrelated auto-rerun fragments.
+  // Whether we've handed a non-auto rerun request to the connection manager
+  // and are still waiting for the server to acknowledge it. This closes the
+  // gap before sessionStatusChanged flips scriptRunState to RUNNING.
   private hasPendingRerunRequest: boolean = false
+
+  // Fragment IDs whose auto-rerun timers should stay quiescent until the next
+  // committed tree update after an in-flight auto-rerun request.
+  private readonly blockedAutoRerunFragmentIds = new Set<string>()
 
   public constructor(props: Props) {
     super(props)
@@ -739,7 +743,7 @@ export class App extends PureComponent<Props, State> {
     // but at this point it should always be set.
     this.connectionManager?.disconnect()
 
-    this.fragmentAutoRerunManager.clearAll()
+    this.cleanupAutoReruns()
 
     this.hostCommunicationMgr.closeHostCommunication()
 
@@ -1275,6 +1279,7 @@ export class App extends PureComponent<Props, State> {
     this.sessionEventDispatcher.handleSessionEventMsg(sessionEvent)
     if (sessionEvent.type === "scriptCompilationException") {
       this.hasPendingRerunRequest = false
+      this.blockedAutoRerunFragmentIds.clear()
       this.setState({ scriptRunState: ScriptRunState.COMPILATION_ERROR })
       const newDialog: DialogProps = {
         type: DialogType.SCRIPT_COMPILE_ERROR,
@@ -1362,6 +1367,7 @@ export class App extends PureComponent<Props, State> {
     // after the latest rerun request:
     this.hasReceivedNewSession = true
     this.hasPendingRerunRequest = false
+    this.blockedAutoRerunFragmentIds.clear()
 
     // First, handle initialization logic. Each NewSession message has
     // initialization data. If this is the _first_ time we're receiving
@@ -1633,6 +1639,7 @@ export class App extends PureComponent<Props, State> {
             this.cleanupAfterElementTreeUpdate({
               pruneInactiveAutoReruns: true,
             })
+            this.blockedAutoRerunFragmentIds.clear()
           }
         )
       }
@@ -1727,12 +1734,15 @@ export class App extends PureComponent<Props, State> {
    * Send the fragment-scoped rerun request when a managed auto-rerun interval fires.
    * `scriptRunState` covers the post-ack window once the server reports RUNNING,
    * and `hasPendingRerunRequest` covers the pre-ack window after a non-auto
-   * rerun is sent but before that status update arrives.
+   * rerun is sent but before that status update arrives. For auto-reruns, we
+   * also block the in-flight fragment subtree so a parent fragment cannot queue
+   * a stale descendant rerun before post-commit pruning runs.
    */
   private readonly handleAutoRerunTick = (fragmentId: string): void => {
     if (
       this.state.scriptRunState !== ScriptRunState.NOT_RUNNING ||
-      this.hasPendingRerunRequest
+      this.hasPendingRerunRequest ||
+      this.blockedAutoRerunFragmentIds.has(fragmentId)
     ) {
       return
     }
@@ -1850,6 +1860,18 @@ export class App extends PureComponent<Props, State> {
    */
   cleanupAutoReruns = (): void => {
     this.fragmentAutoRerunManager.clearAll()
+    this.blockedAutoRerunFragmentIds.clear()
+  }
+
+  /**
+   * Block auto-rerun timers for the in-flight fragment and its live descendants
+   * until the next committed tree update confirms which fragment timers remain.
+   */
+  private blockPendingAutoRerunSubtree(fragmentId: string): void {
+    this.blockedAutoRerunFragmentIds.add(fragmentId)
+    this.state.elements.getFragmentSubtreeIds(fragmentId).forEach(activeId => {
+      this.blockedAutoRerunFragmentIds.add(activeId)
+    })
   }
 
   /**
@@ -2024,13 +2046,7 @@ export class App extends PureComponent<Props, State> {
     const cachedMessageHashes =
       this.connectionManager?.getCachedMessageHashes() ?? []
 
-    // Mark non-auto reruns as pending immediately so auto-rerun timers do not
-    // enqueue another fragment rerun before the server reports that this one
-    // started. Auto-reruns themselves stay concurrent with other fragments, so
-    // auto-parent -> auto-child chains still rely on post-commit tree pruning.
-    this.hasPendingRerunRequest = isAutoRerun !== true
-
-    this.sendBackMsg(
+    const sent = this.sendBackMsg(
       new BackMsg({
         rerunScript: {
           queryString,
@@ -2044,6 +2060,17 @@ export class App extends PureComponent<Props, State> {
         },
       })
     )
+
+    if (sent) {
+      if (isAutoRerun === true && fragmentId) {
+        this.blockPendingAutoRerunSubtree(fragmentId)
+      } else {
+        // Mark non-auto reruns as pending once the request is handed to the
+        // connection manager so auto-rerun timers do not enqueue another
+        // fragment rerun before the server reports that this one started.
+        this.hasPendingRerunRequest = true
+      }
+    }
     // Reset hasReceivedNewSession to false to ensure that we are aware
     // if a finished message is from a previous script run.
     this.hasReceivedNewSession = false
@@ -2145,16 +2172,19 @@ export class App extends PureComponent<Props, State> {
 
   /**
    * Sends a message back to the server.
+   *
+   * @returns Whether the message was handed to the connection manager.
    */
-  private readonly sendBackMsg = (msg: BackMsg): void => {
+  private readonly sendBackMsg = (msg: BackMsg): boolean => {
     if (this.connectionManager) {
       LOG.info(msg)
       this.connectionManager.sendMessage(msg)
-    } else {
-      LOG.error(
-        `Not connected. Cannot send back message: ${msg.type ?? "unknown"}`
-      )
+      return true
     }
+    LOG.error(
+      `Not connected. Cannot send back message: ${msg.type ?? "unknown"}`
+    )
+    return false
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1231,7 +1231,7 @@ export class App extends PureComponent<Props, State> {
     if (statusChangeProto.scriptIsRunning) {
       // runOnSave updates also emit sessionStatusChanged while the app stays idle,
       // so only clear the pending rerun flag once the server reports RUNNING.
-      this.hasPendingRerunRequest = false
+      this.clearPendingRerunRequest()
     }
 
     this.setState((prevState: State) => {
@@ -1288,8 +1288,7 @@ export class App extends PureComponent<Props, State> {
   handleSessionEvent = (sessionEvent: SessionEvent): void => {
     this.sessionEventDispatcher.handleSessionEventMsg(sessionEvent)
     if (sessionEvent.type === "scriptCompilationException") {
-      this.hasPendingRerunRequest = false
-      this.blockedAutoRerunFragmentIds.clear()
+      this.resetPendingAutoRerunState()
       this.setState({ scriptRunState: ScriptRunState.COMPILATION_ERROR })
       const newDialog: DialogProps = {
         type: DialogType.SCRIPT_COMPILE_ERROR,
@@ -1381,8 +1380,7 @@ export class App extends PureComponent<Props, State> {
       // Full-app reruns can deliver a NewSession without a fresh RUNNING status
       // transition if the app was already running. Fragment reruns keep their
       // auto-rerun subtree blocked until the committed tree is updated.
-      this.hasPendingRerunRequest = false
-      this.blockedAutoRerunFragmentIds.clear()
+      this.resetPendingAutoRerunState()
     }
 
     // First, handle initialization logic. Each NewSession message has
@@ -1654,7 +1652,7 @@ export class App extends PureComponent<Props, State> {
             this.cleanupAfterElementTreeUpdate({
               pruneInactiveAutoReruns: true,
             })
-            this.blockedAutoRerunFragmentIds.clear()
+            this.clearBlockedAutoReruns()
           }
         )
       }
@@ -1747,6 +1745,23 @@ export class App extends PureComponent<Props, State> {
     if (pruneInactiveAutoReruns) {
       this.fragmentAutoRerunManager.pruneInactive(fragmentIds)
     }
+  }
+
+  private clearPendingRerunRequest(): void {
+    this.hasPendingRerunRequest = false
+  }
+
+  private clearBlockedAutoReruns(): void {
+    this.blockedAutoRerunFragmentIds.clear()
+  }
+
+  private resetPendingAutoRerunState(): void {
+    this.clearPendingRerunRequest()
+    this.clearBlockedAutoReruns()
+  }
+
+  private markPendingRerunRequest(): void {
+    this.hasPendingRerunRequest = true
   }
 
   /**
@@ -1879,14 +1894,14 @@ export class App extends PureComponent<Props, State> {
    */
   cleanupAutoReruns = (): void => {
     this.fragmentAutoRerunManager.clearAll()
-    this.blockedAutoRerunFragmentIds.clear()
+    this.clearBlockedAutoReruns()
   }
 
   /**
    * Block auto-rerun timers for the in-flight fragment and its live descendants
    * until the next committed tree update confirms which fragment timers remain.
    */
-  private blockPendingAutoRerunSubtree(fragmentId: string): void {
+  private markPendingAutoRerun(fragmentId: string): void {
     // Keep the root fragment blocked even before it appears in the committed
     // tree, since getFragmentSubtreeIds only sees the last committed snapshot.
     this.blockedAutoRerunFragmentIds.add(fragmentId)
@@ -2085,12 +2100,12 @@ export class App extends PureComponent<Props, State> {
     )
 
     if (isAutoRerun === true && fragmentId) {
-      this.blockPendingAutoRerunSubtree(fragmentId)
+      this.markPendingAutoRerun(fragmentId)
     } else {
       // Mark non-auto reruns as pending once the request is handed to the
       // connection manager so auto-rerun timers do not enqueue another
       // fragment rerun before the server reports that this one started.
-      this.hasPendingRerunRequest = true
+      this.markPendingRerunRequest()
     }
     // Reset hasReceivedNewSession to false to ensure that we are aware
     // if a finished message is from a previous script run.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1676,6 +1676,22 @@ export class App extends PureComponent<Props, State> {
             }
           }
         )
+      } else if (
+        status === ForwardMsg.ScriptFinishedStatus.FINISHED_EARLY_FOR_RERUN
+      ) {
+        // The script finished early because another rerun superseded it. The
+        // success path below only releases blocks for fragments that actually
+        // commit, so without this we would leave the interrupted fragment's
+        // entry in `pendingAutoRerunBlocks` indefinitely (until the next
+        // full-app rerun), silently dropping all of its future auto-rerun
+        // ticks. Release the block(s) for the interrupted fragment(s) here so
+        // their timers can resume once the superseding run finishes; the
+        // `scriptRunState` and `hasPendingRerunRequest` guards in
+        // `handleAutoRerunTick` still suppress ticks while another rerun is
+        // in flight.
+        this.state.fragmentIdsThisRun.forEach(interruptedFragmentId => {
+          this.releasePendingAutoRerunBlock(interruptedFragmentId)
+        })
       }
 
       // Tell the ConnectionManager to increment the message cache run
@@ -1932,11 +1948,18 @@ export class App extends PureComponent<Props, State> {
   /**
    * Clear all auto reruns that were registered. This should be called whenever
    * the content of the auto rerun function might not be valid anymore and could
-   * lead to issues, e.g. when a new full app-rerun session is started or the active page changed.
+   * lead to issues, e.g. when a new full app-rerun session is started or the
+   * active page changed.
+   *
+   * Also fully resets the pending auto-rerun guard (timers, blocked-subtree map,
+   * and the `hasPendingRerunRequest` flag) so the helper's effect matches its
+   * name. Any caller invoking `cleanupAutoReruns` expects the auto-rerun
+   * subsystem to start from a clean slate, so leaving `hasPendingRerunRequest`
+   * set could silently suppress the next batch of fragment ticks.
    */
   cleanupAutoReruns = (): void => {
     this.fragmentAutoRerunManager.clearAll()
-    this.clearBlockedAutoReruns()
+    this.resetPendingAutoRerunState()
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -38,6 +38,7 @@ import {
 } from "@streamlit/app/src/components/StreamlitDialog/StreamlitDialog"
 import { UserSettings } from "@streamlit/app/src/components/StreamlitDialog/UserSettings"
 import ToolbarActions from "@streamlit/app/src/components/ToolbarActions/ToolbarActions"
+import { FragmentAutoRerunManager } from "@streamlit/app/src/FragmentAutoRerunManager"
 import withScreencast, {
   ScreenCastHOC,
 } from "@streamlit/app/src/hocs/withScreencast/withScreencast"
@@ -217,7 +218,6 @@ interface State {
   deployedAppMetadata: DeployedAppMetadata
   libConfig: LibConfig
   appConfig: AppConfig
-  autoReruns: NodeJS.Timeout[]
   inputsDisabled: boolean
   scriptChangedOnDisk: boolean
 }
@@ -261,6 +261,12 @@ export class App extends PureComponent<Props, State> {
   private connectionManager: ConnectionManager | null
 
   private readonly widgetMgr: WidgetStateManager
+
+  /**
+   * Tracks fragment `run_every` timers outside React state so duplicate or
+   * stale intervals can be replaced and pruned without triggering rerenders.
+   */
+  private readonly fragmentAutoRerunManager: FragmentAutoRerunManager
 
   private readonly hostCommunicationMgr: HostCommunicationManager
 
@@ -358,7 +364,6 @@ export class App extends PureComponent<Props, State> {
       deployedAppMetadata: {},
       libConfig: {},
       appConfig: {},
-      autoReruns: [],
       inputsDisabled: false,
       navigationPosition: Navigation.Position.SIDEBAR,
       scriptChangedOnDisk: false,
@@ -375,6 +380,10 @@ export class App extends PureComponent<Props, State> {
     this.widgetMgr.setQueryParamsChangeHandler(
       this.handleQueryParamsFromWidget
     )
+
+    this.fragmentAutoRerunManager = new FragmentAutoRerunManager({
+      onTick: this.handleAutoRerunTick,
+    })
 
     this.hostCommunicationMgr = new HostCommunicationManager({
       streamlitExecutionStartedAt: props.streamlitExecutionStartedAt,
@@ -725,6 +734,8 @@ export class App extends PureComponent<Props, State> {
     // but at this point it should always be set.
     this.connectionManager?.disconnect()
 
+    this.fragmentAutoRerunManager.clearAll()
+
     this.hostCommunicationMgr.closeHostCommunication()
 
     window.removeEventListener("popstate", this.onHistoryChange, false)
@@ -879,7 +890,7 @@ export class App extends PureComponent<Props, State> {
         // Script is using fragments (fragments in last run or
         // fragment auto-reruns configured):
         this.state.fragmentIdsThisRun.length > 0 ||
-        this.state.autoReruns.length > 0
+        this.fragmentAutoRerunManager.hasActiveAutoReruns()
       ) {
         LOG.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
@@ -1184,16 +1195,17 @@ export class App extends PureComponent<Props, State> {
     })
   }
 
+  /**
+   * Register or refresh the server-configured `run_every` interval for a fragment.
+   *
+   * Re-scheduling the same fragment replaces its previous timer so reconnects
+   * and reruns do not leave duplicate callbacks behind.
+   */
   handleAutoRerun = (autoRerun: AutoRerun): void => {
-    const intervalId = setInterval(() => {
-      this.widgetMgr.sendUpdateWidgetsMessage(autoRerun.fragmentId, true)
-    }, autoRerun.interval * 1000)
-
-    this.setState((prevState: State) => {
-      return {
-        autoReruns: [...prevState.autoReruns, intervalId],
-      }
-    })
+    this.fragmentAutoRerunManager.schedule(
+      autoRerun.fragmentId,
+      autoRerun.interval
+    )
   }
 
   /**
@@ -1601,17 +1613,17 @@ export class App extends PureComponent<Props, State> {
         // We also don't do this if our script had a compilation error and didn't
         // finish successfully.
         this.setState(
-          ({ scriptRunId, fragmentIdsThisRun, elements }) => {
-            return {
-              // Apply any pending elements that haven't been applied.
-              elements: elements.clearStaleNodes(
-                scriptRunId,
-                fragmentIdsThisRun
-              ),
-            }
-          },
+          ({ scriptRunId, fragmentIdsThisRun, elements }) => ({
+            // Apply any pending elements that haven't been applied.
+            elements: elements.clearStaleNodes(
+              scriptRunId,
+              fragmentIdsThisRun
+            ),
+          }),
           () => {
-            this.removeInactiveWidgetState()
+            this.cleanupAfterElementTreeUpdate({
+              pruneInactiveAutoReruns: true,
+            })
           }
         )
       }
@@ -1665,27 +1677,48 @@ export class App extends PureComponent<Props, State> {
         }
       },
       () => {
-        this.removeInactiveWidgetState()
+        this.cleanupAfterElementTreeUpdate()
       }
     )
   }
 
   /**
-   * Remove widget and element state for items no longer present in the
-   * current render tree. Called from setState callbacks where this.state
-   * access is a false positive (the callback runs after the update is
-   * committed). Converting App to a functional component would let us
-   * use useEffect and remove this suppress entirely.
+   * Remove widget state and fragment timers for items no longer present in the
+   * current render tree.
+   *
+   * This runs from `setState` callbacks after the new tree has committed, so we
+   * can inspect the live fragment IDs before deciding which fragment-scoped
+   * resources should remain active.
+   *
+   * @param pruneInactiveAutoReruns - When true, remove fragment auto-rerun
+   *   timers for fragments that are absent from the committed tree.
    */
-  private removeInactiveWidgetState(): void {
-    const { elements, blockIds } = this.state.elements.getActiveIds()
-    const activeIds = new Set([
+  private cleanupAfterElementTreeUpdate({
+    pruneInactiveAutoReruns = false,
+  }: {
+    pruneInactiveAutoReruns?: boolean
+  } = {}): void {
+    const { elements, blockIds, fragmentIds } =
+      this.state.elements.getActiveIds()
+    const activeWidgetIds = new Set([
       ...Array.from(elements)
         .map(element => getElementId(element))
         .filter(notUndefined),
       ...blockIds,
     ])
-    this.widgetMgr.removeInactive(activeIds)
+
+    this.widgetMgr.removeInactive(activeWidgetIds)
+
+    if (pruneInactiveAutoReruns) {
+      this.fragmentAutoRerunManager.pruneInactive(fragmentIds)
+    }
+  }
+
+  /**
+   * Send the fragment-scoped rerun request when a managed auto-rerun interval fires.
+   */
+  private readonly handleAutoRerunTick = (fragmentId: string): void => {
+    this.widgetMgr.sendUpdateWidgetsMessage(fragmentId, true)
   }
 
   /**
@@ -1797,10 +1830,7 @@ export class App extends PureComponent<Props, State> {
    * lead to issues, e.g. when a new full app-rerun session is started or the active page changed.
    */
   cleanupAutoReruns = (): void => {
-    this.state.autoReruns.forEach((value: NodeJS.Timeout) => {
-      clearInterval(value)
-    })
-    this.setState({ autoReruns: [] })
+    this.fragmentAutoRerunManager.clearAll()
   }
 
   /**

--- a/frontend/app/src/FragmentAutoRerunManager.test.ts
+++ b/frontend/app/src/FragmentAutoRerunManager.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FragmentAutoRerunManager } from "./FragmentAutoRerunManager"
+
+describe("FragmentAutoRerunManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(global, "clearInterval")
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it("schedules fragment auto reruns", () => {
+    const onTick = vi.fn()
+    const manager = new FragmentAutoRerunManager({ onTick })
+
+    manager.schedule("fragment-a", 1)
+
+    expect(manager.hasActiveAutoReruns()).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).toHaveBeenCalledWith("fragment-a")
+  })
+
+  it("replaces the existing timer for the same fragment id", () => {
+    const onTick = vi.fn()
+    const manager = new FragmentAutoRerunManager({ onTick })
+
+    manager.schedule("fragment-a", 1)
+    manager.schedule("fragment-a", 2)
+
+    expect(clearInterval).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+    expect(onTick).toHaveBeenCalledWith("fragment-a")
+  })
+
+  it("prunes timers whose fragment ids are no longer active", () => {
+    const onTick = vi.fn()
+    const manager = new FragmentAutoRerunManager({ onTick })
+
+    manager.schedule("live-fragment", 1)
+    manager.schedule("stale-fragment", 1)
+
+    manager.pruneInactive(new Set(["live-fragment"]))
+
+    expect(clearInterval).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+    expect(onTick).toHaveBeenCalledWith("live-fragment")
+  })
+
+  it("clears all timers on cleanup", () => {
+    const onTick = vi.fn()
+    const manager = new FragmentAutoRerunManager({ onTick })
+
+    manager.schedule("fragment-a", 1)
+    manager.schedule("fragment-b", 1)
+
+    manager.clearAll()
+
+    expect(clearInterval).toHaveBeenCalledTimes(2)
+    expect(manager.hasActiveAutoReruns()).toBe(false)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/src/FragmentAutoRerunManager.test.ts
+++ b/frontend/app/src/FragmentAutoRerunManager.test.ts
@@ -61,6 +61,42 @@ describe("FragmentAutoRerunManager", () => {
     expect(onTick).toHaveBeenCalledWith("fragment-a")
   })
 
+  it("clears the timer for a single fragment id", () => {
+    const onTick = vi.fn()
+    const manager = new FragmentAutoRerunManager({ onTick })
+
+    manager.schedule("fragment-a", 1)
+    manager.schedule("fragment-b", 1)
+
+    manager.clear("fragment-a")
+
+    expect(clearInterval).toHaveBeenCalledTimes(1)
+    expect(manager.hasActiveAutoReruns()).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+    expect(onTick).toHaveBeenCalledWith("fragment-b")
+    expect(onTick).not.toHaveBeenCalledWith("fragment-a")
+  })
+
+  it("is a no-op when clearing an unknown fragment id", () => {
+    const onTick = vi.fn()
+    const manager = new FragmentAutoRerunManager({ onTick })
+
+    manager.schedule("fragment-a", 1)
+
+    manager.clear("not-a-real-fragment")
+
+    expect(clearInterval).not.toHaveBeenCalled()
+    expect(manager.hasActiveAutoReruns()).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+    expect(onTick).toHaveBeenCalledWith("fragment-a")
+  })
+
   it("prunes timers whose fragment ids are no longer active", () => {
     const onTick = vi.fn()
     const manager = new FragmentAutoRerunManager({ onTick })

--- a/frontend/app/src/FragmentAutoRerunManager.ts
+++ b/frontend/app/src/FragmentAutoRerunManager.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type AutoRerunTimer = ReturnType<typeof setInterval>
+
+interface FragmentAutoRerunManagerProps {
+  /** Called whenever a fragment's managed `run_every` timer fires. */
+  onTick: (fragmentId: string) => void
+}
+
+/**
+ * Owns the `run_every` timers for fragment-scoped auto-reruns.
+ *
+ * Each fragment can have at most one active timer. Callers can also prune
+ * timers after a render-tree update so stale fragments stop scheduling reruns
+ * once they disappear from the committed app state.
+ */
+export class FragmentAutoRerunManager {
+  private readonly timers = new Map<string, AutoRerunTimer>()
+
+  private readonly onTick: (fragmentId: string) => void
+
+  public constructor({ onTick }: FragmentAutoRerunManagerProps) {
+    this.onTick = onTick
+  }
+
+  /**
+   * Start or replace the auto-rerun timer for a fragment.
+   *
+   * Re-registering the same fragment clears its previous interval first so only
+   * the latest server configuration stays active.
+   */
+  public schedule(fragmentId: string, intervalSeconds: number): void {
+    this.clear(fragmentId)
+
+    this.timers.set(
+      fragmentId,
+      setInterval(() => {
+        this.onTick(fragmentId)
+      }, intervalSeconds * 1000)
+    )
+  }
+
+  /** Stop the auto-rerun timer for a single fragment, if one exists. */
+  public clear(fragmentId: string): void {
+    const timer = this.timers.get(fragmentId)
+
+    if (timer === undefined) {
+      return
+    }
+
+    clearInterval(timer)
+    this.timers.delete(fragmentId)
+  }
+
+  /** Stop every managed auto-rerun timer. */
+  public clearAll(): void {
+    for (const timer of this.timers.values()) {
+      clearInterval(timer)
+    }
+    this.timers.clear()
+  }
+
+  /**
+   * Remove timers for fragments that are no longer present in the committed tree.
+   */
+  public pruneInactive(activeFragmentIds: ReadonlySet<string>): void {
+    for (const fragmentId of Array.from(this.timers.keys())) {
+      if (!activeFragmentIds.has(fragmentId)) {
+        this.clear(fragmentId)
+      }
+    }
+  }
+
+  /** Return whether any fragment-scoped auto-rerun timers are still active. */
+  public hasActiveAutoReruns(): boolean {
+    return this.timers.size > 0
+  }
+}

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -1585,6 +1585,62 @@ describe("AppRoot", () => {
     })
   })
 
+  describe("AppRoot.getFragmentSubtreeIds", () => {
+    it("returns the fragment ids rendered inside a fragment subtree", () => {
+      const rootWithNestedFragments = ROOT.applyDelta(
+        "current_run",
+        makeProto(DeltaProto, {
+          addBlock: { allowEmpty: true },
+          fragmentId: "parent_fragment",
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      )
+        .applyDelta(
+          "current_run",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "parent child" } },
+            fragmentId: "parent_fragment",
+          }),
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+        .applyDelta(
+          "current_run",
+          makeProto(DeltaProto, {
+            addBlock: { allowEmpty: true },
+            fragmentId: "nested_fragment",
+          }),
+          forwardMsgMetadata([0, 1, 1, 1])
+        )
+        .applyDelta(
+          "current_run",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "nested child" } },
+            fragmentId: "nested_fragment",
+          }),
+          forwardMsgMetadata([0, 1, 1, 1, 0])
+        )
+        .applyDelta(
+          "current_run",
+          makeProto(DeltaProto, {
+            addBlock: { allowEmpty: true },
+            fragmentId: "other_fragment",
+          }),
+          forwardMsgMetadata([0, 1, 2])
+        )
+
+      expect(
+        rootWithNestedFragments.getFragmentSubtreeIds("parent_fragment")
+      ).toEqual(new Set(["parent_fragment", "nested_fragment"]))
+      expect(
+        rootWithNestedFragments.getFragmentSubtreeIds("other_fragment")
+      ).toEqual(new Set(["other_fragment"]))
+    })
+
+    it("returns an empty set when the fragment is not in the tree", () => {
+      expect(ROOT.getFragmentSubtreeIds("missing_fragment")).toEqual(new Set())
+    })
+  })
+
   describe("AppRoot.debug", () => {
     it("prints labeled child sections with tree output", () => {
       const out = ROOT.debug()

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -1508,6 +1508,83 @@ describe("AppRoot", () => {
     })
   })
 
+  describe("AppRoot.getActiveIds", () => {
+    it("returns fragment ids alongside elements and block ids", () => {
+      const rootWithActiveIds = ROOT.applyDelta(
+        "current_run",
+        makeProto(DeltaProto, {
+          addBlock: {
+            id: "$$ID-abc123-fragment-container",
+            allowEmpty: true,
+          },
+          fragmentId: "block_fragment",
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      ).applyDelta(
+        "current_run",
+        makeProto(DeltaProto, {
+          newElement: { text: { body: "fragment child" } },
+          fragmentId: "element_fragment",
+        }),
+        forwardMsgMetadata([0, 1, 1, 0])
+      )
+
+      const { elements, blockIds, fragmentIds } =
+        rootWithActiveIds.getActiveIds()
+      const elementBodies = Array.from(elements).map(
+        element => element.text?.body
+      )
+
+      expect(elementBodies).toContain("fragment child")
+      expect(blockIds).toEqual(new Set(["$$ID-abc123-fragment-container"]))
+      expect(fragmentIds).toEqual(
+        new Set(["block_fragment", "element_fragment"])
+      )
+      expect(fragmentIds.has("missing_fragment")).toBe(false)
+    })
+
+    it("returns fragment ids from the post-prune live tree", () => {
+      const rootWithStaleNestedFragment = ROOT.applyDelta(
+        "current_run",
+        makeProto(DeltaProto, {
+          addBlock: { allowEmpty: true },
+          fragmentId: "live_fragment",
+        }),
+        forwardMsgMetadata([0, 1, 1])
+      )
+        .applyDelta(
+          "old_run",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "stale child" } },
+            fragmentId: "stale_nested_fragment",
+          }),
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+        .applyDelta(
+          "current_run",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "live child" } },
+            fragmentId: "live_fragment",
+          }),
+          forwardMsgMetadata([0, 1, 1, 1])
+        )
+
+      const prunedRoot = rootWithStaleNestedFragment.clearStaleNodes(
+        "current_run",
+        ["live_fragment"]
+      )
+      const { elements, fragmentIds } = prunedRoot.getActiveIds()
+      const elementBodies = Array.from(elements).map(
+        element => element.text?.body
+      )
+
+      expect(fragmentIds).toEqual(new Set(["live_fragment"]))
+      expect(fragmentIds.has("stale_nested_fragment")).toBe(false)
+      expect(elementBodies).toContain("live child")
+      expect(elementBodies).not.toContain("stale child")
+    })
+  })
+
   describe("AppRoot.debug", () => {
     it("prints labeled child sections with tree output", () => {
       const out = ROOT.debug()

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -420,6 +420,43 @@ export class AppRoot {
     }
   }
 
+  /**
+   * Return the fragment IDs currently rendered inside `fragmentId`'s subtree.
+   * This includes `fragmentId` itself when it is present in the committed tree,
+   * plus any nested fragment scopes rendered under it.
+   */
+  public getFragmentSubtreeIds(fragmentId: string): Set<string> {
+    const fragmentIds = new Set<string>()
+
+    const visitNode = (node: AppNode, isInTargetSubtree = false): void => {
+      const inTargetSubtree =
+        isInTargetSubtree || node.fragmentId === fragmentId
+
+      if (inTargetSubtree && node.fragmentId) {
+        fragmentIds.add(node.fragmentId)
+      }
+
+      if (node instanceof BlockNode) {
+        node.children.forEach(child => visitNode(child, inTargetSubtree))
+      } else if (node instanceof TransientNode) {
+        node.transientNodes.forEach(element =>
+          visitNode(element, inTargetSubtree)
+        )
+
+        if (node.anchor) {
+          visitNode(node.anchor, inTargetSubtree)
+        }
+      }
+    }
+
+    visitNode(this.main)
+    visitNode(this.sidebar)
+    visitNode(this.event)
+    visitNode(this.bottom)
+
+    return fragmentIds
+  }
+
   private addElement(
     deltaPath: number[],
     scriptRunId: string,

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -35,6 +35,7 @@ import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
 import { TransientNode } from "./TransientNode"
+import type { AppNodeVisitor } from "./visitors/AppNodeVisitor.interface"
 import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
 import { ClearTransientNodesVisitor } from "./visitors/ClearTransientNodesVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
@@ -74,6 +75,60 @@ interface LogoMetadata {
 }
 interface AppLogo extends LogoMetadata {
   logo: Logo
+}
+
+/**
+ * Collect all fragment IDs rendered inside a target fragment's committed subtree.
+ */
+class FragmentSubtreeIdsVisitor implements AppNodeVisitor<Set<string>> {
+  public readonly fragmentIds = new Set<string>()
+
+  private subtreeDepth = 0
+
+  public constructor(private readonly targetFragmentId: string) {}
+
+  public visitElementNode(node: ElementNode): Set<string> {
+    if (
+      node.fragmentId &&
+      (this.subtreeDepth > 0 || node.fragmentId === this.targetFragmentId)
+    ) {
+      this.fragmentIds.add(node.fragmentId)
+    }
+
+    return this.fragmentIds
+  }
+
+  public visitBlockNode(node: BlockNode): Set<string> {
+    const entersTargetSubtree = node.fragmentId === this.targetFragmentId
+    const isInTargetSubtree = this.subtreeDepth > 0 || entersTargetSubtree
+
+    if (isInTargetSubtree && node.fragmentId) {
+      this.fragmentIds.add(node.fragmentId)
+    }
+
+    if (entersTargetSubtree) {
+      this.subtreeDepth += 1
+    }
+
+    for (const child of node.children) {
+      child.accept(this)
+    }
+
+    if (entersTargetSubtree) {
+      this.subtreeDepth -= 1
+    }
+
+    return this.fragmentIds
+  }
+
+  public visitTransientNode(node: TransientNode): Set<string> {
+    node.transientNodes.forEach(element => {
+      element.accept(this)
+    })
+    node.anchor?.accept(this)
+
+    return this.fragmentIds
+  }
 }
 
 /**
@@ -392,6 +447,10 @@ export class AppRoot {
     return this.getActiveIds().elements
   }
 
+  private visitCommittedTree<T>(visitor: AppNodeVisitor<T>): T {
+    return this.root.accept(visitor)
+  }
+
   /**
    * Return all active elements, block IDs, and fragment IDs in the tree.
    * Block IDs are collected from blocks that have a stable identity
@@ -407,11 +466,7 @@ export class AppRoot {
     fragmentIds: Set<string>
   } {
     const visitor = new ElementsSetVisitor()
-
-    this.main.accept(visitor)
-    this.sidebar.accept(visitor)
-    this.event.accept(visitor)
-    this.bottom.accept(visitor)
+    this.visitCommittedTree(visitor)
 
     return {
       elements: visitor.elements,
@@ -426,35 +481,10 @@ export class AppRoot {
    * plus any nested fragment scopes rendered under it.
    */
   public getFragmentSubtreeIds(fragmentId: string): Set<string> {
-    const fragmentIds = new Set<string>()
+    const visitor = new FragmentSubtreeIdsVisitor(fragmentId)
+    this.visitCommittedTree(visitor)
 
-    const visitNode = (node: AppNode, isInTargetSubtree = false): void => {
-      const inTargetSubtree =
-        isInTargetSubtree || node.fragmentId === fragmentId
-
-      if (inTargetSubtree && node.fragmentId) {
-        fragmentIds.add(node.fragmentId)
-      }
-
-      if (node instanceof BlockNode) {
-        node.children.forEach(child => visitNode(child, inTargetSubtree))
-      } else if (node instanceof TransientNode) {
-        node.transientNodes.forEach(element =>
-          visitNode(element, inTargetSubtree)
-        )
-
-        if (node.anchor) {
-          visitNode(node.anchor, inTargetSubtree)
-        }
-      }
-    }
-
-    visitNode(this.main)
-    visitNode(this.sidebar)
-    visitNode(this.event)
-    visitNode(this.bottom)
-
-    return fragmentIds
+    return visitor.fragmentIds
   }
 
   private addElement(

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -393,14 +393,18 @@ export class AppRoot {
   }
 
   /**
-   * Return all active element IDs and block IDs in the tree.
+   * Return all active elements, block IDs, and fragment IDs in the tree.
    * Block IDs are collected from blocks that have a stable identity
    * (e.g. keyed layout containers), and are needed to prevent
    * elementStates entries from being garbage-collected.
+   * Fragment IDs represent the fragment scopes that are still reachable in the
+   * committed tree, and let callers prune fragment-scoped resources such as
+   * auto-rerun timers.
    */
   public getActiveIds(): {
     elements: Set<Element>
     blockIds: Set<string>
+    fragmentIds: Set<string>
   } {
     const visitor = new ElementsSetVisitor()
 
@@ -409,7 +413,11 @@ export class AppRoot {
     this.event.accept(visitor)
     this.bottom.accept(visitor)
 
-    return { elements: visitor.elements, blockIds: visitor.blockIds }
+    return {
+      elements: visitor.elements,
+      blockIds: visitor.blockIds,
+      fragmentIds: visitor.fragmentIds,
+    }
   }
 
   private addElement(

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -121,6 +121,15 @@ class FragmentSubtreeIdsVisitor implements AppNodeVisitor<Set<string>> {
     return this.fragmentIds
   }
 
+  /**
+   * Forward the traversal into both transient children and the anchor without
+   * touching `subtreeDepth`. Fragments are wrapped in `BlockNode`s in the
+   * current tree shape, so the anchor itself is never the target fragment and
+   * `visitBlockNode` is responsible for entering the matching subtree. If the
+   * tree shape changes such that a `TransientNode` could be anchored on the
+   * target fragment directly, this visitor would need its own depth bookkeeping
+   * here to capture nested fragments under the anchor.
+   */
   public visitTransientNode(node: TransientNode): Set<string> {
     node.transientNodes.forEach(element => {
       element.accept(this)

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
-import { block, blockWithId, text } from "~lib/render-tree/test-utils"
+import { ForwardMsgMetadata } from "@streamlit/protobuf"
+
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+import {
+  block,
+  blockWithId,
+  FAKE_SCRIPT_HASH,
+  text,
+} from "~lib/render-tree/test-utils"
 import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { ElementsSetVisitor } from "./ElementsSetVisitor"
@@ -229,6 +238,63 @@ describe("ElementsSetVisitor", () => {
       expect(visitor.elements.has(child.element)).toBe(true)
       expect(visitor.blockIds.size).toBe(1)
       expect(visitor.blockIds.has("$$ID-abc-mykey")).toBe(true)
+    })
+  })
+
+  describe("fragmentIds collection", () => {
+    it("collects fragment ids from nested block and element nodes", () => {
+      const fragmentElement = new ElementNode(
+        text("fragment child").element,
+        ForwardMsgMetadata.create(),
+        "run",
+        FAKE_SCRIPT_HASH,
+        "element-fragment"
+      )
+      const fragmentBlock = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [fragmentElement],
+        undefined,
+        "run",
+        "block-fragment"
+      )
+      const stableBlock = blockWithId("$$ID-abc-mykey", [fragmentBlock])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(stableBlock)
+
+      expect(visitor.fragmentIds).toEqual(
+        new Set(["block-fragment", "element-fragment"])
+      )
+      expect(visitor.fragmentIds.has("missing-fragment")).toBe(false)
+      expect(visitor.blockIds).toEqual(new Set(["$$ID-abc-mykey"]))
+      expect(visitor.elements).toEqual(new Set([fragmentElement.element]))
+    })
+
+    it("collects fragment ids from transient nodes via elements and anchor", () => {
+      const transientElement = new ElementNode(
+        text("transient child").element,
+        ForwardMsgMetadata.create(),
+        "run",
+        FAKE_SCRIPT_HASH,
+        "transient-fragment"
+      )
+      const anchor = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [],
+        undefined,
+        "run",
+        "anchor-fragment"
+      )
+      const transient = new TransientNode("run", anchor, [transientElement], 1)
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitTransientNode(transient)
+
+      expect(visitor.fragmentIds).toEqual(
+        new Set(["anchor-fragment", "transient-fragment"])
+      )
+      expect(visitor.elements).toEqual(new Set([transientElement.element]))
+      expect(visitor.blockIds.size).toBe(0)
     })
   })
 

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
@@ -23,13 +23,15 @@ import { TransientNode } from "~lib/render-tree/TransientNode"
 import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
 
 /**
- * A visitor that collects all Elements and stable block IDs from an AppNode
- * tree.
+ * A visitor that collects all Elements, stable block IDs, and fragment IDs
+ * from an AppNode tree.
  *
  * - `elements`: all Element protos found in ElementNodes.
  * - `blockIds`: IDs from BlockNodes that have a stable identity (e.g. keyed
  *   layout containers). These are used to prevent `elementStates` entries
  *   from being garbage-collected.
+ * - `fragmentIds`: fragment IDs from live BlockNodes and ElementNodes. These
+ *   are used to determine which fragment-scoped resources should remain active.
  *
  * This visitor uses mutable Sets for performance, accumulating results
  * as it traverses the tree. The visitor methods return the element Set
@@ -42,19 +44,25 @@ import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.in
  * rootNode.accept(visitor)
  * const elements = visitor.elements
  * const blockIds = visitor.blockIds
+ * const fragmentIds = visitor.fragmentIds
  * ```
  */
 export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
   public readonly elements: Set<Element>
   public readonly blockIds: Set<string>
+  public readonly fragmentIds: Set<string>
 
   constructor() {
     this.elements = new Set<Element>()
     this.blockIds = new Set<string>()
+    this.fragmentIds = new Set<string>()
   }
 
   visitElementNode(node: ElementNode): Set<Element> {
     this.elements.add(node.element)
+    if (node.fragmentId) {
+      this.fragmentIds.add(node.fragmentId)
+    }
     return this.elements
   }
 
@@ -62,12 +70,19 @@ export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
     if (node.deltaBlock?.id) {
       this.blockIds.add(node.deltaBlock.id)
     }
+    if (node.fragmentId) {
+      this.fragmentIds.add(node.fragmentId)
+    }
     for (const child of node.children) {
       child.accept(this)
     }
     return this.elements
   }
 
+  /**
+   * Traverse both transient payload elements and the transient anchor so
+   * fragment IDs attached to either side remain visible to callers.
+   */
   visitTransientNode(node: TransientNode): Set<Element> {
     // Add all transient elements to the set
     node.transientNodes.forEach(element => {


### PR DESCRIPTION
This is one approach, but I have a simpler backend-focused approach here: https://github.com/streamlit/streamlit/pull/15130

## Describe your changes

- Move fragment `run_every` timer bookkeeping into a keyed `FragmentAutoRerunManager` so each fragment keeps at most one active auto-rerun timer.
- Prune auto-rerun timers for fragments that disappear from the committed render tree by tracking active fragment IDs in `AppRoot` / `ElementsSetVisitor`.
- Guard the pending-rerun windows so stale child fragment auto-reruns do not fire while parent or full reruns are still in flight.
- Add unit and e2e regression coverage for the nested `run_every` fragment case that previously crashed with a stale delta path.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/15084

## Testing Plan

- ✅ Unit Tests (JS and/or Python)
- ✅ E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.