### PR TITLE
[refactor] Remove circular-import deferral in parallel coordinator

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -707,6 +707,7 @@ def _dispatch_parallel_fragment(
 
     coordinator.submit(
         _run_parallel_fragment,
+        ctx,
         fragment_id,
         wrapped_fragment,
         dg_stack_with_container,

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -687,9 +687,9 @@ def _dispatch_parallel_fragment(
     sees the container delta immediately), then submits the fragment body to
     run on a worker thread.
 
-    The coordinator's submit() handles context propagation: it captures
-    copy_context() and get_script_run_ctx() at submit time, and the worker
-    runs inside captured.run() with _scoped_ctx_attach().
+    The coordinator's submit() handles context propagation: the caller passes
+    ctx explicitly and submit() captures copy_context() at submit time, and the
+    worker runs inside captured.run() with _scoped_ctx_attach().
     """
     import streamlit as st
     from streamlit.delta_generator_singletons import context_dg_stack

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -31,13 +31,16 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,
     StopException,
 )
-from streamlit.runtime.scriptrunner_utils.script_run_context import (
+from streamlit.runtime.scriptrunner_utils.script_run_context_attr import (
     SCRIPT_RUN_CONTEXT_ATTR_NAME,
-    ScriptRunContext,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+
+    from streamlit.runtime.scriptrunner_utils.script_run_context import (
+        ScriptRunContext,
+    )
 
 
 @contextlib.contextmanager

--- a/lib/streamlit/runtime/parallel_coordinator.py
+++ b/lib/streamlit/runtime/parallel_coordinator.py
@@ -14,12 +14,9 @@
 
 """ParallelFragmentCoordinator and supporting helpers.
 
-Separated from ``fragment.py`` to break the import cycle with
-``script_run_context.py``: the coordinator imports from
-``script_run_context`` (for ``get_script_run_ctx`` and
-``SCRIPT_RUN_CONTEXT_ATTR_NAME``), and ``script_run_context`` needs to
-construct a coordinator in ``reset()``.  With the coordinator in its own
-module, ``script_run_context`` can import it at module level.
+Manages a thread pool for parallel fragment execution. The coordinator
+receives the caller's ``ScriptRunContext`` explicitly via ``submit()``
+so that worker threads can access the correct context.
 """
 
 from __future__ import annotations
@@ -37,7 +34,6 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     SCRIPT_RUN_CONTEXT_ATTR_NAME,
     ScriptRunContext,
-    get_script_run_ctx,
 )
 
 if TYPE_CHECKING:
@@ -103,14 +99,19 @@ class ParallelFragmentCoordinator:
         self._yield_check = yield_check
         self._poll_interval = poll_interval
 
-    def submit(self, fn: Callable[..., Any], *args: Any) -> None:
+    def submit(
+        self,
+        fn: Callable[..., Any],
+        ctx: ScriptRunContext | None,
+        *args: Any,
+    ) -> None:
         """Submit a worker function to the thread pool.
 
-        Captures the caller's ``ScriptRunContext`` (thread attribute) and the
-        caller's full ``contextvars.Context`` (which includes ``FragmentThreadState``)
-        at submit time.  The worker runs inside ``copy_context().run(...)`` with a
-        scoped ctx attach so ``get_script_run_ctx()`` and ``ThreadState.get()``
-        return the parent's values for the duration of the call.  Worker-side
+        Captures the caller's full ``contextvars.Context`` (which includes
+        ``FragmentThreadState``) at submit time.  The worker runs inside
+        ``copy_context().run(...)`` with a scoped ctx attach so
+        ``get_script_run_ctx()`` and ``ThreadState.get()`` return the parent's
+        values for the duration of the call.  Worker-side
         ``ThreadState.update()`` writes stay local to the captured copy — they
         never leak back to the parent thread.
 
@@ -118,8 +119,18 @@ class ParallelFragmentCoordinator:
         submit() from inside a running worker is visible to join() before
         the parent's tracked() decrement runs. May be called from any
         thread (main thread or worker threads for nested fragments).
+
+        Parameters
+        ----------
+        fn : Callable[..., Any]
+            The worker function to execute in the thread pool.
+        ctx : ScriptRunContext | None
+            The ScriptRunContext to propagate to the worker thread so that
+            ``get_script_run_ctx()`` returns the correct context inside the
+            worker.
+        *args : Any
+            Positional arguments forwarded to ``fn``.
         """
-        ctx = get_script_run_ctx()
         captured = contextvars.copy_context()
 
         with self._join_condition:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -30,6 +30,7 @@ from typing import (
 
 from typing_extensions import Unpack
 
+from streamlit import config
 from streamlit.errors import (
     NoSessionContext,
 )
@@ -50,7 +51,6 @@ if TYPE_CHECKING:
     from streamlit.proto.PageProfile_pb2 import Command
     from streamlit.runtime.fragment import FragmentStorage
     from streamlit.runtime.pages_manager import PagesManager
-    from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
     from streamlit.runtime.scriptrunner_utils.script_requests import ScriptRequests
     from streamlit.runtime.state import SafeSessionState
     from streamlit.runtime.uploaded_file_manager import UploadedFileManager
@@ -274,11 +274,6 @@ class ScriptRunContext:
         ThreadState.initialize(
             active_script_hash=self.pages_manager.main_script_hash,
         )
-        # Deferred to avoid circular import: parallel_coordinator imports
-        # ScriptRunContext and get_script_run_ctx from this module.
-        from streamlit import config
-        from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
-
         self.parallel_coordinator = ParallelFragmentCoordinator(
             yield_check=yield_check,
             max_workers=config.get_option("runner.parallelMaxWorkers"),
@@ -477,3 +472,8 @@ def enqueue_message(msg: ForwardMsg) -> None:
         msg.delta.fragment_id = ts.fragment_id
 
     ctx.enqueue(msg)
+
+
+from streamlit.runtime.parallel_coordinator import (  # noqa: E402
+    ParallelFragmentCoordinator,
+)

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -39,6 +39,10 @@ from streamlit.runtime.forward_msg_cache import (
     create_reference_msg,
     populate_hash_if_needed,
 )
+from streamlit.runtime.parallel_coordinator import ParallelFragmentCoordinator
+from streamlit.runtime.scriptrunner_utils.script_run_context_attr import (
+    SCRIPT_RUN_CONTEXT_ATTR_NAME,
+)
 from streamlit.runtime.scriptrunner_utils.thread_safe_set import ThreadSafeSet
 
 if TYPE_CHECKING:
@@ -325,7 +329,6 @@ class ScriptRunContext:
         self._enqueue(msg_to_send)
 
 
-SCRIPT_RUN_CONTEXT_ATTR_NAME: Final = "streamlit_script_run_ctx"
 # Thread-attached storage used by add_script_run_ctx:
 # - Fields slot: parent FragmentThreadState snapshot, applied at run() time.
 # - Install slot: sentinel that prevents thread.run from being wrapped
@@ -472,8 +475,3 @@ def enqueue_message(msg: ForwardMsg) -> None:
         msg.delta.fragment_id = ts.fragment_id
 
     ctx.enqueue(msg)
-
-
-from streamlit.runtime.parallel_coordinator import (  # noqa: E402
-    ParallelFragmentCoordinator,
-)

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context_attr.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context_attr.py
@@ -1,0 +1,25 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The thread attribute name under which the active ScriptRunContext is stored.
+
+This is a dependency-free leaf module so that both ``script_run_context`` and
+``parallel_coordinator`` can share the constant without importing each other.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SCRIPT_RUN_CONTEXT_ATTR_NAME: Final = "streamlit_script_run_ctx"

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -1572,7 +1572,8 @@ def test_worker_dg_stack_points_at_pre_allocated_container(
     _dispatch_parallel_fragment(ctx, "test_fragment_id", wrapped_fragment)
 
     call_args = mock_coordinator.submit.call_args[0]
-    dg_stack_snapshot = call_args[3]
+    assert call_args[1] is ctx
+    dg_stack_snapshot = call_args[4]
     assert len(dg_stack_snapshot) == original_len + 1
 
 

--- a/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
+++ b/lib/tests/streamlit/runtime/parallel_fragment_coordinator_test.py
@@ -115,7 +115,7 @@ def test_submit_counter_round_trip(coordinator):
     def explodes() -> None:
         raise ValueError("boom")
 
-    coordinator.submit(explodes)
+    coordinator.submit(explodes, None)
     _wait_for_outstanding_zero(coordinator)
     assert coordinator._outstanding == 0
 
@@ -130,7 +130,7 @@ def test_submit_passes_args(coordinator):
         captured.append((value, label))
         done.set()
 
-    coordinator.submit(worker, 42, "hello")
+    coordinator.submit(worker, None, 42, "hello")
     assert done.wait(timeout=1.0)
     _wait_for_outstanding_zero(coordinator)
     assert captured == [(42, "hello")]
@@ -143,7 +143,7 @@ def test_submit_after_shutdown_rolls_back_outstanding():
     c = ParallelFragmentCoordinator(yield_check=lambda: None)
     c.drain()
     with pytest.raises(RuntimeError):
-        c.submit(lambda: None)
+        c.submit(lambda: None, None)
     assert c._outstanding == 0
 
 
@@ -155,9 +155,9 @@ def test_nested_submit_counter():
     child_done = threading.Event()
 
     def parent() -> None:
-        c.submit(lambda: child_done.set())
+        c.submit(lambda: child_done.set(), None)
 
-    c.submit(parent)
+    c.submit(parent, None)
     c.join()
     assert child_done.is_set()
 
@@ -187,7 +187,7 @@ def test_join_waits_and_yields():
         poll_interval=0.01,
     )
     gate = threading.Event()
-    c.submit(lambda: gate.wait(timeout=2.0))
+    c.submit(lambda: gate.wait(timeout=2.0), None)
     threading.Timer(0.05, gate.set).start()
     c.join()
     assert len(yields) >= 1
@@ -231,7 +231,7 @@ def test_join_propagates_yield_check_exception():
 
     c = ParallelFragmentCoordinator(yield_check=yield_raises, poll_interval=0.01)
     gate = threading.Event()
-    c.submit(lambda: gate.wait(timeout=2.0))
+    c.submit(lambda: gate.wait(timeout=2.0), None)
     try:
         with pytest.raises(RerunException):
             c.join()
@@ -257,7 +257,7 @@ def test_yield_check_exception_preempts_stored_worker_exception():
     worker_rerun = RerunException(RerunData(query_string="from_worker"))
     c.request_rerun(worker_rerun)
     gate = threading.Event()
-    c.submit(lambda: gate.wait(timeout=2.0))
+    c.submit(lambda: gate.wait(timeout=2.0), None)
     try:
         with pytest.raises(RerunException) as excinfo:
             c.join()
@@ -315,7 +315,7 @@ def test_drain_silent_and_synchronous():
         gate.wait(timeout=2.0)
         worker_done.set()
 
-    c.submit(worker)
+    c.submit(worker, None)
     threading.Timer(0.05, gate.set).start()
     c.drain()
     assert worker_done.is_set()
@@ -336,11 +336,9 @@ def test_drain_sets_stop_event():
 
 @pytest.mark.usefixtures("_attach_mock_ctx")
 def test_submit_propagates_ctx_to_worker():
-    """submit() captures the parent's ScriptRunContext at submit time
-    and the worker sees it via get_script_run_ctx()."""
+    """submit() forwards the ctx passed by the caller to the worker, which
+    reads it back via get_script_run_ctx()."""
     mock_ctx = MagicMock()
-    main_thread = threading.current_thread()
-    setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, mock_ctx)
 
     c = ParallelFragmentCoordinator(yield_check=lambda: None)
     holder: list[object] = []
@@ -351,7 +349,7 @@ def test_submit_propagates_ctx_to_worker():
         done.set()
 
     try:
-        c.submit(worker)
+        c.submit(worker, mock_ctx)
         assert done.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
         assert holder[0] is mock_ctx
@@ -374,7 +372,7 @@ def test_submit_propagates_thread_state_to_worker():
         done.set()
 
     try:
-        c.submit(worker)
+        c.submit(worker, None)
         assert done.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
         ts = holder[0]
@@ -398,7 +396,7 @@ def test_submit_isolates_worker_thread_state_writes():
         done.set()
 
     try:
-        c.submit(worker)
+        c.submit(worker, None)
         assert done.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
         assert ThreadState.get().fragment_id == "parent_frag"
@@ -410,7 +408,6 @@ def test_submit_clears_ctx_attribute_between_pool_submissions():
     """With max_workers=1, two submissions with different ctxs each
     see the correct ctx, and the pool thread's attribute is cleaned
     up after both complete."""
-    main_thread = threading.current_thread()
     ThreadState.initialize()
 
     ctx_a = MagicMock(name="ctx_a")
@@ -435,14 +432,12 @@ def test_submit_clears_ctx_attribute_between_pool_submissions():
         done_b.set()
 
     try:
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_a)
-        c.submit(worker_a)
+        c.submit(worker_a, ctx_a)
         gate.set()
         assert done_a.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
 
-        setattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME, ctx_b)
-        c.submit(worker_b)
+        c.submit(worker_b, ctx_b)
         assert done_b.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
 
@@ -454,7 +449,6 @@ def test_submit_clears_ctx_attribute_between_pool_submissions():
         assert remaining is not ctx_a
         assert remaining is not ctx_b
     finally:
-        delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
         c.drain()
 
 
@@ -480,12 +474,12 @@ def test_submit_with_max_workers_1_serializes_distinct_thread_states():
 
     try:
         ThreadState.initialize(fragment_id="state_a", active_script_hash="hash_a")
-        c.submit(worker_a)
+        c.submit(worker_a, None)
         assert done_a.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
 
         ThreadState.update(fragment_id="state_b", active_script_hash="hash_b")
-        c.submit(worker_b)
+        c.submit(worker_b, None)
         assert done_b.wait(timeout=1.0)
         _wait_for_outstanding_zero(c)
 
@@ -499,3 +493,19 @@ def test_submit_with_max_workers_1_serializes_distinct_thread_states():
     finally:
         delattr(main_thread, SCRIPT_RUN_CONTEXT_ATTR_NAME)
         c.drain()
+
+
+def test_submit_with_none_ctx(coordinator):
+    """Passing ctx=None propagates None to the worker, which reads None back
+    via get_script_run_ctx()."""
+    holder: list[object] = []
+    done = threading.Event()
+
+    def worker() -> None:
+        holder.append(get_script_run_ctx(suppress_warning=True))
+        done.set()
+
+    coordinator.submit(worker, None)
+    assert done.wait(timeout=1.0)
+    _wait_for_outstanding_zero(coordinator)
+    assert holder[0] is None

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -462,3 +462,15 @@ class ScriptRunContextTest(unittest.TestCase):
         t.run("test_arg")
 
         assert received_args == ["test_arg"]
+
+
+def test_script_run_context_attr_name_reexported_from_leaf_module() -> None:
+    """SCRIPT_RUN_CONTEXT_ATTR_NAME stays importable from script_run_context,
+    re-exporting the same object defined in the script_run_context_attr leaf
+    module, so existing import paths keep working."""
+    from streamlit.runtime.scriptrunner_utils import script_run_context_attr
+
+    assert (
+        SCRIPT_RUN_CONTEXT_ATTR_NAME
+        is script_run_context_attr.SCRIPT_RUN_CONTEXT_ATTR_NAME
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

`ParallelFragmentCoordinator.submit()` now takes the caller's `ScriptRunContext` as an explicit parameter instead of fetching it internally via `get_script_run_ctx()`. This removes the coordinator's runtime dependency on `get_script_run_ctx` and lets the import cycle between `parallel_coordinator` and `script_run_context` be eliminated rather than worked around.

- `submit(fn, ctx, *args)`: callers (e.g. `_dispatch_parallel_fragment`) now pass `ctx` through to the worker.
- The shared `SCRIPT_RUN_CONTEXT_ATTR_NAME` constant moves to a new dependency-free leaf module, `scriptrunner_utils/script_run_context_attr.py`. Both `script_run_context` and `parallel_coordinator` import it from there. It is re-exported from `script_run_context` so existing import paths keep working.
- `parallel_coordinator` no longer imports `script_run_context` at runtime (`ScriptRunContext` is now a `TYPE_CHECKING`-only import), so `script_run_context` imports `ParallelFragmentCoordinator` at module top — no deferred import and no `# noqa: E402`.

No user-facing or public API changes.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (Python): updated `parallel_fragment_coordinator_test.py` to pass `ctx` explicitly (covering real-ctx and `None` cases, plus a new `test_submit_with_none_ctx`), and adjusted the `fragment_test.py` assertion for the shifted `submit()` positional args.
- No E2E tests needed: this is an internal refactor with no behavioral change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d4736a-37d6-456d-a0b3-a22e7540b64f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d4736a-37d6-456d-a0b3-a22e7540b64f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

