### PR TITLE
Fix ProgressColumn CSV export for clipped values

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
@@ -47,7 +47,9 @@ const PROGRESS_COLUMN_TEMPLATE = {
   },
 } as BaseColumnProps
 
-function getProgressColumn(params?: ProgressColumnParams): ReturnType<typeof ProgressColumn> {
+function getProgressColumn(
+  params?: ProgressColumnParams
+): ReturnType<typeof ProgressColumn> {
   return ProgressColumn(
     {
       ...PROGRESS_COLUMN_TEMPLATE,
@@ -219,14 +221,17 @@ describe("ProgressColumn", () => {
     [255, "%#x"],
     [4096, "%#X"],
     [42, "% d"],
-  ])("cannot format %p using the sprintf format %p", (input: number, format: string) => {
-    const mockColumn = getProgressColumn({
-      format,
-    })
+  ])(
+    "cannot format %p using the sprintf format %p",
+    (input: number, format: string) => {
+      const mockColumn = getProgressColumn({
+        format,
+      })
 
-    const cell = mockColumn.getCell(input)
-    expect(isErrorCell(cell)).toEqual(true)
-  })
+      const cell = mockColumn.getCell(input)
+      expect(isErrorCell(cell)).toEqual(true)
+    }
+  )
 
   it("correctly formats float values to percentage", () => {
     const mockColumn = getProgressColumn()

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
@@ -143,7 +143,7 @@ describe("ProgressColumn", () => {
     }
   )
 
-  it.each([["foo"], [[]], ["foo"], [[1, 2]], ["123.124.123"], ["--123"], ["2,,2"]])(
+  it.each([["foo"], [[]], [[1, 2]], ["123.124.123"], ["--123"], ["2,,2"]])(
     "%p results in error cell",
     (input: unknown) => {
       const mockColumn = getProgressColumn()

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts
@@ -47,9 +47,7 @@ const PROGRESS_COLUMN_TEMPLATE = {
   },
 } as BaseColumnProps
 
-function getProgressColumn(
-  params?: ProgressColumnParams
-): ReturnType<typeof ProgressColumn> {
+function getProgressColumn(params?: ProgressColumnParams): ReturnType<typeof ProgressColumn> {
   return ProgressColumn(
     {
       ...PROGRESS_COLUMN_TEMPLATE,
@@ -110,6 +108,24 @@ describe("ProgressColumn", () => {
     expect(isErrorCell(mockCell3)).toEqual(true)
   })
 
+  it("returns the original value when the displayed progress is clipped", () => {
+    const mockColumn = getProgressColumn({
+      min_value: 0,
+      max_value: 10,
+      format: "%d",
+    })
+
+    const aboveMaxCell = mockColumn.getCell(11)
+    expect((aboveMaxCell as RangeCellType).data?.value).toEqual(10)
+    expect((aboveMaxCell as RangeCellType).data?.label).toEqual("11")
+    expect(mockColumn.getCellValue(aboveMaxCell)).toEqual(11)
+
+    const belowMinCell = mockColumn.getCell(-2)
+    expect((belowMinCell as RangeCellType).data?.value).toEqual(0)
+    expect((belowMinCell as RangeCellType).data?.label).toEqual("-2")
+    expect(mockColumn.getCellValue(belowMinCell)).toEqual(-2)
+  })
+
   it.each([
     // Supports almost the same as toSafeNumber
     [null, null],
@@ -127,19 +143,14 @@ describe("ProgressColumn", () => {
     }
   )
 
-  it.each([
-    ["foo"],
-    [[]],
-    ["foo"],
-    [[1, 2]],
-    ["123.124.123"],
-    ["--123"],
-    ["2,,2"],
-  ])("%p results in error cell", (input: unknown) => {
-    const mockColumn = getProgressColumn()
-    const cell = mockColumn.getCell(input)
-    expect(isErrorCell(cell)).toEqual(true)
-  })
+  it.each([["foo"], [[]], ["foo"], [[1, 2]], ["123.124.123"], ["--123"], ["2,,2"]])(
+    "%p results in error cell",
+    (input: unknown) => {
+      const mockColumn = getProgressColumn()
+      const cell = mockColumn.getCell(input)
+      expect(isErrorCell(cell)).toEqual(true)
+    }
+  )
 
   it.each([
     // This should support everything that is supported by formatNumber
@@ -208,17 +219,14 @@ describe("ProgressColumn", () => {
     [255, "%#x"],
     [4096, "%#X"],
     [42, "% d"],
-  ])(
-    "cannot format %p using the sprintf format %p",
-    (input: number, format: string) => {
-      const mockColumn = getProgressColumn({
-        format,
-      })
+  ])("cannot format %p using the sprintf format %p", (input: number, format: string) => {
+    const mockColumn = getProgressColumn({
+      format,
+    })
 
-      const cell = mockColumn.getCell(input)
-      expect(isErrorCell(cell)).toEqual(true)
-    }
-  )
+    const cell = mockColumn.getCell(input)
+    expect(isErrorCell(cell)).toEqual(true)
+  })
 
   it("correctly formats float values to percentage", () => {
     const mockColumn = getProgressColumn()

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  GridCell,
-  GridCellKind,
-  LoadingCell,
-} from "@glideapps/glide-data-grid"
+import { GridCell, GridCellKind, LoadingCell } from "@glideapps/glide-data-grid"
 import { RangeCellType } from "@glideapps/glide-data-grid-cells"
 
 import { isIntegerType } from "~lib/dataframes/arrowTypeUtils"
@@ -67,14 +63,15 @@ export interface ProgressColumnParams {
   readonly color?: ChartColor
 }
 
+type ProgressCellData = RangeCellType["data"] & {
+  readonly rawValue?: number
+}
+
 /**
  * A read-only column type to support rendering values that have a defined
  * range. This is rendered via a progress-bar-like visualization.
  */
-function ProgressColumn(
-  props: BaseColumnProps,
-  theme: EmotionTheme
-): BaseColumn {
+function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn {
   const isInteger = isIntegerType(props.arrowType)
 
   const parameters = mergeColumnParameters<ProgressColumnParams>(
@@ -98,11 +95,7 @@ function ProgressColumn(
   // Measure the display value of the max value, so that all progress bars are aligned correctly:
   let measureLabel: string
   try {
-    measureLabel = formatNumber(
-      parameters.max_value as number,
-      parameters.format,
-      fixedDecimals
-    )
+    measureLabel = formatNumber(parameters.max_value as number, parameters.format, fixedDecimals)
   } catch {
     measureLabel = toSafeString(parameters.max_value)
   }
@@ -152,10 +145,7 @@ function ProgressColumn(
         )
       }
 
-      if (
-        notNullOrUndefined(parameters.step) &&
-        Number.isNaN(parameters.step)
-      ) {
+      if (notNullOrUndefined(parameters.step) && Number.isNaN(parameters.step)) {
         return getErrorCell(
           "Invalid step parameter",
           `The step parameter (${parameters.step}) must be a valid number.`
@@ -165,10 +155,7 @@ function ProgressColumn(
       const cellData = toSafeNumber(data)
 
       if (Number.isNaN(cellData) || isNullOrUndefined(cellData)) {
-        return getErrorCell(
-          toSafeString(data),
-          "The value cannot be interpreted as a number."
-        )
+        return getErrorCell(toSafeString(data), "The value cannot be interpreted as a number.")
       }
 
       // Check if the value is larger than the maximum supported value:
@@ -206,17 +193,12 @@ function ProgressColumn(
       if (parameters.color === "auto" || parameters.color === "auto-inverse") {
         // Use min/max to determine threshold at 50%
         const range = parameters.max_value - parameters.min_value
-        const ratio =
-          range === 0 ? 0 : (normalizeCellValue - parameters.min_value) / range
+        const ratio = range === 0 ? 0 : (normalizeCellValue - parameters.min_value) / range
         const isAbove = ratio > 0.5
         if (parameters.color === "auto") {
-          progressColor = isAbove
-            ? theme?.colors.greenColor
-            : theme?.colors.redColor
+          progressColor = isAbove ? theme?.colors.greenColor : theme?.colors.redColor
         } else {
-          progressColor = isAbove
-            ? theme?.colors.redColor
-            : theme?.colors.greenColor
+          progressColor = isAbove ? theme?.colors.redColor : theme?.colors.greenColor
         }
       } else if (parameters.color) {
         progressColor = resolveNamedColor(parameters.color, theme)
@@ -228,6 +210,7 @@ function ProgressColumn(
         copyData: String(cellData), // Column sorting is done via the copyData value
         data: {
           ...cellTemplate.data,
+          rawValue: cellData,
           value: normalizeCellValue,
           label: displayData,
           measureLabel:
@@ -244,6 +227,12 @@ function ProgressColumn(
       if (cell.kind === GridCellKind.Loading) {
         return null
       }
+
+      const rawValue = (cell.data as ProgressCellData | undefined)?.rawValue
+      if (rawValue !== undefined) {
+        return rawValue
+      }
+
       return cell.data?.value === undefined ? null : cell.data?.value
     },
   }

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { GridCell, GridCellKind, LoadingCell } from "@glideapps/glide-data-grid"
+import {
+  GridCell,
+  GridCellKind,
+  LoadingCell,
+} from "@glideapps/glide-data-grid"
 import { RangeCellType } from "@glideapps/glide-data-grid-cells"
 
 import { isIntegerType } from "~lib/dataframes/arrowTypeUtils"
@@ -67,7 +71,14 @@ type ProgressCellData = RangeCellType["data"] & {
   readonly rawValue: number
 }
 
-function hasRawValue(data: RangeCellType["data"] | undefined): data is ProgressCellData {
+type ProgressRangeCell = Omit<RangeCellType, "data"> & {
+  readonly data: ProgressCellData
+  readonly isMissingValue: boolean
+}
+
+function hasRawValue(
+  data: RangeCellType["data"] | undefined
+): data is ProgressCellData {
   return (
     data !== undefined &&
     typeof data === "object" &&
@@ -80,7 +91,10 @@ function hasRawValue(data: RangeCellType["data"] | undefined): data is ProgressC
  * A read-only column type to support rendering values that have a defined
  * range. This is rendered via a progress-bar-like visualization.
  */
-function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn {
+function ProgressColumn(
+  props: BaseColumnProps,
+  theme: EmotionTheme
+): BaseColumn {
   const isInteger = isIntegerType(props.arrowType)
 
   const parameters = mergeColumnParameters<ProgressColumnParams>(
@@ -104,7 +118,11 @@ function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn
   // Measure the display value of the max value, so that all progress bars are aligned correctly:
   let measureLabel: string
   try {
-    measureLabel = formatNumber(parameters.max_value as number, parameters.format, fixedDecimals)
+    measureLabel = formatNumber(
+      parameters.max_value as number,
+      parameters.format,
+      fixedDecimals
+    )
   } catch {
     measureLabel = toSafeString(parameters.max_value)
   }
@@ -154,7 +172,10 @@ function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn
         )
       }
 
-      if (notNullOrUndefined(parameters.step) && Number.isNaN(parameters.step)) {
+      if (
+        notNullOrUndefined(parameters.step) &&
+        Number.isNaN(parameters.step)
+      ) {
         return getErrorCell(
           "Invalid step parameter",
           `The step parameter (${parameters.step}) must be a valid number.`
@@ -164,7 +185,10 @@ function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn
       const cellData = toSafeNumber(data)
 
       if (Number.isNaN(cellData) || isNullOrUndefined(cellData)) {
-        return getErrorCell(toSafeString(data), "The value cannot be interpreted as a number.")
+        return getErrorCell(
+          toSafeString(data),
+          "The value cannot be interpreted as a number."
+        )
       }
 
       // Check if the value is larger than the maximum supported value:
@@ -202,18 +226,23 @@ function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn
       if (parameters.color === "auto" || parameters.color === "auto-inverse") {
         // Use min/max to determine threshold at 50%
         const range = parameters.max_value - parameters.min_value
-        const ratio = range === 0 ? 0 : (normalizeCellValue - parameters.min_value) / range
+        const ratio =
+          range === 0 ? 0 : (normalizeCellValue - parameters.min_value) / range
         const isAbove = ratio > 0.5
         if (parameters.color === "auto") {
-          progressColor = isAbove ? theme?.colors.greenColor : theme?.colors.redColor
+          progressColor = isAbove
+            ? theme?.colors.greenColor
+            : theme?.colors.redColor
         } else {
-          progressColor = isAbove ? theme?.colors.redColor : theme?.colors.greenColor
+          progressColor = isAbove
+            ? theme?.colors.redColor
+            : theme?.colors.greenColor
         }
       } else if (parameters.color) {
         progressColor = resolveNamedColor(parameters.color, theme)
       }
 
-      return {
+      const progressCell: ProgressRangeCell = {
         ...cellTemplate,
         isMissingValue: isNullOrUndefined(data),
         copyData: String(cellData), // Column sorting is done via the copyData value
@@ -230,7 +259,9 @@ function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn
               : measureLabel,
           color: progressColor,
         },
-      } as RangeCellType
+      }
+
+      return progressCell
     },
     getCellValue(cell: RangeCellType | LoadingCell): number | null {
       if (cell.kind === GridCellKind.Loading) {

--- a/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts
@@ -64,7 +64,16 @@ export interface ProgressColumnParams {
 }
 
 type ProgressCellData = RangeCellType["data"] & {
-  readonly rawValue?: number
+  readonly rawValue: number
+}
+
+function hasRawValue(data: RangeCellType["data"] | undefined): data is ProgressCellData {
+  return (
+    data !== undefined &&
+    typeof data === "object" &&
+    "rawValue" in data &&
+    typeof data.rawValue === "number"
+  )
 }
 
 /**
@@ -228,9 +237,8 @@ function ProgressColumn(props: BaseColumnProps, theme: EmotionTheme): BaseColumn
         return null
       }
 
-      const rawValue = (cell.data as ProgressCellData | undefined)?.rawValue
-      if (rawValue !== undefined) {
-        return rawValue
+      if (hasRawValue(cell.data)) {
+        return cell.data.rawValue
       }
 
       return cell.data?.value === undefined ? null : cell.data?.value


### PR DESCRIPTION
## Describe your changes

Fixes #14244.

This keeps the raw numeric value on `ProgressColumn` cells separately from the clipped value used to render the progress bar. CSV export calls `getCellValue()`, so it now exports the original value even when the display is clipped to `min_value` or `max_value`.

## Screenshot or video (only for visual changes)

Not a visual change.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/14244

## Testing Plan

- Added a regression test covering values clipped above `max_value` and below `min_value`.
- Confirmed the focused regression test fails before the fix with `expected 10 to deeply equal 11`.
- Unit Tests (JS and/or Python):
  - `yarn workspace @streamlit/lib test src/components/widgets/DataFrame/columns/ProgressColumn.test.ts`
- Additional checks:
  - `yarn run -T eslint --max-warnings 0 lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts`
  - `yarn run -T oxfmt --check --config .oxfmtrc.json 'lib/src/components/widgets/DataFrame/columns/ProgressColumn.ts' 'lib/src/components/widgets/DataFrame/columns/ProgressColumn.test.ts'`
  - `yarn workspace @streamlit/lib typecheck`
  - `git diff --check`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
