### PR TITLE
fix: correct typo 'overriden' to 'overridden' in Modal.tsx

### DIFF
--- a/frontend/lib/src/components/shared/Modal/Modal.tsx
+++ b/frontend/lib/src/components/shared/Modal/Modal.tsx
@@ -216,8 +216,8 @@ function Modal(props: StreamlitModalProps): ReactElement {
     sizes.dialogLargeWidth
   )
   const mergedOverrides = merge(defaultOverrides, props.overrides)
-  const overridenProps = { ...props, size: modalSize }
-  return <UIModal {...overridenProps} overrides={mergedOverrides} />
+  const overriddenProps = { ...props, size: modalSize }
+  return <UIModal {...overriddenProps} overrides={mergedOverrides} />
 }
 
 export default Modal


### PR DESCRIPTION
This is an independent contribution made by an individual developer. This work is not associated with any hackathon, competition, or coordinated PR campaign.

## Describe your changes

Renamed local variable `overridenProps` to `overriddenProps` (double 'd') in Modal.tsx to fix a typo in the identifier name.

## Screenshot or video (only for visual changes)

N/A — not a visual change.

## GitHub Issue Link (if applicable)

No issue filed — this is a straightforward identifier typo fix.

## Testing Plan

- Explanation of why no additional tests are needed: This is a simple identifier rename. The variable is locally scoped (const, created and used within the same function). No runtime behavior changes.
- Unit Tests (JS and/or Python): Existing tests validate Modal functionality; renaming a local const cannot affect test outcomes.
- E2E Tests: Not needed.
- Any manual testing needed?: A grep for `overridenProps` across the codebase confirms the identifier is only used in this file at lines 219-220, so the rename is complete.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.