### PR TITLE
[fix] Discover script-level .streamlit/config.toml when st.App runs under uvicorn

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -252,6 +252,14 @@ class App:
         This feature is experimental and may change or be removed in future
         versions without warning. Use at your own risk.
 
+    .. warning::
+        Hosting multiple ``App`` instances with different ``script_path`` values
+        in the same process is not supported. The first ``App`` constructed in a
+        process pins the script-level config directory (via the process-global
+        ``config._main_script_path``), and subsequent ``App`` instances will
+        resolve relative ``script_path`` values against that first directory
+        rather than the current working directory.
+
     This class provides a way to configure and run Streamlit applications
     with custom routes, middleware, lifespan hooks, and exception handlers.
 

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -423,6 +423,26 @@ class App:
         self._auto_started: bool = False
         self._startup_lock: asyncio.Lock | None = None
 
+        # Cache the resolved script path so _resolve_script_path() is idempotent
+        # even after we set config._main_script_path below. We initialize to
+        # None first so the inner _resolve_script_path() call falls through to
+        # the existing branches; the result is then cached for subsequent
+        # invocations.
+        self._resolved_script_path: Path | None = None
+        self._resolved_script_path = self._resolve_script_path()
+
+        # Mirror what `streamlit run` does in cli.py so the script-level
+        # `.streamlit/config.toml` is discoverable when st.App is launched
+        # directly via an external ASGI server (e.g. uvicorn) from a working
+        # directory that is not the script's directory. We assign here in
+        # __init__ (not in _combined_lifespan) because config.get_option() is
+        # read by _build_starlette_app -> create_streamlit_routes BEFORE the
+        # lifespan startup runs, which would otherwise cache a config_options
+        # dict that omits the script-level config. The guard preserves any
+        # value already set by `streamlit run`.
+        if config._main_script_path is None:
+            config._main_script_path = str(self._resolved_script_path)
+
         # Validate user routes don't conflict with reserved routes
         self._validate_routes()
 
@@ -484,10 +504,20 @@ class App:
         """Resolve the script path to an absolute path.
 
         Resolution order:
-        1. If already absolute, return as-is
-        2. If CLI set main_script_path (via `streamlit run`), resolve relative to it
-        3. Otherwise, resolve relative to current working directory (e.g. when started via uvicorn)
+        1. If `__init__` has already cached a resolved path, return it (so the
+           result remains stable even after config._main_script_path is set
+           by this App instance).
+        2. If already absolute, return as-is.
+        3. If CLI set main_script_path (via `streamlit run`), resolve relative to it.
+        4. Otherwise, resolve relative to current working directory (e.g. when
+           started via uvicorn).
         """
+        # Use getattr with a default so this method is safe to call from inside
+        # __init__ before self._resolved_script_path has been assigned.
+        cached: Path | None = getattr(self, "_resolved_script_path", None)
+        if cached is not None:
+            return cached
+
         if self._script_path.is_absolute():
             return self._script_path
 

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -440,6 +440,12 @@ class App:
         # lifespan startup runs, which would otherwise cache a config_options
         # dict that omits the script-level config. The guard preserves any
         # value already set by `streamlit run`.
+        #
+        # Note: `config._main_script_path` is process-global (like
+        # `config._config_options`), so the first `App` constructed in a
+        # process pins the script-level config directory. Hosting multiple
+        # `App` instances with different configs in one process is not
+        # supported and was not supported prior to this change.
         if config._main_script_path is None:
             config._main_script_path = str(self._resolved_script_path)
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -64,6 +64,24 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
 
