### PR TITLE
[fix] Metrics endpoint error with SQLAlchemy connections

### DIFF
--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -741,14 +741,13 @@ class ResourceCache(Cache[R]):
         if not cache_entries:
             return {}
 
-        # Lazy-load vendored package to prevent import of numpy
-        from streamlit.vendor.pympler.asizeof import asizeof
+        from streamlit.runtime.stats import safe_sizeof
 
         stats = [
             CacheStat(
                 category_name="st_cache_resource",
                 cache_name=self.display_name,
-                byte_length=asizeof(entry),
+                byte_length=safe_sizeof(entry),
             )
             for entry in cache_entries
         ]

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1281,10 +1281,9 @@ class SessionState:
     def get_stats(
         self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        # Lazy-load vendored package to prevent import of numpy
-        from streamlit.vendor.pympler.asizeof import asizeof
+        from streamlit.runtime.stats import safe_sizeof
 
-        stat = CacheStat("st_session_state", "", asizeof(self))
+        stat = CacheStat("st_session_state", "", safe_sizeof(self))
         # In general, get_stats methods need to be able to return only requested stat
         # families, but this method only returns a single family, and we're guaranteed
         # that it was one of those requested if we make it here.

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -35,11 +35,16 @@ def safe_sizeof(obj: Any) -> int:
     references). This function catches those exceptions and returns 0 instead
     of propagating the error.
     """
+    # Import inside function for lazy loading (reduces startup time).
+    # Python's import system caches modules, so repeated calls have minimal overhead.
     from streamlit.vendor.pympler.asizeof import asizeof
 
     try:
         return asizeof(obj)
-    except Exception:
+    except (TypeError, ReferenceError):
+        # TypeError: objects that don't support weak references (e.g., SQLAlchemy's
+        # _EmptyListener). ReferenceError: weak references that have been garbage
+        # collected during traversal.
         _LOGGER.debug(
             "Failed to calculate size for object of type %s",
             type(obj).__name__,

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -15,12 +15,38 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Final, NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, Protocol, runtime_checkable
+
+from streamlit.logger import get_logger
+
+_LOGGER: Final = get_logger(__name__)
 
 CACHE_MEMORY_FAMILY: Final = "cache_memory_bytes"
 SESSION_EVENTS_FAMILY: Final = "session_events"
 SESSION_DURATION_FAMILY: Final = "session_duration_seconds"
 ACTIVE_SESSIONS_FAMILY: Final = "active_sessions"
+
+
+def safe_sizeof(obj: Any) -> int:
+    """Return the memory size of an object in bytes, or 0 if sizing fails.
+
+    Some objects (e.g., SQLAlchemy connections) contain internal references that
+    cannot be sized by pympler.asizeof (e.g., objects that don't support weak
+    references). This function catches those exceptions and returns 0 instead
+    of propagating the error.
+    """
+    from streamlit.vendor.pympler.asizeof import asizeof
+
+    try:
+        return asizeof(obj)
+    except Exception:
+        _LOGGER.debug(
+            "Failed to calculate size for object of type %s",
+            type(obj).__name__,
+            exc_info=True,
+        )
+        return 0
+
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import unittest
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -38,6 +39,7 @@ from streamlit.runtime.stats import (
     StatsProvider,
     group_cache_stats,
     metric_type_string_to_proto,
+    safe_sizeof,
 )
 
 if TYPE_CHECKING:
@@ -412,3 +414,26 @@ class MetricTypeStringToProtoTest(unittest.TestCase):
         """Test that unknown type strings return the UNKNOWN enum value."""
         assert metric_type_string_to_proto("not_a_real_type") == UNKNOWN
         assert metric_type_string_to_proto("") == UNKNOWN
+
+
+class SafeSizeofTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("list", [1, 2, 3]),
+            ("string", "hello world"),
+            ("dict", {"key": "value"}),
+        ]
+    )
+    def test_returns_positive_size_for_normal_objects(
+        self, _name: str, obj: object
+    ) -> None:
+        """safe_sizeof returns a positive size for normal Python objects."""
+        assert safe_sizeof(obj) > 0
+
+    def test_returns_zero_on_exception(self) -> None:
+        """safe_sizeof returns 0 when sizing fails."""
+        with patch(
+            "streamlit.vendor.pympler.asizeof.asizeof",
+            side_effect=TypeError("cannot create weak reference"),
+        ):
+            assert safe_sizeof(object()) == 0

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -430,10 +430,18 @@ class SafeSizeofTest(unittest.TestCase):
         """safe_sizeof returns a positive size for normal Python objects."""
         assert safe_sizeof(obj) > 0
 
-    def test_returns_zero_on_exception(self) -> None:
-        """safe_sizeof returns 0 when sizing fails."""
+    def test_returns_zero_on_type_error(self) -> None:
+        """safe_sizeof returns 0 when TypeError is raised (e.g., weak reference issue)."""
         with patch(
             "streamlit.vendor.pympler.asizeof.asizeof",
             side_effect=TypeError("cannot create weak reference"),
+        ):
+            assert safe_sizeof(object()) == 0
+
+    def test_returns_zero_on_reference_error(self) -> None:
+        """safe_sizeof returns 0 when ReferenceError is raised (e.g., dead weak ref)."""
+        with patch(
+            "streamlit.vendor.pympler.asizeof.asizeof",
+            side_effect=ReferenceError("weakly-referenced object no longer exists"),
         ):
             assert safe_sizeof(object()) == 0


### PR DESCRIPTION
## Describe your changes

Fixes `TypeError` when requesting `/_stcore/metrics` while using `st.connection("sql")`.

- Added `safe_sizeof()` wrapper that catches exceptions from `pympler.asizeof`
- Returns 0 bytes for objects that cannot be sized instead of throwing 500 error
- SQLAlchemy's `_EmptyListener` objects don't support weak references, which caused `asizeof` to fail

## GitHub Issue Link (if applicable)

- Closes #15307

## Testing Plan

- [x] Unit tests for `safe_sizeof()` function
- [x] Verified existing `stats_test.py` and `cache_resource_api_test.py` still pass

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 2 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->