### PR TITLE
fix: st.dataframe horizontal scroll bar not working with width="content" (#14837)

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -284,6 +284,21 @@ describe("DataFrame widget", () => {
     ).toBe(true)
   })
 
+  it("returns true when getBounds returns undefined for a pinned column", () => {
+    const container = document.createElement("div")
+    Object.defineProperty(container, "clientWidth", { value: 600 })
+
+    expect(
+      areDataFramePinnedColumnsTooWide(
+        {
+          getBounds: vi.fn(() => undefined),
+        },
+        container,
+        1
+      )
+    ).toBe(true)
+  })
+
   it("keeps rendered pinned columns active when they fit", () => {
     const container = document.createElement("div")
     Object.defineProperty(container, "clientWidth", { value: 600 })

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -44,7 +44,11 @@ vi.mock("@glideapps/glide-data-grid", async () => ({
 // distribution. But the file picker most likely wouldn't work anyways in jest-dom.
 vi.mock("native-file-system-adapter", () => ({}))
 
-import DataFrame, { DataFrameProps } from "./DataFrame"
+import DataFrame, {
+  areDataFramePinnedColumnsTooWide,
+  DataFrameProps,
+  getDataFrameScrollbarState,
+} from "./DataFrame"
 
 const getProps = (
   data: Uint8Array,
@@ -215,5 +219,88 @@ describe("DataFrame widget", () => {
       }),
       {}
     )
+  })
+
+  it("detects scrollbars from the native Glide scroller", () => {
+    const container = document.createElement("div")
+    const scroller = document.createElement("div")
+    scroller.className = "dvn-scroller"
+    container.appendChild(scroller)
+
+    Object.defineProperty(scroller, "scrollWidth", { value: 500 })
+    Object.defineProperty(scroller, "clientWidth", { value: 250 })
+    Object.defineProperty(scroller, "scrollHeight", { value: 100 })
+    Object.defineProperty(scroller, "clientHeight", { value: 100 })
+
+    expect(getDataFrameScrollbarState(container)).toEqual({
+      hasHorizontalScroll: true,
+      hasVerticalScroll: false,
+    })
+  })
+
+  it("falls back to stack bounds when the native Glide scroller is missing", () => {
+    const container = document.createElement("div")
+    const stack = document.createElement("div")
+    stack.className = "dvn-stack"
+    stack.getBoundingClientRect = vi.fn(() => ({
+      width: 500,
+      height: 100,
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 500,
+      bottom: 100,
+      left: 0,
+      toJSON: vi.fn(),
+    }))
+    container.appendChild(stack)
+
+    Object.defineProperty(container, "clientWidth", { value: 250 })
+    Object.defineProperty(container, "clientHeight", { value: 100 })
+
+    expect(getDataFrameScrollbarState(container)).toEqual({
+      hasHorizontalScroll: true,
+      hasVerticalScroll: false,
+    })
+  })
+
+  it("detects when rendered pinned columns take too much space", () => {
+    const container = document.createElement("div")
+    Object.defineProperty(container, "clientWidth", { value: 600 })
+
+    expect(
+      areDataFramePinnedColumnsTooWide(
+        {
+          getBounds: vi.fn(() => ({
+            width: 400,
+            height: 35,
+            x: 0,
+            y: 0,
+          })),
+        },
+        container,
+        1
+      )
+    ).toBe(true)
+  })
+
+  it("keeps rendered pinned columns active when they fit", () => {
+    const container = document.createElement("div")
+    Object.defineProperty(container, "clientWidth", { value: 600 })
+
+    expect(
+      areDataFramePinnedColumnsTooWide(
+        {
+          getBounds: vi.fn(() => ({
+            width: 300,
+            height: 35,
+            x: 0,
+            y: 0,
+          })),
+        },
+        container,
+        1
+      )
+    ).toBe(false)
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -698,7 +698,7 @@ function DataFrame({
   )
   const { onColumnMoved } = useColumnReordering(
     columns,
-    effectiveFreezeColumns,
+    freezeColumns,
     pinColumn,
     unpinColumn,
     setColumnOrder

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -175,12 +175,13 @@ export function areDataFramePinnedColumnsTooWide(
   for (let columnIndex = 0; columnIndex < freezeColumns; columnIndex++) {
     const columnBounds = dataEditor.getBounds(columnIndex, -1)
     if (!columnBounds) {
-      return false
+      return true
     }
     pinnedColumnsWidth += columnBounds.width
   }
 
-  return pinnedColumnsWidth > containerWidth * 0.6
+  const MAX_PINNED_WIDTH_RATIO = 0.6
+  return pinnedColumnsWidth > containerWidth * MAX_PINNED_WIDTH_RATIO
 }
 
 /**

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -121,6 +121,68 @@ export interface DataFrameProps {
   heightConfig?: streamlit.IHeightConfig | null
 }
 
+export function getDataFrameScrollbarState(container: HTMLElement): {
+  hasVerticalScroll: boolean
+  hasHorizontalScroll: boolean
+} {
+  /* eslint-disable streamlit-custom/no-force-reflow-access -- Existing usage */
+  const scroller = container.querySelector<HTMLElement>(".dvn-scroller")
+  if (scroller) {
+    const scrollbarState = {
+      hasVerticalScroll: scroller.scrollHeight > scroller.clientHeight,
+      hasHorizontalScroll: scroller.scrollWidth > scroller.clientWidth,
+    }
+    /* eslint-enable streamlit-custom/no-force-reflow-access */
+    return scrollbarState
+  }
+
+  // Fallback for older Glide markup where the scroller may not be available.
+  /* eslint-disable streamlit-custom/no-force-reflow-access -- Existing usage */
+  const scrollAreaBounds = container
+    .querySelector(".dvn-stack")
+    ?.getBoundingClientRect()
+
+  const scrollbarState = {
+    hasVerticalScroll: scrollAreaBounds
+      ? scrollAreaBounds.height > container.clientHeight
+      : false,
+    hasHorizontalScroll: scrollAreaBounds
+      ? scrollAreaBounds.width > container.clientWidth
+      : false,
+  }
+  /* eslint-enable streamlit-custom/no-force-reflow-access */
+  return scrollbarState
+}
+
+export function areDataFramePinnedColumnsTooWide(
+  dataEditor: Pick<DataEditorRef, "getBounds">,
+  container: HTMLElement,
+  freezeColumns: number
+): boolean {
+  if (freezeColumns === 0) {
+    return false
+  }
+
+  /* eslint-disable streamlit-custom/no-force-reflow-access -- Existing usage */
+  const containerWidth = container.clientWidth
+  /* eslint-enable streamlit-custom/no-force-reflow-access */
+
+  if (containerWidth <= 0) {
+    return false
+  }
+
+  let pinnedColumnsWidth = 0
+  for (let columnIndex = 0; columnIndex < freezeColumns; columnIndex++) {
+    const columnBounds = dataEditor.getBounds(columnIndex, -1)
+    if (!columnBounds) {
+      return false
+    }
+    pinnedColumnsWidth += columnBounds.width
+  }
+
+  return pinnedColumnsWidth > containerWidth * 0.6
+}
+
 /**
  * The main component used by dataframe & data_editor to render an editable table.
  *
@@ -178,6 +240,7 @@ function DataFrame({
   const scrollbarGutterSize = useScrollbarGutterSize()
 
   const {
+    width: measuredContainerWidth,
     height: measuredContainerHeight,
     elementRef: resizableContainerRef,
   } = useCalculatedDimensions()
@@ -619,11 +682,14 @@ function DataFrame({
   const { pinColumn, unpinColumn, freezeColumns } = useColumnPinning(
     columns,
     isEmptyTable,
-    containerWidth || 0,
+    measuredContainerWidth > 0 ? measuredContainerWidth : containerWidth || 0,
     gridTheme.minColumnWidth,
     clearSelection,
     setColumnConfigMapping
   )
+  const [hasOversizedPinnedColumns, setHasOversizedPinnedColumns] =
+    useState(false)
+  const effectiveFreezeColumns = hasOversizedPinnedColumns ? 0 : freezeColumns
   const { changeColumnFormat } = useColumnFormatting(setColumnConfigMapping)
   const { hideColumn, showColumn } = useColumnVisibility(
     clearSelection,
@@ -631,7 +697,7 @@ function DataFrame({
   )
   const { onColumnMoved } = useColumnReordering(
     columns,
-    freezeColumns,
+    effectiveFreezeColumns,
     pinColumn,
     unpinColumn,
     setColumnOrder
@@ -639,31 +705,20 @@ function DataFrame({
 
   const measureTableScrollbars = useCallback(() => {
     if (resizableContainerRef.current && dataEditorRef.current) {
-      // Get the bounds of the glide-data-grid scroll area (dvn-stack):
-      // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-      const scrollAreaBounds = resizableContainerRef.current
-        ?.querySelector(".dvn-stack")
-        ?.getBoundingClientRect()
+      const { hasVerticalScroll, hasHorizontalScroll } =
+        getDataFrameScrollbarState(resizableContainerRef.current)
 
-      // We might also be able to use the following as an alternative,
-      // but it seems to cause "Maximum update depth exceeded" when scrollbars
-      // are activated or deactivated.
-      // const scrollAreaBounds = dataEditorRef.current?.getBounds()
-      // Also see: https://github.com/glideapps/glide-data-grid/issues/784
-      if (scrollAreaBounds) {
-        setHasVerticalScroll(
-          scrollAreaBounds.height >
-            // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-            resizableContainerRef.current.clientHeight
+      setHasVerticalScroll(hasVerticalScroll)
+      setHasHorizontalScroll(hasHorizontalScroll)
+      setHasOversizedPinnedColumns(
+        areDataFramePinnedColumnsTooWide(
+          dataEditorRef.current,
+          resizableContainerRef.current,
+          freezeColumns
         )
-        setHasHorizontalScroll(
-          scrollAreaBounds.width >
-            // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Existing usage
-            resizableContainerRef.current.clientWidth
-        )
-      }
+      )
     }
-  }, [dataEditorRef, resizableContainerRef])
+  }, [dataEditorRef, freezeColumns, resizableContainerRef])
 
   const {
     clear: clearMeasureTableScrollbarsTimeout,
@@ -704,6 +759,7 @@ function DataFrame({
   }, [
     clearMeasureTableScrollbarsTimeout,
     glideColumns,
+    measuredContainerWidth,
     numRows,
     resizableContainerRef,
     resizableSize,
@@ -940,7 +996,7 @@ function DataFrame({
           // Configure resize indicator to only show on the header:
           resizeIndicator={"header"}
           // Freeze all index columns:
-          freezeColumns={freezeColumns}
+          freezeColumns={effectiveFreezeColumns}
           smoothScrollX={true}
           smoothScrollY={true}
           // Show borders between cells:


### PR DESCRIPTION
## Describe your changes

This PR fixes an issue where the horizontal scrollbar in `st.dataframe` becomes non-functional (visible but unresponsive) when configured with `width="content"` and placed inside layout containers like `st.columns`.

### Root Cause
The `measureTableScrollbars` function in `DataFrame.tsx` was incorrectly reporting `hasHorizontalScroll=false` in some flex-based layouts because it was checking the bounds of the `dvn-stack` against the container's client width. In certain layout configurations, this measurement didn't accurately reflect whether the underlying grid had a scrollbar. When `hasHorizontalScroll` was false, the component didn't correctly handle event propagation for the native scrollbar overlay, allowing `GlideDataGrid` to capture pointer events that should have gone to the scrollbar.

### Fix
1.  **Improved Scrollbar Detection**: Introduced `getDataFrameScrollbarState` which prioritizes checking the `scrollHeight`/`scrollWidth` of the `.dvn-scroller` element directly. This is a more reliable way to detect if Glide has actually rendered scrollbars.
2.  **Pinned Column Safety**: Introduced `areDataFramePinnedColumnsTooWide` to detect if pinned index columns take up too much horizontal space (more than 60% of the container). If they do, pinning is automatically disabled for that render to ensure the main data remains accessible and the layout doesn't break.
3.  **Correct Width Measurement**: Ensured `useColumnPinning` uses the measured container width when available.

## GitHub Issue Link (if applicable)

Closes #14837

## Testing Plan

- [x] **Unit Tests**: Added new test cases in `frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx` to verify:
     - Scrollbar detection from the native Glide scroller.
     - Fallback behavior when the scroller is missing.
     - Detection of oversized pinned columns.
- [x] **Manual Verification**: Verified the fix with a reproduction script placing a wide dataframe in a 2-column layout with `width="content"`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<img width="523" height="245" alt="Lorem ipsum dolor" src="https://github.com/user-attachments/assets/ed6fec01-9919-42be-9756-fb3db79a8f47" />

<img width="423" height="180" alt="ctetur adipiscing elit, sed do eiusmod tempor inci‹" src="https://github.com/user-attachments/assets/1ecd783a-ec52-48e3-b8db-54559084cd72" />

