### PR TITLE
[refactor] Optimize `st.dataframe` row selection remap

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -403,19 +403,20 @@ function DataFrame({
 
     const currentGetOriginalIndex = getOriginalIndexRef.current
 
-    // Build a Map from original index to display index for O(1) lookups.
-    // This converts the O(n²) nested loop into O(n) time complexity.
-    const originalToDisplayMap = new Map<number, number>()
-    for (let displayIdx = 0; displayIdx < originalNumRows; displayIdx++) {
-      originalToDisplayMap.set(currentGetOriginalIndex(displayIdx), displayIdx)
-    }
-
-    // Find the new display indices for the original data rows
+    // Use a Set for O(1) lookup of target original indices.
+    // Time: O(n) single pass through display rows. Space: O(k) where k = selected rows.
+    // Currently k=1 (single-row-required mode), but this scales if multi-row is added.
+    const targetOriginalIndices = new Set(originalRowIndices)
     const newDisplayIndices: number[] = []
-    for (const origIdx of originalRowIndices) {
-      const displayIdx = originalToDisplayMap.get(origIdx)
-      if (displayIdx !== undefined) {
+
+    for (let displayIdx = 0; displayIdx < originalNumRows; displayIdx++) {
+      const origIdx = currentGetOriginalIndex(displayIdx)
+      if (targetOriginalIndices.has(origIdx)) {
         newDisplayIndices.push(displayIdx)
+        // Early exit when all targets found
+        if (newDisplayIndices.length === targetOriginalIndices.size) {
+          break
+        }
       }
     }
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -403,14 +403,19 @@ function DataFrame({
 
     const currentGetOriginalIndex = getOriginalIndexRef.current
 
+    // Build a Map from original index to display index for O(1) lookups.
+    // This converts the O(n²) nested loop into O(n) time complexity.
+    const originalToDisplayMap = new Map<number, number>()
+    for (let displayIdx = 0; displayIdx < originalNumRows; displayIdx++) {
+      originalToDisplayMap.set(currentGetOriginalIndex(displayIdx), displayIdx)
+    }
+
     // Find the new display indices for the original data rows
     const newDisplayIndices: number[] = []
     for (const origIdx of originalRowIndices) {
-      for (let displayIdx = 0; displayIdx < originalNumRows; displayIdx++) {
-        if (currentGetOriginalIndex(displayIdx) === origIdx) {
-          newDisplayIndices.push(displayIdx)
-          break
-        }
+      const displayIdx = originalToDisplayMap.get(origIdx)
+      if (displayIdx !== undefined) {
+        newDisplayIndices.push(displayIdx)
       }
     }
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -403,9 +403,7 @@ function DataFrame({
 
     const currentGetOriginalIndex = getOriginalIndexRef.current
 
-    // Use a Set for O(1) lookup of target original indices.
-    // Time: O(n) single pass through display rows. Space: O(k) where k = selected rows.
-    // Currently k=1 (single-row-required mode), but this scales if multi-row is added.
+    // Build a Set for O(1) lookup instead of O(n²) nested loops
     const targetOriginalIndices = new Set(originalRowIndices)
     const newDisplayIndices: number[] = []
 


### PR DESCRIPTION
## Describe your changes

Refactors `performRowSelectionRemap` in DataFrame to use a Set-based lookup with early exit for finding display indices after sorting.

- Uses `Set(originalRowIndices)` for O(1) membership checks instead of nested loops
- Early exits once all target rows are found
- Space: O(k) where k = selected rows (currently 1 in single-row-required mode)
- Time: O(n) single pass worst case, but typically exits early

This is primarily a code clarity improvement that also future-proofs for potential multi-row remap support.

## GitHub Issue Link (if applicable)

N/A - Refactor from frontend performance improvement research.

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx` - All 9 tests pass
  - `frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.test.ts` - All tests pass
  - `frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.test.ts` - All tests pass
- [x] E2E tests verified:
  - `test_single_row_select_with_sorted_column` - Passes
  - `test_single_row_and_single_column_select_and_sort` - Passes  
  - `test_single_row_required_select_and_sort` - Passes (tests the exact functionality changed)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->