### PR TITLE
Add file path support to st.download_button via pathlib.Path

### DIFF
--- a/e2e_playwright/st_download_button.py
+++ b/e2e_playwright/st_download_button.py
@@ -194,3 +194,9 @@ st.download_button(
     icon_position="right",
     key="download_emoji_right",
 )
+
+st.download_button(
+    "Download by path",
+    data=CAT_IMAGE,
+    key="path_download_button",
+)

--- a/e2e_playwright/st_download_button_test.py
+++ b/e2e_playwright/st_download_button_test.py
@@ -34,7 +34,7 @@ from e2e_playwright.shared.app_utils import (
     goto_app,
 )
 
-DOWNLOAD_BUTTON_ELEMENTS = 19
+DOWNLOAD_BUTTON_ELEMENTS = 20
 
 
 def check_download_button_source_error_count(messages: list[str], expected_count: int):

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import io
+import mimetypes
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -87,6 +88,7 @@ DownloadButtonDataType: TypeAlias = (
     | TextIO
     | BinaryIO
     | io.RawIOBase
+    | os.PathLike[str]
     | Callable[[], str | bytes | TextIO | BinaryIO | io.RawIOBase]
 )
 
@@ -452,13 +454,18 @@ class ButtonMixin:
             .. |st.markdown| replace:: ``st.markdown``
             .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
-        data : str, bytes, file-like, or callable
+        data : str, bytes, file-like, Path, or callable
             The contents of the file to be downloaded or a callable that
             returns the contents of the file.
 
             File contents can be a string, bytes, or file-like object.
             File-like objects include ``io.BytesIO``, ``io.StringIO``, or any
             class that implements the abstract base class ``io.RawIOBase``.
+
+            You can also pass a :class:`pathlib.Path` object to download a
+            local file by path. When a path is passed, ``file_name`` and
+            ``mime`` are automatically inferred from the file name and
+            extension if not explicitly provided.
 
             If a callable is passed, it is executed when the user clicks
             the download button and runs on a separate thread from the
@@ -719,6 +726,16 @@ class ButtonMixin:
         Remember to specify the MIME type if you don't want the default
         type of ``"application/octet-stream"`` for generic binary data. In the
         example below, the MIME type is set to ``"image/png"`` for a PNG file.
+
+        Alternatively, you can pass a :class:`pathlib.Path` object:
+
+        >>> import streamlit as st
+        >>> from pathlib import Path
+        >>>
+        >>> st.download_button(
+        ...     label="Download image",
+        ...     data=Path("flower.png"),
+        ... )
 
         >>> import streamlit as st
         >>>
@@ -1336,6 +1353,17 @@ class ButtonMixin:
         normalized_shortcut: str | None = None
         if shortcut is not None:
             normalized_shortcut = normalize_shortcut(shortcut)
