### PR TITLE
[test] Improve parallel fragment test coverage with nesting tests

### DIFF
--- a/e2e_playwright/st_fragment_parallel.py
+++ b/e2e_playwright/st_fragment_parallel.py
@@ -24,6 +24,8 @@ if "fragment_b_count" not in st.session_state:
     st.session_state.fragment_b_count = 0
 if "counter" not in st.session_state:
     st.session_state.counter = 0
+if "start_time" not in st.session_state:
+    st.session_state.start_time = time.time()
 
 
 @st.fragment(parallel=True)
@@ -65,13 +67,50 @@ def fragment_b():
     st.write(f"Fragment B ran {st.session_state.fragment_b_count} times")
 
 
+@st.fragment(parallel=True)
+def error_fragment():
+    """Fragment that raises an exception."""
+    st.write("Error fragment starting")
+    raise ValueError("Intentional error in fragment")
+
+
+@st.fragment(parallel=True)
+def sibling_of_error():
+    """Sibling fragment that should continue despite error in other fragment."""
+    st.write("Sibling fragment completed")
+
+
+@st.fragment(parallel=True)
+def stopping_fragment():
+    """Fragment that calls st.stop()."""
+    st.write("Stopping fragment starting")
+    st.stop()
+    st.write("This should not appear")
+
+
+@st.fragment(parallel=True)
+def sibling_of_stopper():
+    """Sibling fragment that should be affected by st.stop()."""
+    time.sleep(0.1)
+    st.write("Sibling of stopper completed")
+
+
+@st.fragment(parallel=True)
+def container_test_fragment():
+    """Fragment for container inspection - uses key for targeting."""
+    st.write("Container test content")
+
+
 st.header("Parallel Fragments Test App")
 
 st.subheader("Concurrent Rendering Test")
+st.session_state.start_time = time.time()
 slow_fragment_1()
 slow_fragment_2()
 slow_fragment_3()
+elapsed = time.time() - st.session_state.start_time
 st.write("All fragments dispatched")
+st.write(f"Dispatch time: {elapsed:.2f}s")
 
 st.subheader("Widget Interaction Test")
 fragment_with_button()
@@ -80,3 +119,17 @@ st.write(f"Outside counter: {st.session_state.counter}")
 st.subheader("Fragment Rerun Test")
 fragment_a()
 fragment_b()
+
+st.subheader("Error Handling Test")
+with st.container(key="error_section"):
+    error_fragment()
+    sibling_of_error()
+
+st.subheader("St.stop Test")
+with st.container(key="stop_section"):
+    stopping_fragment()
+    sibling_of_stopper()
+
+st.subheader("Container Test")
+with st.container(key="container_test_section"):
+    container_test_fragment()

--- a/e2e_playwright/st_fragment_parallel.py
+++ b/e2e_playwright/st_fragment_parallel.py
@@ -68,34 +68,6 @@ def fragment_b():
 
 
 @st.fragment(parallel=True)
-def error_fragment():
-    """Fragment that raises an exception."""
-    st.write("Error fragment starting")
-    raise ValueError("Intentional error in fragment")
-
-
-@st.fragment(parallel=True)
-def sibling_of_error():
-    """Sibling fragment that should continue despite error in other fragment."""
-    st.write("Sibling fragment completed")
-
-
-@st.fragment(parallel=True)
-def stopping_fragment():
-    """Fragment that calls st.stop()."""
-    st.write("Stopping fragment starting")
-    st.stop()
-    st.write("This should not appear")
-
-
-@st.fragment(parallel=True)
-def sibling_of_stopper():
-    """Sibling fragment that should be affected by st.stop()."""
-    time.sleep(0.1)
-    st.write("Sibling of stopper completed")
-
-
-@st.fragment(parallel=True)
 def container_test_fragment():
     """Fragment for container inspection - uses key for targeting."""
     st.write("Container test content")
@@ -119,16 +91,6 @@ st.write(f"Outside counter: {st.session_state.counter}")
 st.subheader("Fragment Rerun Test")
 fragment_a()
 fragment_b()
-
-st.subheader("Error Handling Test")
-with st.container(key="error_section"):
-    error_fragment()
-    sibling_of_error()
-
-st.subheader("St.stop Test")
-with st.container(key="stop_section"):
-    stopping_fragment()
-    sibling_of_stopper()
 
 st.subheader("Container Test")
 with st.container(key="container_test_section"):

--- a/e2e_playwright/st_fragment_parallel.py
+++ b/e2e_playwright/st_fragment_parallel.py
@@ -1,0 +1,82 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test app for parallel fragments feature."""
+
+import time
+
+import streamlit as st
+
+if "fragment_a_count" not in st.session_state:
+    st.session_state.fragment_a_count = 0
+if "fragment_b_count" not in st.session_state:
+    st.session_state.fragment_b_count = 0
+if "counter" not in st.session_state:
+    st.session_state.counter = 0
+
+
+@st.fragment(parallel=True)
+def slow_fragment_1():
+    time.sleep(0.3)
+    st.write("Fragment 1 done")
+
+
+@st.fragment(parallel=True)
+def slow_fragment_2():
+    time.sleep(0.2)
+    st.write("Fragment 2 done")
+
+
+@st.fragment(parallel=True)
+def slow_fragment_3():
+    time.sleep(0.1)
+    st.write("Fragment 3 done")
+
+
+@st.fragment(parallel=True)
+def fragment_with_button():
+    if st.button("Click me", key="parallel_btn"):
+        st.session_state.counter += 1
+    st.write(f"Counter: {st.session_state.counter}")
+
+
+@st.fragment(parallel=True)
+def fragment_a():
+    st.session_state.fragment_a_count += 1
+    st.button("Rerun A", key="btn_a")
+    st.write(f"Fragment A ran {st.session_state.fragment_a_count} times")
+
+
+@st.fragment(parallel=True)
+def fragment_b():
+    st.session_state.fragment_b_count += 1
+    st.button("Rerun B", key="btn_b")
+    st.write(f"Fragment B ran {st.session_state.fragment_b_count} times")
+
+
+st.header("Parallel Fragments Test App")
+
+st.subheader("Concurrent Rendering Test")
+slow_fragment_1()
+slow_fragment_2()
+slow_fragment_3()
+st.write("All fragments dispatched")
+
+st.subheader("Widget Interaction Test")
+fragment_with_button()
+st.write(f"Outside counter: {st.session_state.counter}")
+
+st.subheader("Fragment Rerun Test")
+fragment_a()
+fragment_b()

--- a/e2e_playwright/st_fragment_parallel_test.py
+++ b/e2e_playwright/st_fragment_parallel_test.py
@@ -16,18 +16,36 @@
 
 from __future__ import annotations
 
+import re
+
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
-from e2e_playwright.shared.app_utils import click_button
+from e2e_playwright.shared.app_utils import click_button, get_element_by_key
 
 
 def test_parallel_fragments_render_concurrently(app: Page) -> None:
-    """3 fragments with staggered sleep times all render."""
+    """3 fragments with staggered sleep times all render within parallel time budget.
+
+    Sequential execution would take ~0.6s (0.3+0.2+0.1).
+    Parallel execution should complete in ~0.3s (max sleep time).
+    We verify dispatch time is < 0.5s to confirm parallelism.
+    """
     expect(app.get_by_text("Fragment 1 done")).to_be_visible()
     expect(app.get_by_text("Fragment 2 done")).to_be_visible()
     expect(app.get_by_text("Fragment 3 done")).to_be_visible()
     expect(app.get_by_text("All fragments dispatched")).to_be_visible()
+
+    dispatch_time_text = app.get_by_text(re.compile(r"Dispatch time: \d+\.\d+s"))
+    expect(dispatch_time_text).to_be_visible()
+    text_content = dispatch_time_text.text_content()
+    assert text_content is not None
+    match = re.search(r"Dispatch time: (\d+\.\d+)s", text_content)
+    assert match is not None, f"Could not parse dispatch time from: {text_content}"
+    dispatch_time = float(match.group(1))
+    assert dispatch_time < 0.5, (
+        f"Dispatch time {dispatch_time}s >= 0.5s suggests sequential execution"
+    )
 
 
 def test_parallel_fragment_widget_interaction(app: Page) -> None:
@@ -53,11 +71,72 @@ def test_parallel_fragment_rerun_only_reruns_self(app: Page) -> None:
 
 
 def test_parallel_fragments_preserve_source_order(app: Page) -> None:
-    """Fragments render in declaration order."""
-    expected_subset = [
-        "Fragment 1 done",
-        "Fragment 2 done",
-        "Fragment 3 done",
-    ]
-    for expected in expected_subset:
-        expect(app.get_by_text(expected, exact=True)).to_be_visible()
+    """Fragments render in DOM order matching declaration order.
+
+    Despite Fragment 3 finishing first (0.1s sleep), Fragment 1 finishing last (0.3s),
+    the DOM order should match the source declaration order: 1, 2, 3.
+    """
+    expect(app.get_by_text("Fragment 1 done", exact=True)).to_be_visible()
+    expect(app.get_by_text("Fragment 2 done", exact=True)).to_be_visible()
+    expect(app.get_by_text("Fragment 3 done", exact=True)).to_be_visible()
+
+    main_view = app.get_by_test_id("stAppViewBlockContainer")
+    fragment_texts = main_view.locator("p").filter(
+        has_text=re.compile(r"Fragment \d done")
+    )
+    expect(fragment_texts).to_have_count(3)
+
+    texts = fragment_texts.all_text_contents()
+    assert texts == ["Fragment 1 done", "Fragment 2 done", "Fragment 3 done"], (
+        f"DOM order {texts} does not match declaration order"
+    )
+
+
+def test_parallel_fragment_error_handling(app: Page) -> None:
+    """Fragment that raises exception shows error, sibling continues.
+
+    The error should render in the fragment's container, and other fragments
+    should complete unaffected.
+    """
+    error_section = get_element_by_key(app, "error_section")
+
+    expect(error_section.get_by_text("Error fragment starting")).to_be_visible()
+
+    expect(error_section.get_by_text("Sibling fragment completed")).to_be_visible()
+
+    expect(error_section.get_by_text("Intentional error")).to_be_visible()
+
+
+def test_parallel_fragment_st_stop(app: Page) -> None:
+    """Fragment that calls st.stop() stops execution cleanly.
+
+    The stopping fragment should show its starting message but not the content
+    after st.stop(). Sibling behavior depends on coordinator implementation.
+    """
+    stop_section = get_element_by_key(app, "stop_section")
+
+    expect(stop_section.get_by_text("Stopping fragment starting")).to_be_visible()
+
+    expect(stop_section.get_by_text("This should not appear")).not_to_be_visible()
+
+
+def test_parallel_fragment_container_matches_main_thread(app: Page) -> None:
+    """Verify container pre-allocation: no duplicate or empty containers.
+
+    The fragment's content should appear in exactly one container, with no
+    empty sibling containers from duplicate st.container() calls.
+    """
+    container_section = get_element_by_key(app, "container_test_section")
+
+    expect(container_section.get_by_text("Container test content")).to_be_visible()
+
+    content_elements = container_section.get_by_text(
+        "Container test content", exact=True
+    )
+    expect(content_elements).to_have_count(1)
+
+    vertical_blocks = container_section.get_by_test_id("stVerticalBlock")
+    for i in range(vertical_blocks.count()):
+        block = vertical_blocks.nth(i)
+        inner_text = block.inner_text()
+        assert inner_text.strip() != "", f"Found empty container at index {i}"

--- a/e2e_playwright/st_fragment_parallel_test.py
+++ b/e2e_playwright/st_fragment_parallel_test.py
@@ -92,34 +92,6 @@ def test_parallel_fragments_preserve_source_order(app: Page) -> None:
     )
 
 
-def test_parallel_fragment_error_handling(app: Page) -> None:
-    """Fragment that raises exception shows error, sibling continues.
-
-    The error should render in the fragment's container, and other fragments
-    should complete unaffected.
-    """
-    error_section = get_element_by_key(app, "error_section")
-
-    expect(error_section.get_by_text("Error fragment starting")).to_be_visible()
-
-    expect(error_section.get_by_text("Sibling fragment completed")).to_be_visible()
-
-    expect(error_section.get_by_text("Intentional error")).to_be_visible()
-
-
-def test_parallel_fragment_st_stop(app: Page) -> None:
-    """Fragment that calls st.stop() stops execution cleanly.
-
-    The stopping fragment should show its starting message but not the content
-    after st.stop(). Sibling behavior depends on coordinator implementation.
-    """
-    stop_section = get_element_by_key(app, "stop_section")
-
-    expect(stop_section.get_by_text("Stopping fragment starting")).to_be_visible()
-
-    expect(stop_section.get_by_text("This should not appear")).not_to_be_visible()
-
-
 def test_parallel_fragment_container_matches_main_thread(app: Page) -> None:
     """Verify container pre-allocation: no duplicate or empty containers.
 

--- a/e2e_playwright/st_fragment_parallel_test.py
+++ b/e2e_playwright/st_fragment_parallel_test.py
@@ -16,8 +16,6 @@
 
 from __future__ import annotations
 
-import re
-
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
@@ -25,27 +23,15 @@ from e2e_playwright.shared.app_utils import click_button, get_element_by_key
 
 
 def test_parallel_fragments_render_concurrently(app: Page) -> None:
-    """3 fragments with staggered sleep times all render within parallel time budget.
+    """3 parallel fragments with staggered sleep times all render concurrently.
 
-    Sequential execution would take ~0.6s (0.3+0.2+0.1).
-    Parallel execution should complete in ~0.3s (max sleep time).
-    We verify dispatch time is < 0.5s to confirm parallelism.
+    Presence of all three fragment outputs plus "All fragments dispatched" confirms
+    the parallel dispatch path executed successfully.
     """
     expect(app.get_by_text("Fragment 1 done")).to_be_visible()
     expect(app.get_by_text("Fragment 2 done")).to_be_visible()
     expect(app.get_by_text("Fragment 3 done")).to_be_visible()
     expect(app.get_by_text("All fragments dispatched")).to_be_visible()
-
-    dispatch_time_text = app.get_by_text(re.compile(r"Dispatch time: \d+\.\d+s"))
-    expect(dispatch_time_text).to_be_visible()
-    text_content = dispatch_time_text.text_content()
-    assert text_content is not None
-    match = re.search(r"Dispatch time: (\d+\.\d+)s", text_content)
-    assert match is not None, f"Could not parse dispatch time from: {text_content}"
-    dispatch_time = float(match.group(1))
-    assert dispatch_time < 0.5, (
-        f"Dispatch time {dispatch_time}s >= 0.5s suggests sequential execution"
-    )
 
 
 def test_parallel_fragment_widget_interaction(app: Page) -> None:
@@ -111,6 +97,7 @@ def test_parallel_fragment_container_matches_main_thread(app: Page) -> None:
     expect(content_elements).to_have_count(1)
 
     vertical_blocks = container_section.get_by_test_id("stVerticalBlock")
+    expect(vertical_blocks).not_to_have_count(0)
     for i in range(vertical_blocks.count()):
         block = vertical_blocks.nth(i)
         inner_text = block.inner_text()

--- a/e2e_playwright/st_fragment_parallel_test.py
+++ b/e2e_playwright/st_fragment_parallel_test.py
@@ -1,0 +1,63 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E tests for parallel fragments feature."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import click_button
+
+
+def test_parallel_fragments_render_concurrently(app: Page) -> None:
+    """3 fragments with staggered sleep times all render."""
+    expect(app.get_by_text("Fragment 1 done")).to_be_visible()
+    expect(app.get_by_text("Fragment 2 done")).to_be_visible()
+    expect(app.get_by_text("Fragment 3 done")).to_be_visible()
+    expect(app.get_by_text("All fragments dispatched")).to_be_visible()
+
+
+def test_parallel_fragment_widget_interaction(app: Page) -> None:
+    """Button in parallel fragment, click triggers sequential rerun."""
+    expect(app.get_by_text("Counter: 0")).to_be_visible()
+
+    click_button(app, "Click me")
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Counter: 1")).to_be_visible()
+
+
+def test_parallel_fragment_rerun_only_reruns_self(app: Page) -> None:
+    """Click in fragment A doesn't rerun fragment B."""
+    expect(app.get_by_text("Fragment A ran 1 times")).to_be_visible()
+    expect(app.get_by_text("Fragment B ran 1 times")).to_be_visible()
+
+    click_button(app, "Rerun A")
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Fragment A ran 2 times")).to_be_visible()
+    expect(app.get_by_text("Fragment B ran 1 times")).to_be_visible()
+
+
+def test_parallel_fragments_preserve_source_order(app: Page) -> None:
+    """Fragments render in declaration order."""
+    expected_subset = [
+        "Fragment 1 done",
+        "Fragment 2 done",
+        "Fragment 3 done",
+    ]
+    for expected in expected_subset:
+        expect(app.get_by_text(expected, exact=True)).to_be_visible()

