### PR TITLE
[fix] P-mode PIL palette hashing to prevent hash collisions

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -118,7 +118,7 @@ def _polars_sample_seed(obj: Any) -> int:
         else:
             hashed = head.hash(seed=0)
         digest = hashlib.md5(
-            hashed.to_arrow().to_string().encode(), usedforsecurity=False
+            hashed.to_numpy().tobytes(), usedforsecurity=False
         ).digest()
         return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
     except (TypeError, ValueError, BufferError):

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,7 +21,6 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
-import hashlib
 import inspect
 import io
 import os
@@ -65,64 +64,6 @@ HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
 _CYCLE_PLACEHOLDER: Final = (
     b"streamlit-57R34ML17-hesamagicalponyflyingthroughthesky-CYCLE"
 )
-
-
-def _pandas_sample_seed(obj: Any) -> int:
-    """Derive a 32-bit sample seed from a pandas object using hash_pandas_object.
-
-    Returns a data-dependent seed so sample indices vary with the data, preventing
-    attackers from pre-computing which indices will be sampled.
-
-    Falls back to 0 for unhashable payloads to preserve the existing pickle fallback.
-    """
-    try:
-        from pandas.util import hash_pandas_object
-
-        hashes = hash_pandas_object(obj)
-        digest = hashlib.md5(
-            hashes.to_numpy().tobytes(), usedforsecurity=False
-        ).digest()
-        return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
-    except (TypeError, ValueError):
-        return 0
-
-
-def _numpy_sample_seed(np_obj: Any) -> int:
-    """Derive a 32-bit sample seed from a numpy array prefix.
-
-    Uses MD5 of up to the first 64 elements of the flattened array to generate
-    a data-dependent seed, preventing attackers from pre-computing sampled indices.
-
-    Falls back to 0 for unhashable or buffer-incompatible arrays.
-    """
-    try:
-        head = np_obj.flat[:64]
-        digest = hashlib.md5(head.tobytes(), usedforsecurity=False).digest()
-        return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
-    except (TypeError, ValueError, BufferError):
-        return 0
-
-
-def _polars_sample_seed(obj: Any) -> int:
-    """Derive a 32-bit sample seed from a polars DataFrame or Series.
-
-    Uses Polars-native hash_rows() for DataFrames or hash() for Series on the
-    head of the object, then MD5 digests to get a data-dependent seed.
-
-    Falls back to 0 for unhashable payloads to preserve the existing pickle fallback.
-    """
-    try:
-        head = obj.head(64)
-        if hasattr(head, "hash_rows"):
-            hashed = head.hash_rows(seed=0)
-        else:
-            hashed = head.hash(seed=0)
-        digest = hashlib.md5(
-            hashed.to_numpy().tobytes(), usedforsecurity=False
-        ).digest()
-        return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
-    except (TypeError, ValueError, BufferError):
-        return 0
 
 
 class UserHashError(StreamlitAPIException):
@@ -314,10 +255,9 @@ def _key(obj: Any | None) -> Any:
         return None
 
     def is_simple(obj: Any) -> bool:
-        return (
-            isinstance(obj, (bytes, bytearray, str, float, int, bool, uuid.UUID))
-            or obj is None
-        )
+        # Note: bytearray is excluded because it's unhashable and cannot be
+        # used as a dictionary key for memoization
+        return isinstance(obj, (bytes, str, float, int, bool, uuid.UUID)) or obj is None
 
     if is_simple(obj):
         return obj
@@ -419,8 +359,11 @@ class _CacheFuncHasher:
             # deep, so we don't try to hash them at all.
             return self.to_bytes(id(obj))
 
-        if isinstance(obj, (bytes, bytearray)):
+        if isinstance(obj, bytes):
             return obj
+
+        if isinstance(obj, bytearray):
+            return bytes(obj)
 
         if type_util.get_fqn_type(obj) in self._hash_funcs:
             # Escape hatch for unsupported objects
@@ -468,7 +411,9 @@ class _CacheFuncHasher:
             return b"0"
 
         if not isinstance(obj, type) and dataclasses.is_dataclass(obj):
