### PR TITLE
[fix] Fix Vega-Lite chart tooltips in dialogs

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -14,6 +14,7 @@
 
 import time
 
+import altair as alt
 import numpy as np
 import pandas as pd
 
@@ -207,6 +208,33 @@ def dialog_with_chart() -> None:
 
 if st.button("Open Chart Dialog"):
     dialog_with_chart()
+
+
+@st.dialog("Dialog with layered chart")
+def dialog_with_layered_chart() -> None:
+    df = pd.DataFrame(
+        {
+            "x": list(range(1, 11)),
+            "y": list(range(5, 15)),
+            "y2": list(range(1, 11)),
+            "kpi": ["kpi1"] * 10,
+        }
+    )
+    chart1 = (
+        alt.Chart(df)
+        .mark_area()
+        .encode(x="x", y="y2", color="kpi", tooltip=["x", "y2"])
+    )
+    chart2 = (
+        alt.Chart(df)
+        .mark_line(point=alt.OverlayMarkDef(size=80))
+        .encode(x="x", y="y", color="kpi", tooltip=["x", "y"])
+    )
+    st.altair_chart(alt.layer(chart1, chart2).interactive())
+
+
+if st.button("Open Layered Chart Dialog"):
+    dialog_with_layered_chart()
 
 
 @st.dialog("Dialog with dataframe")

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -98,6 +98,10 @@ def open_dialog_with_chart(app: Page):
     click_button(app, "Open Chart Dialog")
 
 
+def open_dialog_with_layered_chart(app: Page):
+    click_button(app, "Open Layered Chart Dialog")
+
+
 def open_dialog_with_rerun(app: Page):
     click_button(app, "Open Dialog with rerun")
 
@@ -501,6 +505,31 @@ def test_dialog_with_chart(app: Page):
     chart_box = chart.bounding_box()
     assert chart_box is not None
     target: Position = {"x": chart_box["width"] * 0.5, "y": chart_box["height"] * 0.5}
+    app.mouse.move(chart_box["x"] + target["x"], chart_box["y"] + target["y"])
+    chart.hover(position=target)
+    tooltip = app.locator("#vg-tooltip-element")
+    expect(tooltip).to_be_visible()
+
+
+def test_dialog_with_layered_chart_shows_tooltips(app: Page):
+    """Check that layered Vega-Lite charts positioned in dialogs respond to hover events
+    on the lower layers and show the tooltip.
+    """
+    open_dialog_with_layered_chart(app)
+    main_dialog = app.get_by_test_id(modal_test_id)
+    expect(main_dialog).to_have_count(1)
+    expect(main_dialog).to_be_visible()
+
+    chart = main_dialog.get_by_test_id("stVegaLiteChart").locator(
+        "[role='graphics-document']"
+    )
+    expect(chart).to_be_visible()
+    wait_for_app_run(app)
+    chart.scroll_into_view_if_needed()
+    chart_box = chart.bounding_box()
+    assert chart_box is not None
+    # Hover in the lower-right of the chart where the area polygon is
+    target: Position = {"x": chart_box["width"] * 0.75, "y": chart_box["height"] * 0.75}
     app.mouse.move(chart_box["x"] + target["x"], chart_box["y"] + target["y"])
     chart.hover(position=target)
     tooltip = app.locator("#vg-tooltip-element")

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
@@ -182,6 +182,12 @@ export const StyledVegaLiteChartContainer =
           "&.fit-y": {
             height: "100%",
           },
+          // Reset pointer events on background/foreground SVG paths to display tooltips on all layers in dialogs.
+          "svg.marks g.role-scope": {
+            "path.background, path.foreground": {
+              pointerEvents: "auto",
+            },
+          },
         },
         summary: {
           position: "absolute",


### PR DESCRIPTION

## Describe your changes

Vega's SVG renderer creates invisible background/foreground helper paths for every scope group (layers, facets, etc.) that cover the full chart area.

Normally these paths don't receive pointer events because they have no fill or stroke. However, inside a `st.dialog`, the dialog wrapper gets the style `pointer-events: all`, which causes these background paths to intercept pointer events before they reach the underlying marks — silently breaking tooltips.

This fixes that behavior by explicitly resetting `pointer-events` on those paths to `auto`,
restoring the default browser behavior.

## GitHub Issue Link (if applicable)

- Closes: https://github.com/streamlit/streamlit/issues/12390

## Testing Plan


- [x] E2E tests for tooltip on layered vega-lite charts
- [x] Manual Testing — reproduce using the example in the linked issue: open a `st.dialog` containing an `st.vega_lite_chart` and verify both tooltips appear on hover.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
