### PR TITLE
Fix stale children when rewriting blocks in same run

### DIFF
--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -428,6 +428,72 @@ describe("AppRoot", () => {
       expect(replacedBlock.children.length).toBe(1)
     })
 
+    it("removes a block's children when replacing it during the same script run", () => {
+      const rootWithThreeChildren = ROOT.applyDelta(
+        "script_run_id",
+        makeProto(DeltaProto, { addBlock: {} }),
+        forwardMsgMetadata([0, 1, 1])
+      )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "First" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "Second" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 1])
+        )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "Stale third" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 2])
+        )
+
+      const rewrittenRoot = rootWithThreeChildren
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, { addBlock: {} }),
+          forwardMsgMetadata([0, 1, 1])
+        )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "Updated first" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "Updated second" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 1])
+        )
+
+      const rewrittenBlock = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rewrittenRoot.main,
+        [1, 1]
+      ) as BlockNode
+
+      expect(rewrittenBlock.children.length).toBe(2)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(rewrittenRoot.main, [1, 1, 0])
+      ).toBeTextNode("Updated first")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(rewrittenRoot.main, [1, 1, 1])
+      ).toBeTextNode("Updated second")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(rewrittenRoot.main, [1, 1, 2])
+      ).toBeUndefined()
+    })
+
     it("inherits children when replacing a block wrapped in a transient node", () => {
       const tabContainerProto = makeProto(DeltaProto, {
         addBlock: { tabContainer: {}, allowEmpty: false },

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -569,6 +569,71 @@ describe("AppRoot", () => {
       ).toBe("tab2")
     })
 
+    it("removes children when replacing a transient-wrapped block during the same script run", () => {
+      const blockProto = makeProto(DeltaProto, {
+        addBlock: { allowEmpty: true },
+      })
+      const clearTransientDelta = makeProto(DeltaProto, {
+        newTransient: { elements: [] },
+      })
+
+      const rootWithBlock = ROOT.applyDelta(
+        "script_run_id",
+        blockProto,
+        forwardMsgMetadata([0, 1, 1])
+      )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "First" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "Stale second" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 1])
+        )
+
+      const rootWithTransientWrapper = rootWithBlock.applyDelta(
+        "script_run_id",
+        clearTransientDelta,
+        forwardMsgMetadata([0, 1, 1])
+      )
+
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(
+          rootWithTransientWrapper.main,
+          [1, 1]
+        )
+      ).toBeInstanceOf(TransientNode)
+
+      const rewrittenRoot = rootWithTransientWrapper
+        .applyDelta("script_run_id", blockProto, forwardMsgMetadata([0, 1, 1]))
+        .applyDelta(
+          "script_run_id",
+          makeProto(DeltaProto, {
+            newElement: { text: { body: "Updated first" } },
+          }),
+          forwardMsgMetadata([0, 1, 1, 0])
+        )
+
+      const rewrittenBlock = GetNodeByDeltaPathVisitor.getNodeAtPath(
+        rewrittenRoot.main,
+        [1, 1]
+      ) as BlockNode
+
+      expect(rewrittenBlock.children.length).toBe(1)
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(rewrittenRoot.main, [1, 1, 0])
+      ).toBeTextNode("Updated first")
+      expect(
+        GetNodeByDeltaPathVisitor.getNodeAtPath(rewrittenRoot.main, [1, 1, 1])
+      ).toBeUndefined()
+    })
+
     it("removes a dialog block's children when replacing with a different dialog identity", () => {
       // Create a dialog with some children. The id field represents the dialog's
       // identity computed from its attributes.

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -459,14 +459,19 @@ export class AppRoot {
         ? (existingNodeAtPath.anchor ?? existingNodeAtPath)
         : existingNodeAtPath
 
-    // If we're replacing an existing Block of the same type, this new Block
-    // inherits the existing Block's children. This preserves two things:
+    // If we're replacing an existing Block of the same type from a prior script
+    // run, this new Block inherits the existing Block's children. This
+    // preserves two things:
     //  1. Widget State
     //  2. React state of all elements
+    // Blocks created earlier in the same script run should not inherit children,
+    // since this indicates that the script is rewriting the same container and
+    // stale children from the previous write should be removed.
     let children: AppNode[] = []
     if (
       existingNode instanceof BlockNode &&
-      existingNode.deltaBlock.type === block.type
+      existingNode.deltaBlock.type === block.type &&
+      existingNode.scriptRunId !== scriptRunId
     ) {
       // For dialog blocks, don't inherit children if the dialog identity is different.
       // The identity is computed from the dialog's attributes.


### PR DESCRIPTION
## Summary

- Prevent same-run block replacements from inheriting stale children from an earlier write.
- Keep child inheritance for same-type block replacements from prior script runs so widget and React state can still be preserved.
- Add AppRoot regression coverage for ordinary block rewrites and transient-wrapped block rewrites in the same run.

## Root Cause

AppRoot.addBlock inherited children whenever an existing block at the same delta path had the same block type. That is correct across script runs, but not when a script rewrites the same block path during the current run, such as repeated writes to st.empty().container(). In that case, old child nodes can remain visible even after the script stops emitting them.

## Impact

Fixes #12069. Rewriting an st.empty() container during a single script run now removes children that are no longer emitted.

## Testing

- npm exec vitest run src/render-tree/AppRoot.test.ts
- npm exec oxfmt -- --check --config ../.oxfmtrc.json ./src/render-tree/AppRoot.test.ts
- git diff --check