### PR TITLE
Add accordion layout container

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -36,12 +36,14 @@ import {
   shouldWidthStretch,
 } from "~lib/components/core/Layout/utils"
 import { ScriptRunContext } from "~lib/components/core/ScriptRunContext"
+import type { AccordionProps } from "~lib/components/elements/Accordion/Accordion"
+import Accordion from "~lib/components/elements/Accordion/Accordion"
 import ChatMessage from "~lib/components/elements/ChatMessage/ChatMessage"
 import Dialog from "~lib/components/elements/Dialog/Dialog"
 import Expander from "~lib/components/elements/Expander/Expander"
 import Popover from "~lib/components/elements/Popover/Popover"
-import Tabs from "~lib/components/elements/Tabs/Tabs"
 import type { TabProps } from "~lib/components/elements/Tabs/Tabs"
+import Tabs from "~lib/components/elements/Tabs/Tabs"
 import Form from "~lib/components/widgets/Form/Form"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useScrollToBottom } from "~lib/hooks/useScrollToBottom"
@@ -426,6 +428,25 @@ export const BlockNodeRenderer = (
       fragmentId: node.fragmentId,
     }
     return <Tabs {...tabsProps} />
+  }
+
+  if (node.deltaBlock.accordionContainer) {
+    const renderAccordionContent = (
+      mappedChildProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
+    ): ReactElement => {
+      return <ContainerContentsWrapper {...mappedChildProps} height="auto" />
+    }
+
+    const accordionProps: AccordionProps = {
+      ...childProps,
+      isStale,
+      renderAccordionContent,
+      width: styles.width,
+      flex: styles.flex,
+      fragmentId: node.fragmentId,
+    }
+
+    return <Accordion {...accordionProps} />
   }
 
   if (containerElement) {

--- a/frontend/lib/src/components/elements/Accordion/Accordion.test.tsx
+++ b/frontend/lib/src/components/elements/Accordion/Accordion.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { vi } from "vitest"
+
+import { Block as BlockProto } from "@streamlit/protobuf"
+
+import { BlockNode } from "~lib/AppNode"
+import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import Accordion from "./Accordion"
+
+const createWidgetMgr = (): WidgetStateManager =>
+  new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+
+const createAccordionNode = (defaultOpenIndex = 0): BlockNode => {
+  const parent = new BlockNode(
+    "script-hash",
+    [],
+    new BlockProto({
+      allowEmpty: true,
+      accordionContainer: {
+        defaultOpenIndex,
+      },
+    })
+  )
+
+  const first = new BlockNode(
+    "script-hash",
+    [],
+    new BlockProto({
+      allowEmpty: true,
+      accordion: {
+        label: "First",
+      },
+    })
+  )
+
+  const second = new BlockNode(
+    "script-hash",
+    [],
+    new BlockProto({
+      allowEmpty: true,
+      accordion: {
+        label: "Second",
+      },
+    })
+  )
+
+  parent.children.push(first)
+  parent.children.push(second)
+
+  return parent
+}
+
+const renderAccordion = (node = createAccordionNode()): void => {
+  render(
+    <Accordion
+      node={node}
+      isStale={false}
+      widgetsDisabled={false}
+      renderAccordionContent={({ node }) => {
+        const blockNode = node
+        const label = blockNode.deltaBlock.accordion?.label ?? "Unknown"
+        return <div>{`${label} content`}</div>
+      }}
+      width="100%"
+      flex="1"
+      endpoints={{} as never}
+      uploadClient={{} as never}
+      componentRegistry={{} as never}
+      widgetMgr={createWidgetMgr()}
+    />
+  )
+}
+
+describe("Accordion", () => {
+  it("renders accordion section labels", () => {
+    renderAccordion()
+
+    expect(screen.getByText("First")).toBeInTheDocument()
+    expect(screen.getByText("Second")).toBeInTheDocument()
+  })
+
+  it("opens the default section content", () => {
+    renderAccordion(createAccordionNode(0))
+
+    expect(screen.getByText("First content")).toBeVisible()
+  })
+
+  it("opens a different default section when defaultOpenIndex changes", () => {
+    renderAccordion(createAccordionNode(1))
+
+    expect(screen.getByText("Second content")).toBeVisible()
+  })
+
+  it("switches open section when clicking another header", async () => {
+    const user = userEvent.setup()
+    renderAccordion(createAccordionNode(0))
+
+    await user.click(screen.getByText("Second"))
+
+    expect(screen.getByText("Second content")).toBeVisible()
+  })
+
+  it("allows closing the currently open section", async () => {
+    const user = userEvent.setup()
+    renderAccordion(createAccordionNode(0))
+
+    const panels = screen.getAllByTestId("stAccordionDetails")
+    expect(panels[0]).not.toHaveAttribute("inert")
+
+    await user.click(screen.getByText("First"))
+
+    expect(panels[0]).toHaveAttribute("inert")
+  })
+})

--- a/frontend/lib/src/components/elements/Accordion/Accordion.tsx
+++ b/frontend/lib/src/components/elements/Accordion/Accordion.tsx
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { memo, ReactElement, useCallback, useState } from "react"
+
+import { AppNode, BlockNode } from "~lib/AppNode"
+import { BlockPropsWithoutWidth } from "~lib/components/core/Block/Block"
+import {
+  StyledAccordionContainer,
+  StyledAccordionItem,
+} from "~lib/components/elements/Accordion/styled-components"
+import {
+  StyledDetails,
+  StyledDetailsPanel,
+  StyledExpandableContainer,
+  StyledSummary,
+  StyledSummaryHeading,
+  StyledSummaryLabelWrapper,
+} from "~lib/components/elements/Expander/styled-components"
+import { useDetailsAnimation } from "~lib/components/elements/Expander/useDetailsAnimation"
+import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
+import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
+import useWidgetManagerElementState from "~lib/hooks/useWidgetManagerElementState"
+
+export interface AccordionProps extends BlockPropsWithoutWidth {
+  node: BlockNode
+  isStale: boolean
+  renderAccordionContent: (
+    childProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
+  ) => ReactElement
+  width: React.CSSProperties["width"]
+  flex: React.CSSProperties["flex"]
+  fragmentId?: string
+}
+
+interface AccordionItemProps extends BlockPropsWithoutWidth {
+  accordionNode: BlockNode
+  label: string
+  isOpen: boolean
+  isStale: boolean
+  onToggle: (label: string, newOpen: boolean) => void
+  renderAccordionContent: (
+    childProps: JSX.IntrinsicAttributes & BlockPropsWithoutWidth
+  ) => ReactElement
+}
+
+const AccordionItem: React.FC<Readonly<AccordionItemProps>> = ({
+  accordionNode,
+  label,
+  isOpen,
+  isStale,
+  onToggle,
+  renderAccordionContent,
+  widgetMgr,
+  ...props
+}): ReactElement => {
+  const { detailsRef, summaryRef, contentRef, handleToggle } =
+    useDetailsAnimation({
+      backendExpanded: isOpen,
+      label,
+      onToggle: (newOpen: boolean) => onToggle(label, newOpen),
+    })
+
+  const childProps: BlockPropsWithoutWidth = {
+    ...props,
+    widgetMgr,
+    node: accordionNode,
+  }
+
+  return (
+    <StyledAccordionItem
+      className="stAccordionItem"
+      data-testid="stAccordionItem"
+    >
+      <StyledExpandableContainer>
+        <StyledDetails ref={detailsRef} isStale={isStale}>
+          <StyledSummary
+            ref={summaryRef}
+            onClick={handleToggle}
+            isStale={isStale}
+            expanded={isOpen}
+          >
+            <StyledSummaryHeading>
+              <DynamicIcon
+                iconValue={
+                  isOpen
+                    ? ":material/keyboard_arrow_down:"
+                    : ":material/keyboard_arrow_right:"
+                }
+                size="lg"
+              />
+              <StyledSummaryLabelWrapper>
+                <StreamlitMarkdown source={label} allowHTML={false} isLabel />
+              </StyledSummaryLabelWrapper>
+            </StyledSummaryHeading>
+          </StyledSummary>
+
+          <StyledDetailsPanel
+            ref={contentRef}
+            data-testid="stAccordionDetails"
+            inert={!isOpen ? "" : undefined}
+          >
+            {renderAccordionContent(childProps)}
+          </StyledDetailsPanel>
+        </StyledDetails>
+      </StyledExpandableContainer>
+    </StyledAccordionItem>
+  )
+}
+
+const Accordion: React.FC<Readonly<AccordionProps>> = ({
+  node,
+  isStale,
+  widgetMgr,
+  renderAccordionContent,
+  width,
+  flex,
+  fragmentId,
+  ...props
+}): ReactElement => {
+  const container = node.deltaBlock.accordionContainer
+  const widgetId = container?.id || undefined
+  const blockId = node.deltaBlock.id || ""
+  const isWidget = Boolean(widgetMgr && widgetId)
+  const isPassivelyKeyed = Boolean(blockId) && !isWidget
+
+  const defaultOpenIndex = container?.defaultOpenIndex ?? 0
+
+  const children = node.children
+
+  const labels = children.map((child, index) => {
+    const accordionNode = child as BlockNode
+    return accordionNode.deltaBlock.accordion?.label ?? index.toString()
+  })
+
+  const defaultOpenLabel = labels[defaultOpenIndex] ?? labels[0] ?? ""
+
+  const [storedOpenLabel, setStoredOpenLabel] =
+    useWidgetManagerElementState<string>({
+      widgetMgr,
+      id: isPassivelyKeyed ? blockId : "",
+      key: "openLabel",
+      defaultValue: defaultOpenLabel,
+    })
+
+  const initialOpenLabel = isPassivelyKeyed
+    ? storedOpenLabel
+    : defaultOpenLabel
+
+  const [openLabel, setOpenLabel] = useState<string>(initialOpenLabel)
+
+  const handleSectionToggle = useCallback(
+    (label: string, newOpen: boolean): void => {
+      const nextOpenLabel = newOpen ? label : ""
+
+      setOpenLabel(nextOpenLabel)
+
+      if (isPassivelyKeyed) {
+        setStoredOpenLabel(nextOpenLabel)
+      }
+
+      if (isWidget && widgetId && widgetMgr) {
+        widgetMgr.setStringValue(
+          { id: widgetId, formId: "" },
+          nextOpenLabel,
+          { fromUi: true },
+          fragmentId
+        )
+      }
+    },
+    [
+      fragmentId,
+      isPassivelyKeyed,
+      isWidget,
+      setStoredOpenLabel,
+      widgetId,
+      widgetMgr,
+    ]
+  )
+
+  return (
+    <StyledAccordionContainer
+      className="stAccordion"
+      data-testid="stAccordion"
+      style={{ width, flex }}
+    >
+      {children.map((child: AppNode, index: number): ReactElement => {
+        const accordionNode = child as BlockNode
+        const label = labels[index] ?? index.toString()
+
+        return (
+          <AccordionItem
+            key={accordionNode.deltaBlock.accordion?.label ?? label}
+            node={accordionNode}
+            accordionNode={accordionNode}
+            label={label}
+            isOpen={openLabel === label}
+            isStale={isStale}
+            onToggle={handleSectionToggle}
+            renderAccordionContent={renderAccordionContent}
+            widgetMgr={widgetMgr}
+            {...props}
+          />
+        )
+      })}
+    </StyledAccordionContainer>
+  )
+}
+
+export default memo(Accordion)

--- a/frontend/lib/src/components/elements/Accordion/Accordion.tsx
+++ b/frontend/lib/src/components/elements/Accordion/Accordion.tsx
@@ -156,17 +156,20 @@ const Accordion: React.FC<Readonly<AccordionProps>> = ({
       defaultValue: defaultOpenLabel,
     })
 
-  const initialOpenLabel = isPassivelyKeyed
-    ? storedOpenLabel
-    : defaultOpenLabel
+  const initialOpenIndex = isPassivelyKeyed
+    ? labels.indexOf(storedOpenLabel)
+    : defaultOpenIndex
 
-  const [openLabel, setOpenLabel] = useState<string>(initialOpenLabel)
+  const [openIndex, setOpenIndex] = useState<number | undefined>(
+    initialOpenIndex >= 0 ? initialOpenIndex : defaultOpenIndex
+  )
 
   const handleSectionToggle = useCallback(
-    (label: string, newOpen: boolean): void => {
-      const nextOpenLabel = newOpen ? label : ""
+    (index: number, label: string): void => {
+      const nextOpenIndex = openIndex === index ? undefined : index
+      const nextOpenLabel = nextOpenIndex === undefined ? "" : label
 
-      setOpenLabel(nextOpenLabel)
+      setOpenIndex(nextOpenIndex)
 
       if (isPassivelyKeyed) {
         setStoredOpenLabel(nextOpenLabel)
@@ -185,6 +188,7 @@ const Accordion: React.FC<Readonly<AccordionProps>> = ({
       fragmentId,
       isPassivelyKeyed,
       isWidget,
+      openIndex,
       setStoredOpenLabel,
       widgetId,
       widgetMgr,
@@ -203,13 +207,14 @@ const Accordion: React.FC<Readonly<AccordionProps>> = ({
 
         return (
           <AccordionItem
-            key={accordionNode.deltaBlock.accordion?.label ?? label}
+            // eslint-disable-next-line @eslint-react/no-array-index-key
+            key={`accordion-item-${index}`}
             node={accordionNode}
             accordionNode={accordionNode}
             label={label}
-            isOpen={openLabel === label}
+            isOpen={openIndex === index}
             isStale={isStale}
-            onToggle={handleSectionToggle}
+            onToggle={() => handleSectionToggle(index, label)}
             renderAccordionContent={renderAccordionContent}
             widgetMgr={widgetMgr}
             {...props}

--- a/frontend/lib/src/components/elements/Accordion/styled-components.ts
+++ b/frontend/lib/src/components/elements/Accordion/styled-components.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+export const StyledAccordionContainer = styled.div({
+  width: "100%",
+})
+
+export const StyledAccordionItem = styled.div({
+  width: "100%",
+})

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
@@ -35,6 +35,7 @@ Run this command with the Streamlit installation relevant to the code being edit
 | **Top-level commands** | |
 | `st.App` | ASGI-compatible Streamlit application. Use it for advanced server configuration, including custom routes, startup and shutdown lifecycle hooks, custom middleware, custom exception handlers, FastAPI integration, and programmatic secrets. |
 | `st.Page` | Configure a page for `st.navigation` in a multipage app. It creates a page object from a Python file or callable with optional title, icon, URL path, default status, and visibility. |
+| `st.accordion` | Creates a coordinated accordion with collapsible sections. |
 | `st.altair_chart` | Display a chart using the Vega-Altair library. Use it when native charts are not expressive enough and you need Altair's encodings, layers, tooltips, or interactions. |
 | `st.area_chart` | Display an area chart. Use it for common area-chart cases with Streamlit-managed rendering. |
 | `st.audio` | Display an audio player. Accepts common audio data sources such as files, URLs, bytes, and arrays. |

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -90,6 +90,9 @@ from streamlit.elements.lib.mutable_popover_container import (
 from streamlit.elements.lib.skeleton_placeholder import (
     SkeletonPlaceholder as _SkeletonPlaceholder,
 )
+from streamlit.elements.lib.mutable_accordion_container import (
+    AccordionContainer as _AccordionContainer,
+)
 
 # instantiate the DeltaGeneratorSingleton
 _dg_singleton = _DeltaGeneratorSingleton(
@@ -100,6 +103,7 @@ _dg_singleton = _DeltaGeneratorSingleton(
     tab_container_cls=_TabContainer,
     popover_container_cls=_PopoverContainer,
     skeleton_placeholder_cls=_SkeletonPlaceholder,
+    accordion_container_cls=_AccordionContainer,
 )
 _main: _DeltaGenerator = _dg_singleton._main_dg
 sidebar: _DeltaGenerator = _dg_singleton._sidebar_dg
@@ -199,6 +203,7 @@ checkbox = _main.checkbox
 code = _main.code
 columns = _main.columns
 tabs = _main.tabs
+accordion = _main.accordion
 container = _main.container
 dataframe = _main.dataframe
 data_editor = _main.data_editor

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.elements.lib.dialog import Dialog
+    from streamlit.elements.lib.mutable_accordion_container import AccordionContainer
     from streamlit.elements.lib.mutable_expander_container import ExpanderContainer
     from streamlit.elements.lib.mutable_popover_container import PopoverContainer
     from streamlit.elements.lib.mutable_status_container import StatusContainer
@@ -62,6 +63,7 @@ class DeltaGeneratorSingleton:
         tab_container_cls: type[TabContainer],
         popover_container_cls: type[PopoverContainer],
         skeleton_placeholder_cls: type[SkeletonPlaceholder],
+        accordion_container_cls: type[AccordionContainer],
     ) -> None:
         """Registers and initializes all delta-generator classes.
 
@@ -108,6 +110,7 @@ class DeltaGeneratorSingleton:
         self._tab_container_cls = tab_container_cls
         self._popover_container_cls = popover_container_cls
         self._skeleton_placeholder_cls = skeleton_placeholder_cls
+        self._accordion_container_cls = accordion_container_cls
 
     @property
     def main_dg(self) -> DeltaGenerator:
@@ -168,6 +171,12 @@ class DeltaGeneratorSingleton:
         circular imports between skeleton_placeholder.py and delta_generator.py.
         """
         return self._skeleton_placeholder_cls
+
+    def accordion_container_cls(self) -> type[AccordionContainer]:
+        """Stub for AccordionContainer. Since AccordionContainer inherits from
+        DeltaGenerator, this is used to avoid circular imports.
+        """
+        return self._accordion_container_cls
 
 
 def get_dg_singleton_instance() -> DeltaGeneratorSingleton:

--- a/lib/streamlit/delta_generator_singletons.py
+++ b/lib/streamlit/delta_generator_singletons.py
@@ -84,6 +84,9 @@ class DeltaGeneratorSingleton:
             The delta-generator class used as return value for `st.popover`.
         skeleton_placeholder_cls : type[SkeletonPlaceholder]
             The delta-generator class used as return value for `st.skeleton`.
+        accordion_container_cls : type[AccordionContainer]
+            The delta-generator class used as return value for individual
+            accordion sections in `st.accordion`.
 
         Raises
         ------
@@ -172,6 +175,7 @@ class DeltaGeneratorSingleton:
         """
         return self._skeleton_placeholder_cls
 
+    @property
     def accordion_container_cls(self) -> type[AccordionContainer]:
         """Stub for AccordionContainer. Since AccordionContainer inherits from
         DeltaGenerator, this is used to avoid circular imports.

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -54,6 +54,7 @@ from streamlit.string_util import validate_icon_or_emoji
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.elements.lib.dialog import Dialog
+    from streamlit.elements.lib.mutable_accordion_container import AccordionContainer
     from streamlit.elements.lib.mutable_expander_container import ExpanderContainer
     from streamlit.elements.lib.mutable_popover_container import PopoverContainer
     from streamlit.elements.lib.mutable_status_container import StatusContainer
@@ -90,6 +91,19 @@ class _PopoverSerde:
 @dataclass
 class _TabsSerde:
     """Serializer/deserializer for tabs widget state (active tab label)."""
+
+    default_label: str
+
+    def serialize(self, v: str) -> str:
+        return str(v)
+
+    def deserialize(self, ui_value: str | None) -> str:
+        return ui_value if ui_value is not None else self.default_label
+
+
+@dataclass
+class _AccordionSerde:
+    """Serializer/deserializer for accordion widget state."""
 
     default_label: str
 
@@ -983,6 +997,322 @@ class LayoutsMixin:
             tab_dgs.append(tab_dg)
 
         return tuple(tab_dgs)
+
+    @gather_metrics("accordion")
+    def accordion(
+        self,
+        sections: Sequence[str],
+        *,
+        width: WidthWithoutContent = "stretch",
+        default: str | None = None,
+        key: Key | None = None,
+        on_change: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+    ) -> Sequence[AccordionContainer]:
+        r"""Insert containers separated into accordion sections.
+
+        Inserts a number of multi-element containers as accordion sections.
+        An accordion is a grouped set of collapsible sections that lets users
+        reveal one section of related content at a time.
+
+        To add elements to the returned containers, you can use the ``with``
+        notation (preferred) or just call methods directly on the returned
+        objects. See examples below.
+
+        By default, all accordion content is computed and sent to the frontend
+        regardless of which section is open. To enable lazy execution where
+        only the open section's content runs, use ``on_change="rerun"`` or
+        pass a callable to ``on_change``. Each section's ``.open`` property
+        indicates whether it is currently open, letting you conditionally
+        render expensive content.
+
+        Parameters
+        ----------
+        sections : list of str
+            Creates an accordion section for each string in the list. The first
+            section is open by default. The string is used as the section label.
+
+        width : "stretch" or int
+            The width of the accordion container. This can be one of the
+            following:
+
+            - ``"stretch"`` (default): The width of the container matches the
+              width of the parent container.
+            - An integer specifying the width in pixels: The container has a
+              fixed width. If the specified width is greater than the width of
+              the parent container, the width of the container matches the width
+              of the parent container.
+
+        default : str or None
+            The default section to open. If this is ``None`` (default), the
+            first section is opened. If this is a string, it must be one of the
+            section labels. If two sections have the same label as ``default``,
+            the first one is opened.
+
+        key : str, int, or None
+            An optional string or integer to use as the unique key for
+            the widget. If this is ``None`` (default), a key will be
+            generated for the widget based on the values of the other
+            parameters. No two widgets may have the same key.
+
+            When ``on_change`` is set to ``"rerun"`` or a callable, setting a
+            key lets you read or update the open section label via
+            ``st.session_state[key]``. For more details, see `Widget behavior
+            <https://docs.streamlit.io/develop/concepts/architecture/widget-behavior>`_.
+
+            Additionally, if ``key`` is provided, it will be used as a
+            CSS class name prefixed with ``st-key-``.
+
+        on_change : "ignore", "rerun", callable, or None
+            How the accordion should respond when the user changes the open
+            section. This controls whether the accordion tracks state and
+            triggers reruns. ``on_change`` can be one of the following values:
+
+            - ``"ignore"`` (default): The accordion doesn't track state. All
+              accordion content runs regardless of which section is open. The
+              ``.open`` attribute of each section container returns ``None``
+              for all sections.
+
+            - ``"rerun"``: The accordion tracks state. Streamlit reruns the
+              app when the user changes the open section. The ``.open``
+              attribute of each section container returns its current state,
+              which is ``True`` if it is open and ``False`` otherwise. This
+              lets you skip expensive work in closed sections.
+
+            - A callable: The accordion tracks state. Streamlit executes the
+              callable as a callback function and reruns the app when the user
+              changes the open section. The ``.open`` attribute of each section
+              container returns its state like when ``on_change="rerun"``. If
+              you need to access the label of the current open section inside
+              your callback, fetch it through Session State.
+
+            When the accordion tracks state, it can't be used inside
+            Streamlit cache-decorated functions.
+
+        args : list or tuple or None
+            An optional list or tuple of args to pass to the ``on_change``
+            callback.
+
+        kwargs : dict or None
+            An optional dict of kwargs to pass to the ``on_change`` callback.
+
+        Returns
+        -------
+        Sequence of AccordionContainers
+            A sequence of ``AccordionContainer`` objects with ``.open``
+            properties to return the current state of the sections if the
+            accordion tracks state.
+
+        Examples
+        --------
+        **Example 1: Use context management**
+
+        You can use the ``with`` statement to insert any element into an
+        accordion section:
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+
+            section1, section2 = st.accordion(["First", "Second"])
+
+            with section1:
+                st.write("Content of the first section")
+
+            with section2:
+                st.write("Content of the second section")
+
+        **Example 2: Call methods directly**
+
+        You can call methods directly on the returned objects:
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+
+            details, settings = st.accordion(["Details", "Settings"])
+
+            details.write("This is the details section")
+            settings.checkbox("Enable feature")
+
+        **Example 3: Set the default open section**
+
+        Use the ``default`` parameter to set the default section.
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+
+            summary, logs = st.accordion(
+                ["Summary", "Logs"],
+                default="Logs",
+            )
+
+            with summary:
+                st.write("Summary content")
+
+            with logs:
+                st.write("Logs content")
+
+        **Example 4: Programmatically control the accordion state**
+
+        You can use a key to programmatically control the accordion state or
+        access the state in callbacks. You must set the ``on_change`` parameter
+        for the accordion to track state.
+
+        .. code-block:: python
+            :filename: streamlit_app.py
+
+            import streamlit as st
+
+
+            def open_logs():
+                st.session_state.panel = "Logs"
+
+
+            def on_accordion_change():
+                st.toast(f"You opened the {st.session_state.panel} section.")
+
+
+            summary, logs = st.accordion(
+                ["Summary", "Logs"],
+                on_change=on_accordion_change,
+                key="panel",
+            )
+
+            if summary.open:
+                with summary:
+                    st.write("This is the summary section")
+
+            if logs.open:
+                with logs:
+                    st.write("This is the logs section")
+
+            st.button("Open logs", on_click=open_logs)
+
+        """
+        if not sections:
+            raise StreamlitAPIException(
+                "The input argument to st.accordion must contain at least one section label."
+            )
+
+        if default and default not in sections:
+            raise StreamlitAPIException(
+                f"The default accordion section '{default}' is not in the list of sections."
+            )
+
+        if any(not isinstance(section, str) for section in sections):
+            raise StreamlitAPIException(
+                "The sections input list to st.accordion is only allowed to contain strings."
+            )
+
+        if not callable(on_change) and on_change not in {"ignore", "rerun"}:
+            raise StreamlitValueError(
+                "on_change",
+                ["'rerun'", "'ignore'", "a callback function"],
+            )
+
+        key = to_key(key)
+        default_index = sections.index(default) if default else 0
+        is_stateful = on_change != "ignore"
+
+        element_id: str | None = None
+        block_id: str | None = None
+        current_section_label = sections[default_index]
+
+        if is_stateful:
+            is_callback = callable(on_change)
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=cast("WidgetCallback", on_change) if is_callback else None,
+                default_value=None,
+                writes_allowed=True,
+                enable_check_callback_rules=is_callback,
+            )
+
+            ctx = get_script_run_ctx()
+
+            element_id = compute_and_register_element_id(
+                "accordion",
+                user_key=key,
+                key_as_main_identity=False,
+                dg=self.dg,
+                sections=tuple(sections),
+                width=width,
+                default=default,
+            )
+            block_id = element_id
+
+            serde = _AccordionSerde(default_label=sections[default_index])
+
+            accordion_state = register_widget(
+                element_id,
+                deserializer=serde.deserialize,
+                serializer=serde.serialize,
+                ctx=ctx,
+                value_type="string_value",
+                on_change_handler=on_change if callable(on_change) else None,
+                args=args if callable(on_change) else None,
+                kwargs=kwargs if callable(on_change) else None,
+            )
+
+            current_section_label = accordion_state.value
+            if current_section_label not in sections:
+                current_section_label = sections[default_index]
+        elif key is not None:
+            block_id = compute_and_register_element_id(
+                "accordion",
+                user_key=key,
+                key_as_main_identity=False,
+                dg=self.dg,
+            )
+
+        def accordion_section_proto(label: str) -> BlockProto:
+            section_proto = BlockProto()
+            section_proto.accordion.label = label
+            section_proto.allow_empty = True
+            return section_proto
+
+        block_proto = BlockProto()
+        block_proto.accordion_container.SetInParent()
+        validate_width(width)
+        block_proto.width_config.CopyFrom(get_width_config(width))
+
+        try:
+            current_section_index = sections.index(current_section_label)
+        except ValueError:
+            current_section_index = default_index
+
+        block_proto.accordion_container.default_open_index = current_section_index
+
+        if is_stateful and element_id is not None:
+            block_proto.accordion_container.id = element_id
+
+        if block_id is not None:
+            block_proto.id = block_id
+
+        section_cls = get_dg_singleton_instance().accordion_container_cls
+        accordion_container = self.dg._block(block_proto)
+
+        section_dgs: list[AccordionContainer] = []
+        for section_label in sections:
+            section_dg = cast(
+                "AccordionContainer",
+                accordion_container._block(
+                    accordion_section_proto(section_label),
+                    dg_type=section_cls,
+                ),
+            )
+            if is_stateful:
+                section_dg.open = section_label == current_section_label
+            section_dgs.append(section_dg)
+
+        return tuple(section_dgs)
 
     @gather_metrics("expander")
     def expander(

--- a/lib/streamlit/elements/lib/mutable_accordion_container.py
+++ b/lib/streamlit/elements/lib/mutable_accordion_container.py
@@ -1,0 +1,60 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from typing_extensions import Self
+
+from streamlit.delta_generator import DeltaGenerator
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from streamlit.cursor import Cursor
+
+
+class AccordionContainer(DeltaGenerator):
+    """A container returned by ``st.accordion``."""
+
+    def __init__(
+        self,
+        root_container: int | None,
+        cursor: Cursor | None,
+        parent: DeltaGenerator | None,
+        block_type: str | None,
+    ) -> None:
+        super().__init__(root_container, cursor, parent, block_type)
+        self._open: bool | None = None
+
+    @property
+    def open(self) -> bool | None:
+        return self._open
+
+    @open.setter  # noqa: A003
+    def open(self, value: bool | None) -> None:
+        self._open = value
+
+    def __enter__(self) -> Self:  # type: ignore[override]
+        super().__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> Literal[False]:
+        return super().__exit__(exc_type, exc_val, exc_tb)

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -15,7 +15,6 @@
 import unittest
 
 import pytest
-
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.delta_generator_singletons import (
@@ -26,7 +25,6 @@ from streamlit.delta_generator_singletons import (
     get_dg_singleton_instance,
     get_last_dg_added_to_context_stack,
 )
-from streamlit.elements.lib.skeleton_placeholder import SkeletonPlaceholder
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.RootContainer_pb2 import RootContainer
 
@@ -189,7 +187,8 @@ def test_singleton_init_raises_when_already_initialized() -> None:
             expander_container_cls=DeltaGenerator,
             tab_container_cls=DeltaGenerator,
             popover_container_cls=DeltaGenerator,
-            skeleton_placeholder_cls=SkeletonPlaceholder,
+            accordion_container_cls=DeltaGenerator,
+            skeleton_placeholder_cls=DeltaGenerator,
         )
 
 

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -15,6 +15,7 @@
 import unittest
 
 import pytest
+
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.delta_generator_singletons import (

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -263,6 +263,7 @@ NON_WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
 CONTAINER_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     ("container", lambda: st.container()),
     ("expander", lambda: st.expander("Expand me")),
+    ("accordion", lambda: st.accordion(["First", "Second"])),
     ("tabs", lambda: st.tabs(["Tab 1", "Tab 2"])),
     ("chat_message", lambda: st.chat_message("user")),
     ("popover", lambda: st.popover("Popover")),

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -1998,3 +1998,505 @@ class DialogTest(DeltaGeneratorTestCase):
 
         dialog_block = self.get_delta_from_queue()
         assert dialog_block.add_block.dialog.id
+
+
+class AccordionTest(DeltaGeneratorTestCase):
+    def test_section_required(self):
+        """Test that at least one section is required."""
+        with pytest.raises(TypeError):
+            st.accordion()
+
+        with pytest.raises(StreamlitAPIException):
+            st.accordion([])
+
+    def test_only_label_strings_allowed(self):
+        """Test that only strings are allowed as section labels."""
+        with pytest.raises(StreamlitAPIException):
+            st.accordion(["First", True])
+
+        with pytest.raises(StreamlitAPIException):
+            st.accordion(["First", 10])
+
+    def test_returns_all_expected_sections(self):
+        """Test that all labels are added in correct order."""
+        sections = st.accordion([f"Section {i}" for i in range(5)])
+        assert len(sections) == 5
+
+        for section in sections:
+            with section:
+                pass
+
+        all_deltas = self.get_all_deltas_from_queue()
+        section_blocks = all_deltas[1:]
+
+        assert len(all_deltas) == 6
+        assert len(section_blocks) == 5
+
+        for index, section_block in enumerate(section_blocks):
+            assert section_block.add_block.accordion.label == f"Section {index}"
+
+    def test_default_section_index_first_section(self):
+        """Test that the default section index is 0 when default is not specified."""
+        st.accordion(["First", "Second", "Third"])
+
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+
+        assert (
+            accordion_container_block.add_block.accordion_container.default_open_index
+            == 0
+        )
+
+    def test_invalid_default_section(self):
+        """Test that an exception is raised if the default section is not in the list."""
+        with pytest.raises(StreamlitAPIException) as context:
+            st.accordion(["First", "Second", "Third"], default="Fourth")
+
+        assert (
+            "The default accordion section 'Fourth' is not in the list of sections."
+            in str(context.value)
+        )
+
+    def test_valid_default_section(self):
+        """Test that a valid default section sets the correct index."""
+        st.accordion(["First", "Second", "Third"], default="Second")
+
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+
+        assert (
+            accordion_container_block.add_block.accordion_container.default_open_index
+            == 1
+        )
+
+    def test_section_labels_with_whitespace(self):
+        """Test that labels with leading/trailing spaces are accepted and preserved."""
+        labels = ["  First", "Second  ", "  Third  "]
+        st.accordion(labels)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        actual_labels = [delta.add_block.accordion.label for delta in all_deltas[1:]]
+
+        assert actual_labels == labels
+
+    def test_duplicate_section_labels(self):
+        """Test that duplicate section labels are allowed."""
+        labels = ["Same", "Same", "Same"]
+        st.accordion(labels)
+
+        all_deltas = self.get_all_deltas_from_queue()
+        actual_labels = [delta.add_block.accordion.label for delta in all_deltas[1:]]
+
+        assert actual_labels == labels
+
+    def test_default_section_with_duplicate_labels_picks_first_occurrence_zero(self):
+        """If default label appears multiple times, pick the first occurrence (index 0)."""
+        st.accordion(["Same", "Unique", "Same"], default="Same")
+
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+
+        assert (
+            accordion_container_block.add_block.accordion_container.default_open_index
+            == 0
+        )
+
+    def test_default_section_with_duplicate_labels_picks_first_occurrence_non_zero(
+        self,
+    ):
+        """If the first occurrence is not at index 0, pick that non-zero index."""
+        st.accordion(["X", "Same", "Unique", "Same"], default="Same")
+
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+
+        assert (
+            accordion_container_block.add_block.accordion_container.default_open_index
+            == 1
+        )
+
+    def test_width_config_pixel_width(self):
+        """Test that pixel width configuration works correctly."""
+        st.accordion(["First", "Second"], width=200)
+        accordion_container_block = self.get_delta_from_queue(0)
+        assert accordion_container_block.add_block.width_config.pixel_width == 200
+
+    def test_width_config_stretch(self):
+        """Test that stretch width configuration works correctly."""
+        st.accordion(["First", "Second"], width="stretch")
+        accordion_container_block = self.get_delta_from_queue(0)
+        assert accordion_container_block.add_block.width_config.use_stretch
+
+    @parameterized.expand(
+        [
+            (None,),
+            ("invalid",),
+            (-100,),
+            (0,),
+            ("content",),
+        ]
+    )
+    def test_invalid_width(self, invalid_width):
+        """Test that invalid width values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.accordion(["First", "Second"], width=invalid_width)
+
+    def test_open_returns_none_by_default(self):
+        """Test that .open returns None on all sections when on_change is not set."""
+        sections = st.accordion(["First", "Second", "Third"])
+        for section in sections:
+            assert section.open is None
+
+    def test_open_returns_none_with_default_section(self):
+        """Test that .open returns None even with a default section (no state tracking)."""
+        sections = st.accordion(["First", "Second", "Third"], default="Second")
+        for section in sections:
+            assert section.open is None
+
+    def test_invalid_on_change_raises(self):
+        """Test that invalid on_change values raise an error."""
+        with pytest.raises(StreamlitAPIException):
+            st.accordion(["First", "Second"], on_change="invalid")
+
+    def test_on_change_rerun_sets_open_on_sections(self):
+        """Test that on_change='rerun' sets .open correctly on each section."""
+        sections = st.accordion(["First", "Second", "Third"], on_change="rerun")
+        assert sections[0].open is True
+        assert sections[1].open is False
+        assert sections[2].open is False
+
+    def test_on_change_rerun_with_default_sets_open(self):
+        """Test that on_change='rerun' with default sets the right section as open."""
+        sections = st.accordion(
+            ["First", "Second", "Third"], default="Second", on_change="rerun"
+        )
+        assert sections[0].open is False
+        assert sections[1].open is True
+        assert sections[2].open is False
+
+    def test_on_change_rerun_sets_id(self):
+        """Test that on_change='rerun' sets id on the accordion container proto."""
+        st.accordion(["First", "Second"], on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.accordion_container.id != ""
+
+    def test_on_change_none_does_not_set_id(self):
+        """Test that no on_change does not set id."""
+        st.accordion(["First", "Second"])
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert not accordion_container_block.add_block.accordion_container.HasField(
+            "id"
+        )
+
+    def test_on_change_rerun_with_key_accessible_via_session_state(self):
+        """Test that on_change='rerun' with key stores the active section label."""
+        st.accordion(
+            ["First", "Second", "Third"], key="my_accordion", on_change="rerun"
+        )
+        assert "my_accordion" in st.session_state
+        assert st.session_state.my_accordion == "First"
+
+    def test_on_change_rerun_with_default_session_state(self):
+        """Test that default section is reflected in session_state."""
+        st.accordion(
+            ["First", "Second", "Third"],
+            key="my_accordion",
+            default="Third",
+            on_change="rerun",
+        )
+        assert st.session_state.my_accordion == "Third"
+
+    def test_on_change_rerun_with_default_sets_correct_section_index(self):
+        """Test that default + on_change='rerun' sets the correct section index in proto."""
+        st.accordion(["First", "Second", "Third"], default="Third", on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert (
+            accordion_container_block.add_block.accordion_container.default_open_index
+            == 2
+        )
+
+    def test_on_change_rerun_falls_back_when_label_not_in_sections(self):
+        """Test that a stale session state label falls back to the default section."""
+        st.session_state["my_accordion"] = "OldSection"
+
+        sections = st.accordion(["X", "Y", "Z"], key="my_accordion", on_change="rerun")
+
+        assert sections[0].open is True
+        assert sections[1].open is False
+        assert sections[2].open is False
+
+    def test_on_change_ignore_with_key_open_remains_none(self):
+        """Test that on_change='ignore' with key leaves .open as None and no widget state."""
+        sections = st.accordion(
+            ["First", "Second", "Third"], key="my_accordion", on_change="ignore"
+        )
+        for section in sections:
+            assert section.open is None
+        assert "my_accordion" not in st.session_state
+
+    def test_passive_key_sets_block_id(self):
+        """Test that key with on_change='ignore' sets block-level id for stable identity."""
+        st.accordion(["First", "Second"], key="my_accordion", on_change="ignore")
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.id != ""
+        assert "my_accordion" in accordion_container_block.add_block.id
+        assert not accordion_container_block.add_block.accordion_container.HasField(
+            "id"
+        )
+
+    def test_passive_key_without_key_does_not_set_block_id(self):
+        """Test that accordion without key does not set block-level id."""
+        st.accordion(["First", "Second"])
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.id == ""
+
+    def test_on_change_rerun_with_key_sets_block_id(self):
+        """Test that on_change='rerun' with key sets the block-level id."""
+        st.accordion(["First", "Second"], key="my_accordion", on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.id != ""
+        assert "my_accordion" in accordion_container_block.add_block.id
+
+    def test_on_change_rerun_without_key_sets_block_id(self):
+        """Test that on_change='rerun' without key still sets block-level id."""
+        st.accordion(["First", "Second"], on_change="rerun")
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.id != ""
+
+    def test_on_change_callback_sets_block_id(self):
+        """Test that a callable on_change with key sets the block-level id."""
+        st.accordion(["First", "Second"], key="cb_accordion2", on_change=lambda: None)
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.id != ""
+        assert "cb_accordion2" in accordion_container_block.add_block.id
+
+    def test_on_change_callback_sets_id(self) -> None:
+        """Test that a callable on_change sets id on the accordion container proto."""
+
+        def on_change() -> None:
+            pass
+
+        st.accordion(["First", "Second"], key="cb_accordion", on_change=on_change)
+        all_deltas = self.get_all_deltas_from_queue()
+        accordion_container_block = all_deltas[0]
+        assert accordion_container_block.add_block.accordion_container.id != ""
+
+    def test_on_change_callback_sets_open_on_sections(self) -> None:
+        """Test that a callable on_change sets .open correctly on each section."""
+
+        def on_change() -> None:
+            pass
+
+        sections = st.accordion(
+            ["First", "Second", "Third"], key="cb_accordion", on_change=on_change
+        )
+        assert sections[0].open is True
+        assert sections[1].open is False
+        assert sections[2].open is False
+
+    def test_on_change_callback_with_default_section(self) -> None:
+        """Test that a callable on_change with default sets correct section open."""
+
+        def on_change() -> None:
+            pass
+
+        sections = st.accordion(
+            ["First", "Second", "Third"],
+            key="cb_accordion",
+            default="Second",
+            on_change=on_change,
+        )
+        assert sections[0].open is False
+        assert sections[1].open is True
+        assert sections[2].open is False
+
+    def _get_accordion_widget_state(self) -> WidgetState:
+        """Get the single accordion WidgetState from session state."""
+        widget_states = self.script_run_ctx.session_state.get_widget_states()
+        assert len(widget_states) == 1, (
+            f"Expected exactly 1 widget state, got {len(widget_states)}"
+        )
+        return widget_states[0]
+
+    def test_on_change_callback_fires_on_state_change(self) -> None:
+        """Test that callback function is invoked when active section switches."""
+        callback_calls: list[str] = []
+
+        def on_accordion_change() -> None:
+            callback_calls.append("called")
+
+        st.accordion(
+            ["First", "Second"], key="cb_accordion", on_change=on_accordion_change
+        )
+
+        current_ws = self._get_accordion_widget_state()
+        new_ws = WidgetState()
+        new_ws.CopyFrom(current_ws)
+        new_ws.string_value = "Second"
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_ws])
+        )
+
+        assert len(callback_calls) == 1
+
+    def test_on_change_callback_no_fire_on_initial_render(self) -> None:
+        """Test that callback does not fire on initial render."""
+        callback_calls: list[str] = []
+
+        def on_accordion_change() -> None:
+            callback_calls.append("called")
+
+        st.accordion(
+            ["First", "Second"], key="cb_accordion", on_change=on_accordion_change
+        )
+
+        assert len(callback_calls) == 0
+
+    def test_on_change_callback_receives_args_kwargs(self) -> None:
+        """Test that callback receives provided args and kwargs."""
+        received_args: list[object] = []
+        received_kwargs: dict[str, object] = {}
+
+        def on_change(*args: object, **kwargs: object) -> None:
+            received_args.extend(args)
+            received_kwargs.update(kwargs)
+
+        st.accordion(
+            ["First", "Second"],
+            key="cb_accordion",
+            on_change=on_change,
+            args=("arg1", "arg2"),
+            kwargs={"key1": "value1"},
+        )
+
+        current_ws = self._get_accordion_widget_state()
+        new_ws = WidgetState()
+        new_ws.CopyFrom(current_ws)
+        new_ws.string_value = "Second"
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[new_ws])
+        )
+
+        assert received_args == ["arg1", "arg2"]
+        assert received_kwargs == {"key1": "value1"}
+
+    def test_on_change_callback_accessible_via_session_state(self) -> None:
+        """Test that active section label is accessible via session_state with callback."""
+
+        def on_change() -> None:
+            pass
+
+        st.accordion(
+            ["First", "Second", "Third"], key="cb_accordion", on_change=on_change
+        )
+        assert "cb_accordion" in st.session_state
+        assert st.session_state.cb_accordion == "First"
+
+    def test_invalid_on_change_with_callback_type_raises(self) -> None:
+        """Test that non-string, non-callable on_change raises."""
+        with pytest.raises(StreamlitAPIException):
+            st.accordion(["First", "Second"], on_change=123)  # type: ignore[arg-type]
+
+    def test_backwards_compat_rerun_still_works(self) -> None:
+        """Test that on_change='rerun' still works after callback support."""
+        sections = st.accordion(["First", "Second"], on_change="rerun")
+        assert sections[0].open is True
+        assert sections[1].open is False
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_callable_on_change_inside_form_raises(self) -> None:
+        """Test that a callable on_change inside st.form raises StreamlitInvalidFormCallbackError."""
+        with pytest.raises(StreamlitInvalidFormCallbackError):
+            with st.form("form"):
+                st.accordion(["First", "Second"], on_change=lambda: None)
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_on_change_rerun_inside_form_does_not_raise(self) -> None:
+        """Test that on_change='rerun' inside st.form does not raise (not a callback)."""
+        with st.form("form"):
+            st.accordion(["First", "Second"], on_change="rerun")
+
+    def test_on_change_callback_fires_on_multiple_section_switches(self) -> None:
+        """Test that the callback fires on multiple accordion section changes."""
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.accordion(["First", "Second", "Third"], key="cb_acc", on_change=on_change)
+
+        current_ws = self._get_accordion_widget_state()
+
+        ws_second = WidgetState()
+        ws_second.CopyFrom(current_ws)
+        ws_second.string_value = "Second"
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[ws_second])
+        )
+        assert len(callback_calls) == 1
+
+        ws_third = WidgetState()
+        ws_third.CopyFrom(ws_second)
+        ws_third.string_value = "Third"
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[ws_third])
+        )
+        assert len(callback_calls) == 2
+
+    def test_on_change_callback_does_not_fire_on_unchanged_value(self) -> None:
+        """Test that the callback does not fire when the accordion value stays the same."""
+        callback_calls: list[str] = []
+
+        def on_change() -> None:
+            callback_calls.append("called")
+
+        st.accordion(["First", "Second"], key="cb_acc", on_change=on_change)
+
+        current_ws = self._get_accordion_widget_state()
+        same_ws = WidgetState()
+        same_ws.CopyFrom(current_ws)
+        self.script_run_ctx.session_state.on_script_will_rerun(
+            WidgetStates(widgets=[same_ws])
+        )
+
+        assert len(callback_calls) == 0
+
+    def test_callback_registered_in_widget_metadata(self) -> None:
+        """Test that the callback is stored in widget metadata."""
+
+        def on_change() -> None:
+            pass
+
+        st.accordion(["First", "Second"], key="cb_acc", on_change=on_change)
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        session_state = ctx.session_state._state
+        widget_id = session_state.get_widget_states()[0].id
+        metadata = session_state._new_widget_state.widget_metadata.get(widget_id)
+        assert metadata is not None
+        assert metadata.callback is not None
+
+    def test_on_change_rerun_falls_back_to_explicit_default_when_session_state_is_stale(
+        self,
+    ) -> None:
+        """Test that stale session state falls back to the explicit default section."""
+        st.session_state["my_accordion"] = "OldSection"
+
+        sections = st.accordion(
+            ["First", "Second", "Third"],
+            key="my_accordion",
+            default="Second",
+            on_change="rerun",
+        )
+
+        assert sections[0].open is False
+        assert sections[1].open is True
+        assert sections[2].open is False

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -34,6 +34,8 @@ message Block {
     Dialog dialog = 11;
     FlexContainer flex_container = 13;
     Transparent transparent = 17;
+    AccordionContainer accordion_container = 18;
+    Accordion accordion = 19;
   }
 
   bool allow_empty = 8;
@@ -188,5 +190,14 @@ message Block {
   // render directly in the parent container's flex context.
   message Transparent {}
 
-  // Next ID: 18
+  message AccordionContainer {
+    int32 default_open_index = 1;
+    optional string id = 2;
+  }
+
+  message Accordion {
+    string label = 1;
+  }
+
+  // Next ID: 20
 }


### PR DESCRIPTION
## Describe your changes

This PR adds `st.accordion`, a new layout container for grouping
multiple collapsible sections into a single coordinated component.

The implementation follows a multi-container API style similar to
`st.tabs`, while providing expand/collapse behavior closer to
`st.expander`.

Key features included in this implementation:

* Multiple accordion sections created from a single API call
* Single-open-section behavior
* Default open section selection
* Width configuration support
* Stateful behavior with `key`
* `on_change="rerun"` support
* Callback support
* `.open` state tracking on returned containers
* Support for widgets inside accordion sections
* Frontend and backend test coverage

This PR adds:

* New protobuf block definitions
* Python API integration in `layouts.py`
* Accordion container support in DeltaGenerator
* Frontend React rendering components and styling
* Backend and frontend tests

This contribution was developed collaboratively with
Madalena Ferreira.

## Screenshot or video (only for visual changes)

https://github.com/user-attachments/assets/ade4b320-4d2b-4c61-b542-9f41734c4e08


## GitHub Issue Link (if applicable)

Closes #11406

## Testing Plan

### Unit Tests (JS and/or Python)

Added backend and frontend tests covering:

* Section labels
* Default open section
* Width handling
* Invalid inputs
* Stateful behavior
* Callback behavior
* Session state integration
* Form behavior
* Frontend rendering
* Open/close interactions

### E2E Tests

Manual testing performed using a Streamlit demo app.

### Any manual testing needed?

Manual verification included:

* Multiple accordion instances
* Widget interactions inside sections
* Rerun persistence behavior
* Single-open-section enforcement
* Default section rendering

## Contribution License Agreement

By submitting this pull request I agree that all contributions to
this project are made under the Apache 2.0 license.
