### PR TITLE
[refactor][Parallel Fragments] Refactor RunningCursor API: replace get_locked_cursor() with lock_element()/open_block()

### DIFF
--- a/lib/streamlit/cursor.py
+++ b/lib/streamlit/cursor.py
@@ -109,8 +109,8 @@ class SparseList(Generic[T]):
 class Cursor:
     """A pointer to a delta location in the app.
 
-    When adding an element to the app, you should always call
-    get_locked_cursor() on that element's respective Cursor.
+    Subclasses provide `lock_element()` and `open_block()` to reserve
+    positions in the element tree.
 
     Parameters
     ----------
@@ -167,7 +167,10 @@ class Cursor:
     def transient_index(self) -> int:
         return 0 if self._transient_index is None else self._transient_index
 
-    def get_locked_cursor(self) -> LockedCursor:
+    def lock_element(self) -> LockedCursor:
+        raise NotImplementedError()
+
+    def open_block(self) -> RunningCursor:
         raise NotImplementedError()
 
     def get_transient_cursor(self) -> Cursor:
@@ -190,7 +193,7 @@ class RunningCursor(Cursor):
         """A moving pointer to a delta location in the app.
 
         RunningCursors auto-increment to the next available location when you
-        call get_locked_cursor() on them.
+        call lock_element() or open_block() on them.
 
         Parameters
         ----------
@@ -226,18 +229,30 @@ class RunningCursor(Cursor):
     def is_locked(self) -> bool:
         return False
 
-    def get_locked_cursor(self) -> LockedCursor:
-        locked_cursor = LockedCursor(
-            root_container=self._root_container,
-            parent_path=self._parent_path,
-            index=self._index,
-        )
-
+    def _advance(self) -> None:
+        """Increment index and reset transient state."""
         self._index += 1
         self._transient_index = None
         self._transient_elements = SparseList[Element]()
 
-        return locked_cursor
+    def lock_element(self) -> LockedCursor:
+        """Reserve the current position for an element and advance."""
+        locked = LockedCursor(
+            root_container=self._root_container,
+            parent_path=self._parent_path,
+            index=self._index,
+        )
+        self._advance()
+        return locked
+
+    def open_block(self) -> RunningCursor:
+        """Create a child cursor for a new block and advance."""
+        child = RunningCursor(
+            root_container=self._root_container,
+            parent_path=(*self._parent_path, self._index),
+        )
+        self._advance()
+        return child
 
 
 class LockedCursor(Cursor):
