### PR TITLE
[refactor] Add useDataFrameCapabilities hook for centralized feature gates

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -231,7 +231,7 @@ function DataFrame({
 
   // Centralized capability layer that determines which features are enabled
   const {
-    canSort: isSortingEnabled,
+    canSort,
     canSearch,
     canExportCsv,
     canEdit,
@@ -974,7 +974,7 @@ function DataFrame({
           }}
           // Header click is used for column sorting:
           onHeaderClicked={(columnIdx: number, _event) => {
-            if (!isSortingEnabled || isColumnSelectionActivated) {
+            if (!canSort || isColumnSelectionActivated) {
               // Deactivate sorting for empty state, for large dataframes, or
               // when column selection is activated.
               return
@@ -1190,7 +1190,7 @@ function DataFrame({
             column={originalColumns[showMenu.columnIdx]}
             onCloseMenu={() => setShowMenu(undefined)}
             onSortColumn={
-              isSortingEnabled
+              canSort
                 ? (direction: "asc" | "desc" | undefined) => {
                     // Hide search before sorting to clear search results
                     if (showSearch) {

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -78,6 +78,7 @@ import useCustomRenderer from "./hooks/useCustomRenderer"
 import useCustomTheme from "./hooks/useCustomTheme"
 import useDataEditor from "./hooks/useDataEditor"
 import useDataExporter from "./hooks/useDataExporter"
+import useDataFrameCapabilities from "./hooks/useDataFrameCapabilities"
 import useDataLoader from "./hooks/useDataLoader"
 import useRowHover from "./hooks/useRowHover"
 import useSelectionHandler from "./hooks/useSelectionHandler"
@@ -92,9 +93,6 @@ import Tooltip from "./Tooltip"
 import "@glideapps/glide-data-grid/dist/index.css"
 import "@glideapps/glide-data-grid-cells/dist/index.css"
 
-// Number of rows that triggers some optimization features
-// for large tables.
-const LARGE_TABLE_ROWS_THRESHOLD = 150000
 // Fallback size for the scrollbar gutter size in rem.
 // If the scrollbar gutter size is 0, it means that we the system is using
 // overlay scrollbars that don't take any space. In this case, we assume
@@ -227,45 +225,26 @@ function DataFrame({
   const editingMode =
     element.editingMode ?? DataframeProto.EditingMode.READ_ONLY
 
-  const { READ_ONLY, DYNAMIC, ADD_ONLY, DELETE_ONLY } =
-    DataframeProto.EditingMode
-
   // Number of rows of the table minus 1 for the header row:
   const dataDimensions = data.dimensions
   const originalNumRows = Math.max(0, dataDimensions.numDataRows)
 
-  // For empty tables, we show an extra row that
-  // contains "empty" as a way to indicate that the table is empty.
-  const isEmptyTable =
-    originalNumRows === 0 &&
-    // We don't show empty state for modes that allow adding rows
-    // with a table that has data columns defined.
-    !(
-      (editingMode === DYNAMIC || editingMode === ADD_ONLY) &&
-      dataDimensions.numDataColumns > 0
-    )
-
-  // For large tables, we apply some optimizations to handle large data
-  const isLargeTable = originalNumRows > LARGE_TABLE_ROWS_THRESHOLD
-  // Sorting is disabled for modes that allow adding rows (DYNAMIC, ADD_ONLY)
-  // because sorting and row addition can conflict
-  const isSortingEnabled =
-    !isLargeTable &&
-    !isEmptyTable &&
-    editingMode !== DYNAMIC &&
-    editingMode !== ADD_ONLY
-
-  // Check if the editing mode allows adding rows (DYNAMIC or ADD_ONLY)
-  const canAddRows =
-    !isEmptyTable &&
-    (editingMode === DYNAMIC || editingMode === ADD_ONLY) &&
-    !disabled
-
-  // Check if the editing mode allows deleting rows (DYNAMIC or DELETE_ONLY)
-  const canDeleteRows =
-    !isEmptyTable &&
-    (editingMode === DYNAMIC || editingMode === DELETE_ONLY) &&
-    !disabled
+  // Centralized capability layer that determines which features are enabled
+  const {
+    canSort: isSortingEnabled,
+    canSearch,
+    canExportCsv,
+    canEdit,
+    canAddRows,
+    canDeleteRows,
+    isEmptyTable,
+    isLargeTable,
+  } = useDataFrameCapabilities({
+    editingMode,
+    disabled,
+    numDataRows: originalNumRows,
+    numDataColumns: dataDimensions.numDataColumns,
+  })
 
   const [columnOrder, setColumnOrder] = useState(element.columnOrder)
 
@@ -859,14 +838,14 @@ function DataFrame({
             />
           </ColumnVisibilityMenu>
         )}
-        {!isLargeTable && !isEmptyTable && (
+        {canExportCsv && (
           <ToolbarAction
             label="Download as CSV"
             icon={FileDownload}
             onClick={exportToCsv}
           />
         )}
-        {!isEmptyTable && (
+        {canSearch && (
           <ToolbarAction
             label="Search"
             icon={Search}
@@ -1157,18 +1136,16 @@ function DataFrame({
             rangeSelectionBlending: "additive",
           })}
           // If element is editable, enable editing features:
-          {...(!isEmptyTable &&
-            editingMode !== READ_ONLY &&
-            !disabled && {
-              // Support fill handle for bulk editing:
-              fillHandle: !isTouchDevice,
-              // Support editing:
-              onCellEdited,
-              // Support pasting data for bulk editing:
-              onPaste,
-              // Support deleting cells & rows:
-              onDelete,
-            })}
+          {...(canEdit && {
+            // Support fill handle for bulk editing:
+            fillHandle: !isTouchDevice,
+            // Support editing:
+            onCellEdited,
+            // Support pasting data for bulk editing:
+            onPaste,
+            // Support deleting cells & rows:
+            onDelete,
+          })}
           // If element allows adding rows (DYNAMIC or ADD_ONLY), enable trailing row
           // and deactivate sorting:
           {...(canAddRows && {

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -212,12 +212,6 @@ function DataFrame({
     []
   )
 
-  // Determine if the device is primary using touch as input:
-  const isTouchDevice = useMemo<boolean>(
-    () => window.matchMedia?.("(pointer: coarse)").matches ?? false,
-    []
-  )
-
   // This is done to keep some backwards compatibility
   // so that old arrow proto messages from the st.dataframe
   // would still work. Those messages don't have the
@@ -239,6 +233,10 @@ function DataFrame({
     canDeleteRows,
     isEmptyTable,
     isLargeTable,
+    isTouchDevice,
+    canResizeColumns,
+    supportsFillHandle,
+    supportsRectangleSelection,
   } = useDataFrameCapabilities({
     editingMode,
     disabled,
@@ -919,7 +917,7 @@ function DataFrame({
           rowHeight={rowHeight}
           headerHeight={gridTheme.defaultHeaderHeight}
           getCellContent={isEmptyTable ? getEmptyStateContent : getCellContent}
-          onColumnResize={isTouchDevice ? undefined : onColumnResize}
+          onColumnResize={canResizeColumns ? onColumnResize : undefined}
           // Configure resize indicator to only show on the header:
           resizeIndicator={"header"}
           // Freeze all index columns:
@@ -933,7 +931,7 @@ function DataFrame({
           // Deactivate row markers and numbers:
           rowMarkers={"none"}
           // Deactivate selections:
-          rangeSelect={isTouchDevice ? "cell" : "rect"}
+          rangeSelect={supportsRectangleSelection ? "rect" : "cell"}
           columnSelect={"none"}
           rowSelect={"none"}
           // Enable interactive column reordering:
@@ -1138,7 +1136,7 @@ function DataFrame({
           // If element is editable, enable editing features:
           {...(canEdit && {
             // Support fill handle for bulk editing:
-            fillHandle: !isTouchDevice,
+            fillHandle: supportsFillHandle,
             // Support editing:
             onCellEdited,
             // Support pasting data for bulk editing:

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { Dataframe as DataframeProto } from "@streamlit/protobuf"
+
+import useDataFrameCapabilities, {
+  LARGE_TABLE_ROWS_THRESHOLD,
+} from "./useDataFrameCapabilities"
+
+const { READ_ONLY, DYNAMIC, ADD_ONLY, DELETE_ONLY } =
+  DataframeProto.EditingMode
+
+describe("useDataFrameCapabilities", () => {
+  const defaultParams = {
+    editingMode: READ_ONLY,
+    disabled: false,
+    numDataRows: 10,
+    numDataColumns: 5,
+  }
+
+  describe("canSort", () => {
+    it("returns true for normal read-only tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canSort).toBe(true)
+    })
+
+    it.each([
+      ["large tables", { numDataRows: LARGE_TABLE_ROWS_THRESHOLD + 1 }],
+      ["empty tables", { numDataRows: 0 }],
+      ["DYNAMIC editing mode", { editingMode: DYNAMIC }],
+      ["ADD_ONLY editing mode", { editingMode: ADD_ONLY }],
+    ])("returns false for %s", (_description, overrides) => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, ...overrides })
+      )
+      expect(result.current.canSort).toBe(false)
+    })
+
+    it("returns true for DELETE_ONLY editing mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DELETE_ONLY,
+        })
+      )
+      expect(result.current.canSort).toBe(true)
+    })
+  })
+
+  describe("canSearch", () => {
+    it("returns true for non-empty tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canSearch).toBe(true)
+    })
+
+    it("returns false for empty tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: 0,
+        })
+      )
+      expect(result.current.canSearch).toBe(false)
+    })
+
+    it("returns true for large tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: LARGE_TABLE_ROWS_THRESHOLD + 1,
+        })
+      )
+      expect(result.current.canSearch).toBe(true)
+    })
+  })
+
+  describe("canExportCsv", () => {
+    it("returns true for normal tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canExportCsv).toBe(true)
+    })
+
+    it.each([
+      ["large tables", { numDataRows: LARGE_TABLE_ROWS_THRESHOLD + 1 }],
+      ["empty tables", { numDataRows: 0 }],
+    ])("returns false for %s", (_description, overrides) => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, ...overrides })
+      )
+      expect(result.current.canExportCsv).toBe(false)
+    })
+  })
+
+  describe("canEdit", () => {
+    it("returns false for READ_ONLY mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canEdit).toBe(false)
+    })
+
+    it.each([
+      ["DYNAMIC", DYNAMIC],
+      ["ADD_ONLY", ADD_ONLY],
+      ["DELETE_ONLY", DELETE_ONLY],
+    ])("returns true for %s mode", (_name, editingMode) => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode,
+        })
+      )
+      expect(result.current.canEdit).toBe(true)
+    })
+
+    it("returns false when disabled", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DYNAMIC,
+          disabled: true,
+        })
+      )
+      expect(result.current.canEdit).toBe(false)
+    })
+
+    it("returns false for empty tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DYNAMIC,
+          numDataRows: 0,
+          numDataColumns: 0,
+        })
+      )
+      expect(result.current.canEdit).toBe(false)
+    })
+  })
+
+  describe("canAddRows", () => {
+    it("returns false for READ_ONLY mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canAddRows).toBe(false)
+    })
+
+    it.each([
+      ["DYNAMIC", DYNAMIC],
+      ["ADD_ONLY", ADD_ONLY],
+    ])("returns true for %s mode", (_name, editingMode) => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode,
+        })
+      )
+      expect(result.current.canAddRows).toBe(true)
+    })
+
+    it("returns false for DELETE_ONLY mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DELETE_ONLY,
+        })
+      )
+      expect(result.current.canAddRows).toBe(false)
+    })
+
+    it("returns false when disabled", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DYNAMIC,
+          disabled: true,
+        })
+      )
+      expect(result.current.canAddRows).toBe(false)
+    })
+  })
+
+  describe("canDeleteRows", () => {
+    it("returns false for READ_ONLY mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canDeleteRows).toBe(false)
+    })
+
+    it.each([
+      ["DYNAMIC", DYNAMIC],
+      ["DELETE_ONLY", DELETE_ONLY],
+    ])("returns true for %s mode", (_name, editingMode) => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode,
+        })
+      )
+      expect(result.current.canDeleteRows).toBe(true)
+    })
+
+    it("returns false for ADD_ONLY mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: ADD_ONLY,
+        })
+      )
+      expect(result.current.canDeleteRows).toBe(false)
+    })
+
+    it("returns false when disabled", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DYNAMIC,
+          disabled: true,
+        })
+      )
+      expect(result.current.canDeleteRows).toBe(false)
+    })
+  })
+
+  describe("empty table detection", () => {
+    it("treats zero-row tables as empty when READ_ONLY", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: 0,
+        })
+      )
+      expect(result.current.isEmptyTable).toBe(true)
+      expect(result.current.canSort).toBe(false)
+      expect(result.current.canSearch).toBe(false)
+    })
+
+    it("treats zero-row tables with columns as non-empty in DYNAMIC mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: 0,
+          numDataColumns: 5,
+          editingMode: DYNAMIC,
+        })
+      )
+      expect(result.current.isEmptyTable).toBe(false)
+      expect(result.current.canSearch).toBe(true)
+      expect(result.current.canAddRows).toBe(true)
+    })
+
+    it("treats zero-row tables with columns as non-empty in ADD_ONLY mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: 0,
+          numDataColumns: 5,
+          editingMode: ADD_ONLY,
+        })
+      )
+      expect(result.current.isEmptyTable).toBe(false)
+      expect(result.current.canSearch).toBe(true)
+      expect(result.current.canAddRows).toBe(true)
+    })
+
+    it("treats zero-row/zero-column tables as empty even in DYNAMIC mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: 0,
+          numDataColumns: 0,
+          editingMode: DYNAMIC,
+        })
+      )
+      expect(result.current.isEmptyTable).toBe(true)
+      expect(result.current.canSearch).toBe(false)
+      expect(result.current.canAddRows).toBe(false)
+    })
+  })
+
+  describe("large table detection", () => {
+    it("returns isLargeTable false for normal tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.isLargeTable).toBe(false)
+    })
+
+    it("returns isLargeTable true for tables exceeding threshold", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: LARGE_TABLE_ROWS_THRESHOLD + 1,
+        })
+      )
+      expect(result.current.isLargeTable).toBe(true)
+    })
+
+    it("returns isLargeTable false for tables at exactly the threshold", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: LARGE_TABLE_ROWS_THRESHOLD,
+        })
+      )
+      expect(result.current.isLargeTable).toBe(false)
+    })
+  })
+})

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
@@ -54,21 +54,14 @@ describe("useDataFrameCapabilities", () => {
       expect(result.current.canSort).toBe(false)
     })
 
