### PR TITLE
[codex] Add alt text support for images

### DIFF
--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -64,10 +64,37 @@ describe("ImageList Element", () => {
     })
   })
 
+  const getImages = (): HTMLImageElement[] =>
+    Array.from(document.querySelectorAll("img"))
+
   it("renders without crashing", () => {
     const props = getProps()
     render(<ImageList {...props} />)
-    expect(screen.getAllByRole("img")).toHaveLength(2)
+    expect(getImages()).toHaveLength(2)
+  })
+
+  it("sets image alt text from the proto", () => {
+    const props = getProps({
+      imgs: [
+        {
+          altText: "A mock test image",
+          caption: "a",
+          url: "/media/mockImage1.jpeg",
+        },
+      ],
+    })
+    render(<ImageList {...props} />)
+
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "A mock test image")
+  })
+
+  it("uses empty alt text by default", () => {
+    const props = getProps({
+      imgs: [{ caption: "a", url: "/media/mockImage1.jpeg" }],
+    })
+    render(<ImageList {...props} />)
+
+    expect(getImages()[0]).toHaveAttribute("alt", "")
   })
 
   describe("Link parameter", () => {
@@ -86,7 +113,7 @@ describe("ImageList Element", () => {
       expect(link).toHaveAttribute("aria-label", "a")
 
       // Image should be inside the link
-      const image = screen.getByRole("img")
+      const image = getImages()[0]
       expect(link).toContainElement(image)
     })
 
@@ -101,6 +128,17 @@ describe("ImageList Element", () => {
       expect(link).toHaveAttribute("aria-label", "https://streamlit.io")
     })
 
+    it("uses alt text as link aria-label when provided", () => {
+      const props = getProps({
+        imgs: [{ altText: "A linked image", url: "/media/mockImage1.jpeg" }],
+        link: "https://streamlit.io",
+      })
+      render(<ImageList {...props} />)
+
+      const link = screen.getByTestId("stImageLink")
+      expect(link).toHaveAttribute("aria-label", "A linked image")
+    })
+
     it("does not render link wrapper when link is not provided", () => {
       const props = getProps({
         imgs: [{ caption: "a", url: "/media/mockImage1.jpeg" }],
@@ -108,7 +146,7 @@ describe("ImageList Element", () => {
       render(<ImageList {...props} />)
 
       expect(screen.queryByTestId("stImageLink")).not.toBeInTheDocument()
-      expect(screen.getByRole("img")).toBeVisible()
+      expect(getImages()[0]).toBeVisible()
     })
 
     it("does not render link wrapper when link is empty string", () => {
@@ -119,7 +157,7 @@ describe("ImageList Element", () => {
       render(<ImageList {...props} />)
 
       expect(screen.queryByTestId("stImageLink")).not.toBeInTheDocument()
-      expect(screen.getByRole("img")).toBeVisible()
+      expect(getImages()[0]).toBeVisible()
     })
 
     it("renders image with caption and link", () => {
@@ -142,7 +180,7 @@ describe("ImageList Element", () => {
       const props = getProps({}, { pixelWidth: 300 })
       render(<ImageList {...props} />)
 
-      const images = screen.getAllByRole("img")
+      const images = getImages()
       expect(images).toHaveLength(2)
       images.forEach(image => {
         expect(image).toHaveStyle("width: 300px")
@@ -153,7 +191,7 @@ describe("ImageList Element", () => {
       const props = getProps({}, { useStretch: true })
       render(<ImageList {...props} />)
 
-      const images = screen.getAllByRole("img")
+      const images = getImages()
       expect(images).toHaveLength(2)
       // When useStretch is true, width should match the element width (250px from mock)
       images.forEach(image => {
@@ -165,7 +203,7 @@ describe("ImageList Element", () => {
       const props = getProps({}, { useContent: true })
       render(<ImageList {...props} />)
 
-      const images = screen.getAllByRole("img")
+      const images = getImages()
       expect(images).toHaveLength(2)
       // When useContent is true, width should be 100% (original size)
       images.forEach(image => {
@@ -179,7 +217,7 @@ describe("ImageList Element", () => {
       const props = getProps()
       render(<ImageList {...props} />)
 
-      const images = screen.getAllByRole("img")
+      const images = getImages()
       expect(images).toHaveLength(2)
       images.forEach(image => {
         expect(image).toHaveStyle("width: 100%")
@@ -190,7 +228,7 @@ describe("ImageList Element", () => {
       const props = getProps({}, null)
       render(<ImageList {...props} />)
 
-      const images = screen.getAllByRole("img")
+      const images = getImages()
       images.forEach(image => {
         expect(image).toHaveStyle("width: 100%")
       })
@@ -200,7 +238,7 @@ describe("ImageList Element", () => {
   it("creates its `src` attribute using buildMediaURL", () => {
     const props = getProps()
     render(<ImageList {...props} />)
-    const images = screen.getAllByRole("img")
+    const images = getImages()
     expect(images).toHaveLength(2)
 
     expect(buildMediaURL).toHaveBeenNthCalledWith(1, "/media/mockImage1.jpeg")
@@ -235,7 +273,7 @@ describe("ImageList Element", () => {
   it("sends an CLIENT_ERROR message when the image source fails to load", () => {
     const props = getProps()
     render(<ImageList {...props} />)
-    const images = screen.getAllByRole("img")
+    const images = getImages()
     expect(images).toHaveLength(2)
 
     // Trigger the error event on the first image using fireEvent
@@ -264,7 +302,7 @@ describe("ImageList Element", () => {
             resourceCrossOriginMode,
           },
         })
-        const images = screen.getAllByRole("img")
+        const images = getImages()
         expect(images).toHaveLength(2)
         images.forEach(image => {
           expect(image).not.toHaveAttribute("crossOrigin")
@@ -341,7 +379,7 @@ describe("ImageList Element", () => {
               resourceCrossOriginMode,
             },
           })
-          const images = screen.getAllByRole("img")
+          const images = getImages()
           expect(images).toHaveLength(2)
           images.forEach(image => {
             expect(image).toHaveAttribute("crossOrigin", expected)
@@ -423,7 +461,7 @@ describe("ImageList Element", () => {
               resourceCrossOriginMode,
             },
           })
-          const images = screen.getAllByRole("img")
+          const images = getImages()
           expect(images).toHaveLength(2)
           images.forEach(image => {
             expect(image).not.toHaveAttribute("crossOrigin")

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -80,7 +80,6 @@ function getImageWidth(
 }
 
 const Image = ({
-  itemKey,
   image,
   imgStyle,
   buildMediaURL,
@@ -88,7 +87,6 @@ const Image = ({
   shouldStretch,
   link,
 }: {
-  itemKey: string
   image: ImageProto
   imgStyle: CSSProperties
   buildMediaURL: (url: string) => string
@@ -102,7 +100,7 @@ const Image = ({
     <img
       style={imgStyle}
       src={buildMediaURL(image.url)}
-      alt={itemKey}
+      alt={image.altText || ""}
       onError={handleImageError}
       crossOrigin={crossOrigin}
     />
@@ -118,7 +116,7 @@ const Image = ({
           href={link}
           target="_blank"
           rel="noreferrer"
-          aria-label={image.caption || link}
+          aria-label={image.altText || image.caption || link}
           data-testid="stImageLink"
         >
           {imageElement}
@@ -221,7 +219,6 @@ function ImageList({
               // TODO: Update to match React best practices
               // eslint-disable-next-line @eslint-react/no-array-index-key
               key={idx}
-              itemKey={idx.toString()}
               image={iimage as ImageProto}
               imgStyle={imgStyle}
               buildMediaURL={(url: string) => endpoints.buildMediaURL(url)}

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -61,6 +61,7 @@ class ImageMixin:
         *,
         use_container_width: bool | None = None,
         link: str | None = None,
+        alt_text: str | list[str] | None = None,
     ) -> DeltaGenerator:
         """Display an image or list of images.
 
@@ -162,11 +163,20 @@ class ImageMixin:
             image will not include a hyperlink.
 
             This parameter is only supported when displaying a single image.
+        alt_text : str, list of str, or None
+            Alternative text for the image(s), used by screen readers. If this
+            is ``None`` (default), the image will have an empty alt attribute.
+            If ``image`` is a list of multiple images, ``alt_text`` must be a
+            list of strings (one alternative text for each image) or ``None``.
 
         Examples
         --------
         >>> import streamlit as st
-        >>> st.image("sunrise.jpg", caption="Sunrise by the mountains")
+        >>> st.image(
+        ...     "sunrise.jpg",
+        ...     caption="Sunrise by the mountains",
+        ...     alt_text="A sunrise over a mountain range",
+        ... )
 
         .. output::
            https://doc-image.streamlit.app/
@@ -223,6 +233,7 @@ class ImageMixin:
             clamp,
             channels,
             output_format,
+            alt_text=alt_text,
         )
 
         if link:

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -359,6 +359,7 @@ def marshall_images(
     clamp: bool,
     channels: Channels = "RGB",
     output_format: ImageFormatOrAuto = "auto",
+    alt_text: str | npt.NDArray[Any] | list[str] | None = None,
 ) -> None:
     """Fill an ImageListProto with a list of images and their captions.
     The images will be resized and reformatted as necessary.
@@ -372,6 +373,9 @@ def marshall_images(
     caption
         Image caption. If displaying multiple images, caption should be a
         list of captions (one for each image).
+    alt_text
+        Alternative text for the image. If displaying multiple images,
+        alt_text should be a list of strings (one for each image).
     layout_config
         The layout configuration for the image, including width settings.
     proto_imgs
@@ -428,13 +432,36 @@ def marshall_images(
             f"Cannot pair {len(captions)} captions with {len(images)} images."
         )
 
+    if isinstance(alt_text, list):
+        alt_texts: Sequence[str | None] = alt_text
+    elif isinstance(alt_text, str):
+        alt_texts = [alt_text]
+    elif isinstance(alt_text, np.ndarray) and len(alt_text.shape) == 1:
+        alt_texts = alt_text.tolist()
+    elif alt_text is None:
+        alt_texts = [None] * len(images)
+    else:
+        alt_texts = [str(alt_text)]
+
+    if not isinstance(alt_texts, list):
+        raise StreamlitAPIException(
+            "If image is a list then alt_text should be a list as well."
+        )
+
+    if len(alt_texts) != len(images):
+        raise StreamlitAPIException(
+            f"Cannot pair {len(alt_texts)} alt_text values with {len(images)} images."
+        )
+
     # Each image in an image list needs to be kept track of at its own coordinates.
-    for coord_suffix, (single_image, single_caption) in enumerate(
-        zip(images, captions, strict=False)
+    for coord_suffix, (single_image, single_caption, single_alt_text) in enumerate(
+        zip(images, captions, alt_texts, strict=False)
     ):
         proto_img = proto_imgs.imgs.add()
         if single_caption is not None:
             proto_img.caption = str(single_caption)
+        if single_alt_text is not None:
+            proto_img.alt_text = str(single_alt_text)
 
         # We use the index of the image in the input image list to identify this image inside
         # MediaFileManager. For this, we just add the index to the image's "coordinates".

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -44,6 +44,7 @@ class PyplotMixin:
         *,
         width: Width = "stretch",
         use_container_width: bool | None = None,
+        alt_text: str | None = None,
         **kwargs: Any,
     ) -> DeltaGenerator:
         """Display a matplotlib.pyplot figure.
@@ -105,6 +106,9 @@ class PyplotMixin:
                 future release. For ``use_container_width=True``, use
                 ``width="stretch"``. For ``use_container_width=False``, use
                 ``width="content"``.
+        alt_text : str or None
+            Alternative text for the figure, used by screen readers. If this
+            is ``None`` (default), the figure will have an empty alt attribute.
 
         **kwargs : any
             Arguments to pass to Matplotlib's savefig function.
@@ -177,6 +181,7 @@ know via [issue on Github](https://github.com/streamlit/streamlit/issues).
             layout_config,
             fig,
             clear_figure,
+            alt_text=alt_text,
             **kwargs,
         )
         return self.dg._enqueue("imgs", image_list_proto, layout_config=layout_config)
@@ -193,6 +198,7 @@ def marshall(
     layout_config: LayoutConfig,
     fig: Figure | None = None,
     clear_figure: bool | None = True,
+    alt_text: str | None = None,
     **kwargs: Any,
 ) -> None:
     try:
@@ -232,6 +238,7 @@ def marshall(
         clamp=False,
         channels="RGB",
         output_format="PNG",
+        alt_text=alt_text,
     )
 
     # Clear the figure after rendering it. This means that subsequent

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -444,11 +444,17 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         """Test st.image with single url."""
         url = "http://server/fake0.jpg"
 
-        st.image(url, caption="some caption", width=300)
+        st.image(
+            url,
+            caption="some caption",
+            alt_text="A fake test image",
+            width=300,
+        )
 
         el = self.get_delta_from_queue().new_element
         assert el.width_config.pixel_width == 300
         assert el.imgs.imgs[0].caption == "some caption"
+        assert el.imgs.imgs[0].alt_text == "A fake test image"
         assert el.imgs.imgs[0].url == url
 
     def test_st_image_with_list_of_urls(self):
@@ -458,12 +464,14 @@ class ImageProtoTest(DeltaGeneratorTestCase):
             "http://server/fake1.png",
             "http://server/fake2.gif",
         ]
-        st.image(urls, caption=["some caption"] * 3, width=300)
+        alt_text = ["Fake image 0", "Fake image 1", "Fake image 2"]
+        st.image(urls, caption=["some caption"] * 3, alt_text=alt_text, width=300)
 
         el = self.get_delta_from_queue().new_element
         assert el.width_config.pixel_width == 300
         for idx, url in enumerate(urls):
             assert el.imgs.imgs[idx].caption == "some caption"
+            assert el.imgs.imgs[idx].alt_text == alt_text[idx]
             assert el.imgs.imgs[idx].url == url
 
     def test_st_image_bad_width(self):

--- a/lib/tests/streamlit/elements/lib/image_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/image_utils_test.py
@@ -256,12 +256,38 @@ def test_marshall_images_splits_4d_ndarray_into_list(no_runtime: None) -> None:
         coordinates="0",
         image=np.zeros((3, 4, 4, 3), dtype=np.uint8),
         caption=["a", "b", "c"],
+        alt_text=["alt a", "alt b", "alt c"],
         layout_config=_DEFAULT_LAYOUT,
         proto_imgs=proto,
         clamp=False,
     )
 
     assert [img.caption for img in proto.imgs] == ["a", "b", "c"]
+    assert [img.alt_text for img in proto.imgs] == ["alt a", "alt b", "alt c"]
+
+
+def test_marshall_images_rejects_alt_text_length_mismatch(
+    no_runtime: None,
+) -> None:
+    """``marshall_images`` requires one alt text value per image."""
+    proto = ImageListProto()
+
+    with pytest.raises(
+        StreamlitAPIException,
+        match=r"Cannot pair 1 alt_text values with 2 images.",
+    ):
+        marshall_images(
+            coordinates="0",
+            image=[
+                np.zeros((4, 4, 3), dtype=np.uint8),
+                np.zeros((4, 4, 3), dtype=np.uint8),
+            ],
+            caption=None,
+            alt_text=["only one"],
+            layout_config=_DEFAULT_LAYOUT,
+            proto_imgs=proto,
+            clamp=False,
+        )
 
 
 def test_marshall_images_caption_from_1d_ndarray(no_runtime: None) -> None:

--- a/lib/tests/streamlit/elements/pyplot_test.py
+++ b/lib/tests/streamlit/elements/pyplot_test.py
@@ -58,11 +58,12 @@ class PyplotTest(DeltaGeneratorTestCase):
         # Add 20 random points to scatter plot.
         ax.scatter(data[0], data[1])
 
-        st.pyplot(fig)
+        st.pyplot(fig, alt_text="Scatter plot of random data")
 
         el = self.get_delta_from_queue().new_element
         assert el.width_config.use_stretch
         assert el.imgs.imgs[0].caption == ""
+        assert el.imgs.imgs[0].alt_text == "Scatter plot of random data"
         assert el.imgs.imgs[0].url.startswith(MEDIA_ENDPOINT)
 
     @parameterized.expand([("true", True), ("false", False), ("none", None)])

--- a/lib/tests/streamlit/typing/image_types.py
+++ b/lib/tests/streamlit/typing/image_types.py
@@ -44,6 +44,14 @@ if TYPE_CHECKING:
         DeltaGenerator,
     )
 
+    # Image with alt_text parameter - str or list of str
+    assert_type(image("image.png", alt_text="An accessible image"), DeltaGenerator)
+    assert_type(image("image.png", alt_text=None), DeltaGenerator)
+    assert_type(
+        image(["img1.png", "img2.png"], alt_text=["Alt 1", "Alt 2"]),
+        DeltaGenerator,
+    )
+
     # Image with width parameter - "content", "stretch", or int
     assert_type(image("image.png", width="content"), DeltaGenerator)
     assert_type(image("image.png", width="stretch"), DeltaGenerator)
@@ -92,6 +100,7 @@ if TYPE_CHECKING:
             output_format="auto",
             use_container_width=None,
             link="https://streamlit.io",
+            alt_text="Full example alt text",
         ),
         DeltaGenerator,
     )

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -20,6 +20,7 @@ syntax = "proto3";
 message Image {
   string url = 3;
   string caption = 2;
+  string alt_text = 5;
 
   reserved 1, 4;
 }


### PR DESCRIPTION
## Summary

Adds explicit alternative text support for Streamlit image-backed elements as a scoped first step for accessibility issue #8563.

- Adds an `alt_text` field to the `Image` protobuf.
- Adds `alt_text` to `st.image`, supporting one string for a single image or one string per image in image lists.
- Adds `alt_text` to `st.pyplot`, which renders through the image element path.
- Uses the protobuf alt text for rendered `<img alt="...">` values and linked-image `aria-label`s.
- Updates frontend tests to account for empty `alt=""` images being treated as presentational.

Closes part of https://github.com/streamlit/streamlit/issues/8563. Broader chart/dataframe/table alt text support can follow in separate PRs because those render through distinct frontend implementations.

## Validation

- `../.venv/bin/python -m pytest -s --no-cov tests/streamlit/elements/lib/image_utils_test.py tests/streamlit/elements/image_test.py tests/streamlit/elements/pyplot_test.py` from `lib/` -> `126 passed`
- `uv run ruff check lib/streamlit/elements/image.py lib/streamlit/elements/pyplot.py lib/streamlit/elements/lib/image_utils.py lib/tests/streamlit/elements/image_test.py lib/tests/streamlit/elements/pyplot_test.py lib/tests/streamlit/elements/lib/image_utils_test.py lib/tests/streamlit/typing/image_types.py` -> passed
- `uv run ruff format --check lib/streamlit/elements/image.py lib/streamlit/elements/pyplot.py lib/streamlit/elements/lib/image_utils.py lib/tests/streamlit/elements/image_test.py lib/tests/streamlit/elements/pyplot_test.py lib/tests/streamlit/elements/lib/image_utils_test.py lib/tests/streamlit/typing/image_types.py` -> passed
- `corepack yarn workspace @streamlit/protobuf run generate-protobuf` -> passed locally
- `corepack yarn vitest run lib/src/components/elements/ImageList/ImageList.test.tsx` -> `30 passed`
- `corepack yarn workspace @streamlit/lib run formatCheck` -> passed
