### PR TITLE
[Parallel Fragments] Refactor RunningCursor API: replace get_locked_cursor() with lock_element()/open_block()

### DIFF
--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -346,8 +346,12 @@ class LockedCursor(Cursor):
         return self
 
     def open_block(self) -> RunningCursor:
-        """LockedCursors cannot open blocks — they represent a fixed position."""
-        raise RuntimeError(
-            "Cannot open a block on a LockedCursor. "
-            "Use a RunningCursor to create child blocks."
+        """Create a child cursor for a new block from this locked position.
+
+        Returns a new RunningCursor whose parent_path includes this cursor's
+        index. The LockedCursor itself is not modified since it's immutable.
+        """
+        return RunningCursor(
+            root_container=self._root_container,
+            parent_path=(*self._parent_path, self._index),
         )

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -283,13 +283,13 @@ class RunningCursor(Cursor):
         self._advance()
         return child
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> dict[str, object]:
         """Return state for pickling, excluding the unpicklable lock."""
         state = self.__dict__.copy()
         del state["_owner_lock"]
         return state
 
-    def __setstate__(self, state: dict) -> None:
+    def __setstate__(self, state: dict[str, object]) -> None:
         """Restore state after unpickling, recreating lock and resetting owner."""
         self.__dict__.update(state)
         self._owner_lock = threading.Lock()

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -260,7 +260,6 @@ class RunningCursor(Cursor):
         Returns a LockedCursor pointing at the current index. The
         RunningCursor advances to the next position.
         """
-        self._check_owner()
         locked = LockedCursor(
             root_container=self._root_container,
             parent_path=self._parent_path,
@@ -275,7 +274,6 @@ class RunningCursor(Cursor):
         Returns a new RunningCursor whose parent_path includes the current
         index. The parent RunningCursor advances to the next position.
         """
-        self._check_owner()
         child = RunningCursor(
             root_container=self._root_container,
             parent_path=(*self._parent_path, self._index),

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -283,6 +283,18 @@ class RunningCursor(Cursor):
         self._advance()
         return child
 
+    def __getstate__(self) -> dict:
+        """Return state for pickling, excluding the unpicklable lock."""
+        state = self.__dict__.copy()
+        del state["_owner_lock"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore state after unpickling, recreating lock and resetting owner."""
+        self.__dict__.update(state)
+        self._owner_lock = threading.Lock()
+        self._owner_ident = None
+
 
 class LockedCursor(Cursor):
     def __init__(

--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from streamlit import util
@@ -109,8 +110,8 @@ class SparseList(Generic[T]):
 class Cursor:
     """A pointer to a delta location in the app.
 
-    When adding an element to the app, you should always call
-    get_locked_cursor() on that element's respective Cursor.
+    Subclasses provide `lock_element()` and `open_block()` to reserve
+    positions in the element tree.
 
     Parameters
     ----------
@@ -167,7 +168,10 @@ class Cursor:
     def transient_index(self) -> int:
         return 0 if self._transient_index is None else self._transient_index
 
-    def get_locked_cursor(self) -> LockedCursor:
+    def lock_element(self) -> LockedCursor:
+        raise NotImplementedError()
+
+    def open_block(self) -> RunningCursor:
         raise NotImplementedError()
 
     def get_transient_cursor(self) -> Cursor:
@@ -190,7 +194,7 @@ class RunningCursor(Cursor):
         """A moving pointer to a delta location in the app.
 
         RunningCursors auto-increment to the next available location when you
-        call get_locked_cursor() on them.
+        call lock_element() or open_block() on them.
 
         Parameters
         ----------
@@ -203,12 +207,13 @@ class RunningCursor(Cursor):
           The running index of the transient elements.
         transient_elements: SparseList[Element]
           The list of active transient elements.
-
         """
         super().__init__(transient_index, transient_elements)
         self._root_container = root_container
         self._parent_path = parent_path
         self._index = 0
+        self._owner_ident: int | None = None
+        self._owner_lock = threading.Lock()
 
     @property
     def root_container(self) -> int:
@@ -226,18 +231,57 @@ class RunningCursor(Cursor):
     def is_locked(self) -> bool:
         return False
 
-    def get_locked_cursor(self) -> LockedCursor:
-        locked_cursor = LockedCursor(
-            root_container=self._root_container,
-            parent_path=self._parent_path,
-            index=self._index,
-        )
+    def _check_owner(self) -> None:
+        """Assert that the calling thread owns this cursor.
 
+        On first call, claims ownership for the calling thread. On subsequent
+        calls, raises RuntimeError if the caller is a different thread.
+        """
+        with self._owner_lock:
+            current_ident = threading.get_ident()
+            if self._owner_ident is None:
+                self._owner_ident = current_ident
+            elif self._owner_ident != current_ident:
+                raise RuntimeError(
+                    "Cursor accessed from a thread that doesn't own it. "
+                    "This usually means a parallel fragment is writing to a "
+                    "container that belongs to another thread."
+                )
+
+    def _advance(self) -> None:
+        """Increment index and reset transient state."""
         self._index += 1
         self._transient_index = None
         self._transient_elements = SparseList[Element]()
 
-        return locked_cursor
+    def lock_element(self) -> LockedCursor:
+        """Reserve the current position for an element and advance.
+
+        Returns a LockedCursor pointing at the current index. The
+        RunningCursor advances to the next position.
+        """
+        self._check_owner()
+        locked = LockedCursor(
+            root_container=self._root_container,
+            parent_path=self._parent_path,
+            index=self._index,
+        )
+        self._advance()
+        return locked
+
+    def open_block(self) -> RunningCursor:
+        """Create a child cursor for a new block and advance.
+
+        Returns a new RunningCursor whose parent_path includes the current
+        index. The parent RunningCursor advances to the next position.
+        """
+        self._check_owner()
+        child = RunningCursor(
+            root_container=self._root_container,
+            parent_path=(*self._parent_path, self._index),
+        )
+        self._advance()
+        return child
 
 
 class LockedCursor(Cursor):
@@ -252,7 +296,7 @@ class LockedCursor(Cursor):
         """A locked pointer to a location in the app.
 
         LockedCursors always point to the same location, even when you call
-        get_locked_cursor() on them.
+        lock_element() on them.
 
         Parameters
         ----------
@@ -266,7 +310,6 @@ class LockedCursor(Cursor):
           The running index of the transient elements.
         transient_elements: SparseList[Element]
           The list of active transient elements.
-
         """
         super().__init__(transient_index, transient_elements)
         self._root_container = root_container
@@ -289,5 +332,12 @@ class LockedCursor(Cursor):
     def is_locked(self) -> bool:
         return True
 
-    def get_locked_cursor(self) -> LockedCursor:
+    def lock_element(self) -> LockedCursor:
         return self
+
+    def open_block(self) -> RunningCursor:
+        """LockedCursors cannot open blocks — they represent a fixed position."""
+        raise RuntimeError(
+            "Cannot open a block on a LockedCursor. "
+            "Use a RunningCursor to create child blocks."
+        )

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -564,9 +564,7 @@ class DeltaGenerator(
         if msg_was_enqueued:
             # Get a DeltaGenerator that is locked to the current element
             # position.
-            new_cursor = (
-                dg._cursor.get_locked_cursor() if dg._cursor is not None else None
-            )
+            new_cursor = dg._cursor.lock_element() if dg._cursor is not None else None
 
             output_dg = DeltaGenerator(
                 root_container=dg._root_container,
@@ -615,13 +613,9 @@ class DeltaGenerator(
         msg.metadata.delta_path[:] = dg._cursor.delta_path
         msg.delta.add_block.CopyFrom(block_proto)
 
-        # Normally we'd return a new DeltaGenerator that uses the locked cursor
-        # below. But in this case we want to return a DeltaGenerator that uses
-        # a brand new cursor for this new block we're creating.
-        block_cursor = cursor.RunningCursor(
-            root_container=dg._root_container,
-            parent_path=(*dg._cursor.parent_path, dg._cursor.index),
-        )
+        # Create a child RunningCursor for the new block and advance the
+        # parent cursor in one operation.
+        block_cursor = dg._cursor.open_block()
 
         # `dg_type` param added for st.status container. It allows us to
         # instantiate DeltaGenerator subclasses from the function.
@@ -641,8 +635,6 @@ class DeltaGenerator(
         # NOTE: Container form ids aren't set in proto.
         block_dg._form_data = FormData(current_form_id(dg))
 
-        # Must be called to increment this cursor's index.
-        dg._cursor.get_locked_cursor()
         _enqueue_message(msg)
 
         caching.save_block_message(

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -297,7 +297,7 @@ class TestRunningCursorDeepcopy:
         from copy import deepcopy
 
         cursor = RunningCursor(RootContainer.MAIN)
-        cursor.lock_element()  # Claim from main thread
+        cursor._check_owner()  # Claim from main thread
 
         copied = deepcopy(cursor)
         assert cursor._owner_ident == threading.get_ident()
@@ -307,7 +307,7 @@ class TestRunningCursorDeepcopy:
         result: list[int | None] = []
 
         def claim_copy() -> None:
-            copied.lock_element()
+            copied._check_owner()
             result.append(copied._owner_ident)
 
         t = threading.Thread(target=claim_copy)
@@ -351,60 +351,3 @@ class TestRunningCursorThreadOwnership:
 
         assert error is not None
         assert "doesn't own it" in str(error)
-
-    def test_lock_element_enforces_ownership(self) -> None:
-        """lock_element raises RuntimeError from a non-owner thread."""
-        cursor = RunningCursor(RootContainer.MAIN)
-        cursor.lock_element()  # Claim from main thread
-
-        error: RuntimeError | None = None
-
-        def access_from_other_thread() -> None:
-            nonlocal error
-            try:
-                cursor.lock_element()
-            except RuntimeError as e:
-                error = e
-
-        t = threading.Thread(target=access_from_other_thread)
-        t.start()
-        t.join()
-
-        assert error is not None
-        assert "doesn't own it" in str(error)
-
-    def test_open_block_enforces_ownership(self) -> None:
-        """open_block raises RuntimeError from a non-owner thread."""
-        cursor = RunningCursor(RootContainer.MAIN)
-        cursor.open_block()  # Claim from main thread
-
-        error: RuntimeError | None = None
-
-        def access_from_other_thread() -> None:
-            nonlocal error
-            try:
-                cursor.open_block()
-            except RuntimeError as e:
-                error = e
-
-        t = threading.Thread(target=access_from_other_thread)
-        t.start()
-        t.join()
-
-        assert error is not None
-
-    def test_unclaimed_cursor_can_be_claimed_by_any_thread(self) -> None:
-        """A fresh cursor can be claimed by a worker thread."""
-        cursor = RunningCursor(RootContainer.MAIN)
-
-        result: list[int | None] = []
-
-        def claim_from_worker() -> None:
-            cursor.lock_element()
-            result.append(cursor._owner_ident)
-
-        t = threading.Thread(target=claim_from_worker)
-        t.start()
-        t.join()
-
-        assert result[0] == t.ident

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,7 +42,7 @@ class TestSparseList:
         with pytest.raises(KeyError):
             _ = sl[1]
 
-    def test_set_invalid_index(self):
+    def test_set_invalid_index(self) -> None:
         """Test setting invalid indices raises IndexError."""
         sl = SparseList()
         with pytest.raises(IndexError):
@@ -49,7 +50,7 @@ class TestSparseList:
         with pytest.raises(IndexError):
             sl["not_int"] = "fail"  # type: ignore
 
-    def test_del_item(self):
+    def test_del_item(self) -> None:
         """Test deleting items."""
         sl = SparseList()
         sl[0] = "a"
@@ -59,14 +60,14 @@ class TestSparseList:
         with pytest.raises(KeyError):
             del sl[1]
 
-    def test_len(self):
+    def test_len(self) -> None:
         """Test length of SparseList."""
         sl = SparseList()
         sl[0] = "a"
         sl[10] = "b"
         assert len(sl) == 2
 
-    def test_iteration(self):
+    def test_iteration(self) -> None:
         """Test iteration over SparseList."""
         sl = SparseList()
         sl[2] = "c"
@@ -76,14 +77,14 @@ class TestSparseList:
         assert list(sl) == ["a", "b", "c"]
         assert list(sl.items()) == [(0, "a"), (1, "b"), (2, "c")]
 
-    def test_contains(self):
+    def test_contains(self) -> None:
         """Test __contains__."""
         sl = SparseList()
         sl[0] = "a"
         assert 0 in sl
         assert 1 not in sl
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """Test __repr__."""
         sl = SparseList()
         sl[0] = "a"
@@ -92,25 +93,25 @@ class TestSparseList:
 
 
 class TestCursorFunctions:
-    def test_make_delta_path(self):
+    def test_make_delta_path(self) -> None:
         """Test make_delta_path."""
         path = make_delta_path(RootContainer.MAIN, (1, 2), 3)
         assert path == [RootContainer.MAIN, 1, 2, 3]
 
     @patch("streamlit.cursor.get_script_run_ctx")
-    def test_get_container_cursor_no_ctx(self, mock_get_ctx):
+    def test_get_container_cursor_no_ctx(self, mock_get_ctx: MagicMock) -> None:
         """Test get_container_cursor when no context exists."""
         mock_get_ctx.return_value = None
         cursor = get_container_cursor(RootContainer.MAIN)
         assert cursor is None
 
-    def test_get_container_cursor_none_root(self):
+    def test_get_container_cursor_none_root(self) -> None:
         """Test get_container_cursor with None root."""
         cursor = get_container_cursor(None)
         assert cursor is None
 
     @patch("streamlit.cursor.get_script_run_ctx")
-    def test_get_container_cursor_creates_new(self, mock_get_ctx):
+    def test_get_container_cursor_creates_new(self, mock_get_ctx: MagicMock) -> None:
         """Test get_container_cursor creates a new cursor if not present."""
         mock_ctx = MagicMock()
         mock_ctx.cursors = {}
@@ -123,7 +124,9 @@ class TestCursorFunctions:
         assert mock_ctx.cursors[RootContainer.MAIN] == cursor
 
     @patch("streamlit.cursor.get_script_run_ctx")
-    def test_get_container_cursor_returns_existing(self, mock_get_ctx):
+    def test_get_container_cursor_returns_existing(
+        self, mock_get_ctx: MagicMock
+    ) -> None:
         """Test get_container_cursor returns existing cursor."""
         mock_ctx = MagicMock()
         existing_cursor = RunningCursor(RootContainer.MAIN)
@@ -135,7 +138,7 @@ class TestCursorFunctions:
 
 
 class TestRunningCursor:
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         """Test initialization of RunningCursor."""
         cursor = RunningCursor(RootContainer.MAIN, (1, 2))
         assert cursor.root_container == RootContainer.MAIN
@@ -145,22 +148,22 @@ class TestRunningCursor:
         assert not cursor.is_locked
         assert len(cursor.transient_elements) == 0
 
-    def test_get_locked_cursor(self):
-        """Test get_locked_cursor from RunningCursor."""
+    def test_lock_element(self) -> None:
+        """Test lock_element from RunningCursor."""
         cursor = RunningCursor(RootContainer.MAIN)
 
         # First lock
-        locked1 = cursor.get_locked_cursor()
+        locked1 = cursor.lock_element()
         assert isinstance(locked1, LockedCursor)
         assert locked1.index == 0
         assert cursor.index == 1
 
         # Second lock
-        locked2 = cursor.get_locked_cursor()
+        locked2 = cursor.lock_element()
         assert locked2.index == 1
         assert cursor.index == 2
 
-    def test_get_transient_cursor(self):
+    def test_get_transient_cursor(self) -> None:
         """Test get_transient_cursor from RunningCursor."""
         cursor = RunningCursor(RootContainer.MAIN)
 
@@ -173,18 +176,34 @@ class TestRunningCursor:
         cursor.get_transient_cursor()
         assert cursor.transient_index == 1
 
-    def test_locked_cursor_resets_transient(self):
-        """Test that get_locked_cursor resets transient state."""
+    def test_lock_element_resets_transient(self) -> None:
+        """Test that lock_element resets transient state."""
         cursor = RunningCursor(RootContainer.MAIN)
         cursor.get_transient_cursor()
-        cursor.transient_elements[0] = "element"  # Simulate adding element
+        cursor.transient_elements[0] = "element"  # type: ignore[assignment]
         assert cursor.transient_index == 0
         assert len(cursor.transient_elements) == 1
 
-        cursor.get_locked_cursor()
+        cursor.lock_element()
         # Should be reset
         assert cursor.transient_index == 0
         assert len(cursor.transient_elements) == 0
+
+    def test_open_block(self) -> None:
+        """Test open_block creates a child cursor and advances."""
+        cursor = RunningCursor(RootContainer.MAIN, parent_path=(1,))
+        assert cursor.index == 0
+
+        child = cursor.open_block()
+        assert isinstance(child, RunningCursor)
+        assert child.root_container == RootContainer.MAIN
+        assert child.parent_path == (1, 0)
+        assert child.index == 0
+        assert cursor.index == 1
+
+        child2 = cursor.open_block()
+        assert child2.parent_path == (1, 1)
+        assert cursor.index == 2
 
 
 class TestCursorBase:
@@ -221,15 +240,21 @@ class TestCursorBase:
         with pytest.raises(NotImplementedError):
             _ = cursor.is_locked
 
-    def test_get_locked_cursor_raises_not_implemented(self) -> None:
-        """Test that get_locked_cursor on base Cursor raises NotImplementedError."""
+    def test_lock_element_raises_not_implemented(self) -> None:
+        """Test that lock_element on base Cursor raises NotImplementedError."""
         cursor = Cursor()
         with pytest.raises(NotImplementedError):
-            cursor.get_locked_cursor()
+            cursor.lock_element()
+
+    def test_open_block_raises_not_implemented(self) -> None:
+        """Test that open_block on base Cursor raises NotImplementedError."""
+        cursor = Cursor()
+        with pytest.raises(NotImplementedError):
+            cursor.open_block()
 
 
 class TestLockedCursor:
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         """Test initialization of LockedCursor."""
         cursor = LockedCursor(RootContainer.MAIN, (1,), 5)
         assert cursor.root_container == RootContainer.MAIN
@@ -237,10 +262,109 @@ class TestLockedCursor:
         assert cursor.index == 5
         assert cursor.is_locked
 
-    def test_get_locked_cursor(self):
-        """Test get_locked_cursor from LockedCursor."""
+    def test_lock_element_returns_self(self) -> None:
+        """Test lock_element from LockedCursor returns self."""
         cursor = LockedCursor(RootContainer.MAIN, index=5)
 
-        locked = cursor.get_locked_cursor()
+        locked = cursor.lock_element()
         assert locked == cursor
         assert cursor.index == 5  # Index doesn't change
+
+    def test_open_block_raises(self) -> None:
+        """Test open_block from LockedCursor raises RuntimeError."""
+        cursor = LockedCursor(RootContainer.MAIN, index=5)
+        with pytest.raises(RuntimeError, match="Cannot open a block"):
+            cursor.open_block()
+
+
+class TestRunningCursorThreadOwnership:
+    def test_check_owner_claims_on_first_use(self) -> None:
+        """First call to _check_owner claims ownership for the calling thread."""
+        cursor = RunningCursor(RootContainer.MAIN)
+        assert cursor._owner_ident is None
+        cursor._check_owner()
+        assert cursor._owner_ident == threading.get_ident()
+
+    def test_check_owner_allows_same_thread(self) -> None:
+        """Subsequent calls from the same thread succeed."""
+        cursor = RunningCursor(RootContainer.MAIN)
+        cursor._check_owner()
+        cursor._check_owner()  # Should not raise
+
+    def test_check_owner_rejects_different_thread(self) -> None:
+        """Calls from a different thread raise RuntimeError."""
+        cursor = RunningCursor(RootContainer.MAIN)
+        cursor._check_owner()  # Claim from main thread
+
+        error: RuntimeError | None = None
+
+        def access_from_other_thread() -> None:
+            nonlocal error
+            try:
+                cursor._check_owner()
+            except RuntimeError as e:
+                error = e
+
+        t = threading.Thread(target=access_from_other_thread)
+        t.start()
+        t.join()
+
+        assert error is not None
+        assert "doesn't own it" in str(error)
+
+    def test_lock_element_enforces_ownership(self) -> None:
+        """lock_element raises RuntimeError from a non-owner thread."""
+        cursor = RunningCursor(RootContainer.MAIN)
+        cursor.lock_element()  # Claim from main thread
+
+        error: RuntimeError | None = None
+
+        def access_from_other_thread() -> None:
+            nonlocal error
+            try:
+                cursor.lock_element()
+            except RuntimeError as e:
+                error = e
+
+        t = threading.Thread(target=access_from_other_thread)
+        t.start()
+        t.join()
+
+        assert error is not None
+        assert "doesn't own it" in str(error)
+
+    def test_open_block_enforces_ownership(self) -> None:
+        """open_block raises RuntimeError from a non-owner thread."""
+        cursor = RunningCursor(RootContainer.MAIN)
+        cursor.open_block()  # Claim from main thread
+
+        error: RuntimeError | None = None
+
+        def access_from_other_thread() -> None:
+            nonlocal error
+            try:
+                cursor.open_block()
+            except RuntimeError as e:
+                error = e
+
+        t = threading.Thread(target=access_from_other_thread)
+        t.start()
+        t.join()
+
+        assert error is not None
+
+    def test_unclaimed_cursor_can_be_claimed_by_any_thread(self) -> None:
+        """A fresh cursor can be claimed by a worker thread."""
+        cursor = RunningCursor(RootContainer.MAIN)
+
+        result: list[int | None] = []
+
+        def claim_from_worker() -> None:
+            cursor.lock_element()
+            result.append(cursor._owner_ident)
+
+        t = threading.Thread(target=claim_from_worker)
+        t.start()
+        t.join()
+
+        assert result[0] == t.ident

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -270,11 +270,14 @@ class TestLockedCursor:
         assert locked == cursor
         assert cursor.index == 5  # Index doesn't change
 
-    def test_open_block_raises(self) -> None:
-        """Test open_block from LockedCursor raises RuntimeError."""
-        cursor = LockedCursor(RootContainer.MAIN, index=5)
-        with pytest.raises(RuntimeError, match="Cannot open a block"):
-            cursor.open_block()
+    def test_open_block(self) -> None:
+        """Test open_block from LockedCursor creates a child RunningCursor."""
+        cursor = LockedCursor(RootContainer.MAIN, parent_path=(1, 2), index=5)
+        child = cursor.open_block()
+        assert isinstance(child, RunningCursor)
+        assert child.root_container == RootContainer.MAIN
+        assert child.parent_path == (1, 2, 5)
+        assert child.index == 0
 
 
 class TestRunningCursorDeepcopy:

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -277,6 +277,46 @@ class TestLockedCursor:
             cursor.open_block()
 
 
+class TestRunningCursorDeepcopy:
+    def test_deepcopy_creates_independent_cursor(self) -> None:
+        """Test that deepcopy creates an independent cursor."""
+        from copy import deepcopy
+
+        cursor = RunningCursor(RootContainer.MAIN, parent_path=(1,))
+        cursor.lock_element()  # Claim ownership and advance
+
+        copied = deepcopy(cursor)
+        assert copied.root_container == cursor.root_container
+        assert copied.parent_path == cursor.parent_path
+        assert copied.index == cursor.index
+        # Ownership should be reset for the copy
+        assert copied._owner_ident is None
+
+    def test_deepcopy_resets_ownership(self) -> None:
+        """Test that deepcopy resets ownership so another thread can claim it."""
+        from copy import deepcopy
+
+        cursor = RunningCursor(RootContainer.MAIN)
+        cursor.lock_element()  # Claim from main thread
+
+        copied = deepcopy(cursor)
+        assert cursor._owner_ident == threading.get_ident()
+        assert copied._owner_ident is None  # Reset
+
+        # The copy can be claimed by a new thread
+        result: list[int | None] = []
+
+        def claim_copy() -> None:
+            copied.lock_element()
+            result.append(copied._owner_ident)
+
+        t = threading.Thread(target=claim_copy)
+        t.start()
+        t.join()
+
+        assert result[0] == t.ident
+
+
 class TestRunningCursorThreadOwnership:
     def test_check_owner_claims_on_first_use(self) -> None:
         """First call to _check_owner claims ownership for the calling thread."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the `RunningCursor` API to improve clarity and prepare for parallel fragment support.

### Changes

#### 1. Replace `get_locked_cursor()` with explicit methods

- **`lock_element()`**: Reserves the current position for an element and returns a `LockedCursor`. Advances the `RunningCursor` to the next position.
- **`open_block()`**: Creates a child `RunningCursor` for a new block and advances the parent cursor.

This replaces the overloaded `get_locked_cursor()` method which returned different cursor types depending on whether the caller wanted to lock an element position or open a new block.

Both `RunningCursor` and `LockedCursor` now implement `open_block()`:
- `RunningCursor.open_block()`: Creates child cursor and advances
- `LockedCursor.open_block()`: Creates child cursor from the locked position (immutable)

#### 2. Thread ownership infrastructure (deferred enforcement)

Added `_check_owner()` method and `_owner_ident`/`_owner_lock` attributes to `RunningCursor` for future parallel fragment support. The infrastructure is in place but **not currently enforced** in `lock_element()` and `open_block()` to maintain backward compatibility with existing patterns like button callbacks writing to containers.

#### 3. Proper serialization support

Implemented `__getstate__` and `__setstate__` methods to make `RunningCursor` properly picklable/deepcopyable. When a cursor is copied, its ownership is reset so the copy can be claimed by a new thread.

### Files Changed

- `lib/streamlit/cursor.py`: Core cursor refactoring
- `lib/streamlit/delta_generator.py`: Updated to use new API methods
- `lib/tests/streamlit/cursor_test.py`: Updated tests for new API

### Testing

- All existing cursor unit tests pass
- Added new tests for `open_block()`, `_check_owner()`, and deepcopy behavior
- Verified `test_out_of_order_blocks` passes (button callbacks writing to containers)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-687c77f6-fb68-4d42-8e1e-c13bfc85a9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-687c77f6-fb68-4d42-8e1e-c13bfc85a9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

