### PR TITLE
[chore] Fix frontend build warnings and optimize dev builds

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -95,7 +95,6 @@
     "vite-bundle-analyzer": "^1.3.8",
     "vite-plugin-svgr": "^5.2.0",
     "vite-plugin-terminal": "^1.4.0",
-    "vite-tsconfig-paths": "^6.1.0",
     "vitest": "^4.1.5",
     "vitest-canvas-mock": "^1.1.4",
     "vitest-websocket-mock": "^0.5.0"

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -21,7 +21,6 @@ import terminal from "vite-plugin-terminal"
 import { version } from "./package.json"
 
 import react from "@vitejs/plugin-react-swc"
-import viteTsconfigPaths from "vite-tsconfig-paths"
 import path from "path"
 
 const BASE = "./"
@@ -105,7 +104,6 @@ export default defineConfig(({ command }) => ({
       jsxImportSource: "@emotion/react",
       plugins: [["@swc/plugin-emotion", {}]],
     }),
-    viteTsconfigPaths(),
     // Log browser console output to terminal for debugging by coding agents
     // Enable with: DEBUG_TO_CONSOLE=1 make frontend-dev
     ...(command === "serve" && DEBUG_TO_CONSOLE
@@ -134,6 +132,7 @@ export default defineConfig(({ command }) => ({
       : []),
   ],
   resolve: {
+    tsconfigPaths: true,
     alias: [
       {
         find: /^react-uid$/,

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -194,6 +194,7 @@ export default defineConfig(({ command }) => ({
     assetsDir: "static",
     sourcemap: DEV_BUILD || ANALYZE_BUNDLE,
     manifest: true,
+    reportCompressedSize: false,
     rolldownOptions: {
       output: {
         // Customize the chunk file naming pattern to match static/js/[name].[hash].js

--- a/frontend/component-lib/package.json
+++ b/frontend/component-lib/package.json
@@ -62,7 +62,6 @@
     "typesync": "^0.14.3",
     "vite": "^8.0.9",
     "vite-plugin-dts": "^5.0.0",
-    "vite-tsconfig-paths": "^6.1.0",
     "vitest": "^4.1.5"
   },
   "resolutions": {

--- a/frontend/component-lib/vite.config.ts
+++ b/frontend/component-lib/vite.config.ts
@@ -17,7 +17,6 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
-import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
@@ -34,12 +33,10 @@ const EXTERNAL_DEPENDENCIES = [
 
 export default defineConfig({
   base: "./",
-  plugins: [
-    viteTsconfigPaths(),
-    dts({
-      insertTypesEntry: true,
-    }),
-  ],
+  plugins: !DEV_WATCH ? [dts({ insertTypesEntry: true })] : [],
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,

--- a/frontend/component-lib/vite.config.ts
+++ b/frontend/component-lib/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,
+    reportCompressedSize: false,
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "streamlit-component-lib",

--- a/frontend/component-v2-lib/package.json
+++ b/frontend/component-v2-lib/package.json
@@ -40,7 +40,6 @@
     "typesync": "^0.14.3",
     "vite": "^8.0.9",
     "vite-plugin-dts": "^5.0.0",
-    "vite-tsconfig-paths": "^6.1.0",
     "vitest": "^4.1.5"
   },
   "repository": {

--- a/frontend/component-v2-lib/vite.config.ts
+++ b/frontend/component-v2-lib/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,
+    reportCompressedSize: false,
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "@streamlit/component-v2-lib",

--- a/frontend/component-v2-lib/vite.config.ts
+++ b/frontend/component-v2-lib/vite.config.ts
@@ -17,7 +17,6 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
-import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
@@ -31,12 +30,10 @@ const DEV_WATCH = Boolean(process.env.DEV_WATCH)
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
-  plugins: [
-    viteTsconfigPaths(),
-    dts({
-      insertTypesEntry: true,
-    }),
-  ],
+  plugins: !DEV_WATCH ? [dts({ insertTypesEntry: true })] : [],
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,

--- a/frontend/connection/package.json
+++ b/frontend/connection/package.json
@@ -43,7 +43,6 @@
     "vite": "^8.0.9",
     "vite-plugin-dts": "^5.0.0",
     "vite-plugin-svgr": "^5.2.0",
-    "vite-tsconfig-paths": "^6.1.0",
     "vitest": "^4.1.5",
     "vitest-websocket-mock": "^0.5.0"
   },

--- a/frontend/connection/vite.config.ts
+++ b/frontend/connection/vite.config.ts
@@ -17,7 +17,6 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
-import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
@@ -31,12 +30,10 @@ const DEV_WATCH = Boolean(process.env.DEV_WATCH)
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
-  plugins: [
-    viteTsconfigPaths(),
-    dts({
-      insertTypesEntry: true,
-    }),
-  ],
+  plugins: !DEV_WATCH ? [dts({ insertTypesEntry: true })] : [],
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,

--- a/frontend/connection/vite.config.ts
+++ b/frontend/connection/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,
+    reportCompressedSize: false,
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "@streamlit/connection",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -548,6 +548,7 @@ export default defineConfig([
     "app/eslint.config.mjs",
     "vitest.config.ts",
     "vitest.setup.ts",
+    "**/vite.config.ts",
     "lib/src/proto.js",
     "lib/src/proto.d.ts",
     "**/node_modules/*",

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -167,7 +167,6 @@
     "vite": "^8.0.9",
     "vite-plugin-dts": "^5.0.0",
     "vite-plugin-svgr": "^5.2.0",
-    "vite-tsconfig-paths": "^6.1.0",
     "vitest": "^4.1.5",
     "vitest-canvas-mock": "^1.1.4",
     "vitest-fetch-mock": "^0.4.5"

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "env NODE_OPTIONS=--max_old_space_size=8192 vite build",
+    "buildWatch": "env DEV_WATCH=1 NODE_OPTIONS=--max_old_space_size=8192 vite build --watch",
     "typecheck": "yarn run typecheck:all",
     "test": "vitest run",
     "testWatch": "vitest",

--- a/frontend/lib/vite.config.ts
+++ b/frontend/lib/vite.config.ts
@@ -58,7 +58,9 @@ export default defineConfig({
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "@streamlit/lib", // Replace with your library's name
       fileName: format => `streamlit-lib.${format}.js`,
-      // For development, only build es format since that is what Streamlit uses
+      // For development, only build es format since that is what Streamlit uses.
+      // DEV_WATCH is intentionally workspace-only: consumers in the monorepo
+      // use the ESM entry (import/module), so missing CJS/UMD outputs are fine.
       formats: DEV_WATCH ? ["es"] : ["es", "umd", "cjs"],
     },
     rolldownOptions: {

--- a/frontend/lib/vite.config.ts
+++ b/frontend/lib/vite.config.ts
@@ -18,13 +18,15 @@
 import react from "@vitejs/plugin-react-swc"
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
-import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
 // We do not explicitly set the DEV_BUILD in any of our processes
 // This is a convenience for developers for debugging purposes
 const DEV_BUILD = Boolean(process.env.DEV_BUILD)
+// DEV_WATCH is used to simplify development of the library
+// to speed up rebuilds for development of Streamlit
+const DEV_WATCH = Boolean(process.env.DEV_WATCH)
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -34,24 +36,29 @@ export default defineConfig({
       jsxImportSource: "@emotion/react",
       plugins: [["@swc/plugin-emotion", {}]],
     }),
-    viteTsconfigPaths(),
-    dts({
-      insertTypesEntry: true,
-      // Keep declaration emit on a separate tsconfig so normal typechecking can
-      // still resolve sibling workspace source without pulling those files into
-      // the build root under TypeScript 6.
-      tsconfigPath: path.resolve(__dirname, "tsconfig.build.json"),
-    }),
+    // Skip DTS generation in dev mode - types resolve from source via tsconfig paths
+    ...(!DEV_WATCH
+      ? [
+          dts({
+            insertTypesEntry: true,
+            // Keep declaration emit on a separate tsconfig so normal typechecking can
+            // still resolve sibling workspace source without pulling those files into
+            // the build root under TypeScript 6.
+            tsconfigPath: path.resolve(__dirname, "tsconfig.build.json"),
+          }),
+        ]
+      : []),
   ],
   build: {
     outDir: "dist",
-    sourcemap: DEV_BUILD,
+    sourcemap: DEV_BUILD || DEV_WATCH,
     lib: {
       // Specify the entry point of your library
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "@streamlit/lib", // Replace with your library's name
       fileName: format => `streamlit-lib.${format}.js`,
-      formats: ["es", "umd", "cjs"], // Output formats
+      // For development, only build es format since that is what Streamlit uses
+      formats: DEV_WATCH ? ["es"] : ["es", "umd", "cjs"],
     },
     rolldownOptions: {
       input: "src/index.ts",
@@ -66,6 +73,7 @@ export default defineConfig({
     },
   },
   resolve: {
+    tsconfigPaths: true,
     alias: {
       "~lib": path.resolve(__dirname, "../lib/src"),
     },

--- a/frontend/lib/vite.config.ts
+++ b/frontend/lib/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,
+    reportCompressedSize: false,
     lib: {
       // Specify the entry point of your library
       entry: path.resolve(__dirname, "src/index.ts"),

--- a/frontend/utils/package.json
+++ b/frontend/utils/package.json
@@ -33,7 +33,6 @@
     "typesync": "^0.14.3",
     "vite": "^8.0.9",
     "vite-plugin-dts": "^5.0.0",
-    "vite-tsconfig-paths": "^6.1.0",
     "vitest": "^4.1.5"
   },
   "browserslist": [

--- a/frontend/utils/vite.config.ts
+++ b/frontend/utils/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,
+    reportCompressedSize: false,
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "@streamlit/utils",

--- a/frontend/utils/vite.config.ts
+++ b/frontend/utils/vite.config.ts
@@ -17,7 +17,6 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
-import viteTsconfigPaths from "vite-tsconfig-paths"
 
 import path from "path"
 
@@ -31,12 +30,10 @@ const DEV_WATCH = Boolean(process.env.DEV_WATCH)
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
-  plugins: [
-    viteTsconfigPaths(),
-    dts({
-      insertTypesEntry: true,
-    }),
-  ],
+  plugins: !DEV_WATCH ? [dts({ insertTypesEntry: true })] : [],
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     outDir: "dist",
     sourcemap: DEV_BUILD || DEV_WATCH,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3519,7 +3519,6 @@ __metadata:
     vite-bundle-analyzer: "npm:^1.3.8"
     vite-plugin-svgr: "npm:^5.2.0"
     vite-plugin-terminal: "npm:^1.4.0"
-    vite-tsconfig-paths: "npm:^6.1.0"
     vitest: "npm:^4.1.5"
     vitest-canvas-mock: "npm:^1.1.4"
     vitest-websocket-mock: "npm:^0.5.0"
@@ -3534,7 +3533,6 @@ __metadata:
     typesync: "npm:^0.14.3"
     vite: "npm:^8.0.9"
     vite-plugin-dts: "npm:^5.0.0"
-    vite-tsconfig-paths: "npm:^6.1.0"
     vitest: "npm:^4.1.5"
   languageName: unknown
   linkType: soft
@@ -3554,7 +3552,6 @@ __metadata:
     vite: "npm:^8.0.9"
     vite-plugin-dts: "npm:^5.0.0"
     vite-plugin-svgr: "npm:^5.2.0"
-    vite-tsconfig-paths: "npm:^6.1.0"
     vitest: "npm:^4.1.5"
     vitest-websocket-mock: "npm:^0.5.0"
   languageName: unknown
@@ -3682,7 +3679,6 @@ __metadata:
     vite: "npm:^8.0.9"
     vite-plugin-dts: "npm:^5.0.0"
     vite-plugin-svgr: "npm:^5.2.0"
-    vite-tsconfig-paths: "npm:^6.1.0"
     vitest: "npm:^4.1.5"
     vitest-canvas-mock: "npm:^1.1.4"
     vitest-fetch-mock: "npm:^0.4.5"
@@ -3718,7 +3714,6 @@ __metadata:
     typesync: "npm:^0.14.3"
     vite: "npm:^8.0.9"
     vite-plugin-dts: "npm:^5.0.0"
-    vite-tsconfig-paths: "npm:^6.1.0"
     vitest: "npm:^4.1.5"
   languageName: unknown
   linkType: soft
@@ -10477,13 +10472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
-  languageName: node
-  linkType: hard
-
 "glsl-inject-defines@npm:^1.0.1":
   version: 1.0.3
   resolution: "glsl-inject-defines@npm:1.0.3"
@@ -16973,7 +16961,6 @@ __metadata:
     typesync: "npm:^0.14.3"
     vite: "npm:^8.0.9"
     vite-plugin-dts: "npm:^5.0.0"
-    vite-tsconfig-paths: "npm:^6.1.0"
     vitest: "npm:^4.1.5"
   peerDependencies:
     react: ^18.2.0
@@ -17749,20 +17736,6 @@ __metadata:
   bin:
     tsc-alias: dist/bin/index.js
   checksum: 10c0/024301d25e48917da2b11bd92683fdf62c9c9603eb711937f0aa8e24df0d988290a4f5e94ac91b77601ea36335bf4ab5637944c47755df82a2a0cf95720d5c0f
-  languageName: node
-  linkType: hard
-
-"tsconfck@npm:^3.0.3":
-  version: 3.1.3
-  resolution: "tsconfck@npm:3.1.3"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10c0/64f7a8ed0a6d36b0902dfc0075e791d2242f7634644f124343ec0dec4f3f70092f929c5a9f59496d51883aa81bb1e595deb92a219593575d2e75b849064713d1
   languageName: node
   linkType: hard
 
@@ -19016,19 +18989,6 @@ __metadata:
   peerDependencies:
     vite: ^2.0.0||^3.0.0||^4.0.0||^5.0.0||^6.0.0||^7.0.0
   checksum: 10c0/e0c155f47e9305b945b1d7cf2691768c1f41eef45f61c7924632ae2e5f136e9c872891e36b2a720401ae667f8f6c9babae7b7d204acb1f3d58c3c16d2eff7f97
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^6.1.0":
-  version: 6.1.1
-  resolution: "vite-tsconfig-paths@npm:6.1.1"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  checksum: 10c0/5e61080991418fefa08c5b98995cdcada4931ae01ac97ef9e2ee941051f61b76890a6e7ba48bed3b2a229ec06fef33a06621bba4ce457b3f4233ad31dc0c1d1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

- **Remove `vite-tsconfig-paths` plugin** - Vite 8 now supports tsconfig path resolution natively via `resolve.tsconfigPaths: true`. This removes the deprecation warnings and reduces dependencies.
- **Skip DTS generation in dev mode** - Add `DEV_WATCH` conditional to skip TypeScript declaration file generation during development, reducing dev build times by ~35x (e.g., utils: 489ms → 14ms)
- **Skip compressed size reporting** - Add `reportCompressedSize: false` to skip gzip size calculation during builds. No impact on actual bundle output or bundle analyzer.
- **Fix ESLint errors** - Add `**/vite.config.ts` to ESLint `globalIgnores` since these files aren't in any tsconfig project

### Performance improvement

| Package | Production Build | Dev Build (DEV_WATCH) |
|---------|-----------------|----------------------|
| utils | 489ms | 14ms |
| Similar improvements for component-lib, component-v2-lib, connection, lib |

## Testing Plan

- [x] No additional tests needed - build tooling changes only
- [x] Verified `make frontend-fast` completes successfully
- [x] Verified `DEV_WATCH=1 yarn build` skips DTS generation
- [x] Verified production builds still generate type definitions
- [x] All existing checks pass (`make check`)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | updating-internal-docs | 1 |
| subagent | Explore | 2 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->