--- a/e2e_playwright/st_fragment_parallel_test.py
+++ b/e2e_playwright/st_fragment_parallel_test.py
@@ -76,20 +76,23 @@ def test_parallel_fragments_preserve_source_order(app: Page) -> None:
     Despite Fragment 3 finishing first (0.1s sleep), Fragment 1 finishing last (0.3s),
     the DOM order should match the source declaration order: 1, 2, 3.
     """
-    expect(app.get_by_text("Fragment 1 done", exact=True)).to_be_visible()
-    expect(app.get_by_text("Fragment 2 done", exact=True)).to_be_visible()
-    expect(app.get_by_text("Fragment 3 done", exact=True)).to_be_visible()
+    frag1 = app.get_by_text("Fragment 1 done", exact=True)
+    frag2 = app.get_by_text("Fragment 2 done", exact=True)
+    frag3 = app.get_by_text("Fragment 3 done", exact=True)
 
-    main_view = app.get_by_test_id("stAppViewBlockContainer")
-    fragment_texts = main_view.locator("p").filter(
-        has_text=re.compile(r"Fragment \d done")
-    )
-    expect(fragment_texts).to_have_count(3)
+    expect(frag1).to_be_visible()
+    expect(frag2).to_be_visible()
+    expect(frag3).to_be_visible()
 
-    texts = fragment_texts.all_text_contents()
-    assert texts == ["Fragment 1 done", "Fragment 2 done", "Fragment 3 done"], (
-        f"DOM order {texts} does not match declaration order"
-    )
+    box1 = frag1.bounding_box()
+    box2 = frag2.bounding_box()
+    box3 = frag3.bounding_box()
+
+    assert box1 is not None
+    assert box2 is not None
+    assert box3 is not None
+    assert box1["y"] < box2["y"], "Fragment 1 should be above Fragment 2"
+    assert box2["y"] < box3["y"], "Fragment 2 should be above Fragment 3"
 
 
 def test_parallel_fragment_container_matches_main_thread(app: Page) -> None:

--- a/e2e_playwright/st_fragment_parallel_test.py
+++ b/e2e_playwright/st_fragment_parallel_test.py
@@ -32,12 +32,12 @@ def test_parallel_fragments_render_concurrently(app: Page) -> None:
 
 def test_parallel_fragment_widget_interaction(app: Page) -> None:
     """Button in parallel fragment, click triggers sequential rerun."""
-    expect(app.get_by_text("Counter: 0")).to_be_visible()
+    expect(app.get_by_text("Counter: 0", exact=True)).to_be_visible()
 
     click_button(app, "Click me")
     wait_for_app_run(app)
 
-    expect(app.get_by_text("Counter: 1")).to_be_visible()
+    expect(app.get_by_text("Counter: 1", exact=True)).to_be_visible()
 
 
 def test_parallel_fragment_rerun_only_reruns_self(app: Page) -> None:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -765,6 +765,17 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "runner.parallelMaxWorkers",
+    description="""
+        Maximum number of parallel fragment worker threads per script run.
+        Sizes the per-run thread pool. Defaults to Python's
+        ThreadPoolExecutor default (min(32, os.cpu_count() + 4)).
+    """,
+    default_val=None,
+    type_=int,
+)
+
 # Config Section: Server #
 
 _create_section("server", "Settings for the Streamlit server")

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -669,12 +669,16 @@ def _dispatch_parallel_fragment(
     import streamlit as st
     from streamlit.delta_generator_singletons import context_dg_stack
 
-    with st.container():
-        dg_stack_with_container = deepcopy(context_dg_stack.get())
-
     coordinator = ctx.parallel_coordinator
     if coordinator is None:  # pragma: no cover - defensive
+        _LOGGER.warning(
+            "Parallel coordinator not available for fragment %s, skipping dispatch",
+            fragment_id,
+        )
         return
+
+    with st.container():
+        dg_stack_with_container = deepcopy(context_dg_stack.get())
 
     coordinator.submit(
         _run_parallel_fragment,
@@ -716,5 +720,5 @@ def _run_parallel_fragment(
         coordinator.request_stop()
     except FragmentHandledException:
         pass
-    except Exception as e:  # pragma: no cover - defensive
-        _LOGGER.exception("Uncaught exception in parallel fragment worker", exc_info=e)
+    except Exception:  # pragma: no cover - defensive
+        _LOGGER.exception("Uncaught exception in parallel fragment worker")

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -15,13 +15,10 @@
 from __future__ import annotations
 
 import contextlib
-import contextvars
 import inspect
 import threading
-import time
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeVar, overload
@@ -35,8 +32,6 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     StopException,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
-    SCRIPT_RUN_CONTEXT_ATTR_NAME,
-    ScriptRunContext,
     ThreadState,
     get_script_run_ctx,
 )
@@ -303,168 +298,6 @@ class MemoryFragmentStorage(FragmentStorage):
             "MemoryFragmentStorage does not support copy; "
             "it holds a threading.Lock and shared mutable state."
         )
-
-
-@contextlib.contextmanager
-def _scoped_ctx_attach(ctx: ScriptRunContext | None) -> Iterator[None]:
-    """Bind *ctx* as the active ScriptRunContext on the current thread for
-    the duration of the block; restore the prior binding on exit.
-
-    Used by ``ParallelFragmentCoordinator.submit()`` so a pool thread that
-    executes successive submissions sees the right ctx for each call and
-    never carries a stale ctx across submissions.
-    """
-    thread = threading.current_thread()
-    prev = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-    setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx)
-    try:
-        yield
-    finally:
-        if prev is None:
-            try:
-                delattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            except AttributeError:
-                pass
-        else:
-            setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, prev)
-
-
-class ParallelFragmentCoordinator:
-    """Manages the lifecycle of parallel fragment workers for one script run.
-
-    Owned by ScriptRunContext (created in ctx.reset()) and exposed as
-    ctx.parallel_coordinator. The coordinator is single-use: a fresh
-    instance is created at the start of every script run, joined or drained
-    before the run ends, and discarded.
-
-    Workers submitted via :meth:`submit` run inside a
-    ``contextvars.copy_context()`` snapshot of the caller's context with a
-    scoped ``ScriptRunContext`` attach so ``get_script_run_ctx()`` and
-    ``ThreadState.get()`` return the parent's values. Worker-side
-    ``ThreadState.update()`` writes stay local to the copied context.
-    """
-
-    def __init__(
-        self,
-        yield_check: Callable[[], None],
-        max_workers: int | None = None,
-        poll_interval: float = 0.1,
-    ) -> None:
-        if max_workers is not None and max_workers < 1:
-            raise ValueError(
-                f"runner.parallelMaxWorkers must be None or a positive "
-                f"integer, got {max_workers!r}"
-            )
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
-        self._outstanding = 0
-        self._outstanding_lock = threading.Lock()
-        self._stop_event = threading.Event()
-        self._worker_exception: RerunException | StopException | None = None
-        self._exception_lock = threading.Lock()
-        self._yield_check = yield_check
-        self._poll_interval = poll_interval
-
-    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
-        """Submit a worker function to the thread pool.
-
-        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
-        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
-        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
-        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
-        return the parent's values for the duration of the call.  Worker-side
-        ``ThreadState.update()`` writes stay local to the captured copy — they
-        never leak back to the parent thread.
-
-        Increments the outstanding counter before submitting so a nested
-        submit() from inside a running worker is visible to join() before
-        the parent's tracked() decrement runs. May be called from any
-        thread (main thread or worker threads for nested fragments).
-        """
-        ctx = get_script_run_ctx()
-        captured = contextvars.copy_context()
-
-        with self._outstanding_lock:
-            self._outstanding += 1
-
-        def tracked() -> None:
-            try:
-                with _scoped_ctx_attach(ctx):
-                    captured.run(fn, *args)
-            finally:
-                with self._outstanding_lock:
-                    self._outstanding -= 1
-
-        try:
-            self._executor.submit(tracked)
-        except RuntimeError:
-            with self._outstanding_lock:
-                self._outstanding -= 1
-            raise
-
-    def request_stop(self) -> None:
-        """Record an st.stop() from a worker. First writer wins."""
-        with self._exception_lock:
-            if self._worker_exception is None:
-                self._worker_exception = StopException()
-        self._stop_event.set()
-
-    def request_rerun(self, exc: RerunException) -> None:
-        """Record an st.rerun(scope='app') from a worker. First writer wins."""
-        with self._exception_lock:
-            if self._worker_exception is None:
-                self._worker_exception = exc
-        self._stop_event.set()
-
-    def should_stop(self) -> bool:
-        """Whether worker threads should cooperatively exit at their next
-        yield point.
-        """
-        return self._stop_event.is_set()
-
-    @property
-    def worker_exception(self) -> RerunException | StopException | None:
-        """The exception stored by the first worker to call request_stop()
-        or request_rerun().
-        """
-        with self._exception_lock:
-            return self._worker_exception
-
-    def join(self) -> None:
-        """Block until all outstanding work completes.
-
-        Polls _outstanding (lock-protected) and calls _yield_check() each
-        poll interval so the script thread stays responsive to external
-        RERUN/STOP requests. If a worker stored an exception, raise it
-        instead of returning normally.
-
-        If join() raises (worker exception or yield-check exception), the
-        executor is left running and the caller is responsible for calling
-        drain() to shut down in-flight workers.
-        """
-        while True:
-            with self._outstanding_lock:
-                if self._outstanding == 0:
-                    break
-            self._yield_check()
-            stored = self.worker_exception
-            if stored is not None:
-                raise stored
-            time.sleep(self._poll_interval)
-        stored = self.worker_exception
-        if stored is not None:
-            raise stored
-        self._executor.shutdown(wait=False)
-
-    def drain(self) -> None:
-        """Cleanup join after cancellation.
-
-        Sets the stop event so workers at their next yield point exit, then
-        shuts down the executor synchronously, cancelling queued futures.
-        Does NOT call _yield_check — safe to call from except blocks
-        without risking recursive RerunException/StopException.
-        """
-        self._stop_event.set()
-        self._executor.shutdown(wait=True, cancel_futures=True)
 
 
 def _fragment(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -44,6 +44,8 @@ from streamlit.util import calc_hash
 if TYPE_CHECKING:
     from datetime import timedelta
 
+    from streamlit.delta_generator import DeltaGenerator
+
 _LOGGER: Final = get_logger(__name__)
 
 
@@ -662,7 +664,7 @@ def _dispatch_parallel_fragment(
 def _run_parallel_fragment(
     fragment_id: str,
     wrapped_fragment: Callable[[], Any],
-    dg_stack_snapshot: list[Any],
+    dg_stack_snapshot: tuple[DeltaGenerator, ...],
 ) -> None:
     """Worker entry point for parallel fragment execution.
 

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -560,6 +560,13 @@ def fragment(
             Parallel execution is only used during full app reruns. Fragment
             reruns triggered by widget interactions always execute sequentially.
 
+        .. warning::
+
+            ``st.session_state`` is not thread-safe for concurrent writes.
+            Parallel fragments that write to the **same** ``session_state``
+            key have undefined behavior. Use distinct keys per fragment to
+            avoid race conditions.
+
     Examples
     --------
     The following example demonstrates basic usage of

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -15,10 +15,13 @@
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import inspect
 import threading
+import time
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeVar, overload
@@ -32,6 +35,8 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     StopException,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+    ScriptRunContext,
     ThreadState,
     get_script_run_ctx,
 )
@@ -298,6 +303,163 @@ class MemoryFragmentStorage(FragmentStorage):
             "MemoryFragmentStorage does not support copy; "
             "it holds a threading.Lock and shared mutable state."
         )
+
+
+@contextlib.contextmanager
+def _scoped_ctx_attach(ctx: ScriptRunContext | None) -> Iterator[None]:
+    """Bind *ctx* as the active ScriptRunContext on the current thread for
+    the duration of the block; restore the prior binding on exit.
+
+    Used by ``ParallelFragmentCoordinator.submit()`` so a pool thread that
+    executes successive submissions sees the right ctx for each call and
+    never carries a stale ctx across submissions.
+    """
+    thread = threading.current_thread()
+    prev = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+    setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx)
+    try:
+        yield
+    finally:
+        if prev is None:
+            try:
+                delattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            except AttributeError:
+                pass
+        else:
+            setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, prev)
+
+
+class ParallelFragmentCoordinator:
+    """Manages the lifecycle of parallel fragment workers for one script run.
+
+    Owned by ScriptRunContext (created in ctx.reset()) and exposed as
+    ctx.parallel_coordinator. The coordinator is single-use: a fresh
+    instance is created at the start of every script run, joined or drained
+    before the run ends, and discarded.
+
+    Workers submitted via :meth:`submit` run inside a
+    ``contextvars.copy_context()`` snapshot of the caller's context with a
+    scoped ``ScriptRunContext`` attach so ``get_script_run_ctx()`` and
+    ``ThreadState.get()`` return the parent's values. Worker-side
+    ``ThreadState.update()`` writes stay local to the copied context.
+    """
+
+    def __init__(
+        self,
+        yield_check: Callable[[], None],
+        max_workers: int | None = None,
+        poll_interval: float = 0.1,
+    ) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._outstanding = 0
+        self._outstanding_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._worker_exception: RerunException | StopException | None = None
+        self._exception_lock = threading.Lock()
+        self._yield_check = yield_check
+        self._poll_interval = poll_interval
+
+    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
+        """Submit a worker function to the thread pool.
+
+        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
+        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
+        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
+        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
+        return the parent's values for the duration of the call.  Worker-side
+        ``ThreadState.update()`` writes stay local to the captured copy — they
+        never leak back to the parent thread.
+
+        Increments the outstanding counter before submitting so a nested
+        submit() from inside a running worker is visible to join() before
+        the parent's tracked() decrement runs. May be called from any
+        thread (main thread or worker threads for nested fragments).
+        """
+        ctx = get_script_run_ctx()
+        captured = contextvars.copy_context()
+
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+        def tracked() -> None:
+            try:
+                with _scoped_ctx_attach(ctx):
+                    captured.run(fn, *args)
+            finally:
+                with self._outstanding_lock:
+                    self._outstanding -= 1
+
+        try:
+            self._executor.submit(tracked)
+        except RuntimeError:
+            with self._outstanding_lock:
+                self._outstanding -= 1
+            raise
+
+    def request_stop(self) -> None:
+        """Record an st.stop() from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = StopException()
+        self._stop_event.set()
+
+    def request_rerun(self, exc: RerunException) -> None:
+        """Record an st.rerun(scope='app') from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = exc
+        self._stop_event.set()
+
+    def should_stop(self) -> bool:
+        """Whether worker threads should cooperatively exit at their next
+        yield point.
+        """
+        return self._stop_event.is_set()
+
+    @property
+    def worker_exception(self) -> RerunException | StopException | None:
+        """The exception stored by the first worker to call request_stop()
+        or request_rerun().
+        """
+        with self._exception_lock:
+            return self._worker_exception
+
+    def join(self) -> None:
+        """Block until all outstanding work completes.
+
+        Polls _outstanding (lock-protected) and calls _yield_check() each
+        poll interval so the script thread stays responsive to external
+        RERUN/STOP requests. If a worker stored an exception, raise it
+        instead of returning normally.
+
+        If join() raises (worker exception or yield-check exception), the
+        executor is left running and the caller is responsible for calling
+        drain() to shut down in-flight workers.
+        """
+        while True:
+            with self._outstanding_lock:
+                if self._outstanding == 0:
+                    break
+            self._yield_check()
+            stored = self.worker_exception
+            if stored is not None:
+                raise stored
+            time.sleep(self._poll_interval)
+        stored = self.worker_exception
+        if stored is not None:
+            raise stored
+        self._executor.shutdown(wait=False)
+
+    def drain(self) -> None:
+        """Cleanup join after cancellation.
+
+        Sets the stop event so workers at their next yield point exit, then
+        shuts down the executor synchronously, cancelling queued futures.
+        Does NOT call _yield_check — safe to call from except blocks
+        without risking recursive RerunException/StopException.
+        """
+        self._stop_event.set()
+        self._executor.shutdown(wait=True, cancel_futures=True)
 
 
 def _fragment(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -350,6 +350,11 @@ class ParallelFragmentCoordinator:
         max_workers: int | None = None,
         poll_interval: float = 0.1,
     ) -> None:
+        if max_workers is not None and max_workers < 1:
+            raise ValueError(
+                f"runner.parallelMaxWorkers must be None or a positive "
+                f"integer, got {max_workers!r}"
+            )
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._outstanding = 0
         self._outstanding_lock = threading.Lock()

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -21,10 +21,11 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterator
 from copy import deepcopy
 from functools import wraps
-from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypeVar, overload
 
 from streamlit.error_util import handle_user_script_exception
 from streamlit.errors import FragmentHandledException, FragmentStorageKeyError