-            return self.to_bytes(dataclasses.asdict(obj))
+            # mypy 2.x narrows to DataclassInstance | type[DataclassInstance]
+            # which doesn't satisfy asdict's expected DataclassInstance type.
+            return self.to_bytes(dataclasses.asdict(cast("Any", obj)))
 
         if isinstance(obj, Enum):
             return str(obj).encode()
@@ -482,11 +427,7 @@ class _CacheFuncHasher:
             self.update(h, series_obj.dtype.name)
 
             if len(series_obj) >= _PANDAS_ROWS_LARGE:
-                # Data-dependent seed so sample indices are not globally fixed.
-                sample_seed = _pandas_sample_seed(series_obj.iloc[:1])
-                series_obj = series_obj.sample(
-                    n=_PANDAS_SAMPLE_SIZE, random_state=sample_seed
-                )
+                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
 
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
@@ -508,9 +449,7 @@ class _CacheFuncHasher:
             self.update(h, df_obj.shape)
 
             if len(df_obj) >= _PANDAS_ROWS_LARGE:
-                # Data-dependent seed so sample indices are not globally fixed.
-                sample_seed = _pandas_sample_seed(df_obj.iloc[:1])
-                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=sample_seed)
+                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -536,17 +475,11 @@ class _CacheFuncHasher:
             self.update(h, str(obj.dtype).encode())
             self.update(h, obj.shape)
 
-            # Data-dependent seed so sample indices are not globally fixed.
-            sample_seed = (
-                _polars_sample_seed(obj) if len(obj) >= _PANDAS_ROWS_LARGE else 0
-            )
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=sample_seed)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
 
             try:
-                self.update(
-                    h, obj.hash(seed=sample_seed).to_arrow().to_string().encode()
-                )
+                self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
                 return h.digest()
 
             except TypeError:
@@ -565,23 +498,15 @@ class _CacheFuncHasher:
             obj = cast("pl.DataFrame", obj)
             self.update(h, obj.shape)
 
-            # Data-dependent seed so sample indices are not globally fixed.
-            sample_seed = (
-                _polars_sample_seed(obj) if len(obj) >= _PANDAS_ROWS_LARGE else 0
-            )
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=sample_seed)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
                     self.update(h, str(t).encode())
 
                 values_hash_bytes = (
-                    obj.hash_rows(seed=sample_seed)
-                    .hash(seed=sample_seed)
-                    .to_arrow()
-                    .to_string()
-                    .encode()
+                    obj.hash_rows(seed=0).hash(seed=0).to_arrow().to_string().encode()
                 )
 
                 self.update(h, values_hash_bytes)
@@ -605,9 +530,7 @@ class _CacheFuncHasher:
             if np_obj.size >= _NP_SIZE_LARGE:
                 import numpy as np
 
-                # Data-dependent seed so sample indices are not globally fixed.
-                sample_seed = _numpy_sample_seed(np_obj)
-                state = np.random.RandomState(sample_seed)
+                state = np.random.RandomState(0)
                 np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,6 +21,7 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
+import hashlib
 import inspect
 import io
 import os
@@ -64,6 +65,64 @@ HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
 _CYCLE_PLACEHOLDER: Final = (
     b"streamlit-57R34ML17-hesamagicalponyflyingthroughthesky-CYCLE"
 )
