### PR TITLE
[fix] Use named Snowflake connection from config file

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/snowflake-connection.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/snowflake-connection.md
@@ -158,7 +158,10 @@ df = conn.query("SELECT * FROM my_table")
 The `type="snowflake"` argument is required here because the connection name is not the
 built-in `"snowflake"` shorthand. Streamlit secrets still take precedence: if a
 `[connections.my_connection]` section exists in `secrets.toml`, those values are used
-instead of the `connections.toml` entry.
+instead of the `connections.toml` entry. Likewise, passing connection keyword arguments
+(e.g. `st.connection("my_connection", type="snowflake", warehouse="wh")`) bypasses the
+named entry entirely—those kwargs are forwarded to the connector as-is, so the
+`connections.toml` entry is not used in that case.
 
 ## Chat with Cortex (Snowflake Cortex required)
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/snowflake-connection.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/snowflake-connection.md
@@ -129,6 +129,37 @@ prod_conn = st.connection("snowflake")
 staging_conn = st.connection("snowflake_staging")
 ```
 
+## Named connections from a Snowflake config file
+
+If you already manage connections in a Snowflake `connections.toml` file (the same
+file the Snowflake CLI and Python connector use), you can select one by name without
+duplicating the credentials in `secrets.toml`. When you call `st.connection` with a
+name other than `"snowflake"` and provide no `[connections.<name>]` secrets and no
+connection keyword arguments, Streamlit uses that name as the Snowflake connection
+name.
+
+```toml
+# ~/.snowflake/connections.toml
+[my_connection]
+account = "ORGNAME-ACCTNAME"
+user = "your_user"
+authenticator = "externalbrowser"
+warehouse = "your_warehouse"
+database = "your_database"
+schema = "your_schema"
+```
+
+```python
+# Uses the [my_connection] entry from connections.toml
+conn = st.connection("my_connection", type="snowflake")
+df = conn.query("SELECT * FROM my_table")
+```
+
+The `type="snowflake"` argument is required here because the connection name is not the
+built-in `"snowflake"` shorthand. Streamlit secrets still take precedence: if a
+`[connections.my_connection]` section exists in `secrets.toml`, those values are used
+instead of the `connections.toml` entry.
+
 ## Chat with Cortex (Snowflake Cortex required)
 
 > **Prerequisite:** This feature requires the `snowflake.cortex` package and a Snowflake account with Cortex access. It is primarily used in Streamlit in Snowflake deployments.

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -660,6 +660,16 @@ class SnowflakeConnection(BaseSnowflakeConnection):
                 )
                 return snowflake.connector.connect()
 
+            # Use a named connection defined in the Snowflake connections.toml file.
+            if self._connection_name and not kwargs:
+                _LOGGER.info(
+                    "Connecting to Snowflake using connection_name=%s.",
+                    self._connection_name,
+                )
+                return snowflake.connector.connect(
+                    connection_name=self._connection_name
+                )
+
             return snowflake.connector.connect(**kwargs)
         except SnowflakeError:
             if not len(st_secrets) and not kwargs:

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -428,7 +428,7 @@ class SnowflakeConnection(BaseSnowflakeConnection):
     `key-pair authentication <https://docs.snowflake.com/en/user-guide/key-pair-auth>`_.
 
     .. code-block:: toml
-        :filename: ~/.snowflake/connections.toml
+        :filename: .streamlit/secrets.toml
 
         [connections.snowflake]
         account = "xxx-xxx"
@@ -485,8 +485,11 @@ class SnowflakeConnection(BaseSnowflakeConnection):
     Snowflake's Python Connector supports a `connection configuration file
     <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#connecting-using-the-connections-toml-file>`_,
     which is well integrated with Streamlit's ``SnowflakeConnection``. If you
-    already have one or more connections configured, all you need to do is pass
-    the name of the connection to use.
+    already have one or more connections configured, you can pass the name of
+    the connection to use. When you use a custom name with no
+    ``[connections.<name>]`` Streamlit secrets and no connection keyword
+    arguments, Streamlit passes the name to Snowflake's Python Connector as
+    ``connection_name``.
 
     .. code-block:: toml
         :filename: ~/.snowflake/connections.toml
@@ -506,6 +509,10 @@ class SnowflakeConnection(BaseSnowflakeConnection):
 
         conn = st.connection("my_connection", type="snowflake")
         df = conn.query("SELECT * FROM my_table")
+
+    Snowflake's CLI uses ``[connections.my_connection]`` sections in
+    ``config.toml``. The shared ``connections.toml`` file used by the Python
+    Connector omits the ``connections.`` prefix, as shown above.
 
     **Example 4: Named connection with Streamlit secrets and Snowflake's connection configuration file**
 
@@ -538,10 +545,9 @@ class SnowflakeConnection(BaseSnowflakeConnection):
     ``my_connection`` as in Example 3, you can set an environment variable to
     declare it as the default Snowflake connection.
 
