### PR TITLE
[feature][ParallelFragments] Add ParallelFragmentCoordinator and post-exec join barrier

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -765,6 +765,17 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "runner.parallelMaxWorkers",
+    description="""
+        Maximum number of parallel fragment worker threads per script run.
+        Sizes the per-run thread pool. Defaults to Python's
+        ThreadPoolExecutor default (min(32, os.cpu_count() + 4)).
+    """,
+    default_val=None,
+    type_=int,
+)
+
 # Config Section: Server #
 
 _create_section("server", "Settings for the Streamlit server")

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -15,13 +15,10 @@
 from __future__ import annotations
 
 import contextlib
-import contextvars
 import inspect
 import threading
-import time
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeVar, overload
@@ -35,8 +32,6 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     StopException,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
-    SCRIPT_RUN_CONTEXT_ATTR_NAME,
-    ScriptRunContext,
     ThreadState,
     get_script_run_ctx,
 )
@@ -303,168 +298,6 @@ class MemoryFragmentStorage(FragmentStorage):
             "MemoryFragmentStorage does not support copy; "
             "it holds a threading.Lock and shared mutable state."
         )
-
-
-@contextlib.contextmanager
-def _scoped_ctx_attach(ctx: ScriptRunContext | None) -> Iterator[None]:
-    """Bind *ctx* as the active ScriptRunContext on the current thread for
-    the duration of the block; restore the prior binding on exit.
-
-    Used by ``ParallelFragmentCoordinator.submit()`` so a pool thread that
-    executes successive submissions sees the right ctx for each call and
-    never carries a stale ctx across submissions.
-    """
-    thread = threading.current_thread()
-    prev = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-    setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx)
-    try:
-        yield
-    finally:
-        if prev is None:
-            try:
-                delattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            except AttributeError:
-                pass
-        else:
-            setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, prev)
-
-
-class ParallelFragmentCoordinator:
-    """Manages the lifecycle of parallel fragment workers for one script run.
-
-    Owned by ScriptRunContext (created in ctx.reset()) and exposed as
-    ctx.parallel_coordinator. The coordinator is single-use: a fresh
-    instance is created at the start of every script run, joined or drained
-    before the run ends, and discarded.
-
-    Workers submitted via :meth:`submit` run inside a
-    ``contextvars.copy_context()`` snapshot of the caller's context with a
-    scoped ``ScriptRunContext`` attach so ``get_script_run_ctx()`` and
-    ``ThreadState.get()`` return the parent's values. Worker-side
-    ``ThreadState.update()`` writes stay local to the copied context.
-    """
-
-    def __init__(
-        self,
-        yield_check: Callable[[], None],
-        max_workers: int | None = None,
-        poll_interval: float = 0.1,
-    ) -> None:
-        if max_workers is not None and max_workers < 1:
-            raise ValueError(
-                f"runner.parallelMaxWorkers must be None or a positive "
-                f"integer, got {max_workers!r}"
-            )
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
-        self._outstanding = 0
-        self._outstanding_lock = threading.Lock()
-        self._stop_event = threading.Event()
-        self._worker_exception: RerunException | StopException | None = None
-        self._exception_lock = threading.Lock()
-        self._yield_check = yield_check
-        self._poll_interval = poll_interval
-
-    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
-        """Submit a worker function to the thread pool.
-
-        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
-        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
-        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
-        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
-        return the parent's values for the duration of the call.  Worker-side
-        ``ThreadState.update()`` writes stay local to the captured copy — they
-        never leak back to the parent thread.
-
-        Increments the outstanding counter before submitting so a nested
-        submit() from inside a running worker is visible to join() before
-        the parent's tracked() decrement runs. May be called from any
-        thread (main thread or worker threads for nested fragments).
-        """
-        ctx = get_script_run_ctx()
-        captured = contextvars.copy_context()
-
-        with self._outstanding_lock:
-            self._outstanding += 1
-
-        def tracked() -> None:
-            try:
-                with _scoped_ctx_attach(ctx):
-                    captured.run(fn, *args)
-            finally:
-                with self._outstanding_lock:
-                    self._outstanding -= 1
-
-        try:
-            self._executor.submit(tracked)
-        except RuntimeError:
-            with self._outstanding_lock:
-                self._outstanding -= 1
-            raise
-
-    def request_stop(self) -> None:
-        """Record an st.stop() from a worker. First writer wins."""
-        with self._exception_lock:
-            if self._worker_exception is None:
-                self._worker_exception = StopException()
-        self._stop_event.set()
-
-    def request_rerun(self, exc: RerunException) -> None:
-        """Record an st.rerun(scope='app') from a worker. First writer wins."""
-        with self._exception_lock:
-            if self._worker_exception is None:
-                self._worker_exception = exc
-        self._stop_event.set()
-
-    def should_stop(self) -> bool:
-        """Whether worker threads should cooperatively exit at their next
-        yield point.
-        """
-        return self._stop_event.is_set()
-
-    @property
-    def worker_exception(self) -> RerunException | StopException | None:
-        """The exception stored by the first worker to call request_stop()
-        or request_rerun().
-        """
-        with self._exception_lock:
-            return self._worker_exception
-
-    def join(self) -> None:
-        """Block until all outstanding work completes.
-
-        Polls _outstanding (lock-protected) and calls _yield_check() each
-        poll interval so the script thread stays responsive to external
-        RERUN/STOP requests. If a worker stored an exception, raise it
-        instead of returning normally.
-
-        If join() raises (worker exception or yield-check exception), the
-        executor is left running and the caller is responsible for calling
-        drain() to shut down in-flight workers.
-        """
-        while True:
-            with self._outstanding_lock:
-                if self._outstanding == 0:
-                    break
-            self._yield_check()
-            stored = self.worker_exception
-            if stored is not None:
-                raise stored
-            time.sleep(self._poll_interval)
-        stored = self.worker_exception
-        if stored is not None:
-            raise stored
-        self._executor.shutdown(wait=False)
-
-    def drain(self) -> None:
-        """Cleanup join after cancellation.
-
-        Sets the stop event so workers at their next yield point exit, then
-        shuts down the executor synchronously, cancelling queued futures.
-        Does NOT call _yield_check — safe to call from except blocks
-        without risking recursive RerunException/StopException.
-        """
-        self._stop_event.set()
-        self._executor.shutdown(wait=True, cancel_futures=True)
 
 
 def _fragment(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -15,10 +15,13 @@
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import inspect
 import threading
+import time
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeVar, overload
@@ -32,6 +35,8 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     StopException,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+    ScriptRunContext,
     ThreadState,
     get_script_run_ctx,
 )
@@ -298,6 +303,163 @@ class MemoryFragmentStorage(FragmentStorage):
             "MemoryFragmentStorage does not support copy; "
             "it holds a threading.Lock and shared mutable state."
         )
+
+
+@contextlib.contextmanager
+def _scoped_ctx_attach(ctx: ScriptRunContext | None) -> Iterator[None]:
+    """Bind *ctx* as the active ScriptRunContext on the current thread for
+    the duration of the block; restore the prior binding on exit.
+
+    Used by ``ParallelFragmentCoordinator.submit()`` so a pool thread that
+    executes successive submissions sees the right ctx for each call and
+    never carries a stale ctx across submissions.
+    """
+    thread = threading.current_thread()
+    prev = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+    setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx)
+    try:
+        yield
+    finally:
+        if prev is None:
+            try:
+                delattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            except AttributeError:
+                pass
+        else:
+            setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, prev)
+
+
+class ParallelFragmentCoordinator:
+    """Manages the lifecycle of parallel fragment workers for one script run.
+
+    Owned by ScriptRunContext (created in ctx.reset()) and exposed as
+    ctx.parallel_coordinator. The coordinator is single-use: a fresh
+    instance is created at the start of every script run, joined or drained
+    before the run ends, and discarded.
+
+    Workers submitted via :meth:`submit` run inside a
+    ``contextvars.copy_context()`` snapshot of the caller's context with a
+    scoped ``ScriptRunContext`` attach so ``get_script_run_ctx()`` and
+    ``ThreadState.get()`` return the parent's values. Worker-side
+    ``ThreadState.update()`` writes stay local to the copied context.
+    """
+
+    def __init__(
+        self,
+        yield_check: Callable[[], None],
+        max_workers: int | None = None,
+        poll_interval: float = 0.1,
+    ) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._outstanding = 0
+        self._outstanding_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._worker_exception: RerunException | StopException | None = None
+        self._exception_lock = threading.Lock()
+        self._yield_check = yield_check
+        self._poll_interval = poll_interval
+
+    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
+        """Submit a worker function to the thread pool.
+
+        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
+        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
+        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
+        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
+        return the parent's values for the duration of the call.  Worker-side
+        ``ThreadState.update()`` writes stay local to the captured copy — they
+        never leak back to the parent thread.
+
+        Increments the outstanding counter before submitting so a nested
+        submit() from inside a running worker is visible to join() before
+        the parent's tracked() decrement runs. May be called from any
+        thread (main thread or worker threads for nested fragments).
+        """
+        ctx = get_script_run_ctx()
+        captured = contextvars.copy_context()
+
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+        def tracked() -> None:
+            try:
+                with _scoped_ctx_attach(ctx):
+                    captured.run(fn, *args)
+            finally:
+                with self._outstanding_lock:
+                    self._outstanding -= 1
+
+        try:
+            self._executor.submit(tracked)
+        except RuntimeError:
+            with self._outstanding_lock:
+                self._outstanding -= 1
+            raise
+
+    def request_stop(self) -> None:
+        """Record an st.stop() from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = StopException()
+        self._stop_event.set()
+
+    def request_rerun(self, exc: RerunException) -> None:
+        """Record an st.rerun(scope='app') from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = exc
+        self._stop_event.set()
+
+    def should_stop(self) -> bool:
+        """Whether worker threads should cooperatively exit at their next
+        yield point.
+        """
+        return self._stop_event.is_set()
+
+    @property
+    def worker_exception(self) -> RerunException | StopException | None:
+        """The exception stored by the first worker to call request_stop()
+        or request_rerun().
+        """
+        with self._exception_lock:
+            return self._worker_exception
+
+    def join(self) -> None:
+        """Block until all outstanding work completes.
+
+        Polls _outstanding (lock-protected) and calls _yield_check() each
+        poll interval so the script thread stays responsive to external
+        RERUN/STOP requests. If a worker stored an exception, raise it
+        instead of returning normally.
+
+        If join() raises (worker exception or yield-check exception), the
+        executor is left running and the caller is responsible for calling
+        drain() to shut down in-flight workers.
+        """
+        while True:
+            with self._outstanding_lock:
+                if self._outstanding == 0:
+                    break
+            self._yield_check()
+            stored = self.worker_exception
+            if stored is not None:
+                raise stored
+            time.sleep(self._poll_interval)
+        stored = self.worker_exception
+        if stored is not None:
+            raise stored
+        self._executor.shutdown(wait=False)
+
+    def drain(self) -> None:
+        """Cleanup join after cancellation.
+
+        Sets the stop event so workers at their next yield point exit, then
+        shuts down the executor synchronously, cancelling queued futures.
+        Does NOT call _yield_check — safe to call from except blocks
+        without risking recursive RerunException/StopException.
+        """
+        self._stop_event.set()
+        self._executor.shutdown(wait=True, cancel_futures=True)
 
 
 def _fragment(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -350,6 +350,11 @@ class ParallelFragmentCoordinator:
         max_workers: int | None = None,
         poll_interval: float = 0.1,
     ) -> None:
