### PR TITLE
[fix] Clear stale and invalid auth cookies on login

### DIFF
--- a/lib/streamlit/auth_util.py
+++ b/lib/streamlit/auth_util.py
@@ -614,41 +614,6 @@ def get_cookie_with_chunks(
     return reconstructed_value
 
 
-def clear_cookie_and_chunks(
-    get_single_cookie_fn: Callable[[str], bytes | None],
-    clear_single_cookie_fn: Callable[[str], None],
-    cookie_name: str,
-) -> None:
-    """Clear a cookie and any associated chunk cookies.
-
-    The main cookie always exists. If there are chunks, also clear
-    cookie_name_1, cookie_name_2, etc., and the count cookie.
-
-    Args:
-        get_single_cookie_fn: Function to get a single cookie (cookie_name) -> bytes | None
-        clear_single_cookie_fn: Function to clear a single cookie (cookie_name)
-        cookie_name: Name of the cookie
-    """
-    cookie_value = get_single_cookie_fn(cookie_name)
-    clear_single_cookie_fn(cookie_name)
-    if cookie_value is None:
-        return
-
-    match = _chunks_regex.match(cookie_value)
-    if match is None:
-        return
-
-    try:
-        chunk_count = int(match.group(1))
-        # Clear additional chunk cookies (starting from 1, since main cookie is chunk 0)
-        for i in range(1, chunk_count + 1):
-            clear_single_cookie_fn(f"{cookie_name}_{i}")
-    except (ValueError, TypeError):  # pragma: no cover - defensive
-        # If count is invalid, but we already cleared the main cookie
-        # so we can ignore it
-        pass
-
-
 def validate_auth_credentials(provider: str) -> None:
     """Validate the general auth credentials and auth credentials for the given
     provider.

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -621,6 +621,9 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
 
     user = token.get("userinfo") or {}
 
+    # Clear any invalid/stale auth cookies (e.g. orphaned chunks from an old
+    # cookie format) before writing the fresh cookies below, so leftover state
+    # cannot interfere with the new login.
     response = await _redirect_to_base_clearing_invalid_cookies(request, base_url)
 
     cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -260,6 +260,23 @@ def _delete_cookie_at_current_and_legacy_paths(
         response.delete_cookie(cookie_name, path="/")
 
 
+def _delete_orphaned_chunk_cookies(
+    response: Response, request: Request, cookie_name: str
+) -> None:
+    """Delete chunk cookies (``{cookie_name}_1``, ``{cookie_name}_2``, ...) by name.
+
+    ``clear_cookie_and_chunks`` only discovers chunk cookies by decoding the main
+    cookie to read its chunk count. When the main cookie is present but invalid
+    (for example signed with a rotated secret), it cannot be decoded, so its
+    chunk siblings would otherwise be orphaned in the browser. This scans the raw
+    request cookies and deletes anything matching the chunk-name pattern.
+    """
+    chunk_prefix = f"{cookie_name}_"
+    for name in request.cookies:
+        if name.startswith(chunk_prefix) and name[len(chunk_prefix) :].isdigit():
+            _delete_cookie_at_current_and_legacy_paths(response, name)
+
+
 def _delete_legacy_root_auth_cookies(response: Response) -> None:
     """Delete legacy root-path auth cookies when auth is scoped to a base path."""
     if _get_cookie_path() == "/":
@@ -288,6 +305,13 @@ def _clear_single_auth_cookie_and_chunks(
         cookie_name,
     )
 
+    # clear_cookie_and_chunks discovers chunk cookies by reading the chunk count
+    # from the decoded main cookie. When the main cookie is present but invalid
+    # (e.g. signed with a rotated secret), it cannot be decoded, so clear any
+    # chunk siblings by name to avoid orphaning them in the browser.
+    if _is_auth_cookie_present_but_invalid(request, cookie_name):
+        _delete_orphaned_chunk_cookies(response, request, cookie_name)
+
 
 def _clear_auth_cookie(response: Response, request: Request) -> None:
     """Clear the auth cookies, including any split cookie chunks.
@@ -312,10 +336,12 @@ def _clear_invalid_auth_cookies(response: Response, request: Request) -> None:
     """Clear auth cookies that are present but fail signature validation."""
     if _is_auth_cookie_present_but_invalid(request, USER_COOKIE_NAME):
         # If the identity cookie is invalid, the token cookie is unusable too.
+        _LOGGER.debug("Clearing invalid auth cookies (identity cookie undecodable).")
         _clear_auth_cookie(response, request)
         return
 
     if _is_auth_cookie_present_but_invalid(request, TOKENS_COOKIE_NAME):
+        _LOGGER.debug("Clearing invalid tokens cookie (tokens cookie undecodable).")
         _clear_single_auth_cookie_and_chunks(response, request, TOKENS_COOKIE_NAME)
 
 

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -60,6 +60,7 @@ _ROUTE_AUTH_LOGIN: Final = "auth/login"
 _ROUTE_AUTH_LOGOUT: Final = "auth/logout"
 _ROUTE_OAUTH_CALLBACK: Final = "oauth2callback"
 _AUTH_COOKIE_SAMESITE: Final = "lax"
+_AUTH_COOKIE_NAMES: Final = (USER_COOKIE_NAME, TOKENS_COOKIE_NAME)
 
 
 def _normalize_nested_config(value: Any) -> Any:
@@ -173,6 +174,8 @@ async def _set_auth_cookie(
     def set_single_cookie(cookie_name: str, value: str) -> None:
         _set_single_cookie(response, cookie_name, value)
 
+    _delete_legacy_root_auth_cookies(response)
+
     cookie_attr_size = _get_auth_cookie_attribute_size()
     set_cookie_with_chunks(
         set_single_cookie,
@@ -247,30 +250,82 @@ def _get_signed_cookie_from_request(request: Request, cookie_name: str) -> bytes
     return decoded
 
 
-def _clear_auth_cookie(response: Response, request: Request) -> None:
-    """Clear the auth cookies, including any split cookie chunks.
-
-    The path must match the path used when setting the cookie, otherwise
-    the browser won't delete it.
-    """
+def _delete_cookie_at_current_and_legacy_paths(
+    response: Response, cookie_name: str
+) -> None:
+    """Delete a cookie at the current auth path and legacy root path."""
     cookie_path = _get_cookie_path()
+    response.delete_cookie(cookie_name, path=cookie_path)
+    if cookie_path != "/":
+        response.delete_cookie(cookie_name, path="/")
+
+
+def _delete_legacy_root_auth_cookies(response: Response) -> None:
+    """Delete legacy root-path auth cookies when auth is scoped to a base path."""
+    if _get_cookie_path() == "/":
+        return
+
+    # Legacy Tornado auth cookies were never chunked, so deleting the base
+    # cookie name at the root path is sufficient here.
+    for cookie_name in _AUTH_COOKIE_NAMES:
+        response.delete_cookie(cookie_name, path="/")
+
+
+def _clear_single_auth_cookie_and_chunks(
+    response: Response, request: Request, cookie_name: str
+) -> None:
+    """Clear an auth cookie, including any split cookie chunks."""
 
     def get_single_cookie(cookie_name: str) -> bytes | None:
         return _get_signed_cookie_from_request(request, cookie_name)
 
     def clear_single_cookie(cookie_name: str) -> None:
-        response.delete_cookie(cookie_name, path=cookie_path)
+        _delete_cookie_at_current_and_legacy_paths(response, cookie_name)
 
     clear_cookie_and_chunks(
         get_single_cookie,
         clear_single_cookie,
-        USER_COOKIE_NAME,
+        cookie_name,
     )
-    clear_cookie_and_chunks(
-        get_single_cookie,
-        clear_single_cookie,
-        TOKENS_COOKIE_NAME,
+
+
+def _clear_auth_cookie(response: Response, request: Request) -> None:
+    """Clear the auth cookies, including any split cookie chunks.
+
+    The path must match the path used when setting the cookie, otherwise
+    the browser won't delete it. Also delete legacy root-path auth cookies left
+    behind by the pre-Starlette Tornado auth implementation.
+    """
+    for cookie_name in _AUTH_COOKIE_NAMES:
+        _clear_single_auth_cookie_and_chunks(response, request, cookie_name)
+
+
+def _is_auth_cookie_present_but_invalid(request: Request, cookie_name: str) -> bool:
+    """Return whether an auth cookie exists but cannot be decoded."""
+    return (
+        request.cookies.get(cookie_name) is not None
+        and _get_signed_cookie_from_request(request, cookie_name) is None
     )
+
+
+def _clear_invalid_auth_cookies(response: Response, request: Request) -> None:
+    """Clear auth cookies that are present but fail signature validation."""
+    if _is_auth_cookie_present_but_invalid(request, USER_COOKIE_NAME):
+        # If the identity cookie is invalid, the token cookie is unusable too.
+        _clear_auth_cookie(response, request)
+        return
+
+    if _is_auth_cookie_present_but_invalid(request, TOKENS_COOKIE_NAME):
+        _clear_single_auth_cookie_and_chunks(response, request, TOKENS_COOKIE_NAME)
+
+
+async def _redirect_to_base_clearing_invalid_cookies(
+    request: Request, base_url: str
+) -> RedirectResponse:
+    """Redirect to the base URL, clearing any invalid auth cookies on the way."""
+    response = await _redirect_to_base(base_url)
+    _clear_invalid_auth_cookies(response, request)
+    return response
 
 
 def _create_oauth_client(provider: str) -> tuple[Any, str]:
@@ -452,12 +507,15 @@ async def _auth_login(request: Request, base_url: str) -> Response:
 
     provider = _parse_provider_token(request.query_params.get("provider"))
     if provider is None:
-        return await _redirect_to_base(base_url)
+        return await _redirect_to_base_clearing_invalid_cookies(request, base_url)
 
     client, redirect_uri = _create_oauth_client(provider)
     try:
-        response = await client.authorize_redirect(request, redirect_uri)
-        return cast("Response", response)
+        auth_response = cast(
+            "Response", await client.authorize_redirect(request, redirect_uri)
+        )
+        _clear_invalid_auth_cookies(auth_response, request)
+        return auth_response
     except Exception:  # pragma: no cover - error path
         from starlette.responses import Response
 
@@ -495,7 +553,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
         _LOGGER.error(
             "Error, misconfigured origin for `redirect_uri` in secrets.",
         )
-        return await _redirect_to_base(base_url)
+        return await _redirect_to_base_clearing_invalid_cookies(request, base_url)
 
     error = request.query_params.get("error")
     if error:
@@ -511,7 +569,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
             sanitized_error,
             sanitized_error_description,
         )
-        return await _redirect_to_base(base_url)
+        return await _redirect_to_base_clearing_invalid_cookies(request, base_url)
 
     if provider is None:
         # See https://github.com/streamlit/streamlit/issues/13101
@@ -520,7 +578,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
             "or replayed callback (for example, from browser back/forward "
             "navigation).",
         )
-        return await _redirect_to_base(base_url)
+        return await _redirect_to_base_clearing_invalid_cookies(request, base_url)
 
     client, _ = _create_oauth_client(provider)
     try:
@@ -537,7 +595,7 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
 
     user = token.get("userinfo") or {}
 
-    response = await _redirect_to_base(base_url)
+    response = await _redirect_to_base_clearing_invalid_cookies(request, base_url)
 
     cookie_value = dict(user, origin=origin, is_logged_in=True, provider=provider)
     tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 from streamlit.auth_util import (
     build_logout_url,
-    clear_cookie_and_chunks,
     decode_provider_token,
     generate_default_provider_section,
     get_cookie_with_chunks,
@@ -260,23 +259,6 @@ def _delete_cookie_at_current_and_legacy_paths(
         response.delete_cookie(cookie_name, path="/")
 
 
-def _delete_orphaned_chunk_cookies(
-    response: Response, request: Request, cookie_name: str
-) -> None:
-    """Delete chunk cookies (``{cookie_name}_1``, ``{cookie_name}_2``, ...) by name.
-
-    ``clear_cookie_and_chunks`` only discovers chunk cookies by decoding the main
-    cookie to read its chunk count. When the main cookie is present but invalid
-    (for example signed with a rotated secret), it cannot be decoded, so its
-    chunk siblings would otherwise be orphaned in the browser. This scans the raw
-    request cookies and deletes anything matching the chunk-name pattern.
-    """
-    chunk_prefix = f"{cookie_name}_"
-    for name in request.cookies:
-        if name.startswith(chunk_prefix) and name[len(chunk_prefix) :].isdigit():
-            _delete_cookie_at_current_and_legacy_paths(response, name)
-
-
 def _delete_legacy_root_auth_cookies(response: Response) -> None:
     """Delete legacy root-path auth cookies when auth is scoped to a base path."""
     if _get_cookie_path() == "/":
@@ -291,26 +273,24 @@ def _delete_legacy_root_auth_cookies(response: Response) -> None:
 def _clear_single_auth_cookie_and_chunks(
     response: Response, request: Request, cookie_name: str
 ) -> None:
-    """Clear an auth cookie, including any split cookie chunks."""
+    """Clear an auth cookie, including any split cookie chunks.
 
-    def get_single_cookie(cookie_name: str) -> bytes | None:
-        return _get_signed_cookie_from_request(request, cookie_name)
+    A large cookie is split into a main cookie plus ``{cookie_name}_1``,
+    ``{cookie_name}_2``, ... siblings. We discover the chunk siblings from the
+    request cookies rather than by decoding the main cookie, so they are cleared
+    even when the main cookie is invalid (e.g. signed with a rotated secret) and
+    can no longer be decoded to read its chunk count.
+    """
+    _delete_cookie_at_current_and_legacy_paths(response, cookie_name)
 
-    def clear_single_cookie(cookie_name: str) -> None:
-        _delete_cookie_at_current_and_legacy_paths(response, cookie_name)
-
-    clear_cookie_and_chunks(
-        get_single_cookie,
-        clear_single_cookie,
-        cookie_name,
-    )
-
-    # clear_cookie_and_chunks discovers chunk cookies by reading the chunk count
-    # from the decoded main cookie. When the main cookie is present but invalid
-    # (e.g. signed with a rotated secret), it cannot be decoded, so clear any
-    # chunk siblings by name to avoid orphaning them in the browser.
-    if _is_auth_cookie_present_but_invalid(request, cookie_name):
-        _delete_orphaned_chunk_cookies(response, request, cookie_name)
+    # The `.isdigit()` check matches only numeric chunk siblings, so clearing
+    # `_streamlit_user` does not accidentally delete the separate
+    # `_streamlit_user_tokens` cookie (or its `_streamlit_user_tokens_<n>`
+    # chunks), even though the latter shares the `_streamlit_user_` prefix.
+    chunk_prefix = f"{cookie_name}_"
+    for name in request.cookies:
+        if name.startswith(chunk_prefix) and name[len(chunk_prefix) :].isdigit():
+            _delete_cookie_at_current_and_legacy_paths(response, name)
 
 
 def _clear_auth_cookie(response: Response, request: Request) -> None:

--- a/lib/tests/streamlit/auth_util_test.py
+++ b/lib/tests/streamlit/auth_util_test.py
@@ -30,7 +30,6 @@ from streamlit.auth_util import (
     AuthCache,
     _calculate_signing_overhead,
     _set_split_cookie,
-    clear_cookie_and_chunks,
     generate_default_provider_section,
     get_cookie_with_chunks,
     get_expose_tokens_config,
@@ -437,71 +436,6 @@ class CookieChunkingTest(unittest.TestCase):
 
         result = get_cookie_with_chunks(mock_get_cookie, "test_cookie")
         assert result == b"chunks-invalid"
-
-    def test_clear_cookie_and_chunks_single_cookie(self):
-        """Test clearing a single (non-chunked) cookie."""
-        cookies: dict[str, bytes] = {
-            "test_cookie": b'{"key": "value"}',
-        }
-        cleared: list[str] = []
-
-        def mock_get_cookie(name: str) -> bytes | None:
-            return cookies.get(name)
-
-        def mock_clear_cookie(name: str) -> None:
-            cleared.append(name)
-            cookies.pop(name, None)
-
-        clear_cookie_and_chunks(mock_get_cookie, mock_clear_cookie, "test_cookie")
-
-        assert "test_cookie" in cleared
-        assert len(cleared) == 1
-
-    def test_clear_cookie_and_chunks_chunked_cookie(self):
-        """Test clearing a chunked cookie."""
-        cookies: dict[str, bytes] = {
-            "test_cookie": b"chunks-3",
-            "test_cookie_1": b"chunk1",
-            "test_cookie_2": b"chunk2",
-            "test_cookie_3": b"chunk3",
-        }
-        cleared: list[str] = []
-
-        def mock_get_cookie(name: str) -> bytes | None:
-            return cookies.get(name)
-
-        def mock_clear_cookie(name: str) -> None:
-            cleared.append(name)
-            cookies.pop(name, None)
-
-        clear_cookie_and_chunks(mock_get_cookie, mock_clear_cookie, "test_cookie")
-
-        # Should clear the main cookie, additional chunks (1, 2), and the count cookie
-        assert "test_cookie" in cleared
-        assert "test_cookie_1" in cleared
-        assert "test_cookie_2" in cleared
-        assert "test_cookie_3" in cleared
-        assert len(cleared) == 4  # main, 1, 2, 3
-
-    def test_clear_cookie_and_chunks_invalid_count(self):
-        """Test clearing a chunked cookie with invalid count."""
-        cookies: dict[str, bytes] = {
-            "test_cookie": b"chunks-invalid",
-        }
-        cleared: list[str] = []
-
-        def mock_get_cookie(name: str) -> bytes | None:
-            return cookies.get(name)
-
-        def mock_clear_cookie(name: str) -> None:
-            cleared.append(name)
-            cookies.pop(name, None)
-
-        clear_cookie_and_chunks(mock_get_cookie, mock_clear_cookie, "test_cookie")
-
-        # Should clear the main cookie and the count cookie
-        assert "test_cookie" in cleared
-        assert len(cleared) == 1
 
     def test_round_trip_small_cookie(self):
         """Test setting and getting a small cookie."""

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -23,7 +23,8 @@ from urllib.parse import parse_qs, urlparse
 from authlib.integrations import starlette_client
 from starlette.applications import Starlette
 from starlette.middleware.sessions import SessionMiddleware
-from starlette.responses import PlainTextResponse, RedirectResponse
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
@@ -133,6 +134,25 @@ def test_logout_clears_cookie() -> None:
         assert response.headers.get("set-cookie")
         follow_up = client.get(response.headers["location"])  # follow redirect manually
         assert follow_up.status_code == 200
+
+
+def test_logout_clears_chunk_cookies() -> None:
+    """Test that logout clears chunk siblings of the auth cookie.
+
+    Logout clears cookies unconditionally, so any ``{cookie_name}_<n>`` chunk
+    siblings present in the request must be deleted alongside the main cookie.
+    """
+    with TestClient(_build_app()) as client:
+        client.cookies.set(USER_COOKIE_NAME, "value")
+        client.cookies.set(f"{USER_COOKIE_NAME}_1", "chunk-1")
+        client.cookies.set(f"{USER_COOKIE_NAME}_2", "chunk-2")
+
+        response = client.get("/auth/logout", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME)
+    assert _has_auth_cookie_deletion(response, f"{USER_COOKIE_NAME}_1")
+    assert _has_auth_cookie_deletion(response, f"{USER_COOKIE_NAME}_2")
 
 
 def test_callback_handles_error_query(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -352,8 +372,9 @@ def test_login_preserves_chunk_cookies_for_valid_cookie(
 ) -> None:
     """Test that a valid main cookie does not trigger chunk-sibling deletion.
 
-    The orphaned-chunk cleanup only applies when the main cookie is invalid; a
-    valid main cookie must not have its chunk siblings deleted by the scan.
+    During login, cookie clearing is gated by ``_clear_invalid_auth_cookies``,
+    which only fires for cookies that fail signature validation. A valid main
+    cookie therefore must not have its chunk siblings deleted.
     """
     _patch_login_with_dummy_client(monkeypatch)
 
@@ -397,6 +418,40 @@ def test_login_clears_invalid_auth_cookies_at_base_and_root_path(
     assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/")
     assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/myapp")
     assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/")
+
+
+def test_clearing_user_cookie_preserves_tokens_cookie() -> None:
+    """Test that clearing the user cookie never touches the tokens cookie.
+
+    ``_streamlit_user`` is a literal prefix of ``_streamlit_user_tokens``, so the
+    chunk scan must rely on the numeric-suffix check to avoid deleting the tokens
+    cookie (or its chunks) when clearing the user cookie.
+    """
+    cookie_header = (
+        f"{USER_COOKIE_NAME}=u; {USER_COOKIE_NAME}_1=c1; "
+        f"{TOKENS_COOKIE_NAME}=t; {TOKENS_COOKIE_NAME}_1=t1"
+    )
+    request = Request(
+        {"type": "http", "headers": [(b"cookie", cookie_header.encode("latin-1"))]}
+    )
+    response = Response()
+
+    starlette_auth_routes._clear_single_auth_cookie_and_chunks(
+        response, request, USER_COOKIE_NAME
+    )
+
+    set_cookie_headers = response.headers.getlist("set-cookie")
+
+    def _is_deleted(cookie_name: str) -> bool:
+        return any(
+            header.startswith(f"{cookie_name}=") and "Max-Age=0" in header
+            for header in set_cookie_headers
+        )
+
+    assert _is_deleted(USER_COOKIE_NAME)
+    assert _is_deleted(f"{USER_COOKIE_NAME}_1")
+    assert not _is_deleted(TOKENS_COOKIE_NAME)
+    assert not _is_deleted(f"{TOKENS_COOKIE_NAME}_1")
 
 
 def test_callback_missing_origin_redirects(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -321,6 +321,59 @@ def test_login_clears_only_invalid_tokens_cookie(
     assert not _has_auth_cookie_deletion(response, USER_COOKIE_NAME)
 
 
+@patch_config_options({"server.cookieSecret": "test-secret"})
+def test_login_clears_orphaned_chunk_cookies_for_invalid_cookie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that login clears orphaned chunk cookies when the main cookie is invalid.
+
+    When a chunked auth cookie was signed with a rotated secret, the main cookie
+    can no longer be decoded to read its chunk count, so the chunk siblings must
+    be cleared by name to avoid leaving them orphaned in the browser.
+    """
+    _patch_login_with_dummy_client(monkeypatch)
+
+    with TestClient(_build_app()) as client:
+        client.cookies.set(USER_COOKIE_NAME, TORNADO_SIGNED_USER_COOKIE)
+        client.cookies.set(f"{USER_COOKIE_NAME}_1", "stale-chunk-1")
+        client.cookies.set(f"{USER_COOKIE_NAME}_2", "stale-chunk-2")
+
+        response = client.get("/auth/login?provider=dummy", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME)
+    assert _has_auth_cookie_deletion(response, f"{USER_COOKIE_NAME}_1")
+    assert _has_auth_cookie_deletion(response, f"{USER_COOKIE_NAME}_2")
+
+
+@patch_config_options({"server.cookieSecret": "test-secret"})
+def test_login_preserves_chunk_cookies_for_valid_cookie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a valid main cookie does not trigger chunk-sibling deletion.
+
+    The orphaned-chunk cleanup only applies when the main cookie is invalid; a
+    valid main cookie must not have its chunk siblings deleted by the scan.
+    """
+    _patch_login_with_dummy_client(monkeypatch)
+
+    valid_user_cookie = starlette_app_utils.create_signed_value(
+        "test-secret",
+        USER_COOKIE_NAME,
+        '{"origin": "http://testserver", "is_logged_in": true}',
+    ).decode("utf-8")
+
+    with TestClient(_build_app()) as client:
+        client.cookies.set(USER_COOKIE_NAME, valid_user_cookie)
+        client.cookies.set(f"{USER_COOKIE_NAME}_1", "some-chunk")
+
+        response = client.get("/auth/login?provider=dummy", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert not _has_auth_cookie_deletion(response, USER_COOKIE_NAME)
+    assert not _has_auth_cookie_deletion(response, f"{USER_COOKIE_NAME}_1")
+
+
 @patch_config_options(
     {"server.cookieSecret": "test-secret", "server.baseUrlPath": "myapp"}
 )

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -45,6 +45,16 @@ from tests.testutil import patch_config_options
 if TYPE_CHECKING:
     import pytest
 
+TORNADO_SIGNED_USER_COOKIE = (
+    "2|1:0|10:1780515959|15:_streamlit_user|68:"
+    "eyJvcmlnaW4iOiJodHRwOi8vdGVzdHNlcnZlciIsImlzX2xvZ2dlZF9pbiI6dHJ1ZX0=|"
+    "7ff7ecbfa76dacaef4fdf8514aacf239aade7cbd9100178292dd1e9664e5060d"
+)
+TORNADO_SIGNED_TOKENS_COOKIE = (
+    "2|1:0|10:1780515959|22:_streamlit_user_tokens|4:e30=|"
+    "59d5f7a7cc7a4d00c6d2e55a37124b1ef32a22d2deffe49f5ffaa1de24a70ed1"
+)
+
 
 def _build_app() -> Starlette:
     async def root(_: Any) -> PlainTextResponse:
@@ -53,6 +63,56 @@ def _build_app() -> Starlette:
     app = Starlette(routes=[*create_auth_routes(""), Route("/", root, methods=["GET"])])
     app.add_middleware(SessionMiddleware, secret_key="test-secret")
     return app
+
+
+def _auth_cookie_headers(response: Any, cookie_name: str) -> list[str]:
+    return [
+        header
+        for header in response.headers.get_list("set-cookie")
+        if header.startswith(f"{cookie_name}=")
+    ]
+
+
+def _has_auth_cookie_deletion(
+    response: Any, cookie_name: str, *, path: str | None = None
+) -> bool:
+    return any(
+        "Max-Age=0" in header and (path is None or f"Path={path}" in header)
+        for header in _auth_cookie_headers(response, cookie_name)
+    )
+
+
+def _get_auth_cookie_set_header(
+    response: Any, cookie_name: str, *, path: str | None = None
+) -> str | None:
+    return next(
+        (
+            header
+            for header in _auth_cookie_headers(response, cookie_name)
+            if f"Max-Age={AUTH_COOKIE_MAX_AGE_SECONDS}" in header
+            and (path is None or f"Path={path}" in header)
+        ),
+        None,
+    )
+
+
+def _patch_login_with_dummy_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the login flow to use a no-op OAuth client that just redirects."""
+
+    class _DummyClient:
+        async def authorize_redirect(
+            self, request: Any, redirect_uri: str
+        ) -> RedirectResponse:
+            return RedirectResponse(redirect_uri)
+
+    monkeypatch.setattr(
+        starlette_auth_routes, "_parse_provider_token", lambda token: "default"
+    )
+    monkeypatch.setattr(
+        starlette_auth_routes,
+        "_create_oauth_client",
+        lambda provider: (_DummyClient(), "/redirect"),
+    )
 
 
 def test_redirect_without_provider(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -192,6 +252,98 @@ def test_login_initializes_session(monkeypatch: pytest.MonkeyPatch) -> None:
         assert response.headers["location"] == "/redirect"
 
     assert captured_session is not None
+
+
+@patch_config_options({"server.cookieSecret": "test-secret"})
+def test_login_clears_invalid_auth_cookies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that login clears auth cookies that fail signature validation."""
+    _patch_login_with_dummy_client(monkeypatch)
+
+    with TestClient(_build_app()) as client:
+        client.cookies.set(USER_COOKIE_NAME, TORNADO_SIGNED_USER_COOKIE)
+        client.cookies.set(TOKENS_COOKIE_NAME, TORNADO_SIGNED_TOKENS_COOKIE)
+
+        response = client.get("/auth/login?provider=dummy", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/")
+    assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/")
+
+
+@patch_config_options({"server.cookieSecret": "test-secret"})
+def test_login_preserves_valid_auth_cookies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that login does not clear auth cookies with valid signatures."""
+    _patch_login_with_dummy_client(monkeypatch)
+
+    valid_user_cookie = starlette_app_utils.create_signed_value(
+        "test-secret",
+        USER_COOKIE_NAME,
+        '{"origin": "http://testserver", "is_logged_in": true}',
+    ).decode("utf-8")
+    valid_tokens_cookie = starlette_app_utils.create_signed_value(
+        "test-secret", TOKENS_COOKIE_NAME, "{}"
+    ).decode("utf-8")
+
+    with TestClient(_build_app()) as client:
+        client.cookies.set(USER_COOKIE_NAME, valid_user_cookie)
+        client.cookies.set(TOKENS_COOKIE_NAME, valid_tokens_cookie)
+
+        response = client.get("/auth/login?provider=dummy", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert not _has_auth_cookie_deletion(response, USER_COOKIE_NAME)
+    assert not _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME)
+
+
+@patch_config_options({"server.cookieSecret": "test-secret"})
+def test_login_clears_only_invalid_tokens_cookie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that login clears the tokens cookie alone when the user cookie is valid."""
+    _patch_login_with_dummy_client(monkeypatch)
+
+    valid_user_cookie = starlette_app_utils.create_signed_value(
+        "test-secret",
+        USER_COOKIE_NAME,
+        '{"origin": "http://testserver", "is_logged_in": true}',
+    ).decode("utf-8")
+
+    with TestClient(_build_app()) as client:
+        client.cookies.set(USER_COOKIE_NAME, valid_user_cookie)
+        client.cookies.set(TOKENS_COOKIE_NAME, TORNADO_SIGNED_TOKENS_COOKIE)
+
+        response = client.get("/auth/login?provider=dummy", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/")
+    assert not _has_auth_cookie_deletion(response, USER_COOKIE_NAME)
+
+
+@patch_config_options(
+    {"server.cookieSecret": "test-secret", "server.baseUrlPath": "myapp"}
+)
+def test_login_clears_invalid_auth_cookies_at_base_and_root_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that login clears invalid auth cookies at both the base and root paths."""
+    _patch_login_with_dummy_client(monkeypatch)
+
+    app = Starlette(routes=create_auth_routes("/myapp"))
+    with TestClient(app) as client:
+        client.cookies.set(USER_COOKIE_NAME, TORNADO_SIGNED_USER_COOKIE)
+        client.cookies.set(TOKENS_COOKIE_NAME, TORNADO_SIGNED_TOKENS_COOKIE)
+
+        response = client.get(
+            "/myapp/auth/login?provider=dummy", follow_redirects=False
+        )
+
+    assert response.status_code == 307
+    assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/myapp")
+    assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/")
+    assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/myapp")
+    assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/")
 
 
 def test_callback_missing_origin_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -502,10 +654,8 @@ class TestAuthCookieFlags:
             )
             assert response.status_code == 302
 
-            set_cookie_headers = response.headers.get_list("set-cookie")
-            user_cookie_header = next(
-                (h for h in set_cookie_headers if h.startswith("_streamlit_user=")),
-                None,
+            user_cookie_header = _get_auth_cookie_set_header(
+                response, USER_COOKIE_NAME, path="/myapp"
             )
             assert user_cookie_header is not None, "User cookie not found"
 
@@ -515,6 +665,8 @@ class TestAuthCookieFlags:
 
             # Check path matches baseUrlPath
             assert cookie["path"] == "/myapp"
+            assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/")
+            assert _has_auth_cookie_deletion(response, TOKENS_COOKIE_NAME, path="/")
 
     @patch_config_options({"server.baseUrlPath": "myapp"})
     def test_logout_clears_cookie_with_correct_path(self) -> None:
@@ -535,9 +687,8 @@ class TestAuthCookieFlags:
             response = client.get("/myapp/auth/logout", follow_redirects=False)
             assert response.status_code == 302
 
-            # The Set-Cookie header should include the path
-            set_cookie_header = response.headers.get("set-cookie", "")
-            assert "Path=/myapp" in set_cookie_header
+            assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/myapp")
+            assert _has_auth_cookie_deletion(response, USER_COOKIE_NAME, path="/")
 
 
 class TestParseProviderToken:


### PR DESCRIPTION
## Describe your changes

Logging in with OIDC could fail to overwrite auth cookies left behind in two scenarios, leaving users stuck in a broken auth state. This clears them during the OAuth login/callback flow:

- **Legacy root-path cookies:** When auth is scoped to a `server.baseUrlPath`, cookies set at the root path `/` by the pre-Starlette (Tornado) implementation are now deleted, both when setting fresh cookies and when clearing.
- **Invalid cookies:** Auth cookies present in the request but failing signature validation (e.g. signed with an old secret, or in the old Tornado format) are now actively deleted on the login/callback redirects. If the identity cookie is invalid, the token cookie is cleared too.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/15407

## Testing Plan

- `lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py` — Covers clearing invalid cookies on login, preserving valid cookies, clearing only the tokens cookie when the user cookie is valid, and dual-path (base + root) deletion when a base path is configured.