### PR TITLE
[fix] pyplot: route SVG savefig output through string-SVG branch (#11489)

### DIFF
--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -223,15 +223,31 @@ def marshall(
 
     image = io.BytesIO()
     fig.savefig(image, **kwargs)
+
+    # When the user requests an SVG render via savefig (e.g. format="svg"),
+    # the BytesIO contains XML text rather than a raster image. The image
+    # marshalling pipeline routes raster bytes through PIL, which cannot
+    # decode SVG and would raise UnidentifiedImageError (see #11489). Hand
+    # SVG output to marshall_images as a decoded string so it takes the
+    # existing string-SVG branch in image_to_url, which emits a
+    # `data:image/svg+xml` URL.
+    fig_format = str(kwargs.get("format", "")).lower()
+    if fig_format == "svg":
+        marshall_image: Any = image.getvalue().decode("utf-8")
+        output_format = "auto"
+    else:
+        marshall_image = image
+        output_format = "PNG"
+
     marshall_images(
         coordinates=coordinates,
-        image=image,
+        image=marshall_image,
         caption=None,
         layout_config=layout_config,
         proto_imgs=image_list_proto,
         clamp=False,
         channels="RGB",
-        output_format="PNG",
+        output_format=output_format,
     )
 
     # Clear the figure after rendering it. This means that subsequent

--- a/lib/tests/streamlit/elements/pyplot_test.py
+++ b/lib/tests/streamlit/elements/pyplot_test.py
@@ -235,3 +235,38 @@ class PyplotTest(DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         assert getattr(el.width_config, expected_attribute)
+
+    def test_st_pyplot_svg_format(self):
+        """Regression test for #11489: ``st.pyplot(fig, format="svg")`` must
+        not crash with PIL.UnidentifiedImageError.
+
+        SVG output from ``Figure.savefig`` is XML text, not raster bytes, so
+        the marshalling pipeline has to route it through the string-SVG
+        branch in ``image_to_url`` and emit a ``data:image/svg+xml;base64``
+        URL instead of running it through PIL.
+        """
+        fig, ax = plt.subplots(figsize=(2, 2))
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        st.pyplot(fig, format="svg")
+
+        el = self.get_delta_from_queue().new_element
+        assert len(el.imgs.imgs) == 1
+        # Expected: an inline data URL, base64-encoded SVG. Before the fix
+        # this assertion was unreachable because st.pyplot raised
+        # PIL.UnidentifiedImageError before the proto could be enqueued.
+        assert el.imgs.imgs[0].url.startswith("data:image/svg+xml;base64,")
+
+    @parameterized.expand([("svg",), ("SVG",), ("Svg",)])
+    def test_st_pyplot_svg_format_case_insensitive(self, fmt: str):
+        """``format`` is matched case-insensitively to mirror Matplotlib's
+        own behavior — ``Figure.savefig(format="SVG")`` and ``"svg"`` are
+        equivalent. The fix must not regress that contract.
+        """
+        fig, ax = plt.subplots(figsize=(2, 2))
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        st.pyplot(fig, format=fmt)
+
+        el = self.get_delta_from_queue().new_element
+        assert el.imgs.imgs[0].url.startswith("data:image/svg+xml;base64,")


### PR DESCRIPTION
## Describe your changes

`st.pyplot(fig, format="svg")` (and any other non-PNG format kwarg) crashes with `PIL.UnidentifiedImageError: cannot identify image file ...` because the marshalling pipeline assumed raster-only output and routed the BytesIO returned by `Figure.savefig` through PIL.

This change detects `format="svg"` (case-insensitive) at the `marshall` boundary in `lib/streamlit/elements/pyplot.py`, decodes the BytesIO to a UTF-8 string, and passes `output_format="auto"` so the existing string-SVG branch in `image_to_url` takes over. That branch already emits a `data:image/svg+xml;base64,...` URL — the same code path used today when a user passes an inline SVG string directly to `st.image`.

The PNG path is unchanged (BytesIO → `output_format="PNG"`), so this is a strictly-additive behavior change for the SVG case.

## GitHub Issue Link (if applicable)

Fixes #11489

## Testing Plan

- **Unit Tests (Python):** Added `test_st_pyplot_svg_format` and `test_st_pyplot_svg_format_case_insensitive` in `lib/tests/streamlit/elements/pyplot_test.py`. Both assert that `el.imgs.imgs[0].url` starts with `data:image/svg+xml;base64,`. Both tests fail on `develop` (raise `PIL.UnidentifiedImageError` before the proto is enqueued) and pass on this branch — verified by stashing the source change and re-running.
- **Local run:** `pytest lib/tests/streamlit/elements/pyplot_test.py -k "pyplot or svg"` — 27/27 passed. Broader `pytest lib/tests/streamlit/elements/image_test.py lib/tests/streamlit/elements/lib/image_utils_test.py` — 102/102 passed (no regressions in the existing image pipeline).
- **No additional E2E tests needed:** the bug was a Python-side `UnidentifiedImageError` raised during marshalling; once the proto carries a valid `data:` URL, the existing frontend SVG rendering path is exercised by every other inline-SVG site.

## Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify end-to-end by pasting the block below.

```bash
# --- one-time setup ---
git clone https://github.com/streamlit/streamlit.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e ./lib
pip install matplotlib pytest parameterized pytest-cov requests-mock
# Compile python protos (the repo Makefile has a `protobuf` target; alternatively:)
pip install mypy-protobuf
protoc --proto_path=proto --python_out=lib --plugin=protoc-gen-mypy=$(which protoc-gen-mypy) --mypy_out=lib proto/streamlit/proto/*.proto

# --- BEFORE (origin/develop) ---
git checkout origin/develop
# Pull the new test file from this PR so we can run the same assertion both ways:
git fetch https://github.com/jbbqqf/streamlit.git feat/11489-pyplot-svg
git checkout FETCH_HEAD -- lib/tests/streamlit/elements/pyplot_test.py
( cd lib && python -m pytest tests/streamlit/elements/pyplot_test.py -k "svg" --no-cov -p no:cacheprovider )
# Expected: 4 FAILED with `PIL.UnidentifiedImageError: cannot identify image file ...`

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
( cd lib && python -m pytest tests/streamlit/elements/pyplot_test.py -k "svg" --no-cov -p no:cacheprovider )
# Expected: 4 passed — st.pyplot now emits `data:image/svg+xml;base64,...`
```

The same script reproduces the original user-reported behavior at runtime: on `develop`, `st.pyplot(fig, format="svg")` raises `UnidentifiedImageError`; on this branch the figure renders as an inline SVG.

## What I ran locally

- `pytest lib/tests/streamlit/elements/pyplot_test.py -k "pyplot or svg" -v` → 27/27 passed (4 of which are new).
- `pytest lib/tests/streamlit/elements/image_test.py lib/tests/streamlit/elements/lib/image_utils_test.py -q` → 102/102 passed (no regression in the existing PNG/JPEG/inline-SVG pipeline).
- `ruff check lib/streamlit/elements/pyplot.py lib/tests/streamlit/elements/pyplot_test.py` → clean.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Default raster path (regression check) | `st.pyplot(fig)` | URL starts with `MEDIA_ENDPOINT`, no crash | `test_st_pyplot` (existing) |
| 2 | SVG via `format="svg"` (the fix) | `st.pyplot(fig, format="svg")` | URL starts with `data:image/svg+xml;base64,` | `test_st_pyplot_svg_format` (new) |
| 3 | Case-variants of `"svg"` | `format="SVG"`, `"Svg"`, `"svg"` | All routed via SVG branch | `test_st_pyplot_svg_format_case_insensitive` (new, parameterized) |

## Risk / blast radius

The change only branches on `kwargs.get("format")` inside `pyplot.marshall`. The PNG path is byte-identical to before (same call to `marshall_images` with `output_format="PNG"`). The new branch reuses an existing, well-tested SVG code path in `image_to_url` that's already exercised whenever a user passes an inline `<svg>` string to `st.image`. No public API change, no proto change, no frontend change.

Other Matplotlib formats (`pdf`, `eps`) are still routed through PIL and would still raise — that's pre-existing behavior. Extending to those formats can be a follow-up if there's user demand; this PR keeps the diff narrow and targeted at the reported regression.

## Release note

```release-note
Fix `st.pyplot(fig, format="svg")` raising `PIL.UnidentifiedImageError`. SVG output is now routed through the existing inline-SVG path and rendered as a `data:image/svg+xml;base64,...` URL.
```

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against streamlit/streamlit's source and the upstream image-marshalling path. The reproducer block above was used during development and is the same one a reviewer can paste verbatim.*
