### PR TITLE
[fix] SettingWithCopyWarning in st.map color column

### DIFF
--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -323,7 +323,7 @@ def to_deckgl_json(
             if c is not None
         ]
     )
-    df = df[used_columns]
+    df = df[used_columns].copy()
 
     converted_color_arg = _convert_color_arg_or_column(df, color_arg, color_col_name)
 
@@ -444,13 +444,10 @@ def _convert_color_arg_or_column(
     if color_col_name is not None:
         # Convert color column to the right format.
         if len(data[color_col_name]) > 0 and is_color_like(data[color_col_name].iat[0]):  # type: ignore[arg-type]
-            # Use .loc[] to avoid a SettingWithCopyWarning in some cases.
             # Convert to object dtype first to support tuple values (pandas 3.x infers
             # string columns as StringDtype which can't hold tuples).
             data[color_col_name] = data[color_col_name].astype(object)
-            data.loc[:, color_col_name] = data.loc[:, color_col_name].map(
-                to_int_color_tuple
-            )
+            data[color_col_name] = data[color_col_name].map(to_int_color_tuple)
         else:
             raise StreamlitAPIException(
                 f'Column "{color_col_name}" does not appear to contain valid colors.'

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import itertools
 import json
 import re
+import warnings
 from unittest import mock
 
 import numpy as np
@@ -278,6 +279,33 @@ class StMapTest(DeltaGeneratorTestCase):
         c = json.loads(self.get_delta_from_queue().new_element.deck_gl_json_chart.json)
         assert len(c.get("layers")[0].get("data")[0]) == 2
         assert len(df.columns) == 3
+
+    def test_no_setting_with_copy_warning_for_color_column(self):
+        """Test that no SettingWithCopyWarning is emitted when using a color column.
+
+        This is a regression test for the fix that ensures the internal DataFrame
+        subset is copied before mutating the color column.
+        """
+        df = pd.DataFrame(
+            {
+                "lat": [38.8762997, 38.8742997, 38.9025842],
+                "lon": [-77.0037, -77.0057, -77.0556545],
+                "color": ["#ff0000", "#00ff00", "#0000ff"],
+            }
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            st.map(df, color="color")
+            # Filter for SettingWithCopyWarning specifically
+            setting_warnings = [
+                warning
+                for warning in w
+                if "SettingWithCopyWarning" in str(warning.category.__name__)
+            ]
+            assert len(setting_warnings) == 0, (
+                f"Expected no SettingWithCopyWarning but got: {setting_warnings}"
+            )
 
     def test_default_map_copy(self):
         """Test that _DEFAULT_MAP is not modified as other work occurs."""


### PR DESCRIPTION
## Describe your changes

Fixes the pandas `SettingWithCopyWarning` that occurs when using `st.map` with a color column:

```
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead
```

**Root cause:** `df = df[used_columns]` created a view/slice rather than a copy. When `_convert_color_arg_or_column` modified this view, pandas issued the warning.

**Fix:**
- Added `.copy()` when creating the column subset: `df = df[used_columns].copy()`
- Simplified the color conversion code by removing the now-unnecessary `.loc[]` workaround

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Existing unit tests pass (38 tests in `map_test.py`)
- [x] `test_original_df_is_untouched` verifies the fix doesn't mutate user data

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | general-purpose | 2 |

</details>
<!-- agent-metrics-end -->