### PR TITLE
fix: correct 'overridenProps' typo to 'overriddenProps' in Modal.tsx

### DIFF
--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -216,8 +216,8 @@ function Modal(props: StreamlitModalProps): ReactElement {
     sizes.dialogLargeWidth
   )
   const mergedOverrides = merge(defaultOverrides, props.overrides)
-  const overridenProps = { ...props, size: modalSize }
-  return <UIModal {...overridenProps} overrides={mergedOverrides} />
+  const overriddenProps = { ...props, size: modalSize }
+  return <UIModal {...overriddenProps} overrides={mergedOverrides} />
 }
 
 export default Modal


### PR DESCRIPTION
## Summary
- Fixes misspelling `overridenProps` → `overriddenProps` in `frontend/lib/src/components/shared/Modal/Modal.tsx`

## Changes
- Line 219: `const overridenProps` → `const overriddenProps`
- Line 220: `{...overridenProps}` → `{...overriddenProps}`

## Test plan
- [ ] Verify Modal component still renders correctly
- [ ] Run existing frontend tests — change is variable rename only, no logic affected