@@ -252,7 +267,7 @@ class LockedCursor(Cursor):
         """A locked pointer to a location in the app.
 
         LockedCursors always point to the same location, even when you call
-        get_locked_cursor() on them.
+        lock_element() on them.
 
         Parameters
         ----------
@@ -289,5 +304,16 @@ class LockedCursor(Cursor):
     def is_locked(self) -> bool:
         return True
 
-    def get_locked_cursor(self) -> LockedCursor:
+    def lock_element(self) -> LockedCursor:
         return self
+
+    def open_block(self) -> RunningCursor:
+        """Create a child RunningCursor from this locked position.
+
+        Used when _block() is called on a DeltaGenerator that has a
+        LockedCursor (e.g., a DG returned from _enqueue as output_dg).
+        """
+        return RunningCursor(
+            root_container=self._root_container,
+            parent_path=(*self._parent_path, self._index),
+        )

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -564,9 +564,7 @@ class DeltaGenerator(
         if msg_was_enqueued:
             # Get a DeltaGenerator that is locked to the current element
             # position.
-            new_cursor = (
-                dg._cursor.get_locked_cursor() if dg._cursor is not None else None
-            )
+            new_cursor = dg._cursor.lock_element() if dg._cursor is not None else None
 
             output_dg = DeltaGenerator(
                 root_container=dg._root_container,
@@ -615,13 +613,9 @@ class DeltaGenerator(
         msg.metadata.delta_path[:] = dg._cursor.delta_path
         msg.delta.add_block.CopyFrom(block_proto)
 
-        # Normally we'd return a new DeltaGenerator that uses the locked cursor
-        # below. But in this case we want to return a DeltaGenerator that uses
-        # a brand new cursor for this new block we're creating.
-        block_cursor = cursor.RunningCursor(
-            root_container=dg._root_container,
-            parent_path=(*dg._cursor.parent_path, dg._cursor.index),
-        )
+        # Create a child cursor for this new block. open_block() also advances
+        # the parent cursor, so we capture delta_path above before this call.
+        block_cursor = dg._cursor.open_block()
 
         # `dg_type` param added for st.status container. It allows us to
         # instantiate DeltaGenerator subclasses from the function.
@@ -641,8 +635,6 @@ class DeltaGenerator(
         # NOTE: Container form ids aren't set in proto.
         block_dg._form_data = FormData(current_form_id(dg))
 
-        # Must be called to increment this cursor's index.
-        dg._cursor.get_locked_cursor()
         _enqueue_message(msg)
 
         caching.save_block_message(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -676,6 +676,18 @@ def fragment(
     return _fragment(func, run_every=run_every, parallel=parallel)
 
 
+def prepare_dg_stack_for_worker(
+    dg_stack: tuple[DeltaGenerator, ...],
+) -> tuple[DeltaGenerator, ...]:
+    """Deep-copy the DG stack for dispatch to a parallel worker thread.
+
+    The deepcopy creates independent cursor state (separate _index, parent_path,
+    etc.) so the worker doesn't race with the main thread. Each worker operates
+    in its own cursor space within a pre-allocated container.
+    """
+    return deepcopy(dg_stack)
+
+
 def _dispatch_parallel_fragment(
     ctx: ScriptRunContext,
     fragment_id: str,
@@ -703,7 +715,7 @@ def _dispatch_parallel_fragment(
         return
 
     with st.container():
-        dg_stack_with_container = deepcopy(context_dg_stack.get())
+        dg_stack_with_container = prepare_dg_stack_for_worker(context_dg_stack.get())
 
     coordinator.submit(
         _run_parallel_fragment,

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -676,7 +676,7 @@ def fragment(
     return _fragment(func, run_every=run_every, parallel=parallel)
 
 
-def prepare_dg_stack_for_worker(
+def _prepare_dg_stack_for_worker(
     dg_stack: tuple[DeltaGenerator, ...],
 ) -> tuple[DeltaGenerator, ...]:
     """Deep-copy the DG stack for dispatch to a parallel worker thread.
