### PR TITLE
Remove `BaseWeb` for `AlertContainer`

### DIFF
--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
@@ -51,19 +51,12 @@ describe("AlertContainer element", () => {
     [Kind.ERROR, "alert"],
     [Kind.INFO, "status"],
     [Kind.SUCCESS, "status"],
-    [Kind.WARNING, "status"],
+    [Kind.WARNING, "alert"],
   ] as const)(
     "for kind=%s, renders role=%s",
     (kind: Kind, expectedRole: string) => {
       render(<AlertContainer {...getProps({ kind })} />)
-      expect(screen.getByRole(expectedRole, { hidden: true })).toBeVisible()
+      expect(screen.getByRole(expectedRole)).toBeVisible()
     }
   )
-
-  it("does not apply role=alert for non-error kinds", () => {
-    render(<AlertContainer {...getProps({ kind: Kind.INFO })} />)
-    expect(
-      screen.queryByRole("alert", { hidden: true })
-    ).not.toBeInTheDocument()
-  })
 })

--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
@@ -30,10 +30,10 @@ const getProps = (
 })
 
 describe("AlertContainer element", () => {
-  it("renders a Notification", () => {
+  it("renders the alert container", () => {
     render(<AlertContainer {...getProps()} />)
     const alertContainer = screen.getByTestId("stAlertContainer")
-    expect(alertContainer).toBeInTheDocument()
+    expect(alertContainer).toBeVisible()
     expect(alertContainer).toHaveClass("stAlertContainer")
   })
 
@@ -44,6 +44,28 @@ describe("AlertContainer element", () => {
       </AlertContainer>
     )
 
-    expect(screen.getByTestId("foo")).toBeInTheDocument()
+    expect(screen.getByTestId("foo")).toBeVisible()
+  })
+
+  it.each([
+    [Kind.ERROR, "alert"],
+    [Kind.INFO, "status"],
+    [Kind.SUCCESS, "status"],
+    [Kind.WARNING, "status"],
+  ] as const)(
+    "applies role=%s for kind=%s",
+    (kind: Kind, expectedRole: string) => {
+      render(<AlertContainer {...getProps({ kind })} />)
+      expect(
+        screen.getByRole(expectedRole, { hidden: true })
+      ).toBeInTheDocument()
+    }
+  )
+
+  it("does not apply role=alert for non-error kinds", () => {
+    render(<AlertContainer {...getProps({ kind: Kind.INFO })} />)
+    expect(
+      screen.queryByRole("alert", { hidden: true })
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.test.tsx
@@ -53,12 +53,10 @@ describe("AlertContainer element", () => {
     [Kind.SUCCESS, "status"],
     [Kind.WARNING, "status"],
   ] as const)(
-    "applies role=%s for kind=%s",
+    "for kind=%s, renders role=%s",
     (kind: Kind, expectedRole: string) => {
       render(<AlertContainer {...getProps({ kind })} />)
-      expect(
-        screen.getByRole(expectedRole, { hidden: true })
-      ).toBeInTheDocument()
+      expect(screen.getByRole(expectedRole, { hidden: true })).toBeVisible()
     }
   )
 

--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.tsx
@@ -49,7 +49,7 @@ export default function AlertContainer({
       $width={width}
       data-testid="stAlertContainer"
       className="stAlertContainer"
-      role={kind === Kind.ERROR ? "alert" : "status"}
+      role={kind === Kind.ERROR || kind === Kind.WARNING ? "alert" : "status"}
     >
       <StyledAlertContent data-testid={`stAlertContent${testid}`}>
         {children}

--- a/frontend/lib/src/components/shared/AlertContainer/AlertContainer.tsx
+++ b/frontend/lib/src/components/shared/AlertContainer/AlertContainer.tsx
@@ -16,40 +16,10 @@
 
 import { ReactElement, ReactNode } from "react"
 
-import { KIND, Notification } from "baseui/notification"
+import { StyledAlertContainer, StyledAlertContent } from "./styled-components"
+import { Kind } from "./types"
 
-import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-
-import { StyledAlertContent } from "./styled-components"
-
-export enum Kind {
-  ERROR = "error",
-  INFO = "info",
-  SUCCESS = "success",
-  WARNING = "warning",
-}
-
-function getNotificationKind(
-  kind: Kind
-):
-  | typeof KIND.negative
-  | typeof KIND.info
-  | typeof KIND.positive
-  | typeof KIND.warning {
-  switch (kind) {
-    case Kind.ERROR:
-      return KIND.negative
-    case Kind.INFO:
-      return KIND.info
-    case Kind.SUCCESS:
-      return KIND.positive
-    case Kind.WARNING:
-      return KIND.warning
-    default:
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      throw new Error(`Unexpected alert type: ${kind}`)
-  }
-}
+export { Kind }
 
 export interface AlertContainerProps {
   width?: number
@@ -58,7 +28,7 @@ export interface AlertContainerProps {
 }
 
 /**
- * Provides Base Styles for any Alert Type UI. Used in the following cases:
+ * Provides base styles for any Alert Type UI. Used in the following cases:
  *   * Alert is the Streamlit specific alert component that users can use with
  *     any Markdown. Users have API access to generate these.
  *   * ExceptionElement is a special type of alert that formats an exception
@@ -72,47 +42,18 @@ export default function AlertContainer({
   width,
   children,
 }: AlertContainerProps): ReactElement {
-  const theme = useEmotionTheme()
-
   const testid = kind.charAt(0).toUpperCase() + kind.slice(1)
   return (
-    <Notification
-      kind={getNotificationKind(kind)}
-      overrides={{
-        Body: {
-          style: {
-            fontWeight: theme.fontWeights.normal,
-            marginTop: theme.spacing.none,
-            marginBottom: theme.spacing.none,
-            marginLeft: theme.spacing.none,
-            marginRight: theme.spacing.none,
-            width: width ? width.toString() : undefined,
-            border: 0,
-            borderTopRightRadius: theme.radii.default,
-            borderBottomRightRadius: theme.radii.default,
-            borderTopLeftRadius: theme.radii.default,
-            borderBottomLeftRadius: theme.radii.default,
-            paddingTop: theme.spacing.lg,
-            paddingBottom: theme.spacing.lg,
-            paddingRight: theme.spacing.lg,
-            paddingLeft: theme.spacing.lg,
-          },
-          props: {
-            "data-testid": "stAlertContainer",
-            className: `stAlertContainer`,
-          },
-        },
-        InnerContainer: {
-          style: {
-            width: "100%",
-            lineHeight: theme.lineHeights.small,
-          },
-        },
-      }}
+    <StyledAlertContainer
+      $kind={kind}
+      $width={width}
+      data-testid="stAlertContainer"
+      className="stAlertContainer"
+      role={kind === Kind.ERROR ? "alert" : "status"}
     >
       <StyledAlertContent data-testid={`stAlertContent${testid}`}>
         {children}
       </StyledAlertContent>
-    </Notification>
+    </StyledAlertContainer>
   )
 }

--- a/frontend/lib/src/components/shared/AlertContainer/styled-components.ts
+++ b/frontend/lib/src/components/shared/AlertContainer/styled-components.ts
@@ -16,8 +16,6 @@
 
 import styled from "@emotion/styled"
 
-import { notNullOrUndefined } from "@streamlit/utils"
-
 import type { EmotionThemeColors } from "~lib/theme/types"
 
 import { Kind } from "./types"
@@ -44,7 +42,7 @@ export const StyledAlertContainer = styled.div<StyledAlertContainerProps>(
     marginBottom: theme.spacing.none,
     marginLeft: theme.spacing.none,
     marginRight: theme.spacing.none,
-    ...(notNullOrUndefined($width) ? { width: `${$width}px` } : {}),
+    ...($width ? { width: `${$width}px` } : {}),
     borderRadius: theme.radii.default,
     paddingTop: theme.spacing.lg,
     paddingBottom: theme.spacing.lg,

--- a/frontend/lib/src/components/shared/AlertContainer/styled-components.ts
+++ b/frontend/lib/src/components/shared/AlertContainer/styled-components.ts
@@ -16,6 +16,46 @@
 
 import styled from "@emotion/styled"
 
+import { notNullOrUndefined } from "@streamlit/utils"
+
+import type { EmotionThemeColors } from "~lib/theme/types"
+
+import { Kind } from "./types"
+
+const KIND_STYLES: Record<
+  Kind,
+  { bg: keyof EmotionThemeColors; text: keyof EmotionThemeColors }
+> = {
+  [Kind.ERROR]: { bg: "redBackgroundColor", text: "redTextColor" },
+  [Kind.WARNING]: { bg: "yellowBackgroundColor", text: "yellowTextColor" },
+  [Kind.INFO]: { bg: "blueBackgroundColor", text: "blueTextColor" },
+  [Kind.SUCCESS]: { bg: "greenBackgroundColor", text: "greenTextColor" },
+}
+
+interface StyledAlertContainerProps {
+  $kind: Kind
+  $width?: number
+}
+
+export const StyledAlertContainer = styled.div<StyledAlertContainerProps>(
+  ({ theme, $kind, $width }) => ({
+    fontWeight: theme.fontWeights.normal,
+    marginTop: theme.spacing.none,
+    marginBottom: theme.spacing.none,
+    marginLeft: theme.spacing.none,
+    marginRight: theme.spacing.none,
+    ...(notNullOrUndefined($width) ? { width: `${$width}px` } : {}),
+    borderRadius: theme.radii.default,
+    paddingTop: theme.spacing.lg,
+    paddingBottom: theme.spacing.lg,
+    paddingRight: theme.spacing.lg,
+    paddingLeft: theme.spacing.lg,
+    lineHeight: theme.lineHeights.small,
+    backgroundColor: theme.colors[KIND_STYLES[$kind].bg],
+    color: theme.colors[KIND_STYLES[$kind].text],
+  })
+)
+
 export const StyledAlertContent = styled.div(({ theme }) => ({
   pre: {
     backgroundColor: theme.colors.transparent,

--- a/frontend/lib/src/components/shared/AlertContainer/types.ts
+++ b/frontend/lib/src/components/shared/AlertContainer/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum Kind {
+  ERROR = "error",
+  INFO = "info",
+  SUCCESS = "success",
+  WARNING = "warning",
+}


### PR DESCRIPTION
## Describe your changes
We currently use `BaseWeb`'s notification for our alerts (`st.info`, `st.success`, etc) which is unnecessary - this PR replicates the element without using an underlying component library

## Testing Plan
Refactor — all existing unit tests pass. Added role assertion tests for the new ARIA role="alert" / role="status" behavior. E2E snapshots should be stable.