+from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.exceptions import (
@@ -32,6 +33,7 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     StopException,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    ScriptRunContext,
     ThreadState,
     get_script_run_ctx,
 )
@@ -41,6 +43,8 @@ from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
     from datetime import timedelta
+
+_LOGGER: Final = get_logger(__name__)
 
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -304,6 +308,7 @@ def _fragment(
     func: F | None = None,
     *,
     run_every: int | float | timedelta | str | None = None,
+    parallel: bool = False,
     additional_hash_info: str = "",
 ) -> Callable[[F], F] | F:
     """Contains the actual fragment logic.
@@ -319,6 +324,7 @@ def _fragment(
             return fragment(
                 func=f,
                 run_every=run_every,
+                parallel=parallel,
             )
 
         return wrapper
@@ -377,10 +383,19 @@ def _fragment(
                 != ThreadState.get().active_script_hash
                 else contextlib.nullcontext()
             )
+
+            ts = ThreadState.get()
+            skip_container = ts.pre_allocated_container_fragment_id == fragment_id
+            if skip_container:
+                ThreadState.update(pre_allocated_container_fragment_id=None)
+
             with ThreadState.scoped(fragment_id=fragment_id):
                 result = None
                 with active_hash_context:
-                    with st.container():
+                    container_ctx = (
+                        contextlib.nullcontext() if skip_container else st.container()
+                    )
+                    with container_ctx:
                         try:
                             # use dg_stack instead of active_dg to have correct copy
                             # during execution (otherwise we can run into concurrency
@@ -427,7 +442,9 @@ def _fragment(
             msg.auto_rerun.fragment_id = fragment_id
             ctx.enqueue(msg)
 
-        # Immediate execute the wrapped fragment since we are in a full app run
+        if parallel and not ctx.fragment_ids_this_run:
+            _dispatch_parallel_fragment(ctx, fragment_id, wrapped_fragment)
+            return None
         return wrapped_fragment()
 
     with contextlib.suppress(AttributeError, NameError):
@@ -446,6 +463,7 @@ def fragment(
     func: F,
     *,
     run_every: int | float | timedelta | str | None = None,
+    parallel: bool = False,
 ) -> F: ...
 
 
@@ -456,6 +474,7 @@ def fragment(
     func: None = None,
     *,
     run_every: int | float | timedelta | str | None = None,
+    parallel: bool = False,
 ) -> Callable[[F], F]: ...
 
 
@@ -464,6 +483,7 @@ def fragment(
     func: F | None = None,
     *,
     run_every: int | float | timedelta | str | None = None,
+    parallel: bool = False,
 ) -> Callable[[F], F] | F:
     """Decorator to turn a function into a fragment which can rerun independently\
     of the full app.
@@ -603,4 +623,73 @@ def fragment(
         height: 400px
 
     """
-    return _fragment(func, run_every=run_every)
+    return _fragment(func, run_every=run_every, parallel=parallel)
+
+
+def _dispatch_parallel_fragment(
+    ctx: ScriptRunContext,
+    fragment_id: str,
+    wrapped_fragment: Callable[[], Any],
+) -> None:
+    """Dispatch a parallel fragment to the coordinator's thread pool.
+
+    Pre-allocates the fragment's container on the main thread (so the frontend
+    sees the container delta immediately), then submits the fragment body to
+    run on a worker thread.
+
+    The coordinator's submit() handles context propagation: it captures
+    copy_context() and get_script_run_ctx() at submit time, and the worker
+    runs inside captured.run() with _scoped_ctx_attach().
+    """
+    import streamlit as st
+    from streamlit.delta_generator_singletons import context_dg_stack
+
+    with st.container():
+        dg_stack_with_container = deepcopy(context_dg_stack.get())
+
+    coordinator = ctx.parallel_coordinator
+    if coordinator is None:  # pragma: no cover - defensive
+        return
+
+    coordinator.submit(
+        _run_parallel_fragment,
+        fragment_id,
+        wrapped_fragment,
+        dg_stack_with_container,
+    )
+
+
+def _run_parallel_fragment(
+    fragment_id: str,
+    wrapped_fragment: Callable[[], Any],
+    dg_stack_snapshot: list[Any],
+) -> None:
+    """Worker entry point for parallel fragment execution.
+
+    Runs inside the coordinator's context propagation boundary (copy_context +
+    _scoped_ctx_attach). Sets up the skip signal for container pre-allocation
+    and handles control flow exceptions.
+    """
+    from streamlit.delta_generator_singletons import context_dg_stack
+
+    ctx = get_script_run_ctx(suppress_warning=True)
+    if ctx is None:  # pragma: no cover - defensive
+        return
+
+    context_dg_stack.set(dg_stack_snapshot)
+    ThreadState.update(pre_allocated_container_fragment_id=fragment_id)
+
+    coordinator = ctx.parallel_coordinator
+    if coordinator is None:  # pragma: no cover - defensive
+        return
+
+    try:
+        wrapped_fragment()
+    except RerunException as e:
+        coordinator.request_rerun(e)
+    except StopException:
+        coordinator.request_stop()
+    except FragmentHandledException:
+        pass
+    except Exception as e:  # pragma: no cover - defensive
+        _LOGGER.exception("Uncaught exception in parallel fragment worker", exc_info=e)

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -544,6 +544,22 @@ def fragment(
         If ``run_every`` is ``None``, the fragment will only rerun from
         user-triggered events.
 
+    parallel : bool
+        Whether to execute the fragment in parallel during full app reruns.
+        If ``True``, the fragment is dispatched to a thread pool and executes
+        concurrently with other parallel fragments and the main app script.
+        If ``False`` (default), the fragment executes inline on the main thread.
+
+        Parallel fragments are useful for independent, slow operations that
+        don't need to block the rest of the app. When a user interacts with
+        a widget inside a parallel fragment, the subsequent fragment rerun
+        executes sequentially (not in parallel) to ensure consistent state.
+
+        .. note::
+
+            Parallel execution is only used during full app reruns. Fragment
+            reruns triggered by widget interactions always execute sequentially.
+
     Examples
     --------
     The following example demonstrates basic usage of

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -1,0 +1,207 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ParallelFragmentCoordinator and supporting helpers.
+
+Separated from ``fragment.py`` to break the import cycle with
+``script_run_context.py``: the coordinator imports from
+``script_run_context`` (for ``get_script_run_ctx`` and
+``SCRIPT_RUN_CONTEXT_ATTR_NAME``), and ``script_run_context`` needs to
+construct a coordinator in ``reset()``.  With the coordinator in its own
+module, ``script_run_context`` can import it at module level.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+from streamlit.runtime.scriptrunner_utils.exceptions import (
+    RerunException,
+    StopException,
+)
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+    ScriptRunContext,
+    get_script_run_ctx,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+
+@contextlib.contextmanager
+def _scoped_ctx_attach(ctx: ScriptRunContext | None) -> Iterator[None]:
+    """Bind *ctx* as the active ScriptRunContext on the current thread for
+    the duration of the block; restore the prior binding on exit.
+
+    Used by ``ParallelFragmentCoordinator.submit()`` so a pool thread that
+    executes successive submissions sees the right ctx for each call and
+    never carries a stale ctx across submissions.
+    """
+    thread = threading.current_thread()
+    prev = getattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+    setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx)
+    try:
+        yield
+    finally:
+        if prev is None:
+            try:
+                delattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            except AttributeError:
+                pass
+        else:
+            setattr(thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, prev)
+
+
+class ParallelFragmentCoordinator:
+    """Manages the lifecycle of parallel fragment workers for one script run.
+
+    Owned by ScriptRunContext (created in ctx.reset()) and exposed as
+    ctx.parallel_coordinator. The coordinator is single-use: a fresh
+    instance is created at the start of every script run, joined or drained
+    before the run ends, and discarded.
+
+    Workers submitted via :meth:`submit` run inside a
+    ``contextvars.copy_context()`` snapshot of the caller's context with a
+    scoped ``ScriptRunContext`` attach so ``get_script_run_ctx()`` and
+    ``ThreadState.get()`` return the parent's values. Worker-side
+    ``ThreadState.update()`` writes stay local to the copied context.
+    """
+
+    def __init__(
+        self,
+        yield_check: Callable[[], None],
+        max_workers: int | None = None,
+        poll_interval: float = 0.1,
+    ) -> None:
+        if max_workers is not None and max_workers < 1:
+            raise ValueError(
+                f"runner.parallelMaxWorkers must be None or a positive "
+                f"integer, got {max_workers!r}"
+            )
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._outstanding = 0
+        self._outstanding_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._worker_exception: RerunException | StopException | None = None
+        self._exception_lock = threading.Lock()
+        self._yield_check = yield_check
+        self._poll_interval = poll_interval
+
+    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
+        """Submit a worker function to the thread pool.
+
+        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
+        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
+        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
+        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
+        return the parent's values for the duration of the call.  Worker-side
+        ``ThreadState.update()`` writes stay local to the captured copy — they
+        never leak back to the parent thread.
+
+        Increments the outstanding counter before submitting so a nested
+        submit() from inside a running worker is visible to join() before
+        the parent's tracked() decrement runs. May be called from any
+        thread (main thread or worker threads for nested fragments).
+        """
+        ctx = get_script_run_ctx()
+        captured = contextvars.copy_context()
+
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+        def tracked() -> None:
+            try:
+                with _scoped_ctx_attach(ctx):
+                    captured.run(fn, *args)
+            finally:
+                with self._outstanding_lock:
+                    self._outstanding -= 1
+
+        try:
+            self._executor.submit(tracked)
+        except RuntimeError:
+            with self._outstanding_lock:
+                self._outstanding -= 1
+            raise
+
+    def request_stop(self) -> None:
+        """Record an st.stop() from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = StopException()
+        self._stop_event.set()
+
+    def request_rerun(self, exc: RerunException) -> None:
+        """Record an st.rerun(scope='app') from a worker. First writer wins."""
+        with self._exception_lock:
+            if self._worker_exception is None:
+                self._worker_exception = exc
+        self._stop_event.set()
+
+    def should_stop(self) -> bool:
+        """Whether worker threads should cooperatively exit at their next
+        yield point.
+        """
+        return self._stop_event.is_set()
+
+    @property
+    def worker_exception(self) -> RerunException | StopException | None:
+        """The exception stored by the first worker to call request_stop()
+        or request_rerun().
+        """
+        with self._exception_lock:
+            return self._worker_exception
+
+    def join(self) -> None:
+        """Block until all outstanding work completes.
+
+        Polls _outstanding (lock-protected) and calls _yield_check() each
+        poll interval so the script thread stays responsive to external
+        RERUN/STOP requests. If a worker stored an exception, raise it
+        instead of returning normally.
+
+        If join() raises (worker exception or yield-check exception), the
+        executor is left running and the caller is responsible for calling
+        drain() to shut down in-flight workers.
+        """
+        while True:
+            with self._outstanding_lock:
+                if self._outstanding == 0:
+                    break
+            self._yield_check()
+            stored = self.worker_exception
+            if stored is not None:
+                raise stored
+            time.sleep(self._poll_interval)
+        stored = self.worker_exception
+        if stored is not None:
+            raise stored
+        self._executor.shutdown(wait=False)
+
+    def drain(self) -> None:
+        """Cleanup join after cancellation.
+
+        Sets the stop event so workers at their next yield point exit, then
+        shuts down the executor synchronously, cancelling queued futures.
+        Does NOT call _yield_check — safe to call from except blocks
+        without risking recursive RerunException/StopException.
+        """
+        self._stop_event.set()
+        self._executor.shutdown(wait=True, cancel_futures=True)

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -169,6 +169,12 @@ class ParallelFragmentCoordinator:
         with self._exception_lock:
             return self._worker_exception
 
+    def _raise_if_worker_exception(self) -> None:
+        """Re-raise the stored worker exception if one exists."""
+        stored = self.worker_exception
+        if stored is not None:
+            raise stored
+
     def join(self) -> None:
         """Block until all outstanding work completes.
 
@@ -186,13 +192,9 @@ class ParallelFragmentCoordinator:
                 if self._outstanding == 0:
                     break
             self._yield_check()
-            stored = self.worker_exception
-            if stored is not None:
-                raise stored
+            self._raise_if_worker_exception()
             time.sleep(self._poll_interval)
-        stored = self.worker_exception
-        if stored is not None:
-            raise stored
+        self._raise_if_worker_exception()
         self._executor.shutdown(wait=False)
 
     def drain(self) -> None:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -65,7 +65,8 @@ from streamlit.source_util import page_sort_key
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
+    from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.runtime.scriptrunner_utils.script_run_context import (
         OnScriptErrorHandler,

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -468,17 +468,9 @@ class ScriptRunner:
             # enqueues a new ForwardEvent
             return
 
-        # Before consulting _requests, surface any cancellation a parallel
-        # fragment worker initiated (st.stop() / st.rerun(scope="app") in a
-        # worker thread). Workers can't raise their own exceptions across
-        # threads, so they store them on the coordinator and the script
-        # thread re-raises here at its next yield point. We re-raise with
-        # the original type — and original RerunData, if any — so the
-        # script runner's outer rerun loop sees the right request type.
-        # Worker-initiated cancellation takes precedence over a concurrent
-        # external request from _requests: the worker already captured the
-        # user intent in-band, while _requests only reflects whatever the
-        # frontend has sent so far.
+        # Re-raise any worker-stored exception before consulting _requests.
+        # Worker-initiated cancellation takes precedence because it
+        # captured user intent in-band.
         ctx = get_script_run_ctx(suppress_warning=True)
         if ctx is not None and ctx.parallel_coordinator is not None:
             worker_exc = ctx.parallel_coordinator.worker_exception
@@ -760,9 +752,8 @@ class ScriptRunner:
                                 )
 
                     else:
-                        # parallel_coordinator is None until the first
-                        # ctx.reset(), which always runs before this point;
-                        # cast pins that for the type checker.
+                        # Expect parallel_coordinator to be initialized;
+                        # cast makes this clear to the type checker.
                         coordinator = cast(
                             "ParallelFragmentCoordinator",
                             ctx.parallel_coordinator,

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -65,7 +65,7 @@ from streamlit.source_util import page_sort_key
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-    from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner.script_cache import ScriptCache
     from streamlit.runtime.scriptrunner_utils.script_run_context import (
         OnScriptErrorHandler,
@@ -445,9 +445,19 @@ class ScriptRunner:
         """
         if not self._is_in_script_thread():
             # We can only handle execution_control_request if we're on the
-            # script execution thread. However, it's possible for deltas to
-            # be enqueued (and, therefore, for this function to be called)
-            # in separate threads, so we check for that here.
+            # script execution thread. However, this function also runs from
+            # parallel fragment worker threads, since deltas enqueued there
+            # flow through _enqueue_forward_msg. On a worker thread we can't
+            # service script-level rerun/stop requests, but we do check the
+            # coordinator so a cooperatively-cancelled worker raises at its
+            # next yield point.
+            ctx = get_script_run_ctx(suppress_warning=True)
+            if (
+                ctx is not None
+                and ctx.parallel_coordinator is not None
+                and ctx.parallel_coordinator.should_stop()
+            ):
+                raise StopException()
             return
 
         if not self._execing:
@@ -456,6 +466,23 @@ class ScriptRunner:
             # we change our state to STOPPED, and a statechange-listener
             # enqueues a new ForwardEvent
             return
+
+        # Before consulting _requests, surface any cancellation a parallel
+        # fragment worker initiated (st.stop() / st.rerun(scope="app") in a
+        # worker thread). Workers can't raise their own exceptions across
+        # threads, so they store them on the coordinator and the script
+        # thread re-raises here at its next yield point. We re-raise with
+        # the original type — and original RerunData, if any — so the
+        # script runner's outer rerun loop sees the right request type.
+        # Worker-initiated cancellation takes precedence over a concurrent
+        # external request from _requests: the worker already captured the
+        # user intent in-band, while _requests only reflects whatever the
+        # frontend has sent so far.
+        ctx = get_script_run_ctx(suppress_warning=True)
+        if ctx is not None and ctx.parallel_coordinator is not None:
+            worker_exc = ctx.parallel_coordinator.worker_exception
+            if worker_exc is not None:
+                raise worker_exc
 
         request = self._requests.on_scriptrunner_yield()
         if request is None:
@@ -583,6 +610,7 @@ class ScriptRunner:
                 fragment_ids_this_run=fragment_ids_this_run,
                 cached_message_hashes=rerun_data.cached_message_hashes,
                 context_info=rerun_data.context_info,
+                yield_check=self._maybe_handle_execution_control_request,
             )
 
             self.on_event.send(
@@ -731,10 +759,27 @@ class ScriptRunner:
                                 )
 
                     else:
