### PR TITLE
[fix] Disable Select all in multiselect for >=1000 options

### DIFF
--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -948,6 +948,23 @@ describe("Multiselect widget", () => {
       expect(screen.getByText("option_0")).toBeVisible()
     })
 
+    it("does not show Select X matches when there are >= 1000 options", async () => {
+      const user = userEvent.setup()
+      const options = Array.from({ length: 1000 }, (_, i) => `option_${i}`)
+      const props = getProps({ default: [], options })
+      render(<Multiselect {...props} />)
+
+      const multiSelect = screen.getByRole("combobox")
+      await user.click(multiSelect)
+      // Search for options matching "option_1" (this will match option_1, option_10-19, option_100-199, etc.)
+      await user.type(multiSelect, "option_1")
+
+      // "Select X matches" should NOT be shown for >= 1000 total options
+      expect(screen.queryByText(/Select \d+ matches/)).not.toBeInTheDocument()
+      // But matching options should still be visible (use queryAllBy since multiple match)
+      expect(screen.queryAllByText(/option_1/).length).toBeGreaterThan(0)
+    })
+
     it("shows Select all when there are less than 1000 options", async () => {
       const user = userEvent.setup()
       const options = Array.from({ length: 999 }, (_, i) => `option_${i}`)

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -933,6 +933,32 @@ describe("Multiselect widget", () => {
       expect(screen.getByText("Select all")).toBeInTheDocument()
       expect(screen.queryByText(/Select.*matches/)).not.toBeInTheDocument()
     })
+
+    it("does not show Select all when there are >= 1000 options", async () => {
+      const user = userEvent.setup()
+      const options = Array.from({ length: 1000 }, (_, i) => `option_${i}`)
+      const props = getProps({ default: [], options })
+      render(<Multiselect {...props} />)
+
+      const expandListButton = screen.getAllByTitle("open")[0]
+      await user.click(expandListButton)
+
+      expect(screen.queryByText("Select all")).not.toBeInTheDocument()
+      // Options should still be visible
+      expect(screen.getByText("option_0")).toBeVisible()
+    })
+
+    it("shows Select all when there are less than 1000 options", async () => {
+      const user = userEvent.setup()
+      const options = Array.from({ length: 999 }, (_, i) => `option_${i}`)
+      const props = getProps({ default: [], options })
+      render(<Multiselect {...props} />)
+
+      const expandListButton = screen.getAllByTitle("open")[0]
+      await user.click(expandListButton)
+
+      expect(screen.getByText("Select all")).toBeVisible()
+    })
   })
 })
 

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -66,6 +66,14 @@ export interface Props {
   fragmentId?: string
 }
 
+/**
+ * Threshold above which "Select all" / "Select X matches" is disabled.
+ * Selecting all items at once with very large option lists causes severe
+ * performance issues (browser freezes, large serialization payloads).
+ * See: https://github.com/streamlit/streamlit/issues/15299
+ */
+const SELECT_ALL_THRESHOLD = 1000
+
 type MultiselectValue = string[]
 
 const getStateFromWidgetMgr = (
@@ -254,7 +262,11 @@ const Multiselect: FC<Props> = props => {
       const filteredOptions = createFilterOptions(value)(options, filterValue)
 
       // Add "Select all" or "Select X matches" option when multiple selectable options
-      if (filteredOptions.length > 1) {
+      // Disable for large option lists to prevent browser freezes
+      if (
+        filteredOptions.length > 1 &&
+        element.options.length < SELECT_ALL_THRESHOLD
+      ) {
         if (filterValue.trim()) {
           // With search: store filtered values in dedicated ref
           // Using separate ref from "Select all" avoids race conditions
@@ -280,7 +292,7 @@ const Multiselect: FC<Props> = props => {
 
       return filteredOptions
     },
-    [createFilterOptions, overMaxSelections, value]
+    [createFilterOptions, element.options.length, overMaxSelections, value]
   )
 
   const disabled = props.disabled || shouldDisable

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -67,9 +67,9 @@ export interface Props {
 }
 
 /**
- * Threshold above which "Select all" / "Select X matches" is disabled.
- * Selecting all items at once with very large option lists causes severe
- * performance issues (browser freezes, large serialization payloads).
+ * Threshold at or above which "Select all" / "Select X matches" is disabled.
+ * Selecting all items at once with very large option lists (>= 1000) causes
+ * severe performance issues (browser freezes, large serialization payloads).
  * See: https://github.com/streamlit/streamlit/issues/15299
  */
 const SELECT_ALL_THRESHOLD = 1000


### PR DESCRIPTION
## Describe your changes

Disables the "Select all" / "Select X matches" feature in `st.multiselect` when there are 1000 or more options. This prevents browser freezes caused by selecting all items at once in large datasets.

- Adds `SELECT_ALL_THRESHOLD = 1000` constant with documentation
- Skips adding bulk selection options when `element.options.length >= 1000`
- Adds unit tests for threshold boundary values

## GitHub Issue Link (if applicable)

- Closes #15299
- Closes #14918

## Testing Plan

- [x] Unit Tests (JS)
  - `frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx` — Tests threshold behavior at 999 and 1000 options

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->