-    .. code-block:: toml
-        :filename: .streamlit/secrets.toml
+    .. code-block:: shell
 
-        SNOWFLAKE_DEFAULT_CONNECTION_NAME = "my_connection"
+        export SNOWFLAKE_DEFAULT_CONNECTION_NAME="my_connection"
 
     .. code-block:: python
         :filename: streamlit_app.py

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 import os
+import sys
 import threading
+import types
 import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -32,6 +36,71 @@ class SomeError(Exception):
     def __init__(self, message, **kwargs):
         self.__dict__.update(kwargs)
         super().__init__(self, message)
+
+
+class TestSnowflakeConnectionConfiguration:
+    """Tests for Snowflake configuration selection without the Snowflake dependency."""
+
+    @staticmethod
+    @contextmanager
+    def _patched_snowflake() -> Iterator[types.ModuleType]:
+        """Patch the Snowflake connector and Streamlit secrets, yielding the connector module."""
+        snowflake_mod = types.ModuleType("snowflake")
+        connector_mod = types.ModuleType("snowflake.connector")
+        connector_mod.Error = type("SnowflakeError", (Exception,), {})
+        connector_mod.connect = MagicMock()
+        snowflake_mod.connector = connector_mod
+
+        with (
+            patch.dict(
+                sys.modules,
+                {"snowflake": snowflake_mod, "snowflake.connector": connector_mod},
+            ),
+            patch(
+                "streamlit.connections.snowflake_connection.running_in_sis",
+                MagicMock(return_value=False),
+            ),
+            patch(
+                "streamlit.connections.snowflake_connection.SnowflakeConnection._secrets",
+                PropertyMock(return_value=AttrDict({})),
+            ),
+        ):
+            yield connector_mod
+
+    @pytest.mark.parametrize(
+        ("connection_name", "kwargs", "expected_connect_kwargs"),
+        [
+            ("my_connection", {}, {"connection_name": "my_connection"}),
+            ("my_connection", {"account": "my_account"}, {"account": "my_account"}),
+            ("snowflake", {}, {}),
+            ("", {}, {}),
+        ],
+        ids=[
+            "custom_name_uses_named_configuration",
+            "custom_name_with_kwargs_keeps_kwargs_behavior",
+            "snowflake_name_uses_default_configuration",
+            "empty_name_uses_default_configuration",
+        ],
+    )
+    def test_connect_selects_expected_configuration(
+        self,
+        connection_name: str,
+        kwargs: dict[str, str],
+        expected_connect_kwargs: dict[str, str],
+    ) -> None:
+        """Test that connect() is called with the configuration implied by name and kwargs."""
+        with self._patched_snowflake() as connector:
+            SnowflakeConnection(connection_name, **kwargs)
+
+        connector.connect.assert_called_once_with(**expected_connect_kwargs)
+
+    def test_failing_named_connection_raises_friendly_error(self) -> None:
+        """Test that a failing named connection without config raises a friendly error."""
+        with self._patched_snowflake() as connector:
+            connector.connect.side_effect = connector.Error("connection not found")
+
+            with pytest.raises(StreamlitAPIException, match="Missing Snowflake"):
+                SnowflakeConnection("unknown_connection")
 
 
 @pytest.mark.require_integration

--- a/lib/tests/streamlit/connections/snowflake_connection_test.py
+++ b/lib/tests/streamlit/connections/snowflake_connection_test.py
@@ -91,8 +91,7 @@ class TestSnowflakeConnectionConfiguration:
         """Test that connect() is called with the configuration implied by name and kwargs."""
         with self._patched_snowflake() as connector:
             SnowflakeConnection(connection_name, **kwargs)
-
-        connector.connect.assert_called_once_with(**expected_connect_kwargs)
+            connector.connect.assert_called_once_with(**expected_connect_kwargs)
 
     def test_failing_named_connection_raises_friendly_error(self) -> None:
         """Test that a failing named connection without config raises a friendly error."""


### PR DESCRIPTION
## Describe your changes

Fixes `st.connection(<name>, type="snowflake")` ignoring a named connection defined in a Snowflake `connections.toml` file.

- When a custom connection name (not `"snowflake"`) is used with no `[connections.<name>]` secrets and no connection kwargs, the name is now passed as `connection_name` to `snowflake.connector.connect()` so the matching `connections.toml` entry is selected. Previously it fell back to the default connection, ignoring the name.

## GitHub Issue Link (if applicable)

- Closes #15353

## Testing Plan

- `lib/tests/streamlit/connections/snowflake_connection_test.py` — dependency-free, parametrized tests covering configuration selection (named connection, custom name + kwargs, `"snowflake"` default, empty name) and the friendly-error fallback for a failing named connection.

Made with [Cursor](https://cursor.com)