### PR TITLE
[chore] Use wsproto for uvicorn websocket protocol

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -85,8 +85,8 @@ dependencies = [
   "typing-extensions>=4.10.0,<5",
   # ASGI web-framework:
   "starlette>=0.40.0",
-  # ASGI server:
-  "uvicorn>=0.30.0",
+  # ASGI server (0.46+ required for wsproto ws_max_size/ping support):
+  "uvicorn>=0.46.0",
   # Faster http parsing for Starlette server:
   "httptools>=0.6.3",
   # Required by starlette:

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
   # Required for file-upload support:
   "python-multipart>=0.0.10",
   # Required for websocket support:
-  "websockets>=12.0.0",
+  "wsproto>=1.2.0",
   # Required for cookie signing:
   "itsdangerous>=2.1.2",
   # Don't require watchdog on MacOS, since it'll fail without xcode tools.

--- a/lib/streamlit/logger.py
+++ b/lib/streamlit/logger.py
@@ -91,7 +91,7 @@ def update_formatter() -> None:
 def init_uvicorn_logs() -> None:
     """Set Uvicorn and related server log levels.
 
-    This function sets up loggers for Uvicorn, websockets, and related components
+    This function sets up loggers for Uvicorn and related components
     so they respect Streamlit's logger.level config option.
     It does not import any server code, so it's safe to call even when the server
     is not running.
@@ -101,7 +101,7 @@ def init_uvicorn_logs() -> None:
         "uvicorn.access",
         "uvicorn.asgi",
         "uvicorn.error",
-        "websockets",
+        "wsproto",
     ):
         # get_logger will set the log level for the logger with the given name.
         get_logger(log)

--- a/lib/streamlit/web/server/starlette/starlette_server.py
+++ b/lib/streamlit/web/server/starlette/starlette_server.py
@@ -143,7 +143,7 @@ def _get_uvicorn_config_kwargs() -> dict[str, Any]:
     return {
         "ssl_certfile": cert_file,
         "ssl_keyfile": key_file,
-        "ws": "auto",
+        "ws": "wsproto",
         "ws_ping_interval": ws_ping_interval,
         "ws_ping_timeout": ws_ping_timeout,
         "ws_max_size": ws_max_size,

--- a/lib/tests/streamlit/logger_test.py
+++ b/lib/tests/streamlit/logger_test.py
@@ -83,12 +83,12 @@ class LoggerTest(unittest.TestCase):
     def test_init_uvicorn_logs(self):
         """Test streamlit.logger.init_uvicorn_logs."""
         logger.init_uvicorn_logs()
-        loggers = [x for x in logger._loggers if "uvicorn" in x or "websockets" in x]
+        loggers = [x for x in logger._loggers if "uvicorn" in x or "wsproto" in x]
         expected = [
             "uvicorn",
             "uvicorn.access",
             "uvicorn.asgi",
             "uvicorn.error",
-            "websockets",
+            "wsproto",
         ]
         assert sorted(expected) == sorted(loggers)

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -19,6 +19,6 @@ starlette==0.40.0
 tenacity==8.1.0
 toml==0.10.1
 typing-extensions==4.10.0
-uvicorn==0.30.0
+uvicorn==0.46.0
 watchdog==2.1.5
 wsproto==1.2.0

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -21,4 +21,4 @@ toml==0.10.1
 typing-extensions==4.10.0
 uvicorn==0.30.0
 watchdog==2.1.5
-websockets==12.0.0
+wsproto==1.2.0


### PR DESCRIPTION
## Describe your changes

- Switches uvicorn websocket implementation from `websockets` to `wsproto`
- `wsproto` is a pure-Python Sans-IO WebSocket implementation that is more lightweight and has been uvicorn's most mature async-free WS backend
- Bumps minimum uvicorn version to 0.46.0 (required for wsproto support of `ws_max_size`, `ws_ping_interval`, and `ws_ping_timeout`)
- Updates logger references from `websockets` to `wsproto`

### Why wsproto over websockets-sansio?

We chose `wsproto` because:
1. It is an established python-hyper project with a longer track record
2. It is uvicorn's most mature pure-Python Sans-IO WebSocket backend
3. It is already an indirect dependency via uvicorn

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python) — existing server tests pass with new websocket implementation
- [x] E2E Tests — Playwright tests validate the WebSocket transport works correctly