+
+
+def _pandas_sample_seed(obj: Any) -> int:
+    """Derive a 32-bit sample seed from a pandas object using hash_pandas_object.
+
+    Returns a data-dependent seed so sample indices vary with the data, preventing
+    attackers from pre-computing which indices will be sampled.
+
+    Falls back to 0 for unhashable payloads to preserve the existing pickle fallback.
+    """
+    try:
+        from pandas.util import hash_pandas_object
+
+        hashes = hash_pandas_object(obj)
+        digest = hashlib.md5(
+            hashes.to_numpy().tobytes(), usedforsecurity=False
+        ).digest()
+        return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
+    except (TypeError, ValueError):
+        return 0
+
+
+def _numpy_sample_seed(np_obj: Any) -> int:
+    """Derive a 32-bit sample seed from a numpy array prefix.
+
+    Uses MD5 of up to the first 64 elements of the flattened array to generate
+    a data-dependent seed, preventing attackers from pre-computing sampled indices.
+
+    Falls back to 0 for unhashable or buffer-incompatible arrays.
+    """
+    try:
+        head = np_obj.flat[:64]
+        digest = hashlib.md5(head.tobytes(), usedforsecurity=False).digest()
+        return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
+    except (TypeError, ValueError, BufferError):
+        return 0
+
+
+def _polars_sample_seed(obj: Any) -> int:
+    """Derive a 32-bit sample seed from a polars DataFrame or Series.
+
+    Uses Polars-native hash_rows() for DataFrames or hash() for Series on the
+    head of the object, then MD5 digests to get a data-dependent seed.
+
+    Falls back to 0 for unhashable payloads to preserve the existing pickle fallback.
+    """
+    try:
+        head = obj.head(64)
+        if hasattr(head, "hash_rows"):
+            hashed = head.hash_rows(seed=0)
+        else:
+            hashed = head.hash(seed=0)
+        digest = hashlib.md5(
+            hashed.to_arrow().to_string().encode(), usedforsecurity=False
+        ).digest()
+        return int.from_bytes(digest[:4], "little") & 0xFFFF_FFFF
+    except (TypeError, ValueError, BufferError):
+        return 0
 
 
 class UserHashError(StreamlitAPIException):
@@ -423,7 +482,11 @@ class _CacheFuncHasher:
             self.update(h, series_obj.dtype.name)
 
             if len(series_obj) >= _PANDAS_ROWS_LARGE:
-                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                # Data-dependent seed so sample indices are not globally fixed.
+                sample_seed = _pandas_sample_seed(series_obj.iloc[:1])
+                series_obj = series_obj.sample(
+                    n=_PANDAS_SAMPLE_SIZE, random_state=sample_seed
+                )
 
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
@@ -445,7 +508,9 @@ class _CacheFuncHasher:
             self.update(h, df_obj.shape)
 
             if len(df_obj) >= _PANDAS_ROWS_LARGE:
-                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                # Data-dependent seed so sample indices are not globally fixed.
+                sample_seed = _pandas_sample_seed(df_obj.iloc[:1])
+                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=sample_seed)
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -471,11 +536,17 @@ class _CacheFuncHasher:
             self.update(h, str(obj.dtype).encode())
             self.update(h, obj.shape)
 
+            # Data-dependent seed so sample indices are not globally fixed.
+            sample_seed = (
+                _polars_sample_seed(obj) if len(obj) >= _PANDAS_ROWS_LARGE else 0
+            )
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=sample_seed)
 
             try:
-                self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
+                self.update(
+                    h, obj.hash(seed=sample_seed).to_arrow().to_string().encode()
+                )
                 return h.digest()
 
             except TypeError:
@@ -494,15 +565,23 @@ class _CacheFuncHasher:
             obj = cast("pl.DataFrame", obj)
             self.update(h, obj.shape)
 
+            # Data-dependent seed so sample indices are not globally fixed.
+            sample_seed = (
+                _polars_sample_seed(obj) if len(obj) >= _PANDAS_ROWS_LARGE else 0
+            )
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=sample_seed)
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
                     self.update(h, str(t).encode())
 
                 values_hash_bytes = (
-                    obj.hash_rows(seed=0).hash(seed=0).to_arrow().to_string().encode()
+                    obj.hash_rows(seed=sample_seed)
+                    .hash(seed=sample_seed)
+                    .to_arrow()
+                    .to_string()
+                    .encode()
                 )
 
                 self.update(h, values_hash_bytes)
@@ -526,7 +605,9 @@ class _CacheFuncHasher:
             if np_obj.size >= _NP_SIZE_LARGE:
                 import numpy as np
 
-                state = np.random.RandomState(0)
+                # Data-dependent seed so sample indices are not globally fixed.
+                sample_seed = _numpy_sample_seed(np_obj)
+                state = np.random.RandomState(sample_seed)
                 np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())
@@ -537,9 +618,18 @@ class _CacheFuncHasher:
 
             pil_obj: Image = cast("Image", obj)
 
