### PR TITLE
[fix] Block javascript: and vbscript: URLs in markdown links

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -436,7 +436,9 @@ describe("link URL scheme security", () => {
     render(
       <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
     )
-    expect(screen.getByText("Click me")).toHaveAttribute("href", "")
+    // Returns "#" to prevent navigation (empty href with target="_blank"
+    // would open current page in new tab)
+    expect(screen.getByText("Click me")).toHaveAttribute("href", "#")
   })
 
   it.each([

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -441,6 +441,29 @@ describe("link URL scheme security", () => {
     expect(screen.getByText("Click me")).toHaveAttribute("href", "#")
   })
 
+  // Raw HTML links go through rehype-raw and reach transformLinkUri.
+  // Test C0 control characters and internal whitespace bypasses in this context.
+  // The markdown parser already sanitizes these for standard [text](url) links,
+  // but raw HTML needs explicit protection.
+  // Note: Some C0 control characters (like SOH \x01) are converted to Unicode
+  // replacement characters by rehype-raw before reaching transformLinkUri.
+  // This is safe because browsers don't strip replacement characters from URLs.
+  it.each([
+    '<a href="javascript:alert(1)">link</a>',
+    '<a href="vbscript:alert(1)">link</a>',
+    '<a href="JAVASCRIPT:alert(1)">link</a>', // case-insensitive
+    '<a href="  javascript:alert(1)">link</a>', // leading whitespace
+    // HTML entity-encoded bypass attempts (internal tabs/newlines)
+    // These become actual C0 control characters when parsed by the browser
+    '<a href="java&#9;script:alert(1)">link</a>', // tab via HTML entity
+    '<a href="java&#10;script:alert(1)">link</a>', // newline via HTML entity
+    '<a href="java&#13;script:alert(1)">link</a>', // CR via HTML entity
+  ])("blocks dangerous raw HTML URLs: %s", async source => {
+    render(<StreamlitMarkdown source={source} allowHTML={true} />)
+    const link = await screen.findByText("link")
+    expect(link).toHaveAttribute("href", "#")
+  })
+
   it.each([
     "https://example.com",
     "http://example.com",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -424,6 +424,38 @@ describe("linkReference", () => {
   })
 })
 
+describe("link URL scheme security", () => {
+  it.each([
+    "javascript:alert(document.domain)",
+    "JavaScript:alert(1)", // case-insensitive
+    "  javascript:alert(1)", // leading whitespace
+    "javascript:alert(1)  ", // trailing whitespace
+    "vbscript:msgbox(1)",
+    "VBScript:execute()", // case-insensitive
+  ])("blocks dangerous URL: %s", url => {
+    render(
+      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
+    )
+    expect(screen.getByText("Click me")).toHaveAttribute("href", "")
+  })
+
+  it.each([
+    "https://example.com",
+    "http://example.com",
+    "mailto:test@example.com",
+    "tel:+1234567890",
+    "data:image/png;base64,abc123",
+    "data:text/plain,hello",
+    "/relative/path",
+    "#anchor",
+  ])("allows safe URL: %s", url => {
+    render(
+      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
+    )
+    expect(screen.getByText("Click me")).toHaveAttribute("href", url)
+  })
+})
+
 describe("StreamlitMarkdown", () => {
   let bgColors: ReturnType<typeof getThemeBackgroundColors>
   let backgroundColorMapping: Map<string, string>

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -438,7 +438,11 @@ describe("link URL scheme security", () => {
     )
     // Returns "#" to prevent navigation (empty href with target="_blank"
     // would open current page in new tab)
-    expect(screen.getByText("Click me")).toHaveAttribute("href", "#")
+    const link = screen.getByText("Click me")
+    expect(link).toHaveAttribute("href", "#")
+    // Verify blocked links don't open in new tab (LinkWithTargetBlank returns
+    // target="_self" for URLs starting with "#")
+    expect(link).not.toHaveAttribute("target", "_blank")
   })
 
   // Raw HTML links go through rehype-raw and reach transformLinkUri.
@@ -462,6 +466,8 @@ describe("link URL scheme security", () => {
     render(<StreamlitMarkdown source={source} allowHTML={true} />)
     const link = await screen.findByText("link")
     expect(link).toHaveAttribute("href", "#")
+    // Verify blocked links don't open in new tab
+    expect(link).not.toHaveAttribute("target", "_blank")
   })
 
   it.each([

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -255,10 +255,24 @@ export function createAnchorFromText(text: string | null): string {
   return xxhash.h32(text, 0xabcd).toString(16)
 }
 
-// Note: React markdown limits hrefs to specific protocols ('http', 'https',
-// 'mailto', 'tel') We are essentially allowing any URL (a data URL). It can
-// be considered a security flaw, but developers can choose to expose it.
+// Dangerous URL schemes that can execute arbitrary code when clicked
+const DANGEROUS_URL_SCHEMES = ["javascript:", "vbscript:"]
+
+/**
+ * Transforms link URIs for markdown rendering.
+ *
+ * Note: React Markdown limits hrefs to specific protocols ('http', 'https',
+ * 'mailto', 'tel') by default. We allow most URLs including data: URLs, which
+ * are intentionally supported for embedding inline content (e.g., images).
+ * Only explicitly dangerous schemes (javascript:, vbscript:) are blocked.
+ */
 function transformLinkUri(href: string): string {
+  const normalizedHref = href.toLowerCase().trim()
+  if (
+    DANGEROUS_URL_SCHEMES.some(scheme => normalizedHref.startsWith(scheme))
+  ) {
+    return ""
+  }
   return href
 }
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -267,10 +267,13 @@ const C0_CONTROL_CHARS_REGEX = /[\x00-\x1F]/g
 /**
  * Transforms link URIs for markdown rendering.
  *
- * Note: React Markdown limits hrefs to specific protocols ('http', 'https',
- * 'mailto', 'tel') by default. We allow most URLs including data: URLs, which
- * are intentionally supported for embedding inline content (e.g., images).
+ * Uses a blocklist approach instead of React Markdown's default allowlist
+ * (defaultUrlTransform) to preserve compatibility with data: URLs and other
+ * custom schemes that Streamlit users rely on (e.g., inline images, PDFs).
  * Only explicitly dangerous schemes (javascript:, vbscript:) are blocked.
+ *
+ * Note: data:text/html URLs can execute JavaScript but run in a sandboxed
+ * null-origin context, making them less dangerous than javascript: URLs.
  *
  * Blocked URLs return "#" instead of "" to prevent navigation. An empty href
  * combined with target="_blank" would open the current page in a new tab.

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -258,6 +258,12 @@ export function createAnchorFromText(text: string | null): string {
 // Dangerous URL schemes that can execute arbitrary code when clicked
 const DANGEROUS_URL_SCHEMES = ["javascript:", "vbscript:"]
 
+// C0 control characters (U+0000-U+001F) that browsers silently strip from URLs
+// per the WHATWG URL spec. These must be removed before checking schemes to
+// prevent bypass attacks like "\x01javascript:alert(1)".
+// eslint-disable-next-line no-control-regex
+const C0_CONTROL_CHARS_REGEX = /[\x00-\x1F]/g
+
 /**
  * Transforms link URIs for markdown rendering.
  *
@@ -265,13 +271,24 @@ const DANGEROUS_URL_SCHEMES = ["javascript:", "vbscript:"]
  * 'mailto', 'tel') by default. We allow most URLs including data: URLs, which
  * are intentionally supported for embedding inline content (e.g., images).
  * Only explicitly dangerous schemes (javascript:, vbscript:) are blocked.
+ *
+ * Blocked URLs return "#" instead of "" to prevent navigation. An empty href
+ * combined with target="_blank" would open the current page in a new tab.
  */
 function transformLinkUri(href: string): string {
-  const normalizedHref = href.toLowerCase().trim()
+  // Strip C0 control characters and whitespace, then lowercase for comparison.
+  // Browsers strip C0 chars per WHATWG URL spec, so we must normalize first
+  // to prevent bypass attacks like "\x01javascript:alert(1)".
+  const normalizedHref = href
+    .replace(C0_CONTROL_CHARS_REGEX, "")
+    .toLowerCase()
+    .trim()
   if (
     DANGEROUS_URL_SCHEMES.some(scheme => normalizedHref.startsWith(scheme))
   ) {
-    return ""
+    // Return "#" instead of "" to prevent navigation. Empty href with
+    // target="_blank" would open the current page in a new tab.
+    return "#"
   }
   return href
 }


### PR DESCRIPTION
## Describe your changes

Blocks dangerous URL schemes (`javascript:`, `vbscript:`) in markdown links to prevent XSS attacks, while intentionally preserving support for `data:` URLs.

- Adds blocklist check in `transformLinkUri` for dangerous URL schemes
- Handles case variations and leading/trailing whitespace
- Documents that `data:` URLs are intentionally allowed for inline content

## GitHub Issue Link (if applicable)

N/A - Security hardening

## Testing Plan

- [x] Frontend unit tests for blocked and allowed URL schemes