### PR TITLE
[docs] Add comments-serve-future-readers guidance to AGENTS.md

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -90,6 +90,7 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
+- **Comments and docstrings serve future readers, not the PR**: Never write comments or docstrings that narrate the changes being made — e.g., "Separated from X to avoid circular imports", "Extracted from Y for better modularity", "Moved here from Z". These are useless to future readers. If someone wants to understand why code was changed, they can look at git history. Instead, describe what the code does and why it exists.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - Use `agent-wiki/` (gitignored, cloned on first use) to share intermediate files (specs, plans, learnings) relevant for the current PR. This is a local checkout of [streamlit.wiki](https://github.com/streamlit/streamlit.wiki.git). Files are stored in `pull-requests/<pr-number>/` and accessible at `https://issues.streamlit.app/agent_wiki_explorer?file=<relative-path>`. See `sharing-pr-agent-artifacts` skill.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,7 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
+- **Comments and docstrings serve future readers, not the PR**: Never write comments or docstrings that narrate the changes being made — e.g., "Separated from X to avoid circular imports", "Extracted from Y for better modularity", "Moved here from Z". These are useless to future readers. If someone wants to understand why code was changed, they can look at git history. Instead, describe what the code does and why it exists.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - Use `agent-wiki/` (gitignored, cloned on first use) to share intermediate files (specs, plans, learnings) relevant for the current PR. This is a local checkout of [streamlit.wiki](https://github.com/streamlit/streamlit.wiki.git). Files are stored in `pull-requests/<pr-number>/` and accessible at `https://issues.streamlit.app/agent_wiki_explorer?file=<relative-path>`. See `sharing-pr-agent-artifacts` skill.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
+- **Comments and docstrings serve future readers, not the PR**: Never write comments or docstrings that narrate the changes being made — e.g., "Separated from X to avoid circular imports", "Extracted from Y for better modularity", "Moved here from Z". These are useless to future readers. If someone wants to understand why code was changed, they can look at git history. Instead, describe what the code does and why it exists.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - Use `agent-wiki/` (gitignored, cloned on first use) to share intermediate files (specs, plans, learnings) relevant for the current PR. This is a local checkout of [streamlit.wiki](https://github.com/streamlit/streamlit.wiki.git). Files are stored in `pull-requests/<pr-number>/` and accessible at `https://issues.streamlit.app/agent_wiki_explorer?file=<relative-path>`. See `sharing-pr-agent-artifacts` skill.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Adds a new rule in the `### Development Tips` section of `AGENTS.md` instructing agents to write comments and docstrings that serve future readers, not narrate the PR changes being made.

- New bullet placed after "Follow existing patterns" in Development Tips
- Regenerated derived rule files (`.cursor/rules/overview.mdc`, `.github/copilot-instructions.md`) via `scripts/generate_agent_rules.py`

## GitHub Issue Link (if applicable)

## Testing Plan

- No additional tests needed — this is a documentation-only change to agent guidance rules
- Verified via `make check` that all pre-commit hooks pass and generated files are in sync

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f15fbde0-d87e-4ead-8a9d-0f512f258698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f15fbde0-d87e-4ead-8a9d-0f512f258698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

