### PR TITLE
[chore] Remove starlette from metrics attribution

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -207,7 +207,6 @@ _ATTRIBUTIONS_TO_CHECK: Final = [
     "snowflake",
     "pydantic",
     "fastapi",
-    "starlette",
     "playwright",
     "folium",
     "geopandas",


### PR DESCRIPTION
## Describe your changes

Removes `starlette` from the `_ATTRIBUTIONS_TO_CHECK` list in `metrics_util.py` since it's already a required Streamlit dependency (`starlette>=0.40.0` in `pyproject.toml`). Attribution tracking is meant for optional/third-party dependencies, not core requirements.

## Testing Plan

- No additional tests needed — existing `metrics_util_test.py` tests pass
- Change is internal telemetry only, no user-facing behavior affected

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->