+
+        if isinstance(data, os.PathLike):
+            path_str = os.fspath(data)
+            if file_name is None:
+                file_name = os.path.basename(path_str)
+            if mime is None:
+                guessed_mime, _ = mimetypes.guess_type(path_str)
+                if guessed_mime is not None:
+                    mime = guessed_mime
+            with open(path_str, "rb") as f:
+                data = f.read()
 
         check_widget_policies(
             self.dg,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -478,6 +478,12 @@ class ButtonMixin:
             your data for download. For more information, see the Example 1
             below.
 
+            .. note::
+                When passing a file path via :class:`pathlib.Path`, the file is
+                read into memory during widget rendering on each script rerun.
+                For large files, prefer the callable form to avoid loading the
+                file into memory until the user clicks the download button.
+
         file_name: str
             An optional string to use as the name of the file to be downloaded,
             such as ``"my_file.csv"``. If not specified, the name will be
@@ -1362,8 +1368,13 @@ class ButtonMixin:
                 guessed_mime, _ = mimetypes.guess_type(path_str)
                 if guessed_mime is not None:
                     mime = guessed_mime
-            with open(path_str, "rb") as f:
-                data = f.read()
+            try:
+                with open(path_str, "rb") as f:
+                    data = f.read()
+            except (FileNotFoundError, PermissionError) as e:
+                raise StreamlitAPIException(
+                    f"Path does not exist or is not readable: {path_str}"
+                ) from e
 
         check_widget_policies(
             self.dg,

--- a/lib/tests/streamlit/elements/download_button_test.py
+++ b/lib/tests/streamlit/elements/download_button_test.py
@@ -15,6 +15,7 @@
 """download_button unit test."""
 
 import io
+from pathlib import Path
 
 from parameterized import parameterized
 
@@ -162,3 +163,53 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
         c2 = self.get_delta_from_queue().new_element.download_button
         assert not c2.HasField("deferred_file_id")
         assert "/media/" in c2.url
+
+    def test_path_data(self, tmp_path):
+        """Test that Path objects are handled correctly."""
+        p = tmp_path / "test.txt"
+        p.write_text("hello from path")
+        st.download_button("Download Path", data=Path(p))
+
+        c = self.get_delta_from_queue().new_element.download_button
+        assert not c.HasField("deferred_file_id")
+        assert "/media/" in c.url
+
+    def test_path_data_infers_file_name(self, tmp_path):
+        """Test that file_name is inferred from path when not provided."""
+        p = tmp_path / "myfile.txt"
+        p.write_text("content")
+        st.download_button("Download Path", data=Path(p))
+
+        c = self.get_delta_from_queue().new_element.download_button
+        assert "/media/" in c.url
+        # The file is stored with the inferred name; the URL should contain it
+        assert "myfile" in c.url
+
+    def test_path_data_infers_mime(self, tmp_path):
+        """Test that mime is inferred from file extension when not provided."""
+        p = tmp_path / "data.csv"
+        p.write_text("a,b,c\n1,2,3")
+        st.download_button("Download Path", data=Path(p))
+
+        c = self.get_delta_from_queue().new_element.download_button
+        assert "/media/" in c.url
+        assert "data" in c.url
+
+    def test_path_data_explicit_file_name(self, tmp_path):
+        """Test that explicit file_name overrides path inference."""
+        p = tmp_path / "actual_name.dat"
+        p.write_text("data")
+        st.download_button("Download Path", data=Path(p), file_name="custom.txt")
+
+        c = self.get_delta_from_queue().new_element.download_button
+        assert "/media/" in c.url
+        assert "custom" in c.url
+
+    def test_path_data_explicit_mime(self, tmp_path):
+        """Test that explicit mime overrides path inference."""
+        p = tmp_path / "data.bin"
+        p.write_text("binary")
+        st.download_button("Download Path", data=Path(p), mime="application/json")
+
+        c = self.get_delta_from_queue().new_element.download_button
+        assert "/media/" in c.url

--- a/lib/tests/streamlit/elements/download_button_test.py
+++ b/lib/tests/streamlit/elements/download_button_test.py
@@ -164,6 +164,13 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
         assert not c2.HasField("deferred_file_id")
         assert "/media/" in c2.url
 
+    def _last_file(self):
+        """Return the most recently stored MemoryFile."""
+        files = self.media_file_storage._files_by_id
+        # Get the last inserted file (Python 3.7+ dict order)
+        last_id = next(reversed(files))
+        return files[last_id]
+
     def test_path_data(self, tmp_path):
         """Test that Path objects are handled correctly."""
         p = tmp_path / "test.txt"
@@ -173,6 +180,8 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.download_button
         assert not c.HasField("deferred_file_id")
         assert "/media/" in c.url
+        f = self._last_file()
+        assert f.content == b"hello from path"
 
     def test_path_data_infers_file_name(self, tmp_path):
         """Test that file_name is inferred from path when not provided."""
@@ -182,8 +191,8 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.download_button
         assert "/media/" in c.url
-        # The file is stored with the inferred name; the URL should contain it
-        assert "myfile" in c.url
+        f = self._last_file()
+        assert f.file_name == "myfile.txt"
 
     def test_path_data_infers_mime(self, tmp_path):
         """Test that mime is inferred from file extension when not provided."""
@@ -193,7 +202,8 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.download_button
         assert "/media/" in c.url
-        assert "data" in c.url
+        f = self._last_file()
+        assert f.mimetype == "text/csv"
 
     def test_path_data_explicit_file_name(self, tmp_path):
         """Test that explicit file_name overrides path inference."""
@@ -203,7 +213,8 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.download_button
         assert "/media/" in c.url
-        assert "custom" in c.url
+        f = self._last_file()
+        assert f.file_name == "custom.txt"
 
     def test_path_data_explicit_mime(self, tmp_path):
         """Test that explicit mime overrides path inference."""
@@ -213,3 +224,5 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
 
         c = self.get_delta_from_queue().new_element.download_button
         assert "/media/" in c.url
+        f = self._last_file()
+        assert f.mimetype == "application/json"


### PR DESCRIPTION
## Describe your changes

Adds support for passing `pathlib.Path` objects to `st.download_button` data parameter. When a Path is passed, the file is automatically read, and `file_name` and `mime` are inferred from the path.

## GitHub Issue Link (if applicable)

Closes #7618

## Testing Plan

- Added 5 unit tests covering:
  - Basic Path object handling
  - Auto-inference of `file_name` from basename
  - Auto-inference of `mime` from file extension
  - Explicit `file_name` overrides path inference
  - Explicit `mime` overrides path inference
- Added e2e test button using the existing CAT_IMAGE static path
- Existing tests pass (non-callable data unchanged)

## Example

```python
from pathlib import Path

st.download_button(
    label="Download image",
    data=Path("flower.png"),
)
```

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.