### PR TITLE
Extend embed-mode self-dispatch to sendMessageToHost + filter SF syst…

### DIFF
--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -172,13 +172,37 @@ export default class HostCommunicationManager {
    * Register a function to deliver a message to the Host
    */
   public sendMessageToHost = (message: IGuestToHostMessage): void => {
-    window.parent.postMessage(
-      {
-        stCommVersion: HOST_COMM_VERSION,
-        ...message,
-      },
-      "*"
-    )
+    const embedParentOrigin =
+      (
+        window as {
+          __snowsight?: {
+            STREAMLIT_EMBED_MODE?: boolean
+            STREAMLIT_PREAMBLE_PARENT_ORIGIN?: string
+          }
+        }
+      ).__snowsight?.STREAMLIT_EMBED_MODE === true
+        ? (
+            window as {
+              __snowsight?: { STREAMLIT_PREAMBLE_PARENT_ORIGIN?: string }
+            }
+          ).__snowsight?.STREAMLIT_PREAMBLE_PARENT_ORIGIN
+        : null
+    const targetOrigin =
+      typeof embedParentOrigin === "string" && embedParentOrigin.length > 0
+        ? embedParentOrigin
+        : "*"
+    const versioned = {
+      stCommVersion: HOST_COMM_VERSION,
+      ...message,
+    }
+    window.parent.postMessage(versioned, targetOrigin)
+
+    // In embed mode, also self-dispatch so iframe-side listeners (e.g. the
+    // embed adapter's navigationListener listening for SET_QUERY_PARAM) can
+    // catch host-bound messages without monkey-patching window.parent.
+    if (embedParentOrigin) {
+      window.postMessage(versioned, window.location.origin)
+    }
   }
 
   /**

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -34,9 +34,17 @@ QueryParamsInput = Mapping[str, QueryParamValue] | Iterable[tuple[str, QueryPara
 
 EMBED_QUERY_PARAM: Final[str] = "embed"
 EMBED_OPTIONS_QUERY_PARAM: Final[str] = "embed_options"
+# Snowflake host-injected system params that should not surface in
+# st.query_params. Match is case-insensitive (see uses below).
+PARENT_ORIGIN_QUERY_PARAM: Final[str] = "__parentorigin"
+CLIENT_VERSION_QUERY_PARAM: Final[str] = "__clientversion"
+EMBEDDED_APP_QUERY_PARAM: Final[str] = "embeddedapp"
 EMBED_QUERY_PARAMS_KEYS: Final[list[str]] = [
     EMBED_QUERY_PARAM,
     EMBED_OPTIONS_QUERY_PARAM,
+    PARENT_ORIGIN_QUERY_PARAM,
+    CLIENT_VERSION_QUERY_PARAM,
+    EMBEDDED_APP_QUERY_PARAM,
 ]
 
 # Protected parameters that cannot be bound to widgets


### PR DESCRIPTION
…em query params

For embed-mode integrations the iframe's xstate machinery runs in-frame rather than in an outer host frame, so guest-to-host messages need to be observable on the iframe's own window for in-iframe listeners to react.

1. HostCommunicationManager.sendMessageToHost: when STREAMLIT_EMBED_MODE is true, narrow targetOrigin from "*" to STREAMLIT_PREAMBLE_PARENT_ORIGIN AND self-dispatch the message on window so iframe-side listeners (e.g. for SET_QUERY_PARAM, SET_CURRENT_PAGE_NAME) can catch host-bound traffic. No behavior change for non-embed flows.

2. query_params.py: add the Snowflake host-injected system params (__parentOrigin, __clientVersion, embeddedApp) to EMBED_QUERY_PARAMS_KEYS so they don't surface in st.query_params reads. These are present in the iframe URL for any host-managed Streamlit, so this also fixes a pre-existing leak.

## Describe your changes

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
