### PR TITLE
[feature] Add schema-based identity for st.data_editor

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -278,12 +278,8 @@ function DataFrame({
     originalColumns,
   })
 
-  const { getCellContent: getOriginalCellContent } = useDataLoader(
-    data,
-    originalColumns,
-    numRows,
-    editingState
-  )
+  const { getCellContent: getOriginalCellContent, getSourceCellValue } =
+    useDataLoader(data, originalColumns, numRows, editingState)
 
   const { columns, sortColumn, getOriginalIndex, getCellContent } =
     useColumnSort(originalNumRows, originalColumns, getOriginalCellContent)
@@ -496,12 +492,49 @@ function DataFrame({
       canDeleteRows,
       editingState,
       getCellContent,
+      getSourceCellValue,
       getOriginalIndex,
       refreshCells,
       updateNumRows,
       syncEditState,
       clearSelection,
     })
+
+  // Clean up edits that now match source data when source data changes.
+  // This allows cells to receive updated values when the user has edited
+  // them back to their original values.
+  useEffect(() => {
+    // Build a map from indexNumber to column for efficient lookup
+    const columnsByIndex = new Map(
+      originalColumns.map(col => [col.indexNumber, col])
+    )
+
+    let anyCleared = false
+    // Collect edits to clear to avoid modifying during iteration
+    const editsToCheck = [...editingState.current.getEditedCells()]
+
+    for (const [row, col, cell] of editsToCheck) {
+      const column = columnsByIndex.get(col)
+      if (!column) {
+        continue
+      }
+
+      const editValue = column.getCellValue(cell)
+      const sourceValue = getSourceCellValue(col, row, column)
+
+      if (editValue === sourceValue) {
+        if (editingState.current.clearCell(col, row)) {
+          anyCleared = true
+        }
+      }
+    }
+
+    if (anyCleared) {
+      syncEditState()
+    }
+    // Only run when `data` changes (tracked via getSourceCellValue dependency)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
 
   const ignoredRowIndices = useMemo(() => {
     // If empty table, ignore row index 0 which is just a visual gimmick

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/EditingState.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/EditingState.test.ts
@@ -385,4 +385,94 @@ describe("EditingState class", () => {
     // Should have an empty cell since it wasn't specified in the JSON:
     expect(editingState.getCell(2, 3)).toEqual(MOCK_COLUMNS[2].getCell(null))
   })
+
+  it("allows to clear an edited cell", () => {
+    const NUM_OF_ROWS = 3
+    const editingState = new EditingState(NUM_OF_ROWS)
+
+    // Set some cells
+    editingState.setCell(0, 0, MOCK_TEXT_CELL_1)
+    editingState.setCell(1, 0, MOCK_TEXT_CELL_2)
+    editingState.setCell(0, 1, MOCK_TEXT_CELL_1)
+
+    // Verify cells are set
+    expect(editingState.getCell(0, 0)).toEqual(MOCK_TEXT_CELL_1)
+    expect(editingState.getCell(1, 0)).toEqual(MOCK_TEXT_CELL_2)
+    expect(editingState.getCell(0, 1)).toEqual(MOCK_TEXT_CELL_1)
+
+    // Clear one cell
+    const cleared = editingState.clearCell(0, 0)
+    expect(cleared).toBe(true)
+    expect(editingState.getCell(0, 0)).toBeUndefined()
+
+    // Other cells should still exist
+    expect(editingState.getCell(1, 0)).toEqual(MOCK_TEXT_CELL_2)
+    expect(editingState.getCell(0, 1)).toEqual(MOCK_TEXT_CELL_1)
+
+    // Clear a cell that doesn't exist
+    const notCleared = editingState.clearCell(2, 2)
+    expect(notCleared).toBe(false)
+
+    // Cannot clear cells from added rows
+    const rowCells: Map<number, GridCell> = new Map()
+    rowCells.set(0, MOCK_TEXT_CELL_1)
+    editingState.addRow(rowCells)
+    const addedRowCleared = editingState.clearCell(0, 3)
+    expect(addedRowCleared).toBe(false)
+  })
+
+  it("cleans up empty row maps when clearing the last cell", () => {
+    const NUM_OF_ROWS = 3
+    const editingState = new EditingState(NUM_OF_ROWS)
+
+    // Set a single cell in a row
+    editingState.setCell(0, 0, MOCK_TEXT_CELL_1)
+    expect(editingState.getCell(0, 0)).toEqual(MOCK_TEXT_CELL_1)
+
+    // Clear it
+    editingState.clearCell(0, 0)
+    expect(editingState.getCell(0, 0)).toBeUndefined()
+
+    // Verify via getEditedCells that no edits remain
+    const edits = [...editingState.getEditedCells()]
+    expect(edits).toHaveLength(0)
+  })
+
+  it("iterates over edited cells with getEditedCells", () => {
+    const NUM_OF_ROWS = 3
+    const editingState = new EditingState(NUM_OF_ROWS)
+
+    // Set some cells
+    editingState.setCell(0, 0, MOCK_TEXT_CELL_1)
+    editingState.setCell(1, 0, MOCK_TEXT_CELL_2)
+    editingState.setCell(0, 2, MOCK_TEXT_CELL_1)
+
+    const edits = [...editingState.getEditedCells()]
+    expect(edits).toHaveLength(3)
+
+    // Should contain all edited cells (order may vary)
+    const editSet = new Set(edits.map(([row, col]) => `${row},${col}`))
+    expect(editSet.has("0,0")).toBe(true)
+    expect(editSet.has("0,1")).toBe(true)
+    expect(editSet.has("2,0")).toBe(true)
+  })
+
+  it("getEditedCells excludes added rows", () => {
+    const NUM_OF_ROWS = 3
+    const editingState = new EditingState(NUM_OF_ROWS)
+
+    // Edit a cell in existing row
+    editingState.setCell(0, 0, MOCK_TEXT_CELL_1)
+
+    // Add a row
+    const rowCells: Map<number, GridCell> = new Map()
+    rowCells.set(0, MOCK_TEXT_CELL_2)
+    editingState.addRow(rowCells)
+
+    // getEditedCells should only return the edit from existing rows
+    const edits = [...editingState.getEditedCells()]
+    expect(edits).toHaveLength(1)
+    expect(edits[0][0]).toBe(0) // row
+    expect(edits[0][1]).toBe(0) // col
+  })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/EditingState.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/EditingState.ts
@@ -277,6 +277,45 @@ class EditingState {
   }
 
   /**
+   * Clears the edit for a specific cell, restoring it to use source data.
+   * This is used when an edit results in the same value as the source data.
+   *
+   * @param col - The column index
+   * @param row - The row index
+   * @returns true if an edit was cleared, false if no edit existed
+   */
+  clearCell(col: number, row: number): boolean {
+    if (this.isAddedRow(row)) {
+      // Cannot clear cells from added rows - they must have values
+      return false
+    }
+
+    const rowCache = this.editedCells.get(row)
+    if (rowCache === undefined) {
+      return false
+    }
+
+    const deleted = rowCache.delete(col)
+    // Clean up empty row maps
+    if (rowCache.size === 0) {
+      this.editedCells.delete(row)
+    }
+    return deleted
+  }
+
+  /**
+   * Returns an iterator over all edited cells (excluding added rows).
+   * Each entry contains [row, col, cell].
+   */
+  *getEditedCells(): Generator<[number, number, GridCell]> {
+    for (const [row, rowMap] of this.editedCells) {
+      for (const [col, cell] of rowMap) {
+        yield [row, col, cell]
+      }
+    }
+  }
+
+  /**
    * Adds a new row to the editing state.
    *
    * @param rowCells - The cells of the row to add

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.test.ts
@@ -102,6 +102,7 @@ const getCellContentMock = vi
     }
     return column.getCell("foo")
   })
+const getSourceCellValueMock = vi.fn().mockReturnValue(undefined)
 
 describe("useDataEditor hook", () => {
   beforeEach(() => {
@@ -120,6 +121,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -165,6 +167,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -209,6 +212,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -259,6 +263,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -304,6 +309,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -349,6 +355,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -381,6 +388,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -445,6 +453,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -492,6 +501,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -524,6 +534,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -577,6 +588,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -622,6 +634,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: false,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -668,6 +681,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -726,6 +740,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: false,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -784,6 +799,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -820,6 +836,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -855,6 +872,7 @@ describe("useDataEditor hook", () => {
         canDeleteRows: true,
         editingState,
         getCellContent: getCellContentMock,
+        getSourceCellValue: getSourceCellValueMock,
         getOriginalIndex: getOriginalIndexMock,
         refreshCells: refreshCellsMock,
         updateNumRows,
@@ -877,5 +895,93 @@ describe("useDataEditor hook", () => {
     )
 
     expect(validResult).toEqual(true)
+  })
+
+  it("clears edit when new value matches source value", () => {
+    const editingState = {
+      current: new EditingState(INITIAL_NUM_ROWS),
+    }
+
+    // First, add an edit
+    editingState.current.setCell(1, 0, MOCK_COLUMNS[1].getCell("edited"))
+
+    // Mock getSourceCellValue to return the original source value
+    const mockSourceValue = vi.fn().mockReturnValue("original")
+
+    const { result } = renderHook(() => {
+      return useDataEditor({
+        columns: MOCK_COLUMNS,
+        allColumns: MOCK_COLUMNS,
+        canAddRows: true,
+        canDeleteRows: true,
+        editingState,
+        getCellContent: getCellContentMock,
+        getSourceCellValue: mockSourceValue,
+        getOriginalIndex: getOriginalIndexMock,
+        refreshCells: refreshCellsMock,
+        updateNumRows,
+        syncEditState: syncEditsMock,
+        clearSelection: clearSelectionMock,
+      })
+    })
+
+    if (typeof result.current.onCellEdited !== "function") {
+      throw new Error("onCellEdited is expected to be a function")
+    }
+
+    // Edit the cell to match the source value
+    const columnToEdit = MOCK_COLUMNS[1]
+    result.current.onCellEdited(
+      [1, 0],
+      columnToEdit.getCell("original") as TextCell
+    )
+
+    // The edit should be cleared (since it matches source)
+    expect(editingState.current.getCell(1, 0)).toBeUndefined()
+    expect(syncEditsMock).toHaveBeenCalled()
+  })
+
+  it("stores edit when new value differs from source value", () => {
+    const editingState = {
+      current: new EditingState(INITIAL_NUM_ROWS),
+    }
+
+    // Mock getSourceCellValue to return the original source value
+    const mockSourceValue = vi.fn().mockReturnValue("original")
+
+    const { result } = renderHook(() => {
+      return useDataEditor({
+        columns: MOCK_COLUMNS,
+        allColumns: MOCK_COLUMNS,
+        canAddRows: true,
+        canDeleteRows: true,
+        editingState,
+        getCellContent: getCellContentMock,
+        getSourceCellValue: mockSourceValue,
+        getOriginalIndex: getOriginalIndexMock,
+        refreshCells: refreshCellsMock,
+        updateNumRows,
+        syncEditState: syncEditsMock,
+        clearSelection: clearSelectionMock,
+      })
+    })
+
+    if (typeof result.current.onCellEdited !== "function") {
+      throw new Error("onCellEdited is expected to be a function")
+    }
+
+    // Edit the cell to a different value than source
+    const columnToEdit = MOCK_COLUMNS[1]
+    result.current.onCellEdited(
+      [1, 0],
+      columnToEdit.getCell("different") as TextCell
+    )
+
+    // The edit should be stored
+    const editedCell = editingState.current.getCell(1, 0)
+    expect(notNullOrUndefined(editedCell)).toBe(true)
+    // @ts-expect-error
+    expect(columnToEdit.getCellValue(editedCell)).toEqual("different")
+    expect(syncEditsMock).toHaveBeenCalled()
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataEditor.ts
@@ -35,6 +35,33 @@ import { notNullOrUndefined } from "~lib/util/utils"
 import EditingState from "./EditingState"
 
 /**
+ * Checks if an edit matches the source data and should be cleared.
+ * Returns true if the edit was cleared, false otherwise.
+ */
+function tryClearEditIfMatchesSource(
+  editingState: EditingState,
+  getSourceCellValue: (
+    col: number,
+    row: number,
+    column: BaseColumn
+  ) => unknown,
+  column: BaseColumn,
+  originalCol: number,
+  originalRow: number,
+  newValue: unknown
+): boolean {
+  if (editingState.isAddedRow(originalRow)) {
+    return false
+  }
+
+  const sourceValue = getSourceCellValue(originalCol, originalRow, column)
+  if (newValue === sourceValue) {
+    return editingState.clearCell(originalCol, originalRow)
+  }
+  return false
+}
+
+/**
  * Create return type for useDataEditor hook based on the DataEditorProps.
  */
 type DataEditorReturn = Pick<
@@ -61,6 +88,11 @@ interface UseDataEditorParams {
   editingState: MutableRefObject<EditingState>
   /** Function to get a specific cell. */
   getCellContent: ([col, row]: readonly [number, number]) => GridCell
+  /**
+   * Function to get the source cell value (from Arrow data, ignoring edits).
+   * Returns the raw value for comparison, or undefined if unavailable.
+   */
+  getSourceCellValue: (col: number, row: number, column: BaseColumn) => unknown
   /**
    * Function to map a row ID of the current state to the original row ID.
    * This mainly changed by sorting of columns.
@@ -94,6 +126,7 @@ function useDataEditor({
   canDeleteRows,
   editingState,
   getCellContent,
+  getSourceCellValue,
   getOriginalIndex,
   refreshCells,
   updateNumRows,
@@ -130,6 +163,21 @@ function useDataEditor({
       const newCell = column.getCell(newValue, true)
       // Only update the cell if the new cell is not causing any errors:
       if (!isErrorCell(newCell)) {
+        // Clear the edit if it matches the source data value.
+        if (
+          tryClearEditIfMatchesSource(
+            editingState.current,
+            getSourceCellValue,
+            column,
+            originalCol,
+            originalRow,
+            newValue
+          )
+        ) {
+          syncEditState()
+          return
+        }
+
         editingState.current.setCell(originalCol, originalRow, {
           ...newCell,
           lastUpdated: performance.now(),
@@ -142,7 +190,14 @@ function useDataEditor({
         )
       }
     },
-    [columns, editingState, getOriginalIndex, getCellContent, syncEditState]
+    [
+      columns,
+      editingState,
+      getOriginalIndex,
+      getCellContent,
+      getSourceCellValue,
+      syncEditState,
+    ]
   )
 
   /**
@@ -301,6 +356,23 @@ function useDataEditor({
               const newValue = column.getCellValue(newCell)
               // Edit the cell only if the value actually changed:
               if (newValue !== currentValue) {
+                // Clear the edit if it matches the source data value.
+                if (
+                  tryClearEditIfMatchesSource(
+                    editingState.current,
+                    getSourceCellValue,
+                    column,
+                    originalCol,
+                    originalRow,
+                    newValue
+                  )
+                ) {
+                  updatedCells.push({
+                    cell: [colIndex, rowIndex],
+                  })
+                  continue
+                }
+
                 editingState.current.setCell(originalCol, originalRow, {
                   ...newCell,
                   lastUpdated: performance.now(),
@@ -328,6 +400,7 @@ function useDataEditor({
       canAddRows,
       getOriginalIndex,
       getCellContent,
+      getSourceCellValue,
       appendEmptyRow,
       syncEditState,
       refreshCells,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataLoader.ts
@@ -29,7 +29,13 @@ import { notNullOrUndefined } from "~lib/util/utils"
 
 import EditingState from "./EditingState"
 
-type DataLoaderReturn = Pick<DataEditorProps, "getCellContent">
+type DataLoaderReturn = Pick<DataEditorProps, "getCellContent"> & {
+  /**
+   * Get the source cell value from Arrow data (ignoring any edits).
+   * Returns undefined if the row is out of bounds or an error occurs.
+   */
+  getSourceCellValue: (col: number, row: number, column: BaseColumn) => unknown
+}
 
 /**
  * Custom hook that handles all data loading capabilities for the interactive data table.
@@ -122,8 +128,36 @@ function useDataLoader(
     [columns, numRows, data, editingState]
   )
 
+  const getSourceCellValue = useCallback(
+    (col: number, row: number, column: BaseColumn): unknown => {
+      const dataDimensions = data.dimensions
+      if (
+        row >= dataDimensions.numDataRows ||
+        col >= dataDimensions.numDataColumns
+      ) {
+        return undefined
+      }
+
+      try {
+        const arrowCell = data.getCell(row, col)
+        const styledCell = getStyledCell(data, row, col)
+        const sourceCell = getCellFromArrow(
+          column,
+          arrowCell,
+          styledCell,
+          data.styler?.cssStyles
+        )
+        return column.getCellValue(sourceCell)
+      } catch {
+        return undefined
+      }
+    },
+    [data]
+  )
+
   return {
     getCellContent,
+    getSourceCellValue,
   }
 }
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -573,11 +573,14 @@ def _compute_data_editor_signature(
         for col_name in column_order:
             h.update(f"order:{col_name}".encode())
 
-    # Hash index type and name
+    # Hash index type and name(s)
     index = data_df.index
     h.update(f"index_type:{type(index).__name__}".encode())
-    if index.name is not None:
-        h.update(f"index_name:{index.name}".encode())
+    # Use index.names for MultiIndex (FrozenList of level names), fall back to
+    # index.name for single-level Index
+    for name in index.names:
+        if name is not None:
+            h.update(f"index_name:{name}".encode())
 
     # Hash Arrow field types with nullability
     for field in arrow_schema:
@@ -591,16 +594,23 @@ def _compute_data_editor_signature(
     h.update(f"rows:{len(data_df)}".encode())
 
     # Hash column config mapping (deterministic JSON sort)
-    config_json = json.dumps(
-        {str(k): v for k, v in column_config_mapping.items()},
-        sort_keys=True,
-        default=str,
-    )
+    # Use _pos: prefix for int keys to match _convert_column_config_to_json behavior
+    # and avoid collisions with columns named like "1"
+    config_dict = {
+        (f"_pos:{k}" if isinstance(k, int) else str(k)): v
+        for k, v in column_config_mapping.items()
+        if v is not None
+    }
+    config_json = json.dumps(config_dict, sort_keys=True, default=str)
     h.update(f"config:{config_json}".encode())
 
-    # Hash disabled state when it disables all editing
+    # Hash disabled state (all-disabled or specific columns)
     if disabled is True:
         h.update(b"disabled:all")
+    elif disabled is not False:
+        # disabled is an iterable of column names; sort for stability
+        for col in sorted(str(c) for c in disabled):
+            h.update(f"disabled_col:{col}".encode())
 
     return h.hexdigest()
 
@@ -1216,6 +1226,24 @@ class DataEditorMixin:
         # format that will hash consistently, so we do it late here to have it
         # as close as possible to how it used to be.
         ctx = get_script_run_ctx()
+
+        # Build the kwargs for compute_and_register_element_id. Only include
+        # data_signature when schema identity is enabled to avoid changing the
+        # element ID for existing non-schema-identity data editors.
+        element_id_kwargs: dict[str, Any] = {
+            "data": arrow_bytes,
+            "width": width,
+            "height": height,
+            "use_container_width": use_container_width,
+            "column_order": column_order,
+            "column_config_mapping": str(column_config_mapping),
+            "num_rows": num_rows,
+            "row_height": row_height,
+            "placeholder": placeholder,
+        }
+        if use_schema_identity:
+            element_id_kwargs["data_signature"] = data_signature
+
         element_id = compute_and_register_element_id(
             "data_editor",
             user_key=key,
@@ -1223,16 +1251,7 @@ class DataEditorMixin:
             if use_schema_identity
             else False,
             dg=self.dg,
-            data=arrow_bytes,
-            data_signature=data_signature,
-            width=width,
-            height=height,
-            use_container_width=use_container_width,
-            column_order=column_order,
-            column_config_mapping=str(column_config_mapping),
-            num_rows=num_rows,
-            row_height=row_height,
-            placeholder=placeholder,
+            **element_id_kwargs,
         )
 
         proto = DataframeProto()

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -599,7 +599,6 @@ def _compute_data_editor_signature(
     config_dict = {
         (f"_pos:{k}" if isinstance(k, int) else str(k)): v
         for k, v in column_config_mapping.items()
-        if v is not None
     }
     config_json = json.dumps(config_dict, sort_keys=True, default=str)
     h.update(f"config:{config_json}".encode())
@@ -1185,8 +1184,10 @@ class DataEditorMixin:
             )
 
         # If disabled not a boolean, we assume it is a list of columns to disable.
-        # This gets translated into the columns configuration:
+        # Materialize the iterable early to avoid exhaustion issues with generators,
+        # since disabled is iterated multiple times (column config and signature hash).
         if not isinstance(disabled, bool):
+            disabled = list(disabled)
             for column in disabled:
                 update_column_config(column_config_mapping, column, {"disabled": True})
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -73,7 +73,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.type_util import is_list_like, is_type
-from streamlit.util import calc_hash
+from streamlit.util import calc_hash, create_fast_hasher
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -509,6 +509,100 @@ def _is_supported_index(df_index: pd.Index[Any]) -> bool:
         or is_type(df_index, "pandas.core.indexes.numeric.Float64Index")
         or is_type(df_index, "pandas.core.indexes.numeric.UInt64Index")
     )
+
+
+def _compute_data_editor_signature(
+    data_df: pd.DataFrame,
+    arrow_schema: pa.Schema,
+    dataframe_schema: DataframeSchema,
+    data_format: dataframe_util.DataFormat,
+    column_config_mapping: ColumnConfigMapping,
+    column_order: list[str] | None,
+    disabled: bool | Iterable[str | int],
+) -> str:
+    """Compute a schema-based signature for the data editor.
+
+    This signature captures the structural aspects of the dataframe (schema)
+    without including the actual data values. This allows the element ID to
+    remain stable when only data values change, preserving edit state.
+
+    The signature includes:
+    - Data format (for return type conversion)
+    - Column names in order
+    - Effective visible/editable columns when column_order is provided
+    - Index type and names
+    - Arrow field types with nullability
+    - DataframeSchema data kinds for parsing
+    - Row count (for fixed mode identity)
+    - Column config mapping (deterministic JSON)
+    - Disabled state when it disables all editing
+
+    Parameters
+    ----------
+    data_df : pd.DataFrame
+        The pandas dataframe being edited.
+    arrow_schema : pa.Schema
+        The Arrow schema of the dataframe.
+    dataframe_schema : DataframeSchema
+        The determined data kinds for each column.
+    data_format : dataframe_util.DataFormat
+        The original format of the input data.
+    column_config_mapping : ColumnConfigMapping
+        The processed column configuration.
+    column_order : list[str] | None
+        The column order if specified.
+    disabled : bool | Iterable[str | int]
+        The disabled state or list of disabled columns.
+
+    Returns
+    -------
+    str
+        A hex digest representing the schema signature.
+    """
+    h = create_fast_hasher()
+
+    # Hash data format (affects return type conversion)
+    h.update(f"format:{data_format.name}".encode())
+
+    # Hash column names in order
+    for col_name in data_df.columns:
+        h.update(f"col:{col_name}".encode())
+
+    # Hash effective column order if specified
+    if column_order is not None:
+        for col_name in column_order:
+            h.update(f"order:{col_name}".encode())
+
+    # Hash index type and name
+    index = data_df.index
+    h.update(f"index_type:{type(index).__name__}".encode())
+    if index.name is not None:
+        h.update(f"index_name:{index.name}".encode())
+
+    # Hash Arrow field types with nullability
+    for field in arrow_schema:
+        h.update(f"arrow_field:{field.name}:{field.type}:{field.nullable}".encode())
+
+    # Hash DataframeSchema data kinds (used for parsing edits)
+    for col_name, data_kind in sorted(dataframe_schema.items()):
+        h.update(f"schema:{col_name}:{data_kind.value}".encode())
+
+    # Hash row count (critical for fixed mode - row count changes should reset state)
+    h.update(f"rows:{len(data_df)}".encode())
+
+    # Hash column config mapping (deterministic JSON sort)
+    config_json = json.dumps(
+        {str(k): v for k, v in column_config_mapping.items()},
+        sort_keys=True,
+        default=str,
+    )
+    h.update(f"config:{config_json}".encode())
+
+    # Hash disabled state when it disables all editing
+    if disabled is True:
+        h.update(b"disabled:all")
+
+    return h.hexdigest()
 
 
 def _fix_column_headers(data_df: pd.DataFrame) -> None:
@@ -1101,6 +1195,22 @@ class DataEditorMixin:
 
         arrow_bytes = dataframe_util.convert_arrow_table_to_arrow_bytes(arrow_table)
 
+        # Compute a schema-based signature for keyed fixed-mode editors.
+        # This allows data values to change without resetting edit state,
+        # while schema changes (columns, types, row count) still reset state.
+        data_signature: str | None = None
+        use_schema_identity = key is not None and num_rows == "fixed"
+        if use_schema_identity:
+            data_signature = _compute_data_editor_signature(
+                data_df=data_df,
+                arrow_schema=arrow_table.schema,
+                dataframe_schema=dataframe_schema,
+                data_format=data_format,
+                column_config_mapping=column_config_mapping,
+                column_order=column_order,
+                disabled=disabled,
+            )
+
         # We want to do this as early as possible to avoid introducing nondeterminism,
         # but it isn't clear how much processing is needed to have the data in a
         # format that will hash consistently, so we do it late here to have it
@@ -1109,9 +1219,12 @@ class DataEditorMixin:
         element_id = compute_and_register_element_id(
             "data_editor",
             user_key=key,
-            key_as_main_identity=False,
+            key_as_main_identity={"data_signature", "num_rows"}
+            if use_schema_identity
+            else False,
             dg=self.dg,
             data=arrow_bytes,
+            data_signature=data_signature,
             width=width,
             height=height,
             use_container_width=use_container_width,

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1426,3 +1426,133 @@ class DataEditorSignatureTest(unittest.TestCase):
             disabled=False,
         )
         assert sig1 != sig2
+
+    def test_disabled_list_produces_different_signature(self):
+        """Test that disabled with list of columns produces different signature."""
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=["A"],
+        )
+        sig3 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=["B"],
+        )
+        # All three should be different
+        assert sig1 != sig2
+        assert sig2 != sig3
+        assert sig1 != sig3
+
+    def test_disabled_list_order_independent(self):
+        """Test that disabled column list is order-independent."""
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=["A", "B"],
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=["B", "A"],
+        )
+        # Order should not matter - signatures should be the same
+        assert sig1 == sig2
+
+    def test_multiindex_level_names_affect_signature(self):
+        """Test that MultiIndex level names are included in signature."""
+        arrays1 = [[1, 1, 2, 2], ["a", "b", "a", "b"]]
+        arrays2 = [[1, 1, 2, 2], ["a", "b", "a", "b"]]
+        index1 = pd.MultiIndex.from_arrays(arrays1, names=["first", "second"])
+        index2 = pd.MultiIndex.from_arrays(arrays2, names=["one", "two"])
+
+        df1 = pd.DataFrame({"A": [1, 2, 3, 4]}, index=index1)
+        df2 = pd.DataFrame({"A": [1, 2, 3, 4]}, index=index2)
+
+        schema1 = _get_arrow_schema(df1)
+        schema2 = _get_arrow_schema(df2)
+        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
+        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df1,
+            arrow_schema=schema1,
+            dataframe_schema=dataframe_schema1,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df2,
+            arrow_schema=schema2,
+            dataframe_schema=dataframe_schema2,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        # Different MultiIndex level names should produce different signatures
+        assert sig1 != sig2
+
+    def test_int_column_config_key_no_collision(self):
+        """Test that int keys in column_config use _pos: prefix to avoid collision."""
+        df = pd.DataFrame({"1": [1, 2, 3], "A": [4, 5, 6]})
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+
+        # Config with int key 1 (positional column reference)
+        sig1 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={1: {"hidden": True}},
+            column_order=None,
+            disabled=False,
+        )
+        # Config with string key "1" (column named "1")
+        sig2 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={"1": {"hidden": True}},
+            column_order=None,
+            disabled=False,
+        )
+        # These should be different due to _pos: prefix
+        assert sig1 != sig2

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -47,6 +47,7 @@ from streamlit.elements.widgets.data_editor import (
     _apply_row_deletions,
     _check_column_names,
     _check_type_compatibilities,
+    _compute_data_editor_signature,
     _parse_value,
 )
 from streamlit.errors import StreamlitAPIException
@@ -1227,3 +1228,201 @@ class DataEditorTest(DeltaGeneratorTestCase):
             == HeightConfigFields.USE_CONTENT.value
         )
         assert el.height_config.use_content is True
+
+
+class DataEditorSignatureTest(unittest.TestCase):
+    """Tests for _compute_data_editor_signature function."""
+
+    def test_same_data_produces_same_signature(self):
+        """Test that identical data produces the same signature."""
+        df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        assert sig1 == sig2
+
+    def test_different_values_same_schema_produces_same_signature(self):
+        """Test that different values with the same schema produce same signature."""
+        df1 = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
+        df2 = pd.DataFrame({"A": [10, 20, 30], "B": ["a", "b", "c"]})
+        schema1 = _get_arrow_schema(df1)
+        schema2 = _get_arrow_schema(df2)
+        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
+        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df1,
+            arrow_schema=schema1,
+            dataframe_schema=dataframe_schema1,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df2,
+            arrow_schema=schema2,
+            dataframe_schema=dataframe_schema2,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        assert sig1 == sig2
+
+    def test_different_column_names_produces_different_signature(self):
+        """Test that different column names produce different signatures."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})
+        df2 = pd.DataFrame({"B": [1, 2, 3]})
+        schema1 = _get_arrow_schema(df1)
+        schema2 = _get_arrow_schema(df2)
+        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
+        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df1,
+            arrow_schema=schema1,
+            dataframe_schema=dataframe_schema1,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df2,
+            arrow_schema=schema2,
+            dataframe_schema=dataframe_schema2,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        assert sig1 != sig2
+
+    def test_different_column_types_produces_different_signature(self):
+        """Test that different column types produce different signatures."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})  # int
+        df2 = pd.DataFrame({"A": [1.0, 2.0, 3.0]})  # float
+        schema1 = _get_arrow_schema(df1)
+        schema2 = _get_arrow_schema(df2)
+        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
+        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df1,
+            arrow_schema=schema1,
+            dataframe_schema=dataframe_schema1,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df2,
+            arrow_schema=schema2,
+            dataframe_schema=dataframe_schema2,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        assert sig1 != sig2
+
+    def test_different_row_count_produces_different_signature(self):
+        """Test that different row counts produce different signatures."""
+        df1 = pd.DataFrame({"A": [1, 2, 3]})
+        df2 = pd.DataFrame({"A": [1, 2, 3, 4]})
+        schema1 = _get_arrow_schema(df1)
+        schema2 = _get_arrow_schema(df2)
+        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
+        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df1,
+            arrow_schema=schema1,
+            dataframe_schema=dataframe_schema1,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df2,
+            arrow_schema=schema2,
+            dataframe_schema=dataframe_schema2,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        assert sig1 != sig2
+
+    def test_disabled_true_produces_different_signature(self):
+        """Test that disabled=True produces different signature than disabled=False."""
+        df = pd.DataFrame({"A": [1, 2, 3]})
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=True,
+        )
+        assert sig1 != sig2
+
+    def test_column_order_affects_signature(self):
+        """Test that different column_order produces different signatures."""
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+
+        sig1 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=None,
+            disabled=False,
+        )
+        sig2 = _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping={},
+            column_order=["B", "A"],
+            disabled=False,
+        )
+        assert sig1 != sig2

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1233,233 +1233,75 @@ class DataEditorTest(DeltaGeneratorTestCase):
 class DataEditorSignatureTest(unittest.TestCase):
     """Tests for _compute_data_editor_signature function."""
 
+    def _compute_signature(
+        self,
+        df: pd.DataFrame,
+        column_config_mapping: dict[str | int, Any] | None = None,
+        column_order: list[str] | None = None,
+        disabled: bool | list[str] = False,
+    ) -> str:
+        """Helper to compute a signature with default parameters."""
+        schema = _get_arrow_schema(df)
+        dataframe_schema = determine_dataframe_schema(df, schema)
+        return _compute_data_editor_signature(
+            data_df=df,
+            arrow_schema=schema,
+            dataframe_schema=dataframe_schema,
+            data_format=DataFormat.PANDAS_DATAFRAME,
+            column_config_mapping=column_config_mapping or {},
+            column_order=column_order,
+            disabled=disabled,
+        )
+
     def test_same_data_produces_same_signature(self):
         """Test that identical data produces the same signature."""
         df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
-        schema = _get_arrow_schema(df)
-        dataframe_schema = determine_dataframe_schema(df, schema)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        assert sig1 == sig2
+        assert self._compute_signature(df) == self._compute_signature(df)
 
     def test_different_values_same_schema_produces_same_signature(self):
         """Test that different values with the same schema produce same signature."""
         df1 = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
         df2 = pd.DataFrame({"A": [10, 20, 30], "B": ["a", "b", "c"]})
-        schema1 = _get_arrow_schema(df1)
-        schema2 = _get_arrow_schema(df2)
-        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
-        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df1,
-            arrow_schema=schema1,
-            dataframe_schema=dataframe_schema1,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df2,
-            arrow_schema=schema2,
-            dataframe_schema=dataframe_schema2,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        assert sig1 == sig2
+        assert self._compute_signature(df1) == self._compute_signature(df2)
 
     def test_different_column_names_produces_different_signature(self):
         """Test that different column names produce different signatures."""
         df1 = pd.DataFrame({"A": [1, 2, 3]})
         df2 = pd.DataFrame({"B": [1, 2, 3]})
-        schema1 = _get_arrow_schema(df1)
-        schema2 = _get_arrow_schema(df2)
-        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
-        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df1,
-            arrow_schema=schema1,
-            dataframe_schema=dataframe_schema1,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df2,
-            arrow_schema=schema2,
-            dataframe_schema=dataframe_schema2,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        assert sig1 != sig2
+        assert self._compute_signature(df1) != self._compute_signature(df2)
 
     def test_different_column_types_produces_different_signature(self):
         """Test that different column types produce different signatures."""
         df1 = pd.DataFrame({"A": [1, 2, 3]})  # int
         df2 = pd.DataFrame({"A": [1.0, 2.0, 3.0]})  # float
-        schema1 = _get_arrow_schema(df1)
-        schema2 = _get_arrow_schema(df2)
-        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
-        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df1,
-            arrow_schema=schema1,
-            dataframe_schema=dataframe_schema1,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df2,
-            arrow_schema=schema2,
-            dataframe_schema=dataframe_schema2,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        assert sig1 != sig2
+        assert self._compute_signature(df1) != self._compute_signature(df2)
 
     def test_different_row_count_produces_different_signature(self):
         """Test that different row counts produce different signatures."""
         df1 = pd.DataFrame({"A": [1, 2, 3]})
         df2 = pd.DataFrame({"A": [1, 2, 3, 4]})
-        schema1 = _get_arrow_schema(df1)
-        schema2 = _get_arrow_schema(df2)
-        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
-        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df1,
-            arrow_schema=schema1,
-            dataframe_schema=dataframe_schema1,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df2,
-            arrow_schema=schema2,
-            dataframe_schema=dataframe_schema2,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        assert sig1 != sig2
+        assert self._compute_signature(df1) != self._compute_signature(df2)
 
     def test_disabled_true_produces_different_signature(self):
         """Test that disabled=True produces different signature than disabled=False."""
         df = pd.DataFrame({"A": [1, 2, 3]})
-        schema = _get_arrow_schema(df)
-        dataframe_schema = determine_dataframe_schema(df, schema)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
+        assert self._compute_signature(df, disabled=False) != self._compute_signature(
+            df, disabled=True
         )
-        sig2 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=True,
-        )
-        assert sig1 != sig2
 
     def test_column_order_affects_signature(self):
         """Test that different column_order produces different signatures."""
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        schema = _get_arrow_schema(df)
-        dataframe_schema = determine_dataframe_schema(df, schema)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=["B", "A"],
-            disabled=False,
-        )
-        assert sig1 != sig2
+        assert self._compute_signature(
+            df, column_order=None
+        ) != self._compute_signature(df, column_order=["B", "A"])
 
     def test_disabled_list_produces_different_signature(self):
         """Test that disabled with list of columns produces different signature."""
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        schema = _get_arrow_schema(df)
-        dataframe_schema = determine_dataframe_schema(df, schema)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=["A"],
-        )
-        sig3 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=["B"],
-        )
+        sig1 = self._compute_signature(df, disabled=False)
+        sig2 = self._compute_signature(df, disabled=["A"])
+        sig3 = self._compute_signature(df, disabled=["B"])
         # All three should be different
         assert sig1 != sig2
         assert sig2 != sig3
@@ -1468,91 +1310,24 @@ class DataEditorSignatureTest(unittest.TestCase):
     def test_disabled_list_order_independent(self):
         """Test that disabled column list is order-independent."""
         df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        schema = _get_arrow_schema(df)
-        dataframe_schema = determine_dataframe_schema(df, schema)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=["A", "B"],
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=["B", "A"],
-        )
-        # Order should not matter - signatures should be the same
-        assert sig1 == sig2
+        assert self._compute_signature(
+            df, disabled=["A", "B"]
+        ) == self._compute_signature(df, disabled=["B", "A"])
 
     def test_multiindex_level_names_affect_signature(self):
         """Test that MultiIndex level names are included in signature."""
-        arrays1 = [[1, 1, 2, 2], ["a", "b", "a", "b"]]
-        arrays2 = [[1, 1, 2, 2], ["a", "b", "a", "b"]]
-        index1 = pd.MultiIndex.from_arrays(arrays1, names=["first", "second"])
-        index2 = pd.MultiIndex.from_arrays(arrays2, names=["one", "two"])
+        arrays = [[1, 1, 2, 2], ["a", "b", "a", "b"]]
+        index1 = pd.MultiIndex.from_arrays(arrays, names=["first", "second"])
+        index2 = pd.MultiIndex.from_arrays(arrays, names=["one", "two"])
 
         df1 = pd.DataFrame({"A": [1, 2, 3, 4]}, index=index1)
         df2 = pd.DataFrame({"A": [1, 2, 3, 4]}, index=index2)
-
-        schema1 = _get_arrow_schema(df1)
-        schema2 = _get_arrow_schema(df2)
-        dataframe_schema1 = determine_dataframe_schema(df1, schema1)
-        dataframe_schema2 = determine_dataframe_schema(df2, schema2)
-
-        sig1 = _compute_data_editor_signature(
-            data_df=df1,
-            arrow_schema=schema1,
-            dataframe_schema=dataframe_schema1,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        sig2 = _compute_data_editor_signature(
-            data_df=df2,
-            arrow_schema=schema2,
-            dataframe_schema=dataframe_schema2,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={},
-            column_order=None,
-            disabled=False,
-        )
-        # Different MultiIndex level names should produce different signatures
-        assert sig1 != sig2
+        assert self._compute_signature(df1) != self._compute_signature(df2)
 
     def test_int_column_config_key_no_collision(self):
         """Test that int keys in column_config use _pos: prefix to avoid collision."""
         df = pd.DataFrame({"1": [1, 2, 3], "A": [4, 5, 6]})
-        schema = _get_arrow_schema(df)
-        dataframe_schema = determine_dataframe_schema(df, schema)
-
-        # Config with int key 1 (positional column reference)
-        sig1 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={1: {"hidden": True}},
-            column_order=None,
-            disabled=False,
-        )
-        # Config with string key "1" (column named "1")
-        sig2 = _compute_data_editor_signature(
-            data_df=df,
-            arrow_schema=schema,
-            dataframe_schema=dataframe_schema,
-            data_format=DataFormat.PANDAS_DATAFRAME,
-            column_config_mapping={"1": {"hidden": True}},
-            column_order=None,
-            disabled=False,
-        )
-        # These should be different due to _pos: prefix
-        assert sig1 != sig2
+        # Config with int key 1 (positional) vs string key "1" (column name)
+        assert self._compute_signature(
+            df, column_config_mapping={1: {"hidden": True}}
+        ) != self._compute_signature(df, column_config_mapping={"1": {"hidden": True}})

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -568,6 +568,7 @@ class ComputeElementIdTests(DeltaGeneratorTestCase):
 
         # Make some changes to expected_sig unique to st.data_editor.
         expected_sig["column_config_mapping"] = ANY
+        expected_sig["data_signature"] = ANY
         del expected_sig["hide_index"]
         del expected_sig["column_config"]
 

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -568,7 +568,6 @@ class ComputeElementIdTests(DeltaGeneratorTestCase):
 
         # Make some changes to expected_sig unique to st.data_editor.
         expected_sig["column_config_mapping"] = ANY
-        expected_sig["data_signature"] = ANY
         del expected_sig["hide_index"]
         del expected_sig["column_config"]
 


### PR DESCRIPTION
## Describe your changes

Adds schema-based element identity for `st.data_editor` when `key` is provided and `num_rows="fixed"`. This allows data values to change without resetting edit state, while schema changes (columns, types, row count) still reset state.

- Added `_compute_data_editor_signature()` function that hashes schema properties (columns, types, row count) without cell values
- Modified element ID computation to use `key_as_main_identity={"data_signature", "num_rows"}` when `key` is provided and `num_rows="fixed"`
- Unkeyed editors and non-fixed modes retain current behavior (full data hash in element ID)

This enables common patterns like "spreadsheet with computed columns" where downstream columns update based on user edits without losing those edits.

## GitHub Issue Link (if applicable)

- Closes #7749
- Closes #6540

## Testing Plan

- [x] Unit tests for `_compute_data_editor_signature` stability and sensitivity
- [ ] E2E tests (deferred to follow-up due to canvas click targeting complexity)