### PR TITLE
[chore] Revert AI PR review models to cheaper versions

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
         required: false
         type: string
-        default: "gpt-5.4-xhigh,gemini-3.1-pro,claude-opus-4-7-thinking-xhigh"
+        default: "gpt-5.3-codex-high,gemini-3.1-pro,claude-4.6-opus-high-thinking"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'gpt-5.4-xhigh,gemini-3.1-pro,claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,gemini-3.1-pro,claude-4.6-opus-high-thinking' }}
 
 jobs:
   # Job 1: Parse model list and check for API key
@@ -51,7 +51,7 @@ jobs:
           # Guard against empty/whitespace model input
           if [ -z "${MODEL// /}" ]; then
             echo "::error::MODEL is empty or whitespace-only. Using default."
-            MODEL="claude-opus-4-7-thinking-xhigh"
+            MODEL="claude-4.6-opus-high-thinking"
           fi
 
           # Split comma-separated, trim whitespace, convert to JSON array
@@ -62,7 +62,7 @@ jobs:
           MODEL_COUNT=$(echo "$MODELS_JSON" | jq 'length')
           if [ "$MODEL_COUNT" -eq 0 ]; then
             echo "::error::No valid models found after parsing. Using default."
-            MODELS_JSON='["claude-opus-4-7-thinking-xhigh"]'
+            MODELS_JSON='["claude-4.6-opus-high-thinking"]'
             MODEL_COUNT=1
           fi
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -14,12 +14,12 @@ on:
         description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
         required: false
         type: string
-        default: "gpt-5.3-codex-high,gemini-3.1-pro,claude-4.6-opus-high-thinking"
+        default: "gpt-5.3-codex-high,claude-4.6-opus-high-thinking"
 
 # Computed PR number and model for use in jobs
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,gemini-3.1-pro,claude-4.6-opus-high-thinking' }}
+  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking' }}
 
 jobs:
   # Job 1: Parse model list and check for API key


### PR DESCRIPTION
## Describe your changes

Reverts the AI PR review workflow to use cheaper model versions to reduce costs:

- `gpt-5.4-xhigh` → `gpt-5.3-codex-high`
- `claude-opus-4-7-thinking-xhigh` → `claude-4.6-opus-high-thinking`
- `gemini-3.1-pro` -> removed

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Workflow YAML syntax validated via `make check`
- No code changes, workflow execution will be validated on next AI review trigger

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->