### PR TITLE
fix: add usedforsecurity=False to blake2b for FIPS compatibility

### DIFF
--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -71,7 +71,7 @@ def create_fast_hasher() -> _Hash:
 
     Uses BLAKE2b which produces 32-character hex digests (16 bytes).
     """
-    return hashlib.blake2b(digest_size=16)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    return hashlib.blake2b(digest_size=16, usedforsecurity=False)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
 
 
 def calc_hash(s: bytes | str) -> str:


### PR DESCRIPTION
## Describe your changes

Add `usedforsecurity=False` to the `hashlib.blake2b()` call in `create_fast_hasher()`. This is a fix for a regression introduced in #14842.

`usedforsecurity=False` signals to FIPS-enforcing OpenSSL that the hash is not used for a security-sensitive purpose, which is true there, `create_fast_hasher()` is used for element IDs, cache keys, and file change detection, not cryptographic security. The parameter has been available since Python 3.9.

Fixes #15148.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/15148

## Testing Plan

- Verified on a FIPS Python 3.12 image (`chainguard python-fips:3.12`) that `create_fast_hasher()` and `calc_hash()` raise `ValueError` on unpatched 1.57.0 and pass cleanly with this fix applied.
- No behaviour change on non-FIPS systems, `usedforsecurity=False` is a no-op when FIPS is not enforced.
- No new tests needed: the fix restores the behaviour that existed before #14842 (MD5 has no `usedforsecurity` parameter, so it was always FIPS-compatible).