### PR TITLE
[chore] Fix pandas Timedelta 'd' deprecation warning

### DIFF
--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -509,7 +509,7 @@ class CacheDataAPI:
             - A number specifying the time in seconds.
             - A string specifying the time in a format supported by `Pandas's
               Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_,
-              e.g. ``"1d"``, ``"1.5 days"``, or ``"1h23s"``.
+              e.g. ``"1D"``, ``"1.5 days"``, or ``"1h23s"``.
             - A ``timedelta`` object from `Python's built-in datetime library
               <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_,
               e.g. ``timedelta(days=1)``.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -415,7 +415,7 @@ class CacheResourceAPI:
             - A number specifying the time in seconds.
             - A string specifying the time in a format supported by `Pandas's
               Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_,
-              e.g. ``"1d"``, ``"1.5 days"``, or ``"1h23s"``. Note that number strings
+              e.g. ``"1D"``, ``"1.5 days"``, or ``"1h23s"``. Note that number strings
               without units are treated by Pandas as nanoseconds.
             - A ``timedelta`` object from `Python's built-in datetime library
               <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_,

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -514,7 +514,7 @@ def fragment(
             - An ``int`` or ``float`` specifying the interval in seconds.
             - A string specifying the time in a format supported by `Pandas'
               Timedelta constructor <https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html>`_,
-              e.g. ``"1d"``, ``"1.5 days"``, or ``"1h23s"``.
+              e.g. ``"1D"``, ``"1.5 days"``, or ``"1h23s"``.
             - A ``timedelta`` object from `Python's built-in datetime library
               <https://docs.python.org/3/library/datetime.html#timedelta-objects>`_,
               e.g. ``timedelta(days=1)``.

--- a/lib/tests/streamlit/time_util_test.py
+++ b/lib/tests/streamlit/time_util_test.py
@@ -27,14 +27,14 @@ from streamlit.time_util import adjust_years, time_to_seconds
 TIME_STRING_TO_SECONDS_PARAMS = [
     ("float", 3.5, 3.5),
     ("timedelta", timedelta(minutes=3), 60 * 3),
-    ("str 1 arg", "1d", 24 * 60 * 60),
-    ("str 2 args", "1d23h", 24 * 60 * 60 + 23 * 60 * 60),
+    ("str 1 arg", "1D", 24 * 60 * 60),
+    ("str 2 args", "1D23h", 24 * 60 * 60 + 23 * 60 * 60),
     (
         "complex str 3 args",
         "1 day 23hr 45minutes",
         24 * 60 * 60 + 23 * 60 * 60 + 45 * 60,
     ),
-    ("str 2 args with float", "1.5d23.5h", 1.5 * 24 * 60 * 60 + 23.5 * 60 * 60),
+    ("str 2 args with float", "1.5D23.5h", 1.5 * 24 * 60 * 60 + 23.5 * 60 * 60),
 ]
 
 


### PR DESCRIPTION
## Describe your changes

Update lowercase `'d'` (days) to uppercase `'D'` in time string examples and tests to fix pandas 3.0+ deprecation warning:

> `'d' is deprecated and will be removed in a future version. Please use 'D' instead of 'd'.`

**Changes:**
- Updated test strings in `time_util_test.py`: `"1d"` → `"1D"`, `"1d23h"` → `"1D23h"`, `"1.5d23.5h"` → `"1.5D23.5h"`
- Updated docstring examples in `cache_data_api.py`, `cache_resource_api.py`, and `fragment.py`

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python) - existing `time_util_test.py` tests pass with updated strings
- No new tests needed; this is a string literal update to match pandas 3.0+ requirements

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->