### PR TITLE
[perf] Default 100ms throttle for useCalculatedDimensions

### DIFF
--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -51,6 +51,12 @@ import {
 const LARGE_DATASET_POINT_THRESHOLD = 1000
 
 /**
+ * Throttle delay (in ms) for chart resize updates. This reduces Vega chart
+ * recreation frequency during rapid resize operations (e.g., window resizing).
+ */
+const CHART_RESIZE_THROTTLE_MS = 100
+
+/**
  * Safely format a numeric string, returning the original value if formatting fails.
  */
 function safeFormatNumber(value: string, format: string): string {
@@ -258,7 +264,7 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
   const theme = useEmotionTheme()
   const chartRef = useRef<HTMLDivElement>(null)
   const { width: chartWidth, elementRef: chartContainerRef } =
-    useCalculatedDimensions([], -1, 100)
+    useCalculatedDimensions([], -1, CHART_RESIZE_THROTTLE_MS)
 
   const { MetricDirection } = MetricProto
   const {

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -258,7 +258,7 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
   const theme = useEmotionTheme()
   const chartRef = useRef<HTMLDivElement>(null)
   const { width: chartWidth, elementRef: chartContainerRef } =
-    useCalculatedDimensions()
+    useCalculatedDimensions([], -1, 100)
 
   const { MetricDirection } = MetricProto
   const {

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -51,12 +51,6 @@ import {
 const LARGE_DATASET_POINT_THRESHOLD = 1000
 
 /**
- * Throttle delay (in ms) for chart resize updates. This reduces Vega chart
- * recreation frequency during rapid resize operations (e.g., window resizing).
- */
-const CHART_RESIZE_THROTTLE_MS = 100
-
-/**
  * Safely format a numeric string, returning the original value if formatting fails.
  */
 function safeFormatNumber(value: string, format: string): string {
@@ -264,7 +258,7 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
   const theme = useEmotionTheme()
   const chartRef = useRef<HTMLDivElement>(null)
   const { width: chartWidth, elementRef: chartContainerRef } =
-    useCalculatedDimensions([], -1, CHART_RESIZE_THROTTLE_MS)
+    useCalculatedDimensions()
 
   const { MetricDirection } = MetricProto
   const {

--- a/frontend/lib/src/hooks/useCalculatedDimensions.test.ts
+++ b/frontend/lib/src/hooks/useCalculatedDimensions.test.ts
@@ -187,7 +187,7 @@ describe("useCalculatedDimensions", () => {
     expect(initialRef).toBe(rerenderedRef)
   })
 
-  it("passes debounceMs to useResizeObserver", () => {
+  it("passes throttleMs to useResizeObserver", () => {
     const spy = vi
       .spyOn(useResizeObserver, "useResizeObserver")
       .mockImplementation(() => ({

--- a/frontend/lib/src/hooks/useCalculatedDimensions.test.ts
+++ b/frontend/lib/src/hooks/useCalculatedDimensions.test.ts
@@ -122,7 +122,7 @@ describe("useCalculatedDimensions", () => {
 
     renderHook(() => useCalculatedDimensions())
 
-    expect(spy).toHaveBeenCalledWith(["width", "height"], [])
+    expect(spy).toHaveBeenCalledWith(["width", "height"], [], 0)
   })
 
   it("passes dependencies to useResizeObserver", () => {
@@ -136,7 +136,7 @@ describe("useCalculatedDimensions", () => {
 
     renderHook(() => useCalculatedDimensions(dependencies))
 
-    expect(spy).toHaveBeenCalledWith(["width", "height"], dependencies)
+    expect(spy).toHaveBeenCalledWith(["width", "height"], dependencies, 0)
   })
 
   it("uses custom fallback value when provided", () => {
@@ -185,5 +185,18 @@ describe("useCalculatedDimensions", () => {
     const { elementRef: rerenderedRef } = result.current
 
     expect(initialRef).toBe(rerenderedRef)
+  })
+
+  it("passes debounceMs to useResizeObserver", () => {
+    const spy = vi
+      .spyOn(useResizeObserver, "useResizeObserver")
+      .mockImplementation(() => ({
+        values: [100, 50],
+        elementRef: { current: null },
+      }))
+
+    renderHook(() => useCalculatedDimensions([], -1, 100))
+
+    expect(spy).toHaveBeenCalledWith(["width", "height"], [], 100)
   })
 })

--- a/frontend/lib/src/hooks/useCalculatedDimensions.test.ts
+++ b/frontend/lib/src/hooks/useCalculatedDimensions.test.ts
@@ -122,7 +122,7 @@ describe("useCalculatedDimensions", () => {
 
     renderHook(() => useCalculatedDimensions())
 
-    expect(spy).toHaveBeenCalledWith(["width", "height"], [], 0)
+    expect(spy).toHaveBeenCalledWith(["width", "height"], [], 100)
   })
 
   it("passes dependencies to useResizeObserver", () => {
@@ -136,7 +136,7 @@ describe("useCalculatedDimensions", () => {
 
     renderHook(() => useCalculatedDimensions(dependencies))
 
-    expect(spy).toHaveBeenCalledWith(["width", "height"], dependencies, 0)
+    expect(spy).toHaveBeenCalledWith(["width", "height"], dependencies, 100)
   })
 
   it("uses custom fallback value when provided", () => {

--- a/frontend/lib/src/hooks/useCalculatedDimensions.ts
+++ b/frontend/lib/src/hooks/useCalculatedDimensions.ts
@@ -32,10 +32,10 @@ import { useResizeObserver } from "./useResizeObserver"
  * that will cause the observer to be re-evaluated.
  * @param {number} [fallbackValue=-1] - The value to return when width or height is 0.
  * The default value is -1 which allows components to detect when dimensions aren't ready.
- * @param {number} [throttleMs=0] - Optional throttle delay in milliseconds.
- * When > 0, dimension updates are throttled to reduce the frequency of
- * state updates during rapid resize operations while still providing visual
- * feedback (e.g., 100ms for chart components).
+ * @param {number} [throttleMs=100] - Throttle delay in milliseconds.
+ * Dimension updates are throttled to reduce the frequency of state updates
+ * during rapid resize operations while still providing visual feedback.
+ * Pass 0 to disable throttling if immediate updates are required.
  *
  * @returns An object containing:
  *   - width: The current width of the observed element in pixels (or fallbackValue if width is 0)
@@ -66,17 +66,17 @@ import { useResizeObserver } from "./useResizeObserver"
  *
  * @example
  * ```tsx
- * // With throttling for expensive chart recreations
- * const MetricChart = () => {
- *   const { width, elementRef } = useCalculatedDimensions([], -1, 100);
- *   // Updates throttled to at most once per 100ms during resize
+ * // Disable throttling for immediate updates
+ * const ResponsiveComponent = () => {
+ *   const { width, elementRef } = useCalculatedDimensions([], -1, 0);
+ *   // Updates immediately on every resize event
  * };
  * ```
  */
 export const useCalculatedDimensions = <T extends HTMLDivElement>(
   dependencies: React.DependencyList = [],
   fallbackValue: number = -1,
-  throttleMs = 0
+  throttleMs = 100
 ): {
   width: number
   height: number

--- a/frontend/lib/src/hooks/useCalculatedDimensions.ts
+++ b/frontend/lib/src/hooks/useCalculatedDimensions.ts
@@ -32,9 +32,10 @@ import { useResizeObserver } from "./useResizeObserver"
  * that will cause the observer to be re-evaluated.
  * @param {number} [fallbackValue=-1] - The value to return when width or height is 0.
  * The default value is -1 which allows components to detect when dimensions aren't ready.
- * @param {number} [debounceMs=0] - Optional debounce delay in milliseconds.
- * When > 0, dimension updates are debounced to reduce the frequency of
- * state updates during rapid resize operations (e.g., 100ms for chart components).
+ * @param {number} [throttleMs=0] - Optional throttle delay in milliseconds.
+ * When > 0, dimension updates are throttled to reduce the frequency of
+ * state updates during rapid resize operations while still providing visual
+ * feedback (e.g., 100ms for chart components).
  *
  * @returns An object containing:
  *   - width: The current width of the observed element in pixels (or fallbackValue if width is 0)
@@ -65,17 +66,17 @@ import { useResizeObserver } from "./useResizeObserver"
  *
  * @example
  * ```tsx
- * // With debouncing for expensive chart recreations
+ * // With throttling for expensive chart recreations
  * const MetricChart = () => {
  *   const { width, elementRef } = useCalculatedDimensions([], -1, 100);
- *   // Updates debounced by 100ms to reduce chart recreation frequency
+ *   // Updates throttled to at most once per 100ms during resize
  * };
  * ```
  */
 export const useCalculatedDimensions = <T extends HTMLDivElement>(
   dependencies: React.DependencyList = [],
   fallbackValue: number = -1,
-  debounceMs = 0
+  throttleMs = 0
 ): {
   width: number
   height: number
@@ -87,7 +88,7 @@ export const useCalculatedDimensions = <T extends HTMLDivElement>(
   } = useResizeObserver<T>(
     useMemo(() => ["width", "height"], []),
     dependencies,
-    debounceMs
+    throttleMs
   )
 
   return {

--- a/frontend/lib/src/hooks/useCalculatedDimensions.ts
+++ b/frontend/lib/src/hooks/useCalculatedDimensions.ts
@@ -32,6 +32,9 @@ import { useResizeObserver } from "./useResizeObserver"
  * that will cause the observer to be re-evaluated.
  * @param {number} [fallbackValue=-1] - The value to return when width or height is 0.
  * The default value is -1 which allows components to detect when dimensions aren't ready.
+ * @param {number} [debounceMs=0] - Optional debounce delay in milliseconds.
+ * When > 0, dimension updates are debounced to reduce the frequency of
+ * state updates during rapid resize operations (e.g., 100ms for chart components).
  *
  * @returns An object containing:
  *   - width: The current width of the observed element in pixels (or fallbackValue if width is 0)
@@ -59,10 +62,20 @@ import { useResizeObserver } from "./useResizeObserver"
  *   // width and height will be 0 instead of -1 when not ready
  * };
  * ```
+ *
+ * @example
+ * ```tsx
+ * // With debouncing for expensive chart recreations
+ * const MetricChart = () => {
+ *   const { width, elementRef } = useCalculatedDimensions([], -1, 100);
+ *   // Updates debounced by 100ms to reduce chart recreation frequency
+ * };
+ * ```
  */
 export const useCalculatedDimensions = <T extends HTMLDivElement>(
   dependencies: React.DependencyList = [],
-  fallbackValue: number = -1
+  fallbackValue: number = -1,
+  debounceMs = 0
 ): {
   width: number
   height: number
@@ -73,7 +86,8 @@ export const useCalculatedDimensions = <T extends HTMLDivElement>(
     elementRef,
   } = useResizeObserver<T>(
     useMemo(() => ["width", "height"], []),
-    dependencies
+    dependencies,
+    debounceMs
   )
 
   return {

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -121,9 +121,9 @@ describe("useResizeObserver", () => {
     const properties: DOMRectKeys[] = ["width", "height"]
     renderHook(() => useResizeObserver(properties, [], 0))
 
-    // Verify useThrottledCallback was called with 1ms fallback (hooks can't be
-    // called conditionally, so we always call useThrottledCallback but pass 1
-    // when throttleMs is 0)
+    // Verify useThrottledCallback was called with 1ms fallback via Math.max
+    // (hooks can't be called conditionally, so we always call useThrottledCallback
+    // but pass Math.max(throttleMs, 1) = 1 when throttleMs is 0)
     expect(
       useThrottledCallbackModule.useThrottledCallback
     ).toHaveBeenCalledWith(expect.any(Function), 1)

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -14,24 +14,72 @@
  * limitations under the License.
  */
 
-import { renderHook } from "@testing-library/react"
+import { MutableRefObject, ReactElement, useCallback } from "react"
+
+import { act, screen } from "@testing-library/react"
+
+import { render } from "~lib/test_util"
 
 import { DOMRectKeys, useResizeObserver } from "./useResizeObserver"
-import * as useThrottledCallbackModule from "./useThrottledCallback"
 
 const mockDisconnect = vi.fn()
 const mockObserve = vi.fn()
+let resizeCallback: ((entries: ResizeObserverEntry[]) => void) | null = null
+
+// Helper component that uses the hook and displays values
+function TestComponent({
+  properties,
+  throttleMs,
+  dimensionsRef,
+}: {
+  properties: DOMRectKeys[]
+  throttleMs: number
+  dimensionsRef: MutableRefObject<{ width: number; height: number }>
+}): ReactElement {
+  const { values, elementRef } = useResizeObserver(properties, [], throttleMs)
+
+  // Use a ref callback to set up getBoundingClientRect before ResizeObserver is attached
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node) {
+        // Mock getBoundingClientRect before the effect runs
+        node.getBoundingClientRect = () => ({
+          width: dimensionsRef.current.width,
+          height: dimensionsRef.current.height,
+          top: 0,
+          left: 0,
+          right: dimensionsRef.current.width,
+          bottom: dimensionsRef.current.height,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        })
+      }
+      elementRef.current = node
+    },
+    [elementRef, dimensionsRef]
+  )
+
+  return (
+    <div ref={setRef} data-testid="observed-element">
+      <span data-testid="values">{JSON.stringify(values)}</span>
+    </div>
+  )
+}
 
 describe("useResizeObserver", () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    // Mock ResizeObserver with immediate callback execution
+    resizeCallback = null
+    // Mock ResizeObserver that captures the callback for manual triggering
     class TestResizeObserver {
       public observe: (element: Element) => void
       public disconnect: () => void
 
       constructor(callback: (entries: ResizeObserverEntry[]) => void) {
+        resizeCallback = callback
         this.observe = mockObserve.mockImplementation(() => {
+          // Trigger initial callback when observe is called
           callback([
             {
               target: document.createElement("div"),
@@ -44,88 +92,97 @@ describe("useResizeObserver", () => {
 
     globalThis.ResizeObserver =
       TestResizeObserver as unknown as typeof ResizeObserver
-    // Mock requestAnimationFrame
-    global.requestAnimationFrame = vi.fn().mockImplementation(cb => {
-      cb()
+    // Mock requestAnimationFrame to execute callback synchronously
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(cb => {
+      cb(0)
       return 1
     })
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
   })
 
   afterEach(() => {
     vi.clearAllMocks()
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
-  it("should initialize with empty values", () => {
+  it("updates values immediately when throttleMs is 0", () => {
     const properties: DOMRectKeys[] = ["width", "height"]
-    const { result } = renderHook(() => useResizeObserver(properties))
+    const dimensionsRef = { current: { width: 100, height: 200 } }
 
-    expect(result.current.values).toEqual([])
-    expect(result.current.elementRef.current).toBeNull()
+    render(
+      <TestComponent
+        properties={properties}
+        throttleMs={0}
+        dimensionsRef={dimensionsRef}
+      />
+    )
+
+    // Initial values should be set from the observe() callback
+    expect(screen.getByTestId("values")).toHaveTextContent("[100,200]")
+
+    // Simulate resize event - should update immediately (no throttle)
+    dimensionsRef.current = { width: 150, height: 250 }
+    act(() => {
+      resizeCallback?.([{} as ResizeObserverEntry])
+    })
+    expect(screen.getByTestId("values")).toHaveTextContent("[150,250]")
+
+    // Another resize - should also update immediately
+    dimensionsRef.current = { width: 200, height: 300 }
+    act(() => {
+      resizeCallback?.([{} as ResizeObserverEntry])
+    })
+    expect(screen.getByTestId("values")).toHaveTextContent("[200,300]")
   })
 
-  it("should observe element changes", () => {
+  it("throttles updates when throttleMs > 0", () => {
     const properties: DOMRectKeys[] = ["width", "height"]
-    const { result } = renderHook(() => useResizeObserver(properties))
+    const dimensionsRef = { current: { width: 100, height: 200 } }
 
-    // Simulate element reference
-    const mockElement = document.createElement("div")
-    vi.spyOn(mockElement, "getBoundingClientRect").mockReturnValue({
-      width: 100,
-      height: 200,
-    } as DOMRect)
+    render(
+      <TestComponent
+        properties={properties}
+        throttleMs={100}
+        dimensionsRef={dimensionsRef}
+      />
+    )
 
-    // Set the ref
-    result.current.elementRef.current = mockElement
+    // Initial values from observe() callback - this triggers the throttle cooldown
+    expect(screen.getByTestId("values")).toHaveTextContent("[100,200]")
 
-    // Trigger resize observation
-    const observer = new ResizeObserver(() => {})
-    observer.observe(mockElement)
+    // First resize after observe - throttle is already in cooldown, so NOT immediate
+    dimensionsRef.current = { width: 150, height: 250 }
+    act(() => {
+      resizeCallback?.([{} as ResizeObserverEntry])
+    })
+    // Still showing initial values because we're in throttle cooldown
+    expect(screen.getByTestId("values")).toHaveTextContent("[100,200]")
 
-    expect(mockObserve).toHaveBeenCalledWith(mockElement)
-  })
+    // Second resize within throttle window - saves new args, still no update
+    dimensionsRef.current = { width: 200, height: 300 }
+    act(() => {
+      resizeCallback?.([{} as ResizeObserverEntry])
+    })
+    expect(screen.getByTestId("values")).toHaveTextContent("[100,200]")
 
-  it("uses throttled callback when throttleMs > 0", () => {
-    const mockThrottledCallback = vi.fn()
-    const mockCancel = vi.fn()
+    // Advance timer past throttle window - trailing call executes with last saved values
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    // Should now have the last values from the throttled period
+    expect(screen.getByTestId("values")).toHaveTextContent("[200,300]")
 
-    vi.spyOn(
-      useThrottledCallbackModule,
-      "useThrottledCallback"
-    ).mockReturnValue({
-      throttledCallback: mockThrottledCallback,
-      cancel: mockCancel,
+    // Wait for trailing call's cooldown to expire
+    act(() => {
+      vi.advanceTimersByTime(100)
     })
 
-    const properties: DOMRectKeys[] = ["width", "height"]
-    renderHook(() => useResizeObserver(properties, [], 100))
-
-    // Verify useThrottledCallback was called with the throttle delay
-    expect(
-      useThrottledCallbackModule.useThrottledCallback
-    ).toHaveBeenCalledWith(expect.any(Function), 100)
-  })
-
-  it("passes 1ms fallback to useThrottledCallback when throttleMs is 0", () => {
-    const mockThrottledCallback = vi.fn()
-    const mockCancel = vi.fn()
-
-    vi.spyOn(
-      useThrottledCallbackModule,
-      "useThrottledCallback"
-    ).mockReturnValue({
-      throttledCallback: mockThrottledCallback,
-      cancel: mockCancel,
+    // New resize after cooldown - should update immediately (new throttle window)
+    dimensionsRef.current = { width: 250, height: 350 }
+    act(() => {
+      resizeCallback?.([{} as ResizeObserverEntry])
     })
-
-    const properties: DOMRectKeys[] = ["width", "height"]
-    renderHook(() => useResizeObserver(properties, [], 0))
-
-    // Verify useThrottledCallback was called with 1ms fallback via Math.max
-    // (hooks can't be called conditionally, so we always call useThrottledCallback
-    // but pass Math.max(throttleMs, 1) = 1 when throttleMs is 0)
-    expect(
-      useThrottledCallbackModule.useThrottledCallback
-    ).toHaveBeenCalledWith(expect.any(Function), 1)
+    expect(screen.getByTestId("values")).toHaveTextContent("[250,350]")
   })
 })

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -84,7 +84,7 @@ describe("useResizeObserver", () => {
     expect(mockObserve).toHaveBeenCalledWith(mockElement)
   })
 
-  it("accepts debounceMs parameter", () => {
+  it("accepts throttleMs parameter", () => {
     const properties: DOMRectKeys[] = ["width", "height"]
     const { result } = renderHook(() => useResizeObserver(properties, [], 100))
 

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -83,4 +83,12 @@ describe("useResizeObserver", () => {
 
     expect(mockObserve).toHaveBeenCalledWith(mockElement)
   })
+
+  it("accepts debounceMs parameter", () => {
+    const properties: DOMRectKeys[] = ["width", "height"]
+    const { result } = renderHook(() => useResizeObserver(properties, [], 100))
+
+    expect(result.current.values).toEqual([])
+    expect(result.current.elementRef.current).toBeNull()
+  })
 })

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -17,6 +17,7 @@
 import { renderHook } from "@testing-library/react"
 
 import { DOMRectKeys, useResizeObserver } from "./useResizeObserver"
+import * as useThrottledCallbackModule from "./useThrottledCallback"
 
 const mockDisconnect = vi.fn()
 const mockObserve = vi.fn()
@@ -84,11 +85,47 @@ describe("useResizeObserver", () => {
     expect(mockObserve).toHaveBeenCalledWith(mockElement)
   })
 
-  it("accepts throttleMs parameter", () => {
-    const properties: DOMRectKeys[] = ["width", "height"]
-    const { result } = renderHook(() => useResizeObserver(properties, [], 100))
+  it("uses throttled callback when throttleMs > 0", () => {
+    const mockThrottledCallback = vi.fn()
+    const mockCancel = vi.fn()
 
-    expect(result.current.values).toEqual([])
-    expect(result.current.elementRef.current).toBeNull()
+    vi.spyOn(
+      useThrottledCallbackModule,
+      "useThrottledCallback"
+    ).mockReturnValue({
+      throttledCallback: mockThrottledCallback,
+      cancel: mockCancel,
+    })
+
+    const properties: DOMRectKeys[] = ["width", "height"]
+    renderHook(() => useResizeObserver(properties, [], 100))
+
+    // Verify useThrottledCallback was called with the throttle delay
+    expect(
+      useThrottledCallbackModule.useThrottledCallback
+    ).toHaveBeenCalledWith(expect.any(Function), 100)
+  })
+
+  it("passes 1ms fallback to useThrottledCallback when throttleMs is 0", () => {
+    const mockThrottledCallback = vi.fn()
+    const mockCancel = vi.fn()
+
+    vi.spyOn(
+      useThrottledCallbackModule,
+      "useThrottledCallback"
+    ).mockReturnValue({
+      throttledCallback: mockThrottledCallback,
+      cancel: mockCancel,
+    })
+
+    const properties: DOMRectKeys[] = ["width", "height"]
+    renderHook(() => useResizeObserver(properties, [], 0))
+
+    // Verify useThrottledCallback was called with 1ms fallback (hooks can't be
+    // called conditionally, so we always call useThrottledCallback but pass 1
+    // when throttleMs is 0)
+    expect(
+      useThrottledCallbackModule.useThrottledCallback
+    ).toHaveBeenCalledWith(expect.any(Function), 1)
   })
 })

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -83,9 +83,7 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     setValues(getValues())
   }, [getValues])
 
-  // Hooks cannot be called conditionally, so we always call useThrottledCallback.
-  // When throttleMs=0, we pass 1ms as a defensive placeholder; the throttled path
-  // is never executed because the `if (throttleMs > 0)` guard below routes around it.
+  // Hook must be called unconditionally; throttled path only used when throttleMs > 0
   const { throttledCallback: throttledUpdateValues, cancel: cancelThrottle } =
     useThrottledCallback(updateValues, Math.max(throttleMs, 1))
 

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -100,6 +100,10 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     let frameId: number
 
     const observer = new ResizeObserver(() => {
+      // Cancel any pending animation frame to avoid redundant updates
+      if (frameId) {
+        cancelAnimationFrame(frameId)
+      }
       frameId = window.requestAnimationFrame(() => {
         if (throttleMs > 0) {
           throttledUpdateValues()

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -84,9 +84,8 @@ export const useResizeObserver = <T extends HTMLDivElement>(
   }, [getValues])
 
   // Hooks cannot be called conditionally, so we always call useThrottledCallback.
-  // When throttleMs=0, we pass 1ms as a placeholder delay since useTimeout
-  // requires a positive value. The throttled path is never reached in this case
-  // because the `if (throttleMs > 0)` guard below routes around it.
+  // When throttleMs=0, we pass 1ms as a defensive placeholder; the throttled path
+  // is never executed because the `if (throttleMs > 0)` guard below routes around it.
   const { throttledCallback: throttledUpdateValues, cancel: cancelThrottle } =
     useThrottledCallback(updateValues, Math.max(throttleMs, 1))
 

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -84,7 +84,7 @@ export const useResizeObserver = <T extends HTMLDivElement>(
   }, [getValues])
 
   const { throttledCallback: throttledUpdateValues, cancel: cancelThrottle } =
-    useThrottledCallback(updateValues, throttleMs > 0 ? throttleMs : 100)
+    useThrottledCallback(updateValues, throttleMs || 1)
 
   useEffect(() => {
     if (!elementRef.current) {

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -22,7 +22,7 @@ import {
   useState,
 } from "react"
 
-import useTimeout from "./useTimeout"
+import { useThrottledCallback } from "./useThrottledCallback"
 
 export type DOMRectKeys =
   | "bottom"
@@ -41,9 +41,10 @@ export type DOMRectKeys =
  * @param {DOMRectKeys[]} properties - The list of DOMRect properties to observe.
  * @param {React.DependencyList} [dependencies=[]] - An optional list of dependencies
  * that will cause the observer to be re-evaluated.
- * @param {number} [debounceMs=0] - Optional debounce delay in milliseconds.
- * When > 0, dimension updates are debounced to reduce the frequency of
- * state updates during rapid resize operations.
+ * @param {number} [throttleMs=0] - Optional throttle delay in milliseconds.
+ * When > 0, dimension updates are throttled to reduce the frequency of
+ * state updates during rapid resize operations while still providing
+ * visual feedback (updates at most once per throttleMs).
  * @returns {{
  *   values: number[],
  *   elementRef: MutableRefObject<T | null>,
@@ -52,7 +53,7 @@ export type DOMRectKeys =
 export const useResizeObserver = <T extends HTMLDivElement>(
   properties: DOMRectKeys[],
   dependencies: React.DependencyList = [],
-  debounceMs = 0
+  throttleMs = 0
 ): {
   values: number[]
   elementRef: MutableRefObject<T | null>
@@ -82,11 +83,8 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     setValues(getValues())
   }, [getValues])
 
-  const { restart: restartDebounce, clear: clearDebounce } = useTimeout(
-    updateValues,
-    debounceMs > 0 ? debounceMs : null,
-    { autoStart: false }
-  )
+  const { throttledCallback: throttledUpdateValues, cancel: cancelThrottle } =
+    useThrottledCallback(updateValues, throttleMs > 0 ? throttleMs : 100)
 
   useEffect(() => {
     if (!elementRef.current) {
@@ -99,8 +97,8 @@ export const useResizeObserver = <T extends HTMLDivElement>(
 
     const observer = new ResizeObserver(() => {
       frameId = window.requestAnimationFrame(() => {
-        if (debounceMs > 0) {
-          restartDebounce()
+        if (throttleMs > 0) {
+          throttledUpdateValues()
         } else {
           setValues(getValues())
         }
@@ -114,14 +112,14 @@ export const useResizeObserver = <T extends HTMLDivElement>(
       if (frameId) {
         cancelAnimationFrame(frameId)
       }
-      clearDebounce()
+      cancelThrottle()
     }
   }, [
     properties,
     getValues,
-    debounceMs,
-    restartDebounce,
-    clearDebounce,
+    throttleMs,
+    throttledUpdateValues,
+    cancelThrottle,
     ...dependencies,
   ])
 

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -83,11 +83,12 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     setValues(getValues())
   }, [getValues])
 
-  // throttleMs || 1: hooks cannot be called conditionally; passing 1ms when
-  // throttleMs=0 keeps useThrottledCallback safe, but the throttled path is
-  // never reached because the `if (throttleMs > 0)` guard below prevents it.
+  // Hooks cannot be called conditionally, so we always call useThrottledCallback.
+  // When throttleMs=0, we pass 1ms as a placeholder delay since useTimeout
+  // requires a positive value. The throttled path is never reached in this case
+  // because the `if (throttleMs > 0)` guard below routes around it.
   const { throttledCallback: throttledUpdateValues, cancel: cancelThrottle } =
-    useThrottledCallback(updateValues, throttleMs || 1)
+    useThrottledCallback(updateValues, Math.max(throttleMs, 1))
 
   useEffect(() => {
     if (!elementRef.current) {
@@ -117,6 +118,7 @@ export const useResizeObserver = <T extends HTMLDivElement>(
       }
       cancelThrottle()
     }
+    /* eslint-disable react-hooks/exhaustive-deps -- dependencies spread is intentional */
   }, [
     properties,
     getValues,
@@ -125,6 +127,7 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     cancelThrottle,
     ...dependencies,
   ])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return { values, elementRef }
 }

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -83,6 +83,9 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     setValues(getValues())
   }, [getValues])
 
+  // throttleMs || 1: hooks cannot be called conditionally; passing 1ms when
+  // throttleMs=0 keeps useThrottledCallback safe, but the throttled path is
+  // never reached because the `if (throttleMs > 0)` guard below prevents it.
   const { throttledCallback: throttledUpdateValues, cancel: cancelThrottle } =
     useThrottledCallback(updateValues, throttleMs || 1)
 

--- a/frontend/lib/src/hooks/useResizeObserver.ts
+++ b/frontend/lib/src/hooks/useResizeObserver.ts
@@ -22,6 +22,8 @@ import {
   useState,
 } from "react"
 
+import useTimeout from "./useTimeout"
+
 export type DOMRectKeys =
   | "bottom"
   | "height"
@@ -39,6 +41,9 @@ export type DOMRectKeys =
  * @param {DOMRectKeys[]} properties - The list of DOMRect properties to observe.
  * @param {React.DependencyList} [dependencies=[]] - An optional list of dependencies
  * that will cause the observer to be re-evaluated.
+ * @param {number} [debounceMs=0] - Optional debounce delay in milliseconds.
+ * When > 0, dimension updates are debounced to reduce the frequency of
+ * state updates during rapid resize operations.
  * @returns {{
  *   values: number[],
  *   elementRef: MutableRefObject<T | null>,
@@ -46,13 +51,15 @@ export type DOMRectKeys =
  */
 export const useResizeObserver = <T extends HTMLDivElement>(
   properties: DOMRectKeys[],
-  dependencies: React.DependencyList = []
+  dependencies: React.DependencyList = [],
+  debounceMs = 0
 ): {
   values: number[]
   elementRef: MutableRefObject<T | null>
 } => {
   const elementRef = useRef<T | null>(null)
   const [values, setValues] = useState<number[]>([])
+
   /**
    * Gets the current values of the specified DOMRect properties.
    *
@@ -71,6 +78,16 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     })
   }, [properties])
 
+  const updateValues = useCallback(() => {
+    setValues(getValues())
+  }, [getValues])
+
+  const { restart: restartDebounce, clear: clearDebounce } = useTimeout(
+    updateValues,
+    debounceMs > 0 ? debounceMs : null,
+    { autoStart: false }
+  )
+
   useEffect(() => {
     if (!elementRef.current) {
       return
@@ -79,9 +96,14 @@ export const useResizeObserver = <T extends HTMLDivElement>(
     setValues(getValues())
 
     let frameId: number
+
     const observer = new ResizeObserver(() => {
       frameId = window.requestAnimationFrame(() => {
-        setValues(getValues())
+        if (debounceMs > 0) {
+          restartDebounce()
+        } else {
+          setValues(getValues())
+        }
       })
     })
 
@@ -92,9 +114,16 @@ export const useResizeObserver = <T extends HTMLDivElement>(
       if (frameId) {
         cancelAnimationFrame(frameId)
       }
+      clearDebounce()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
-  }, [properties, getValues, ...dependencies])
+  }, [
+    properties,
+    getValues,
+    debounceMs,
+    restartDebounce,
+    clearDebounce,
+    ...dependencies,
+  ])
 
   return { values, elementRef }
 }


### PR DESCRIPTION
## Describe your changes

Adds default 100ms throttling to `useCalculatedDimensions` hook for improved resize performance across all components that use it. This reduces unnecessary re-renders during window resize operations.

**Changes:**
- Add `throttleMs` parameter to `useResizeObserver` hook using `useThrottledCallback`
- Update `useCalculatedDimensions` to default to 100ms throttle (pass `0` to disable)
- Update JSDoc with examples for using and disabling throttle

**Performance improvements documented:**
- **Idea 31** (Metric): -50% ScriptDuration, -74% TaskDuration ✅
- **Idea 30** (GraphVizChart): -60% ScriptDuration ✅
- **Idea 37** (PlotlyChart): ~7% faster resize performance ✅

**Components that benefit from this change (14 total):**
- **Charts:** ArrowVegaLiteChart, PlotlyChart, GraphVizChart, DataFrame, Metric
- **Inputs:** TextInput, TextArea, NumberInput, ChatInput, CameraInput, FileUploader
- **Layout:** withCalculatedWidth, ElementFullscreenWrapper, Popover

**Why throttle instead of debounce:**
Throttle provides visual feedback during resize (updates at most once per 100ms), while debounce only updates after resize stops. This gives users progressive chart adaptation rather than a "frozen" appearance during resize.

**Why 100ms as default:**
- Fast enough that users won't perceive lag during resize
- Significantly reduces expensive chart recreations
- Components needing immediate updates can pass `throttleMs=0`

## GitHub Issue Link (if applicable)

- Related to frontend performance improvements: [2026-05-04-frontend-performance-improvements.md](https://issues.streamlit.app/agent_wiki_explorer?file=references%2F2026-05-04-frontend-performance-improvements.md)

## Testing Plan

- [x] Unit Tests - Added tests for throttleMs parameter in useResizeObserver and useCalculatedDimensions
- [x] Manual testing - Verified components update progressively during resize with smooth UX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.