-            # we don't just hash the results of obj.tobytes() because we want to use
-            # the sampling logic for numpy data
-            np_array = np.frombuffer(pil_obj.tobytes(), dtype="uint8")
+            # We don't just hash the results of obj.tobytes() because we want to use
+            # the sampling logic for numpy data.
+            pixel_bytes = pil_obj.tobytes()
+
+            # P-mode (palette-indexed) images need the palette included in the hash,
+            # since tobytes() only returns palette indices, not the color table.
+            if pil_obj.mode == "P":
+                palette_data = pil_obj.getpalette()
+                if palette_data is not None:
+                    pixel_bytes = bytes(palette_data) + pixel_bytes
+
+            np_array = np.frombuffer(pixel_bytes, dtype="uint8")
             return self.to_bytes(np_array)
 
         elif inspect.isbuiltin(obj):

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -143,6 +143,29 @@ def prepare_polars_data():
 
 
 class HashTest(unittest.TestCase):
+    def test_bytes(self):
+        """Test that bytes objects hash consistently."""
+        assert get_hash(b"hello") == get_hash(b"hello")
+        assert get_hash(b"hello") != get_hash(b"world")
+
+    def test_bytearray(self):
+        """Test that bytearray objects hash consistently.
+
+        bytearray is unhashable and cannot be memoized, but should still
+        be hashed correctly via conversion to bytes.
+        """
+        ba1 = bytearray(b"hello")
+        ba2 = bytearray(b"hello")
+        ba3 = bytearray(b"world")
+
+        assert get_hash(ba1) == get_hash(ba2)
+        assert get_hash(ba1) != get_hash(ba3)
+
+        # Verify bytearray and bytes with same content produce same hash
+        # (after type prefix is added)
+        # Note: Due to type prefix, they won't be exactly equal
+        assert get_hash(ba1) != get_hash(b"hello")
+
     def test_string(self):
         assert get_hash("hello") == get_hash("hello")
         assert get_hash("hello") != get_hash("hellö")
@@ -991,88 +1014,3 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
 
     # But the hashes should differ because we now include the palette
     assert get_hash(im1) != get_hash(im2)
-
-
-def test_numpy_large_array_seed_prefix_change_differs() -> None:
-    """Large numpy arrays with different prefixes produce different hashes.
-
-    Regression test for GitHub issue #14622: the large-data sampling path for numpy
-    used a hardcoded seed=0. Since the seed was constant and public, an attacker
-    could pre-compute which indices would be sampled and craft a collision.
-    """
-    arr_a = np.arange(_NP_SIZE_LARGE, dtype=np.float64)
-    arr_b = arr_a.copy()
-    arr_b[:64] = 999.0
-
-    # Mutating the prefix changes the derived seed, leading to different samples
-    # and a different hash. Using arange ensures varied values throughout the array.
-    assert get_hash(arr_a) != get_hash(arr_b)
-
-
-def test_pandas_large_dataframe_seed_row_change_differs() -> None:
-    """Large pandas DataFrames with different first rows produce different hashes.
-
-    Regression test for GitHub issue #14622: the large-data sampling path for pandas
-    used a hardcoded random_state=0. An attacker could pre-compute which indices would
-    be sampled and craft a collision.
-    """
-    df_a = pd.DataFrame(np.ones((_PANDAS_ROWS_LARGE, 4)), columns=list("ABCD"))
-    df_b = df_a.copy()
-    df_b.iloc[0, 0] = 255.0
-
-    # Mutating the first row should change the derived seed, leading to different samples
-    assert get_hash(df_a) != get_hash(df_b)
-
-
-def test_pandas_large_dataframe_unhashable_payload_uses_pickle_fallback() -> None:
-    """Large DataFrames with unhashable cells fall back to pickle consistently.
-
-    Ensures that the seed derivation helper properly falls back to seed=0 for
-    unhashable payloads (like list-valued cells), preserving the pickle fallback path.
-    """
-    # Create a large DataFrame with list-valued cells (unhashable by hash_pandas_object)
-    df_a = pd.DataFrame({"col": [[1, 2]] * _PANDAS_ROWS_LARGE})
-    df_b = pd.DataFrame({"col": [[1, 2]] * _PANDAS_ROWS_LARGE})
-
-    # Both should hash to the same value via pickle fallback
-    assert get_hash(df_a) == get_hash(df_b)
-
-
-@pytest.mark.require_integration
-def test_polars_large_series_seed_head_change_differs() -> None:
-    """Large Polars Series with different heads produce different hashes.
-
-    Regression test for GitHub issue #14622: the large-data sampling path for Polars
-    used a hardcoded seed=0. An attacker could pre-compute which indices would be
-    sampled and craft a collision.
-    """
-    import polars as pl
-
-    series_a = pl.Series("val", list(range(_PANDAS_ROWS_LARGE)))
-    series_b = pl.concat([pl.Series("val", [999] * 64), series_a.slice(64)])
-
-    assert get_hash(series_a) != get_hash(series_b)
-
-
-@pytest.mark.require_integration
-def test_polars_large_dataframe_seed_head_change_differs() -> None:
-    """Large Polars DataFrames with different heads produce different hashes.
-
-    Regression test for GitHub issue #14622: the large-data sampling path for Polars
-    used a hardcoded seed=0. An attacker could pre-compute which indices would be
-    sampled and craft a collision.
-    """
-    import polars as pl
-
-    df_a = pl.DataFrame(
-        {"a": list(range(_PANDAS_ROWS_LARGE)), "b": list(range(_PANDAS_ROWS_LARGE))}
-    )
-    df_b = df_a.clone()
-    df_b = df_b.with_columns(
-        pl.when(pl.int_range(pl.len()) < 64)
-        .then(pl.lit(999))
-        .otherwise(pl.col("a"))
-        .alias("a")
-    )
-
-    assert get_hash(df_a) != get_hash(df_b)

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -966,3 +966,73 @@ def test_pydantic_model_unhashable_when_model_dump_json_fails() -> None:
         with pytest.raises(UnhashableTypeError) as exc_info:
             get_hash(instance)
     assert "unhashable members" in str(exc_info.value).lower()
