### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -5,6 +5,8 @@
 !.gitignore
 !hooks.json
 !worktrees.json
+!environment.json
+!Dockerfile
 
 # Allow specific commands
 !commands/

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,44 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:24.04
+
+ENV PYTHONUNBUFFERED=1
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    rsync \
+    unzip \
+    protobuf-compiler \
+    python3 \
+    python3-pip \
+    python3-venv \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 24
+RUN curl -sL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable corepack (for yarn)
+RUN corepack enable
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "make init"
+}

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -123,7 +123,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
 - **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
 - **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
-- **All make commands** must be run from the repo root (`/agent/repos/streamlit`).
+- **All make commands** must be run from the repo root.
 - **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
 - **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
 - For standard build/test/lint commands, see the `make` commands section above and the Makefile.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -121,8 +121,8 @@ Selection of `make` commands for development (run in the repo root):
 
 - **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
 - **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
-- **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
-- **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
+- **Python `tzdata` package**: If you encounter `ZoneInfoNotFoundError`, install `tzdata` with `uv pip install tzdata`.
+- **`python` command**: Some environments only provide `python3`. Prefer `python3` in commands, or create a local `python -> python3` shim if a tool requires `python`.
 - **All make commands** must be run from the repo root.
 - **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
 - **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -106,3 +106,24 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | How to start | Default port |
+|---------|-------------|-------------|
+| Streamlit backend | `uv run streamlit run <script.py> --server.headless=true` | 8501 |
+| Frontend dev server | `make frontend-dev` | 3000 |
+| Both (recommended) | `make debug <script.py>` | 3001 (frontend), 8501 (backend) |
+
+### Gotchas
+
+- **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
+- **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
+- **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
+- **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
+- **All make commands** must be run from the repo root (`/agent/repos/streamlit`).
+- **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
+- **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
+- For standard build/test/lint commands, see the `make` commands section above and the Makefile.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,8 +115,8 @@ Selection of `make` commands for development (run in the repo root):
 
 - **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
 - **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
-- **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
-- **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
+- **Python `tzdata` package**: If you encounter `ZoneInfoNotFoundError`, install `tzdata` with `uv pip install tzdata`.
+- **`python` command**: Some environments only provide `python3`. Prefer `python3` in commands, or create a local `python -> python3` shim if a tool requires `python`.
 - **All make commands** must be run from the repo root.
 - **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
 - **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -117,7 +117,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
 - **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
 - **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
-- **All make commands** must be run from the repo root (`/agent/repos/streamlit`).
+- **All make commands** must be run from the repo root.
 - **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
 - **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
 - For standard build/test/lint commands, see the `make` commands section above and the Makefile.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,3 +100,24 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | How to start | Default port |
+|---------|-------------|-------------|
+| Streamlit backend | `uv run streamlit run <script.py> --server.headless=true` | 8501 |
+| Frontend dev server | `make frontend-dev` | 3000 |
+| Both (recommended) | `make debug <script.py>` | 3001 (frontend), 8501 (backend) |
+
+### Gotchas
+
+- **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
+- **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
+- **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
+- **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
+- **All make commands** must be run from the repo root (`/agent/repos/streamlit`).
+- **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
+- **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
+- For standard build/test/lint commands, see the `make` commands section above and the Makefile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,24 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | How to start | Default port |
+|---------|-------------|-------------|
+| Streamlit backend | `uv run streamlit run <script.py> --server.headless=true` | 8501 |
+| Frontend dev server | `make frontend-dev` | 3000 |
+| Both (recommended) | `make debug <script.py>` | 3001 (frontend), 8501 (backend) |
+
+### Gotchas
+
+- **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
+- **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
+- **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
+- **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
+- **All make commands** must be run from the repo root (`/agent/repos/streamlit`).
+- **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
+- **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
+- For standard build/test/lint commands, see the `make` commands section above and the Makefile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,14 +33,14 @@
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
-- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
+- **Important:** Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.
 
 ## `make` commands
 
-Selection of `make` commands for development (run in the repo root):
+Selection of `make` commands for development (**Important: run from the repo root**):
 
 - `help`: Show all available make commands. [~1s]
 - `check`: Run all checks (format, lint, types, unit tests) on changed files only. Add `E2E_CHECK=true` to include E2E tests. [varies by changes]
@@ -101,6 +101,8 @@ Selection of `make` commands for development (run in the repo root):
 
 ## Cursor Cloud specific instructions
 