-    it("returns true for DELETE_ONLY editing mode", () => {
+    it.each([
+      ["DELETE_ONLY", DELETE_ONLY],
+      ["FIXED", FIXED],
+    ])("returns true for %s editing mode", (_name, editingMode) => {
       const { result } = renderHook(() =>
         useDataFrameCapabilities({
           ...defaultParams,
-          editingMode: DELETE_ONLY,
-        })
-      )
-      expect(result.current.canSort).toBe(true)
-    })
-
-    it("returns true for FIXED editing mode", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities({
-          ...defaultParams,
-          editingMode: FIXED,
+          editingMode,
         })
       )
       expect(result.current.canSort).toBe(true)
@@ -191,21 +184,14 @@ describe("useDataFrameCapabilities", () => {
       expect(result.current.canAddRows).toBe(true)
     })
 
-    it("returns false for DELETE_ONLY mode", () => {
+    it.each([
+      ["DELETE_ONLY", DELETE_ONLY],
+      ["FIXED", FIXED],
+    ])("returns false for %s mode", (_name, editingMode) => {
       const { result } = renderHook(() =>
         useDataFrameCapabilities({
           ...defaultParams,
-          editingMode: DELETE_ONLY,
-        })
-      )
-      expect(result.current.canAddRows).toBe(false)
-    })
-
-    it("returns false for FIXED mode", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities({
-          ...defaultParams,
-          editingMode: FIXED,
+          editingMode,
         })
       )
       expect(result.current.canAddRows).toBe(false)
@@ -244,21 +230,14 @@ describe("useDataFrameCapabilities", () => {
       expect(result.current.canDeleteRows).toBe(true)
     })
 
-    it("returns false for ADD_ONLY mode", () => {
+    it.each([
+      ["ADD_ONLY", ADD_ONLY],
+      ["FIXED", FIXED],
+    ])("returns false for %s mode", (_name, editingMode) => {
       const { result } = renderHook(() =>
         useDataFrameCapabilities({
           ...defaultParams,
-          editingMode: ADD_ONLY,
-        })
-      )
-      expect(result.current.canDeleteRows).toBe(false)
-    })
-
-    it("returns false for FIXED mode", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities({
-          ...defaultParams,
-          editingMode: FIXED,
+          editingMode,
         })
       )
       expect(result.current.canDeleteRows).toBe(false)
@@ -362,67 +341,47 @@ describe("useDataFrameCapabilities", () => {
   })
 
   describe("touch device capabilities", () => {
-    it("returns isTouchDevice flag", () => {
+    it("returns isTouchDevice as boolean and touch-dependent flags are inversely related", () => {
       const { result } = renderHook(() =>
         useDataFrameCapabilities(defaultParams)
       )
       expect(typeof result.current.isTouchDevice).toBe("boolean")
-    })
-
-    it("canResizeColumns and supportsRectangleSelection are consistent", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities(defaultParams)
-      )
-      expect(result.current.canResizeColumns).toBe(
-        result.current.supportsRectangleSelection
-      )
-    })
-
-    it("canResizeColumns equals !isTouchDevice", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities(defaultParams)
-      )
+      // canResizeColumns and supportsRectangleSelection are both disabled on touch
       expect(result.current.canResizeColumns).toBe(
         !result.current.isTouchDevice
-      )
-    })
-
-    it("supportsRectangleSelection equals !isTouchDevice", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities(defaultParams)
       )
       expect(result.current.supportsRectangleSelection).toBe(
         !result.current.isTouchDevice
       )
     })
 
-    it("supportsFillHandle is false when canEdit is false", () => {
-      const { result } = renderHook(() =>
+    it("supportsFillHandle requires canEdit and non-touch device", () => {
+      // READ_ONLY: canEdit is false, so supportsFillHandle must be false
+      const readOnly = renderHook(() =>
         useDataFrameCapabilities({ ...defaultParams, editingMode: READ_ONLY })
       )
-      expect(result.current.canEdit).toBe(false)
-      expect(result.current.supportsFillHandle).toBe(false)
-    })
+      expect(readOnly.result.current.canEdit).toBe(false)
+      expect(readOnly.result.current.supportsFillHandle).toBe(false)
 
-    it("supportsFillHandle equals canEdit && !isTouchDevice", () => {
-      const { result } = renderHook(() =>
-        useDataFrameCapabilities({ ...defaultParams, editingMode: DYNAMIC })
-      )
-      expect(result.current.supportsFillHandle).toBe(
-        result.current.canEdit && !result.current.isTouchDevice
-      )
-    })
-
-    it("supportsFillHandle is false when disabled even for editable modes", () => {
-      const { result } = renderHook(() =>
+      // DYNAMIC + disabled: canEdit is false, so supportsFillHandle must be false
+      const disabled = renderHook(() =>
         useDataFrameCapabilities({
           ...defaultParams,
           editingMode: DYNAMIC,
           disabled: true,
         })
       )
-      expect(result.current.canEdit).toBe(false)
-      expect(result.current.supportsFillHandle).toBe(false)
+      expect(disabled.result.current.canEdit).toBe(false)
+      expect(disabled.result.current.supportsFillHandle).toBe(false)
+
+      // DYNAMIC + enabled: supportsFillHandle depends on touch device state
+      const editable = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, editingMode: DYNAMIC })
+      )
+      expect(editable.result.current.canEdit).toBe(true)
+      expect(editable.result.current.supportsFillHandle).toBe(
+        !editable.result.current.isTouchDevice
+      )
     })
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
@@ -23,7 +23,7 @@ import useDataFrameCapabilities, {
   LARGE_TABLE_ROWS_THRESHOLD,
 } from "./useDataFrameCapabilities"
 
-const { READ_ONLY, DYNAMIC, ADD_ONLY, DELETE_ONLY } =
+const { READ_ONLY, DYNAMIC, ADD_ONLY, DELETE_ONLY, FIXED } =
   DataframeProto.EditingMode
 
 describe("useDataFrameCapabilities", () => {
@@ -59,6 +59,16 @@ describe("useDataFrameCapabilities", () => {
         useDataFrameCapabilities({
           ...defaultParams,
           editingMode: DELETE_ONLY,
+        })
+      )
+      expect(result.current.canSort).toBe(true)
+    })
+
+    it("returns true for FIXED editing mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: FIXED,
         })
       )
       expect(result.current.canSort).toBe(true)
@@ -125,6 +135,7 @@ describe("useDataFrameCapabilities", () => {
       ["DYNAMIC", DYNAMIC],
       ["ADD_ONLY", ADD_ONLY],
       ["DELETE_ONLY", DELETE_ONLY],
+      ["FIXED", FIXED],
     ])("returns true for %s mode", (_name, editingMode) => {
       const { result } = renderHook(() =>
         useDataFrameCapabilities({
@@ -190,6 +201,16 @@ describe("useDataFrameCapabilities", () => {
       expect(result.current.canAddRows).toBe(false)
     })
 
+    it("returns false for FIXED mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: FIXED,
+        })
+      )
+      expect(result.current.canAddRows).toBe(false)
+    })
+
     it("returns false when disabled", () => {
       const { result } = renderHook(() =>
         useDataFrameCapabilities({
@@ -228,6 +249,16 @@ describe("useDataFrameCapabilities", () => {
         useDataFrameCapabilities({
           ...defaultParams,
           editingMode: ADD_ONLY,
+        })
+      )
+      expect(result.current.canDeleteRows).toBe(false)
+    })
+
+    it("returns false for FIXED mode", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: FIXED,
         })
       )
       expect(result.current.canDeleteRows).toBe(false)

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
@@ -360,4 +360,69 @@ describe("useDataFrameCapabilities", () => {
       expect(result.current.isLargeTable).toBe(false)
     })
   })
+
+  describe("touch device capabilities", () => {
+    it("returns isTouchDevice flag", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(typeof result.current.isTouchDevice).toBe("boolean")
+    })
+
+    it("canResizeColumns and supportsRectangleSelection are consistent", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canResizeColumns).toBe(
+        result.current.supportsRectangleSelection
+      )
+    })
+
+    it("canResizeColumns equals !isTouchDevice", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canResizeColumns).toBe(
+        !result.current.isTouchDevice
+      )
+    })
+
+    it("supportsRectangleSelection equals !isTouchDevice", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.supportsRectangleSelection).toBe(
+        !result.current.isTouchDevice
+      )
+    })
+
+    it("supportsFillHandle is false when canEdit is false", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, editingMode: READ_ONLY })
+      )
+      expect(result.current.canEdit).toBe(false)
+      expect(result.current.supportsFillHandle).toBe(false)
+    })
+
+    it("supportsFillHandle equals canEdit && !isTouchDevice", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, editingMode: DYNAMIC })
+      )
+      expect(result.current.supportsFillHandle).toBe(
+        result.current.canEdit && !result.current.isTouchDevice
+      )
+    })
+
+    it("supportsFillHandle is false when disabled even for editable modes", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          editingMode: DYNAMIC,
+          disabled: true,
+        })
+      )
+      expect(result.current.canEdit).toBe(false)
+      expect(result.current.supportsFillHandle).toBe(false)
+    })
+  })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react"
+
+import { Dataframe as DataframeProto } from "@streamlit/protobuf"
+
+/** Threshold for large tables that triggers performance optimizations. */
+export const LARGE_TABLE_ROWS_THRESHOLD = 150000
+
+/** Feature flags for the dataframe component. */
+interface DataFrameCapabilities {
+  /** Whether column sorting is enabled. */
+  canSort: boolean
+  /** Whether search functionality is enabled. */
+  canSearch: boolean
+  /** Whether CSV export is enabled. */
+  canExportCsv: boolean
+  /** Whether cell editing is enabled. */
+  canEdit: boolean
+  /** Whether adding rows is enabled. */
+  canAddRows: boolean
+  /** Whether deleting rows is enabled. */
+  canDeleteRows: boolean
+  /** Whether the table is empty and should show empty state. */
+  isEmptyTable: boolean
+  /** Whether the table exceeds the large table threshold. */
+  isLargeTable: boolean
+}
+
+interface UseDataFrameCapabilitiesParams {
+  /** The editing mode from the proto element. */
+  editingMode: DataframeProto.EditingMode
+  /** Whether the widget is disabled. */
+  disabled: boolean
+  /** Number of data rows in the table. */
+  numDataRows: number
+  /** Number of data columns in the table. */
+  numDataColumns: number
+}
+
+/**
+ * Determines whether the table should show the empty state.
+ * Empty tables are shown for zero rows, unless the editing mode allows adding
+ * rows and there are data columns defined.
+ */
+function computeIsEmptyTable(
+  numDataRows: number,
+  numDataColumns: number,
+  editingMode: DataframeProto.EditingMode
+): boolean {
+  const { DYNAMIC, ADD_ONLY } = DataframeProto.EditingMode
+  if (numDataRows > 0) {
+    return false
+  }
+  const canAddRowsInMode = editingMode === DYNAMIC || editingMode === ADD_ONLY
+  return !(canAddRowsInMode && numDataColumns > 0)
+}
+
+/**
+ * Custom hook that centralizes all capability/feature decisions for the
+ * dataframe component.
+ *
+ * Rather than scattering conditional logic throughout the component, this hook
+ * returns an explicit set of capability flags that can be used to enable or
+ * disable features.
+ */
+function useDataFrameCapabilities({
+  editingMode,
+  disabled,
+  numDataRows,
+  numDataColumns,
+}: UseDataFrameCapabilitiesParams): DataFrameCapabilities {
+  return useMemo(() => {
+    const { READ_ONLY, DYNAMIC, ADD_ONLY, DELETE_ONLY } =
+      DataframeProto.EditingMode
+
+    const isEmptyTable = computeIsEmptyTable(
+      numDataRows,
+      numDataColumns,
+      editingMode
+    )
+    const isLargeTable = numDataRows > LARGE_TABLE_ROWS_THRESHOLD
+
+    const canSort =
+      !isLargeTable &&
+      !isEmptyTable &&
+      editingMode !== DYNAMIC &&
+      editingMode !== ADD_ONLY
+
+    const canSearch = !isEmptyTable
+
+    const canExportCsv = !isLargeTable && !isEmptyTable
+
+    const canEdit = !isEmptyTable && editingMode !== READ_ONLY && !disabled
+
+    const canAddRows =
+      !isEmptyTable &&
+      (editingMode === DYNAMIC || editingMode === ADD_ONLY) &&
+      !disabled
+
+    const canDeleteRows =
+      !isEmptyTable &&
+      (editingMode === DYNAMIC || editingMode === DELETE_ONLY) &&
+      !disabled
+
+    return {
+      canSort,
+      canSearch,
+      canExportCsv,
+      canEdit,
+      canAddRows,
+      canDeleteRows,
+      isEmptyTable,
+      isLargeTable,
+    }
+  }, [editingMode, disabled, numDataRows, numDataColumns])
+}
+
+export default useDataFrameCapabilities

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.ts
@@ -39,6 +39,14 @@ interface DataFrameCapabilities {
   isEmptyTable: boolean
   /** Whether the table exceeds the large table threshold. */
   isLargeTable: boolean
+  /** Whether the device primarily uses touch input. */
+  isTouchDevice: boolean
+  /** Whether column resizing via drag is supported. Disabled on touch devices. */
+  canResizeColumns: boolean
+  /** Whether the fill handle for bulk editing is supported. Disabled on touch devices. */
+  supportsFillHandle: boolean
+  /** Whether rectangle (multi-cell) selection is supported. Touch devices use cell-only selection. */
+  supportsRectangleSelection: boolean
 }
 
 interface UseDataFrameCapabilitiesParams {
@@ -88,6 +96,10 @@ function useDataFrameCapabilities({
     const { READ_ONLY, DYNAMIC, ADD_ONLY, DELETE_ONLY } =
       DataframeProto.EditingMode
 
+    const isTouchDevice =
+      typeof window !== "undefined" &&
+      (window.matchMedia?.("(pointer: coarse)").matches ?? false)
+
     const isEmptyTable = computeIsEmptyTable(
       numDataRows,
       numDataColumns,
@@ -117,6 +129,12 @@ function useDataFrameCapabilities({
       (editingMode === DYNAMIC || editingMode === DELETE_ONLY) &&
       !disabled
 
+    const canResizeColumns = !isTouchDevice
+
+    const supportsFillHandle = canEdit && !isTouchDevice
+
+    const supportsRectangleSelection = !isTouchDevice
+
     return {
       canSort,
       canSearch,
@@ -126,6 +144,10 @@ function useDataFrameCapabilities({
       canDeleteRows,
       isEmptyTable,
       isLargeTable,
+      isTouchDevice,
+      canResizeColumns,
+      supportsFillHandle,
+      supportsRectangleSelection,
     }
   }, [editingMode, disabled, numDataRows, numDataColumns])
 }


### PR DESCRIPTION
## Describe your changes

Introduces a new `useDataFrameCapabilities` hook that centralizes capability/feature flag logic for the DataFrame component. This is a preparatory refactoring for dataframe lazy loading support.

- Adds `useDataFrameCapabilities` hook with explicit feature gates:
  - Core capabilities: `canSort`, `canSearch`, `canExportCsv`, `canEdit`, `canAddRows`, `canDeleteRows`
  - Table state flags: `isEmptyTable`, `isLargeTable`
  - Touch device support: `isTouchDevice`, `canResizeColumns`, `supportsFillHandle`, `supportsRectangleSelection`
- Consolidates scattered conditional logic from DataFrame.tsx into the hook
- Exports `LARGE_TABLE_ROWS_THRESHOLD` constant for reuse

## GitHub Issue Link (if applicable)

- Related to #15092 (dataframe lazy loading spec)

## Testing Plan

- [x] Unit Tests (JS)
  - `frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts` — 41 tests covering all capability flags across different editing modes, disabled states, table sizes, and touch device detection

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 2 |
| skill | finalizing-pr | 1 |
| skill | updating-internal-docs | 2 |
| subagent | Explore | 1 |
| subagent | fixing-pr | 3 |
| subagent | general-purpose | 7 |
| subagent | reviewing-local-changes | 2 |
| subagent | simplifying-local-changes | 2 |

</details>
<!-- agent-metrics-end -->