+@pytest.fixture(autouse=True)
+def _reset_main_script_path_and_config_options() -> Iterator[None]:
+    """Snapshot and restore module-level config state between tests.
+
+    `App.__init__` now sets `config._main_script_path` (so script-level
+    `.streamlit/config.toml` is discoverable under direct uvicorn launches).
+    That mutation, plus the lazily cached `_config_options` dict that depends
+    on it, would leak across tests without this autouse reset.
+    """
+    from streamlit import config
+
+    original_main_script_path = config._main_script_path
+    original_config_options = config._config_options
+    yield
+    config._main_script_path = original_main_script_path
+    config._config_options = original_config_options
+
+
 class _DummyStatsManager:
     def __init__(self) -> None:
         self._stats: dict[str, list[CacheStat | CounterStat | GaugeStat]] = {
@@ -1636,6 +1654,147 @@ class TestAppScriptPathResolution:
         # Error message should include the path and be descriptive
         assert "does_not_exist.py" in str(exc_info.value)
         assert "not found" in str(exc_info.value).lower()
+
+    def test_init_sets_main_script_path_when_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App.__init__ sets config._main_script_path when it is unset.
+
+        This makes the script-level `.streamlit/config.toml` discoverable when
+        st.App is launched directly via an external ASGI server (regression
+        guard for issue #15215).
+        """
+        from streamlit import config
+
+        monkeypatch.setattr(config, "_main_script_path", None)
+
+        script = tmp_path / "app.py"
+        script.write_text("import streamlit as st\n")
+        monkeypatch.chdir(tmp_path)
+
+        App("app.py")
+
+        assert config._main_script_path == str(script.resolve())
+
+    def test_init_does_not_overwrite_main_script_path_when_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """App.__init__ must not clobber a value already set by `streamlit run`."""
+        from streamlit import config
+
+        cli_script = tmp_path / "cli_entry.py"
+        cli_script.touch()
+        monkeypatch.setattr(config, "_main_script_path", str(cli_script))
+
+        App("dashboard/app.py")
+
+        assert config._main_script_path == str(cli_script)
+
+    def test_init_caches_resolved_script_path_against_main_script_path_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cached _resolved_script_path keeps _resolve_script_path() stable.
+
+        After __init__ assigns config._main_script_path, a second call to
+        _resolve_script_path() must NOT re-route the relative path through the
+        CLI branch (which would mis-resolve `myapp/app.py` to
+        `<cwd>/myapp/myapp/app.py`).
+        """
+        from streamlit import config
+
+        monkeypatch.setattr(config, "_main_script_path", None)
+
+        project = tmp_path / "myproject"
+        myapp = project / "myapp"
+        myapp.mkdir(parents=True)
+        (myapp / "app.py").write_text("import streamlit as st\n")
+        monkeypatch.chdir(project)
+
+        app = App("myapp/app.py")
+
+        expected = (myapp / "app.py").resolve()
+        # Calling _resolve_script_path() again must return the original cached
+        # value, not a path with a duplicated `myapp/` segment.
+        assert app._resolve_script_path() == expected
+        assert app._resolve_script_path() == expected
+        # And the public script_path property still reflects the user input.
+        assert app.script_path == Path("myapp/app.py")
+
+
+class TestAppConfigDiscovery:
+    """Regression tests for issue #15215.
+
+    `st.App` launched directly via uvicorn (or another external ASGI server)
+    from a working directory that is not the script's directory must still
+    discover the script-level `.streamlit/config.toml`.
+    """
+
+    def test_script_level_config_discovered_with_relative_script_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reproduce issue #15215: cwd != script dir, relative script path."""
+        from streamlit import config
+
+        monkeypatch.setattr(config, "_main_script_path", None)
+        monkeypatch.setattr(config, "_config_options", None)
+
+        project = tmp_path / "myproject"
+        myapp = project / "myapp"
+        (myapp / ".streamlit").mkdir(parents=True)
+        (myapp / ".streamlit" / "config.toml").write_text(
+            '[theme]\nprimaryColor = "#ff0000"\n'
+        )
+        (myapp / "app.py").write_text("import streamlit as st\n")
+        monkeypatch.chdir(project)
+
+        App("myapp/app.py")
+        config.get_config_options(force_reparse=True)
+
+        assert config.get_option("theme.primaryColor") == "#ff0000"
+
+    def test_script_level_config_discovered_with_absolute_script_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same regression as #15215, but with an absolute script path."""
+        from streamlit import config
+
+        monkeypatch.setattr(config, "_main_script_path", None)
+        monkeypatch.setattr(config, "_config_options", None)
+
+        myapp = tmp_path / "myapp"
+        (myapp / ".streamlit").mkdir(parents=True)
+        (myapp / ".streamlit" / "config.toml").write_text(
+            '[theme]\nprimaryColor = "#00ff00"\n'
+        )
+        (myapp / "app.py").write_text("import streamlit as st\n")
+        monkeypatch.chdir(tmp_path)
+
+        App(str((myapp / "app.py").resolve()))
+        config.get_config_options(force_reparse=True)
+
+        assert config.get_option("theme.primaryColor") == "#00ff00"
+
+    def test_get_config_files_includes_script_level_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Anti-regression: `config.get_config_files` must include the
+        script-level config path after `App.__init__` runs."""
+        from streamlit import config
+
+        monkeypatch.setattr(config, "_main_script_path", None)
+
+        myapp = tmp_path / "myapp"
+        myapp.mkdir()
+        (myapp / "app.py").write_text("import streamlit as st\n")
+        monkeypatch.chdir(tmp_path)
+
+        App("myapp/app.py")
+
+        expected = file_util.get_main_script_streamlit_file_path(
+            str((myapp / "app.py").resolve()), "config.toml"
+        )
+        files = config.get_config_files("config.toml")
+        assert expected in files
 
 
 class TestAppExports:

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -1611,14 +1611,26 @@ class TestAppScriptPathResolution:
         resolved = app._resolve_script_path()
         assert resolved == script_path
 
-    def test_relative_path_is_resolved_to_cwd(self) -> None:
+    def test_relative_path_is_resolved_to_cwd(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that relative script paths are resolved relative to cwd."""
+        from streamlit import config
+
+        # Ensure _main_script_path is None at construction so __init__ takes
+        # the CWD branch. The autouse fixture restores state between tests but
+        # does not reset to None at start, so we pin it here for robustness
+        # against any cross-module test-order pollution.
+        monkeypatch.setattr(config, "_main_script_path", None)
+
         app = App("main.py")
-        # The relative path should be resolved to an absolute path
+        # The relative path should be resolved to an absolute path. Note that
+        # App.__init__ caches the resolved path and sets config._main_script_path
+        # as a side-effect, so this call returns the cached value computed via
+        # the CWD branch during __init__.
         resolved = app._resolve_script_path()
         assert resolved.is_absolute()
         assert resolved.name == "main.py"
-        # Without config._main_script_path set, should resolve relative to cwd
         assert resolved == (Path.cwd() / "main.py").resolve()
 
     def test_relative_path_uses_main_script_path_when_set(

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -21,6 +21,7 @@ from contextlib import asynccontextmanager
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import pytest
 from starlette.applications import Starlette
@@ -1748,7 +1749,12 @@ class TestAppConfigDiscovery:
         monkeypatch.chdir(project)
 
         App("myapp/app.py")
-        config.get_config_options(force_reparse=True)
+        # Stub out the config-parsed signal: any prior test that constructed
+        # an `AppSession` and registered file watchers leaves a strong
+        # reference on `_on_config_parsed`. Firing those receivers here would
+        # touch closed asyncio event loops from those defunct sessions.
+        with patch.object(config._on_config_parsed, "send"):
+            config.get_config_options(force_reparse=True)
 
         assert config.get_option("theme.primaryColor") == "#ff0000"
 
@@ -1770,7 +1776,9 @@ class TestAppConfigDiscovery:
         monkeypatch.chdir(tmp_path)
 
         App(str((myapp / "app.py").resolve()))
-        config.get_config_options(force_reparse=True)
+        # See note in the relative-path variant above.
+        with patch.object(config._on_config_parsed, "send"):
+            config.get_config_options(force_reparse=True)
 
         assert config.get_option("theme.primaryColor") == "#00ff00"
 


### PR DESCRIPTION
## Describe your changes

When `st.App` is launched directly via an external ASGI server (e.g. `uvicorn myapp.asgi:app`) from a working directory that is not the script's directory, the script-level `.streamlit/config.toml` was silently ignored. The same config worked correctly under `streamlit run` because `cli.py` sets `config._main_script_path` before any config load.

This PR makes `App.__init__` mirror that behavior: set `config._main_script_path = str(<resolved script path>)` (guarded by `if config._main_script_path is None` so we never clobber a value already set by `streamlit run`).

### Why `__init__` instead of `_combined_lifespan` (the submitter's proposal)

`App.__call__` calls `_build_starlette_app` → `create_streamlit_routes` _before_ the lifespan runs. That code path reads `config.get_option(...)` (e.g., `server.baseUrlPath`), which lazily parses and caches `_config_options` with `_main_script_path` still unset. Setting `_main_script_path` in the lifespan is therefore too late — the cached config dict already omits the script-level file. Setting it in `__init__` runs before any config read.

### Idempotency safeguard

Once `config._main_script_path` is set, a second call to `_resolve_script_path()` would re-route a relative input through the CLI branch (`Path(_main_script_path).parent / self._script_path`) and produce a path with a duplicated segment (e.g. `<cwd>/myapp/myapp/app.py`). To keep resolution stable, `__init__` caches the result on `self._resolved_script_path` and `_resolve_script_path()` short-circuits to it. The public `app.script_path` property still returns the user-supplied path.

## GitHub Issue Link (if applicable)

- Closes #15215

## Testing Plan

- Unit Tests (Python): added 6 tests in `lib/tests/streamlit/web/server/starlette/starlette_app_test.py`:
  - `test_init_sets_main_script_path_when_unset` — direct uvicorn launch sets `_main_script_path`.
  - `test_init_does_not_overwrite_main_script_path_when_set` — preserves a CLI-set value.
  - `test_init_caches_resolved_script_path_against_main_script_path_mutation` — `_resolve_script_path` stays idempotent.
  - `TestAppConfigDiscovery` (3 tests) — the script-level `config.toml` is discovered for both relative and absolute script paths, and the expected path appears in `config.get_config_files("config.toml")`.
- Added a module-level autouse fixture that snapshots & restores `config._main_script_path` and `config._config_options` between tests (since `App.__init__` now mutates that global).
- E2E Tests: not added. Bug is pure Python config wiring; the existing `e2e_playwright/asgi_app*` harness uses `streamlit run` (already works correctly), and reproducing #15215 requires direct uvicorn invocation from a different cwd. Unit coverage exercises the same code paths.
- Manual verification: ran `uvicorn myapp.asgi:app` from a project root different from the script dir and confirmed `st.get_option("theme.primaryColor")` returns the script-level value (was `None` without the fix).

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | finalizing-pr | 1 |
| skill | sharing-pr-agent-artifacts | 1 |
| subagent | Plan | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |

</details>
<!-- agent-metrics-end -->