@@ -715,7 +715,7 @@ def _dispatch_parallel_fragment(
         return
 
     with st.container():
-        dg_stack_with_container = prepare_dg_stack_for_worker(context_dg_stack.get())
+        dg_stack_with_container = _prepare_dg_stack_for_worker(context_dg_stack.get())
 
     coordinator.submit(
         _run_parallel_fragment,

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -200,6 +200,7 @@ class TestRunningCursor:
 
         child2 = cursor.open_block()
         assert child2.parent_path == (1, 1)
+        assert child2.index == 0
         assert cursor.index == 2
 
 

--- a/lib/tests/streamlit/cursor_test.py
+++ b/lib/tests/streamlit/cursor_test.py
@@ -145,18 +145,18 @@ class TestRunningCursor:
         assert not cursor.is_locked
         assert len(cursor.transient_elements) == 0
 
-    def test_get_locked_cursor(self):
-        """Test get_locked_cursor from RunningCursor."""
+    def test_lock_element(self):
+        """Test lock_element from RunningCursor."""
         cursor = RunningCursor(RootContainer.MAIN)
 
         # First lock
-        locked1 = cursor.get_locked_cursor()
+        locked1 = cursor.lock_element()
         assert isinstance(locked1, LockedCursor)
         assert locked1.index == 0
         assert cursor.index == 1
 
         # Second lock
-        locked2 = cursor.get_locked_cursor()
+        locked2 = cursor.lock_element()
         assert locked2.index == 1
         assert cursor.index == 2
 
@@ -173,18 +173,34 @@ class TestRunningCursor:
         cursor.get_transient_cursor()
         assert cursor.transient_index == 1
 
-    def test_locked_cursor_resets_transient(self):
-        """Test that get_locked_cursor resets transient state."""
+    def test_lock_element_resets_transient(self):
+        """Test that lock_element resets transient state."""
         cursor = RunningCursor(RootContainer.MAIN)
         cursor.get_transient_cursor()
         cursor.transient_elements[0] = "element"  # Simulate adding element
         assert cursor.transient_index == 0
         assert len(cursor.transient_elements) == 1
 
-        cursor.get_locked_cursor()
+        cursor.lock_element()
         # Should be reset
         assert cursor.transient_index == 0
         assert len(cursor.transient_elements) == 0
+
+    def test_open_block(self):
+        """Test open_block creates a child cursor and advances."""
+        cursor = RunningCursor(RootContainer.MAIN, parent_path=(1,))
+        assert cursor.index == 0
+
+        child = cursor.open_block()
+        assert isinstance(child, RunningCursor)
+        assert child.root_container == RootContainer.MAIN
+        assert child.parent_path == (1, 0)
+        assert child.index == 0
+        assert cursor.index == 1
+
+        child2 = cursor.open_block()
+        assert child2.parent_path == (1, 1)
+        assert cursor.index == 2
 
 
 class TestCursorBase:
@@ -221,11 +237,17 @@ class TestCursorBase:
         with pytest.raises(NotImplementedError):
             _ = cursor.is_locked
 
-    def test_get_locked_cursor_raises_not_implemented(self) -> None:
-        """Test that get_locked_cursor on base Cursor raises NotImplementedError."""
+    def test_lock_element_raises_not_implemented(self) -> None:
+        """Test that lock_element on base Cursor raises NotImplementedError."""
         cursor = Cursor()
         with pytest.raises(NotImplementedError):
-            cursor.get_locked_cursor()
+            cursor.lock_element()
+
+    def test_open_block_raises_not_implemented(self) -> None:
+        """Test that open_block on base Cursor raises NotImplementedError."""
+        cursor = Cursor()
+        with pytest.raises(NotImplementedError):
+            cursor.open_block()
 
 
 class TestLockedCursor:
@@ -237,10 +259,19 @@ class TestLockedCursor:
         assert cursor.index == 5
         assert cursor.is_locked
 
-    def test_get_locked_cursor(self):
-        """Test get_locked_cursor from LockedCursor."""
+    def test_lock_element_returns_self(self):
+        """Test lock_element from LockedCursor returns itself."""
         cursor = LockedCursor(RootContainer.MAIN, index=5)
 
-        locked = cursor.get_locked_cursor()
+        locked = cursor.lock_element()
         assert locked == cursor
         assert cursor.index == 5  # Index doesn't change
+
+    def test_open_block_returns_child_cursor(self):
+        """Test open_block from LockedCursor returns a child RunningCursor."""
+        cursor = LockedCursor(RootContainer.MAIN, parent_path=(1,), index=3)
+        child = cursor.open_block()
+        assert isinstance(child, RunningCursor)
+        assert child.root_container == RootContainer.MAIN
+        assert child.parent_path == (1, 3)
+        assert child.index == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Refactors the cursor API to clarify the semantics of position reservation in the element tree.

**Changes:**
- `RunningCursor.get_locked_cursor()` → split into `lock_element()` (reserves current position for an element) and `open_block()` (creates a child cursor for a new block)
- Added `_advance()` private helper to `RunningCursor` that increments index and resets transient state
- `LockedCursor.get_locked_cursor()` → replaced with `lock_element()` (returns self) and `open_block()` (returns child cursor)
- Added `prepare_dg_stack_for_worker()` helper in `fragment.py` that names the worker isolation boundary (wraps existing `deepcopy` call)

**Motivation:**
- Clarifies the cursor API by splitting the overloaded `get_locked_cursor()` into explicit single-purpose methods
- Names the worker isolation boundary via `prepare_dg_stack_for_worker()` for better code readability

No behavior change — purely mechanical refactor.

## GitHub Issue Link (if applicable)

N/A (internal refactor for parallel fragments feature)

## Testing Plan

- [x] Unit Tests (Python) - Updated and added tests for `lock_element()`, `open_block()` in `cursor_test.py`
- All existing `delta_generator_test.py` tests pass unchanged

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef87969c-60bf-4d4c-b2b1-c570b6686041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef87969c-60bf-4d4c-b2b1-c570b6686041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

