### PR TITLE
[chore] Add Codex subagent support and agent documentation

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -38,6 +38,8 @@ skills/*
 # Allow agents
 !agents/
 agents/*
+!agents/AGENTS.md
+!agents/CLAUDE.md
 !agents/reviewing-local-changes.md
 !agents/simplifying-local-changes.md
 !agents/fixing-pr.md

--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent Definitions
+
+This directory contains custom subagent definitions for Claude Code (and Cursor, which reads from this directory).
+
+## File Format
+
+Each agent is a Markdown file with YAML frontmatter. See the [Claude Code subagents docs](https://code.claude.com/docs/en/sub-agents) and [Cursor rules docs](https://docs.cursor.com/context/rules) for full details.
+
+```markdown
+---
+name: agent-name           # Required: lowercase with hyphens
+description: When to use   # Required: helps agents decide when to delegate
+model: inherit             # Required: always use inherit
+tools: Read, Grep, Glob    # Optional: restrict tools (inherits all if omitted)
+disallowedTools: Write     # Optional: deny specific tools
+skills:                    # Optional: preload skills into context
+  - skill-name
+memory: user               # Optional: user, project, or local
+---
+
+System prompt / instructions here...
+```
+
+## Best Practices
+
+- **Focused scope**: Each agent should excel at one specific task
+- **Clear descriptions**: Agents use this to decide when to delegate
+- **Minimal tools**: Grant only necessary permissions
+- **Actionable prompts**: Tell the agent what to do, not just what it is
+- **Always use `model: inherit`**: Let the parent session control the model choice
+
+## Cross-Platform Compatibility
+
+These agents are the **single source of truth**:
+
+| Platform | How it uses these agents |
+|----------|--------------------------|
+| Claude Code | Native support — reads `.claude/agents/` directly |
+| Cursor | Native support — reads `.claude/agents/` directly |
+| Codex | `.codex/agents/*.toml` files reference these via `developer_instructions` |
+
+**When adding a new agent:**
+1. Create the agent file in this directory
+2. Create a matching command in `.claude/commands/` (see below)
+3. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+
+**When modifying an existing agent:**
+1. Update the agent file — other platforms will pick up changes automatically
+
+## Slash Command Support
+
+Each agent should have a corresponding command file in `.claude/commands/` to enable `/agent-name` invocation:
+
+```markdown
+---
+description: Brief description of what the command does
+---
+
+Run the agent-name subagent to [do the task].
+```
+
+Example for `fixing-pr`:
+```markdown
+---
+description: Fix CI failures and address PR review comments
+---
+
+Run the fixing-pr subagent to fix CI failures and address PR review comments for the current branch.
+```
+
+## Agent Inventory
+
+| Agent | Purpose |
+|-------|---------|
+| `fixing-pr` | Fix CI failures and address PR review comments |
+| `qa-testing-feature` | QA test features using Playwright |
+| `reviewing-local-changes` | Code review for quality, security, best practices |
+| `simplifying-local-changes` | Simplify and refine code changes |

--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -31,21 +31,24 @@ System prompt / instructions here...
 
 ## Cross-Platform Compatibility
 
-These agents are the **single source of truth**:
+These agents are the **single source of truth** for agent instructions:
 
 | Platform | How it uses these agents |
 |----------|--------------------------|
-| Claude Code | Native support — reads `.claude/agents/` directly |
-| Cursor | Native support — reads `.claude/agents/` directly |
+| Claude Code | Native support — reads `.claude/agents/` directly as subagents |
+| Cursor | Uses `.cursor/rules/agents.mdc` (generated from this file) for context when editing agent files. Note: Cursor rules provide editing context only — Cursor does not execute these as subagents like Claude Code does. |
 | Codex | `.codex/agents/*.toml` files reference these via `developer_instructions` |
 
 **When adding a new agent:**
 1. Create the agent file in this directory
-2. Create a matching command in `.claude/commands/` (see below)
-3. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+2. Add the new file to `.claude/.gitignore` (allowlist pattern: `!agents/<name>.md`)
+3. Create a matching command in `.claude/commands/` and add it to `.claude/.gitignore`
+4. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+5. Run `uv run scripts/generate_agent_rules.py` to regenerate Cursor/Copilot rules
 
 **When modifying an existing agent:**
-1. Update the agent file — other platforms will pick up changes automatically
+1. Update the agent file — Codex picks up changes via `developer_instructions` reference
+2. Note: Codex `config.toml` descriptions must be updated manually (they don't auto-sync)
 
 ## Slash Command Support
 

--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -48,7 +48,7 @@ These agents are the **single source of truth** for agent instructions:
 
 **When modifying an existing agent:**
 1. Update the agent file — Codex picks up changes via `developer_instructions` reference
-2. Note: Codex `config.toml` descriptions must be updated manually (they don't auto-sync)
+2. Note: Codex agent descriptions in `.codex/agents/*.toml` must be updated manually (they don't auto-sync from the Claude agent file)
 
 ## Slash Command Support
 

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/.codex/.gitignore
+++ b/.codex/.gitignore
@@ -4,3 +4,6 @@
 # Allow specific files
 !.gitignore
 !skills
+!config.toml
+!agents/
+!agents/*.toml

--- a/.codex/agents/fixing-pr.toml
+++ b/.codex/agents/fixing-pr.toml
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = "fixing-pr"
+description = "Fix CI failures and address PR review comments for the current branch."
+developer_instructions = "Read and follow the instructions in `.claude/agents/fixing-pr.md`."

--- a/.codex/agents/qa-testing-feature.toml
+++ b/.codex/agents/qa-testing-feature.toml
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = "qa-testing-feature"
+description = "QA test the feature in the current branch using Playwright."
+developer_instructions = "Read and follow the instructions in `.claude/agents/qa-testing-feature.md`."

--- a/.codex/agents/reviewing-local-changes.toml
+++ b/.codex/agents/reviewing-local-changes.toml
@@ -1,0 +1,18 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = "reviewing-local-changes"
+description = "Review the current branch's changes for code quality, test coverage, security, and best practices."
+sandbox_mode = "read-only"
+developer_instructions = "Read and follow the instructions in `.claude/agents/reviewing-local-changes.md`."

--- a/.codex/agents/simplifying-local-changes.toml
+++ b/.codex/agents/simplifying-local-changes.toml
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = "simplifying-local-changes"
+description = "Simplify and refine code for clarity, consistency, and maintainability."
+developer_instructions = "Read and follow the instructions in `.claude/agents/simplifying-local-changes.md`."

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,36 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Codex Multi-Agent Configuration
+# Agents reference instructions from .claude/agents/ to avoid duplication
+
+[agents]
+max_threads = 3
+max_depth = 2
+
+[agents.reviewing-local-changes]
+description = "Review the current branch's changes for code quality, test coverage, security, and best practices."
+config_file = "./agents/reviewing-local-changes.toml"
+
+[agents.simplifying-local-changes]
+description = "Simplify and refine code for clarity, consistency, and maintainability."
+config_file = "./agents/simplifying-local-changes.toml"
+
+[agents.fixing-pr]
+description = "Fix CI failures and address PR review comments for the current branch."
+config_file = "./agents/fixing-pr.toml"
+
+[agents.qa-testing-feature]
+description = "QA test the feature in the current branch using Playwright."
+config_file = "./agents/qa-testing-feature.toml"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -13,24 +13,10 @@
 # limitations under the License.
 
 # Codex Multi-Agent Configuration
-# Agents reference instructions from .claude/agents/ to avoid duplication
+# Agents are auto-discovered from .codex/agents/ directory.
+# Each agent's description is defined in its own TOML file.
+# The developer_instructions reference .claude/agents/ as the single source of truth.
 
 [agents]
 max_threads = 3
 max_depth = 2
-
-[agents.reviewing-local-changes]
-description = "Review the current branch's changes for code quality, test coverage, security, and best practices."
-config_file = "./agents/reviewing-local-changes.toml"
-
-[agents.simplifying-local-changes]
-description = "Simplify and refine code for clarity, consistency, and maintainability."
-config_file = "./agents/simplifying-local-changes.toml"
-
-[agents.fixing-pr]
-description = "Fix CI failures and address PR review comments for the current branch."
-config_file = "./agents/fixing-pr.toml"
-
-[agents.qa-testing-feature]
-description = "QA test the feature in the current branch using Playwright."
-config_file = "./agents/qa-testing-feature.toml"

--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -23,6 +23,7 @@ rules/*
 !rules/e2e_playwright.mdc
 !rules/overview.mdc
 !rules/skills.mdc
+!rules/agents.mdc
 !rules/workflows.mdc
 !rules/scripts.mdc
 !rules/specs.mdc

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -39,21 +39,24 @@ System prompt / instructions here...
 
 ## Cross-Platform Compatibility
 
-These agents are the **single source of truth**:
+These agents are the **single source of truth** for agent instructions:
 
 | Platform | How it uses these agents |
 |----------|--------------------------|
-| Claude Code | Native support — reads `.claude/agents/` directly |
-| Cursor | Native support — reads `.claude/agents/` directly |
+| Claude Code | Native support — reads `.claude/agents/` directly as subagents |
+| Cursor | Uses `.cursor/rules/agents.mdc` (generated from this file) for context when editing agent files. Note: Cursor rules provide editing context only — Cursor does not execute these as subagents like Claude Code does. |
 | Codex | `.codex/agents/*.toml` files reference these via `developer_instructions` |
 
 **When adding a new agent:**
 1. Create the agent file in this directory
-2. Create a matching command in `.claude/commands/` (see below)
-3. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+2. Add the new file to `.claude/.gitignore` (allowlist pattern: `!agents/<name>.md`)
+3. Create a matching command in `.claude/commands/` and add it to `.claude/.gitignore`
+4. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+5. Run `uv run scripts/generate_agent_rules.py` to regenerate Cursor/Copilot rules
 
 **When modifying an existing agent:**
-1. Update the agent file — other platforms will pick up changes automatically
+1. Update the agent file — Codex picks up changes via `developer_instructions` reference
+2. Note: Codex `config.toml` descriptions must be updated manually (they don't auto-sync)
 
 ## Slash Command Support
 

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,86 @@
+---
+description:
+globs: .claude/agents/**/*
+alwaysApply: false
+---
+
+<!-- Generated from .claude/agents/AGENTS.md. Edit that file instead, then run: uv run python scripts/generate_agent_rules.py -->
+
+# Agent Definitions
+
+This directory contains custom subagent definitions for Claude Code (and Cursor, which reads from this directory).
+
+## File Format
+
+Each agent is a Markdown file with YAML frontmatter. See the [Claude Code subagents docs](https://code.claude.com/docs/en/sub-agents) and [Cursor rules docs](https://docs.cursor.com/context/rules) for full details.
+
+```markdown
+---
+name: agent-name           # Required: lowercase with hyphens
+description: When to use   # Required: helps agents decide when to delegate
+model: inherit             # Required: always use inherit
+tools: Read, Grep, Glob    # Optional: restrict tools (inherits all if omitted)
+disallowedTools: Write     # Optional: deny specific tools
+skills:                    # Optional: preload skills into context
+  - skill-name
+memory: user               # Optional: user, project, or local
+---
+
+System prompt / instructions here...
+```
+
+## Best Practices
+
+- **Focused scope**: Each agent should excel at one specific task
+- **Clear descriptions**: Agents use this to decide when to delegate
+- **Minimal tools**: Grant only necessary permissions
+- **Actionable prompts**: Tell the agent what to do, not just what it is
+- **Always use `model: inherit`**: Let the parent session control the model choice
+
+## Cross-Platform Compatibility
+
+These agents are the **single source of truth**:
+
+| Platform | How it uses these agents |
+|----------|--------------------------|
+| Claude Code | Native support — reads `.claude/agents/` directly |
+| Cursor | Native support — reads `.claude/agents/` directly |
+| Codex | `.codex/agents/*.toml` files reference these via `developer_instructions` |
+
+**When adding a new agent:**
+1. Create the agent file in this directory
+2. Create a matching command in `.claude/commands/` (see below)
+3. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+
+**When modifying an existing agent:**
+1. Update the agent file — other platforms will pick up changes automatically
+
+## Slash Command Support
+
+Each agent should have a corresponding command file in `.claude/commands/` to enable `/agent-name` invocation:
+
+```markdown
+---
+description: Brief description of what the command does
+---
+
+Run the agent-name subagent to [do the task].
+```
+
+Example for `fixing-pr`:
+```markdown
+---
+description: Fix CI failures and address PR review comments
+---
+
+Run the fixing-pr subagent to fix CI failures and address PR review comments for the current branch.
+```
+
+## Agent Inventory
+
+| Agent | Purpose |
+|-------|---------|
+| `fixing-pr` | Fix CI failures and address PR review comments |
+| `qa-testing-feature` | QA test features using Playwright |
+| `reviewing-local-changes` | Code review for quality, security, best practices |
+| `simplifying-local-changes` | Simplify and refine code changes |

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -56,7 +56,7 @@ These agents are the **single source of truth** for agent instructions:
 
 **When modifying an existing agent:**
 1. Update the agent file — Codex picks up changes via `developer_instructions` reference
-2. Note: Codex `config.toml` descriptions must be updated manually (they don't auto-sync)
+2. Note: Codex agent descriptions in `.codex/agents/*.toml` must be updated manually (they don't auto-sync from the Claude agent file)
 
 ## Slash Command Support
 

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -10,6 +10,7 @@ instructions/*
 !instructions/typescript_tests.instructions.md
 !instructions/e2e_playwright.instructions.md
 !instructions/skills.instructions.md
+!instructions/agents.instructions.md
 !instructions/workflows.instructions.md
 !instructions/scripts.instructions.md
 !instructions/specs.instructions.md

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -1,0 +1,84 @@
+---
+applyTo: ".claude/agents/**/*"
+---
+
+<!-- Generated from .claude/agents/AGENTS.md. Edit that file instead, then run: uv run python scripts/generate_agent_rules.py -->
+
+# Agent Definitions
+
+This directory contains custom subagent definitions for Claude Code (and Cursor, which reads from this directory).
+
+## File Format
+
+Each agent is a Markdown file with YAML frontmatter. See the [Claude Code subagents docs](https://code.claude.com/docs/en/sub-agents) and [Cursor rules docs](https://docs.cursor.com/context/rules) for full details.
+
+```markdown
+---
+name: agent-name           # Required: lowercase with hyphens
+description: When to use   # Required: helps agents decide when to delegate
+model: inherit             # Required: always use inherit
+tools: Read, Grep, Glob    # Optional: restrict tools (inherits all if omitted)
+disallowedTools: Write     # Optional: deny specific tools
+skills:                    # Optional: preload skills into context
+  - skill-name
+memory: user               # Optional: user, project, or local
+---
+
+System prompt / instructions here...
+```
+
+## Best Practices
+
+- **Focused scope**: Each agent should excel at one specific task
+- **Clear descriptions**: Agents use this to decide when to delegate
+- **Minimal tools**: Grant only necessary permissions
+- **Actionable prompts**: Tell the agent what to do, not just what it is
+- **Always use `model: inherit`**: Let the parent session control the model choice
+
+## Cross-Platform Compatibility
+
+These agents are the **single source of truth**:
+
+| Platform | How it uses these agents |
+|----------|--------------------------|
+| Claude Code | Native support — reads `.claude/agents/` directly |
+| Cursor | Native support — reads `.claude/agents/` directly |
+| Codex | `.codex/agents/*.toml` files reference these via `developer_instructions` |
+
+**When adding a new agent:**
+1. Create the agent file in this directory
+2. Create a matching command in `.claude/commands/` (see below)
+3. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+
+**When modifying an existing agent:**
+1. Update the agent file — other platforms will pick up changes automatically
+
+## Slash Command Support
+
+Each agent should have a corresponding command file in `.claude/commands/` to enable `/agent-name` invocation:
+
+```markdown
+---
+description: Brief description of what the command does
+---
+
+Run the agent-name subagent to [do the task].
+```
+
+Example for `fixing-pr`:
+```markdown
+---
+description: Fix CI failures and address PR review comments
+---
+
+Run the fixing-pr subagent to fix CI failures and address PR review comments for the current branch.
+```
+
+## Agent Inventory
+
+| Agent | Purpose |
+|-------|---------|
+| `fixing-pr` | Fix CI failures and address PR review comments |
+| `qa-testing-feature` | QA test features using Playwright |
+| `reviewing-local-changes` | Code review for quality, security, best practices |
+| `simplifying-local-changes` | Simplify and refine code changes |

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -37,21 +37,24 @@ System prompt / instructions here...
 
 ## Cross-Platform Compatibility
 
-These agents are the **single source of truth**:
+These agents are the **single source of truth** for agent instructions:
 
 | Platform | How it uses these agents |
 |----------|--------------------------|
-| Claude Code | Native support — reads `.claude/agents/` directly |
-| Cursor | Native support — reads `.claude/agents/` directly |
+| Claude Code | Native support — reads `.claude/agents/` directly as subagents |
+| Cursor | Uses `.cursor/rules/agents.mdc` (generated from this file) for context when editing agent files. Note: Cursor rules provide editing context only — Cursor does not execute these as subagents like Claude Code does. |
 | Codex | `.codex/agents/*.toml` files reference these via `developer_instructions` |
 
 **When adding a new agent:**
 1. Create the agent file in this directory
-2. Create a matching command in `.claude/commands/` (see below)
-3. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+2. Add the new file to `.claude/.gitignore` (allowlist pattern: `!agents/<name>.md`)
+3. Create a matching command in `.claude/commands/` and add it to `.claude/.gitignore`
+4. Add a Codex config in `.codex/agents/` and update `.codex/config.toml`
+5. Run `uv run scripts/generate_agent_rules.py` to regenerate Cursor/Copilot rules
 
 **When modifying an existing agent:**
-1. Update the agent file — other platforms will pick up changes automatically
+1. Update the agent file — Codex picks up changes via `developer_instructions` reference
+2. Note: Codex `config.toml` descriptions must be updated manually (they don't auto-sync)
 
 ## Slash Command Support
 

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -54,7 +54,7 @@ These agents are the **single source of truth** for agent instructions:
 
 **When modifying an existing agent:**
 1. Update the agent file — Codex picks up changes via `developer_instructions` reference
-2. Note: Codex `config.toml` descriptions must be updated manually (they don't auto-sync)
+2. Note: Codex agent descriptions in `.codex/agents/*.toml` must be updated manually (they don't auto-sync from the Claude agent file)
 
 ## Slash Command Support
 

--- a/scripts/generate_agent_rules.py
+++ b/scripts/generate_agent_rules.py
@@ -136,6 +136,13 @@ AGENT_RULE_FILES: Final[list[AgentRuleFile]] = [
         "always_apply": False,
     },
     {
+        "cursor_mdc": ".cursor/rules/agents.mdc",
+        "github_copilot": ".github/instructions/agents.instructions.md",
+        "agents_md": ".claude/agents/AGENTS.md",
+        "globs": ".claude/agents/**/*",
+        "always_apply": False,
+    },
+    {
         "cursor_mdc": ".cursor/rules/workflows.mdc",
         "github_copilot": ".github/instructions/workflows.instructions.md",
         "agents_md": ".github/workflows/AGENTS.md",


### PR DESCRIPTION
## Describe your changes

Adds support for OpenAI Codex subagents by creating lightweight config files that reference the existing Claude Code agents as the single source of truth.

- Add `.codex/config.toml` and `.codex/agents/*.toml` that reference `.claude/agents/*.md`
- Add `.claude/agents/AGENTS.md` with best practices for writing agents
- Update `scripts/generate_agent_rules.py` to generate Cursor and GitHub Copilot rules for the agents directory
- Update gitignore files to track the new agent-related files

This enables the same agent definitions to work across Claude Code, Cursor, and Codex without duplication.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Pre-commit hooks pass
- [x] `make check` passes