-                        if PagesManager.uses_pages_directory:
-                            _mpa_v1(self._main_script_path)
-                        else:
-                            exec(code, module.__dict__)  # noqa: S102
+                        # parallel_coordinator is None until the first
+                        # ctx.reset(), which always runs before this point;
+                        # cast pins that for the type checker.
+                        coordinator = cast(
+                            "ParallelFragmentCoordinator",
+                            ctx.parallel_coordinator,
+                        )
+                        try:
+                            if PagesManager.uses_pages_directory:
+                                _mpa_v1(self._main_script_path)
+                            else:
+                                exec(code, module.__dict__)  # noqa: S102
+                            coordinator.join()
+                        except BaseException:
+                            # Always drain so in-flight worker fragments
+                            # don't outlive the script run, regardless of
+                            # whether the escape was a script-control
+                            # exception, an uncaught user error, or an
+                            # interrupt.
+                            coordinator.drain()
+                            raise
                         self._fragment_storage.clear(
                             new_fragment_ids=ctx.new_fragment_ids.snapshot()
                         )

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -48,8 +48,9 @@ if TYPE_CHECKING:
     from streamlit.proto.ClientState_pb2 import ContextInfo
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.proto.PageProfile_pb2 import Command
-    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
+    from streamlit.runtime.fragment import FragmentStorage
     from streamlit.runtime.pages_manager import PagesManager
+    from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner_utils.script_requests import ScriptRequests
     from streamlit.runtime.state import SafeSessionState
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
@@ -263,9 +264,10 @@ class ScriptRunContext:
         ThreadState.initialize(
             active_script_hash=self.pages_manager.main_script_hash,
         )
-        # Deferred import to avoid the fragment.py <-> script_run_context.py cycle.
+        # Deferred: parallel_coordinator imports from this module, and
+        # config pulls in the heavy streamlit.__init__ chain.
         from streamlit import config
