### PR TITLE
fix: Show hex color swatches in Markdown rendering (#11643)

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1110,6 +1110,79 @@ describe("StreamlitMarkdown", () => {
       expect(markdown).not.toHaveClass("stMarkdownColoredBackground")
     })
   })
+
+  // Hex color swatch tests
+  describe("hex color swatches", () => {
+    it("renders 6-digit hex color with swatch", () => {
+      const source = "The color #0969DA is blue."
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const hexSpan = screen.getByText("#0969DA")
+      expect(hexSpan.tagName.toLowerCase()).toBe("span")
+      expect(hexSpan).toHaveClass("stHexColor")
+      expect(hexSpan).toHaveAttribute("style", "--hex-color: #0969DA")
+    })
+
+    it("renders 3-digit hex color with swatch", () => {
+      const source = "The color #F00 is red."
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const hexSpan = screen.getByText("#F00")
+      expect(hexSpan).toHaveClass("stHexColor")
+      expect(hexSpan).toHaveAttribute("style", "--hex-color: #F00")
+    })
+
+    it("renders multiple hex colors in the same text", () => {
+      const source = "Colors: #FF0000, #00FF00, #0000FF."
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      // Each hex color should have its own swatch span
+      const hexSpans = [
+        screen.getByText("#FF0000"),
+        screen.getByText("#00FF00"),
+        screen.getByText("#0000FF"),
+      ]
+      for (const span of hexSpans) {
+        expect(span).toHaveClass("stHexColor")
+      }
+    })
+
+    it("does not match hex colors inside inline code", () => {
+      const source = "The color `#0969DA` is in code."
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      // #0969DA is inside inline code, should NOT have stHexColor class
+      const codeElement = screen.getByText("#0969DA")
+      expect(codeElement.tagName.toLowerCase()).toBe("code")
+      expect(codeElement).not.toHaveClass("stHexColor")
+    })
+
+    it("does not match hex colors inside code blocks", () => {
+      const source = "```\n#0969DA\n```"
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      // The code block text should render inside a pre > code structure
+      const codeBlockText = screen.getByText("#0969DA")
+      // Should be inside a code block, not a swatch span
+      expect(codeBlockText.tagName.toLowerCase()).toBe("code")
+      expect(codeBlockText).not.toHaveClass("stHexColor")
+    })
+
+    it("does not match hashes that are not hex colors", () => {
+      const source = "This is ##a-heading and #not-a-color."
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      // "##a-heading" should render as a heading, not be matched
+      // "#not-a-color" - 'n' is not hex, should not match
+      expect(screen.queryByText("#not-a-color")).toBeTruthy()
+      // Should be no stHexColor spans since neither is a valid hex
+      const hexSpans = document.querySelectorAll(".stHexColor")
+      expect(hexSpans.length).toBe(0)
+    })
+
+    it("renders mixed case hex colors", () => {
+      const source = "Mixed case: #AbC123 and #aBc."
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const upperHex = screen.getByText("#AbC123")
+      expect(upperHex).toHaveClass("stHexColor")
+      const lowerHex = screen.getByText("#aBc")
+      expect(lowerHex).toHaveClass("stHexColor")
+    })
+  })
 })
 
 const getCustomCodeTagProps = (

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -778,6 +778,45 @@ function createRemarkColoringAndSmall(
 }
 
 /**
+ * Factory function to create the hex color swatch plugin.
+ * Detects hex color codes like #RRGGBB or #RGB in plain text and renders
+ * a small color swatch (colored dot) next to them, similar to GitHub.
+ *
+ * Hex codes inside code blocks and inline code are not affected since
+ * they are separate AST nodes by the time this plugin runs.
+ */
+function createRemarkHexColorSwatches() {
+  return () => (tree: MdastRoot) => {
+    // Match standalone hex colors: #RRGGBB or #RGB
+    // Must not be preceded or followed by alphanumeric or # characters
+    // to avoid matching inside URLs (e.g. #section), headings (e.g. ##heading),
+    // or longer color values (e.g. #RRGGBBAA).
+    const hexColorRegex =
+      /(?<![a-zA-Z0-9#])(#[0-9A-Fa-f]{6}|#[0-9A-Fa-f]{3})(?![a-zA-Z0-9])/g
+
+    findAndReplace(tree, [
+      [
+        hexColorRegex,
+        (_fullMatch: string, hexCode: string): MdastTextWithHastData => {
+          return {
+            type: "text",
+            value: hexCode,
+            data: {
+              hName: "span",
+              hProperties: {
+                className: "stHexColor",
+                style: `--hex-color: ${hexCode}`,
+              },
+            },
+          }
+        },
+      ],
+    ])
+    return tree
+  }
+}
+
+/**
  * Factory function to create the unsupported directives cleanup plugin.
  * This plugin should run last to convert any unsupported text directives
  * to plain text, ensuring they are rendered rather than ignored.
@@ -1128,6 +1167,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       ...BASE_REMARK_PLUGINS,
       createRemarkColoringAndSmall(theme, colorMapping),
       createRemarkMaterialIcons(theme),
+      createRemarkHexColorSwatches(),
     ]
 
     if (needsEmoji && wrappedEmojiPlugin) {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/styled-components.ts
@@ -419,6 +419,24 @@ export const StyledStreamlitMarkdown =
           },
         },
 
+        "span.stHexColor": {
+          // Render a small color swatch dot before hex color codes,
+          // similar to GitHub's hex color rendering.
+          "&::before": {
+            content: "",
+            display: "inline-block",
+            width: "0.75em",
+            height: "0.75em",
+            borderRadius: theme.radii.full,
+            backgroundColor: "var(--hex-color)",
+            marginRight: "0.25em",
+            verticalAlign: "middle",
+            // Subtle border so the swatch is visible even for colors
+            // similar to the background (light or dark themes).
+            border: `1px solid ${theme.colors.fadedText10}`,
+          },
+        },
+
         "p, ol, ul, dl, li": {
           fontSize: "inherit",
         },


### PR DESCRIPTION
## Describe your changes

This PR adds automatic hex color swatch rendering in Markdown, similar to GitHub. When a user writes a hex color like `#0969DA` in `st.markdown()`, it now renders with a small colored dot/swatch next to it.

**Fixes #11643**

## Root Cause

Streamlit's Markdown renderer did not detect or visually enhance hex color codes (`#RRGGBB` or `#RGB`) in text. GitHub already does this — they show a small colored circle next to hex color codes in issues, PRs, and READMEs.

## Fix

Added a remark plugin (`createRemarkHexColorSwatches`) that finds standalone hex color codes in markdown text nodes and wraps them in `<span class="stHexColor" style="--hex-color: #XXXXXX">` elements. A CSS `::before` pseudo-element renders a small colored dot using the `--hex-color` CSS variable with a subtle border for cross-theme visibility.

## Changes

- **`StreamlitMarkdown.tsx`**: Added `createRemarkHexColorSwatches()` plugin function using `findAndReplace` from mdast-util-find-and-replace. The regex matches `#RGB` or `#RRGGBB` hex codes that are standalone (not inside code blocks, inline code, URLs, or headings). Registered the plugin in the remark pipeline.
- **`styled-components.ts`**: Added `span.stHexColor` rules with a `&::before` pseudo-element that renders a 0.75em circular color swatch using `var(--hex-color)`, with a subtle border for visibility on both light and dark themes.
- **`StreamlitMarkdown.test.tsx`**: Added 7 unit tests covering: 6-digit hex rendering, 3-digit hex rendering, multiple hex colors, code block exclusion, inline code exclusion, non-hex hashes, and mixed case hex colors.

## Testing Plan

### Unit Tests (JS)
All 7 new test cases are in `StreamlitMarkdown.test.tsx` under the "hex color swatches" describe block.

### Testing Scenarios
1. **Basic hex color**: `st.markdown("The color #0969DA is blue.")` — should show a blue dot before `#0969DA`
2. **Multiple colors**: `st.markdown("Colors: #FF0000, #00FF00, #0000FF.")` — should show red, green, and blue dots
3. **Code blocks excluded**: `st.markdown("The color `#0969DA` is in code.")` — hex inside inline code should NOT have a swatch

### Manual Testing
- Verify on both light and dark themes that the swatch dot is visible
- Verify that hex colors inside code blocks and inline code do not get swatches
- Verify that `#RGB` (3-digit) hex colors also get swatches

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.