### PR TITLE
Fix accidental overscrolling in table, dataframe, and data_editor

### DIFF
--- a/frontend/lib/src/components/elements/Table/styled-components.ts
+++ b/frontend/lib/src/components/elements/Table/styled-components.ts
@@ -72,6 +72,8 @@ export const StyledTableBorder = styled.div<{
   position: "relative",
   // Use block display with hidden vertical overflow to eliminate inline-table baseline gap
   display: "block",
+  // This prevents accidental overscrolling that triggers the browser's Back button.
+  overscrollBehaviorX: "contain",
 }))
 
 export const StyledTable = styled.table<{

--- a/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
@@ -44,6 +44,8 @@ export const StyledResizableContainer =
       "& .dvn-scroller": {
         ["overflowX" as unknown as string]: "auto !important",
         ["overflowY" as unknown as string]: "auto !important",
+        // This prevents accidental overscrolling that triggers the browser's Back button.
+        overscrollBehaviorX: "contain",
       },
       "& .gdg-search-bar": {
         ...getPopoverContainerStyle(theme),


### PR DESCRIPTION
## Describe your changes

This PR fixes an issue where accidentally overscrolling a table, dataframe, or data_editor to the left triggers the browser's back navigation.

## Screenshot or video (only for visual changes)

Before:

<img width="1488" height="1084" alt="before" src="https://github.com/user-attachments/assets/59b75c94-e52c-46c3-b6c1-e03803c9d21f" />


After:

<img width="1488" height="1084" alt="after" src="https://github.com/user-attachments/assets/dd9b4daf-172f-4b78-836f-5f9ff24c15b1" />


## GitHub Issue Link (if applicable)

See SNOW-2113538

## Testing Plan

It's pretty hard to test. An E2E is needed for this as the table must be rendered inside an iframe - otherwise the back navigation wouldn't be triggered. It's not worth the hassle, IMO.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
