### PR TITLE
[spec] Capture nested-in-parallel and container-proto invariants from prototype bugfixes

### DIFF
--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -483,6 +483,29 @@ thread's cursor, which advances it past the fragment's slot and creates a child
 immediately. The child cursor starts with
 `_owner_thread = None` — it hasn't been used yet.
 
+The pre-creation step **must** go through `st.container()` rather than a raw
+`Block_pb2()`. The frontend's `AppRoot.addBlock` reconciliation inherits the
+existing `BlockNode`'s children only when the incoming Block's `oneof type`
+matches the existing block's `oneof type`. The initial run produces this
+container from the main thread (R1) and the first fragment rerun produces it
+again from `wrapped_fragment` (R2); if their `oneof type` values differ — e.g.
+R1 emits an empty `Block` and R2 emits a `flex_container` — the frontend resets
+the children list to empty, every widget unmounts and remounts, and any user
+input landing in that window can be reverted by stale React state.
+
+The matching `wrapped_fragment` invocation on the worker thread must skip its
+own `st.container()` call so that R1 and R2 produce the same container delta at
+the same `delta_path`. This skip signal is **call-local to a single
+`wrapped_fragment` invocation**, not thread-local: dispatch stores the
+pre-allocated fragment's `fragment_id` in a field on `FragmentThreadState`
+(`pre_allocated_container_fragment_id`), and `wrapped_fragment` reads and
+clears it on entry, skipping its own `st.container()` only when the stored id
+matches the fragment currently being run. Any nested sequential `@st.fragment`
+invoked from inside the parallel fragment's body — running inline on the same
+worker thread — therefore observes `None` and creates its own container,
+preserving delta-path symmetry between its initial run and its subsequent
+rerun on the main thread.
+
 **3. Lazy thread ownership.** When the worker thread runs and calls `lock_element()`
 on the container's cursor for the first time, `_check_owner()` claims it — setting
 `_owner_ident` to the worker thread's ID via `threading.get_ident()`. The
@@ -878,6 +901,12 @@ class FragmentThreadState:
     in_fragment_callback: bool = False
     active_script_hash: str = ""
     is_parallel_worker: bool = False
+    # Fragment id whose container was just pre-allocated on this thread by
+    # ``_dispatch_parallel_fragment``. The matching ``wrapped_fragment`` reads
+    # and clears this on entry, so nested fragments do not inherit it and
+    # correctly create their own container. Call-local in spirit; cleared as
+    # soon as it is consumed.
+    pre_allocated_container_fragment_id: str | None = None
 ```
 
 This uses the same `ContextVar` + `copy_context()` mechanism already used for

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -484,27 +484,20 @@ immediately. The child cursor starts with
 `_owner_thread = None` — it hasn't been used yet.
 
 The pre-creation step **must** go through `st.container()` rather than a raw
-`Block_pb2()`. The frontend's `AppRoot.addBlock` reconciliation inherits the
-existing `BlockNode`'s children only when the incoming Block's `oneof type`
-matches the existing block's `oneof type`. The initial run produces this
-container from the main thread (R1) and the first fragment rerun produces it
-again from `wrapped_fragment` (R2); if their `oneof type` values differ — e.g.
-R1 emits an empty `Block` and R2 emits a `flex_container` — the frontend resets
-the children list to empty, every widget unmounts and remounts, and any user
-input landing in that window can be reverted by stale React state.
+`Block_pb2()`. The frontend's `addBlock` reconciliation preserves a
+`BlockNode`'s children only when the incoming Block's `oneof type` matches
+the existing one; a mismatch (e.g. empty `Block` vs `flex_container`) resets
+children, unmounts every widget, and can revert user input via stale React
+state. Using `st.container()` guarantees the main-thread delta (R1) and the
+worker-thread delta (R2) carry the same `oneof type`.
 
-The matching `wrapped_fragment` invocation on the worker thread must skip its
-own `st.container()` call so that R1 and R2 produce the same container delta at
-the same `delta_path`. This skip signal is **call-local to a single
-`wrapped_fragment` invocation**, not thread-local: dispatch stores the
-pre-allocated fragment's `fragment_id` in a field on `FragmentThreadState`
-(`pre_allocated_container_fragment_id`), and `wrapped_fragment` reads and
-clears it on entry, skipping its own `st.container()` only when the stored id
-matches the fragment currently being run. Any nested sequential `@st.fragment`
-invoked from inside the parallel fragment's body — running inline on the same
-worker thread — therefore observes `None` and creates its own container,
-preserving delta-path symmetry between its initial run and its subsequent
-rerun on the main thread.
+The worker's `wrapped_fragment` must therefore **skip** its own
+`st.container()` call so R1 and R2 produce identical container deltas at
+the same `delta_path`. The skip signal is **call-local**: dispatch stores the
+fragment id in `FragmentThreadState.pre_allocated_container_fragment_id`,
+and `wrapped_fragment` reads-and-clears it on entry. Nested sequential
+`@st.fragment` calls on the same worker thread see `None` and create their
+own containers normally.
 
 **3. Lazy thread ownership.** When the worker thread runs and calls `lock_element()`
 on the container's cursor for the first time, `_check_owner()` claims it — setting
@@ -901,11 +894,9 @@ class FragmentThreadState:
     in_fragment_callback: bool = False
     active_script_hash: str = ""
     is_parallel_worker: bool = False
-    # Fragment id whose container was just pre-allocated on this thread by
-    # ``_dispatch_parallel_fragment``. The matching ``wrapped_fragment`` reads
-    # and clears this on entry, so nested fragments do not inherit it and
-    # correctly create their own container. Call-local in spirit; cleared as
-    # soon as it is consumed.
+    # Signals ``wrapped_fragment`` to skip its own ``st.container()`` call
+    # because the container was already pre-allocated on the main thread.
+    # Read-and-cleared on entry so nested fragments are unaffected.
     pre_allocated_container_fragment_id: str | None = None
 ```
 

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -483,21 +483,15 @@ thread's cursor, which advances it past the fragment's slot and creates a child
 immediately. The child cursor starts with
 `_owner_thread = None` — it hasn't been used yet.
 
