### PR TITLE
Remove `BaseWeb` for `Spinner`

### DIFF
--- a/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.test.tsx
@@ -15,7 +15,6 @@
  */
 
 import { act, screen, waitFor } from "@testing-library/react"
-import { BaseProvider, LightTheme } from "baseui"
 
 import { Spinner as SpinnerProto } from "@streamlit/protobuf"
 
@@ -44,11 +43,7 @@ describe("Spinner component", () => {
   })
 
   it("renders without crashing", () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps()} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps()} />)
 
     const spinnerContainer = screen.getByTestId("stSpinner")
     expect(spinnerContainer).toBeInTheDocument()
@@ -56,22 +51,14 @@ describe("Spinner component", () => {
   })
 
   it("sets the text and width correctly", () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps()} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps()} />)
 
     const markdownText = screen.getByText("Loading...")
     expect(markdownText).toBeInTheDocument()
   })
 
   it("sets additional className/CSS for caching spinner", () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps({}, { cache: true })} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps({}, { cache: true })} />)
 
     const spinnerContainer = screen.getByTestId("stSpinner")
     expect(spinnerContainer).toBeInTheDocument()
@@ -82,11 +69,7 @@ describe("Spinner component", () => {
   })
 
   it("shows timer when showTime is true", () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps({}, { showTime: true })} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps({}, { showTime: true })} />)
 
     const spinnerContainer = screen.getByTestId("stSpinner")
     expect(spinnerContainer).toBeInTheDocument()
@@ -94,11 +77,7 @@ describe("Spinner component", () => {
   })
 
   it("updates timer based on system time", async () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps({}, { showTime: true })} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps({}, { showTime: true })} />)
 
     // Initially shows 0.0 seconds
     expect(screen.getByText("(0.0 seconds)")).toBeInTheDocument()
@@ -127,11 +106,7 @@ describe("Spinner component", () => {
   })
 
   it("formats time correctly for different durations", async () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps({}, { showTime: true })} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps({}, { showTime: true })} />)
 
     // Test seconds
     act(() => {
@@ -155,11 +130,7 @@ describe("Spinner component", () => {
   })
 
   it("does not show timer when showTime is false", () => {
-    render(
-      <BaseProvider theme={LightTheme}>
-        <Spinner {...getProps({}, { showTime: false })} />
-      </BaseProvider>
-    )
+    render(<Spinner {...getProps({}, { showTime: false })} />)
 
     const spinnerContainer = screen.getByTestId("stSpinner")
     expect(spinnerContainer).toBeInTheDocument()

--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.test.tsx
@@ -35,6 +35,12 @@ const getProps = (
 })
 
 describe("Dynamic icon", () => {
+  it("renders spinner with aria-hidden", () => {
+    render(<DynamicIcon iconValue="spinner" />)
+    const spinnerIcon = screen.getByTestId("stSpinnerIcon")
+    expect(spinnerIcon).toHaveAttribute("aria-hidden", "true")
+  })
+
   it("renders without crashing with Material icon", () => {
     const props = getProps({ iconValue: ":material/add_circle:" })
     render(<DynamicIcon {...props} />)

--- a/frontend/lib/src/components/shared/Icon/DynamicIcon.tsx
+++ b/frontend/lib/src/components/shared/Icon/DynamicIcon.tsx
@@ -135,6 +135,7 @@ const DynamicIconDispatcher = ({
     return (
       <StyledDynamicIcon {...props}>
         <StyledSpinnerIcon
+          aria-hidden="true"
           data-testid={props.testid || "stSpinnerIcon"}
           {...props}
         />

--- a/frontend/lib/src/components/shared/Icon/styled-components.ts
+++ b/frontend/lib/src/components/shared/Icon/styled-components.ts
@@ -33,7 +33,7 @@ interface StyledSpinnerIconProps {
   padding?: string
 }
 
-export const StyledSpinnerIcon = styled("i", {
+export const StyledSpinnerIcon = styled("span", {
   shouldForwardProp: (prop: string) =>
     isPropValid(prop) && !["size"].includes(prop),
 })<StyledSpinnerIconProps>(({
@@ -47,7 +47,6 @@ export const StyledSpinnerIcon = styled("i", {
 
   return {
     display: "block",
-    fontStyle: "normal",
     animationName: spinKeyframe,
     animationDuration: "1000ms",
     animationIterationCount: "infinite",
@@ -64,6 +63,9 @@ export const StyledSpinnerIcon = styled("i", {
     borderWidth: theme.sizes.spinnerThickness,
     flexGrow: 0,
     flexShrink: 0,
+    "@media (prefers-reduced-motion: reduce)": {
+      animation: "none",
+    },
   }
 })
 

--- a/frontend/lib/src/components/shared/Icon/styled-components.ts
+++ b/frontend/lib/src/components/shared/Icon/styled-components.ts
@@ -47,6 +47,7 @@ export const StyledSpinnerIcon = styled("i", {
 
   return {
     display: "block",
+    fontStyle: "normal",
     animationName: spinKeyframe,
     animationDuration: "1000ms",
     animationIterationCount: "infinite",
@@ -56,8 +57,6 @@ export const StyledSpinnerIcon = styled("i", {
     cursor: "wait",
     width: adjustedSpinnerSize,
     height: adjustedSpinnerSize,
-    fontSize: adjustedSpinnerSize,
-    justifyContent: "center",
     margin: computeSpacingStyle(margin, theme),
     padding: computeSpacingStyle(padding, theme),
     borderColor: theme.colors.fadedText10,

--- a/frontend/lib/src/components/shared/Icon/styled-components.ts
+++ b/frontend/lib/src/components/shared/Icon/styled-components.ts
@@ -15,12 +15,17 @@
  */
 
 import isPropValid from "@emotion/is-prop-valid"
+import { keyframes } from "@emotion/react"
 import styled from "@emotion/styled"
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
-import { Spinner } from "baseui/spinner"
 
 import type { IconSize } from "~lib/theme/types"
 import { computeSpacingStyle } from "~lib/theme/utils"
+
+const spinKeyframe = keyframes({
+  from: { transform: "rotate(0deg)" },
+  to: { transform: "rotate(360deg)" },
+})
 
 interface StyledSpinnerIconProps {
   size?: IconSize
@@ -28,7 +33,7 @@ interface StyledSpinnerIconProps {
   padding?: string
 }
 
-export const StyledSpinnerIcon = styled(Spinner, {
+export const StyledSpinnerIcon = styled("i", {
   shouldForwardProp: (prop: string) =>
     isPropValid(prop) && !["size"].includes(prop),
 })<StyledSpinnerIconProps>(({
@@ -41,6 +46,14 @@ export const StyledSpinnerIcon = styled(Spinner, {
   const adjustedSpinnerSize = `calc(${theme.iconSizes[size]} * 0.80)`
 
   return {
+    display: "block",
+    animationName: spinKeyframe,
+    animationDuration: "1000ms",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "linear",
+    borderStyle: "solid",
+    borderRadius: "50%",
+    cursor: "wait",
     width: adjustedSpinnerSize,
     height: adjustedSpinnerSize,
     fontSize: adjustedSpinnerSize,


### PR DESCRIPTION
## Describe your changes
We currently use `BaseWeb`'s spinner for our spinner which is unnecessary - this PR replicates the element without using an underlying component library

## Testing Plan
Refactor — all existing unit tests pass. E2E snapshots should be stable.