+
+
+def test_PIL_pmode_palette_collision_prevention() -> None:
+    """P-mode PIL images with different palettes produce different hashes.
+
+    Regression test for GitHub issue #14622: tobytes() on palette-indexed (P-mode)
+    PIL images returns only palette indices, not the color table. Two images with
+    identical index arrays but different palettes would collide without this fix.
+    """
+    # Create two P-mode images with identical pixel indices but different palettes
+    im1 = Image.new("P", (10, 10), 0)
+    im2 = Image.new("P", (10, 10), 0)
+
+    # Set different palettes (768 values for 256 RGB colors)
+    palette1 = [i % 256 for i in range(768)]
+    palette2 = [(i + 128) % 256 for i in range(768)]
+
+    im1.putpalette(palette1)
+    im2.putpalette(palette2)
+
+    # Confirm the vulnerability trigger: tobytes() is equal for both images
+    assert im1.tobytes() == im2.tobytes()
+
+    # But the hashes should differ because we now include the palette
+    assert get_hash(im1) != get_hash(im2)
+
+
+def test_numpy_large_array_seed_prefix_change_differs() -> None:
+    """Large numpy arrays with different prefixes produce different hashes.
+
+    Regression test for GitHub issue #14622: the large-data sampling path for numpy
+    used a hardcoded seed=0. Since the seed was constant and public, an attacker
+    could pre-compute which indices would be sampled and craft a collision.
+    """
+    arr_a = np.arange(_NP_SIZE_LARGE, dtype=np.float64)
+    arr_b = arr_a.copy()
+    arr_b[:64] = 999.0
+
+    # Mutating the prefix changes the derived seed, leading to different samples
+    # and a different hash. Using arange ensures varied values throughout the array.
+    assert get_hash(arr_a) != get_hash(arr_b)
+
+
+def test_pandas_large_dataframe_seed_row_change_differs() -> None:
+    """Large pandas DataFrames with different first rows produce different hashes.
+
+    Regression test for GitHub issue #14622: the large-data sampling path for pandas
+    used a hardcoded random_state=0. An attacker could pre-compute which indices would
+    be sampled and craft a collision.
+    """
+    df_a = pd.DataFrame(np.ones((_PANDAS_ROWS_LARGE, 4)), columns=list("ABCD"))
+    df_b = df_a.copy()
+    df_b.iloc[0, 0] = 255.0
+
+    # Mutating the first row should change the derived seed, leading to different samples
+    assert get_hash(df_a) != get_hash(df_b)
+
+
+def test_pandas_large_dataframe_unhashable_payload_uses_pickle_fallback() -> None:
+    """Large DataFrames with unhashable cells fall back to pickle consistently.
+
+    Ensures that the seed derivation helper properly falls back to seed=0 for
+    unhashable payloads (like list-valued cells), preserving the pickle fallback path.
+    """
+    # Create a large DataFrame with list-valued cells (unhashable by hash_pandas_object)
+    df_a = pd.DataFrame({"col": [[1, 2]] * _PANDAS_ROWS_LARGE})
+    df_b = pd.DataFrame({"col": [[1, 2]] * _PANDAS_ROWS_LARGE})
+
+    # Both should hash to the same value via pickle fallback
+    assert get_hash(df_a) == get_hash(df_b)

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1049,8 +1049,7 @@ def test_polars_large_series_seed_head_change_differs() -> None:
     import polars as pl
 
     series_a = pl.Series("val", list(range(_PANDAS_ROWS_LARGE)))