-The pre-creation step **must** go through `st.container()` rather than a raw
-`Block_pb2()`. The frontend's `addBlock` reconciliation preserves a
-`BlockNode`'s children only when the incoming Block's `oneof type` matches
-the existing one; a mismatch (e.g. empty `Block` vs `flex_container`) resets
-children, unmounts every widget, and can revert user input via stale React
-state. Using `st.container()` guarantees the main-thread delta (R1) and the
-worker-thread delta (R2) carry the same `oneof type`.
-
-The worker's `wrapped_fragment` must therefore **skip** its own
-`st.container()` call so R1 and R2 produce identical container deltas at
-the same `delta_path`. The skip signal is **call-local**: dispatch stores the
-fragment id in `FragmentThreadState.pre_allocated_container_fragment_id`,
-and `wrapped_fragment` reads-and-clears it on entry. Nested sequential
-`@st.fragment` calls on the same worker thread see `None` and create their
-own containers normally.
+The pre-creation step **must** use `st.container()` rather than a raw
+`Block_pb2()` — the frontend's `addBlock` reconciliation resets a
+`BlockNode`'s children when the incoming Block's `oneof type` changes,
+so the main-thread delta and worker-thread delta must carry the same type.
+To avoid a duplicate container delta, dispatch stores the fragment id in
+`FragmentThreadState.pre_allocated_container_fragment_id` and the worker's
+`wrapped_fragment` reads-and-clears it on entry, skipping its own
+`st.container()` call. Nested `@st.fragment` calls see `None` and create
+their containers normally.
 
 **3. Lazy thread ownership.** When the worker thread runs and calls `lock_element()`
 on the container's cursor for the first time, `_check_owner()` claims it — setting


### PR DESCRIPTION

## Describe your changes

Surgical additions to the parallel-fragments tech spec to capture two
invariants discovered while fixing bugs in the prototype branch
(`feature/parallel-fragments-prototype`) 

Two paragraphs and one dataclass field added under existing sections — no
restructuring.

Source bugfix: [a82085aa46](https://github.com/streamlit/streamlit/commit/a82085aa462c430e873fcd1e3ef7e963d314e862).

Source bugfix: [a46f5bc63a](https://github.com/streamlit/streamlit/commit/a46f5bc63ae6d67f01b80dedc833a0e05ff30888).

## Screenshot or video (only for visual changes)

N/A — spec-only change.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Explanation of why no additional tests are needed
- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

Spec-only PR, no code changes. The invariants are already verified by
existing prototype-branch tests
(`ParallelFragmentDispatchTest.test_pre_created_container_uses_flex_container_proto_type`
and the M9 nested-in-parallel demo repro), which will land with PRs 6/7/8/9.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
