### PR TITLE
Update license format in pyproject.toml

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -23,7 +23,7 @@ description = "A faster way to build and share data apps"
 # Note: README.md is in the repo root. The build process copies it to lib/
 # before building. See .github/workflows/release.yml.
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 authors = [{ name = "Snowflake Inc", email = "hello@streamlit.io" }]
 classifiers = [


### PR DESCRIPTION
Hi! I was building this application in FreeBSD ports tree and came across this issue

Currently, the `license` field in `pyproject.toml` is defined as a simple string:
`license = "Apache-2.0"`

And its causing build to fail in the FreeBSD Poudriere build system.

While some older package managers accept this, it seems it doesn't comply with PEP 621, which says that the `license` field must be a table containing either a `file` or `text` key. 

This makes it PEP-621 compliant without needing custom patches. 

This is the error:

```  
===>  Building for py311-streamlit-1.57.0_2
* Getting build dependencies for wheel...
/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:104: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']

DESCRIPTION:
    `Project license <https://www.python.org/dev/peps/pep-0621/#license>`_.

GIVEN VALUE:
    "Apache-2.0"

OFFENDING RULE: 'oneOf'

DEFINITION:
    {
        "oneOf": [
            {
                "properties": {
                    "file": {
                        "type": "string",
                        "$$description": [
                            "Relative path to the file (UTF-8) which contains the license for the",
                            "project."
                        ]
                    }
                },
                "required": [
                    "file"
                ]
            },
            {
                "properties": {
                    "text": {
                        "type": "string",
                        "$$description": [
                            "The license of the project whose meaning is that of the",
                            "`License field from the core metadata",
                            "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                        ]
                    }
                },
                "required": [
                    "text"
                ]
            }
        ]
    }
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
  File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
    return hook(config_settings)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/setuptools/build_meta.py", line 177, in get_requires_for_build_wheel
    return self._get_build_requires(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/setuptools/build_meta.py", line 159, in _get_build_requires
    self.run_setup()
  File "/usr/local/lib/python3.11/site-packages/setuptools/build_meta.py", line 174, in run_setup
    exec(compile(code, __file__, 'exec'), locals())
  File "setup.py", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 151, in setup
    dist.parse_config_files()
  File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 868, in parse_config_files
    pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
  File "/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 58, in apply_configuration
    config = read_configuration(filepath, True, ignore_option_errors, dist)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 122, in read_configuration
    validate(subset, filepath)
  File "/usr/local/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 47, in validate
    raise error from None
ValueError: invalid pyproject.toml config: `project.license`

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
*** Error code 1
```


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