-    series_b = series_a.clone()
-    series_b[:64] = pl.Series("val", [999] * 64)
+    series_b = pl.concat([pl.Series("val", [999] * 64), series_a.slice(64)])
 
     assert get_hash(series_a) != get_hash(series_b)
 

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1036,3 +1036,44 @@ def test_pandas_large_dataframe_unhashable_payload_uses_pickle_fallback() -> Non
 
     # Both should hash to the same value via pickle fallback
     assert get_hash(df_a) == get_hash(df_b)
+
+
+@pytest.mark.require_integration
+def test_polars_large_series_seed_head_change_differs() -> None:
+    """Large Polars Series with different heads produce different hashes.
+
+    Regression test for GitHub issue #14622: the large-data sampling path for Polars
+    used a hardcoded seed=0. An attacker could pre-compute which indices would be
+    sampled and craft a collision.
+    """
+    import polars as pl
+
+    series_a = pl.Series("val", list(range(_PANDAS_ROWS_LARGE)))
+    series_b = series_a.clone()
+    series_b[:64] = pl.Series("val", [999] * 64)
+
+    assert get_hash(series_a) != get_hash(series_b)
+
+
+@pytest.mark.require_integration
+def test_polars_large_dataframe_seed_head_change_differs() -> None:
+    """Large Polars DataFrames with different heads produce different hashes.
+
+    Regression test for GitHub issue #14622: the large-data sampling path for Polars
+    used a hardcoded seed=0. An attacker could pre-compute which indices would be
+    sampled and craft a collision.
+    """
+    import polars as pl
+
+    df_a = pl.DataFrame(
+        {"a": list(range(_PANDAS_ROWS_LARGE)), "b": list(range(_PANDAS_ROWS_LARGE))}
+    )
+    df_b = df_a.clone()
+    df_b = df_b.with_columns(
+        pl.when(pl.int_range(pl.len()) < 64)
+        .then(pl.lit(999))
+        .otherwise(pl.col("a"))
+        .alias("a")
+    )
+
+    assert get_hash(df_a) != get_hash(df_b)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Fixes a hash collision vulnerability in `@st.cache_data`/`@st.cache_resource` for PIL P-mode images.

**PIL P-mode palette omission**: `tobytes()` on palette-indexed (P-mode) PIL images returns only palette indices, not the color table. Two images with identical index arrays but different palettes would collide. This PR prepends palette bytes to pixel bytes before hashing.

The sampling-seed fix (for pandas, polars, and numpy large-data paths) has been removed from this PR and will be addressed in a follow-up PR with a more robust approach.

Thanks to @3em0 for filing the issue and original fix, and @mserdukoff for the refined implementation.

Partially addresses #14622

## Cache Invalidation Note

This change will produce different hashes for:
- All P-mode PIL images (regardless of size)

Users with existing caches containing P-mode PIL images will see one-time cache misses after upgrading. This is consistent with Streamlit's caching documentation which notes that cache keys can change between versions, and is an acceptable trade-off for closing this vulnerability.

## GitHub Issue Link (if applicable)

Partially addresses #14622

## Testing Plan

- [x] Unit Tests (Python) - One regression test added:
  - `test_PIL_pmode_palette_collision_prevention`: P-mode images with different palettes now hash differently

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->