### PR TITLE
[fix] Support symlinks in Starlette static file serving

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_static_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_static_routes.py
@@ -63,6 +63,9 @@ def create_streamlit_static_handler(
 
     class _StreamlitStaticFiles(StaticFiles):
         def __init__(self, directory: str, base_url: str | None) -> None:
+            # follow_symlink=True restores Tornado parity for Bazel/Nix-style deployments
+            # where the static directory may contain or be a symlink. The static dir is
+            # read-only package content, not user-controlled, so this is safe.
             super().__init__(directory=directory, html=True, follow_symlink=True)
             self._base_url = (base_url or "").strip("/")
             self._index_path = os.path.join(directory, "index.html")

--- a/lib/streamlit/web/server/starlette/starlette_static_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_static_routes.py
@@ -63,7 +63,7 @@ def create_streamlit_static_handler(
 
     class _StreamlitStaticFiles(StaticFiles):
         def __init__(self, directory: str, base_url: str | None) -> None:
-            super().__init__(directory=directory, html=True)
+            super().__init__(directory=directory, html=True, follow_symlink=True)
             self._base_url = (base_url or "").strip("/")
             self._index_path = os.path.join(directory, "index.html")
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_static_routes_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -527,3 +528,79 @@ class TestCacheHeadersOnRedirects:
         assert response.status_code == 200
         expected = f"public, immutable, max-age={STATIC_ASSET_CACHE_MAX_AGE_SECONDS}"
         assert response.headers["Cache-Control"] == expected
+
+
+class TestSymlinkSupport:
+    """Tests for symlink support in static file serving.
+
+    Verifies that follow_symlink=True is working correctly, which is required
+    for Bazel/Nix-style deployments where the static directory may contain
+    or be a symlink.
+    """
+
+    @pytest.mark.skipif(
+        not hasattr(os, "symlink"),
+        reason="Symlinks not supported on this platform",
+    )
+    def test_serves_symlinked_file(self, tmp_path: Path) -> None:
+        """Test that symlinked files are served correctly."""
+        # Create static directory
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        # Create a real file outside the static directory
+        external_file = tmp_path / "external.js"
+        external_file.write_text("console.log('external')")
+
+        # Create a symlink to the external file inside the static directory
+        symlink_path = static_dir / "linked.js"
+        try:
+            symlink_path.symlink_to(external_file)
+        except OSError:
+            pytest.skip("Unable to create symlinks (requires privileges on Windows)")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app) as client:
+            response = client.get("/linked.js")
+
+            assert response.status_code == 200
+            assert response.text == "console.log('external')"
+
+    @pytest.mark.skipif(
+        not hasattr(os, "symlink"),
+        reason="Symlinks not supported on this platform",
+    )
+    def test_serves_symlinked_directory(self, tmp_path: Path) -> None:
+        """Test that symlinked directories are served correctly."""
+        # Create static directory
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text("<html>Home</html>")
+
+        # Create an external directory with files
+        external_dir = tmp_path / "external_assets"
+        external_dir.mkdir()
+        (external_dir / "asset.css").write_text("body { color: red; }")
+
+        # Create a symlink to the external directory inside the static directory
+        symlink_dir = static_dir / "assets"
+        try:
+            symlink_dir.symlink_to(external_dir)
+        except OSError:
+            pytest.skip("Unable to create symlinks (requires privileges on Windows)")
+
+        static_files = create_streamlit_static_handler(
+            directory=str(static_dir), base_url=None
+        )
+        app = Starlette(routes=[Mount("/", app=static_files)])
+
+        with TestClient(app) as client:
+            response = client.get("/assets/asset.css")
+
+            assert response.status_code == 200
+            assert response.text == "body { color: red; }"


### PR DESCRIPTION
## Describe your changes

Enables `follow_symlink=True` for Starlette's `StaticFiles` handler serving Streamlit's bundled frontend assets. This restores compatibility with Bazel and other symlink-based deployment environments that broke after the Tornado → Starlette migration.

- Sets `follow_symlink=True` in `_StreamlitStaticFiles` constructor
- Fixes 404 errors when static files are symlinked (common in Bazel, Nix, containers)

## Security Note

**This change does not introduce new security issues.** The previous Tornado implementation used `os.path.abspath()` for path validation, which follows symlinks (equivalent to Starlette's `follow_symlink=True`). The Starlette migration inadvertently changed this to `os.path.realpath()` (the default), which blocks symlinked files.

The static directory (`lib/streamlit/static/`) is read-only package content—not user-controlled. An attacker with write access to this directory could already execute arbitrary code by modifying Python files, making symlink-based attacks strictly weaker than existing capabilities. This matches the security posture of standard web servers (nginx, Apache) which follow symlinks by default.

## GitHub Issue Link (if applicable)

- Fixes https://github.com/streamlit/streamlit/issues/13600#issuecomment-4402911564

## Testing Plan

- [x] Existing unit tests pass (`starlette_static_routes_test.py` - 31 tests)
- [x] Type checks pass (mypy, ty)
- [x] Lint checks pass (ruff)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->