### PR TITLE
[refactor] Add theme opacity primitives

### DIFF
--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -154,7 +154,7 @@ export const StyledMenuItemShortcut = styled.kbd(({ theme }) => ({
   justifyContent: "center",
   whiteSpace: "nowrap",
   fontSize: theme.fontSizes.sm,
-  opacity: 0.6,
+  opacity: theme.opacities.secondary,
   fontFamily: "inherit",
   lineHeight: theme.lineHeights.tight,
   letterSpacing: "0.01em",
@@ -355,7 +355,7 @@ export const StyledMenuVersionRow = styled.div(({ theme }) => ({
 export const StyledMenuVersionText = styled.span(({ theme }) => ({
   display: "inline-flex",
   alignItems: "center",
-  opacity: 0.6,
+  opacity: theme.opacities.secondary,
   fontSize: theme.fontSizes.twoSm,
   lineHeight: theme.lineHeights.menuItem,
   color: theme.colors.bodyText,

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -47,7 +47,7 @@ export const StyledSpinnerText = styled.div(({ theme }) => ({
 // TODO: Maybe move this to `theme/consts.ts`, see
 // https://github.com/streamlit/streamlit/pull/10085/files#diff-a5cce939bf6c73209a258132c71ccb368a3a1fd57b68b373d242736adb920093
 export const StyledSpinnerTimeText = styled.span(({ theme }) => ({
-  opacity: 0.6,
+  opacity: theme.opacities.secondary,
   fontSize: theme.fontSizes.sm,
   lineHeight: theme.lineHeights.none,
   whiteSpace: "nowrap",

--- a/frontend/lib/src/components/elements/Spinner/styled-components.ts
+++ b/frontend/lib/src/components/elements/Spinner/styled-components.ts
@@ -44,8 +44,6 @@ export const StyledSpinnerText = styled.div(({ theme }) => ({
   alignItems: "baseline",
 }))
 
-// TODO: Maybe move this to `theme/consts.ts`, see
-// https://github.com/streamlit/streamlit/pull/10085/files#diff-a5cce939bf6c73209a258132c71ccb368a3a1fd57b68b373d242736adb920093
 export const StyledSpinnerTimeText = styled.span(({ theme }) => ({
   opacity: theme.opacities.secondary,
   fontSize: theme.fontSizes.sm,

--- a/frontend/lib/src/components/shared/BaseButton/styled-components.ts
+++ b/frontend/lib/src/components/shared/BaseButton/styled-components.ts
@@ -585,7 +585,7 @@ export const StyledButtonShortcut = styled.kbd(({ theme }) => ({
   justifyContent: "center",
   whiteSpace: "nowrap",
   fontSize: theme.fontSizes.sm,
-  opacity: 0.6,
+  opacity: theme.opacities.secondary,
   fontFamily: "inherit",
   lineHeight: theme.lineHeights.tight,
   letterSpacing: "0.01em",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -223,7 +223,7 @@ export const StyledStreamlitMarkdown =
         fontWeight: inheritFont ? "inherit" : undefined,
         marginBottom:
           isLabel || isInHorizontalLayout ? "" : `-${theme.spacing.lg}`,
-        opacity: isCaption ? 0.6 : undefined,
+        opacity: isCaption ? theme.opacities.secondary : undefined,
         color: "inherit",
         // Always respect the width of the parent container:
         maxWidth: "100%",
@@ -307,7 +307,7 @@ export const StyledStreamlitMarkdown =
           margin: "1em 0 1em 0",
           padding: `0 0 0 0.75em`,
           borderLeft: `0.15em solid ${theme.colors.borderColor}`,
-          opacity: 0.6,
+          opacity: theme.opacities.secondary,
         },
 
         "b, strong": {

--- a/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/CameraInput/styled-components.ts
@@ -115,7 +115,7 @@ export const StyledSwitchFacingModeButton = styled.div(({ theme }) => ({
   zIndex: theme.zIndices.priority,
   color: theme.colors.fadedText40,
   mixBlendMode: "difference",
-  opacity: 0.6,
+  opacity: theme.opacities.secondary,
 }))
 
 export const StyledProgressBar = styled.div({

--- a/frontend/lib/src/mocks/mockTheme.ts
+++ b/frontend/lib/src/mocks/mockTheme.ts
@@ -25,6 +25,7 @@ import { createShadows } from "~lib/theme/getShadows"
 import { breakpoints } from "~lib/theme/primitives/breakpoints"
 import { colors } from "~lib/theme/primitives/colors"
 import { iconSizes } from "~lib/theme/primitives/iconSizes"
+import { opacities } from "~lib/theme/primitives/opacities"
 import { radii } from "~lib/theme/primitives/radii"
 import { sizes } from "~lib/theme/primitives/sizes"
 import { spacing } from "~lib/theme/primitives/spacing"
@@ -102,6 +103,7 @@ const emotionMockTheme = {
   genericFonts,
   iconSizes,
   lineHeights,
+  opacities,
   radii,
   shadows,
   sizes,

--- a/frontend/lib/src/theme/emotionBaseTheme/index.ts
+++ b/frontend/lib/src/theme/emotionBaseTheme/index.ts
@@ -18,6 +18,7 @@ import { createEmotionColors } from "~lib/theme/getColors"
 import { createShadows } from "~lib/theme/getShadows"
 import { breakpoints } from "~lib/theme/primitives/breakpoints"
 import { iconSizes } from "~lib/theme/primitives/iconSizes"
+import { opacities } from "~lib/theme/primitives/opacities"
 import { radii } from "~lib/theme/primitives/radii"
 import { sizes } from "~lib/theme/primitives/sizes"
 import { spacing } from "~lib/theme/primitives/spacing"
@@ -50,6 +51,7 @@ export default {
   genericFonts,
   iconSizes,
   lineHeights,
+  opacities,
   radii,
   shadows,
   sizes,

--- a/frontend/lib/src/theme/primitives/opacities.ts
+++ b/frontend/lib/src/theme/primitives/opacities.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import { opacities } from "~lib/theme/primitives/opacities"
-
-export const STALE_TRANSITION_PARAMS = "1s ease-in 0.5s"
-
-export const STALE_STYLES = {
-  opacity: opacities.stale,
-  transition: `opacity ${STALE_TRANSITION_PARAMS}`,
+export const opacities = {
+  /** De-emphasized or secondary content (shortcuts, timestamps, blockquotes, captions) */
+  secondary: 0.6,
+  /** Stale or outdated elements during rerun */
+  stale: 0.33,
 }


### PR DESCRIPTION
## Describe your changes

Introduces a new `opacities` theme primitive to centralize opacity values used across the codebase:

- Added `frontend/lib/src/theme/primitives/opacities.ts` with semantic opacity values:
  - `secondary` (0.6): For de-emphasized content like shortcuts, timestamps, blockquotes, and captions
  - `stale` (0.33): For elements during rerun transitions
- Updated components to use `theme.opacities.secondary` instead of hardcoded `0.6`:
  - MainMenu shortcuts and version text
  - Spinner time text
  - BaseButton shortcuts
  - StreamlitMarkdown captions and blockquotes
  - CameraInput switch button
- Updated `STALE_STYLES` to use `opacities.stale`

This follows the existing pattern for theme primitives (colors, spacing, sizes, etc.) and improves consistency.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Frontend type check (tsc)
- [x] Frontend lint (oxlint + eslint)
- [x] Existing visual tests cover these components

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->