+The environment is configured via `.cursor/environment.json`, which installs system dependencies (Node.js 24, protoc, rsync) via a Dockerfile and runs `make init` to install all project dependencies.
+
 ### Services
 
 | Service | How to start | Default port |
@@ -109,13 +111,4 @@ Selection of `make` commands for development (run in the repo root):
 | Frontend dev server | `make frontend-dev` | 3000 |
 | Both (recommended) | `make debug <script.py>` | 3001 (frontend), 8501 (backend) |
 
-### Gotchas
-
-- **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
-- **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
-- **Python `tzdata` package**: If you encounter `ZoneInfoNotFoundError`, install `tzdata` with `uv pip install tzdata`.
-- **`python` command**: Some environments only provide `python3`. Prefer `python3` in commands, or create a local `python -> python3` shim if a tool requires `python`.
-- **All make commands** must be run from the repo root.
-- **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
-- **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
-- For standard build/test/lint commands, see the `make` commands section above and the Makefile.
+For standard build/test/lint commands, see the `make` commands section above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,8 @@ Selection of `make` commands for development (run in the repo root):
 
 - **ESLint cache staleness**: After installing frontend dependencies or building workspace packages, delete ESLint caches before running `make frontend-lint`: `find frontend -name ".eslintcache" -delete`. Stale caches can cause false `import-x/no-unresolved` errors for workspace packages like `@streamlit/utils`.
 - **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
-- **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
-- **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
+- **Python `tzdata` package**: If you encounter `ZoneInfoNotFoundError`, install `tzdata` with `uv pip install tzdata`.
+- **`python` command**: Some environments only provide `python3`. Prefer `python3` in commands, or create a local `python -> python3` shim if a tool requires `python`.
 - **All make commands** must be run from the repo root.
 - **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
 - **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Selection of `make` commands for development (run in the repo root):
 - **Workspace packages must be built before frontend lint**: The `connection` and other workspaces import `@streamlit/utils` which needs its `dist/` output. Run `cd frontend && yarn workspaces foreach --all --exclude @streamlit/app --exclude @streamlit/lib --topological --parallel run build` (or `make frontend-fast`) before `make frontend-lint`.
 - **Python `tzdata` package**: The VM may not have timezone data available to Python. The update script installs `tzdata` via `uv pip install tzdata` to prevent `ZoneInfoNotFoundError` in tests.
 - **`python` command**: The VM only has `python3` by default. The update script creates a symlink `python -> python3`.
-- **All make commands** must be run from the repo root (`/agent/repos/streamlit`).
+- **All make commands** must be run from the repo root.
 - **Pre-commit hooks** require `uv run git commit` / `uv run git push` so linters/formatters in the uv venv are available.
 - **E2E tests** require Playwright browsers: `uv run python -m playwright install --with-deps` (installed via `make python-init` by default).
 - For standard build/test/lint commands, see the `make` commands section above and the Makefile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ test = [
   # Used for memory tracking in E2E test statistics:
   "psutil>=5.9.0",
   "types-psutil>=5.9.0",
+  # Timezone data for Python (needed on minimal OS images without system tzdata):
+  "tzdata>=2024.1",
 ]
 
 # Integration test dependencies


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for this repo with proper system dependencies, project dependency installation, and agent instructions.

### Changes

1. **`pyproject.toml`**: Added `tzdata>=2024.1` as an explicit test dependency so timezone data is available on minimal OS images without system tzdata.

2. **`.cursor/environment.json` + `.cursor/Dockerfile`**: Cursor Cloud environment configuration that:
   - Installs system deps (Node.js 24, protoc, rsync, uv) via a Dockerfile -- mirroring the existing `.devcontainer/Dockerfile`
   - Runs `make init` as the install command (which does `python-init`, `frontend-init`, `protobuf`)
   - Updated `.cursor/.gitignore` to allow tracking these files

3. **`AGENTS.md`**:
   - Added **bold emphasis** to "run from repo root" and `uv run git` instructions to reduce agents missing them
   - Simplified Cursor Cloud section to just a service table and reference to existing `make` commands -- removed items that are redundant with existing docs or now handled by `make init` / `pyproject.toml`

### Screenshot of working dev environment

[Streamlit hello app running](https://cursor.com/agents/bc-e6718129-4258-4f00-8ea6-1859d521fb71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstreamlit_hello_app.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6718129-4258-4f00-8ea6-1859d521fb71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6718129-4258-4f00-8ea6-1859d521fb71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