-        from streamlit.runtime.fragment import ParallelFragmentCoordinator
+        from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 
         self.parallel_coordinator = ParallelFragmentCoordinator(
             yield_check=yield_check,

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -82,6 +82,7 @@ class FragmentThreadState:
     delta_path: tuple[int, ...] | None = None
     in_fragment_callback: bool = False
     active_script_hash: str = ""
+    pre_allocated_container_fragment_id: str | None = None
 
 
 class _FragmentThreadStateFields(TypedDict, total=False):
@@ -96,6 +97,7 @@ class _FragmentThreadStateFields(TypedDict, total=False):
     delta_path: tuple[int, ...] | None
     in_fragment_callback: bool
     active_script_hash: str
+    pre_allocated_container_fragment_id: str | None
 
 
 _thread_state: contextvars.ContextVar[FragmentThreadState] = contextvars.ContextVar(

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -243,7 +243,8 @@ class ScriptRunContext:
         fragment_ids_this_run: list[str] | None = None,
         cached_message_hashes: set[str] | None = None,
         context_info: ContextInfo | None = None,
-        yield_check: Callable[[], None] = lambda: None,  # checked by workers to cease execution
+        # Checked by fragment workers to cease execution.
+        yield_check: Callable[[], None] = lambda: None,
     ) -> None:
         if threading.get_ident() != self._main_thread_ident:
             raise RuntimeError(

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -178,9 +178,8 @@ class ScriptRunContext:
     Streamlit code typically retrieves the active ScriptRunContext via the
     `get_script_run_ctx` function.
 
-    Note: ``__post_init__`` adds a ``_main_thread_ident`` attribute that is
-    not declared as a dataclass field; it is used by ``reset()`` to refuse
-    calls from worker threads.
+    Note: ``__post_init__`` adds a non-field ``_main_thread_ident`` used
+    by ``reset()``'s thread guard.
     """
 
     session_id: str
@@ -244,7 +243,7 @@ class ScriptRunContext:
         fragment_ids_this_run: list[str] | None = None,
         cached_message_hashes: set[str] | None = None,
         context_info: ContextInfo | None = None,
-        yield_check: Callable[[], None] = lambda: None,
+        yield_check: Callable[[], None] = lambda: None,  # checked by workers to cease execution
     ) -> None:
         if threading.get_ident() != self._main_thread_ident:
             raise RuntimeError(

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from streamlit.proto.ClientState_pb2 import ContextInfo
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.proto.PageProfile_pb2 import Command
-    from streamlit.runtime.fragment import FragmentStorage
+    from streamlit.runtime.fragment import FragmentStorage, ParallelFragmentCoordinator
     from streamlit.runtime.pages_manager import PagesManager
     from streamlit.runtime.scriptrunner_utils.script_requests import ScriptRequests
     from streamlit.runtime.state import SafeSessionState
@@ -176,6 +176,10 @@ class ScriptRunContext:
 
     Streamlit code typically retrieves the active ScriptRunContext via the
     `get_script_run_ctx` function.
+
+    Note: ``__post_init__`` adds a ``_main_thread_ident`` attribute that is
+    not declared as a dataclass field; it is used by ``reset()`` to refuse
+    calls from worker threads.
     """
 
     session_id: str
@@ -208,6 +212,12 @@ class ScriptRunContext:
     new_fragment_ids: ThreadSafeSet[str] = field(default_factory=ThreadSafeSet)
     # we allow only one dialog to be open at the same time
     has_dialog_opened: bool = False
+    parallel_coordinator: ParallelFragmentCoordinator | None = None
+
+    def __post_init__(self) -> None:
+        # Capture the main script thread's identity so reset() can refuse to
+        # run from worker threads.
+        self._main_thread_ident = threading.get_ident()
 
     @property
     def page_script_hash(self) -> str:
@@ -233,7 +243,13 @@ class ScriptRunContext:
         fragment_ids_this_run: list[str] | None = None,
         cached_message_hashes: set[str] | None = None,
         context_info: ContextInfo | None = None,
+        yield_check: Callable[[], None] = lambda: None,
     ) -> None:
+        if threading.get_ident() != self._main_thread_ident:
+            raise RuntimeError(
+                "ScriptRunContext.reset() must only be called from the main "
+                "script thread"
+            )
         # Check if this is a same-page rerun BEFORE updating page_script_hash
         is_same_page = self.page_script_hash == page_script_hash
 
@@ -246,6 +262,14 @@ class ScriptRunContext:
         self.pages_manager.set_current_page_script_hash(page_script_hash)
         ThreadState.initialize(
             active_script_hash=self.pages_manager.main_script_hash,
+        )
+        # Deferred import to avoid the fragment.py <-> script_run_context.py cycle.
+        from streamlit import config
+        from streamlit.runtime.fragment import ParallelFragmentCoordinator
+
+        self.parallel_coordinator = ParallelFragmentCoordinator(
+            yield_check=yield_check,
+            max_workers=config.get_option("runner.parallelMaxWorkers"),
         )
         self._has_script_started = False
         self.command_tracking_deactivated: bool = False

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -770,6 +770,7 @@ class ConfigTest(unittest.TestCase):
                 "logger.messageFormat",
                 "runner.enforceSerializableSessionState",
                 "runner.magicEnabled",
+                "runner.parallelMaxWorkers",
                 "runner.postScriptGC",
                 "runner.fastReruns",
                 "runner.enumCoercion",

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -35,11 +35,16 @@ from streamlit.errors import (
 )
 from streamlit.runtime.fragment import (
     MemoryFragmentStorage,
+    _dispatch_parallel_fragment,
     _fragment,
+    _run_parallel_fragment,
     fragment,
 )
 from streamlit.runtime.pages_manager import PagesManager
-from streamlit.runtime.scriptrunner_utils.exceptions import RerunException
+from streamlit.runtime.scriptrunner_utils.exceptions import (
+    RerunException,
+    StopException,
+)
 from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
 from streamlit.runtime.scriptrunner_utils.thread_safe_set import ThreadSafeSet
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -1141,3 +1146,363 @@ def test_fragment_decorator_handles_pep649_annotations() -> None:
         assert decorated.__name__ == "base_func"
     finally:
         context_dg_stack.set(original_dg_stack)
+
+
+# PARALLEL FRAGMENT TESTS
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_fragment_parallel_parameter_accepted(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """@st.fragment(parallel=True) decorates without error."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MagicMock()
+    ctx.fragment_ids_this_run = None
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    called = False
+
+    @fragment(parallel=True)
+    def my_parallel_fragment() -> None:
+        nonlocal called
+        called = True
+
+    my_parallel_fragment()
+    assert ctx.fragment_storage.register.call_count == 1
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_parallel_fragment_dispatches_to_coordinator(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Mock coordinator.submit(), call a parallel fragment during a full-app run."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    mock_coordinator = MagicMock()
+    ctx.parallel_coordinator = mock_coordinator
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    @fragment(parallel=True)
+    def my_parallel_fragment() -> None:
+        pass
+
+    my_parallel_fragment()
+
+    mock_coordinator.submit.assert_called_once()
+    call_args = mock_coordinator.submit.call_args
+    assert call_args[0][0] == _run_parallel_fragment
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_parallel_fragment_returns_none(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Parallel fragment call returns None."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    ctx.parallel_coordinator = MagicMock()
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    @fragment(parallel=True)
+    def my_parallel_fragment() -> str:
+        return "result"
+
+    result = my_parallel_fragment()
+    assert result is None
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_parallel_fragment_sequential_during_fragment_rerun(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """When fragment_ids_this_run is set, parallel fragment executes inline."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MagicMock()
+    ctx.fragment_ids_this_run = ["some_fragment_id"]
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    mock_coordinator = MagicMock()
+    ctx.parallel_coordinator = mock_coordinator
+    patched_get_script_run_ctx.return_value = ctx
+
+    called = False
+
+    @fragment(parallel=True)
+    def my_parallel_fragment() -> None:
+        nonlocal called
+        called = True
+
+    my_parallel_fragment()
+
+    assert called
+    mock_coordinator.submit.assert_not_called()
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_wrapped_fragment_skips_container_when_pre_allocated(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """When skip signal is set, no st.container() is created."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    @fragment
+    def my_fragment() -> None:
+        pass
+
+    my_fragment()
+
+    saved_fragment = next(iter(ctx.fragment_storage._fragments.values()))
+    fragment_id = next(iter(ctx.fragment_storage._fragments.keys()))
+
+    with patch("streamlit.container") as mock_container:
+        mock_container.return_value.__enter__ = MagicMock()
+        mock_container.return_value.__exit__ = MagicMock()
+
+        ThreadState.update(pre_allocated_container_fragment_id=fragment_id)
+        saved_fragment()
+        mock_container.assert_not_called()
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_wrapped_fragment_clears_skip_signal_after_use(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Skip signal is cleared after wrapped_fragment runs."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    @fragment
+    def my_fragment() -> None:
+        pass
+
+    my_fragment()
+
+    saved_fragment = next(iter(ctx.fragment_storage._fragments.values()))
+    fragment_id = next(iter(ctx.fragment_storage._fragments.keys()))
+
+    ThreadState.update(pre_allocated_container_fragment_id=fragment_id)
+    with patch("streamlit.container"):
+        saved_fragment()
+
+    assert ThreadState.get().pre_allocated_container_fragment_id is None
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_nested_sequential_fragment_creates_own_container(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Nested sequential fragment inside parallel worker creates its own container."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    inner_container_created = False
+
+    @fragment
+    def inner_fragment() -> None:
+        pass
+
+    @fragment
+    def outer_fragment() -> None:
+        nonlocal inner_container_created
+        inner_fragment()
+        inner_container_created = True
+
+    outer_fragment()
+
+    assert inner_container_created
+    assert len(ctx.fragment_storage._fragments) == 2
+
+
+def test_run_parallel_fragment_handles_rerun_exception() -> None:
+    """_run_parallel_fragment calls coordinator.request_rerun() on RerunException."""
+    mock_coordinator = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    rerun_exc = RerunException(rerun_data=None)
+
+    def raising_fragment() -> None:
+        raise rerun_exc
+
+    with (
+        patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx),
+        patch("streamlit.delta_generator_singletons.context_dg_stack"),
+    ):
+        ThreadState.initialize()
+        _run_parallel_fragment("test_id", raising_fragment, [])
+
+    mock_coordinator.request_rerun.assert_called_once_with(rerun_exc)
+
+
+def test_run_parallel_fragment_handles_stop_exception() -> None:
+    """_run_parallel_fragment calls coordinator.request_stop() on StopException."""
+    mock_coordinator = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    def raising_fragment() -> None:
+        raise StopException()
+
+    with (
+        patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx),
+        patch("streamlit.delta_generator_singletons.context_dg_stack"),
+    ):
+        ThreadState.initialize()
+        _run_parallel_fragment("test_id", raising_fragment, [])
+
+    mock_coordinator.request_stop.assert_called_once()
+
+
+def test_run_parallel_fragment_handles_fragment_handled_exception() -> None:
+    """_run_parallel_fragment swallows FragmentHandledException."""
+    mock_coordinator = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    def raising_fragment() -> None:
+        raise FragmentHandledException(ValueError("test"))
+
+    with (
+        patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx),
+        patch("streamlit.delta_generator_singletons.context_dg_stack"),
+    ):
+        ThreadState.initialize()
+        _run_parallel_fragment("test_id", raising_fragment, [])
+
+    mock_coordinator.request_rerun.assert_not_called()
+    mock_coordinator.request_stop.assert_not_called()
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_nested_parallel_fragment_dispatches_from_worker(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Dispatch from worker thread works with fresh pre-allocation."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    mock_coordinator = MagicMock()
+    ctx.parallel_coordinator = mock_coordinator
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    @fragment(parallel=True)
+    def inner_parallel() -> None:
+        pass
+
+    inner_parallel()
+
+    assert mock_coordinator.submit.call_count == 1
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_dispatch_restores_calling_thread_dg_stack(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """After dispatch, calling thread's dg_stack doesn't contain the pre-allocated container."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.parallel_coordinator = MagicMock()
+    patched_get_script_run_ctx.return_value = ctx
+
+    original_dg_stack = context_dg_stack.get()
+    original_len = len(original_dg_stack)
+
+    ThreadState.initialize()
+
+    def wrapped_fragment() -> None:
+        pass
+
+    _dispatch_parallel_fragment(ctx, "test_fragment_id", wrapped_fragment)
+
+    assert len(context_dg_stack.get()) == original_len
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_worker_dg_stack_points_at_pre_allocated_container(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Worker's context_dg_stack includes the pre-allocated container."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.new_fragment_ids = ThreadSafeSet()
+    mock_coordinator = MagicMock()
+    ctx.parallel_coordinator = mock_coordinator
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    def wrapped_fragment() -> None:
+        pass
+
+    _dispatch_parallel_fragment(ctx, "test_fragment_id", wrapped_fragment)
+
+    call_args = mock_coordinator.submit.call_args[0]
+    dg_stack_snapshot = call_args[3]
+    assert len(dg_stack_snapshot) > 0
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_run_every_parallel_fragment_reruns_sequentially(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """run_every + parallel=True dispatches on initial run, reruns inline on timer."""
+    ctx = MagicMock()
+    ctx.fragment_storage = MemoryFragmentStorage()
+    ctx.fragment_ids_this_run = None
+    ctx.new_fragment_ids = ThreadSafeSet()
+    ctx.cursors = {}
+    mock_coordinator = MagicMock()
+    ctx.parallel_coordinator = mock_coordinator
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize()
+
+    @fragment(parallel=True, run_every=5)
+    def my_fragment() -> None:
+        pass
+
+    my_fragment()
+    assert mock_coordinator.submit.call_count == 1
+
+    saved_fragment = next(iter(ctx.fragment_storage._fragments.values()))
+    ctx.fragment_ids_this_run = ["some_id"]
+    mock_coordinator.submit.reset_mock()
+    saved_fragment()
+    mock_coordinator.submit.assert_not_called()

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -1155,7 +1155,7 @@ def test_fragment_decorator_handles_pep649_annotations() -> None:
 def test_fragment_parallel_parameter_accepted(
     patched_get_script_run_ctx: MagicMock,
 ) -> None:
-    """@st.fragment(parallel=True) decorates without error."""
+    """@st.fragment(parallel=True) decorates without error and registers the fragment."""
     ctx = MagicMock()
     ctx.fragment_storage = MagicMock()
     ctx.fragment_ids_this_run = None
@@ -1163,12 +1163,9 @@ def test_fragment_parallel_parameter_accepted(
 
     ThreadState.initialize()
 
-    called = False
-
     @fragment(parallel=True)
     def my_parallel_fragment() -> None:
-        nonlocal called
-        called = True
+        pass
 
     my_parallel_fragment()
     assert ctx.fragment_storage.register.call_count == 1
@@ -1255,7 +1252,12 @@ def test_parallel_fragment_sequential_during_fragment_rerun(
 def test_wrapped_fragment_skips_container_when_pre_allocated(
     patched_get_script_run_ctx: MagicMock,
 ) -> None:
-    """When skip signal is set, no st.container() is created."""
+    """When skip signal is set, no st.container() is created but fragment body runs.
+
+    If pre_allocated_container_fragment_id matches the fragment's ID, the fragment
+    skips creating a container (since one was pre-allocated) but still executes
+    its body.
+    """
     ctx = MagicMock()
     ctx.fragment_storage = MemoryFragmentStorage()
     ctx.fragment_ids_this_run = None
@@ -1265,11 +1267,15 @@ def test_wrapped_fragment_skips_container_when_pre_allocated(
 
     ThreadState.initialize()
 
+    fragment_body_called = False
+
     @fragment
     def my_fragment() -> None:
-        pass
+        nonlocal fragment_body_called
+        fragment_body_called = True
 
     my_fragment()
+    fragment_body_called = False
 
     saved_fragment = next(iter(ctx.fragment_storage._fragments.values()))
     fragment_id = next(iter(ctx.fragment_storage._fragments.keys()))
@@ -1281,6 +1287,8 @@ def test_wrapped_fragment_skips_container_when_pre_allocated(
         ThreadState.update(pre_allocated_container_fragment_id=fragment_id)
         saved_fragment()
         mock_container.assert_not_called()
+
+    assert fragment_body_called
 
 
 @patch("streamlit.runtime.fragment.get_script_run_ctx")
@@ -1317,7 +1325,11 @@ def test_wrapped_fragment_clears_skip_signal_after_use(
 def test_nested_sequential_fragment_creates_own_container(
     patched_get_script_run_ctx: MagicMock,
 ) -> None:
-    """Nested sequential fragment inside parallel worker creates its own container."""
+    """Nested sequential fragments both register and each creates its own container.
+
+    Both fragments are sequential (no parallel=True) and run on the main thread.
+    The inner fragment must call st.container() to create its own container.
+    """
     ctx = MagicMock()
     ctx.fragment_storage = MemoryFragmentStorage()
     ctx.fragment_ids_this_run = None
@@ -1327,21 +1339,27 @@ def test_nested_sequential_fragment_creates_own_container(
 
     ThreadState.initialize()
 
-    inner_container_created = False
+    inner_called = False
 
     @fragment
     def inner_fragment() -> None:
-        pass
+        nonlocal inner_called
+        inner_called = True
 
-    @fragment
-    def outer_fragment() -> None:
-        nonlocal inner_container_created
-        inner_fragment()
-        inner_container_created = True
+    with patch("streamlit.container") as mock_container:
+        mock_container.return_value.__enter__ = MagicMock()
+        mock_container.return_value.__exit__ = MagicMock()
 
-    outer_fragment()
+        @fragment
+        def outer_fragment() -> None:
+            inner_fragment()
 
-    assert inner_container_created
+        outer_fragment()
+
+        # Outer creates a container, then inner creates its own container
+        assert mock_container.call_count == 2
+
+    assert inner_called
     assert len(ctx.fragment_storage._fragments) == 2
 
 
@@ -1405,29 +1423,42 @@ def test_run_parallel_fragment_handles_fragment_handled_exception() -> None:
     mock_coordinator.request_stop.assert_not_called()
 
 
-@patch("streamlit.runtime.fragment.get_script_run_ctx")
-def test_nested_parallel_fragment_dispatches_from_worker(
-    patched_get_script_run_ctx: MagicMock,
-) -> None:
-    """Dispatch from worker thread works with fresh pre-allocation."""
-    ctx = MagicMock()
-    ctx.fragment_storage = MemoryFragmentStorage()
-    ctx.fragment_ids_this_run = None
-    ctx.new_fragment_ids = ThreadSafeSet()
-    ctx.cursors = {}
-    mock_coordinator = MagicMock()
-    ctx.parallel_coordinator = mock_coordinator
-    patched_get_script_run_ctx.return_value = ctx
+def test_nested_parallel_fragment_dispatches_from_worker() -> None:
+    """Nested parallel fragment inside a worker also dispatches to the coordinator.
 
-    ThreadState.initialize()
+    When _run_parallel_fragment executes a wrapped_fragment whose body calls
+    a nested @fragment(parallel=True), that nested fragment should also dispatch
+    via coordinator.submit() (since fragment_ids_this_run is None in full-app runs).
+    """
+    mock_coordinator = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.new_fragment_ids = ThreadSafeSet()
+    mock_ctx.cursors = {}
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    inner_fragment_called = False
 
     @fragment(parallel=True)
     def inner_parallel() -> None:
-        pass
+        nonlocal inner_fragment_called
+        inner_fragment_called = True
 
-    inner_parallel()
+    def outer_wrapped_fragment() -> None:
+        inner_parallel()
 
+    with (
+        patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx),
+        patch("streamlit.delta_generator_singletons.context_dg_stack"),
+    ):
+        ThreadState.initialize()
+        _run_parallel_fragment("outer_id", outer_wrapped_fragment, [])
+
+    # The inner parallel fragment dispatches to the coordinator
     assert mock_coordinator.submit.call_count == 1
+    # The inner fragment body does not run inline (it's dispatched)
+    assert not inner_fragment_called
 
 
 @patch("streamlit.runtime.fragment.get_script_run_ctx")
@@ -1458,7 +1489,11 @@ def test_dispatch_restores_calling_thread_dg_stack(
 def test_worker_dg_stack_points_at_pre_allocated_container(
     patched_get_script_run_ctx: MagicMock,
 ) -> None:
-    """Worker's context_dg_stack includes the pre-allocated container."""
+    """Worker's context_dg_stack includes the pre-allocated container.
+
+    The dg_stack passed to the worker should have exactly one more entry than
+    the original stack (the pre-allocated container for the fragment).
+    """
     ctx = MagicMock()
     ctx.fragment_storage = MemoryFragmentStorage()
     ctx.new_fragment_ids = ThreadSafeSet()
@@ -1467,6 +1502,7 @@ def test_worker_dg_stack_points_at_pre_allocated_container(
     patched_get_script_run_ctx.return_value = ctx
 
     ThreadState.initialize()
+    original_len = len(context_dg_stack.get())
 
     def wrapped_fragment() -> None:
         pass
@@ -1475,14 +1511,19 @@ def test_worker_dg_stack_points_at_pre_allocated_container(
 
     call_args = mock_coordinator.submit.call_args[0]
     dg_stack_snapshot = call_args[3]
-    assert len(dg_stack_snapshot) > 0
+    assert len(dg_stack_snapshot) == original_len + 1
 
 
 @patch("streamlit.runtime.fragment.get_script_run_ctx")
 def test_run_every_parallel_fragment_reruns_sequentially(
     patched_get_script_run_ctx: MagicMock,
 ) -> None:
-    """run_every + parallel=True dispatches on initial run, reruns inline on timer."""
+    """run_every + parallel=True dispatches on initial run, reruns inline on timer.
+
+    Phase 1: Initial full-app run dispatches to coordinator.
+    Phase 2: Subsequent fragment rerun (fragment_ids_this_run is set) executes inline,
+    not dispatched to coordinator.
+    """
     ctx = MagicMock()
     ctx.fragment_storage = MemoryFragmentStorage()
     ctx.fragment_ids_this_run = None
@@ -1494,15 +1535,194 @@ def test_run_every_parallel_fragment_reruns_sequentially(
 
     ThreadState.initialize()
 
+    call_count = 0
+
     @fragment(parallel=True, run_every=5)
     def my_fragment() -> None:
-        pass
+        nonlocal call_count
+        call_count += 1
 
+    # Phase 1: Initial run dispatches (body does not execute inline)
     my_fragment()
     assert mock_coordinator.submit.call_count == 1
+    assert call_count == 0
 
+    # Phase 2: Fragment rerun executes inline
     saved_fragment = next(iter(ctx.fragment_storage._fragments.values()))
     ctx.fragment_ids_this_run = ["some_id"]
     mock_coordinator.submit.reset_mock()
     saved_fragment()
     mock_coordinator.submit.assert_not_called()
+    assert call_count == 1
+
+
+def test_sequential_fragment_inside_parallel_worker_creates_own_container() -> None:
+    """Sequential fragment inside a parallel worker creates its own container.
+
+    When _run_parallel_fragment executes a wrapped_fragment whose body calls
+    a sequential @fragment, that inner fragment must create its own container
+    via st.container() because the outer's pre_allocated_container_fragment_id
+    skip signal has already been consumed (and is cleared after use).
+    """
+    mock_coordinator = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.new_fragment_ids = ThreadSafeSet()
+    mock_ctx.cursors = {}
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    inner_called = False
+
+    @fragment
+    def inner_sequential() -> None:
+        nonlocal inner_called
+        inner_called = True
+
+    def outer_wrapped_fragment() -> None:
+        inner_sequential()
+
+    with (
+        patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx),
+        patch("streamlit.delta_generator_singletons.context_dg_stack"),
+        patch("streamlit.container") as mock_container,
+    ):
+        mock_container.return_value.__enter__ = MagicMock(return_value=None)
+        mock_container.return_value.__exit__ = MagicMock(return_value=False)
+
+        ThreadState.initialize()
+        _run_parallel_fragment("outer_id", outer_wrapped_fragment, [])
+
+        # Inner sequential fragment creates its own container
+        assert mock_container.call_count == 1
+        assert inner_called
+
+
+@patch("streamlit.runtime.fragment.get_script_run_ctx")
+def test_skip_signal_isolation_inner_fragment_sees_none_after_outer_consumes(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """Skip signal is isolated: inner fragment sees None after outer consumes it.
+
+    When the outer fragment runs with pre_allocated_container_fragment_id set
+    to the outer's ID, the outer consumes (clears) the signal. A nested inner
+    fragment should then see None, confirming the skip signal doesn't leak to
+    nested fragments.
+    """
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.new_fragment_ids = ThreadSafeSet()
+    mock_ctx.cursors = {}
+    patched_get_script_run_ctx.return_value = mock_ctx
+
+    ThreadState.initialize()
+
+    captured_inner_skip_signal: list[str | None] = []
+
+    @fragment
+    def inner_fragment() -> None:
+        captured_inner_skip_signal.append(
+            ThreadState.get().pre_allocated_container_fragment_id
+        )
+
+    @fragment
+    def outer_fragment() -> None:
+        inner_fragment()
+
+    # First call registers fragments and gets their IDs
+    outer_fragment()
+    outer_fragment_id = list(mock_ctx.fragment_storage._fragments.keys())[0]
+
+    # Get saved wrapped_fragment for outer
+    outer_saved = mock_ctx.fragment_storage._fragments[outer_fragment_id]
+
+    # Reset and set up for second call with skip signal
+    captured_inner_skip_signal.clear()
+    ThreadState.update(pre_allocated_container_fragment_id=outer_fragment_id)
+
+    with patch("streamlit.container") as mock_container:
+        mock_container.return_value.__enter__ = MagicMock(return_value=None)
+        mock_container.return_value.__exit__ = MagicMock(return_value=False)
+
+        outer_saved()
+
+    # Inner fragment should see None because outer consumed the signal
+    assert len(captured_inner_skip_signal) == 1
+    assert captured_inner_skip_signal[0] is None
+
+
+def test_parallel_fragment_nested_inside_rerun_executes_sequentially() -> None:
+    """Parallel fragment nested inside a fragment rerun executes sequentially.
+
+    When ctx.fragment_ids_this_run is set (indicating a fragment rerun), any
+    nested @fragment(parallel=True) should execute inline rather than dispatch
+    to the coordinator. The sequential fallback propagates into nested parallel
+    fragments during reruns.
+    """
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = ["outer_id"]
+    mock_ctx.new_fragment_ids = ThreadSafeSet()
+    mock_ctx.cursors = {}
+    mock_coordinator = MagicMock()
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    inner_called = False
+
+    @fragment(parallel=True)
+    def inner_parallel() -> None:
+        nonlocal inner_called
+        inner_called = True
+
+    with patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx):
+        ThreadState.initialize()
+
+        inner_parallel()
+
+        # During fragment rerun, parallel fragments execute inline
+        mock_coordinator.submit.assert_not_called()
+        assert inner_called
+
+
+def test_rerun_exception_propagates_from_nested_fragment_inside_worker() -> None:
+    """RerunException from nested fragment inside worker triggers request_rerun.
+
+    When _run_parallel_fragment executes a wrapped_fragment whose body calls
+    an inner fragment that raises RerunException, the exception propagates up:
+    1. Inner fragment's wrapped_fragment re-raises RerunException (lines 420-427)
+    2. Outer _run_parallel_fragment catches it and calls coordinator.request_rerun()
+
+    This documents the actual exception propagation path through nested fragments.
+    """
+    mock_coordinator = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.new_fragment_ids = ThreadSafeSet()
+    mock_ctx.cursors = {}
+    mock_ctx.parallel_coordinator = mock_coordinator
+
+    rerun_exc = RerunException(rerun_data=None)
+
+    @fragment
+    def inner_fragment_raises_rerun() -> None:
+        raise rerun_exc
+
+    def outer_wrapped_fragment() -> None:
+        inner_fragment_raises_rerun()
+
+    with (
+        patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx),
+        patch("streamlit.delta_generator_singletons.context_dg_stack"),
+        patch("streamlit.container") as mock_container,
+    ):
+        mock_container.return_value.__enter__ = MagicMock(return_value=None)
+        mock_container.return_value.__exit__ = MagicMock(return_value=False)
+
+        ThreadState.initialize()
+        _run_parallel_fragment("outer_id", outer_wrapped_fragment, [])
+
+    # RerunException propagates from inner fragment to _run_parallel_fragment
+    # which catches it and calls coordinator.request_rerun()
+    mock_coordinator.request_rerun.assert_called_once_with(rerun_exc)

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -1632,7 +1632,7 @@ def test_skip_signal_isolation_inner_fragment_sees_none_after_outer_consumes(
 
     # First call registers fragments and gets their IDs
     outer_fragment()
-    outer_fragment_id = list(mock_ctx.fragment_storage._fragments.keys())[0]
+    outer_fragment_id = next(iter(mock_ctx.fragment_storage._fragments.keys()))
 
     # Get saved wrapped_fragment for outer
     outer_saved = mock_ctx.fragment_storage._fragments[outer_fragment_id]

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -29,7 +29,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from streamlit.runtime.fragment import ParallelFragmentCoordinator
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,
     StopException,

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -1,0 +1,451 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ParallelFragmentCoordinator.
+
+The coordinator owns a ThreadPoolExecutor plus the bookkeeping that lets the
+script thread block on outstanding worker fragments and surface
+worker-initiated rerun/stop intent. These tests exercise the public surface
+in isolation; integration with ScriptRunContext / ScriptRunner lives in
+``script_runner_test.py`` and ``script_run_context_test.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+from streamlit.runtime.fragment import ParallelFragmentCoordinator
+from streamlit.runtime.scriptrunner_utils.exceptions import (
+    RerunException,
+    StopException,
+)
+from streamlit.runtime.scriptrunner_utils.script_requests import RerunData
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+    ThreadState,
+    get_script_run_ctx,
+)
+
+
+def _wait_for_outstanding_zero(
+    c: ParallelFragmentCoordinator, timeout: float = 1.0
+) -> None:
+    """Spin-wait until the coordinator's outstanding counter drains to zero.
+
+    Used by tests that submit a worker but don't drive ``join()`` themselves;
+    the executor's ``finally`` block runs asynchronously so we need to poll.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with c._outstanding_lock:
+            if c._outstanding == 0:
+                return
+        time.sleep(0.01)
+    with c._outstanding_lock:
+        last_value = c._outstanding
+    raise AssertionError(
+        f"outstanding never reached 0 within {timeout}s (last value: {last_value})"
+    )
+
+
+class ParallelFragmentCoordinatorTest(unittest.TestCase):
+    def test_construction_defaults(self):
+        """A freshly constructed coordinator is idle: no outstanding work,
+        no captured worker exception, no stop requested."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            assert c._outstanding == 0
+            assert c.worker_exception is None
+            assert c.should_stop() is False
+        finally:
+            c.drain()
+
+    def test_submit_counter_round_trip(self):
+        """submit() must restore _outstanding to zero even when the worker
+        raises, otherwise join() would hang forever on a worker error."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+
+            def explodes() -> None:
+                raise ValueError("boom")
+
+            c.submit(explodes)
+            _wait_for_outstanding_zero(c)
+            assert c._outstanding == 0
+        finally:
+            c.drain()
+
+    def test_join_returns_immediately_when_idle(self):
+        """If no work was submitted, join() must not invoke yield_check.
+
+        Calling yield_check with no outstanding work could surface external
+        cancellation requests at the wrong time relative to the script
+        runner's existing yield logic.
+        """
+        yields: list[int] = []
+        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+        c.join()
+        assert yields == []
+
+    def test_join_waits_and_yields(self):
+        """While work is outstanding, join() polls and calls yield_check
+        each interval so the script thread stays responsive."""
+        yields: list[int] = []
+        c = ParallelFragmentCoordinator(
+            yield_check=lambda: yields.append(1),
+            poll_interval=0.01,
+        )
+        gate = threading.Event()
+        c.submit(lambda: gate.wait(timeout=2.0))
+        threading.Timer(0.05, gate.set).start()
+        c.join()
+        assert len(yields) >= 1
+
+    def test_join_raises_stored_rerun_exception_with_data(self):
+        """A worker's RerunException must surface from join() with its
+        original RerunData attached so the script runner's rerun loop sees
+        the correct request."""
+        rerun_data = RerunData()
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.request_rerun(RerunException(rerun_data))
+        with pytest.raises(RerunException) as excinfo:
+            c.join()
+        assert excinfo.value.rerun_data is rerun_data
+
+    def test_join_raises_stored_stop_exception(self):
+        """request_stop() stores a StopException that join() re-raises."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.request_stop()
+        with pytest.raises(StopException):
+            c.join()
+
+    def test_first_writer_wins_and_should_stop(self):
+        """The first request_rerun/request_stop wins; later calls are
+        ignored. Both unconditionally set the stop event."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            assert not c.should_stop()
+            rerun_exc = RerunException(RerunData())
+            c.request_rerun(rerun_exc)
+            c.request_stop()
+            assert c.worker_exception is rerun_exc
+            assert c.should_stop() is True
+        finally:
+            c.drain()
+
+    def test_first_writer_wins_stop_then_rerun(self):
+        """Symmetric to test_first_writer_wins_and_should_stop: first
+        request_stop wins over a later request_rerun."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            c.request_stop()
+            assert isinstance(c.worker_exception, StopException)
+            c.request_rerun(RerunException(RerunData()))
+            assert isinstance(c.worker_exception, StopException)
+            assert c.should_stop() is True
+        finally:
+            c.drain()
+
+    def test_drain_silent_and_synchronous(self):
+        """drain() must not call yield_check (it's invoked from except
+        blocks where re-raising would shadow the original exception) and
+        must wait synchronously for in-flight workers to exit."""
+        yields: list[int] = []
+        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+        gate = threading.Event()
+        worker_done = threading.Event()
+
+        def worker() -> None:
+            gate.wait(timeout=2.0)
+            worker_done.set()
+
+        c.submit(worker)
+        threading.Timer(0.05, gate.set).start()
+        c.drain()
+        assert worker_done.is_set()
+        assert yields == []
+
+    def test_drain_sets_stop_event(self):
+        """drain() must set the stop event so any worker that reaches a
+        yield point during drain notices and exits cooperatively."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        assert not c.should_stop()
+        c.drain()
+        assert c.should_stop()
+
+    def test_nested_submit_counter(self):
+        """A worker that calls submit() must increment the counter before
+        the parent's tracked() finally runs, so join() waits for the
+        grandchild rather than returning when the parent finishes."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None, poll_interval=0.01)
+        child_done = threading.Event()
+
+        def parent() -> None:
+            c.submit(lambda: child_done.set())
+
+        c.submit(parent)
+        c.join()
+        assert child_done.is_set()
+
+    def test_join_propagates_yield_check_exception(self):
+        """If yield_check raises (e.g. an external RERUN arrived while
+        join() was polling), the exception must propagate so the caller's
+        try/except can run drain()."""
+
+        def yield_raises() -> None:
+            raise RerunException(RerunData())
+
+        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+        gate = threading.Event()
+        c.submit(lambda: gate.wait(timeout=2.0))
+        try:
+            with pytest.raises(RerunException):
+                c.join()
+        finally:
+            gate.set()
+            c.drain()
+
+    def test_yield_check_exception_preempts_stored_worker_exception(self):
+        """If both ``_yield_check`` raises and a worker exception is already
+        stored, the yield-check exception wins because ``join()`` calls
+        ``_yield_check()`` before checking ``worker_exception``. This pins
+        the precedence ordering — symmetric to the script-thread branch
+        contract where the worker exception wins over an external
+        ``ScriptRequests`` entry.
+        """
+        external_rerun = RerunException(RerunData(query_string="external"))
+
+        def yield_raises() -> None:
+            raise external_rerun
+
+        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+        worker_rerun = RerunException(RerunData(query_string="from_worker"))
+        c.request_rerun(worker_rerun)
+        gate = threading.Event()
+        c.submit(lambda: gate.wait(timeout=2.0))
+        try:
+            with pytest.raises(RerunException) as excinfo:
+                c.join()
+            assert excinfo.value is external_rerun
+        finally:
+            gate.set()
+            c.drain()
+
+    def test_submit_passes_args(self):
+        """submit() forwards positional args to the worker function so
+        callers can capture per-fragment context."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        try:
+            captured: list[tuple[int, str]] = []
+            done = threading.Event()
+
+            def worker(value: int, label: str) -> None:
+                captured.append((value, label))
+                done.set()
+
+            c.submit(worker, 42, "hello")
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            assert captured == [(42, "hello")]
+        finally:
+            c.drain()
+
+    def test_join_after_drain_is_safe(self):
+        """drain() shuts the executor down; calling join() afterwards on
+        an idle coordinator must not crash."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.drain()
+        c.join()
+
+    def test_submit_after_shutdown_rolls_back_outstanding(self):
+        """If ``submit()`` races with a concurrent ``drain()`` and the
+        executor is already shut down, the outstanding counter must be
+        rolled back so a subsequent ``join()`` doesn't hang."""
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        c.drain()
+        with pytest.raises(RuntimeError):
+            c.submit(lambda: None)
+        assert c._outstanding == 0
+
+    def test_submit_propagates_ctx_to_worker(self):
+        """submit() captures the parent's ScriptRunContext at submit time
+        and the worker sees it via get_script_run_ctx()."""
+        mock_ctx = MagicMock()
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
+        ThreadState.initialize()
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        holder: list[object] = []
+        done = threading.Event()
+
+        def worker() -> None:
+            holder.append(get_script_run_ctx())
+            done.set()
+
+        try:
+            c.submit(worker)
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            assert holder[0] is mock_ctx
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_propagates_thread_state_to_worker(self):
+        """submit() captures the parent's ContextVars (including
+        FragmentThreadState) so the worker sees the parent's snapshot."""
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        holder: list[object] = []
+        done = threading.Event()
+
+        def worker() -> None:
+            holder.append(ThreadState.get())
+            done.set()
+
+        try:
+            c.submit(worker)
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            ts = holder[0]
+            assert ts.fragment_id == "parent_frag"
+            assert ts.active_script_hash == "abc"
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_isolates_worker_thread_state_writes(self):
+        """Worker-side ThreadState.update() writes stay local to the
+        captured copy_context() and never leak back to the parent."""
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+        done = threading.Event()
+
+        def worker() -> None:
+            ThreadState.update(fragment_id="worker_frag")
+            done.set()
+
+        try:
+            c.submit(worker)
+            assert done.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+            assert ThreadState.get().fragment_id == "parent_frag"
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_clears_ctx_attribute_between_pool_submissions(self):
+        """With max_workers=1, two submissions with different ctxs each
+        see the correct ctx, and the pool thread's attribute is cleaned
+        up after both complete."""
+        main_thread = threading.current_thread()
+        ThreadState.initialize()
+
+        ctx_a = MagicMock(name="ctx_a")
+        ctx_b = MagicMock(name="ctx_b")
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+        holder_a: list[object] = []
+        holder_b: list[object] = []
+        pool_thread_ref: list[threading.Thread] = []
+        gate = threading.Event()
+        done_a = threading.Event()
+        done_b = threading.Event()
+
+        def worker_a() -> None:
+            holder_a.append(get_script_run_ctx())
+            pool_thread_ref.append(threading.current_thread())
+            gate.wait(timeout=2.0)
+            done_a.set()
+
+        def worker_b() -> None:
+            holder_b.append(get_script_run_ctx())
+            done_b.set()
+
+        try:
+            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
+            c.submit(worker_a)
+            gate.set()
+            assert done_a.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
+            c.submit(worker_b)
+            assert done_b.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            assert holder_a[0] is ctx_a
+            assert holder_b[0] is ctx_b
+
+            pool_thread = pool_thread_ref[0]
+            remaining = getattr(pool_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+            assert remaining is not ctx_a
+            assert remaining is not ctx_b
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()
+
+    def test_submit_with_max_workers_1_serializes_distinct_thread_states(self):
+        """With max_workers=1, two submissions see their respective
+        parent ThreadState snapshots, not each other's."""
+        main_thread = threading.current_thread()
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+
+        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+        holder_a: list[object] = []
+        holder_b: list[object] = []
+        done_a = threading.Event()
+        done_b = threading.Event()
+
+        def worker_a() -> None:
+            holder_a.append(ThreadState.get())
+            done_a.set()
+
+        def worker_b() -> None:
+            holder_b.append(ThreadState.get())
+            done_b.set()
+
+        try:
+            ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
+            c.submit(worker_a)
+            assert done_a.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
+            c.submit(worker_b)
+            assert done_b.wait(timeout=1.0)
+            _wait_for_outstanding_zero(c)
+
+            ts_a = holder_a[0]
+            assert ts_a.fragment_id == "state_a"
+            assert ts_a.active_script_hash == "hash_a"
+
+            ts_b = holder_b[0]
+            assert ts_b.fragment_id == "state_b"
+            assert ts_b.active_script_hash == "hash_b"
+        finally:
+            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+            c.drain()

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import threading
 import time
-import unittest
 from unittest.mock import MagicMock
 
 import pytest
@@ -64,388 +63,439 @@ def _wait_for_outstanding_zero(
     )
 
 
-class ParallelFragmentCoordinatorTest(unittest.TestCase):
-    def test_construction_defaults(self):
-        """A freshly constructed coordinator is idle: no outstanding work,
-        no captured worker exception, no stop requested."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            assert c._outstanding == 0
-            assert c.worker_exception is None
-            assert c.should_stop() is False
-        finally:
-            c.drain()
+@pytest.fixture
+def coordinator():
+    """Yield a coordinator with a no-op yield check; drain on teardown."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    yield c
+    c.drain()
 
-    def test_submit_counter_round_trip(self):
-        """submit() must restore _outstanding to zero even when the worker
-        raises, otherwise join() would hang forever on a worker error."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
 
-            def explodes() -> None:
-                raise ValueError("boom")
+@pytest.fixture
+def _attach_mock_ctx():
+    """Set a MagicMock as the current thread's ScriptRunContext and
+    initialize ThreadState for tests that exercise submit() propagation.
+    Cleans up on teardown.
+    """
+    main_thread = threading.current_thread()
+    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+    ThreadState.initialize()
+    yield
+    try:
+        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+    except AttributeError:
+        pass
 
-            c.submit(explodes)
-            _wait_for_outstanding_zero(c)
-            assert c._outstanding == 0
-        finally:
-            c.drain()
 
-    def test_join_returns_immediately_when_idle(self):
-        """If no work was submitted, join() must not invoke yield_check.
+# --- Construction ---
 
-        Calling yield_check with no outstanding work could surface external
-        cancellation requests at the wrong time relative to the script
-        runner's existing yield logic.
-        """
-        yields: list[int] = []
-        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+
+def test_construction_defaults(coordinator):
+    """A freshly constructed coordinator is idle: no outstanding work,
+    no captured worker exception, no stop requested."""
+    assert coordinator._outstanding == 0
+    assert coordinator.worker_exception is None
+    assert coordinator.should_stop() is False
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, -100])
+def test_construction_rejects_non_positive_max_workers(bad_value):
+    """max_workers must be None or a positive integer."""
+    with pytest.raises(ValueError, match="positive integer"):
+        ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=bad_value)
+
+
+# --- Submit / counter ---
+
+
+def test_submit_counter_round_trip(coordinator):
+    """submit() must restore _outstanding to zero even when the worker
+    raises, otherwise join() would hang forever on a worker error."""
+
+    def explodes() -> None:
+        raise ValueError("boom")
+
+    coordinator.submit(explodes)
+    _wait_for_outstanding_zero(coordinator)
+    assert coordinator._outstanding == 0
+
+
+def test_submit_passes_args(coordinator):
+    """submit() forwards positional args to the worker function so
+    callers can capture per-fragment context."""
+    captured: list[tuple[int, str]] = []
+    done = threading.Event()
+
+    def worker(value: int, label: str) -> None:
+        captured.append((value, label))
+        done.set()
+
+    coordinator.submit(worker, 42, "hello")
+    assert done.wait(timeout=1.0)
+    _wait_for_outstanding_zero(coordinator)
+    assert captured == [(42, "hello")]
+
+
+def test_submit_after_shutdown_rolls_back_outstanding():
+    """If ``submit()`` races with a concurrent ``drain()`` and the
+    executor is already shut down, the outstanding counter must be
+    rolled back so a subsequent ``join()`` doesn't hang."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.drain()
+    with pytest.raises(RuntimeError):
+        c.submit(lambda: None)
+    assert c._outstanding == 0
+
+
+def test_nested_submit_counter():
+    """A worker that calls submit() must increment the counter before
+    the parent's tracked() finally runs, so join() waits for the
+    grandchild rather than returning when the parent finishes."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None, poll_interval=0.01)
+    child_done = threading.Event()
+
+    def parent() -> None:
+        c.submit(lambda: child_done.set())
+
+    c.submit(parent)
+    c.join()
+    assert child_done.is_set()
+
+
+# --- Join ---
+
+
+def test_join_returns_immediately_when_idle():
+    """If no work was submitted, join() must not invoke yield_check.
+
+    Calling yield_check with no outstanding work could surface external
+    cancellation requests at the wrong time relative to the script
+    runner's existing yield logic.
+    """
+    yields: list[int] = []
+    c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+    c.join()
+    assert yields == []
+
+
+def test_join_waits_and_yields():
+    """While work is outstanding, join() polls and calls yield_check
+    each interval so the script thread stays responsive."""
+    yields: list[int] = []
+    c = ParallelFragmentCoordinator(
+        yield_check=lambda: yields.append(1),
+        poll_interval=0.01,
+    )
+    gate = threading.Event()
+    c.submit(lambda: gate.wait(timeout=2.0))
+    threading.Timer(0.05, gate.set).start()
+    c.join()
+    assert len(yields) >= 1
+
+
+def test_join_raises_stored_rerun_exception_with_data():
+    """A worker's RerunException must surface from join() with its
+    original RerunData attached so the script runner's rerun loop sees
+    the correct request."""
+    rerun_data = RerunData()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.request_rerun(RerunException(rerun_data))
+    with pytest.raises(RerunException) as excinfo:
         c.join()
-        assert yields == []
+    assert excinfo.value.rerun_data is rerun_data
 
-    def test_join_waits_and_yields(self):
-        """While work is outstanding, join() polls and calls yield_check
-        each interval so the script thread stays responsive."""
-        yields: list[int] = []
-        c = ParallelFragmentCoordinator(
-            yield_check=lambda: yields.append(1),
-            poll_interval=0.01,
-        )
-        gate = threading.Event()
-        c.submit(lambda: gate.wait(timeout=2.0))
-        threading.Timer(0.05, gate.set).start()
+
+def test_join_raises_stored_stop_exception():
+    """request_stop() stores a StopException that join() re-raises."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.request_stop()
+    with pytest.raises(StopException):
         c.join()
-        assert len(yields) >= 1
 
-    def test_join_raises_stored_rerun_exception_with_data(self):
-        """A worker's RerunException must surface from join() with its
-        original RerunData attached so the script runner's rerun loop sees
-        the correct request."""
-        rerun_data = RerunData()
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        c.request_rerun(RerunException(rerun_data))
+
+def test_join_after_drain_is_safe():
+    """drain() shuts the executor down; calling join() afterwards on
+    an idle coordinator must not crash."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    c.drain()
+    c.join()
+
+
+def test_join_propagates_yield_check_exception():
+    """If yield_check raises (e.g. an external RERUN arrived while
+    join() was polling), the exception must propagate so the caller's
+    try/except can run drain()."""
+
+    def yield_raises() -> None:
+        raise RerunException(RerunData())
+
+    c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+    gate = threading.Event()
+    c.submit(lambda: gate.wait(timeout=2.0))
+    try:
+        with pytest.raises(RerunException):
+            c.join()
+    finally:
+        gate.set()
+        c.drain()
+
+
+def test_yield_check_exception_preempts_stored_worker_exception():
+    """If both ``_yield_check`` raises and a worker exception is already
+    stored, the yield-check exception wins because ``join()`` calls
+    ``_yield_check()`` before checking ``worker_exception``. This pins
+    the precedence ordering — symmetric to the script-thread branch
+    contract where the worker exception wins over an external
+    ``ScriptRequests`` entry.
+    """
+    external_rerun = RerunException(RerunData(query_string="external"))
+
+    def yield_raises() -> None:
+        raise external_rerun
+
+    c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
+    worker_rerun = RerunException(RerunData(query_string="from_worker"))
+    c.request_rerun(worker_rerun)
+    gate = threading.Event()
+    c.submit(lambda: gate.wait(timeout=2.0))
+    try:
         with pytest.raises(RerunException) as excinfo:
             c.join()
-        assert excinfo.value.rerun_data is rerun_data
-
-    def test_join_raises_stored_stop_exception(self):
-        """request_stop() stores a StopException that join() re-raises."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        c.request_stop()
-        with pytest.raises(StopException):
-            c.join()
-
-    def test_first_writer_wins_and_should_stop(self):
-        """The first request_rerun/request_stop wins; later calls are
-        ignored. Both unconditionally set the stop event."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            assert not c.should_stop()
-            rerun_exc = RerunException(RerunData())
-            c.request_rerun(rerun_exc)
-            c.request_stop()
-            assert c.worker_exception is rerun_exc
-            assert c.should_stop() is True
-        finally:
-            c.drain()
-
-    def test_first_writer_wins_stop_then_rerun(self):
-        """Symmetric to test_first_writer_wins_and_should_stop: first
-        request_stop wins over a later request_rerun."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            c.request_stop()
-            assert isinstance(c.worker_exception, StopException)
-            c.request_rerun(RerunException(RerunData()))
-            assert isinstance(c.worker_exception, StopException)
-            assert c.should_stop() is True
-        finally:
-            c.drain()
-
-    def test_drain_silent_and_synchronous(self):
-        """drain() must not call yield_check (it's invoked from except
-        blocks where re-raising would shadow the original exception) and
-        must wait synchronously for in-flight workers to exit."""
-        yields: list[int] = []
-        c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
-        gate = threading.Event()
-        worker_done = threading.Event()
-
-        def worker() -> None:
-            gate.wait(timeout=2.0)
-            worker_done.set()
-
-        c.submit(worker)
-        threading.Timer(0.05, gate.set).start()
+        assert excinfo.value is external_rerun
+    finally:
+        gate.set()
         c.drain()
-        assert worker_done.is_set()
-        assert yields == []
 
-    def test_drain_sets_stop_event(self):
-        """drain() must set the stop event so any worker that reaches a
-        yield point during drain notices and exits cooperatively."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+
+# --- First-writer-wins ---
+
+
+def test_first_writer_wins_rerun_then_stop():
+    """The first request_rerun/request_stop wins; later calls are
+    ignored. Both unconditionally set the stop event."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    try:
         assert not c.should_stop()
+        rerun_exc = RerunException(RerunData())
+        c.request_rerun(rerun_exc)
+        c.request_stop()
+        assert c.worker_exception is rerun_exc
+        assert c.should_stop() is True
+    finally:
         c.drain()
-        assert c.should_stop()
 
-    def test_nested_submit_counter(self):
-        """A worker that calls submit() must increment the counter before
-        the parent's tracked() finally runs, so join() waits for the
-        grandchild rather than returning when the parent finishes."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None, poll_interval=0.01)
-        child_done = threading.Event()
 
-        def parent() -> None:
-            c.submit(lambda: child_done.set())
-
-        c.submit(parent)
-        c.join()
-        assert child_done.is_set()
-
-    def test_join_propagates_yield_check_exception(self):
-        """If yield_check raises (e.g. an external RERUN arrived while
-        join() was polling), the exception must propagate so the caller's
-        try/except can run drain()."""
-
-        def yield_raises() -> None:
-            raise RerunException(RerunData())
-
-        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
-        gate = threading.Event()
-        c.submit(lambda: gate.wait(timeout=2.0))
-        try:
-            with pytest.raises(RerunException):
-                c.join()
-        finally:
-            gate.set()
-            c.drain()
-
-    def test_yield_check_exception_preempts_stored_worker_exception(self):
-        """If both ``_yield_check`` raises and a worker exception is already
-        stored, the yield-check exception wins because ``join()`` calls
-        ``_yield_check()`` before checking ``worker_exception``. This pins
-        the precedence ordering — symmetric to the script-thread branch
-        contract where the worker exception wins over an external
-        ``ScriptRequests`` entry.
-        """
-        external_rerun = RerunException(RerunData(query_string="external"))
-
-        def yield_raises() -> None:
-            raise external_rerun
-
-        c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
-        worker_rerun = RerunException(RerunData(query_string="from_worker"))
-        c.request_rerun(worker_rerun)
-        gate = threading.Event()
-        c.submit(lambda: gate.wait(timeout=2.0))
-        try:
-            with pytest.raises(RerunException) as excinfo:
-                c.join()
-            assert excinfo.value is external_rerun
-        finally:
-            gate.set()
-            c.drain()
-
-    def test_submit_passes_args(self):
-        """submit() forwards positional args to the worker function so
-        callers can capture per-fragment context."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        try:
-            captured: list[tuple[int, str]] = []
-            done = threading.Event()
-
-            def worker(value: int, label: str) -> None:
-                captured.append((value, label))
-                done.set()
-
-            c.submit(worker, 42, "hello")
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            assert captured == [(42, "hello")]
-        finally:
-            c.drain()
-
-    def test_join_after_drain_is_safe(self):
-        """drain() shuts the executor down; calling join() afterwards on
-        an idle coordinator must not crash."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+def test_first_writer_wins_stop_then_rerun():
+    """Symmetric to test_first_writer_wins_rerun_then_stop: first
+    request_stop wins over a later request_rerun."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    try:
+        c.request_stop()
+        assert isinstance(c.worker_exception, StopException)
+        c.request_rerun(RerunException(RerunData()))
+        assert isinstance(c.worker_exception, StopException)
+        assert c.should_stop() is True
+    finally:
         c.drain()
-        c.join()
 
-    def test_submit_after_shutdown_rolls_back_outstanding(self):
-        """If ``submit()`` races with a concurrent ``drain()`` and the
-        executor is already shut down, the outstanding counter must be
-        rolled back so a subsequent ``join()`` doesn't hang."""
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
+
+# --- Drain ---
+
+
+def test_drain_silent_and_synchronous():
+    """drain() must not call yield_check (it's invoked from except
+    blocks where re-raising would shadow the original exception) and
+    must wait synchronously for in-flight workers to exit."""
+    yields: list[int] = []
+    c = ParallelFragmentCoordinator(yield_check=lambda: yields.append(1))
+    gate = threading.Event()
+    worker_done = threading.Event()
+
+    def worker() -> None:
+        gate.wait(timeout=2.0)
+        worker_done.set()
+
+    c.submit(worker)
+    threading.Timer(0.05, gate.set).start()
+    c.drain()
+    assert worker_done.is_set()
+    assert yields == []
+
+
+def test_drain_sets_stop_event():
+    """drain() must set the stop event so any worker that reaches a
+    yield point during drain notices and exits cooperatively."""
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    assert not c.should_stop()
+    c.drain()
+    assert c.should_stop()
+
+
+# --- submit() propagation ---
+
+
+@pytest.mark.usefixtures("_attach_mock_ctx")
+def test_submit_propagates_ctx_to_worker():
+    """submit() captures the parent's ScriptRunContext at submit time
+    and the worker sees it via get_script_run_ctx()."""
+    mock_ctx = MagicMock()
+    main_thread = threading.current_thread()
+    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
+
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    holder: list[object] = []
+    done = threading.Event()
+
+    def worker() -> None:
+        holder.append(get_script_run_ctx())
+        done.set()
+
+    try:
+        c.submit(worker)
+        assert done.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
+        assert holder[0] is mock_ctx
+    finally:
         c.drain()
-        with pytest.raises(RuntimeError):
-            c.submit(lambda: None)
-        assert c._outstanding == 0
 
-    def test_submit_propagates_ctx_to_worker(self):
-        """submit() captures the parent's ScriptRunContext at submit time
-        and the worker sees it via get_script_run_ctx()."""
-        mock_ctx = MagicMock()
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
-        ThreadState.initialize()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        holder: list[object] = []
-        done = threading.Event()
+@pytest.mark.usefixtures("_attach_mock_ctx")
+def test_submit_propagates_thread_state_to_worker():
+    """submit() captures the parent's ContextVars (including
+    FragmentThreadState) so the worker sees the parent's snapshot."""
+    ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
 
-        def worker() -> None:
-            holder.append(get_script_run_ctx())
-            done.set()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    holder: list[object] = []
+    done = threading.Event()
 
-        try:
-            c.submit(worker)
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            assert holder[0] is mock_ctx
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+    def worker() -> None:
+        holder.append(ThreadState.get())
+        done.set()
 
-    def test_submit_propagates_thread_state_to_worker(self):
-        """submit() captures the parent's ContextVars (including
-        FragmentThreadState) so the worker sees the parent's snapshot."""
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
-        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+    try:
+        c.submit(worker)
+        assert done.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
+        ts = holder[0]
+        assert ts.fragment_id == "parent_frag"
+        assert ts.active_script_hash == "abc"
+    finally:
+        c.drain()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        holder: list[object] = []
-        done = threading.Event()
 
-        def worker() -> None:
-            holder.append(ThreadState.get())
-            done.set()
+@pytest.mark.usefixtures("_attach_mock_ctx")
+def test_submit_isolates_worker_thread_state_writes():
+    """Worker-side ThreadState.update() writes stay local to the
+    captured copy_context() and never leak back to the parent."""
+    ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
 
-        try:
-            c.submit(worker)
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            ts = holder[0]
-            assert ts.fragment_id == "parent_frag"
-            assert ts.active_script_hash == "abc"
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None)
+    done = threading.Event()
 
-    def test_submit_isolates_worker_thread_state_writes(self):
-        """Worker-side ThreadState.update() writes stay local to the
-        captured copy_context() and never leak back to the parent."""
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
-        ThreadState.initialize(fragment_id="parent_frag", active_script_hash="abc")
+    def worker() -> None:
+        ThreadState.update(fragment_id="worker_frag")
+        done.set()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None)
-        done = threading.Event()
+    try:
+        c.submit(worker)
+        assert done.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
+        assert ThreadState.get().fragment_id == "parent_frag"
+    finally:
+        c.drain()
 
-        def worker() -> None:
-            ThreadState.update(fragment_id="worker_frag")
-            done.set()
 
-        try:
-            c.submit(worker)
-            assert done.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
-            assert ThreadState.get().fragment_id == "parent_frag"
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+def test_submit_clears_ctx_attribute_between_pool_submissions():
+    """With max_workers=1, two submissions with different ctxs each
+    see the correct ctx, and the pool thread's attribute is cleaned
+    up after both complete."""
+    main_thread = threading.current_thread()
+    ThreadState.initialize()
 
-    def test_submit_clears_ctx_attribute_between_pool_submissions(self):
-        """With max_workers=1, two submissions with different ctxs each
-        see the correct ctx, and the pool thread's attribute is cleaned
-        up after both complete."""
-        main_thread = threading.current_thread()
-        ThreadState.initialize()
+    ctx_a = MagicMock(name="ctx_a")
+    ctx_b = MagicMock(name="ctx_b")
 
-        ctx_a = MagicMock(name="ctx_a")
-        ctx_b = MagicMock(name="ctx_b")
+    c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+    holder_a: list[object] = []
+    holder_b: list[object] = []
+    pool_thread_ref: list[threading.Thread] = []
+    gate = threading.Event()
+    done_a = threading.Event()
+    done_b = threading.Event()
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
-        holder_a: list[object] = []
-        holder_b: list[object] = []
-        pool_thread_ref: list[threading.Thread] = []
-        gate = threading.Event()
-        done_a = threading.Event()
-        done_b = threading.Event()
+    def worker_a() -> None:
+        holder_a.append(get_script_run_ctx())
+        pool_thread_ref.append(threading.current_thread())
+        gate.wait(timeout=2.0)
+        done_a.set()
 
-        def worker_a() -> None:
-            holder_a.append(get_script_run_ctx())
-            pool_thread_ref.append(threading.current_thread())
-            gate.wait(timeout=2.0)
-            done_a.set()
+    def worker_b() -> None:
+        holder_b.append(get_script_run_ctx())
+        done_b.set()
 
-        def worker_b() -> None:
-            holder_b.append(get_script_run_ctx())
-            done_b.set()
+    try:
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
+        c.submit(worker_a)
+        gate.set()
+        assert done_a.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-        try:
-            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
-            c.submit(worker_a)
-            gate.set()
-            assert done_a.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
+        c.submit(worker_b)
+        assert done_b.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-            setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
-            c.submit(worker_b)
-            assert done_b.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+        assert holder_a[0] is ctx_a
+        assert holder_b[0] is ctx_b
 
-            assert holder_a[0] is ctx_a
-            assert holder_b[0] is ctx_b
+        pool_thread = pool_thread_ref[0]
+        remaining = getattr(pool_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+        assert remaining is not ctx_a
+        assert remaining is not ctx_b
+    finally:
+        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+        c.drain()
 
-            pool_thread = pool_thread_ref[0]
-            remaining = getattr(pool_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-            assert remaining is not ctx_a
-            assert remaining is not ctx_b
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
 
-    def test_submit_with_max_workers_1_serializes_distinct_thread_states(self):
-        """With max_workers=1, two submissions see their respective
-        parent ThreadState snapshots, not each other's."""
-        main_thread = threading.current_thread()
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
+def test_submit_with_max_workers_1_serializes_distinct_thread_states():
+    """With max_workers=1, two submissions see their respective
+    parent ThreadState snapshots, not each other's."""
+    main_thread = threading.current_thread()
+    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, MagicMock())
 
-        c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
-        holder_a: list[object] = []
-        holder_b: list[object] = []
-        done_a = threading.Event()
-        done_b = threading.Event()
+    c = ParallelFragmentCoordinator(yield_check=lambda: None, max_workers=1)
+    holder_a: list[object] = []
+    holder_b: list[object] = []
+    done_a = threading.Event()
+    done_b = threading.Event()
 
-        def worker_a() -> None:
-            holder_a.append(ThreadState.get())
-            done_a.set()
+    def worker_a() -> None:
+        holder_a.append(ThreadState.get())
+        done_a.set()
 
-        def worker_b() -> None:
-            holder_b.append(ThreadState.get())
-            done_b.set()
+    def worker_b() -> None:
+        holder_b.append(ThreadState.get())
+        done_b.set()
 
-        try:
-            ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
-            c.submit(worker_a)
-            assert done_a.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+    try:
+        ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
+        c.submit(worker_a)
+        assert done_a.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-            ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
-            c.submit(worker_b)
-            assert done_b.wait(timeout=1.0)
-            _wait_for_outstanding_zero(c)
+        ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
+        c.submit(worker_b)
+        assert done_b.wait(timeout=1.0)
+        _wait_for_outstanding_zero(c)
 
-            ts_a = holder_a[0]
-            assert ts_a.fragment_id == "state_a"
-            assert ts_a.active_script_hash == "hash_a"
+        ts_a = holder_a[0]
+        assert ts_a.fragment_id == "state_a"
+        assert ts_a.active_script_hash == "hash_a"
 
-            ts_b = holder_b[0]
-            assert ts_b.fragment_id == "state_b"
-            assert ts_b.active_script_hash == "hash_b"
-        finally:
-            delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
-            c.drain()
+        ts_b = holder_b[0]
+        assert ts_b.fragment_id == "state_b"
+        assert ts_b.active_script_hash == "hash_b"
+    finally:
+        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
+        c.drain()

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -33,7 +33,11 @@ from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
-from streamlit.runtime.fragment import MemoryFragmentStorage, _fragment
+from streamlit.runtime.fragment import (
+    MemoryFragmentStorage,
+    ParallelFragmentCoordinator,
+    _fragment,
+)
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
@@ -609,6 +613,14 @@ class ScriptRunnerTest(unittest.TestCase):
         """
 
         ctx = MagicMock()
+        # The script-thread yield-point branch of
+        # _maybe_handle_execution_control_request reads
+        # ctx.parallel_coordinator.worker_exception and re-raises it if
+        # set. Without an explicit None, MagicMock returns a MagicMock,
+        # which raises TypeError ("exceptions must derive from
+        # BaseException") when the production code tries to raise it —
+        # masking the KeyError this test is actually checking for.
+        ctx.parallel_coordinator.worker_exception = None
         patched_get_script_run_ctx.return_value = ctx
 
         def non_optional_func():
@@ -1236,6 +1248,181 @@ class ScriptRunnerTest(unittest.TestCase):
                     ScriptRunnerEvent.SHUTDOWN,
                 ],
             )
+
+    def test_parallel_coordinator_is_fresh_per_run(self):
+        """Each script run constructs a brand new
+        ParallelFragmentCoordinator. A leaked instance would carry the
+        previous run's stop event / worker exception into the next run.
+
+        ``coordinator_id_capture.py`` calls ``st.rerun()`` once so the
+        runner does two full runs in a single start/join cycle —
+        back-to-back ``request_rerun`` calls coalesce.
+        """
+        scriptrunner = TestScriptRunner("coordinator_id_capture.py")
+        scriptrunner.request_rerun(RerunData())
+        scriptrunner.start()
+        scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        ids = scriptrunner._session_state["coordinator_ids"]
+        assert len(ids) == 2
+        assert ids[0] != ids[1]
+
+    def test_parallel_coordinator_join_called_after_exec(self):
+        """The script runner must call ``coordinator.join()`` exactly once
+        after a successful full-app run, before clearing fragment storage."""
+        join_calls: list[int] = []
+        original_join = ParallelFragmentCoordinator.join
+
+        def recording_join(self):
+            join_calls.append(1)
+            return original_join(self)
+
+        with patch.object(ParallelFragmentCoordinator, "join", recording_join):
+            scriptrunner = TestScriptRunner("good_script.py")
+            scriptrunner.request_rerun(RerunData())
+            scriptrunner.start()
+            scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        assert len(join_calls) == 1
+
+    def test_parallel_coordinator_drain_on_rerun_exception(self):
+        """When ``exec()`` raises RerunException (e.g. user code calls
+        ``st.rerun()``), the script runner's try/except must call
+        ``coordinator.drain()`` and re-raise so the rerun loop sees the
+        exception and runs the script again."""
+        drain_calls: list[int] = []
+        original_drain = ParallelFragmentCoordinator.drain
+
+        def recording_drain(self):
+            drain_calls.append(1)
+            return original_drain(self)
+
+        with patch.object(ParallelFragmentCoordinator, "drain", recording_drain):
+            scriptrunner = TestScriptRunner("rerun_once_then_finish.py")
+            scriptrunner.request_rerun(RerunData())
+            scriptrunner.start()
+            scriptrunner.join()
+
+        self._assert_no_exceptions(scriptrunner)
+        # The first run's st.rerun() raises RerunException -> drain() runs once.
+        # The second run completes normally -> no drain call.
+        assert len(drain_calls) == 1
+        # Two SCRIPT_STARTED events confirm the rerun was honored.
+        started_events = [
+            e for e in scriptrunner.events if e == ScriptRunnerEvent.SCRIPT_STARTED
+        ]
+        assert len(started_events) == 2
+
+    def test_worker_thread_yield_check_noop_when_idle(self):
+        """A worker thread (attached via add_script_run_ctx) hits the
+        worker-thread branch of ``_maybe_handle_execution_control_request``.
+        With no stop requested it must not raise so that existing
+        worker-thread paths (e.g. spinner) keep working."""
+        import threading as _threading
+
+        from streamlit.runtime.scriptrunner_utils.script_run_context import (
+            SCRIPT_RUN_CONTEXT_ATTR_NAME,
+            add_script_run_ctx,
+        )
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.request_rerun(RerunData())
+        scriptrunner.start()
+        scriptrunner.join()
+        self._assert_no_exceptions(scriptrunner)
+
+        script_thread = scriptrunner._script_thread
+        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+        assert ctx is not None
+        assert ctx.parallel_coordinator is not None
+        assert ctx.parallel_coordinator.should_stop() is False
+
+        worker_errors: list[BaseException] = []
+
+        def worker() -> None:
+            add_script_run_ctx(_threading.current_thread(), ctx)
+            try:
+                # The script runner is no longer in script-thread, so this
+                # call hits the worker-thread branch. With should_stop() False
+                # it must return without raising.
+                scriptrunner._maybe_handle_execution_control_request()
+            except BaseException as e:
+                worker_errors.append(e)
+
+        t = _threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert worker_errors == []
+
+    @patch("streamlit.runtime.scriptrunner.script_runner.get_script_run_ctx")
+    def test_script_thread_yield_check_worker_exception_wins_over_request(
+        self, patched_get_script_run_ctx
+    ):
+        """On the script-thread branch, a stored worker exception is
+        re-raised before any external RERUN/STOP request from
+        ``ScriptRequests`` is dequeued. The worker's RerunData is preserved
+        so the rerun loop honors the worker's intent, not the external
+        request that arrived concurrently.
+        """
+        worker_rerun_data = RerunData(query_string="from_worker")
+        worker_exc = RerunException(worker_rerun_data)
+
+        ctx = MagicMock()
+        ctx.parallel_coordinator.worker_exception = worker_exc
+        patched_get_script_run_ctx.return_value = ctx
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        # Queue an external rerun request that should NOT win over the
+        # worker's stored exception.
+        external_rerun_data = RerunData(query_string="external")
+        scriptrunner._requests.request_rerun(external_rerun_data)
+
+        with patch.object(scriptrunner, "_is_in_script_thread", return_value=True):
+            scriptrunner._execing = True
+            with pytest.raises(RerunException) as excinfo:
+                scriptrunner._maybe_handle_execution_control_request()
+
+        assert excinfo.value.rerun_data is worker_rerun_data
+
+    def test_worker_thread_yield_check_raises_when_stop_requested(self):
+        """When the coordinator's stop event is set (e.g. a sibling worker
+        called ``request_stop``), the worker-thread branch raises
+        StopException so the worker exits at its next yield point."""
+        import threading as _threading
+
+        from streamlit.runtime.scriptrunner_utils.script_run_context import (
+            SCRIPT_RUN_CONTEXT_ATTR_NAME,
+            add_script_run_ctx,
+        )
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner.request_rerun(RerunData())
+        scriptrunner.start()
+        scriptrunner.join()
+        self._assert_no_exceptions(scriptrunner)
+
+        script_thread = scriptrunner._script_thread
+        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
+        assert ctx is not None
+        assert ctx.parallel_coordinator is not None
+        ctx.parallel_coordinator.request_stop()
+
+        worker_errors: list[BaseException] = []
+
+        def worker() -> None:
+            add_script_run_ctx(_threading.current_thread(), ctx)
+            try:
+                scriptrunner._maybe_handle_execution_control_request()
+            except BaseException as e:
+                worker_errors.append(e)
+
+        t = _threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert len(worker_errors) == 1
+        assert isinstance(worker_errors[0], StopException)
 
     def test_page_script_hash_to_script_path(self):
         scriptrunner = TestScriptRunner("good_navigation_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -613,13 +613,8 @@ class ScriptRunnerTest(unittest.TestCase):
         """
 
         ctx = MagicMock()
-        # The script-thread yield-point branch of
-        # _maybe_handle_execution_control_request reads
-        # ctx.parallel_coordinator.worker_exception and re-raises it if
-        # set. Without an explicit None, MagicMock returns a MagicMock,
-        # which raises TypeError ("exceptions must derive from
-        # BaseException") when the production code tries to raise it —
-        # masking the KeyError this test is actually checking for.
+        # Set to None to prevent MagicMock being returned, which would
+        # cause the test to fail with TypeError instead of KeyError.
         ctx.parallel_coordinator.worker_exception = None
         patched_get_script_run_ctx.return_value = ctx
 

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -35,13 +35,13 @@ from streamlit.runtime import Runtime
 from streamlit.runtime.forward_msg_queue import ForwardMsgQueue
 from streamlit.runtime.fragment import (
     MemoryFragmentStorage,
-    ParallelFragmentCoordinator,
     _fragment,
 )
 from streamlit.runtime.media_file_manager import MediaFileManager
 from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 from streamlit.runtime.scriptrunner import (
     RerunData,
     RerunException,

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -1315,47 +1315,6 @@ class ScriptRunnerTest(unittest.TestCase):
         ]
         assert len(started_events) == 2
 
-    def test_worker_thread_yield_check_noop_when_idle(self):
-        """A worker thread (attached via add_script_run_ctx) hits the
-        worker-thread branch of ``_maybe_handle_execution_control_request``.
-        With no stop requested it must not raise so that existing
-        worker-thread paths (e.g. spinner) keep working."""
-        import threading as _threading
-
-        from streamlit.runtime.scriptrunner_utils.script_run_context import (
-            SCRIPT_RUN_CONTEXT_ATTR_NAME,
-            add_script_run_ctx,
-        )
-
-        scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.request_rerun(RerunData())
-        scriptrunner.start()
-        scriptrunner.join()
-        self._assert_no_exceptions(scriptrunner)
-
-        script_thread = scriptrunner._script_thread
-        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-        assert ctx is not None
-        assert ctx.parallel_coordinator is not None
-        assert ctx.parallel_coordinator.should_stop() is False
-
-        worker_errors: list[BaseException] = []
-
-        def worker() -> None:
-            add_script_run_ctx(_threading.current_thread(), ctx)
-            try:
-                # The script runner is no longer in script-thread, so this
-                # call hits the worker-thread branch. With should_stop() False
-                # it must return without raising.
-                scriptrunner._maybe_handle_execution_control_request()
-            except BaseException as e:
-                worker_errors.append(e)
-
-        t = _threading.Thread(target=worker)
-        t.start()
-        t.join()
-        assert worker_errors == []
-
     @patch("streamlit.runtime.scriptrunner.script_runner.get_script_run_ctx")
     def test_script_thread_yield_check_worker_exception_wins_over_request(
         self, patched_get_script_run_ctx
@@ -1385,44 +1344,6 @@ class ScriptRunnerTest(unittest.TestCase):
                 scriptrunner._maybe_handle_execution_control_request()
 
         assert excinfo.value.rerun_data is worker_rerun_data
-
-    def test_worker_thread_yield_check_raises_when_stop_requested(self):
-        """When the coordinator's stop event is set (e.g. a sibling worker
-        called ``request_stop``), the worker-thread branch raises
-        StopException so the worker exits at its next yield point."""
-        import threading as _threading
-
-        from streamlit.runtime.scriptrunner_utils.script_run_context import (
-            SCRIPT_RUN_CONTEXT_ATTR_NAME,
-            add_script_run_ctx,
-        )
-
-        scriptrunner = TestScriptRunner("good_script.py")
-        scriptrunner.request_rerun(RerunData())
-        scriptrunner.start()
-        scriptrunner.join()
-        self._assert_no_exceptions(scriptrunner)
-
-        script_thread = scriptrunner._script_thread
-        ctx = getattr(script_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, None)
-        assert ctx is not None
-        assert ctx.parallel_coordinator is not None
-        ctx.parallel_coordinator.request_stop()
-
-        worker_errors: list[BaseException] = []
-
-        def worker() -> None:
-            add_script_run_ctx(_threading.current_thread(), ctx)
-            try:
-                scriptrunner._maybe_handle_execution_control_request()
-            except BaseException as e:
-                worker_errors.append(e)
-
-        t = _threading.Thread(target=worker)
-        t.start()
-        t.join()
-        assert len(worker_errors) == 1
-        assert isinstance(worker_errors[0], StopException)
 
     def test_page_script_hash_to_script_path(self):
         scriptrunner = TestScriptRunner("good_navigation_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/test_data/coordinator_id_capture.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/test_data/coordinator_id_capture.py
@@ -1,0 +1,33 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Records each run's ParallelFragmentCoordinator id so the test can assert
+that ScriptRunContext.reset() builds a fresh one per script run.
+
+Calls ``st.rerun()`` exactly once so the script runs twice in a single
+``ScriptRunner.start()`` -> ``join()`` cycle (back-to-back
+``request_rerun`` calls get coalesced by ``ScriptRequests`` and only
+trigger one run)."""
+
+import streamlit as st
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    get_script_run_ctx,
+)
+
+ctx = get_script_run_ctx()
+st.session_state.setdefault("coordinator_ids", [])
+st.session_state["coordinator_ids"].append(id(ctx.parallel_coordinator))
+
+if len(st.session_state["coordinator_ids"]) == 1:
+    st.rerun()

--- a/lib/tests/streamlit/runtime/scriptrunner/test_data/rerun_once_then_finish.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/test_data/rerun_once_then_finish.py
@@ -1,0 +1,25 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calls ``st.rerun()`` exactly once. Used by the script runner integration
+test that asserts ``coordinator.drain()`` runs when a RerunException
+escapes from inside ``exec()``."""
+
+import streamlit as st
+
+st.session_state["run_count"] = st.session_state.get("run_count", 0) + 1
+if st.session_state["run_count"] == 1:
+    st.rerun()
+
+st.text("done")

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -23,7 +23,10 @@ import pytest
 from streamlit.errors import NoSessionContext
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
-from streamlit.runtime.fragment import MemoryFragmentStorage
+from streamlit.runtime.fragment import (
+    MemoryFragmentStorage,
+    ParallelFragmentCoordinator,
+)
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
@@ -345,6 +348,54 @@ class ScriptRunContextTest(unittest.TestCase):
         t.join()
 
         assert captured["fragment_id"] == "frag2"
+
+    def test_reset_raises_when_called_from_non_main_thread(self):
+        """``reset()`` may only be called from the script thread that
+        constructed the context. Worker threads (parallel fragments) must
+        not be able to mutate the context's coordinator out from under the
+        main thread."""
+        ctx = _create_script_run_context(lambda _msg: None)
+        captured: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                ctx.reset()
+            except RuntimeError as e:
+                captured.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert len(captured) == 1
+        assert "main script thread" in str(captured[0])
+
+    def test_reset_creates_fresh_coordinator_each_run(self):
+        """Each ``reset()`` constructs a new coordinator. Reusing one across
+        runs would let a previous run's stop event / worker exception leak
+        into the next run."""
+        pages_manager = PagesManager("/main/script/path")
+        pages_manager.set_pages({})
+        ctx = _create_script_run_context(lambda _msg: None, pages_manager=pages_manager)
+
+        ctx.reset(page_script_hash=pages_manager.main_script_hash)
+        first = ctx.parallel_coordinator
+        assert isinstance(first, ParallelFragmentCoordinator)
+
+        ctx.reset(page_script_hash=pages_manager.main_script_hash)
+        second = ctx.parallel_coordinator
+        assert isinstance(second, ParallelFragmentCoordinator)
+        assert first is not second
+
+    def test_reset_passes_yield_check_to_coordinator(self):
+        """The yield_check supplied to ``reset()`` is wired into the
+        coordinator so ``join()`` can drive the script runner's
+        execution-control hook."""
+        ctx = _create_script_run_context(lambda _msg: None)
+        calls: list[int] = []
+        ctx.reset(yield_check=lambda: calls.append(1))
+        assert ctx.parallel_coordinator is not None
+        ctx.parallel_coordinator._yield_check()
+        assert calls == [1]
 
     def test_add_script_run_ctx_propagates_thread_state_to_child(self):
         """Child threads observe the parent's ``FragmentThreadState``

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -23,12 +23,10 @@ import pytest
 from streamlit.errors import NoSessionContext
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.forward_msg_cache import populate_hash_if_needed
-from streamlit.runtime.fragment import (
-    MemoryFragmentStorage,
-    ParallelFragmentCoordinator,
-)
+from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     SCRIPT_RUN_CONTEXT_ATTR_NAME,
     ScriptRunContext,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Improves test coverage for the parallel fragment dispatch feature (#15214) by fixing 6 existing test issues and adding 4 new nesting tests.

### Existing test fixes (Part A)

- **A1**: Remove dead `called` variable from `test_fragment_parallel_parameter_accepted` (was set but never asserted)
- **A2**: Fix misleading docstring in `test_nested_sequential_fragment_creates_own_container` and add container creation assertion
- **A3**: Rewrite `test_nested_parallel_fragment_dispatches_from_worker` to actually test dispatch from worker context via `_run_parallel_fragment`
- **A4**: Strengthen assertion in `test_worker_dg_stack_points_at_pre_allocated_container` to verify stack grows by exactly 1 (not just >0)
- **A5**: Add positive execution assertion to `test_wrapped_fragment_skips_container_when_pre_allocated` to verify body actually runs
- **A6**: Add inline execution assertion to `test_run_every_parallel_fragment_reruns_sequentially` to verify fragment body executes during rerun phase

### New nesting tests (Part B)

- **B1**: `test_sequential_fragment_inside_parallel_worker_creates_own_container` - Verifies inner sequential fragment creates container when outer's skip signal is consumed
- **B2**: `test_skip_signal_isolation_inner_fragment_sees_none_after_outer_consumes` - Verifies skip signal doesn't leak to nested fragments
- **B3**: `test_parallel_fragment_nested_inside_rerun_executes_sequentially` - Verifies sequential fallback propagates into nested parallel fragments during reruns
- **B4**: `test_rerun_exception_propagates_from_nested_fragment_inside_worker` - Documents exception propagation path through nested fragments

## GitHub Issue Link (if applicable)

Related to PR #15214 (parallel fragment dispatch)

## Testing Plan

- Unit Tests (Python): 566 passed, 1 skipped in `lib/tests/streamlit/runtime/fragment_test.py`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8d86fbe-ca52-4834-8a6a-e23a4daa9f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8d86fbe-ca52-4834-8a6a-e23a4daa9f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