+        if max_workers is not None and max_workers < 1:
+            raise ValueError(
+                f"runner.parallelMaxWorkers must be None or a positive "
+                f"integer, got {max_workers!r}"
+            )
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._outstanding = 0
         self._outstanding_lock = threading.Lock()

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -1,0 +1,207 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ParallelFragmentCoordinator and supporting helpers.
+
+Separated from ``fragment.py`` to break the import cycle with
+``script_run_context.py``: the coordinator imports from
+``script_run_context`` (for ``get_script_run_ctx`` and
+``SCRIPT_RUN_CONTEXT_ATTR_NAME``), and ``script_run_context`` needs to
+construct a coordinator in ``reset()``.  With the coordinator in its own
+module, ``script_run_context`` can import it at module level.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+from streamlit.runtime.scriptrunner_utils.exceptions import (
+    RerunException,
+    StopException,
+)
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+    ScriptRunContext,
+    get_script_run_ctx,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+
+@contextlib.contextmanager
+def _scoped_ctx_attach(ctx: ScriptRunContext | None) -> Iterator[None]:
+    """Bind *ctx* as the active ScriptRunContext on the current thread for
+    the duration of the block; restore the prior binding on exit.
+
+    Used by ``ParallelFragmentCoordinator.submit()`` so a pool thread that
+    executes successive submissions sees the right ctx for each call and
+    never carries a stale ctx across submissions.
+    """
+    thread = threading.current_thread()
+    prev = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+    setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx)
+    try:
+        yield
+    finally:
+        if prev is None:
+            try:
+                delattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            except AttributeError:
+                pass
+        else:
+            setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, prev)
+
+
+class ParallelFragmentCoordinator:
+    """Manages the lifecycle of parallel fragment workers for one script run.
+
+    Owned by ScriptRunContext (created in ctx.reset()) and exposed as
+    ctx.parallel_coordinator. The coordinator is single-use: a fresh
+    instance is created at the start of every script run, joined or drained
+    before the run ends, and discarded.
+
+    Workers submitted via :meth:`submit` run inside a
+    ``contextvars.copy_context()`` snapshot of the caller's context with a
+    scoped ``ScriptRunContext`` attach so ``get_script_run_ctx()`` and
+    ``ThreadState.get()`` return the parent's values. Worker-side
+    ``ThreadState.update()`` writes stay local to the copied context.
+    """
+
+    def __init__(
+        self,
+        yield_check: Callable[[], None],
+        max_workers: int | None = None,
+        poll_interval: float = 0.1,
+    ) -> None:
+        if max_workers is not None and max_workers < 1:
+            raise ValueError(
+                f"runner.parallelMaxWorkers must be None or a positive "
+                f"integer, got {max_workers!r}"
+            )
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._outstanding = 0
+        self._outstanding_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._worker_exception: RerunException | StopException | None = None
+        self._exception_lock = threading.Lock()
+        self._yield_check = yield_check
+        self._poll_interval = poll_interval
+
+    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
+        """Submit a worker function to the thread pool.
+
+        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
+        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
+        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
+        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
+        return the parent's values for the duration of the call.  Worker-side
+        ``ThreadState.update()`` writes stay local to the captured copy — they
+        never leak back to the parent thread.
+
+        Increments the outstanding counter before submitting so a nested
+        submit() from inside a running worker is visible to join() before
+        the parent's tracked() decrement runs. May be called from any
+        thread (main thread or worker threads for nested fragments).
+        """
+        ctx = get_script_run_ctx()
+        captured = contextvars.copy_context()
+
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+        def tracked() -> None:
+            try:
+                with _scoped_ctx_attach(ctx):
+                    captured.run(fn, *args)
+            finally:
+                with self._outstanding_lock:
+                    self._outstanding -= 1
+
+        try:
+            self._executor.submit(tracked)
+        except RuntimeError:
+            with self._outstanding_lock:
+                self._outstanding -= 1
+            raise
+
+    def request_stop(self) -> None:
+        """Record an st.stop() from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = StopException()
+        self._stop_event.set()
+
+    def request_rerun(self, exc: RerunException) -> None:
+        """Record an st.rerun(scope='app') from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = exc
+        self._stop_event.set()
+
+    def should_stop(self) -> bool:
+        """Whether worker threads should cooperatively exit at their next
+        yield point.
+        """
+        return self._stop_event.is_set()
+
+    @property
+    def worker_exception(self) -> RerunException | StopException | None:
+        """The exception stored by the first worker to call request_stop()
+        or request_rerun().
+        """
+        with self._exception_lock:
+            return self._worker_exception
+
+    def join(self) -> None:
+        """Block until all outstanding work completes.
+
+        Polls _outstanding (lock-protected) and calls _yield_check() each
+        poll interval so the script thread stays responsive to external
+        RERUN/STOP requests. If a worker stored an exception, raise it
+        instead of returning normally.
+
+        If join() raises (worker exception or yield-check exception), the
+        executor is left running and the caller is responsible for calling
+        drain() to shut down in-flight workers.
+        """
+        while True:
+            with self._outstanding_lock:
+                if self._outstanding == 0:
+                    break
+            self._yield_check()
+            stored = self.worker_exception
+            if stored is not None:
+                raise stored
+            time.sleep(self._poll_interval)
+        stored = self.worker_exception
+        if stored is not None:
+            raise stored
+        self._executor.shutdown(wait=False)
+
+    def drain(self) -> None:
+        """Cleanup join after cancellation.
+
+        Sets the stop event so workers at their next yield point exit, then
+        shuts down the executor synchronously, cancelling queued futures.
+        Does NOT call _yield_check — safe to call from except blocks
+        without risking recursive RerunException/StopException.
+        """
+        self._stop_event.set()
+        self._executor.shutdown(wait=True, cancel_futures=True)

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -169,6 +169,12 @@ class ParallelFragmentCoordinator:
         with self._exception_lock:
             return self._worker_exception
 
+    def _raise_if_worker_exception(self) -> None:
+        """Re-raise the stored worker exception if one exists."""
+        stored = self.worker_exception
+        if stored is not None:
+            raise stored
+
     def join(self) -> None:
         """Block until all outstanding work completes.
 
@@ -186,13 +192,9 @@ class ParallelFragmentCoordinator:
                 if self._outstanding == 0:
                     break
             self._yield_check()
-            stored = self.worker_exception
-            if stored is not None:
-                raise stored
+            self._raise_if_worker_exception()
             time.sleep(self._poll_interval)
-        stored = self.worker_exception
-        if stored is not None:
-            raise stored
+        self._raise_if_worker_exception()
         self._executor.shutdown(wait=False)
 
     def drain(self) -> None:

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
@@ -97,7 +96,7 @@ class ParallelFragmentCoordinator:
             )
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._outstanding = 0
-        self._outstanding_lock = threading.Lock()
+        self._join_condition = threading.Condition(threading.Lock())
         self._stop_event = threading.Event()
         self._worker_exception: RerunException | StopException | None = None
         self._exception_lock = threading.Lock()
@@ -123,7 +122,7 @@ class ParallelFragmentCoordinator:
         ctx = get_script_run_ctx()
         captured = contextvars.copy_context()
 
-        with self._outstanding_lock:
+        with self._join_condition:
             self._outstanding += 1
 
         def tracked() -> None:
@@ -131,14 +130,16 @@ class ParallelFragmentCoordinator:
                 with _scoped_ctx_attach(ctx):
                     captured.run(fn, *args)
             finally:
-                with self._outstanding_lock:
+                with self._join_condition:
                     self._outstanding -= 1
+                    self._join_condition.notify_all()
 
         try:
             self._executor.submit(tracked)
         except RuntimeError:
-            with self._outstanding_lock:
+            with self._join_condition:
                 self._outstanding -= 1
+                self._join_condition.notify_all()
             raise
 
     def request_stop(self) -> None:
@@ -147,6 +148,7 @@ class ParallelFragmentCoordinator:
             if self._worker_exception is None:
                 self._worker_exception = StopException()
         self._stop_event.set()
+        self.notify_yield_waiters()
 
     def request_rerun(self, exc: RerunException) -> None:
         """Record an st.rerun(scope='app') from a worker. First writer wins."""
@@ -154,6 +156,7 @@ class ParallelFragmentCoordinator:
             if self._worker_exception is None:
                 self._worker_exception = exc
         self._stop_event.set()
+        self.notify_yield_waiters()
 
     def should_stop(self) -> bool:
         """Whether worker threads should cooperatively exit at their next
@@ -175,25 +178,40 @@ class ParallelFragmentCoordinator:
         if stored is not None:
             raise stored
 
+    def notify_yield_waiters(self) -> None:
+        """Wake the thread blocked in :meth:`join` so ``yield_check`` runs promptly.
+
+        Called from workers (:meth:`request_stop` / :meth:`request_rerun`) and from
+        ``ScriptRunner`` when a rerun/stop request is enqueued from another thread
+        while the script thread is blocked inside :meth:`join`.
+        """
+        with self._join_condition:
+            self._join_condition.notify_all()
+
     def join(self) -> None:
         """Block until all outstanding work completes.
 
-        Polls _outstanding (lock-protected) and calls _yield_check() each
-        poll interval so the script thread stays responsive to external
-        RERUN/STOP requests. If a worker stored an exception, raise it
-        instead of returning normally.
+        Uses ``_join_condition`` so the script thread wakes immediately when a
+        worker finishes (via ``notify_all`` on ``_outstanding`` decrement) or when
+        :meth:`notify_yield_waiters` is called.  Falls back to
+        ``poll_interval`` as a worst-case ceiling so ``yield_check()`` still runs
+        periodically even when ``_outstanding`` is unchanged (e.g. one slow
+        fragment still running).
 
+        If a worker stored an exception, raises it instead of returning normally.
         If join() raises (worker exception or yield-check exception), the
         executor is left running and the caller is responsible for calling
         drain() to shut down in-flight workers.
         """
         while True:
-            with self._outstanding_lock:
+            with self._join_condition:
                 if self._outstanding == 0:
                     break
             self._yield_check()
             self._raise_if_worker_exception()
-            time.sleep(self._poll_interval)
+            with self._join_condition:
+                if self._outstanding > 0:
+                    self._join_condition.wait(timeout=self._poll_interval)
         self._raise_if_worker_exception()
         self._executor.shutdown(wait=False)
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -65,7 +65,8 @@ from streamlit.source_util import page_sort_key
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
+    from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.runtime.scriptrunner_utils.script_run_context import (
         OnScriptErrorHandler,

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -468,17 +468,9 @@ class ScriptRunner:
             # enqueues a new ForwardEvent
             return
 
-        # Before consulting _requests, surface any cancellation a parallel
-        # fragment worker initiated (st.stop() / st.rerun(scope="app") in a
-        # worker thread). Workers can't raise their own exceptions across
-        # threads, so they store them on the coordinator and the script
-        # thread re-raises here at its next yield point. We re-raise with
-        # the original type — and original RerunData, if any — so the
-        # script runner's outer rerun loop sees the right request type.
-        # Worker-initiated cancellation takes precedence over a concurrent
-        # external request from _requests: the worker already captured the
-        # user intent in-band, while _requests only reflects whatever the
-        # frontend has sent so far.
+        # Re-raise any worker-stored exception before consulting _requests.
+        # Worker-initiated cancellation takes precedence because it
+        # captured user intent in-band.
         ctx = get_script_run_ctx(suppress_warning=True)
         if ctx is not None and ctx.parallel_coordinator is not None:
             worker_exc = ctx.parallel_coordinator.worker_exception
@@ -760,9 +752,8 @@ class ScriptRunner:
                                 )
 
                     else:
