### PR TITLE
[refactor] Move Arrow data models from render-tree to components

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/references/frontend.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/frontend.md
@@ -86,8 +86,8 @@ Immutable root with 4 top-level containers:
 
 **ElementNode** (`ElementNode.ts`):
 - Leaf node for UI elements
-- Contains `Element` protobuf message
-- Lazy-loads processed data (Quiver for dataframes)
+- Contains `Element` protobuf message and metadata (elementHash)
+- Data model derivation (e.g., Quiver for dataframes) is handled at the component level
 
 **TransientNode** (`TransientNode.ts`):
 - Holds transient elements (currently used for spinners) at a delta path position

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -65,6 +65,7 @@ import {
   Text as TextProto,
   TimeInput as TimeInputProto,
   Toast as ToastProto,
+  VegaLiteChart as VegaLiteChartProto,
   Video as VideoProto,
 } from "@streamlit/protobuf"
 
@@ -282,7 +283,7 @@ const RawElementNodeRenderer = (
         >
           <Table
             element={tableProto}
-            data={node.quiverElement}
+            elementHash={node.elementHash}
             {...elementProps}
           />
         </ElementContainer>
@@ -693,7 +694,7 @@ const RawElementNodeRenderer = (
             // be undefined.
             key={dataframeProto.id || undefined}
             element={dataframeProto}
-            data={node.quiverElement}
+            elementHash={node.elementHash}
             {...widgetProps}
           />
         </ElementContainer>
@@ -701,7 +702,7 @@ const RawElementNodeRenderer = (
     }
 
     case "vegaLiteChart": {
-      const vegaLiteElement = node.vegaLiteChartElement
+      const vegaLiteProto = node.element.vegaLiteChart as VegaLiteChartProto
 
       // VegaLite charts with embedded dataframes need a defined parent width
       // (not fit-content) for proper measurement and rendering due to the resize feature.
@@ -724,12 +725,13 @@ const RawElementNodeRenderer = (
       return (
         <ElementContainer node={node} config={config} isStale={isStale}>
           <ArrowVegaLiteChart
-            element={vegaLiteElement}
+            element={vegaLiteProto}
+            elementHash={node.elementHash}
             // Vega-lite chart can be used as a widget (when selections are activated) or
             // an element. We only want to set the key in case of it being used as a widget
             // since otherwise it might break some apps that show the same charts multiple times.
             // So we only compute an element ID if it's a widget, otherwise its an empty string.
-            key={vegaLiteElement.id || undefined}
+            key={vegaLiteProto.id || undefined}
             {...widgetProps}
           />
         </ElementContainer>

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.test.tsx
@@ -19,6 +19,8 @@ import { useMemo } from "react"
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
+import { VegaLiteChart as VegaLiteChartProto } from "@streamlit/protobuf"
+
 // Avoid real Vega embedding side-effects in tests
 vi.mock("./useVegaEmbed", () => ({
   useVegaEmbed: () => {
@@ -32,13 +34,11 @@ vi.mock("./useVegaEmbed", () => ({
   },
 }))
 
-import { Quiver } from "~lib/dataframes/Quiver"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { UNICODE } from "~lib/mocks/arrow/types/unicode"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
-import { VegaLiteChartElement } from "./arrowUtils"
 import ArrowVegaLiteChart, {
   hasNestedComposition,
   isFacetChart,
@@ -46,11 +46,10 @@ import ArrowVegaLiteChart, {
 } from "./ArrowVegaLiteChart"
 
 const getProps = (
-  elementProps: Partial<VegaLiteChartElement> = {},
+  elementProps: Partial<VegaLiteChartProto> = {},
   props: Partial<Props> = {}
 ): Props => ({
-  element: {
-    data: null,
+  element: VegaLiteChartProto.create({
     id: "1",
     useContainerWidth: false,
     datasets: [],
@@ -76,9 +75,10 @@ const getProps = (
         y: { field: "value", type: "quantitative" },
       },
     }),
-    vegaLiteTheme: "streamlit",
+    theme: "streamlit",
     ...elementProps,
-  },
+  }),
+  elementHash: "test-hash",
   widgetMgr: new WidgetStateManager({
     sendRerunBackMsg: vi.fn(),
     formsDataChanged: vi.fn(),
@@ -106,9 +106,10 @@ describe("ArrowVegaLiteChart", () => {
   it("shows data grid when 'Show data' is clicked for inline data, and toggles back to chart", async () => {
     const user = userEvent.setup()
 
-    const dataQuiver = new Quiver({ data: UNICODE })
     render(
-      <ArrowVegaLiteChart {...getProps({ data: dataQuiver, datasets: [] })} />
+      <ArrowVegaLiteChart
+        {...getProps({ data: { data: UNICODE }, datasets: [] })}
+      />
     )
 
     // Initially, the chart container should be present
@@ -136,7 +137,6 @@ describe("ArrowVegaLiteChart", () => {
   })
 
   it("shows data grid when 'Show data' is clicked for first dataset", () => {
-    const datasetQuiver = new Quiver({ data: UNICODE })
     render(
       <ArrowVegaLiteChart
         {...getProps({
@@ -145,7 +145,7 @@ describe("ArrowVegaLiteChart", () => {
             {
               name: "dataset0",
               hasName: true,
-              data: datasetQuiver,
+              data: { data: UNICODE },
             },
           ],
         })}

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -145,7 +145,8 @@ const ArrowVegaLiteChart: FC<Props> = ({
       selectionMode: elementProto.selectionMode,
       formId: elementProto.formId,
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- elementHash is the primary cache key
+    // elementHash is intentionally included as a stability anchor for memoization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [elementHash, elementProto]
   )
   const [showData, setShowData] = useState(false)

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-import { FC, memo, useEffect, useLayoutEffect, useState } from "react"
+import { FC, memo, useEffect, useLayoutEffect, useMemo, useState } from "react"
 
 import { Global } from "@emotion/react"
 import { InsertChart, TableChart } from "@emotion-icons/material-outlined"
 
-import { streamlit } from "@streamlit/protobuf"
+import {
+  IArrowData,
+  IArrowNamedDataSet,
+  streamlit,
+  VegaLiteChart as VegaLiteChartProto,
+} from "@streamlit/protobuf"
 
 import {
   shouldHeightStretch,
@@ -30,11 +35,12 @@ import withFullScreenWrapper from "~lib/components/shared/FullScreenWrapper/with
 import { StyledToolbarElementContainer } from "~lib/components/shared/Toolbar/styled-components"
 import Toolbar, { ToolbarAction } from "~lib/components/shared/Toolbar/Toolbar"
 import { ReadOnlyGrid } from "~lib/components/widgets/DataFrame/ReadOnlyGrid"
+import { Quiver } from "~lib/dataframes/Quiver"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
-import { VegaLiteChartElement } from "./arrowUtils"
+import { VegaLiteChartElement, WrappedNamedDataset } from "./arrowUtils"
 import {
   StyledVegaLiteChartContainer,
   StyledVegaLiteChartTooltips,
@@ -98,7 +104,8 @@ export function hasNestedComposition(spec: string | object): boolean {
   }
 }
 export interface Props {
-  element: VegaLiteChartElement
+  element: VegaLiteChartProto
+  elementHash?: string
   widgetMgr: WidgetStateManager
   fragmentId?: string
   disableFullscreenMode?: boolean
@@ -106,14 +113,41 @@ export interface Props {
   heightConfig: streamlit.IHeightConfig | null | undefined
 }
 
+/** Iterates over datasets and converts data to Quiver. */
+function wrapDatasets(datasets: IArrowNamedDataSet[]): WrappedNamedDataset[] {
+  return datasets.map((dataset: IArrowNamedDataSet) => ({
+    hasName: dataset.hasName as boolean,
+    name: dataset.name as string,
+    data: new Quiver(dataset.data as IArrowData),
+  }))
+}
+
 const ArrowVegaLiteChart: FC<Props> = ({
   disableFullscreenMode,
-  element: inputElement,
+  element: elementProto,
+  elementHash,
   fragmentId,
   widgetMgr,
   widthConfig,
   heightConfig,
 }) => {
+  // Construct the VegaLiteChartElement from the proto's data. The elementHash
+  // serves as the primary memoization key to avoid unnecessary re-parsing when
+  // the payload hasn't changed.
+  const inputElement = useMemo<VegaLiteChartElement>(
+    () => ({
+      data: elementProto.data ? new Quiver(elementProto.data) : null,
+      spec: elementProto.spec,
+      datasets: wrapDatasets(elementProto.datasets),
+      useContainerWidth: elementProto.useContainerWidth,
+      vegaLiteTheme: elementProto.theme,
+      id: elementProto.id,
+      selectionMode: elementProto.selectionMode,
+      formId: elementProto.formId,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- elementHash is the primary cache key
+    [elementHash, elementProto]
+  )
   const [showData, setShowData] = useState(false)
   const [enableShowData, setEnableShowData] = useState(false)
 

--- a/frontend/lib/src/components/elements/Table/Table.test.tsx
+++ b/frontend/lib/src/components/elements/Table/Table.test.tsx
@@ -18,7 +18,6 @@ import { screen } from "@testing-library/react"
 
 import { Table as TableProto } from "@streamlit/protobuf"
 
-import { Quiver } from "~lib/dataframes/Quiver"
 import { EMPTY } from "~lib/mocks/arrow/empty"
 import { MULTI } from "~lib/mocks/arrow/multi"
 import { UNICODE } from "~lib/mocks/arrow/types/unicode"
@@ -27,8 +26,11 @@ import { render } from "~lib/test_util"
 import { Table, TableProps } from "./Table"
 
 const getProps = (data: Uint8Array): TableProps => ({
-  element: TableProto.create({ borderMode: TableProto.BorderMode.ALL }),
-  data: new Quiver({ data }),
+  element: TableProto.create({
+    borderMode: TableProto.BorderMode.ALL,
+    arrowData: { data },
+  }),
+  elementHash: "test-hash",
 })
 
 describe("st.table", () => {
@@ -58,8 +60,11 @@ describe("st.table", () => {
 
   it("renders with all borders when border=true", () => {
     const modifiedProps: TableProps = {
-      element: TableProto.create({ borderMode: TableProto.BorderMode.ALL }),
-      data: new Quiver({ data: UNICODE }),
+      element: TableProto.create({
+        borderMode: TableProto.BorderMode.ALL,
+        arrowData: { data: UNICODE },
+      }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...modifiedProps} />)
@@ -74,10 +79,12 @@ describe("st.table", () => {
   })
 
   it("renders without borders when border=false", () => {
-    // Create a Quiver with border=false
     const modifiedProps: TableProps = {
-      element: TableProto.create({ borderMode: TableProto.BorderMode.NONE }),
-      data: new Quiver({ data: UNICODE }),
+      element: TableProto.create({
+        borderMode: TableProto.BorderMode.NONE,
+        arrowData: { data: UNICODE },
+      }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...modifiedProps} />)
@@ -97,8 +104,9 @@ describe("st.table", () => {
     const modifiedProps: TableProps = {
       element: TableProto.create({
         borderMode: TableProto.BorderMode.HORIZONTAL,
+        arrowData: { data: UNICODE },
       }),
-      data: new Quiver({ data: UNICODE }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...modifiedProps} />)
@@ -231,8 +239,9 @@ describe("st.table", () => {
       element: TableProto.create({
         borderMode: TableProto.BorderMode.ALL,
         hideIndex: true,
+        arrowData: { data: UNICODE },
       }),
-      data: new Quiver({ data: UNICODE }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...props} />)
@@ -251,8 +260,9 @@ describe("st.table", () => {
       element: TableProto.create({
         borderMode: TableProto.BorderMode.ALL,
         hideIndex: false,
+        arrowData: { data: UNICODE },
       }),
-      data: new Quiver({ data: UNICODE }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...props} />)
@@ -267,8 +277,9 @@ describe("st.table", () => {
       element: TableProto.create({
         borderMode: TableProto.BorderMode.ALL,
         hideHeader: true,
+        arrowData: { data: UNICODE },
       }),
-      data: new Quiver({ data: UNICODE }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...props} />)
@@ -289,8 +300,9 @@ describe("st.table", () => {
       element: TableProto.create({
         borderMode: TableProto.BorderMode.ALL,
         hideHeader: false,
+        arrowData: { data: UNICODE },
       }),
-      data: new Quiver({ data: UNICODE }),
+      elementHash: "test-hash",
     }
 
     const { container } = render(<Table {...props} />)

--- a/frontend/lib/src/components/elements/Table/Table.tsx
+++ b/frontend/lib/src/components/elements/Table/Table.tsx
@@ -18,7 +18,11 @@ import { memo, ReactElement, useMemo } from "react"
 
 import { range } from "lodash-es"
 
-import { streamlit, Table as TableProto } from "@streamlit/protobuf"
+import {
+  IArrowData,
+  streamlit,
+  Table as TableProto,
+} from "@streamlit/protobuf"
 
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { format as formatArrowCell } from "~lib/dataframes/arrowFormatUtils"
@@ -46,7 +50,7 @@ import {
 
 export interface TableProps {
   element: TableProto
-  data: Quiver
+  elementHash?: string
   widthConfig?: streamlit.IWidthConfig | null
   heightConfig?: streamlit.IHeightConfig | null
 }
@@ -78,7 +82,17 @@ function getStickyType(stickyTop: boolean, stickyLeft: boolean): StickyType {
 }
 
 export function Table(props: Readonly<TableProps>): ReactElement {
-  const table = props.data
+  const { element, elementHash } = props
+
+  // Construct Quiver from the proto's arrowData. The elementHash serves as the
+  // primary memoization key to avoid unnecessary re-parsing when the payload
+  // hasn't changed.
+  const table = useMemo(
+    () => new Quiver(element.arrowData as IArrowData),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- elementHash is the primary cache key
+    [elementHash, element.arrowData]
+  )
+
   const { cssId, cssStyles, caption } = table.styler ?? {}
   const { numHeaderRows, numDataRows, numColumns, numIndexColumns } =
     table.dimensions

--- a/frontend/lib/src/components/elements/Table/Table.tsx
+++ b/frontend/lib/src/components/elements/Table/Table.tsx
@@ -18,11 +18,7 @@ import { memo, ReactElement, useMemo } from "react"
 
 import { range } from "lodash-es"
 
-import {
-  IArrowData,
-  streamlit,
-  Table as TableProto,
-} from "@streamlit/protobuf"
+import { streamlit, Table as TableProto } from "@streamlit/protobuf"
 
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { format as formatArrowCell } from "~lib/dataframes/arrowFormatUtils"
@@ -87,11 +83,14 @@ export function Table(props: Readonly<TableProps>): ReactElement {
   // Construct Quiver from the proto's arrowData. The elementHash serves as the
   // primary memoization key to avoid unnecessary re-parsing when the payload
   // hasn't changed.
-  const table = useMemo(
-    () => new Quiver(element.arrowData as IArrowData),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- elementHash is the primary cache key
-    [elementHash, element.arrowData]
-  )
+  const table = useMemo(() => {
+    if (!element.arrowData) {
+      throw new Error("Table element is missing arrowData")
+    }
+    return new Quiver(element.arrowData)
+    // elementHash is intentionally included as a stability anchor for memoization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementHash, element.arrowData])
 
   const { cssId, cssStyles, caption } = table.styler ?? {}
   const { numHeaderRows, numDataRows, numColumns, numIndexColumns } =

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -20,7 +20,6 @@ import { screen } from "@testing-library/react"
 
 import { Dataframe as DataframeProto } from "@streamlit/protobuf"
 
-import { Quiver } from "~lib/dataframes/Quiver"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { TEN_BY_TEN } from "~lib/mocks/arrow/tenByTen"
 import { render } from "~lib/test_util"
@@ -48,25 +47,23 @@ vi.mock("native-file-system-adapter", () => ({}))
 import DataFrame, { DataFrameProps } from "./DataFrame"
 
 const getProps = (
-  data: Quiver,
+  data: Uint8Array,
   editingMode: DataframeProto.EditingMode = DataframeProto.EditingMode
     .READ_ONLY
 ): DataFrameProps => ({
   element: DataframeProto.create({
-    arrowData: { data: new Uint8Array() },
+    arrowData: { data },
     editingMode,
   }),
-  data,
+  elementHash: "test-hash",
   disabled: false,
   widgetMgr: {
     getStringValue: vi.fn(),
   } as unknown as WidgetStateManager,
 })
 
-const { ResizeObserver } = window
-
 describe("DataFrame widget", () => {
-  const props = getProps(new Quiver({ data: TEN_BY_TEN }))
+  const props = getProps(TEN_BY_TEN)
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -78,7 +75,6 @@ describe("DataFrame widget", () => {
   })
 
   afterEach(() => {
-    window.ResizeObserver = ResizeObserver
     vi.restoreAllMocks()
   })
 
@@ -89,7 +85,7 @@ describe("DataFrame widget", () => {
 
   it("renders when widgetMgr is undefined", () => {
     const propsWithoutWidgetMgr = {
-      ...getProps(new Quiver({ data: TEN_BY_TEN })),
+      ...getProps(TEN_BY_TEN),
       widgetMgr: undefined,
     }
 
@@ -134,12 +130,7 @@ describe("DataFrame widget", () => {
     }))
 
     render(
-      <DataFrame
-        {...getProps(
-          new Quiver({ data: TEN_BY_TEN }),
-          DataframeProto.EditingMode.FIXED
-        )}
-      />
+      <DataFrame {...getProps(TEN_BY_TEN, DataframeProto.EditingMode.FIXED)} />
     )
     // Check the mock was called with the expected props
     expect(dataEditorMockFn).toHaveBeenCalledWith(
@@ -155,10 +146,7 @@ describe("DataFrame widget", () => {
   it("enables trailing row for ADD_ONLY editing mode", () => {
     render(
       <DataFrame
-        {...getProps(
-          new Quiver({ data: TEN_BY_TEN }),
-          DataframeProto.EditingMode.ADD_ONLY
-        )}
+        {...getProps(TEN_BY_TEN, DataframeProto.EditingMode.ADD_ONLY)}
       />
     )
 
@@ -186,10 +174,7 @@ describe("DataFrame widget", () => {
   it("enables row selection for DELETE_ONLY editing mode", () => {
     render(
       <DataFrame
-        {...getProps(
-          new Quiver({ data: TEN_BY_TEN }),
-          DataframeProto.EditingMode.DELETE_ONLY
-        )}
+        {...getProps(TEN_BY_TEN, DataframeProto.EditingMode.DELETE_ONLY)}
       />
     )
 
@@ -214,10 +199,7 @@ describe("DataFrame widget", () => {
   it("enables both trailing row and row selection for DYNAMIC editing mode", () => {
     render(
       <DataFrame
-        {...getProps(
-          new Quiver({ data: TEN_BY_TEN }),
-          DataframeProto.EditingMode.DYNAMIC
-        )}
+        {...getProps(TEN_BY_TEN, DataframeProto.EditingMode.DYNAMIC)}
       />
     )
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -47,11 +47,7 @@ import {
 import { Resizable } from "re-resizable"
 import { createPortal } from "react-dom"
 
-import {
-  Dataframe as DataframeProto,
-  IArrowData,
-  streamlit,
-} from "@streamlit/protobuf"
+import { Dataframe as DataframeProto, streamlit } from "@streamlit/protobuf"
 
 import { FlexContext } from "~lib/components/core/Layout/FlexContext"
 import { LibConfigContext } from "~lib/components/core/LibConfigContext"
@@ -148,11 +144,17 @@ function DataFrame({
   // Use provided Quiver data or construct from proto's arrowData. The
   // elementHash serves as the primary memoization key to avoid unnecessary
   // re-parsing when the payload hasn't changed.
-  const data = useMemo(
-    () => dataProp ?? new Quiver(element.arrowData as IArrowData),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- elementHash is the primary cache key
-    [dataProp, elementHash, element.arrowData]
-  )
+  const data = useMemo(() => {
+    if (dataProp !== undefined) {
+      return dataProp
+    }
+    if (!element.arrowData) {
+      throw new Error("DataFrame element is missing arrowData")
+    }
+    return new Quiver(element.arrowData)
+    // elementHash is intentionally included as a stability anchor for memoization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataProp, elementHash, element.arrowData])
 
   const {
     expanded: isFullScreen,

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -47,7 +47,11 @@ import {
 import { Resizable } from "re-resizable"
 import { createPortal } from "react-dom"
 
-import { Dataframe as DataframeProto, streamlit } from "@streamlit/protobuf"
+import {
+  Dataframe as DataframeProto,
+  IArrowData,
+  streamlit,
+} from "@streamlit/protobuf"
 
 import { FlexContext } from "~lib/components/core/Layout/FlexContext"
 import { LibConfigContext } from "~lib/components/core/LibConfigContext"
@@ -104,7 +108,13 @@ const SCROLLBAR_FALLBACK_SIZE_REM = "0.5rem"
 
 export interface DataFrameProps {
   element: DataframeProto
-  data: Quiver
+  elementHash?: string
+  /**
+   * Optional pre-constructed Quiver data. If provided, this is used directly
+   * instead of constructing from element.arrowData. This is primarily used by
+   * ReadOnlyGrid which already has a Quiver instance.
+   */
+  data?: Quiver
   disabled: boolean
   widgetMgr: WidgetStateManager | undefined
   disableFullscreenMode?: boolean
@@ -119,13 +129,14 @@ export interface DataFrameProps {
  * The main component used by dataframe & data_editor to render an editable table.
  *
  * @param element - The element's proto message
- * @param data - The Arrow data to render (extracted from the proto message)
+ * @param data - Optional pre-constructed Quiver data (for ReadOnlyGrid use case)
  * @param disabled - Whether the widget is disabled
  * @param widgetMgr - The widget manager
  */
 function DataFrame({
   element,
-  data,
+  elementHash,
+  data: dataProp,
   disabled,
   widgetMgr,
   disableFullscreenMode,
@@ -134,6 +145,15 @@ function DataFrame({
   widthConfig,
   heightConfig,
 }: Readonly<DataFrameProps>): ReactElement {
+  // Use provided Quiver data or construct from proto's arrowData. The
+  // elementHash serves as the primary memoization key to avoid unnecessary
+  // re-parsing when the payload hasn't changed.
+  const data = useMemo(
+    () => dataProp ?? new Quiver(element.arrowData as IArrowData),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- elementHash is the primary cache key
+    [dataProp, elementHash, element.arrowData]
+  )
+
   const {
     expanded: isFullScreen,
     expand,

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -252,7 +252,7 @@ export class AppRoot {
           deltaPath
         )
 
-        // Check if we can reuse the payload (and derived caches) from an existing node
+        // Check if we can reuse the payload from an existing node
         const canReuse = canReuseElementPayload(
           existingNode,
           elementHash,
@@ -266,8 +266,7 @@ export class AppRoot {
           metadata,
           activeScriptHash,
           delta.fragmentId,
-          elementHash,
-          canReuse ? existingNode : undefined
+          elementHash
         )
       }
 
@@ -419,27 +418,16 @@ export class AppRoot {
     metadata: ForwardMsgMetadata,
     activeScriptHash: string,
     fragmentId?: string,
-    elementHash?: string,
-    existingNodeForDerivations?: ElementNode
+    elementHash?: string
   ): AppRoot {
-    // If we have an existing node to preserve derivations from, use its helper method
-    // to create a new node with updated lifecycle metadata but preserved lazy caches
-    const elementNode = existingNodeForDerivations
-      ? existingNodeForDerivations.withPreservedDerivations(
-          metadata,
-          scriptRunId,
-          activeScriptHash,
-          fragmentId,
-          elementHash
-        )
-      : new ElementNode(
-          element,
-          metadata,
-          scriptRunId,
-          activeScriptHash,
-          fragmentId,
-          elementHash
-        )
+    const elementNode = new ElementNode(
+      element,
+      metadata,
+      scriptRunId,
+      activeScriptHash,
+      fragmentId,
+      elementHash
+    )
     return new AppRoot(
       this.mainScriptHash,
       SetNodeByDeltaPathVisitor.setNodeAtPath(

--- a/frontend/lib/src/render-tree/ElementNode.test.ts
+++ b/frontend/lib/src/render-tree/ElementNode.test.ts
@@ -14,228 +14,86 @@
  * limitations under the License.
  */
 
-import { UNICODE } from "~lib/mocks/arrow/types/unicode"
-
-import { dataframe, table, text, vegaLiteChart } from "./test-utils"
+import { text } from "./test-utils"
 import { TransientNode } from "./TransientNode"
 
 describe("ElementNode", () => {
-  describe("ElementNode.quiverElement", () => {
-    it("returns a quiverElement (table)", () => {
-      const node = table()
-      const q = node.quiverElement
-      expect(q.columnNames).toEqual([["", "c1", "c2"]])
-      expect(q.getCell(0, 0).content).toEqual("i1")
-    })
-
-    it("returns a quiverElement (dataframe)", () => {
-      const node = dataframe()
-      const q = node.quiverElement
-      expect(q.columnNames).toEqual([["", "c1", "c2"]])
-      expect(q.getCell(0, 0).content).toEqual("i1")
-    })
-
-    it("does not recompute its value (table)", () => {
-      // accessing `quiverElement` twice should return the same instance.
-      const node = table()
-      expect(node.quiverElement).toStrictEqual(node.quiverElement)
-    })
-
-    it("does not recompute its value (dataframe)", () => {
-      // accessing `quiverElement` twice should return the same instance.
-      const node = dataframe()
-      expect(node.quiverElement).toStrictEqual(node.quiverElement)
-    })
-
-    it("throws an error for other element types", () => {
-      const node = text("foo")
-      expect(() => node.quiverElement).toThrow(
-        "elementType 'text' is not a valid Quiver element!"
-      )
-    })
-  })
-
-  describe("ElementNode.vegaLiteChartElement", () => {
-    it("returns a vegaLiteChartElement (data)", () => {
-      const MOCK_VEGA_LITE_CHART = {
-        spec: JSON.stringify({
-          mark: "circle",
-          encoding: {
-            x: { field: "a", type: "quantitative" },
-            y: { field: "b", type: "quantitative" },
-            size: { field: "c", type: "quantitative" },
-            color: { field: "c", type: "quantitative" },
-          },
-        }),
-        data: { data: UNICODE },
-        datasets: [],
-        useContainerWidth: true,
+  describe("ElementNode.accept", () => {
+    it("calls visitElementNode on the visitor", () => {
+      const node = text("test")
+      const mockVisitor = {
+        visitElementNode: vi.fn().mockReturnValue("element-result"),
+        visitBlockNode: vi.fn().mockReturnValue("block-result"),
+        visitTransientNode: vi.fn().mockReturnValue("transient-result"),
       }
-      const node = vegaLiteChart(MOCK_VEGA_LITE_CHART)
-      const element = node.vegaLiteChartElement
 
-      // spec
-      expect(element.spec).toEqual(MOCK_VEGA_LITE_CHART.spec)
+      const result = node.accept(mockVisitor)
 
-      // data
-      expect(element.data?.columnNames).toEqual([["", "c1", "c2"]])
-      expect(element.data?.getCell(0, 0).content).toEqual("i1")
-
-      // datasets
-      expect(element.datasets.length).toEqual(0)
-
-      // use container width
-      expect(element.useContainerWidth).toEqual(
-        MOCK_VEGA_LITE_CHART.useContainerWidth
-      )
+      expect(mockVisitor.visitElementNode).toHaveBeenCalledWith(node)
+      expect(mockVisitor.visitBlockNode).not.toHaveBeenCalled()
+      expect(result).toEqual("element-result")
     })
 
-    it("returns a vegaLiteChartElement (datasets)", () => {
-      const MOCK_VEGA_LITE_CHART = {
-        spec: JSON.stringify({
-          mark: "circle",
-          encoding: {
-            x: { field: "a", type: "quantitative" },
-            y: { field: "b", type: "quantitative" },
-            size: { field: "c", type: "quantitative" },
-            color: { field: "c", type: "quantitative" },
-          },
-        }),
-        data: null,
-        datasets: [{ hasName: true, name: "foo", data: { data: UNICODE } }],
-        useContainerWidth: true,
+    it("allows visitor to return the same node", () => {
+      const node = text("test")
+      const identityVisitor = {
+        visitElementNode: vi.fn().mockReturnValue(node),
+        visitBlockNode: vi.fn(),
+        visitTransientNode: vi.fn(),
       }
-      const node = vegaLiteChart(MOCK_VEGA_LITE_CHART)
-      const element = node.vegaLiteChartElement
 
-      // spec
-      expect(element.spec).toEqual(MOCK_VEGA_LITE_CHART.spec)
+      const result = node.accept(identityVisitor)
 
-      // data
-      expect(element.data).toEqual(null)
-
-      // datasets
-      expect(element.datasets[0].hasName).toEqual(
-        MOCK_VEGA_LITE_CHART.datasets[0].hasName
-      )
-      expect(element.datasets[0].name).toEqual(
-        MOCK_VEGA_LITE_CHART.datasets[0].name
-      )
-      expect(element.datasets[0].data.columnNames).toEqual([["", "c1", "c2"]])
-      expect(element.datasets[0].data.getCell(0, 0).content).toEqual("i1")
-
-      // use container width
-      expect(element.useContainerWidth).toEqual(
-        MOCK_VEGA_LITE_CHART.useContainerWidth
-      )
+      expect(result).toBe(node)
     })
 
-    it("does not recompute its value", () => {
-      const MOCK_VEGA_LITE_CHART = {
-        spec: JSON.stringify({
-          mark: "circle",
-          encoding: {
-            x: { field: "a", type: "quantitative" },
-            y: { field: "b", type: "quantitative" },
-            size: { field: "c", type: "quantitative" },
-            color: { field: "c", type: "quantitative" },
-          },
-        }),
-        data: { data: UNICODE },
-        datasets: [],
-        useContainerWidth: true,
+    it("allows visitor to return undefined", () => {
+      const node = text("test")
+      const nullVisitor = {
+        visitElementNode: vi.fn().mockReturnValue(undefined),
+        visitBlockNode: vi.fn(),
+        visitTransientNode: vi.fn(),
       }
-      // accessing `vegaLiteChartElement` twice should return the same instance.
-      const node = vegaLiteChart(MOCK_VEGA_LITE_CHART)
-      expect(node.vegaLiteChartElement).toStrictEqual(
-        node.vegaLiteChartElement
-      )
-    })
 
-    it("throws an error for other element types", () => {
-      const node = text("foo")
-      expect(() => node.vegaLiteChartElement).toThrow(
-        "elementType 'text' is not a valid VegaLiteChartElement!"
-      )
+      const result = node.accept(nullVisitor)
+
+      expect(result).toBeUndefined()
     })
   })
-})
 
-describe("ElementNode.accept", () => {
-  it("calls visitElementNode on the visitor", () => {
-    const node = text("test")
-    const mockVisitor = {
-      visitElementNode: vi.fn().mockReturnValue("element-result"),
-      visitBlockNode: vi.fn().mockReturnValue("block-result"),
-      visitTransientNode: vi.fn().mockReturnValue("transient-result"),
-    }
+  describe("ElementNode.replaceTransientNodeWithSelf", () => {
+    it("returns this when transient node scriptRunId differs", () => {
+      const el = text("a", "runA")
+      const t = new TransientNode("runB", text("anchor"), [text("t")], 1)
+      const result = el.replaceTransientNodeWithSelf(t)
+      expect(result).toBe(el)
+    })
 
-    const result = node.accept(mockVisitor)
+    it("returns this when transient node has no transients", () => {
+      const el = text("a", "runA")
+      const t = new TransientNode("runA", text("anchor"), [], 1)
+      const result = el.replaceTransientNodeWithSelf(t)
+      expect(result).toBe(el)
+    })
 
-    expect(mockVisitor.visitElementNode).toHaveBeenCalledWith(node)
-    expect(mockVisitor.visitBlockNode).not.toHaveBeenCalled()
-    expect(result).toEqual("element-result")
-  })
+    it("returns TransientNode anchored to this element with filtered transients", () => {
+      const runId = "cur"
+      const el = text("a", runId)
+      const keep = text("keep", runId)
+      const drop = text("drop", "old")
+      const t = new TransientNode(
+        runId,
+        text("old-anchor", "old"),
+        [keep, drop],
+        42
+      )
 
-  it("allows visitor to return the same node", () => {
-    const node = text("test")
-    const identityVisitor = {
-      visitElementNode: vi.fn().mockReturnValue(node),
-      visitBlockNode: vi.fn(),
-      visitTransientNode: vi.fn(),
-    }
-
-    const result = node.accept(identityVisitor)
-
-    expect(result).toBe(node)
-  })
-
-  it("allows visitor to return undefined", () => {
-    const node = text("test")
-    const nullVisitor = {
-      visitElementNode: vi.fn().mockReturnValue(undefined),
-      visitBlockNode: vi.fn(),
-      visitTransientNode: vi.fn(),
-    }
-
-    const result = node.accept(nullVisitor)
-
-    expect(result).toBeUndefined()
-  })
-})
-
-describe("ElementNode.replaceTransientNodeWithSelf", () => {
-  it("returns this when transient node scriptRunId differs", () => {
-    const el = text("a", "runA")
-    const t = new TransientNode("runB", text("anchor"), [text("t")], 1)
-    const result = el.replaceTransientNodeWithSelf(t)
-    expect(result).toBe(el)
-  })
-
-  it("returns this when transient node has no transients", () => {
-    const el = text("a", "runA")
-    const t = new TransientNode("runA", text("anchor"), [], 1)
-    const result = el.replaceTransientNodeWithSelf(t)
-    expect(result).toBe(el)
-  })
-
-  it("returns TransientNode anchored to this element with filtered transients", () => {
-    const runId = "cur"
-    const el = text("a", runId)
-    const keep = text("keep", runId)
-    const drop = text("drop", "old")
-    const t = new TransientNode(
-      runId,
-      text("old-anchor", "old"),
-      [keep, drop],
-      42
-    )
-
-    const result = el.replaceTransientNodeWithSelf(t) as TransientNode
-    expect(result).toBeInstanceOf(TransientNode)
-    expect(result.anchor).toBe(el)
-    expect(result.transientNodes).toEqual([keep])
-    expect(result.scriptRunId).toBe(runId)
-    expect(result.deltaMsgReceivedAt).toBe(42)
+      const result = el.replaceTransientNodeWithSelf(t) as TransientNode
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(result.anchor).toBe(el)
+      expect(result.transientNodes).toEqual([keep])
+      expect(result.scriptRunId).toBe(runId)
+      expect(result.deltaMsgReceivedAt).toBe(42)
+    })
   })
 })

--- a/frontend/lib/src/render-tree/ElementNode.ts
+++ b/frontend/lib/src/render-tree/ElementNode.ts
@@ -14,20 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Dataframe as DataframeProto,
-  Element,
-  ForwardMsgMetadata,
-  IArrowData,
-  IArrowNamedDataSet,
-  VegaLiteChart as VegaLiteChartProto,
-} from "@streamlit/protobuf"
-
-import type {
-  VegaLiteChartElement,
-  WrappedNamedDataset,
-} from "~lib/components/elements/ArrowVegaLiteChart/arrowUtils"
-import { Quiver } from "~lib/dataframes/Quiver"
+import { Element, ForwardMsgMetadata } from "@streamlit/protobuf"
 
 import { AppNode } from "./AppNode.interface"
 import { TransientNode } from "./TransientNode"
@@ -46,10 +33,6 @@ export class ElementNode implements AppNode {
   public readonly scriptRunId: string
 
   public readonly fragmentId?: string
-
-  private lazyQuiverElement?: Quiver
-
-  private lazyVegaLiteChartElement?: VegaLiteChartElement
 
   // The hash of the script that created this element.
   public readonly activeScriptHash: string
@@ -72,84 +55,6 @@ export class ElementNode implements AppNode {
     this.activeScriptHash = activeScriptHash
     this.fragmentId = fragmentId
     this.elementHash = elementHash
-  }
-
-  /**
-   * Create a new ElementNode with updated lifecycle metadata but preserved
-   * lazy caches (quiverElement, vegaLiteChartElement). This is used when
-   * reusing an element payload based on matching elementHash.
-   */
-  public withPreservedDerivations(
-    metadata: ForwardMsgMetadata,
-    scriptRunId: string,
-    activeScriptHash: string,
-    fragmentId?: string,
-    elementHash?: string
-  ): ElementNode {
-    const newNode = new ElementNode(
-      this.element,
-      metadata,
-      scriptRunId,
-      activeScriptHash,
-      fragmentId,
-      elementHash
-    )
-    // Preserve the lazy caches from this node
-    newNode.lazyQuiverElement = this.lazyQuiverElement
-    newNode.lazyVegaLiteChartElement = this.lazyVegaLiteChartElement
-    return newNode
-  }
-
-  public get quiverElement(): Quiver {
-    if (this.lazyQuiverElement !== undefined) {
-      return this.lazyQuiverElement
-    }
-
-    if (this.element.type !== "table" && this.element.type !== "dataframe") {
-      throw new Error(
-        `elementType '${this.element.type}' is not a valid Quiver element!`
-      )
-    }
-
-    const arrowData =
-      this.element.type === "table"
-        ? (this.element.table?.arrowData as IArrowData)
-        : ((this.element.dataframe as DataframeProto)?.arrowData as IArrowData)
-    const toReturn = new Quiver(arrowData)
-    // TODO (lukasmasuch): Delete element from proto object?
-    this.lazyQuiverElement = toReturn
-    return toReturn
-  }
-
-  public get vegaLiteChartElement(): VegaLiteChartElement {
-    if (this.lazyVegaLiteChartElement !== undefined) {
-      return this.lazyVegaLiteChartElement
-    }
-
-    if (this.element.type !== "vegaLiteChart") {
-      throw new Error(
-        `elementType '${this.element.type}' is not a valid VegaLiteChartElement!`
-      )
-    }
-
-    const proto = this.element.vegaLiteChart as VegaLiteChartProto
-    const modifiedData = proto.data ? new Quiver(proto.data) : null
-    const modifiedDatasets =
-      proto.datasets.length > 0 ? wrapDatasets(proto.datasets) : []
-
-    const toReturn = {
-      data: modifiedData,
-      spec: proto.spec,
-      datasets: modifiedDatasets,
-      useContainerWidth: proto.useContainerWidth,
-      vegaLiteTheme: proto.theme,
-      id: proto.id,
-      selectionMode: proto.selectionMode,
-      formId: proto.formId,
-    }
-
-    this.lazyVegaLiteChartElement = toReturn
-    return toReturn
   }
 
   /**
@@ -210,15 +115,4 @@ export class ElementNode implements AppNode {
       node.deltaMsgReceivedAt
     )
   }
-}
-
-/** Iterates over datasets and converts data to Quiver. */
-function wrapDatasets(datasets: IArrowNamedDataSet[]): WrappedNamedDataset[] {
-  return datasets.map((dataset: IArrowNamedDataSet) => {
-    return {
-      hasName: dataset.hasName as boolean,
-      name: dataset.name as string,
-      data: new Quiver(dataset.data as IArrowData),
-    }
-  })
 }

--- a/frontend/lib/src/render-tree/test-utils.ts
+++ b/frontend/lib/src/render-tree/test-utils.ts
@@ -20,11 +20,9 @@ import {
   Block as BlockProto,
   Element,
   ForwardMsgMetadata,
-  IVegaLiteChart,
   TextInput as TextInputProto,
 } from "@streamlit/protobuf"
 
-import { UNICODE } from "~lib/mocks/arrow/types/unicode"
 import {
   GENERATED_ELEMENT_ID_PREFIX,
   isNullOrUndefined,
@@ -103,59 +101,6 @@ export function blockWithId(
     children,
     makeProto(BlockProto, { id }),
     scriptRunId
-  )
-}
-
-/** Create a table element node with the given properties. */
-export function table(
-  scriptRunId = NO_SCRIPT_RUN_ID,
-  elementHash?: string
-): ElementNode {
-  const element = makeProto(Element, {
-    table: { arrowData: { data: UNICODE } },
-  })
-  return new ElementNode(
-    element,
-    ForwardMsgMetadata.create(),
-    scriptRunId,
-    FAKE_SCRIPT_HASH,
-    undefined,
-    elementHash
-  )
-}
-
-/** Create a dataframe element node with the given properties. */
-export function dataframe(
-  scriptRunId = NO_SCRIPT_RUN_ID,
-  elementHash?: string
-): ElementNode {
-  const element = makeProto(Element, {
-    dataframe: { arrowData: { data: UNICODE } },
-  })
-  return new ElementNode(
-    element,
-    ForwardMsgMetadata.create(),
-    scriptRunId,
-    FAKE_SCRIPT_HASH,
-    undefined,
-    elementHash
-  )
-}
-
-/** Create a vegaLiteChart element node with the given properties. */
-export function vegaLiteChart(
-  data: IVegaLiteChart,
-  scriptRunId = NO_SCRIPT_RUN_ID,
-  elementHash?: string
-): ElementNode {
-  const element = makeProto(Element, { vegaLiteChart: data })
-  return new ElementNode(
-    element,
-    ForwardMsgMetadata.create(),
-    scriptRunId,
-    FAKE_SCRIPT_HASH,
-    undefined,
-    elementHash
   )
 }
 


### PR DESCRIPTION
## Describe your changes

Moves Arrow-derived data models (`Quiver` construction, `VegaLiteChartElement` wrapper) from the render-tree `ElementNode` class into the components that render them (`Table`, `DataFrame`, `ArrowVegaLiteChart`).

- Components now construct their own `Quiver` instances via `useMemo` with `elementHash` as the primary memoization key
- Removes `quiverElement`, `vegaLiteChartElement` getters and `withPreservedDerivations()` from `ElementNode`
- `ElementNode` now only stores proto payloads and metadata (cleaner separation of concerns)

## GitHub Issue Link (if applicable)

N/A - Internal architecture refactor

## Testing Plan

- [x] Frontend unit tests (Vitest)
- [x] Manual QA testing with `make debug`
- [x] TypeScript type checking
- [x] Linting passes

**Scope**: Frontend-only refactor with no user-facing API changes. Existing E2E tests for `st.table`, `st.dataframe`, and Vega-Lite charts provide coverage.