### PR TITLE
[feature] Add accept_video parameter to st.chat_input

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -26,12 +26,14 @@ import {
   useState,
 } from "react"
 
-import { MicNone } from "@emotion-icons/material-outlined"
+import { MicNone, Videocam } from "@emotion-icons/material-outlined"
 import {
   ArrowUpward,
   Check,
   Close,
   ErrorOutline,
+  Pause,
+  PlayArrow,
 } from "@emotion-icons/material-rounded"
 import type { AxiosProgressEvent } from "axios"
 import { Textarea as UITextArea } from "baseui/textarea"
@@ -86,10 +88,15 @@ import {
   StyledInputInstructions,
   StyledInputRow,
   StyledLeftCluster,
+  StyledPendingMediaChip,
+  StyledPendingMediaChipRemove,
+  StyledRecordingIndicator,
   StyledRightCluster,
   StyledSendIconButton,
   StyledTextareaWrapper,
   StyledToolbarRow,
+  StyledVideoPausedOverlay,
+  StyledVideoPreviewContainer,
   StyledWaveformContainer,
 } from "./styled-components"
 
@@ -190,7 +197,12 @@ function ChatInput({
   const chatInputRef = useRef<HTMLTextAreaElement>(null)
   const processedSetValueRef = useRef(false)
   const waveformContainerRef = useRef<HTMLDivElement>(null)
+  const videoPreviewRef = useRef<HTMLVideoElement>(null)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const [videoStream, setVideoStream] = useState<MediaStream | null>(null)
   const uploadAbortControllerRef = useRef<AbortController | null>(null)
+  const videoApprovedRef = useRef<boolean>(false)
 
   const { width, elementRef } = useCalculatedDimensions()
   const { innerWidth, innerHeight } = useWindowDimensionsContext()
@@ -200,6 +212,13 @@ function ChatInput({
   const [files, setFiles] = useState<UploadFileInfo[]>([])
   const [fileDragged, setFileDragged] = useState(false)
   const [audioUploading, setAudioUploading] = useState(false)
+  const [videoUploading, setVideoUploading] = useState(false)
+  const [isVideoRecording, setIsVideoRecording] = useState(false)
+  const [isVideoPaused, setIsVideoPaused] = useState(false)
+  const [pendingAudio, setPendingAudio] =
+    useState<UploadedFileInfoProto | null>(null)
+  const [pendingVideo, setPendingVideo] =
+    useState<UploadedFileInfoProto | null>(null)
   const [recordingError, setRecordingError] = useState<string | null>(null)
   const [isStacked, setIsStacked] = useState(false)
 
@@ -207,6 +226,28 @@ function ChatInput({
   const [dropzoneResetCounter, setDropzoneResetCounter] = useState(0)
 
   const acceptAudio = element.acceptAudio ?? false
+  const acceptVideo = element.acceptVideo ?? false
+
+  useEffect(() => {
+    const video = videoPreviewRef.current
+    if (!videoStream || !video) {
+      return
+    }
+    video.srcObject = videoStream
+    // Safari ignores autoPlay when srcObject is used; force .play().
+    video.play().catch(error => {
+      LOG.error("Video preview play failed:", error)
+    })
+  }, [videoStream])
+
+  const stopAllTracks = useCallback((stream: MediaStream | null) => {
+    if (!stream) return
+    for (const track of stream.getTracks()) {
+      if (track.readyState !== "ended") {
+        track.stop()
+      }
+    }
+  }, [])
 
   // Cleanup: abort any in-progress uploads on unmount
   useEffect(() => {
@@ -214,8 +255,9 @@ function ChatInput({
       if (uploadAbortControllerRef.current) {
         uploadAbortControllerRef.current.abort()
       }
+      stopAllTracks(streamRef.current)
     }
-  }, [])
+  }, [stopAllTracks])
 
   // Track if we've done the initial height calculation with a valid width.
   // This prevents unnecessary recalculations on every window resize.
@@ -333,8 +375,13 @@ function ChatInput({
       return false
     }
 
-    return value !== "" || files.length > 0
-  }, [files, value])
+    return (
+      value !== "" ||
+      files.length > 0 ||
+      pendingAudio !== null ||
+      pendingVideo !== null
+    )
+  }, [files, value, pendingAudio, pendingVideo])
 
   const acceptFile = chatInputAcceptFileProtoValueToEnum(element.acceptFile)
   const maxFileSize = sizeConverter(
@@ -530,19 +577,14 @@ function ChatInput({
 
   const submitChatInput = useCallback(
     // eslint-disable-next-line react-hooks/preserve-manual-memoization -- chatInputRef is a ref; setFiles/setValue/setIsStacked/setDropzoneResetCounter are stable setters
-    (audioInfo?: UploadedFileInfoProto): void => {
+    (): void => {
       // We want the chat input to always be in focus
       // even if the user clicks the submit button
       if (chatInputRef.current) {
         chatInputRef.current.focus()
       }
 
-      // Allow submission if:
-      // - dirty=true (user typed text or uploaded files), OR
-      // - audioInfo is provided (audio was just recorded and uploaded)
-      // Audio bypasses the dirty check because it's uploaded and submitted
-      // immediately without being added to the files state.
-      if ((!dirty && !audioInfo) || disabled) {
+      if (!dirty || disabled) {
         return
       }
 
@@ -551,7 +593,8 @@ function ChatInput({
       const composedValue: IChatInputValue = {
         data: value,
         fileUploaderState: filesValue,
-        audioFileInfo: audioInfo,
+        audioFileInfo: pendingAudio ?? undefined,
+        videoFileInfo: pendingVideo ?? undefined,
       }
 
       widgetMgr.setChatInputValue(
@@ -568,6 +611,8 @@ function ChatInput({
 
       setFiles([])
       setValue("")
+      setPendingAudio(null)
+      setPendingVideo(null)
       setIsStacked(false)
       autoExpand.clearScrollHeight()
     },
@@ -576,6 +621,8 @@ function ChatInput({
       disabled,
       value,
       files.length,
+      pendingAudio,
+      pendingVideo,
       createChatInputWidgetFilesValue,
       widgetMgr,
       element,
@@ -584,7 +631,58 @@ function ChatInput({
     ]
   )
 
-  // Handle audio approval and upload
+  const uploadMediaToPending = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- refs to abort/input; pending+error setters are stable
+    async (
+      file: File,
+      kind: "audio" | "video",
+      setUploading: (uploading: boolean) => void
+    ): Promise<void> => {
+      try {
+        setUploading(true)
+
+        const fileURLsArray = await uploadClient.fetchFileURLs([file])
+        if (fileURLsArray.length === 0) {
+          throw new Error(`Failed to get upload URL for ${kind} file`)
+        }
+        const fileUrls = fileURLsArray[0]
+
+        uploadAbortControllerRef.current = new AbortController()
+        await uploadClient.uploadFile(
+          { formId: "", ...element },
+          fileUrls.uploadUrl as string,
+          file,
+          () => {},
+          uploadAbortControllerRef.current.signal
+        )
+
+        const info = new UploadedFileInfoProto({
+          fileId: fileUrls.fileId as string,
+          fileUrls,
+          name: file.name,
+          size: file.size,
+        })
+
+        if (kind === "audio") {
+          setPendingAudio(info)
+        } else {
+          setPendingVideo(info)
+        }
+      } catch (error) {
+        LOG.error(`${kind} upload failed:`, error)
+        setRecordingError(
+          kind === "audio" ? "Recording failed" : "Video recording failed"
+        )
+        if (chatInputRef.current) {
+          chatInputRef.current.focus()
+        }
+      } finally {
+        setUploading(false)
+      }
+    },
+    [uploadClient, element]
+  )
+
   const handleAudioApprove = useCallback(
     // eslint-disable-next-line react-hooks/preserve-manual-memoization -- chatInputRef and uploadAbortControllerRef are refs; setAudioUploading and setRecordingError are stable setters
     async (wav: Blob): Promise<void> => {
@@ -593,57 +691,144 @@ function ChatInput({
       const audioFile = new File([wav], `audio-${timestamp}.wav`, {
         type: "audio/wav",
       })
+      await uploadMediaToPending(audioFile, "audio", setAudioUploading)
+    },
+    [uploadMediaToPending]
+  )
+
+  const handleVideoApprove = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- setVideoUploading is a stable setter
+    async (videoBlob: Blob): Promise<void> => {
+      // Strip ";codecs=..." — browsers emit different suffixes per container.
+      const mimeType =
+        (videoBlob.type || "video/webm").split(";")[0].trim() || "video/webm"
+      const extension = mimeType.includes("mp4") ? "mp4" : "webm"
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+
+      const videoFile = new File(
+        [videoBlob],
+        `video-${timestamp}.${extension}`,
+        { type: mimeType }
+      )
+      await uploadMediaToPending(videoFile, "video", setVideoUploading)
+    },
+    [uploadMediaToPending]
+  )
+
+  const startVideoRecording = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- media refs; video/recording setters are stable
+    async () => {
+      if (typeof MediaRecorder === "undefined") {
+        setRecordingError("Video recording is not supported in this browser")
+        return
+      }
 
       try {
-        setAudioUploading(true)
+        setRecordingError(null)
 
-        // 1. Fetch upload URL
-        const fileURLsArray = await uploadClient.fetchFileURLs([audioFile])
-
-        if (fileURLsArray.length === 0) {
-          throw new Error("Failed to get upload URL for audio file")
-        }
-
-        const fileUrls = fileURLsArray[0]
-
-        // 2. Upload audio file with progress tracking
-        uploadAbortControllerRef.current = new AbortController()
-        await uploadClient.uploadFile(
-          {
-            formId: "",
-            ...element,
-          },
-          fileUrls.uploadUrl as string,
-          audioFile,
-          () => {
-            // Progress callback - track upload progress (could display percentage if needed)
-          },
-          uploadAbortControllerRef.current.signal
-        )
-
-        // 3. Create audio file info
-        const audioInfo = new UploadedFileInfoProto({
-          fileId: fileUrls.fileId as string,
-          fileUrls,
-          name: audioFile.name,
-          size: audioFile.size,
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: true,
         })
+        streamRef.current = stream
+        setVideoStream(stream)
 
-        // 4. Submit immediately with audio info
-        submitChatInput(audioInfo)
-      } catch (error) {
-        const errorMessage = "Recording failed"
-        LOG.error("Audio upload failed:", error)
-        setRecordingError(errorMessage)
-        // Refocus on input after error
-        if (chatInputRef.current) {
-          chatInputRef.current.focus()
+        const mimeType = [
+          "video/webm;codecs=vp9,opus",
+          "video/webm;codecs=vp8,opus",
+          "video/webm",
+          "video/mp4",
+        ].find(type => MediaRecorder.isTypeSupported(type))
+
+        if (!mimeType) {
+          stopAllTracks(stream)
+          streamRef.current = null
+          setVideoStream(null)
+          setRecordingError("No supported video format in this browser")
+          return
         }
-      } finally {
-        setAudioUploading(false)
+
+        const recorder = new MediaRecorder(stream, { mimeType })
+        const chunks: Blob[] = []
+
+        recorder.ondataavailable = e => {
+          if (e.data.size > 0) {
+            chunks.push(e.data)
+          }
+        }
+
+        recorder.onstop = async () => {
+          const approved = videoApprovedRef.current
+          videoApprovedRef.current = false
+          if (approved) {
+            const blob = new Blob(chunks, { type: recorder.mimeType })
+            await handleVideoApprove(blob)
+          }
+          stopAllTracks(stream)
+          streamRef.current = null
+          setVideoStream(null)
+        }
+
+        videoApprovedRef.current = false
+        mediaRecorderRef.current = recorder
+        recorder.start()
+        setIsVideoRecording(true)
+      } catch (error) {
+        LOG.error("Video recording start failed:", error)
+        setRecordingError("Could not access camera")
       }
     },
-    [uploadClient, element, submitChatInput]
+    [handleVideoApprove, stopAllTracks]
+  )
+
+  const stopVideoRecording = useCallback(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization -- media refs; video setters are stable
+    (approved: boolean) => {
+      if (mediaRecorderRef.current && isVideoRecording) {
+        videoApprovedRef.current = approved
+        mediaRecorderRef.current.stop()
+        setIsVideoRecording(false)
+        setIsVideoPaused(false)
+      }
+    },
+    [isVideoRecording]
+  )
+
+  const handleVideoCancel = useCallback(() => {
+    stopVideoRecording(false)
+  }, [stopVideoRecording])
+
+  const handleVideoApproveAction = useCallback(() => {
+    stopVideoRecording(true)
+  }, [stopVideoRecording])
+
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- ref + stable setter
+  const handleVideoPause = useCallback(() => {
+    const recorder = mediaRecorderRef.current
+    if (recorder?.state !== "recording") return
+    recorder.pause()
+    setIsVideoPaused(true)
+  }, [])
+
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- ref + stable setter
+  const handleVideoResume = useCallback(() => {
+    const recorder = mediaRecorderRef.current
+    if (recorder?.state !== "paused") return
+    recorder.resume()
+    setIsVideoPaused(false)
+  }, [])
+
+  const handleVideoClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      if (!acceptVideo || disabled || isVideoRecording) {
+        return
+      }
+      void startVideoRecording()
+    },
+    [acceptVideo, disabled, isVideoRecording, startVideoRecording]
   )
 
   // Memoize events to ensure fresh closures when dependencies change
@@ -876,6 +1061,60 @@ function ChatInput({
           </StyledFilesArea>
         )}
 
+        {(pendingAudio || pendingVideo) && (
+          <StyledFilesArea>
+            {pendingAudio && (
+              <StyledPendingMediaChip data-testid="stChatInputPendingAudio">
+                <Icon content={MicNone} size="md" color="inherit" />
+                <span>{pendingAudio.name}</span>
+                <StyledPendingMediaChipRemove
+                  onClick={() => setPendingAudio(null)}
+                  aria-label="Remove audio recording"
+                >
+                  <Icon content={Close} size="md" color="inherit" />
+                </StyledPendingMediaChipRemove>
+              </StyledPendingMediaChip>
+            )}
+            {pendingVideo && (
+              <StyledPendingMediaChip data-testid="stChatInputPendingVideo">
+                <Icon content={Videocam} size="md" color="inherit" />
+                <span>{pendingVideo.name}</span>
+                <StyledPendingMediaChipRemove
+                  onClick={() => setPendingVideo(null)}
+                  aria-label="Remove video recording"
+                >
+                  <Icon content={Close} size="md" color="inherit" />
+                </StyledPendingMediaChipRemove>
+              </StyledPendingMediaChip>
+            )}
+          </StyledFilesArea>
+        )}
+
+        {isVideoRecording && (
+          <StyledVideoPreviewContainer>
+            {/* eslint-disable-next-line jsx-a11y/control-has-associated-label -- local-only camera preview without playback controls */}
+            <video
+              ref={videoPreviewRef}
+              autoPlay
+              muted
+              playsInline
+              style={{
+                width: "100%",
+                borderRadius: theme.radii.default,
+                transform: "scaleX(-1)",
+                filter: isVideoPaused ? "blur(8px)" : "none",
+                transition: "filter 200ms ease",
+              }}
+            />
+            {!isVideoPaused && <StyledRecordingIndicator />}
+            {isVideoPaused && (
+              <StyledVideoPausedOverlay>
+                <Icon content={Pause} size="threeXL" color="inherit" />
+              </StyledVideoPausedOverlay>
+            )}
+          </StyledVideoPreviewContainer>
+        )}
+
         {/* Main row - contains textarea and button clusters
             When expanded (hasExpandedHeight): column layout with textarea above toolbar row
             When not expanded: row layout (inline or stacked via flex-wrap)
@@ -953,6 +1192,63 @@ function ChatInput({
                     />
                   </StyledInputInstructions>
                 )}
+                {acceptVideo &&
+                  (isVideoRecording ? (
+                    <>
+                      <StyledSendIconButton
+                        onClick={handleVideoCancel}
+                        disabled={disabled}
+                        data-testid="stChatInputVideoCancelButton"
+                        aria-label="Cancel video recording"
+                      >
+                        <Icon content={Close} size="lg" color="inherit" />
+                      </StyledSendIconButton>
+                      <StyledSendIconButton
+                        onClick={
+                          isVideoPaused ? handleVideoResume : handleVideoPause
+                        }
+                        disabled={disabled}
+                        data-testid="stChatInputVideoPauseButton"
+                        aria-label={
+                          isVideoPaused
+                            ? "Resume video recording"
+                            : "Pause video recording"
+                        }
+                      >
+                        <Icon
+                          content={isVideoPaused ? PlayArrow : Pause}
+                          size="lg"
+                          color="inherit"
+                        />
+                      </StyledSendIconButton>
+                      <StyledSendIconButton
+                        onClick={handleVideoApproveAction}
+                        disabled={disabled || videoUploading}
+                        data-testid="stChatInputVideoApproveButton"
+                        aria-label="Approve video recording"
+                      >
+                        {videoUploading ? (
+                          <DynamicIcon size="lg" iconValue="spinner" />
+                        ) : (
+                          <Icon content={Check} size="lg" color="inherit" />
+                        )}
+                      </StyledSendIconButton>
+                    </>
+                  ) : (
+                    <StyledSendIconButton
+                      onClick={handleVideoClick}
+                      disabled={
+                        disabled ||
+                        videoUploading ||
+                        audioUploading ||
+                        pendingVideo !== null
+                      }
+                      data-testid="stChatInputVideoButton"
+                      aria-label="Start video recording"
+                    >
+                      <Icon content={Videocam} size="xl" color="inherit" />
+                    </StyledSendIconButton>
+                  ))}
                 {acceptAudio && (
                   <>
                     {recordingError ? (
@@ -963,7 +1259,9 @@ function ChatInput({
                       >
                         <StyledSendIconButton
                           onClick={handleMicClickVoid}
-                          disabled={disabled || audioUploading}
+                          disabled={
+                            disabled || audioUploading || pendingAudio !== null
+                          }
                           hasError
                           data-testid="stChatInputMicButton"
                           aria-label="Start recording"
@@ -978,7 +1276,9 @@ function ChatInput({
                     ) : (
                       <StyledSendIconButton
                         onClick={handleMicClickVoid}
-                        disabled={disabled || audioUploading}
+                        disabled={
+                          disabled || audioUploading || pendingAudio !== null
+                        }
                         data-testid="stChatInputMicButton"
                         aria-label="Start recording"
                       >
@@ -989,7 +1289,13 @@ function ChatInput({
                 )}
                 <StyledSendIconButton
                   onClick={handleSubmit}
-                  disabled={!dirty || disabled || audioUploading}
+                  disabled={
+                    !dirty ||
+                    disabled ||
+                    audioUploading ||
+                    videoUploading ||
+                    isVideoRecording
+                  }
                   data-testid="stChatInputSubmitButton"
                   aria-label="Send message"
                   primary
@@ -1064,6 +1370,69 @@ function ChatInput({
                         />
                       </StyledInputInstructions>
                     )}
+                    {acceptVideo &&
+                      (isVideoRecording ? (
+                        <>
+                          <StyledSendIconButton
+                            onClick={handleVideoCancel}
+                            disabled={disabled}
+                            data-testid="stChatInputVideoCancelButton"
+                            aria-label="Cancel video recording"
+                          >
+                            <Icon content={Close} size="lg" color="inherit" />
+                          </StyledSendIconButton>
+                          <StyledSendIconButton
+                            onClick={
+                              isVideoPaused
+                                ? handleVideoResume
+                                : handleVideoPause
+                            }
+                            disabled={disabled}
+                            data-testid="stChatInputVideoPauseButton"
+                            aria-label={
+                              isVideoPaused
+                                ? "Resume video recording"
+                                : "Pause video recording"
+                            }
+                          >
+                            <Icon
+                              content={isVideoPaused ? PlayArrow : Pause}
+                              size="lg"
+                              color="inherit"
+                            />
+                          </StyledSendIconButton>
+                          <StyledSendIconButton
+                            onClick={handleVideoApproveAction}
+                            disabled={disabled || videoUploading}
+                            data-testid="stChatInputVideoApproveButton"
+                            aria-label="Approve video recording"
+                          >
+                            {videoUploading ? (
+                              <DynamicIcon size="lg" iconValue="spinner" />
+                            ) : (
+                              <Icon
+                                content={Check}
+                                size="lg"
+                                color="inherit"
+                              />
+                            )}
+                          </StyledSendIconButton>
+                        </>
+                      ) : (
+                        <StyledSendIconButton
+                          onClick={handleVideoClick}
+                          disabled={
+                            disabled ||
+                            videoUploading ||
+                            audioUploading ||
+                            pendingVideo !== null
+                          }
+                          data-testid="stChatInputVideoButton"
+                          aria-label="Start video recording"
+                        >
+                          <Icon content={Videocam} size="xl" color="inherit" />
+                        </StyledSendIconButton>
+                      ))}
                     {acceptAudio && (
                       <>
                         {recordingError ? (
@@ -1074,7 +1443,11 @@ function ChatInput({
                           >
                             <StyledSendIconButton
                               onClick={handleMicClickVoid}
-                              disabled={disabled || audioUploading}
+                              disabled={
+                                disabled ||
+                                audioUploading ||
+                                pendingAudio !== null
+                              }
                               hasError
                               data-testid="stChatInputMicButton"
                               aria-label="Start recording"
@@ -1089,7 +1462,11 @@ function ChatInput({
                         ) : (
                           <StyledSendIconButton
                             onClick={handleMicClickVoid}
-                            disabled={disabled || audioUploading}
+                            disabled={
+                              disabled ||
+                              audioUploading ||
+                              pendingAudio !== null
+                            }
                             data-testid="stChatInputMicButton"
                             aria-label="Start recording"
                           >
@@ -1104,7 +1481,13 @@ function ChatInput({
                     )}
                     <StyledSendIconButton
                       onClick={handleSubmit}
-                      disabled={!dirty || disabled || audioUploading}
+                      disabled={
+                        !dirty ||
+                        disabled ||
+                        audioUploading ||
+                        videoUploading ||
+                        isVideoRecording
+                      }
                       data-testid="stChatInputSubmitButton"
                       aria-label="Send message"
                       primary

--- a/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/styled-components.ts
@@ -251,3 +251,75 @@ export const StyledChatAudioWave = styled.div(({ theme }) => ({
     inset: 0,
   },
 }))
+
+export const StyledVideoPreviewContainer = styled.div(({ theme }) => ({
+  position: "absolute",
+  bottom: `calc(100% + ${theme.spacing.sm})`,
+  left: "50%",
+  transform: "translateX(-50%)",
+  width: theme.sizes.minPopupWidth,
+  backgroundColor: theme.colors.secondaryBg,
+  padding: theme.spacing.sm,
+  borderRadius: theme.radii.default,
+  boxShadow: theme.shadows.popover,
+  zIndex: theme.zIndices.popup,
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.spacing.xs,
+  border: `${theme.sizes.borderWidth} solid ${theme.colors.widgetBorderColor}`,
+}))
+
+export const StyledRecordingIndicator = styled.div(({ theme }) => ({
+  position: "absolute",
+  top: theme.spacing.md,
+  right: theme.spacing.md,
+  width: theme.iconSizes.base,
+  height: theme.iconSizes.base,
+  backgroundColor: theme.colors.redColor,
+  borderRadius: "50%",
+  animation: "pulse 1.5s infinite",
+  "@keyframes pulse": {
+    "0%": { opacity: 1 },
+    "50%": { opacity: 0.3 },
+    "100%": { opacity: 1 },
+  },
+}))
+
+export const StyledVideoPausedOverlay = styled.div(({ theme }) => ({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: theme.colors.white,
+  pointerEvents: "none",
+}))
+
+export const StyledPendingMediaChip = styled.div(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: theme.spacing.xs,
+  padding: `${theme.spacing.twoXS} ${theme.spacing.sm}`,
+  backgroundColor: theme.colors.secondaryBg,
+  borderRadius: theme.radii.default,
+  fontSize: theme.fontSizes.sm,
+  border: `${theme.sizes.borderWidth} solid ${theme.colors.widgetBorderColor}`,
+}))
+
+export const StyledPendingMediaChipRemove = styled.button(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "transparent",
+  border: "none",
+  cursor: "pointer",
+  padding: theme.spacing.twoXS,
+  borderRadius: theme.radii.default,
+  color: theme.colors.fadedText60,
+  "&:hover": {
+    color: theme.colors.bodyText,
+  },
+}))

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import io
+import mimetypes
 import os
 import re
 from datetime import timedelta
@@ -31,6 +32,7 @@ from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
 from streamlit.runtime import caching
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.uploaded_file_manager import UploadedFile
 from streamlit.time_util import time_to_seconds
 
 if TYPE_CHECKING:
@@ -72,7 +74,7 @@ class MediaMixin:
     def audio(
         self,
         data: MediaData,
-        format: str = "audio/wav",
+        format: str | None = None,
         start_time: MediaTime = 0,
         *,
         sample_rate: int | None = None,
@@ -228,7 +230,7 @@ class MediaMixin:
     def video(
         self,
         data: MediaData,
-        format: str = "video/mp4",
+        format: str | None = None,
         start_time: MediaTime = 0,
         *,  # keyword-only arguments:
         subtitles: SubtitleData = None,
@@ -450,7 +452,7 @@ def _marshall_av_media(
     coordinates: str,
     proto: AudioProto | VideoProto,
     data: MediaData,
-    mimetype: str,
+    mimetype: str | None,
 ) -> None:
     """Fill audio or video proto based on contents of data.
 
@@ -475,6 +477,17 @@ def _marshall_av_media(
         data_or_filename = data
     elif isinstance(data, Path):
         data_or_filename = str(data)
+    elif isinstance(data, UploadedFile):
+        if mimetype is None:
+            mimetype = data.type
+        if mimetype is not None:
+            mimetype = mimetype.split(";", 1)[0].strip()
+        if not mimetype or mimetype == "application/octet-stream":
+            guessed, _ = mimetypes.guess_type(data.name, strict=False)
+            if guessed:
+                mimetype = guessed
+        data.seek(0)
+        data_or_filename = data.getvalue()
     elif isinstance(data, io.BytesIO):
         data.seek(0)
         data_or_filename = data.getvalue()
@@ -489,13 +502,15 @@ def _marshall_av_media(
     else:
         raise RuntimeError(f"Invalid binary data format: {type(data)}")
 
+    if mimetype is None:
+        mimetype = "audio/wav" if isinstance(proto, AudioProto) else "video/mp4"
+
     if runtime.exists():
         file_url = runtime.get_instance().media_file_mgr.add(
             data_or_filename, mimetype, coordinates
         )
         caching.save_media_data(data_or_filename, mimetype, coordinates)
     else:
-        # When running in "raw mode", we can't access the MediaFileManager.
         file_url = ""
 
     proto.url = file_url
@@ -506,7 +521,7 @@ def marshall_video(
     coordinates: str,
     proto: VideoProto,
     data: MediaData,
-    mimetype: str = "video/mp4",
+    mimetype: str | None = "video/mp4",
     start_time: int = 0,
     subtitles: SubtitleData = None,
     end_time: int | None = None,
@@ -773,7 +788,7 @@ def marshall_audio(
     coordinates: str,
     proto: AudioProto,
     data: MediaData,
-    mimetype: str = "audio/wav",
+    mimetype: str | None = None,
     start_time: int = 0,
     sample_rate: int | None = None,
     end_time: int | None = None,

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -60,9 +60,6 @@ from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStatePro
 from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
 from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
-from streamlit.runtime.memory_uploaded_file_manager import (
-    MemoryUploadedFileManager,
-)
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.runtime.state import (
@@ -89,14 +86,25 @@ _ACCEPTED_AUDIO_MIME_TYPES: frozenset[str] = frozenset(
     }
 )
 
+_ACCEPTED_VIDEO_EXTENSIONS: tuple[str, ...] = (".mp4", ".webm", ".mov")
+_ACCEPTED_VIDEO_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        "video/mp4",
+        "video/webm",
+        "video/quicktime",
+        "video/x-matroska",
+        "application/octet-stream",
+    }
+)
+
 
 @dataclass
 class ChatInputValue(MutableMapping[str, Any]):
     """Represents the value returned by `st.chat_input` after user interaction.
 
     This dataclass contains the user's input text, any files uploaded, and optionally
-    an audio recording. It provides a dict-like interface for accessing and modifying
-    its attributes.
+    an audio recording or video recording. It provides a dict-like interface for
+    accessing and modifying its attributes.
 
     Attributes
     ----------
@@ -106,6 +114,8 @@ class ChatInputValue(MutableMapping[str, Any]):
         A list of files uploaded by the user. Only present when accept_file=True.
     audio : UploadedFile or None, optional
         An audio recording uploaded by the user, if any. Only present when accept_audio=True.
+    video : UploadedFile or None, optional
+        A video recording uploaded by the user, if any. Only present when accept_video=True.
 
     Notes
     -----
@@ -113,13 +123,16 @@ class ChatInputValue(MutableMapping[str, Any]):
     - Use `to_dict()` to convert the value to a standard dictionary.
     - The 'files' key is only present when accept_file=True.
     - The 'audio' key is only present when accept_audio=True.
+    - The 'video' key is only present when accept_video=True.
     """
 
     text: str
     files: list[UploadedFile] = field(default_factory=list)
     audio: UploadedFile | None = None
+    video: UploadedFile | None = None
     _include_files: bool = field(default=False, repr=False, compare=False)
     _include_audio: bool = field(default=False, repr=False, compare=False)
+    _include_video: bool = field(default=False, repr=False, compare=False)
     _included_keys: tuple[str, ...] = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -129,6 +142,8 @@ class ChatInputValue(MutableMapping[str, Any]):
             keys.append("files")
         if self._include_audio:
             keys.append("audio")
+        if self._include_video:
+            keys.append("video")
         object.__setattr__(self, "_included_keys", tuple(keys))
 
     def _get_included_keys(self) -> tuple[str, ...]:
@@ -155,7 +170,7 @@ class ChatInputValue(MutableMapping[str, Any]):
             raise KeyError(f"Invalid key: {item}") from None
 
     def __getattribute__(self, name: str) -> Any:
-        # Intercept access to files/audio when they're excluded
+        # Intercept access to files/audio/video when they're excluded
         # Use object.__getattribute__ to avoid infinite recursion
         if name == "files" and not object.__getattribute__(self, "_include_files"):
             raise AttributeError(
@@ -164,6 +179,10 @@ class ChatInputValue(MutableMapping[str, Any]):
         if name == "audio" and not object.__getattribute__(self, "_include_audio"):
             raise AttributeError(
                 "'ChatInputValue' object has no attribute 'audio' (accept_audio=False)"
+            )
+        if name == "video" and not object.__getattribute__(self, "_include_video"):
+            raise AttributeError(
+                "'ChatInputValue' object has no attribute 'video' (accept_video=False)"
             )
         # For all other attributes, use normal lookup
         return object.__getattribute__(self, name)
@@ -189,6 +208,8 @@ class ChatInputValue(MutableMapping[str, Any]):
             result["files"] = self.files
         if self._include_audio:
             result["audio"] = self.audio
+        if self._include_video:
+            result["video"] = self.video
         return result
 
 
@@ -280,16 +301,6 @@ def _pop_upload_files(
             uploaded_file = UploadedFile(maybe_file_rec, f.file_urls)
             collected_files.append(uploaded_file)
 
-            # Remove file from manager after creating UploadedFile object.
-            # Only MemoryUploadedFileManager implements remove_file.
-            # This explicit type check ensures we only use this cleanup logic
-            # with manager types we've explicitly approved.
-            if isinstance(ctx.uploaded_file_mgr, MemoryUploadedFileManager):
-                ctx.uploaded_file_mgr.remove_file(
-                    session_id=ctx.session_id,
-                    file_id=f.file_id,
-                )
-
     return collected_files
 
 
@@ -317,7 +328,7 @@ def _pop_audio_file(
         If the uploaded audio file does not have a `.wav` extension or its MIME type is not
         one of the accepted WAV types (`audio/wav`, `audio/wave`, `audio/x-wav`).
     """
-    if audio_file_info is None:
+    if audio_file_info is None or not audio_file_info.file_id:
         return None
 
     ctx = get_script_run_ctx()
@@ -342,21 +353,71 @@ def _pop_audio_file(
             f"Only WAV files ({_ACCEPTED_AUDIO_EXTENSION}) are accepted."
         )
 
-    # Validate MIME type (browsers may send different variations of WAV MIME types)
-    if uploaded_file.type not in _ACCEPTED_AUDIO_MIME_TYPES:
+    base_mime_type = uploaded_file.type.split(";")[0].strip()
+    if base_mime_type not in _ACCEPTED_AUDIO_MIME_TYPES:
         raise StreamlitAPIException(
             f"Invalid MIME type for audio input: `{uploaded_file.type}`. "
-            f"Expected one of {_ACCEPTED_AUDIO_MIME_TYPES}."
+            f"Accepted MIME types: {sorted(_ACCEPTED_AUDIO_MIME_TYPES)}."
         )
 
-    # Remove the file from the manager after creating the UploadedFile object.
-    # Only MemoryUploadedFileManager implements remove_file (not part of the
-    # UploadedFileManager Protocol). This explicit type check ensures we only
-    # use this cleanup logic with manager types we've explicitly approved.
-    if audio_file_info and isinstance(ctx.uploaded_file_mgr, MemoryUploadedFileManager):
-        ctx.uploaded_file_mgr.remove_file(
-            session_id=ctx.session_id,
-            file_id=audio_file_info.file_id,
+    return uploaded_file
+
+
+def _pop_video_file(
+    video_file_info: UploadedFileInfoProto | None,
+) -> UploadedFile | None:
+    """Extract and return a single video file from the protobuf message.
+
+    Similar to _pop_upload_files but handles a single video file instead of a list.
+    Validates that the uploaded file is a supported video file.
+
+    Parameters
+    ----------
+    video_file_info : UploadedFileInfoProto or None
+        The protobuf message containing information about the uploaded video file.
+
+    Returns
+    -------
+    UploadedFile or None
+        The extracted video file if available, None otherwise.
+
+    Raises
+    ------
+    StreamlitAPIException
+        If the uploaded video file does not have a supported extension or its
+        MIME type is not one of the accepted video types.
+    """
+    if video_file_info is None or not video_file_info.file_id:
+        return None
+
+    ctx = get_script_run_ctx()
+    if ctx is None:  # pragma: no cover - defensive
+        return None
+
+    file_recs_list = ctx.uploaded_file_mgr.get_files(
+        session_id=ctx.session_id,
+        file_ids=[video_file_info.file_id],
+    )
+
+    if len(file_recs_list) == 0:
+        return None
+
+    file_rec = file_recs_list[0]
+    uploaded_file = UploadedFile(file_rec, video_file_info.file_urls)
+
+    if not any(
+        uploaded_file.name.lower().endswith(ext) for ext in _ACCEPTED_VIDEO_EXTENSIONS
+    ):
+        raise StreamlitAPIException(
+            f"Invalid file extension for video input: `{uploaded_file.name}`. "
+            f"Allowed extensions: {_ACCEPTED_VIDEO_EXTENSIONS}."
+        )
+
+    base_mime_type = uploaded_file.type.split(";")[0].strip()
+    if base_mime_type not in _ACCEPTED_VIDEO_MIME_TYPES:
+        raise StreamlitAPIException(
+            f"Invalid MIME type for video input: `{uploaded_file.type}`. "
+            f"Accepted MIME types: {sorted(_ACCEPTED_VIDEO_MIME_TYPES)}."
         )
 
     return uploaded_file
@@ -366,31 +427,49 @@ def _pop_audio_file(
 class ChatInputSerde:
     accept_files: bool = False
     accept_audio: bool = False
+    accept_video: bool = False
     allowed_types: Sequence[str] | None = None
 
     def deserialize(
         self, ui_value: ChatInputValueProto | None
     ) -> str | ChatInputValue | None:
-        if ui_value is None or not ui_value.HasField("data"):
+        if ui_value is None:
             return None
-        if not self.accept_files and not self.accept_audio:
-            return ui_value.data
-        uploaded_files = _pop_upload_files(ui_value.file_uploader_state)
-        for file in uploaded_files:
-            if self.allowed_types and not isinstance(file, DeletedFile):
-                enforce_filename_restriction(file.name, self.allowed_types)
 
-        # Extract audio file separately from the audio_file_info field
-        audio_file = _pop_audio_file(
-            ui_value.audio_file_info if ui_value.HasField("audio_file_info") else None
-        )
+        if not self.accept_files and not self.accept_audio and not self.accept_video:
+            return ui_value.data
+
+        uploaded_files = []
+        if self.accept_files:
+            uploaded_files = _pop_upload_files(ui_value.file_uploader_state)
+            for file in uploaded_files:
+                if self.allowed_types and not isinstance(file, DeletedFile):
+                    enforce_filename_restriction(file.name, self.allowed_types)
+
+        audio_file = None
+        if self.accept_audio:
+            audio_file = _pop_audio_file(ui_value.audio_file_info)
+
+        video_file = None
+        if self.accept_video:
+            video_file = _pop_video_file(ui_value.video_file_info)
+
+        if (
+            not ui_value.data
+            and not uploaded_files
+            and audio_file is None
+            and video_file is None
+        ):
+            return None
 
         return ChatInputValue(
             text=ui_value.data,
             files=uploaded_files,
             audio=audio_file,
+            video=video_file,
             _include_files=self.accept_files,
             _include_audio=self.accept_audio,
+            _include_video=self.accept_video,
         )
 
     def serialize(self, v: str | None) -> ChatInputValueProto:
@@ -555,6 +634,7 @@ class ChatMixin:
         accept_file: Literal[False] = False,
         file_type: str | Sequence[str] | None = None,
         accept_audio: Literal[False] = False,
+        accept_video: Literal[False] = False,
         disabled: bool = False,
         on_submit: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
@@ -574,7 +654,28 @@ class ChatMixin:
         accept_file: Literal[False] = False,
         file_type: str | Sequence[str] | None = None,
         accept_audio: Literal[True],
+        accept_video: bool = False,
         audio_sample_rate: int | None = 16000,
+        disabled: bool = False,
+        on_submit: WidgetCallback | None = None,
+        args: WidgetArgs | None = None,
+        kwargs: WidgetKwargs | None = None,
+        width: WidthWithoutContent = "stretch",
+        height: Height = "content",
+    ) -> ChatInputValue | None: ...
+
+    @overload
+    def chat_input(
+        self,
+        placeholder: str = "Your message",
+        *,
+        key: Key | None = None,
+        max_chars: int | None = None,
+        max_upload_size: int | None = None,
+        accept_file: Literal[False] = False,
+        file_type: str | Sequence[str] | None = None,
+        accept_audio: bool = False,
+        accept_video: Literal[True],
         disabled: bool = False,
         on_submit: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
@@ -594,6 +695,7 @@ class ChatMixin:
         accept_file: Literal[True, "multiple", "directory"],
         file_type: str | Sequence[str] | None = None,
         accept_audio: bool = False,
+        accept_video: bool = False,
         audio_sample_rate: int | None = 16000,
         disabled: bool = False,
         on_submit: WidgetCallback | None = None,
@@ -614,6 +716,7 @@ class ChatMixin:
         accept_file: bool | Literal["multiple", "directory"] = False,
         file_type: str | Sequence[str] | None = None,
         accept_audio: bool = False,
+        accept_video: bool = False,
         audio_sample_rate: int | None = 16000,
         disabled: bool = False,
         on_submit: WidgetCallback | None = None,
@@ -728,6 +831,12 @@ class ChatMixin:
             ``None``. If this is ``None``, the widget uses the browser's
             default sample rate (typically 44100 or 48000 Hz).
 
+        accept_video : bool
+            Whether to show a video recording button in the chat input. This
+            defaults to ``False``. If this is ``True``, users can record and
+            submit video messages. Recorded video is available as an
+            ``UploadedFile`` object.
+
         disabled : bool
             Whether the chat input should be disabled. This defaults to
             ``False``.
@@ -773,33 +882,38 @@ class ChatMixin:
 
             - ``None``: If the user didn't submit a message, file, or audio
               recording in the last rerun, the widget returns ``None``.
-            - A string: When the widget isn't configured to accept files or
-              audio recordings, and the user submitted a message in the last
-              rerun, the widget returns the user's message as a string.
-            - A dict-like object: When the widget is configured to accept files
-              or audio recordings, and the user submitted any content in the
-              last rerun, the widget returns a dict-like object.
+            - A string: When the widget isn't configured to accept files,
+              audio recordings, or video recordings, and the user submitted a
+              message in the last rerun, the widget returns the user's message
+              as a string.
+            - A dict-like object: When the widget is configured to accept files,
+              audio recordings, or video recordings, and the user submitted any
+              content in the last rerun, the widget returns a dict-like object.
               The object always includes the ``text`` attribute, and
-              optionally includes ``files`` and/or ``audio`` attributes depending
-              on the ``accept_file`` and ``accept_audio`` parameters.
+              optionally includes ``files``, ``audio`` and/or ``video`` attributes
+              depending on the ``accept_file``, ``accept_audio``, and
+              ``accept_video`` parameters.
 
-            When the widget is configured to accept files or audio recordings,
-            and the user submitted content in the last rerun, you can access
-            the user's submission with key or attribute notation from the
-            dict-like object. This is shown in Example 3 below.
+            When the widget is configured to accept files, audio recordings, or
+            video recordings, and the user submitted content in the last rerun,
+            you can access the user's submission with key or attribute notation
+            from the dict-like object. This is shown in Example 3 below.
 
             - The ``text`` attribute holds a string that is the user's message.
               This is an empty string if the user only submitted one or more
-              files or audio recordings.
+              files, audio recordings, or video recordings.
             - The ``files`` attribute is only present when ``accept_file``
               isn't ``False``. When present, it holds a list of
               ``UploadedFile`` objects. The list is empty if the user only
-              submitted a message or audio recording. Unlike
+              submitted a message, audio recording, or video recording. Unlike
               ``st.file_uploader``, this attribute always returns a list, even
               when the widget is configured to accept only one file at a time.
             - The ``audio`` attribute is only present when ``accept_audio`` is
               ``True``. When present, it holds an ``UploadedFile`` object if
               audio was recorded or ``None`` if no audio was recorded.
+            - The ``video`` attribute is only present when ``accept_video`` is
+              ``True``. When present, it holds an ``UploadedFile`` object if
+              video was recorded or ``None`` if no video was recorded.
 
             The ``UploadedFile`` class is a subclass of ``BytesIO`` and
             therefore is "file-like". This means you can pass an instance of it
@@ -957,6 +1071,7 @@ class ChatMixin:
             file_type=file_type,
             accept_audio=accept_audio,
             audio_sample_rate=audio_sample_rate,
+            accept_video=accept_video,
             width=width,
             height=height,
         )
@@ -1022,9 +1137,12 @@ class ChatMixin:
         if audio_sample_rate is not None:
             chat_input_proto.audio_sample_rate = audio_sample_rate
 
+        chat_input_proto.accept_video = accept_video
+
         serde = ChatInputSerde(
             accept_files=accept_file in {True, "multiple", "directory"},
             accept_audio=accept_audio,
+            accept_video=accept_video,
             allowed_types=file_type,
         )
         widget_state = register_widget(  # type: ignore[misc]
@@ -1061,22 +1179,15 @@ class ChatMixin:
 
         if ctx:
             save_for_app_testing(ctx, element_id, widget_state.value)
-        has_one_shot = widget_state.value_changed and widget_state.value is not None
         if position == "bottom":
             # We need to enqueue the chat input into the bottom container
             # instead of the currently active dg.
             get_dg_singleton_instance().bottom_dg._enqueue(
-                "chat_input",
-                chat_input_proto,
-                layout_config=layout_config,
-                has_one_shot_effect=has_one_shot,
+                "chat_input", chat_input_proto, layout_config=layout_config
             )
         else:
             self.dg._enqueue(
-                "chat_input",
-                chat_input_proto,
-                layout_config=layout_config,
-                has_one_shot_effect=has_one_shot,
+                "chat_input", chat_input_proto, layout_config=layout_config
             )
 
         return widget_state.value if not widget_state.value_changed else None

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -73,6 +73,9 @@ class LocalSourcesWatcher:
 
         self._watched_modules: dict[str, WatchedModule] = {}
         self._watched_pages: set[str] = set()
+
+        # Defer sys.modules eviction to the script thread to avoid mutating
+        # sys.modules from the file-watcher thread while user code runs.
         self._pending_evictions: set[str] = set()
         self._pending_evictions_lock = threading.Lock()
 
@@ -164,6 +167,13 @@ class LocalSourcesWatcher:
             for wm in self._watched_modules.values()
             if wm.module_name is not None and wm.module_name in sys.modules
         }
+        # Skip Streamlit's own modules: re-importing them mid-session reinitialises
+        # singletons (e.g. DeltaGeneratorSingleton) and crashes the runtime.
+        modules_to_evict = {
+            name
+            for name in modules_to_evict
+            if not (name == "streamlit" or name.startswith("streamlit."))
+        }
         if modules_to_evict:
             with self._pending_evictions_lock:
                 self._pending_evictions.update(modules_to_evict)
@@ -174,19 +184,19 @@ class LocalSourcesWatcher:
     def on_script_run(self) -> None:
         """Hook called by ``ScriptRunner`` at the start of each script run.
 
-        Runs on the script thread before any user code executes.  Currently
-        flushes deferred ``sys.modules`` evictions so that the watcher thread
-        never mutates ``sys.modules`` while user code is running.
+        Runs on the script thread before any user code executes. Flushes
+        deferred ``sys.modules`` evictions so the file-watcher thread never
+        mutates ``sys.modules`` while user code (or cache serialization) runs.
         """
+
         self.flush_pending_evictions()
 
     def flush_pending_evictions(self) -> None:
         """Remove pending watched modules from ``sys.modules``.
 
-        Called at the start of each script run on the script thread so that
-        ``sys.modules`` is not mutated from the file watcher thread while user
-        code (or cache serialization) is executing.
+        Called at the start of each script run on the script thread.
         """
+
         with self._pending_evictions_lock:
             pending = self._pending_evictions
             self._pending_evictions = set()

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import mimetypes
 import os
 from typing import TYPE_CHECKING, Final
 from urllib.parse import quote
@@ -699,12 +700,21 @@ def create_upload_routes(
         if len(data) > max_size_bytes:
             raise HTTPException(status_code=413, detail="File too large")
 
+        content_type = upload.content_type or "application/octet-stream"
+        # Some clients don't set a useful per-file Content-Type for multipart
+        # uploads. In those cases, infer a better type from the filename so media
+        # playback works reliably.
+        if content_type == "application/octet-stream" and upload.filename:
+            guessed, _ = mimetypes.guess_type(upload.filename, strict=False)
+            if guessed:
+                content_type = guessed
+
         upload_mgr.add_file(
             session_id=session_id,
             file=UploadedFileRec(
                 file_id=file_id,
                 name=upload.filename or "",
-                type=upload.content_type or "application/octet-stream",
+                type=content_type,
                 data=data,
             ),
         )

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -26,6 +26,7 @@ from streamlit.elements.widgets.chat import (
     ChatInputValue,
     _pop_audio_file,
     _pop_upload_files,
+    _pop_video_file,
 )
 from streamlit.errors import (
     StreamlitAPIException,
@@ -833,12 +834,125 @@ class ChatTest(DeltaGeneratorTestCase):
             st.chat_input(accept_audio=True, audio_sample_rate=12345)
         assert "Invalid audio_sample_rate" in str(exc.value)
 
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_video_file(self, deserialize_patch):
+        """Test that a video file is properly handled by ChatInputValue."""
+        rec = UploadedFileRec("video0", "recording.webm", "video/webm", b"video data")
+
+        video_file = UploadedFile(
+            rec, FileURLsProto(file_id="video0", delete_url="d0", upload_url="u0")
+        )
+
+        deserialize_patch.return_value = ChatInputValue(
+            text="",
+            files=[],
+            video=video_file,
+            _include_files=True,
+            _include_video=True,
+        )
+
+        return_val = st.chat_input(accept_file="multiple", accept_video=True)
+
+        assert return_val.video == video_file
+        assert return_val.video.name == "recording.webm"
+        assert return_val.video.type == "video/webm"
+        assert return_val.video.getvalue() == b"video data"
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_video_file_none(self, deserialize_patch):
+        """Test that ChatInputValue handles a None video file correctly."""
+        deserialize_patch.return_value = ChatInputValue(
+            text="hello", files=[], video=None, _include_files=True, _include_video=True
+        )
+
+        return_val = st.chat_input(accept_file="multiple", accept_video=True)
+
+        assert return_val.video is None
+        assert return_val.text == "hello"
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_chat_input_value_with_video(self, deserialize_patch):
+        """Test ChatInputValue dict-like interface with the video field."""
+        rec = UploadedFileRec("video0", "recording.mp4", "video/mp4", b"video data")
+        video_file = UploadedFile(
+            rec, FileURLsProto(file_id="video0", delete_url="d0", upload_url="u0")
+        )
+
+        deserialize_patch.return_value = ChatInputValue(
+            text="test",
+            files=[],
+            video=video_file,
+            _include_files=True,
+            _include_video=True,
+        )
+
+        return_val = st.chat_input(accept_file="multiple", accept_video=True)
+
+        assert return_val["video"] == video_file
+        assert return_val["text"] == "test"
+        assert "video" in return_val
+        assert len(return_val) == 3  # text, files, video
+
+        as_dict = return_val.to_dict()
+        assert as_dict["video"] == video_file
+        assert as_dict["text"] == "test"
+        assert as_dict["files"] == []
+
+    @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
+    def test_chat_input_value_with_audio_and_video(self, deserialize_patch):
+        """Test ChatInputValue exposes audio and video simultaneously."""
+        audio_rec = UploadedFileRec(
+            "audio0", "recording.wav", "audio/wav", b"audio data"
+        )
+        audio_file = UploadedFile(
+            audio_rec, FileURLsProto(file_id="audio0", delete_url="da", upload_url="ua")
+        )
+        video_rec = UploadedFileRec(
+            "video0", "recording.mp4", "video/mp4", b"video data"
+        )
+        video_file = UploadedFile(
+            video_rec, FileURLsProto(file_id="video0", delete_url="dv", upload_url="uv")
+        )
+
+        deserialize_patch.return_value = ChatInputValue(
+            text="hi",
+            files=[],
+            audio=audio_file,
+            video=video_file,
+            _include_audio=True,
+            _include_video=True,
+        )
+
+        return_val = st.chat_input(accept_audio=True, accept_video=True)
+
+        assert return_val.audio == audio_file
+        assert return_val.video == video_file
+        assert set(return_val.keys()) == {"text", "audio", "video"}
+
+    @parameterized.expand([(None, False), (False, False), (True, True)])
+    def test_chat_input_accept_video(self, value, expected) -> None:
+        """The accept_video kwarg maps onto the proto field."""
+        kwargs = {} if value is None else {"accept_video": value}
+        st.chat_input(**kwargs)
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.accept_video is expected
+
     @parameterized.expand(
         [
-            (False, False, False, False, {"text"}),
-            ("multiple", False, True, False, {"text", "files"}),
-            (False, True, False, True, {"text", "audio"}),
-            ("multiple", True, True, True, {"text", "files", "audio"}),
+            (False, False, False, False, False, False, {"text"}),
+            ("multiple", False, False, True, False, False, {"text", "files"}),
+            (False, True, False, False, True, False, {"text", "audio"}),
+            (False, False, True, False, False, True, {"text", "video"}),
+            (False, True, True, False, True, True, {"text", "audio", "video"}),
+            (
+                "multiple",
+                True,
+                True,
+                True,
+                True,
+                True,
+                {"text", "files", "audio", "video"},
+            ),
         ]
     )
     @patch("streamlit.elements.widgets.chat.ChatInputSerde.deserialize")
@@ -846,21 +960,29 @@ class ChatTest(DeltaGeneratorTestCase):
         self,
         accept_file,
         accept_audio,
+        accept_video,
         include_files,
         include_audio,
+        include_video,
         expected_keys,
         deserialize_patch,
     ):
-        """Test that ChatInputValue only includes keys based on accept_file/accept_audio."""
+        """Test that ChatInputValue only exposes keys based on the accept_* flags."""
         deserialize_patch.return_value = ChatInputValue(
             text="test",
             files=[],
             audio=None,
+            video=None,
             _include_files=include_files,
             _include_audio=include_audio,
+            _include_video=include_video,
         )
 
-        return_val = st.chat_input(accept_file=accept_file, accept_audio=accept_audio)
+        return_val = st.chat_input(
+            accept_file=accept_file,
+            accept_audio=accept_audio,
+            accept_video=accept_video,
+        )
 
         # Verify expected keys are present
         assert set(return_val.keys()) == expected_keys
@@ -893,6 +1015,17 @@ class ChatTest(DeltaGeneratorTestCase):
                 _ = return_val["audio"]
             with pytest.raises(AttributeError):
                 _ = return_val.audio
+
+        if "video" in expected_keys:
+            assert "video" in return_val
+            assert return_val["video"] is None
+            assert return_val.video is None
+        else:
+            assert "video" not in return_val
+            with pytest.raises(KeyError):
+                _ = return_val["video"]
+            with pytest.raises(AttributeError):
+                _ = return_val.video
 
         # Verify to_dict matches expected keys
         as_dict = return_val.to_dict()
@@ -983,6 +1116,59 @@ class ChatInputSerdeTest(DeltaGeneratorTestCase):
 
         assert result == "test message"
 
+    def test_deserialize_returns_string_when_only_video_accepted_and_no_video(self):
+        """Test deserialize returns a string when only video is accepted but text is sent."""
+        serde = ChatInputSerde(
+            accept_files=False, accept_audio=False, accept_video=True
+        )
+        proto = ChatInputValueProto()
+        proto.data = "no video, just text"
+
+        result = serde.deserialize(proto)
+
+        assert isinstance(result, ChatInputValue)
+        assert result.text == "no video, just text"
+        assert result.video is None
+
+    def test_deserialize_returns_none_when_video_accepted_but_nothing_submitted(self):
+        """Test deserialize returns None when accept_video=True but no content was sent."""
+        serde = ChatInputSerde(
+            accept_files=False, accept_audio=False, accept_video=True
+        )
+        proto = ChatInputValueProto()  # data unset, no video_file_info
+
+        result = serde.deserialize(proto)
+
+        assert result is None
+
+    def test_deserialize_includes_video_when_present(self):
+        """Test deserialize attaches the video file to ChatInputValue."""
+        ctx = self.script_run_ctx
+        file_id = "video-serde"
+        ctx.uploaded_file_mgr.add_file(
+            session_id=ctx.session_id,
+            file=UploadedFileRec(
+                file_id=file_id,
+                name="recording.mp4",
+                type="video/mp4",
+                data=b"video bytes",
+            ),
+        )
+
+        serde = ChatInputSerde(
+            accept_files=False, accept_audio=False, accept_video=True
+        )
+        proto = ChatInputValueProto()
+        proto.data = ""
+        proto.video_file_info.file_id = file_id
+
+        result = serde.deserialize(proto)
+
+        assert isinstance(result, ChatInputValue)
+        assert result.video is not None
+        assert result.video.name == "recording.mp4"
+        assert result.video.getvalue() == b"video bytes"
+
 
 class PopUploadFilesTest(DeltaGeneratorTestCase):
     """Test _pop_upload_files and _pop_audio_file functions."""
@@ -1018,3 +1204,75 @@ class PopUploadFilesTest(DeltaGeneratorTestCase):
         ):
             result = _pop_audio_file(proto)
             assert result is None
+
+    def test_pop_video_file_returns_none_for_none(self):
+        """Return None for None, empty file_id, or a missing record."""
+        assert _pop_video_file(None) is None
+        assert _pop_video_file(UploadedFileInfoProto()) is None
+
+        proto = UploadedFileInfoProto(file_id="missing-video")
+        assert _pop_video_file(proto) is None
+
+    def test_pop_video_file_returns_none_no_ctx(self):
+        """Return None when there is no active ScriptRunContext."""
+        proto = UploadedFileInfoProto(file_id="video123")
+        with patch(
+            "streamlit.elements.widgets.chat.get_script_run_ctx", return_value=None
+        ):
+            assert _pop_video_file(proto) is None
+
+    @parameterized.expand(
+        [
+            ("recording.mp4", "video/mp4"),
+            ("recording.webm", "video/webm"),
+            ("recording.MOV", "video/quicktime"),
+            ("recording.webm", "video/webm;codecs=vp8,opus"),
+        ]
+    )
+    def test_pop_video_file_accepts_supported_videos(
+        self, name: str, mime_type: str
+    ) -> None:
+        """Accept the supported extensions and MIME types, including codec parameters."""
+        ctx = self.script_run_ctx
+        file_id = "video-ok"
+        ctx.uploaded_file_mgr.add_file(
+            session_id=ctx.session_id,
+            file=UploadedFileRec(
+                file_id=file_id, name=name, type=mime_type, data=b"video bytes"
+            ),
+        )
+
+        proto = UploadedFileInfoProto()
+        proto.file_id = file_id
+
+        result = _pop_video_file(proto)
+
+        assert result is not None
+        assert result.name == name
+        assert result.type == mime_type
+        assert result.getvalue() == b"video bytes"
+
+        remaining = ctx.uploaded_file_mgr.get_files(
+            session_id=ctx.session_id, file_ids=[file_id]
+        )
+        assert remaining == []
+
+    @parameterized.expand(
+        [
+            ("recording.gif", "video/mp4", "Invalid file extension for video input"),
+            ("recording.mp4", "text/plain", "Invalid MIME type for video input"),
+        ]
+    )
+    def test_pop_video_file_rejects_invalid(
+        self, name: str, mime: str, message: str
+    ) -> None:
+        """Raise when extension or MIME type is unsupported."""
+        ctx = self.script_run_ctx
+        file_id = "video-bad"
+        ctx.uploaded_file_mgr.add_file(
+            session_id=ctx.session_id,
+            file=UploadedFileRec(file_id=file_id, name=name, type=mime, data=b"bytes"),
+        )
+
+        with pytest.raises(StreamlitAPIException, match=message):
+            _pop_video_file(UploadedFileInfoProto(file_id=file_id))

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -122,7 +122,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         assert ds.type == "method"
 
         signature = (
-            "(data: 'MediaData', format: 'str' = 'audio/wav', start_time: 'MediaTime' = 0, *, "
+            "(data: 'MediaData', format: 'str | None' = None, start_time: 'MediaTime' = 0, *, "
             "sample_rate: 'int | None' = None, end_time: 'MediaTime | None' = None, loop: 'bool' = False, "
             "autoplay: 'bool' = False, width: 'WidthWithoutContent' = 'stretch') -> 'DeltaGenerator'"
         )

--- a/lib/tests/streamlit/typing/chat_input_types.py
+++ b/lib/tests/streamlit/typing/chat_input_types.py
@@ -19,9 +19,10 @@ from typing import TYPE_CHECKING
 from typing_extensions import assert_type
 
 # Perform type checking tests for st.chat_input
-# The return type depends on accept_file and accept_audio parameters:
-# - accept_file=False and accept_audio=False (default) -> returns str | None
-# - accept_file=True/multiple/directory OR accept_audio=True -> returns ChatInputValue | None
+# The return type depends on accept_file, accept_audio, and accept_video parameters:
+# - all three False (default) -> returns str | None
+# - any of accept_file=True/multiple/directory, accept_audio=True, or
+#   accept_video=True -> returns ChatInputValue | None
 if TYPE_CHECKING:
     from streamlit.elements.widgets.chat import ChatInputValue, ChatMixin
 
@@ -54,6 +55,8 @@ if TYPE_CHECKING:
     # accept_audio=True returns ChatInputValue | None
     assert_type(chat_input("Message", accept_audio=True), ChatInputValue | None)
 
+    assert_type(chat_input("Message", accept_video=True), ChatInputValue | None)
+
     # Both accept_file and accept_audio enabled returns ChatInputValue | None
     assert_type(
         chat_input("Message", accept_file=True, accept_audio=True),
@@ -61,6 +64,15 @@ if TYPE_CHECKING:
     )
     assert_type(
         chat_input("Message", accept_file="multiple", accept_audio=True),
+        ChatInputValue | None,
+    )
+
+    assert_type(
+        chat_input("Message", accept_audio=True, accept_video=True),
+        ChatInputValue | None,
+    )
+    assert_type(
+        chat_input("Message", accept_file="multiple", accept_video=True),
         ChatInputValue | None,
     )
 

--- a/proto/streamlit/proto/ChatInput.proto
+++ b/proto/streamlit/proto/ChatInput.proto
@@ -46,5 +46,8 @@ message ChatInput {
   // If not set, uses browser default
   optional int32 audio_sample_rate = 13;
 
+  // Whether to show video recording button
+  bool accept_video = 14;
+
   reserved 8;
 }

--- a/proto/streamlit/proto/Common.proto
+++ b/proto/streamlit/proto/Common.proto
@@ -97,4 +97,5 @@ message ChatInputValue {
   optional string data = 1;
   optional FileUploaderState file_uploader_state = 2;
   optional UploadedFileInfo audio_file_info = 3;
+  optional UploadedFileInfo video_file_info = 4;
 }


### PR DESCRIPTION
## Describe your changes

Adds an `accept_video` parameter to `st.chat_input` that lets users record
and submit a video alongside text, files, and audio in a single multimodal
submission. Includes pause/resume/cancel/approve recording controls, plus
pending audio/video chips so a single send bundles all attached media.

Co-authored with Inês Cadete.

## Testing Plan

✅ Passes the respective unit tests (Python and TypeScript)
✅ Manual testing via `make debug` with camera/microphone recording flow

## GitHub Issue Link (if applicable)

Closes [#8668](https://github.com/streamlit/streamlit/issues/8668)