### PR TITLE
fix(build): fix make all-dev and make protobuf on non-Debian Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ $ sudo apt-get install -y ripgrep
 
 ```bash
 # Install some essentials
-$ sudo dnf install -y make gcc-c++ curl git rsync unzip protobuf-compiler ripgrep
+$ sudo dnf install -y make gcc-c++ curl git rsync unzip protobuf-compiler
 
 # Set frontend dependencies:
 $ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
@@ -172,10 +172,13 @@ $ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # (Recommended) Install GitHub CLI - used by AI agents for PR and issue management
 # See https://cli.github.com/ for installation instructions
+
+# (Recommended) Install ripgrep - used by AI agents for fast log/code search
+$ sudo dnf install -y ripgrep
 ```
 
 > [!Note]
-> If you're not on Debian or Ubuntu, `make python-init` skips `playwright install --with-deps`. That command only officially supports those two distros. Browser binaries still download fine. If e2e tests later complain about missing system libraries, grab them through your package manager. See Playwright's [system requirements](https://playwright.dev/python/docs/intro#system-requirements) for the list. To force or skip the deps step, set `INSTALL_PLAYWRIGHT_DEPS=true` or `false`.
+> If you're not on Debian, Ubuntu, or macOS, `make python-init` skips `playwright install --with-deps`. That command only officially supports those platforms. Browser binaries still download fine. If e2e tests later complain about missing system libraries, grab them through your package manager. See Playwright's [system requirements](https://playwright.dev/python/docs/intro#system-requirements) for the list. To force or skip the deps step, set `INSTALL_PLAYWRIGHT_DEPS=true` or `false`.
 
 #### Windows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,28 @@ $ curl -LsSf https://astral.sh/uv/install.sh | sh
 $ sudo apt-get install -y ripgrep
 ```
 
+#### Rocky Linux / RHEL / Fedora
+
+```bash
+# Install some essentials
+$ sudo dnf install -y make gcc-c++ curl git rsync unzip protobuf-compiler ripgrep
+
+# Set frontend dependencies:
+$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+$ source ~/.bashrc
+$ nvm install node
+$ corepack enable
+
+# Install uv for Python
+$ curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# (Recommended) Install GitHub CLI - used by AI agents for PR and issue management
+# See https://cli.github.com/ for installation instructions
+```
+
+> [!Note]
+> If you're not on Debian or Ubuntu, `make python-init` skips `playwright install --with-deps`. That command only officially supports those two distros. Browser binaries still download fine. If e2e tests later complain about missing system libraries, grab them through your package manager. See Playwright's [system requirements](https://playwright.dev/python/docs/intro#system-requirements) for the list. To force or skip the deps step, set `INSTALL_PLAYWRIGHT_DEPS=true` or `false`.
+
 #### Windows
 
 Streamlit's development setup is pretty Mac- and Linux-centric. If you're doing Streamlit development on Windows, we suggest using our [devcontainer](./.devcontainer) via Github Codespaces or locally via VS Code. Alternatively, you can also spin up a Linux VM (e.g. via [VirtualBox](https://www.virtualbox.org/), which is free); or your own Linux Docker image; or using Microsoft's WSL ("Windows Subsystem for Linux").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ $ curl -LsSf https://astral.sh/uv/install.sh | sh
 $ sudo dnf install -y ripgrep
 ```
 
-> [!Note]
+> [!NOTE]
 > If you're not on Debian, Ubuntu, or macOS, `make python-init` skips `playwright install --with-deps`. That command only officially supports those platforms. Browser binaries still download fine. If e2e tests later complain about missing system libraries, grab them through your package manager. See Playwright's [system requirements](https://playwright.dev/python/docs/intro#system-requirements) for the list. To force or skip the deps step, set `INSTALL_PLAYWRIGHT_DEPS=true` or `false`.
 
 #### Windows

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,16 @@ SHELL=/bin/bash
 INSTALL_DEV_REQS ?= true
 INSTALL_TEST_REQS ?= true
 INSTALL_PLAYWRIGHT ?= true
+INSTALL_PLAYWRIGHT_DEPS ?= auto
 # Flags:
 #  - INSTALL_DEV_REQS: install dev requirements (default: true)
 #  - INSTALL_TEST_REQS: install test requirements (default: true)
 #  - INSTALL_PLAYWRIGHT: install Playwright browsers during python-init (default: true)
 #    CI uses a dedicated action to install browsers and typically sets this to false.
 #    Local dev can opt out when not needed: `INSTALL_PLAYWRIGHT=false make init`
+#  - INSTALL_PLAYWRIGHT_DEPS: install Playwright OS-level system deps (default: auto)
+#    `auto` runs --with-deps on Debian, Ubuntu, and macOS only. Use `true` to force
+#    it everywhere, or `false` to skip it (browsers still install in either case).
 PYTHON_VERSION := $(shell python --version | cut -d " " -f 2 | cut -d "." -f 1-2)
 MIN_PROTOC_VERSION = 3.20
 
@@ -121,6 +125,10 @@ protobuf:
 		proto/streamlit/proto/*.proto
 
 	@# JS/TS protobuf generation
+	@if [ ! -d "frontend/node_modules" ]; then \
+		echo "frontend/node_modules not found. Running 'make frontend-init' first..."; \
+		$(MAKE) frontend-init; \
+	fi
 	cd frontend/ ; yarn workspace @streamlit/protobuf run generate-protobuf
 
 .PHONY: protobuf-lint
@@ -158,7 +166,15 @@ python-init:
 	fi
 	@# Install playwright if requested
 	@if [ "${INSTALL_TEST_REQS}" = "true" ] && [ "${INSTALL_PLAYWRIGHT}" = "true" ]; then \
-		uv run python -m playwright install --with-deps; \
+		if [ "${INSTALL_PLAYWRIGHT_DEPS}" = "false" ]; then \
+			uv run python -m playwright install; \
+		elif [ "${INSTALL_PLAYWRIGHT_DEPS}" = "true" ] || [ -f /etc/debian_version ] || [ "$$(uname)" = "Darwin" ]; then \
+			uv run python -m playwright install --with-deps; \
+		else \
+			echo "Skipping 'playwright install --with-deps': not officially supported on this OS."; \
+			echo "Browsers will be downloaded. Install browser system libraries through your distro's package manager (see CONTRIBUTING.md)."; \
+			uv run python -m playwright install; \
+		fi; \
 	fi
 
 .PHONY: python-lint


### PR DESCRIPTION
## Describe your changes

`make all-dev` aborted on RHEL-family distros (Rocky, Fedora, etc.) because `playwright install --with-deps` is only officially supported on Debian/Ubuntu and falls back to invoking apt-get, which doesn't exist on those systems. `make protobuf` failed on a fresh checkout when frontend/node_modules wasn't yet populated, surfacing a cryptic yarn error instead of bootstrapping itself.

* Makefile: add INSTALL_PLAYWRIGHT_DEPS flag (default `auto`). The python-init target now runs `--with-deps` only on Debian, Ubuntu, and macOS, and downloads the browser binaries without system-deps elsewhere. Set the flag to `true` or `false` to override.
* Makefile: protobuf now lazy-bootstraps frontend deps via `make frontend-init` if frontend/node_modules is missing, instead of dropping straight into yarn.
* CONTRIBUTING.md: add a Rocky Linux / RHEL / Fedora setup section alongside the existing Ubuntu and macOS instructions, and a note explaining the Playwright system-deps behavior on non-Debian distros.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Manually tested on non-Debian distro.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
