### PR TITLE
[chore] Add repository variable for AI PR review models

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -11,15 +11,15 @@ on:
         required: true
         type: number
       model:
-        description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews."
+        description: "Model(s) to use for the review (comma-separated for multi-model). The last model serves as the 'judge' for consolidating reviews. Leave empty to use the repository default."
         required: false
         type: string
-        default: "gpt-5.3-codex-high,claude-4.6-opus-high-thinking"
 
 # Computed PR number and model for use in jobs
+# Model priority: manual input > repository variable (AI_PR_REVIEW_MODELS) > default
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking' }}
+  MODEL: ${{ github.event.inputs.model || vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking' }}
 
 jobs:
   # Job 1: Parse model list and check for API key


### PR DESCRIPTION
## Describe your changes

Adds support for configuring AI PR review models via the `AI_PR_REVIEW_MODELS` repository variable. This allows changing the default models without modifying the workflow file.

- Model priority: manual input > repository variable > hardcoded default
- Configure via Settings > Secrets and variables > Actions > Variables

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [ ] Workflow syntax validated by GitHub Actions on push

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->