-                        # parallel_coordinator is None until the first
-                        # ctx.reset(), which always runs before this point;
-                        # cast pins that for the type checker.
+                        # Expect parallel_coordinator to be initialized;
+                        # cast makes this clear to the type checker.
                         coordinator = cast(
                             "ParallelFragmentCoordinator",
                             ctx.parallel_coordinator,

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -65,7 +65,7 @@ from streamlit.source_util import page_sort_key
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-    from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.runtime.scriptrunner_utils.script_run_context import (
         OnScriptErrorHandler,
@@ -445,9 +445,19 @@ class ScriptRunner:
         """
         if not self._is_in_script_thread():
             # We can only handle execution_control_request if we're on the
-            # script execution thread. However, it's possible for deltas to
-            # be enqueued (and, therefore, for this function to be called)
-            # in separate threads, so we check for that here.
+            # script execution thread. However, this function also runs from
+            # parallel fragment worker threads, since deltas enqueued there
+            # flow through _enqueue_forward_msg. On a worker thread we can't
+            # service script-level rerun/stop requests, but we do check the
+            # coordinator so a cooperatively-cancelled worker raises at its
+            # next yield point.
+            ctx = get_script_run_ctx(suppress_warning=True)
+            if (
+                ctx is not None
+                and ctx.parallel_coordinator is not None
+                and ctx.parallel_coordinator.should_stop()
+            ):
+                raise StopException()
             return
 
         if not self._execing:
@@ -456,6 +466,23 @@ class ScriptRunner:
             # we change our state to STOPPED, and a statechange-listener
             # enqueues a new ForwardEvent
             return
+
+        # Before consulting _requests, surface any cancellation a parallel
+        # fragment worker initiated (st.stop() / st.rerun(scope="app") in a
+        # worker thread). Workers can't raise their own exceptions across
+        # threads, so they store them on the coordinator and the script
+        # thread re-raises here at its next yield point. We re-raise with
+        # the original type — and original RerunData, if any — so the
+        # script runner's outer rerun loop sees the right request type.
+        # Worker-initiated cancellation takes precedence over a concurrent
+        # external request from _requests: the worker already captured the
+        # user intent in-band, while _requests only reflects whatever the
+        # frontend has sent so far.
+        ctx = get_script_run_ctx(suppress_warning=True)
+        if ctx is not None and ctx.parallel_coordinator is not None:
+            worker_exc = ctx.parallel_coordinator.worker_exception
+            if worker_exc is not None:
+                raise worker_exc
 
         request = self._requests.on_scriptrunner_yield()
         if request is None:
@@ -583,6 +610,7 @@ class ScriptRunner:
                 fragment_ids_this_run=fragment_ids_this_run,
                 cached_message_hashes=rerun_data.cached_message_hashes,
                 context_info=rerun_data.context_info,
+                yield_check=self._maybe_handle_execution_control_request,
             )
 
             self.on_event.send(
@@ -731,10 +759,27 @@ class ScriptRunner:
                                 )
 
                     else:
-                        if PagesManager.uses_pages_directory:
-                            _mpa_v1(self._main_script_path)
-                        else:
-                            exec(code, module.__dict__)  # noqa: S102
+                        # parallel_coordinator is None until the first
+                        # ctx.reset(), which always runs before this point;
+                        # cast pins that for the type checker.
+                        coordinator = cast(
+                            "ParallelFragmentCoordinator",
+                            ctx.parallel_coordinator,
+                        )
+                        try:
+                            if PagesManager.uses_pages_directory:
+                                _mpa_v1(self._main_script_path)
+                            else:
+                                exec(code, module.__dict__)  # noqa: S102
+                            coordinator.join()
+                        except BaseException:
+                            # Always drain so in-flight worker fragments
+                            # don't outlive the script run, regardless of
+                            # whether the escape was a script-control
+                            # exception, an uncaught user error, or an
+                            # interrupt.
+                            coordinator.drain()
+                            raise
                         self._fragment_storage.clear(
                             new_fragment_ids=ctx.new_fragment_ids.snapshot()
                         )

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -285,6 +285,10 @@ class ScriptRunner:
         # This is initialized in the start() method
         self._script_thread: threading.Thread | None = None
 
+        # Coordinator blocking the script thread in join(); other threads poke
+        # notify_yield_waiters() when rerun/stop is enqueued during that window.
+        self._join_wake_coordinator: ParallelFragmentCoordinator | None = None
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -296,6 +300,7 @@ class ScriptRunner:
         Safe to call from any thread.
         """
         self._requests.request_stop()
+        self._wake_parallel_join_barrier_if_waiting()
 
     def request_rerun(self, rerun_data: RerunData) -> bool:
         """Request that the ScriptRunner interrupt its currently-running
@@ -309,7 +314,19 @@ class ScriptRunner:
 
         Safe to call from any thread.
         """
-        return self._requests.request_rerun(rerun_data)
+        rv = self._requests.request_rerun(rerun_data)
+        self._wake_parallel_join_barrier_if_waiting()
+        return rv
+
+    def _wake_parallel_join_barrier_if_waiting(self) -> None:
+        """If the script thread is blocked in ParallelFragmentCoordinator.join(), wake it.
+
+        Rerun/stop requests can arrive on other threads; join() sleeps on a
+        Condition bounded by poll_interval unless notified.
+        """
+        coord = self._join_wake_coordinator
+        if coord is not None:
+            coord.notify_yield_waiters()
 
     def start(self) -> None:
         """Start a new thread to process the ScriptEventQueue.
@@ -605,6 +622,7 @@ class ScriptRunner:
                 context_info=rerun_data.context_info,
                 yield_check=self._maybe_handle_execution_control_request,
             )
+            self._join_wake_coordinator = ctx.parallel_coordinator
 
             self.on_event.send(
                 self,
@@ -641,6 +659,7 @@ class ScriptRunner:
                 # We got a compile error. Send an error event and bail immediately.
                 _LOGGER.exception("Script compilation error", exc_info=ex)
                 self._session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY] = False
+                self._join_wake_coordinator = None
                 self.on_event.send(
                     self,
                     event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_COMPILE_ERROR,
@@ -837,6 +856,8 @@ class ScriptRunner:
         """Called when our script finishes executing, even if it finished
         early with an exception. We perform post-run cleanup here.
         """
+        self._join_wake_coordinator = None
+
         # Tell session_state to update itself in response
         if not premature_stop:
             self._session_state.on_script_finished(ctx.widget_ids_this_run.snapshot())

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -287,6 +287,8 @@ class ScriptRunner:
 
         # Coordinator blocking the script thread in join(); other threads poke
         # notify_yield_waiters() when rerun/stop is enqueued during that window.
+        # Lock-protected so this is safe under free-threaded Python (PEP 703).
+        self._join_wake_lock = threading.Lock()
         self._join_wake_coordinator: ParallelFragmentCoordinator | None = None
 
     def __repr__(self) -> str:
@@ -324,7 +326,8 @@ class ScriptRunner:
         Rerun/stop requests can arrive on other threads; join() sleeps on a
         Condition bounded by poll_interval unless notified.
         """
-        coord = self._join_wake_coordinator
+        with self._join_wake_lock:
+            coord = self._join_wake_coordinator
         if coord is not None:
             coord.notify_yield_waiters()
 
@@ -622,7 +625,8 @@ class ScriptRunner:
                 context_info=rerun_data.context_info,
                 yield_check=self._maybe_handle_execution_control_request,
             )
-            self._join_wake_coordinator = ctx.parallel_coordinator
+            with self._join_wake_lock:
+                self._join_wake_coordinator = ctx.parallel_coordinator
 
             self.on_event.send(
                 self,
@@ -659,7 +663,8 @@ class ScriptRunner:
                 # We got a compile error. Send an error event and bail immediately.
                 _LOGGER.exception("Script compilation error", exc_info=ex)
                 self._session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY] = False
-                self._join_wake_coordinator = None
+                with self._join_wake_lock:
+                    self._join_wake_coordinator = None
                 self.on_event.send(
                     self,
                     event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_COMPILE_ERROR,
@@ -856,7 +861,8 @@ class ScriptRunner:
         """Called when our script finishes executing, even if it finished
         early with an exception. We perform post-run cleanup here.
         """
-        self._join_wake_coordinator = None
+        with self._join_wake_lock:
+            self._join_wake_coordinator = None
 
         # Tell session_state to update itself in response
         if not premature_stop:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -48,8 +48,9 @@ if TYPE_CHECKING:
     from streamlit.proto.ClientState_pb2 import ContextInfo
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.proto.PageProfile_pb2 import Command
-    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
+    from streamlit.runtime.fragment import FragmentStorage
     from streamlit.runtime.pages_manager import PagesManager
+    from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner_utils.script_requests import ScriptRequests
     from streamlit.runtime.state import SafeSessionState
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
@@ -263,9 +264,10 @@ class ScriptRunContext:
         ThreadState.initialize(
             active_script_hash=self.pages_manager.main_script_hash,
         )
-        # Deferred import to avoid the fragment.py <-> script_run_context.py cycle.
+        # Deferred: parallel_coordinator imports from this module, and
+        # config pulls in the heavy streamlit.__init__ chain.
         from streamlit import config
-        from streamlit.runtime.fragment import ParallelFragmentCoordinator
+        from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 
         self.parallel_coordinator = ParallelFragmentCoordinator(
             yield_check=yield_check,

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -243,7 +243,8 @@ class ScriptRunContext:
         fragment_ids_this_run: list[str] | None = None,
         cached_message_hashes: set[str] | None = None,
         context_info: ContextInfo | None = None,
-        yield_check: Callable[[], None] = lambda: None,  # checked by workers to cease execution
+        # Checked by fragment workers to cease execution.
+        yield_check: Callable[[], None] = lambda: None,
     ) -> None:
         if threading.get_ident() != self._main_thread_ident:
             raise RuntimeError(

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -178,9 +178,8 @@ class ScriptRunContext:
     Streamlit code typically retrieves the active ScriptRunContext via the
     `get_script_run_ctx` function.
 
-    Note: ``__post_init__`` adds a ``_main_thread_ident`` attribute that is
-    not declared as a dataclass field; it is used by ``reset()`` to refuse
-    calls from worker threads.
+    Note: ``__post_init__`` adds a non-field ``_main_thread_ident`` used
+    by ``reset()``'s thread guard.
     """
 
     session_id: str
@@ -244,7 +243,7 @@ class ScriptRunContext:
         fragment_ids_this_run: list[str] | None = None,
         cached_message_hashes: set[str] | None = None,
         context_info: ContextInfo | None = None,
-        yield_check: Callable[[], None] = lambda: None,
+        yield_check: Callable[[], None] = lambda: None,  # checked by workers to cease execution
     ) -> None:
         if threading.get_ident() != self._main_thread_ident:
             raise RuntimeError(

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from streamlit.proto.ClientState_pb2 import ContextInfo
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.proto.PageProfile_pb2 import Command
-    from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
     from streamlit.runtime.pages_manager import PagesManager
     from streamlit.runtime.scriptrunner_utils.script_requests import ScriptRequests
     from streamlit.runtime.state import SafeSessionState
@@ -176,6 +176,10 @@ class ScriptRunContext:
 
     Streamlit code typically retrieves the active ScriptRunContext via the
     `get_script_run_ctx` function.
+
+    Note: ``__post_init__`` adds a ``_main_thread_ident`` attribute that is
+    not declared as a dataclass field; it is used by ``reset()`` to refuse
+    calls from worker threads.
     """
 
     session_id: str
@@ -208,6 +212,12 @@ class ScriptRunContext:
     new_fragment_ids: ThreadSafeSet[str] = field(default_factory=ThreadSafeSet)
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
+    parallel_coordinator: ParallelFragmentCoordinator | None = None
+
+    def __post_init__(self) -> None:
+        # Capture the main script thread's identity so reset() can refuse to
+        # run from worker threads.
+        self._main_thread_ident = threading.get_ident()
 
     @property
     def page_script_hash(self) -> str:
@@ -233,7 +243,13 @@ class ScriptRunContext:
         fragment_ids_this_run: list[str] | None = None,
         cached_message_hashes: set[str] | None = None,
         context_info: ContextInfo | None = None,
+        yield_check: Callable[[], None] = lambda: None,
     ) -> None:
+        if threading.get_ident() != self._main_thread_ident:
+            raise RuntimeError(
+                "ScriptRunContext.reset() must only be called from the main "
+                "script thread"
+            )
         # Check if this is a same-page rerun BEFORE updating page_script_hash
         is_same_page = self.page_script_hash == page_script_hash
 
@@ -246,6 +262,14 @@ class ScriptRunContext:
         self.pages_manager.set_current_page_script_hash(page_script_hash)
         ThreadState.initialize(
             active_script_hash=self.pages_manager.main_script_hash,
+        )
+        # Deferred import to avoid the fragment.py <-> script_run_context.py cycle.
+        from streamlit import config
+        from streamlit.runtime.fragment import ParallelFragmentCoordinator
+
+        self.parallel_coordinator = ParallelFragmentCoordinator(
+            yield_check=yield_check,
+            max_workers=config.get_option("runner.parallelMaxWorkers"),
         )
         self._has_script_started = False
         self.command_tracking_deactivated: bool = False

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -264,8 +264,8 @@ class ScriptRunContext:
         ThreadState.initialize(
             active_script_hash=self.pages_manager.main_script_hash,
         )
-        # Deferred: parallel_coordinator imports from this module, and
-        # config pulls in the heavy streamlit.__init__ chain.
+        # Deferred to avoid circular import: parallel_coordinator imports
+        # ScriptRunContext and get_script_run_ctx from this module.
         from streamlit import config
         from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -770,6 +770,7 @@ class ConfigTest(unittest.TestCase):
                 "logger.messageFormat",
                 "runner.enforceSerializableSessionState",
                 "runner.magicEnabled",
+                "runner.parallelMaxWorkers",
                 "runner.postScriptGC",
                 "runner.fastReruns",
                 "runner.enumCoercion",

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -52,11 +52,11 @@ def _wait_for_outstanding_zero(
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        with c._outstanding_lock:
+        with c._join_condition:
             if c._outstanding == 0:
                 return
         time.sleep(0.01)
-    with c._outstanding_lock:
+    with c._join_condition:
         last_value = c._outstanding
     raise AssertionError(
         f"outstanding never reached 0 within {timeout}s (last value: {last_value})"

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -29,7 +29,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from streamlit.runtime.fragment import ParallelFragmentCoordinator
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,
     StopException,

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -1,0 +1,451 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ParallelFragmentCoordinator.
+
+The coordinator owns a ThreadPoolExecutor plus the bookkeeping that lets the
+script thread block on outstanding worker fragments and surface
+worker-initiated rerun/stop intent. These tests exercise the public surface
+in isolation; integration with ScriptRunContext / ScriptRunner lives in
+``script_runner_test.py`` and ``script_run_context_test.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+from streamlit.runtime.fragment import ParallelFragmentCoordinator
+from streamlit.runtime.scriptrunner_utils.exceptions import (
+    RerunException,
+    StopException,
+)
+from streamlit.runtime.scriptrunner_utils.script_requests import RerunData
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+    ThreadState,
+    get_script_run_ctx,
+)
+
+
+def _wait_for_outstanding_zero(
+    c: ParallelFragmentCoordinator, timeout: float = 1.0
+) -> None:
+    """Spin-wait until the coordinator's outstanding counter drains to zero.
+
+    Used by tests that submit a worker but don't drive ``join()`` themselves;
+    the executor's ``finally`` block runs asynchronously so we need to poll.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with c._outstanding_lock:
+            if c._outstanding == 0:
+                return
+        time.sleep(0.01)
+    with c._outstanding_lock:
+        last_value = c._outstanding
+    raise AssertionError(
+        f"outstanding never reached 0 within {timeout}s (last value: {last_value})"
+    )
+
+
+class ParallelFragmentCoordinatorTest(unittest.TestCase):
+    def test_construction_defaults(self):
+        """A freshly constructed coordinator is idle: no outstanding work,
+        no captured worker exception, no stop requested."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            assert c._outstanding == 0
+            assert c.worker_exception is None
+            assert c.should_stop() is False
+        finally:
+            c.drain()
+
+    def test_submit_counter_round_trip(self):
+        """submit() must restore _outstanding to zero even when the worker
+        raises, otherwise join() would hang forever on a worker error."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+
+            def explodes() -> None:
+                raise ValueError("boom")
+
+            c.submit(explodes)
+            _wait_for_outstanding_zero(c)
+            assert c._outstanding == 0
+        finally:
+            c.drain()
+
+    def test_join_returns_immediately_when_idle(self):
+        """If no work was submitted, join() must not invoke yield_check.
+
+        Calling yield_check with no outstanding work could surface external
+        cancellation requests at the wrong time relative to the script
+        runner's existing yield logic.
+        """
+        yields: list[int] = []
+        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+        c.join()
+        assert yields == []
+
+    def test_join_waits_and_yields(self):
+        """While work is outstanding, join() polls and calls yield_check
+        each interval so the script thread stays responsive."""
+        yields: list[int] = []
+        c = ParallelFragmentCoordinator(
+            yield_check=lambda: yields.append(1),
+            poll_interval=0.01,
+        )
+        gate = threading.Event()
+        c.submit(lambda: gate.wait(timeout=2.0))
+        threading.Timer(0.05, gate.set).start()
+        c.join()
+        assert len(yields) >= 1
+
+    def test_join_raises_stored_rerun_exception_with_data(self):
+        """A worker's RerunException must surface from join() with its
+        original RerunData attached so the script runner's rerun loop sees
+        the correct request."""
+        rerun_data = RerunData()
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.request_rerun(RerunException(rerun_data))
+        with pytest.raises(RerunException) as excinfo:
+            c.join()
+        assert excinfo.value.rerun_data is rerun_data
+
+    def test_join_raises_stored_stop_exception(self):
+        """request_stop() stores a StopException that join() re-raises."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.request_stop()
+        with pytest.raises(StopException):
+            c.join()
+
+    def test_first_writer_wins_and_should_stop(self):
+        """The first request_rerun/request_stop wins; later calls are
+        ignored. Both unconditionally set the stop event."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            assert not c.should_stop()
+            rerun_exc = RerunException(RerunData())
+            c.request_rerun(rerun_exc)
+            c.request_stop()
+            assert c.worker_exception is rerun_exc
+            assert c.should_stop() is True
+        finally:
+            c.drain()
+
+    def test_first_writer_wins_stop_then_rerun(self):
+        """Symmetric to test_first_writer_wins_and_should_stop: first
+        request_stop wins over a later request_rerun."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            c.request_stop()
+            assert isinstance(c.worker_exception, StopException)
+            c.request_rerun(RerunException(RerunData()))
+            assert isinstance(c.worker_exception, StopException)
+            assert c.should_stop() is True
+        finally:
+            c.drain()
+
+    def test_drain_silent_and_synchronous(self):
+        """drain() must not call yield_check (it's invoked from except
+        blocks where re-raising would shadow the original exception) and
+        must wait synchronously for in-flight workers to exit."""
+        yields: list[int] = []
+        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+        gate = threading.Event()
+        worker_done = threading.Event()
+
+        def worker() -> None:
+            gate.wait(timeout=2.0)
+            worker_done.set()
+
+        c.submit(worker)
+        threading.Timer(0.05, gate.set).start()
+        c.drain()
+        assert worker_done.is_set()
+        assert yields == []
+
+    def test_drain_sets_stop_event(self):
+        """drain() must set the stop event so any worker that reaches a
+        yield point during drain notices and exits cooperatively."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        assert not c.should_stop()
+        c.drain()
+        assert c.should_stop()
+
+    def test_nested_submit_counter(self):
+        """A worker that calls submit() must increment the counter before
+        the parent's tracked() finally runs, so join() waits for the
+        grandchild rather than returning when the parent finishes."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None, poll_interval=0.01)
+        child_done = threading.Event()
+
+        def parent() -> None:
+            c.submit(lambda: child_done.set())
+
+        c.submit(parent)
+        c.join()
+        assert child_done.is_set()
+
+    def test_join_propagates_yield_check_exception(self):
+        """If yield_check raises (e.g. an external RERUN arrived while
+        join() was polling), the exception must propagate so the caller's
+        try/except can run drain()."""
+
+        def yield_raises() -> None:
+            raise RerunException(RerunData())
+
+        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+        gate = threading.Event()
+        c.submit(lambda: gate.wait(timeout=2.0))
+        try:
+            with pytest.raises(RerunException):
+                c.join()
+        finally:
+            gate.set()
+            c.drain()
+
+    def test_yield_check_exception_preempts_stored_worker_exception(self):
+        """If both ``_yield_check`` raises and a worker exception is already
+        stored, the yield-check exception wins because ``join()`` calls
+        ``_yield_check()`` before checking ``worker_exception``. This pins
+        the precedence ordering — symmetric to the script-thread branch
+        contract where the worker exception wins over an external
+        ``ScriptRequests`` entry.
+        """
+        external_rerun = RerunException(RerunData(query_string="external"))
+
+        def yield_raises() -> None:
+            raise external_rerun
+
+        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+        worker_rerun = RerunException(RerunData(query_string="from_worker"))
+        c.request_rerun(worker_rerun)
+        gate = threading.Event()
+        c.submit(lambda: gate.wait(timeout=2.0))
+        try:
+            with pytest.raises(RerunException) as excinfo:
+                c.join()
+            assert excinfo.value is external_rerun
+        finally:
+            gate.set()
+            c.drain()
+
+    def test_submit_passes_args(self):
+        """submit() forwards positional args to the worker function so
+        callers can capture per-fragment context."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            captured: list[tuple[int, str]] = []
+            done = threading.Event()
+
+            def worker(value: int, label: str) -> None:
+                captured.append((value, label))
+                done.set()
+
+            c.submit(worker, 42, "hello")
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            assert captured == [(42, "hello")]
+        finally:
+            c.drain()
+
+    def test_join_after_drain_is_safe(self):
+        """drain() shuts the executor down; calling join() afterwards on
+        an idle coordinator must not crash."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.drain()
+        c.join()
+
+    def test_submit_after_shutdown_rolls_back_outstanding(self):
+        """If ``submit()`` races with a concurrent ``drain()`` and the
+        executor is already shut down, the outstanding counter must be
+        rolled back so a subsequent ``join()`` doesn't hang."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.drain()
+        with pytest.raises(RuntimeError):
+            c.submit(lambda: None)
+        assert c._outstanding == 0
+
+    def test_submit_propagates_ctx_to_worker(self):
+        """submit() captures the parent's ScriptRunContext at submit time
+        and the worker sees it via get_script_run_ctx()."""
+        mock_ctx = MagicMock()
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
+        ThreadState.initialize()
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        holder: list[object] = []
+        done = threading.Event()
+
+        def worker() -> None:
+            holder.append(get_script_run_ctx())
+            done.set()
+
+        try:
+            c.submit(worker)
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            assert holder[0] is mock_ctx
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_propagates_thread_state_to_worker(self):
+        """submit() captures the parent's ContextVars (including
+        FragmentThreadState) so the worker sees the parent's snapshot."""
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        holder: list[object] = []
+        done = threading.Event()
+
+        def worker() -> None:
+            holder.append(ThreadState.get())
+            done.set()
+
+        try:
+            c.submit(worker)
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            ts = holder[0]
+            assert ts.fragment_id == "parent_frag"
+            assert ts.active_script_hash == "abc"
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_isolates_worker_thread_state_writes(self):
+        """Worker-side ThreadState.update() writes stay local to the
+        captured copy_context() and never leak back to the parent."""
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        done = threading.Event()
+
+        def worker() -> None:
+            ThreadState.update(fragment_id="worker_frag")
+            done.set()
+
+        try:
+            c.submit(worker)
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            assert ThreadState.get().fragment_id == "parent_frag"
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_clears_ctx_attribute_between_pool_submissions(self):
+        """With max_workers=1, two submissions with different ctxs each
+        see the correct ctx, and the pool thread's attribute is cleaned
+        up after both complete."""
+        main_thread = threading.current_thread()
+        ThreadState.initialize()
+
+        ctx_a = MagicMock(name="ctx_a")
+        ctx_b = MagicMock(name="ctx_b")
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+        holder_a: list[object] = []
+        holder_b: list[object] = []
+        pool_thread_ref: list[threading.Thread] = []
+        gate = threading.Event()
+        done_a = threading.Event()
+        done_b = threading.Event()
+
+        def worker_a() -> None:
+            holder_a.append(get_script_run_ctx())
+            pool_thread_ref.append(threading.current_thread())
+            gate.wait(timeout=2.0)
+            done_a.set()
+
+        def worker_b() -> None:
+            holder_b.append(get_script_run_ctx())
+            done_b.set()
+
+        try:
+            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
+            c.submit(worker_a)
+            gate.set()
+            assert done_a.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
+            c.submit(worker_b)
+            assert done_b.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            assert holder_a[0] is ctx_a
+            assert holder_b[0] is ctx_b
+
+            pool_thread = pool_thread_ref[0]
+            remaining = getattr(pool_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+            assert remaining is not ctx_a
+            assert remaining is not ctx_b
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_with_max_workers_1_serializes_distinct_thread_states(self):
+        """With max_workers=1, two submissions see their respective
+        parent ThreadState snapshots, not each other's."""
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+        holder_a: list[object] = []
+        holder_b: list[object] = []
+        done_a = threading.Event()
+        done_b = threading.Event()
+
+        def worker_a() -> None:
+            holder_a.append(ThreadState.get())
+            done_a.set()
+
+        def worker_b() -> None:
+            holder_b.append(ThreadState.get())
+            done_b.set()
+
+        try:
+            ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
+            c.submit(worker_a)
+            assert done_a.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
+            c.submit(worker_b)
+            assert done_b.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            ts_a = holder_a[0]
+            assert ts_a.fragment_id == "state_a"
+            assert ts_a.active_script_hash == "hash_a"
+
+            ts_b = holder_b[0]
+            assert ts_b.fragment_id == "state_b"
+            assert ts_b.active_script_hash == "hash_b"
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import threading
 import time
-import unittest
 from unittest.mock import MagicMock
 
 import pytest
@@ -64,388 +63,439 @@ def _wait_for_outstanding_zero(
     )
 
 
-class ParallelFragmentCoordinatorTest(unittest.TestCase):
-    def test_construction_defaults(self):
-        """A freshly constructed coordinator is idle: no outstanding work,
-        no captured worker exception, no stop requested."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            assert c._outstanding == 0
-            assert c.worker_exception is None
-            assert c.should_stop() is False
-        finally:
-            c.drain()
+@pytest.fixture
+def coordinator():
+    """Yield a coordinator with a no-op yield check; drain on teardown."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    yield c
+    c.drain()
 
-    def test_submit_counter_round_trip(self):
-        """submit() must restore _outstanding to zero even when the worker
-        raises, otherwise join() would hang forever on a worker error."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
 
-            def explodes() -> None:
-                raise ValueError("boom")
+@pytest.fixture
+def _attach_mock_ctx():
+    """Set a MagicMock as the current thread's ScriptRunContext and
+    initialize ThreadState for tests that exercise submit() propagation.
+    Cleans up on teardown.
+    """
+    main_thread = threading.current_thread()
+    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+    ThreadState.initialize()
+    yield
+    try:
+        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+    except AttributeError:
+        pass
 
-            c.submit(explodes)
-            _wait_for_outstanding_zero(c)
-            assert c._outstanding == 0
-        finally:
-            c.drain()
 
-    def test_join_returns_immediately_when_idle(self):
-        """If no work was submitted, join() must not invoke yield_check.
+# --- Construction ---
 
-        Calling yield_check with no outstanding work could surface external
-        cancellation requests at the wrong time relative to the script
-        runner's existing yield logic.
-        """
-        yields: list[int] = []
-        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+
+def test_construction_defaults(coordinator):
+    """A freshly constructed coordinator is idle: no outstanding work,
+    no captured worker exception, no stop requested."""
+    assert coordinator._outstanding == 0
+    assert coordinator.worker_exception is None
+    assert coordinator.should_stop() is False
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, -100])
+def test_construction_rejects_non_positive_max_workers(bad_value):
+    """max_workers must be None or a positive integer."""
+    with pytest.raises(ValueError, match="positive integer"):
+        ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=bad_value)
+
+
+# --- Submit / counter ---
+
+
+def test_submit_counter_round_trip(coordinator):
+    """submit() must restore _outstanding to zero even when the worker
+    raises, otherwise join() would hang forever on a worker error."""
+
+    def explodes() -> None:
+        raise ValueError("boom")
+
+    coordinator.submit(explodes)
+    _wait_for_outstanding_zero(coordinator)
+    assert coordinator._outstanding == 0
+
+
+def test_submit_passes_args(coordinator):
+    """submit() forwards positional args to the worker function so
+    callers can capture per-fragment context."""
+    captured: list[tuple[int, str]] = []
+    done = threading.Event()
+
+    def worker(value: int, label: str) -> None:
+        captured.append((value, label))
+        done.set()
+
+    coordinator.submit(worker, 42, "hello")
+    assert done.wait(timeout=1.0)
+    _wait_for_outstanding_zero(coordinator)
+    assert captured == [(42, "hello")]
+
+
+def test_submit_after_shutdown_rolls_back_outstanding():
+    """If ``submit()`` races with a concurrent ``drain()`` and the
+    executor is already shut down, the outstanding counter must be
+    rolled back so a subsequent ``join()`` doesn't hang."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.drain()
+    with pytest.raises(RuntimeError):
+        c.submit(lambda: None)
+    assert c._outstanding == 0
+
+
+def test_nested_submit_counter():
+    """A worker that calls submit() must increment the counter before
+    the parent's tracked() finally runs, so join() waits for the
+    grandchild rather than returning when the parent finishes."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None, poll_interval=0.01)
+    child_done = threading.Event()
+
+    def parent() -> None:
+        c.submit(lambda: child_done.set())
+
+    c.submit(parent)
+    c.join()
+    assert child_done.is_set()
+
+
+# --- Join ---
+
+
+def test_join_returns_immediately_when_idle():
+    """If no work was submitted, join() must not invoke yield_check.
+
+    Calling yield_check with no outstanding work could surface external
+    cancellation requests at the wrong time relative to the script
+    runner's existing yield logic.
+    """
+    yields: list[int] = []
+    c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+    c.join()
+    assert yields == []
+
+
+def test_join_waits_and_yields():
+    """While work is outstanding, join() polls and calls yield_check
+    each interval so the script thread stays responsive."""
+    yields: list[int] = []
+    c = ParallelFragmentCoordinator(
+        yield_check=lambda: yields.append(1),
+        poll_interval=0.01,
+    )
+    gate = threading.Event()
+    c.submit(lambda: gate.wait(timeout=2.0))
+    threading.Timer(0.05, gate.set).start()
+    c.join()
+    assert len(yields) >= 1
+
+
+def test_join_raises_stored_rerun_exception_with_data():
+    """A worker's RerunException must surface from join() with its
+    original RerunData attached so the script runner's rerun loop sees
+    the correct request."""
+    rerun_data = RerunData()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.request_rerun(RerunException(rerun_data))
+    with pytest.raises(RerunException) as excinfo:
         c.join()
-        assert yields == []
+    assert excinfo.value.rerun_data is rerun_data
 
-    def test_join_waits_and_yields(self):
-        """While work is outstanding, join() polls and calls yield_check
-        each interval so the script thread stays responsive."""
-        yields: list[int] = []
-        c = ParallelFragmentCoordinator(
-            yield_check=lambda: yields.append(1),
-            poll_interval=0.01,
-        )
-        gate = threading.Event()
-        c.submit(lambda: gate.wait(timeout=2.0))
-        threading.Timer(0.05, gate.set).start()
+
+def test_join_raises_stored_stop_exception():
+    """request_stop() stores a StopException that join() re-raises."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.request_stop()
+    with pytest.raises(StopException):
         c.join()
-        assert len(yields) >= 1
 
-    def test_join_raises_stored_rerun_exception_with_data(self):
-        """A worker's RerunException must surface from join() with its
-        original RerunData attached so the script runner's rerun loop sees
-        the correct request."""
-        rerun_data = RerunData()
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        c.request_rerun(RerunException(rerun_data))
+
+def test_join_after_drain_is_safe():
+    """drain() shuts the executor down; calling join() afterwards on
+    an idle coordinator must not crash."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.drain()
+    c.join()
+
+
+def test_join_propagates_yield_check_exception():
+    """If yield_check raises (e.g. an external RERUN arrived while
+    join() was polling), the exception must propagate so the caller's
+    try/except can run drain()."""
+
+    def yield_raises() -> None:
+        raise RerunException(RerunData())
+
+    c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+    gate = threading.Event()
+    c.submit(lambda: gate.wait(timeout=2.0))
+    try:
+        with pytest.raises(RerunException):
+            c.join()
+    finally:
+        gate.set()
+        c.drain()
+
+
+def test_yield_check_exception_preempts_stored_worker_exception():
+    """If both ``_yield_check`` raises and a worker exception is already
+    stored, the yield-check exception wins because ``join()`` calls
+    ``_yield_check()`` before checking ``worker_exception``. This pins
+    the precedence ordering — symmetric to the script-thread branch
+    contract where the worker exception wins over an external
+    ``ScriptRequests`` entry.
+    """
+    external_rerun = RerunException(RerunData(query_string="external"))
+
+    def yield_raises() -> None:
+        raise external_rerun
+
+    c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+    worker_rerun = RerunException(RerunData(query_string="from_worker"))
+    c.request_rerun(worker_rerun)
+    gate = threading.Event()
+    c.submit(lambda: gate.wait(timeout=2.0))
+    try:
         with pytest.raises(RerunException) as excinfo:
             c.join()
-        assert excinfo.value.rerun_data is rerun_data
-
-    def test_join_raises_stored_stop_exception(self):
-        """request_stop() stores a StopException that join() re-raises."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        c.request_stop()
-        with pytest.raises(StopException):
-            c.join()
-
-    def test_first_writer_wins_and_should_stop(self):
-        """The first request_rerun/request_stop wins; later calls are
-        ignored. Both unconditionally set the stop event."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            assert not c.should_stop()
-            rerun_exc = RerunException(RerunData())
-            c.request_rerun(rerun_exc)
-            c.request_stop()
-            assert c.worker_exception is rerun_exc
-            assert c.should_stop() is True
-        finally:
-            c.drain()
-
-    def test_first_writer_wins_stop_then_rerun(self):
-        """Symmetric to test_first_writer_wins_and_should_stop: first
-        request_stop wins over a later request_rerun."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            c.request_stop()
-            assert isinstance(c.worker_exception, StopException)
-            c.request_rerun(RerunException(RerunData()))
-            assert isinstance(c.worker_exception, StopException)
-            assert c.should_stop() is True
-        finally:
-            c.drain()
-
-    def test_drain_silent_and_synchronous(self):
-        """drain() must not call yield_check (it's invoked from except
-        blocks where re-raising would shadow the original exception) and
-        must wait synchronously for in-flight workers to exit."""
-        yields: list[int] = []
-        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
-        gate = threading.Event()
-        worker_done = threading.Event()
-
-        def worker() -> None:
-            gate.wait(timeout=2.0)
-            worker_done.set()
-
-        c.submit(worker)
-        threading.Timer(0.05, gate.set).start()
+        assert excinfo.value is external_rerun
+    finally:
+        gate.set()
         c.drain()
-        assert worker_done.is_set()
-        assert yields == []
 
-    def test_drain_sets_stop_event(self):
-        """drain() must set the stop event so any worker that reaches a
-        yield point during drain notices and exits cooperatively."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+
+# --- First-writer-wins ---
+
+
+def test_first_writer_wins_rerun_then_stop():
+    """The first request_rerun/request_stop wins; later calls are
+    ignored. Both unconditionally set the stop event."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    try:
         assert not c.should_stop()
+        rerun_exc = RerunException(RerunData())
+        c.request_rerun(rerun_exc)
+        c.request_stop()
+        assert c.worker_exception is rerun_exc
+        assert c.should_stop() is True
+    finally:
         c.drain()
-        assert c.should_stop()
 
-    def test_nested_submit_counter(self):
-        """A worker that calls submit() must increment the counter before
-        the parent's tracked() finally runs, so join() waits for the
-        grandchild rather than returning when the parent finishes."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None, poll_interval=0.01)
-        child_done = threading.Event()
 
-        def parent() -> None:
-            c.submit(lambda: child_done.set())
-
-        c.submit(parent)
-        c.join()
-        assert child_done.is_set()
-
-    def test_join_propagates_yield_check_exception(self):
-        """If yield_check raises (e.g. an external RERUN arrived while
-        join() was polling), the exception must propagate so the caller's
-        try/except can run drain()."""
-
-        def yield_raises() -> None:
-            raise RerunException(RerunData())
-
-        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
-        gate = threading.Event()
-        c.submit(lambda: gate.wait(timeout=2.0))
-        try:
-            with pytest.raises(RerunException):
-                c.join()
-        finally:
-            gate.set()
-            c.drain()
-
-    def test_yield_check_exception_preempts_stored_worker_exception(self):
-        """If both ``_yield_check`` raises and a worker exception is already
-        stored, the yield-check exception wins because ``join()`` calls
-        ``_yield_check()`` before checking ``worker_exception``. This pins
-        the precedence ordering — symmetric to the script-thread branch
-        contract where the worker exception wins over an external
-        ``ScriptRequests`` entry.
-        """
-        external_rerun = RerunException(RerunData(query_string="external"))
-
-        def yield_raises() -> None:
-            raise external_rerun
-
-        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
-        worker_rerun = RerunException(RerunData(query_string="from_worker"))
-        c.request_rerun(worker_rerun)
-        gate = threading.Event()
-        c.submit(lambda: gate.wait(timeout=2.0))
-        try:
-            with pytest.raises(RerunException) as excinfo:
-                c.join()
-            assert excinfo.value is external_rerun
-        finally:
-            gate.set()
-            c.drain()
-
-    def test_submit_passes_args(self):
-        """submit() forwards positional args to the worker function so
-        callers can capture per-fragment context."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            captured: list[tuple[int, str]] = []
-            done = threading.Event()
-
-            def worker(value: int, label: str) -> None:
-                captured.append((value, label))
-                done.set()
-
-            c.submit(worker, 42, "hello")
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            assert captured == [(42, "hello")]
-        finally:
-            c.drain()
-
-    def test_join_after_drain_is_safe(self):
-        """drain() shuts the executor down; calling join() afterwards on
-        an idle coordinator must not crash."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+def test_first_writer_wins_stop_then_rerun():
+    """Symmetric to test_first_writer_wins_rerun_then_stop: first
+    request_stop wins over a later request_rerun."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    try:
+        c.request_stop()
+        assert isinstance(c.worker_exception, StopException)
+        c.request_rerun(RerunException(RerunData()))
+        assert isinstance(c.worker_exception, StopException)
+        assert c.should_stop() is True
+    finally:
         c.drain()
-        c.join()
 
-    def test_submit_after_shutdown_rolls_back_outstanding(self):
-        """If ``submit()`` races with a concurrent ``drain()`` and the
-        executor is already shut down, the outstanding counter must be
-        rolled back so a subsequent ``join()`` doesn't hang."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+
+# --- Drain ---
+
+
+def test_drain_silent_and_synchronous():
+    """drain() must not call yield_check (it's invoked from except
+    blocks where re-raising would shadow the original exception) and
+    must wait synchronously for in-flight workers to exit."""
+    yields: list[int] = []
+    c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+    gate = threading.Event()
+    worker_done = threading.Event()
+
+    def worker() -> None:
+        gate.wait(timeout=2.0)
+        worker_done.set()
+
+    c.submit(worker)
+    threading.Timer(0.05, gate.set).start()
+    c.drain()
+    assert worker_done.is_set()
+    assert yields == []
+
+
+def test_drain_sets_stop_event():
+    """drain() must set the stop event so any worker that reaches a
+    yield point during drain notices and exits cooperatively."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    assert not c.should_stop()
+    c.drain()
+    assert c.should_stop()
+
+
+# --- submit() propagation ---
+
+
+@pytest.mark.usefixtures("_attach_mock_ctx")
+def test_submit_propagates_ctx_to_worker():
+    """submit() captures the parent's ScriptRunContext at submit time
+    and the worker sees it via get_script_run_ctx()."""
+    mock_ctx = MagicMock()
+    main_thread = threading.current_thread()
+    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
+
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    holder: list[object] = []
+    done = threading.Event()
+
+    def worker() -> None:
+        holder.append(get_script_run_ctx())
+        done.set()
+
+    try:
+        c.submit(worker)
+        assert done.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
+        assert holder[0] is mock_ctx
+    finally:
         c.drain()
-        with pytest.raises(RuntimeError):
-            c.submit(lambda: None)
-        assert c._outstanding == 0
 
-    def test_submit_propagates_ctx_to_worker(self):
-        """submit() captures the parent's ScriptRunContext at submit time
-        and the worker sees it via get_script_run_ctx()."""
-        mock_ctx = MagicMock()
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
-        ThreadState.initialize()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        holder: list[object] = []
-        done = threading.Event()
+@pytest.mark.usefixtures("_attach_mock_ctx")
+def test_submit_propagates_thread_state_to_worker():
+    """submit() captures the parent's ContextVars (including
+    FragmentThreadState) so the worker sees the parent's snapshot."""
+    ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
 
-        def worker() -> None:
-            holder.append(get_script_run_ctx())
-            done.set()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    holder: list[object] = []
+    done = threading.Event()
 
-        try:
-            c.submit(worker)
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            assert holder[0] is mock_ctx
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+    def worker() -> None:
+        holder.append(ThreadState.get())
+        done.set()
 
-    def test_submit_propagates_thread_state_to_worker(self):
-        """submit() captures the parent's ContextVars (including
-        FragmentThreadState) so the worker sees the parent's snapshot."""
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
-        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+    try:
+        c.submit(worker)
+        assert done.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
+        ts = holder[0]
+        assert ts.fragment_id == "parent_frag"
+        assert ts.active_script_hash == "abc"
+    finally:
+        c.drain()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        holder: list[object] = []
-        done = threading.Event()
 
-        def worker() -> None:
-            holder.append(ThreadState.get())
-            done.set()
+@pytest.mark.usefixtures("_attach_mock_ctx")
+def test_submit_isolates_worker_thread_state_writes():
+    """Worker-side ThreadState.update() writes stay local to the
+    captured copy_context() and never leak back to the parent."""
+    ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
 
-        try:
-            c.submit(worker)
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            ts = holder[0]
-            assert ts.fragment_id == "parent_frag"
-            assert ts.active_script_hash == "abc"
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    done = threading.Event()
 
-    def test_submit_isolates_worker_thread_state_writes(self):
-        """Worker-side ThreadState.update() writes stay local to the
-        captured copy_context() and never leak back to the parent."""
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
-        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+    def worker() -> None:
+        ThreadState.update(fragment_id="worker_frag")
+        done.set()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        done = threading.Event()
+    try:
+        c.submit(worker)
+        assert done.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
+        assert ThreadState.get().fragment_id == "parent_frag"
+    finally:
+        c.drain()
 
-        def worker() -> None:
-            ThreadState.update(fragment_id="worker_frag")
-            done.set()
 
-        try:
-            c.submit(worker)
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            assert ThreadState.get().fragment_id == "parent_frag"
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+def test_submit_clears_ctx_attribute_between_pool_submissions():
+    """With max_workers=1, two submissions with different ctxs each
+    see the correct ctx, and the pool thread's attribute is cleaned
+    up after both complete."""
+    main_thread = threading.current_thread()
+    ThreadState.initialize()
 
-    def test_submit_clears_ctx_attribute_between_pool_submissions(self):
-        """With max_workers=1, two submissions with different ctxs each
-        see the correct ctx, and the pool thread's attribute is cleaned
-        up after both complete."""
-        main_thread = threading.current_thread()
-        ThreadState.initialize()
+    ctx_a = MagicMock(name="ctx_a")
+    ctx_b = MagicMock(name="ctx_b")
 
-        ctx_a = MagicMock(name="ctx_a")
-        ctx_b = MagicMock(name="ctx_b")
+    c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+    holder_a: list[object] = []
+    holder_b: list[object] = []
+    pool_thread_ref: list[threading.Thread] = []
+    gate = threading.Event()
+    done_a = threading.Event()
+    done_b = threading.Event()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
-        holder_a: list[object] = []
-        holder_b: list[object] = []
-        pool_thread_ref: list[threading.Thread] = []
-        gate = threading.Event()
-        done_a = threading.Event()
-        done_b = threading.Event()
+    def worker_a() -> None:
+        holder_a.append(get_script_run_ctx())
+        pool_thread_ref.append(threading.current_thread())
+        gate.wait(timeout=2.0)
+        done_a.set()
 
-        def worker_a() -> None:
-            holder_a.append(get_script_run_ctx())
-            pool_thread_ref.append(threading.current_thread())
-            gate.wait(timeout=2.0)
-            done_a.set()
+    def worker_b() -> None:
+        holder_b.append(get_script_run_ctx())
+        done_b.set()
 
-        def worker_b() -> None:
-            holder_b.append(get_script_run_ctx())
-            done_b.set()
+    try:
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
+        c.submit(worker_a)
+        gate.set()
+        assert done_a.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-        try:
-            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
-            c.submit(worker_a)
-            gate.set()
-            assert done_a.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
+        c.submit(worker_b)
+        assert done_b.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
-            c.submit(worker_b)
-            assert done_b.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+        assert holder_a[0] is ctx_a
+        assert holder_b[0] is ctx_b
 
-            assert holder_a[0] is ctx_a
-            assert holder_b[0] is ctx_b
+        pool_thread = pool_thread_ref[0]
+        remaining = getattr(pool_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+        assert remaining is not ctx_a
+        assert remaining is not ctx_b
+    finally:
+        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+        c.drain()
 
-            pool_thread = pool_thread_ref[0]
-            remaining = getattr(pool_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-            assert remaining is not ctx_a
-            assert remaining is not ctx_b
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
 
-    def test_submit_with_max_workers_1_serializes_distinct_thread_states(self):
-        """With max_workers=1, two submissions see their respective
-        parent ThreadState snapshots, not each other's."""
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+def test_submit_with_max_workers_1_serializes_distinct_thread_states():
+    """With max_workers=1, two submissions see their respective
+    parent ThreadState snapshots, not each other's."""
+    main_thread = threading.current_thread()
+    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
-        holder_a: list[object] = []
-        holder_b: list[object] = []
-        done_a = threading.Event()
-        done_b = threading.Event()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+    holder_a: list[object] = []
+    holder_b: list[object] = []
+    done_a = threading.Event()
+    done_b = threading.Event()
 
-        def worker_a() -> None:
-            holder_a.append(ThreadState.get())
-            done_a.set()
+    def worker_a() -> None:
+        holder_a.append(ThreadState.get())
+        done_a.set()
 
-        def worker_b() -> None:
-            holder_b.append(ThreadState.get())
-            done_b.set()
+    def worker_b() -> None:
+        holder_b.append(ThreadState.get())
+        done_b.set()
 
-        try:
-            ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
-            c.submit(worker_a)
-            assert done_a.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+    try:
+        ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
+        c.submit(worker_a)
+        assert done_a.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-            ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
-            c.submit(worker_b)
-            assert done_b.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+        ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
+        c.submit(worker_b)
+        assert done_b.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-            ts_a = holder_a[0]
-            assert ts_a.fragment_id == "state_a"
-            assert ts_a.active_script_hash == "hash_a"
+        ts_a = holder_a[0]
+        assert ts_a.fragment_id == "state_a"
+        assert ts_a.active_script_hash == "hash_a"
 
-            ts_b = holder_b[0]
-            assert ts_b.fragment_id == "state_b"
-            assert ts_b.active_script_hash == "hash_b"
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+        ts_b = holder_b[0]
+        assert ts_b.fragment_id == "state_b"
+        assert ts_b.active_script_hash == "hash_b"
+    finally:
+        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+        c.drain()

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -33,7 +33,11 @@ from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
-from streamlit.runtime.fragment import MemoryFragmentStorage, _fragment
+from streamlit.runtime.fragment import (
+    MemoryFragmentStorage,
+    ParallelFragmentCoordinator,
+    _fragment,
+)
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
@@ -609,6 +613,14 @@ class ScriptRunnerTest(unittest.TestCase):
         """
 
         ctx = MagicMock()
+        # The script-thread yield-point branch of
+        # _maybe_handle_execution_control_request reads
+        # ctx.parallel_coordinator.worker_exception and re-raises it if
+        # set. Without an explicit None, MagicMock returns a MagicMock,
+        # which raises TypeError ("exceptions must derive from
+        # BaseException") when the production code tries to raise it —
+        # masking the KeyError this test is actually checking for.
+        ctx.parallel_coordinator.worker_exception = None
         patched_get_script_run_ctx.return_value = ctx
 
         def non_optional_func():
@@ -1236,6 +1248,181 @@ class ScriptRunnerTest(unittest.TestCase):
                     ScriptRunnerEvent.SHUTDOWN,
                 ],
             )
+
+    def test_parallel_coordinator_is_fresh_per_run(self):
+        """Each script run constructs a brand new
+        ParallelFragmentCoordinator. A leaked instance would carry the
+        previous run's stop event / worker exception into the next run.
+
+        ``coordinator_id_capture.py`` calls ``st.rerun()`` once so the
+        runner does two full runs in a single start/join cycle —
+        back-to-back ``request_rerun`` calls coalesce.
+        """
+        scriptrunner = TestScriptRunner("coordinator_id_capture.py")
+        scriptrunner.request_rerun(RerunData())
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        ids = scriptrunner._session_state["coordinator_ids"]
+        assert len(ids) == 2
+        assert ids[0] != ids[1]
+
+    def test_parallel_coordinator_join_called_after_exec(self):
+        """The script runner must call ``coordinator.join()`` exactly once
+        after a successful full-app run, before clearing fragment storage."""
+        join_calls: list[int] = []
+        original_join = ParallelFragmentCoordinator.join
+
+        def recording_join(self):
+            join_calls.append(1)
+            return original_join(self)
+
+        with patch.object(ParallelFragmentCoordinator, "join", recording_join):
+            scriptrunner = TestScriptRunner("good_script.py")
+            scriptrunner.request_rerun(RerunData())
+            scriptrunner.start()
+            scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        assert len(join_calls) == 1
+
+    def test_parallel_coordinator_drain_on_rerun_exception(self):
+        """When ``exec()`` raises RerunException (e.g. user code calls
+        ``st.rerun()``), the script runner's try/except must call
+        ``coordinator.drain()`` and re-raise so the rerun loop sees the
+        exception and runs the script again."""
+        drain_calls: list[int] = []
+        original_drain = ParallelFragmentCoordinator.drain
+
+        def recording_drain(self):
+            drain_calls.append(1)
+            return original_drain(self)
+
+        with patch.object(ParallelFragmentCoordinator, "drain", recording_drain):
+            scriptrunner = TestScriptRunner("rerun_once_then_finish.py")
+            scriptrunner.request_rerun(RerunData())
+            scriptrunner.start()
+            scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        # The first run's st.rerun() raises RerunException -> drain() runs once.
+        # The second run completes normally -> no drain call.
+        assert len(drain_calls) == 1
+        # Two SCRIPT_STARTED events confirm the rerun was honored.
+        started_events = [
+            e for e in scriptrunner.events if e == ScriptRunnerEvent.SCRIPT_STARTED
+        ]
+        assert len(started_events) == 2
+
+    def test_worker_thread_yield_check_noop_when_idle(self):
+        """A worker thread (attached via add_script_run_ctx) hits the
+        worker-thread branch of ``_maybe_handle_execution_control_request``.
+        With no stop requested it must not raise so that existing
+        worker-thread paths (e.g. spinner) keep working."""
+        import threading as _threading
+
+        from streamlit.runtime.scriptrunner_utils.script_run_context import (
+            SCRIPT_RUN_CONTEXT_ATTR_NAME,
+            add_script_run_ctx,
+        )
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.request_rerun(RerunData())
+        scriptrunner.start()
+        scriptrunner.join()
+        self._assert_no_exceptions(scriptrunner)
+
+        script_thread = scriptrunner._script_thread
+        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+        assert ctx is not None
+        assert ctx.parallel_coordinator is not None
+        assert ctx.parallel_coordinator.should_stop() is False
+
+        worker_errors: list[BaseException] = []
+
+        def worker() -> None:
+            add_script_run_ctx(_threading.current_thread(), ctx)
+            try:
+                # The script runner is no longer in script-thread, so this
+                # call hits the worker-thread branch. With should_stop() False
+                # it must return without raising.
+                scriptrunner._maybe_handle_execution_control_request()
+            except BaseException as e:
+                worker_errors.append(e)
+
+        t = _threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert worker_errors == []
+
+    @patch("streamlit.runtime.scriptrunner.script_runner.get_script_run_ctx")
+    def test_script_thread_yield_check_worker_exception_wins_over_request(
+        self, patched_get_script_run_ctx
+    ):
+        """On the script-thread branch, a stored worker exception is
+        re-raised before any external RERUN/STOP request from
+        ``ScriptRequests`` is dequeued. The worker's RerunData is preserved
+        so the rerun loop honors the worker's intent, not the external
+        request that arrived concurrently.
+        """
+        worker_rerun_data = RerunData(query_string="from_worker")
+        worker_exc = RerunException(worker_rerun_data)
+
+        ctx = MagicMock()
+        ctx.parallel_coordinator.worker_exception = worker_exc
+        patched_get_script_run_ctx.return_value = ctx
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        # Queue an external rerun request that should NOT win over the
+        # worker's stored exception.
+        external_rerun_data = RerunData(query_string="external")
+        scriptrunner._requests.request_rerun(external_rerun_data)
+
+        with patch.object(scriptrunner, "_is_in_script_thread", return_value=True):
+            scriptrunner._execing = True
+            with pytest.raises(RerunException) as excinfo:
+                scriptrunner._maybe_handle_execution_control_request()
+
+        assert excinfo.value.rerun_data is worker_rerun_data
+
+    def test_worker_thread_yield_check_raises_when_stop_requested(self):
+        """When the coordinator's stop event is set (e.g. a sibling worker
+        called ``request_stop``), the worker-thread branch raises
+        StopException so the worker exits at its next yield point."""
+        import threading as _threading
+
+        from streamlit.runtime.scriptrunner_utils.script_run_context import (
+            SCRIPT_RUN_CONTEXT_ATTR_NAME,
+            add_script_run_ctx,
+        )
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.request_rerun(RerunData())
+        scriptrunner.start()
+        scriptrunner.join()
+        self._assert_no_exceptions(scriptrunner)
+
+        script_thread = scriptrunner._script_thread
+        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+        assert ctx is not None
+        assert ctx.parallel_coordinator is not None
+        ctx.parallel_coordinator.request_stop()
+
+        worker_errors: list[BaseException] = []
+
+        def worker() -> None:
+            add_script_run_ctx(_threading.current_thread(), ctx)
+            try:
+                scriptrunner._maybe_handle_execution_control_request()
+            except BaseException as e:
+                worker_errors.append(e)
+
+        t = _threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert len(worker_errors) == 1
+        assert isinstance(worker_errors[0], StopException)
 
     def test_page_script_hash_to_script_path(self):
         scriptrunner = TestScriptRunner("good_navigation_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -613,13 +613,8 @@ class ScriptRunnerTest(unittest.TestCase):
         """
 
         ctx = MagicMock()
-        # The script-thread yield-point branch of
-        # _maybe_handle_execution_control_request reads
-        # ctx.parallel_coordinator.worker_exception and re-raises it if
-        # set. Without an explicit None, MagicMock returns a MagicMock,
-        # which raises TypeError ("exceptions must derive from
-        # BaseException") when the production code tries to raise it —
-        # masking the KeyError this test is actually checking for.
+        # Set to None to prevent MagicMock being returned, which would
+        # cause the test to fail with TypeError instead of KeyError.
         ctx.parallel_coordinator.worker_exception = None
         patched_get_script_run_ctx.return_value = ctx
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -35,13 +35,13 @@ from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import (
     MemoryFragmentStorage,
-    ParallelFragmentCoordinator,
     _fragment,
 )
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 from streamlit.runtime.scriptrunner import (
     RerunData,
     RerunException,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -1315,47 +1315,6 @@ class ScriptRunnerTest(unittest.TestCase):
         ]
         assert len(started_events) == 2
 
-    def test_worker_thread_yield_check_noop_when_idle(self):
-        """A worker thread (attached via add_script_run_ctx) hits the
-        worker-thread branch of ``_maybe_handle_execution_control_request``.
-        With no stop requested it must not raise so that existing
-        worker-thread paths (e.g. spinner) keep working."""
-        import threading as _threading
-
-        from streamlit.runtime.scriptrunner_utils.script_run_context import (
-            SCRIPT_RUN_CONTEXT_ATTR_NAME,
-            add_script_run_ctx,
-        )
-
-        scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.request_rerun(RerunData())
-        scriptrunner.start()
-        scriptrunner.join()
-        self._assert_no_exceptions(scriptrunner)
-
-        script_thread = scriptrunner._script_thread
-        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-        assert ctx is not None
-        assert ctx.parallel_coordinator is not None
-        assert ctx.parallel_coordinator.should_stop() is False
-
-        worker_errors: list[BaseException] = []
-
-        def worker() -> None:
-            add_script_run_ctx(_threading.current_thread(), ctx)
-            try:
-                # The script runner is no longer in script-thread, so this
-                # call hits the worker-thread branch. With should_stop() False
-                # it must return without raising.
-                scriptrunner._maybe_handle_execution_control_request()
-            except BaseException as e:
-                worker_errors.append(e)
-
-        t = _threading.Thread(target=worker)
-        t.start()
-        t.join()
-        assert worker_errors == []
-
     @patch("streamlit.runtime.scriptrunner.script_runner.get_script_run_ctx")
     def test_script_thread_yield_check_worker_exception_wins_over_request(
         self, patched_get_script_run_ctx
@@ -1385,44 +1344,6 @@ class ScriptRunnerTest(unittest.TestCase):
                 scriptrunner._maybe_handle_execution_control_request()
 
         assert excinfo.value.rerun_data is worker_rerun_data
-
-    def test_worker_thread_yield_check_raises_when_stop_requested(self):
-        """When the coordinator's stop event is set (e.g. a sibling worker
-        called ``request_stop``), the worker-thread branch raises
-        StopException so the worker exits at its next yield point."""
-        import threading as _threading
-
-        from streamlit.runtime.scriptrunner_utils.script_run_context import (
-            SCRIPT_RUN_CONTEXT_ATTR_NAME,
-            add_script_run_ctx,
-        )
-
-        scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.request_rerun(RerunData())
-        scriptrunner.start()
-        scriptrunner.join()
-        self._assert_no_exceptions(scriptrunner)
-
-        script_thread = scriptrunner._script_thread
-        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-        assert ctx is not None
-        assert ctx.parallel_coordinator is not None
-        ctx.parallel_coordinator.request_stop()
-
-        worker_errors: list[BaseException] = []
-
-        def worker() -> None:
-            add_script_run_ctx(_threading.current_thread(), ctx)
-            try:
-                scriptrunner._maybe_handle_execution_control_request()
-            except BaseException as e:
-                worker_errors.append(e)
-
-        t = _threading.Thread(target=worker)
-        t.start()
-        t.join()
-        assert len(worker_errors) == 1
-        assert isinstance(worker_errors[0], StopException)
 
     def test_page_script_hash_to_script_path(self):
         scriptrunner = TestScriptRunner("good_navigation_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/test_data/coordinator_id_capture.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/test_data/coordinator_id_capture.py
@@ -1,0 +1,33 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Records each run's ParallelFragmentCoordinator id so the test can assert
+that ScriptRunContext.reset() builds a fresh one per script run.
+
+Calls ``st.rerun()`` exactly once so the script runs twice in a single
+``ScriptRunner.start()`` -> ``join()`` cycle (back-to-back
+``request_rerun`` calls get coalesced by ``ScriptRequests`` and only
+trigger one run)."""
+
+import streamlit as st
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    get_script_run_ctx,
+)
+
+ctx = get_script_run_ctx()
+st.session_state.setdefault("coordinator_ids", [])
+st.session_state["coordinator_ids"].append(id(ctx.parallel_coordinator))
+
+if len(st.session_state["coordinator_ids"]) == 1:
+    st.rerun()

--- a/lib/tests/streamlit/runtime/scriptrunner/test_data/rerun_once_then_finish.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/test_data/rerun_once_then_finish.py
@@ -1,0 +1,25 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calls ``st.rerun()`` exactly once. Used by the script runner integration
+test that asserts ``coordinator.drain()`` runs when a RerunException
+escapes from inside ``exec()``."""
+
+import streamlit as st
+
+st.session_state["run_count"] = st.session_state.get("run_count", 0) + 1
+if st.session_state["run_count"] == 1:
+    st.rerun()
+
+st.text("done")

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -23,7 +23,10 @@ import pytest
 from streamlit.errors import NoSessionContext
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
-from streamlit.runtime.fragment import MemoryFragmentStorage
+from streamlit.runtime.fragment import (
+    MemoryFragmentStorage,
+    ParallelFragmentCoordinator,
+)
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
@@ -345,6 +348,54 @@ class ScriptRunContextTest(unittest.TestCase):
         t.join()
 
         assert captured["fragment_id"] == "frag2"
+
+    def test_reset_raises_when_called_from_non_main_thread(self):
+        """``reset()`` may only be called from the script thread that
+        constructed the context. Worker threads (parallel fragments) must
+        not be able to mutate the context's coordinator out from under the
+        main thread."""
+        ctx = _create_script_run_context(lambda _msg: None)
+        captured: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                ctx.reset()
+            except RuntimeError as e:
+                captured.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert len(captured) == 1
+        assert "main script thread" in str(captured[0])
+
+    def test_reset_creates_fresh_coordinator_each_run(self):
+        """Each ``reset()`` constructs a new coordinator. Reusing one across
+        runs would let a previous run's stop event / worker exception leak
+        into the next run."""
+        pages_manager = PagesManager("/main/script/path")
+        pages_manager.set_pages({})
+        ctx = _create_script_run_context(lambda _msg: None, pages_manager=pages_manager)
+
+        ctx.reset(page_script_hash=pages_manager.main_script_hash)
+        first = ctx.parallel_coordinator
+        assert isinstance(first, ParallelFragmentCoordinator)
+
+        ctx.reset(page_script_hash=pages_manager.main_script_hash)
+        second = ctx.parallel_coordinator
+        assert isinstance(second, ParallelFragmentCoordinator)
+        assert first is not second
+
+    def test_reset_passes_yield_check_to_coordinator(self):
+        """The yield_check supplied to ``reset()`` is wired into the
+        coordinator so ``join()`` can drive the script runner's
+        execution-control hook."""
+        ctx = _create_script_run_context(lambda _msg: None)
+        calls: list[int] = []
+        ctx.reset(yield_check=lambda: calls.append(1))
+        assert ctx.parallel_coordinator is not None
+        ctx.parallel_coordinator._yield_check()
+        assert calls == [1]
 
     def test_add_script_run_ctx_propagates_thread_state_to_child(self):
         """Child threads observe the parent's ``FragmentThreadState``

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -23,12 +23,10 @@ import pytest
 from streamlit.errors import NoSessionContext
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
-from streamlit.runtime.fragment import (
-    MemoryFragmentStorage,
-    ParallelFragmentCoordinator,
-)
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     SCRIPT_RUN_CONTEXT_ATTR_NAME,
     ScriptRunContext,


### PR DESCRIPTION

## Describe your changes

Lands the coordinator + join-barrier infrastructure for parallel fragments. No fragment is dispatched yet — `join()` is a no-op because nothing calls `submit()` — so runtime behaviour is identical to develop, but every full-app run now owns a `ParallelFragmentCoordinator` and the script runner is wired to wait on outstanding worker fragments after `exec()`.

- New `ParallelFragmentCoordinator` in `lib/streamlit/runtime/fragment.py` owns a `ThreadPoolExecutor`, an outstanding-work counter, a stop event, and a first-writer-wins worker-exception slot.
- `ScriptRunContext` gains a `parallel_coordinator` field (constructed in `reset()`), a thread-identity guard in `__post_init__` + `reset()`, and a new `yield_check` parameter on `reset()`.
- `script_runner.py` passes `_maybe_handle_execution_control_request` as the yield check, calls `coordinator.join()` after `exec()`, and runs `coordinator.drain()` if `RerunException` / `StopException` escape from the exec/join pair. The yield-point hook now also re-raises any worker-stored exception (preserving original type + `RerunData`) on the script-thread branch and raises `StopException` on the worker-thread branch when `should_stop()` is set.
- New `runner.parallelMaxWorkers` config option (default `None` → Python's `ThreadPoolExecutor` default).

Stacked on `feature/parallel-fragments/fragment-thread-state` (#15072) via Graphite. Implementation plan: [pr6-parallel-fragment-coordinator.md](https://github.com/lawilby-orchestrator/dev-orchestrator/blob/main/projects/active/parallel-fragments/pr6-parallel-fragment-coordinator.md). Tech-spec reference: PR #14536 (`ParallelFragmentCoordinator` L96-182, execution flow L42-94, cooperative cancellation L267-403).

## Screenshot or video (only for visual changes)

n/a — no user-visible behaviour change.

## GitHub Issue Link (if applicable)

n/a — part of the parallel fragments stack (tracked in the linked tech spec).

## Testing Plan

- [x] Unit Tests (JS and/or Python) — 14 tests for `ParallelFragmentCoordinator` (construction, counter round-trip, idle/wait join, raise stored rerun/stop, first-writer-wins, drain silence + stop event, nested submit, yield-check propagation, args forwarding, post-drain join), 3 new `ScriptRunContext` tests (thread-guard, fresh-coordinator-per-run, yield_check wiring), 5 new `ScriptRunner` integration tests (fresh-per-run via `st.rerun()`, join called after exec, drain on `RerunException`, worker-thread yield-check no-op when idle, worker-thread yield-check raises `StopException` when `should_stop` is set).
- [ ] E2E Tests — none added; no user-facing behaviour change. End-to-end coverage will land with PR 7 (parallel dispatch).
- [ ] Any manual testing needed?


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
