### PR TITLE
fix(auth): clear stale Tornado auth cookies after upgrade to Starlette

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -31,6 +31,9 @@ from streamlit.web.server.starlette.starlette_auth_routes import create_auth_rou
 from streamlit.web.server.starlette.starlette_gzip_middleware import (
     SelectiveGZipMiddleware,
 )
+from streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware import (
+    InvalidAuthCookieMiddleware,
+)
 from streamlit.web.server.starlette.starlette_path_security_middleware import (
     PathSecurityMiddleware,
 )
@@ -179,6 +182,13 @@ def create_streamlit_middleware() -> list[Middleware]:
 
     # FIRST: Path security middleware to block dangerous paths before any other processing.
     middleware.append(Middleware(PathSecurityMiddleware))
+
+    # Clear auth cookies that were signed by the old Tornado backend (<=1.56) and
+    # cannot be verified by the current Starlette backend.  Without this, browsers
+    # that were logged-in before the upgrade keep sending unverifiable cookies
+    # on every request, leaving the app stuck on the loading screen for up to 30
+    # days (the original cookie max-age).  See GitHub issue #15407.
+    middleware.append(Middleware(InvalidAuthCookieMiddleware))
 
     # Add session middleware
     middleware.append(

--- a/lib/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware.py
@@ -1,0 +1,248 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Middleware that clears auth cookies that cannot be verified by the current server.
+
+Background
+----------
+Streamlit 1.57.0 migrated the server backend from Tornado to Starlette.  The
+two backends sign auth cookies (``_streamlit_user`` / ``_streamlit_user_tokens``)
+with incompatible schemes:
+
+* **Tornado** – ``set_signed_cookie`` / ``get_secure_cookie`` (HMAC-SHA256 over a
+  proprietary format).
+* **Starlette** – ``itsdangerous.URLSafeTimedSerializer`` (a different format and
+  salt strategy).
+
+A browser that was logged in under the Tornado backend retains valid-looking
+cookies for up to 30 days after the upgrade.  Every subsequent request resends
+those cookies; ``decode_signed_value`` rejects them silently (returns ``None``),
+but *never instructs the browser to delete them*.  The result is that the app
+appears stuck on the loading screen until the user manually clears cookies or
+they expire naturally.
+
+Fix
+---
+This middleware runs on every HTTP request.  Whenever it encounters an auth
+cookie that is present in the request **but fails signature verification**
+(i.e. ``decode_signed_value`` returns ``None``), it appends ``Set-Cookie`` delete
+headers to the response so the browser discards those stale cookies immediately.
+
+Chunked cookies (``_streamlit_user_1``, ``_streamlit_user_2``, …) are handled as
+well: if the base cookie exists but is unverifiable, any related chunk cookies
+are also deleted.
+
+This middleware is intentionally limited to HTTP requests; WebSocket and
+lifespan scopes are passed through without modification.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from streamlit.logger import get_logger
+from streamlit.web.server.server_util import get_cookie_secret
+from streamlit.web.server.starlette.starlette_app_utils import decode_signed_value
+from streamlit.web.server.starlette.starlette_server_config import (
+    TOKENS_COOKIE_NAME,
+    USER_COOKIE_NAME,
+)
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+_LOGGER = get_logger(__name__)
+
+# Pattern used to detect chunked cookies: the base cookie value starts with
+# "chunks-<N>" when the payload was split across multiple cookies.
+_CHUNKS_RE = re.compile(r"^chunks-(\d+)$")
+
+# Auth cookies that should be verified and, if invalid, cleared.
+_AUTH_COOKIE_NAMES: tuple[str, ...] = (USER_COOKIE_NAME, TOKENS_COOKIE_NAME)
+
+
+def _cookie_names_to_clear(cookies: dict[str, str]) -> list[str]:
+    """Return the names of all auth cookies that exist but fail verification.
+
+    Includes chunk cookies (e.g. ``_streamlit_user_1``) when the base cookie
+    indicates a chunked value.
+
+    Parameters
+    ----------
+    cookies
+        The request cookies as a plain ``{name: value}`` mapping.
+
+    Returns
+    -------
+    list[str]
+        Cookie names that should be deleted from the browser.
+    """
+    secret = get_cookie_secret()
+    if not secret:
+        return []
+
+    names_to_delete: list[str] = []
+
+    for base_name in _AUTH_COOKIE_NAMES:
+        raw_value = cookies.get(base_name)
+        if raw_value is None:
+            # Cookie not present – nothing to do.
+            continue
+
+        # Attempt to verify the cookie with the current (Starlette) scheme.
+        signed_bytes = raw_value.encode("latin-1")
+        decoded = decode_signed_value(secret, base_name, signed_bytes)
+
+        if decoded is not None:
+            # Cookie is valid – leave it alone.
+            continue
+
+        # Cookie exists but cannot be verified.  Schedule it for deletion.
+        _LOGGER.debug(
+            "Auth cookie '%s' is present but could not be verified "
+            "(possibly signed by an older Tornado backend). "
+            "It will be cleared from the browser.",
+            base_name,
+        )
+        names_to_delete.append(base_name)
+
+        # Also clear any chunk cookies that may accompany this base cookie.
+        # The base cookie value encodes the chunk count as "chunks-<N>" when
+        # the payload was split.  Even though we couldn't verify the signed
+        # value, we can still check the raw (unsigned) string for this prefix
+        # as a best-effort cleanup — worst case, we attempt to delete cookies
+        # that don't exist, which is harmless.
+        chunk_match = _CHUNKS_RE.match(raw_value)
+        if chunk_match:
+            try:
+                chunk_count = int(chunk_match.group(1))
+                for i in range(1, chunk_count + 1):
+                    names_to_delete.append(f"{base_name}_{i}")
+            except ValueError:
+                pass  # Malformed chunk count; ignore.
+
+        # Regardless of the chunk check above, also clean up any stray chunk
+        # cookies that might be present in the request (e.g. leftover from a
+        # previous split that now has fewer chunks).
+        for key in cookies:
+            if key.startswith(f"{base_name}_") and key not in names_to_delete:
+                names_to_delete.append(key)
+
+    return names_to_delete
+
+
+def _build_delete_cookie_header(name: str, path: str) -> bytes:
+    """Build a ``Set-Cookie`` header value that instructs the browser to delete *name*.
+
+    Parameters
+    ----------
+    name
+        The cookie name to delete.
+    path
+        The cookie path that was used when the cookie was originally set.
+        Must match exactly, otherwise the browser will not delete the cookie.
+
+    Returns
+    -------
+    bytes
+        The raw header value, ready to be appended to ``headers`` as
+        ``(b"set-cookie", value)``.
+    """
+    return (
+        f"{name}=; Path={path}; HttpOnly; SameSite=lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ).encode("latin-1")
+
+
+class InvalidAuthCookieMiddleware:
+    """ASGI middleware that clears unverifiable auth cookies from the browser.
+
+    This handles the regression introduced when upgrading from Streamlit ≤1.56
+    (Tornado backend) to ≥1.57 (Starlette backend): browsers that were
+    logged-in under the old backend retain cookies signed with Tornado's scheme,
+    which the new server cannot verify.  Without this middleware those cookies
+    are silently ignored on every request, leaving the app stuck on the loading
+    screen until the cookies expire (up to 30 days).
+
+    The middleware intercepts ``Set-Cookie`` delete headers onto *every* response
+    for which unverifiable auth cookies are detected in the request.  Chunk
+    cookies are cleaned up as well.
+
+    Only HTTP request/response cycles are affected; WebSocket and lifespan scopes
+    are forwarded unchanged.
+
+    Parameters
+    ----------
+    app
+        The ASGI application to wrap.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Process each ASGI event.
+
+        For HTTP requests: inspect incoming cookies and, if any auth cookies
+        are present but unverifiable, inject ``Set-Cookie`` delete directives
+        into the response headers before forwarding them to the client.
+
+        For all other scope types (``websocket``, ``lifespan``): delegate
+        directly without modification.
+        """
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Parse cookies from the request scope headers.
+        raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+        cookies: dict[str, str] = {}
+        for header_name, header_value in raw_headers:
+            if header_name.lower() == b"cookie":
+                for part in header_value.decode("latin-1").split(";"):
+                    part = part.strip()
+                    if "=" in part:
+                        k, _, v = part.partition("=")
+                        cookies[k.strip()] = v.strip()
+
+        names_to_delete = _cookie_names_to_clear(cookies)
+
+        if not names_to_delete:
+            # Fast-path: nothing to do; delegate immediately.
+            await self.app(scope, receive, send)
+            return
+
+        # Determine the cookie path from server configuration so that the
+        # delete directive matches the path used when the cookie was set.
+        from streamlit import config as st_config
+
+        base_path: str | None = st_config.get_option("server.baseUrlPath")
+        cookie_path = ("/" + base_path.strip("/")) if base_path else "/"
+
+        delete_headers = [
+            (b"set-cookie", _build_delete_cookie_header(name, cookie_path))
+            for name in names_to_delete
+        ]
+
+        async def send_with_delete_cookies(message: dict) -> None:  # type: ignore[type-arg]
+            if message["type"] == "http.response.start":
+                # Append our delete-cookie headers to the response.
+                existing: list[tuple[bytes, bytes]] = list(message.get("headers", []))
+                message = {
+                    **message,
+                    "headers": existing + delete_headers,
+                }
+            await send(message)
+
+        await self.app(scope, receive, send_with_delete_cookies)

--- a/lib/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware.py
+++ b/lib/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware.py
@@ -143,7 +143,7 @@ def _cookie_names_to_clear(cookies: dict[str, str]) -> list[str]:
     return names_to_delete
 
 
-def _build_delete_cookie_header(name: str, path: str) -> bytes:
+def _build_delete_cookie_header(name: str, path: str, secure: bool = False) -> bytes:
     """Build a ``Set-Cookie`` header value that instructs the browser to delete *name*.
 
     Parameters
@@ -153,6 +153,12 @@ def _build_delete_cookie_header(name: str, path: str) -> bytes:
     path
         The cookie path that was used when the cookie was originally set.
         Must match exactly, otherwise the browser will not delete the cookie.
+    secure
+        Whether to include the ``Secure`` flag.  This **must** match the flag
+        that was present when the cookie was originally set — browsers treat
+        ``Secure`` and non-``Secure`` cookies as distinct entries, so omitting
+        it on an HTTPS deployment would leave the stale cookie in place.
+        Pass ``True`` when ``server.sslCertFile`` is configured.
 
     Returns
     -------
@@ -160,9 +166,10 @@ def _build_delete_cookie_header(name: str, path: str) -> bytes:
         The raw header value, ready to be appended to ``headers`` as
         ``(b"set-cookie", value)``.
     """
-    return (
-        f"{name}=; Path={path}; HttpOnly; SameSite=lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
-    ).encode("latin-1")
+    header = f"{name}=; Path={path}; HttpOnly; SameSite=lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    if secure:
+        header += "; Secure"
+    return header.encode("latin-1")
 
 
 class InvalidAuthCookieMiddleware:
@@ -223,15 +230,19 @@ class InvalidAuthCookieMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Determine the cookie path from server configuration so that the
-        # delete directive matches the path used when the cookie was set.
+        # Determine the cookie path and Secure flag from server configuration
+        # so that the delete directive exactly matches the attributes used when
+        # the cookie was originally set.  Browsers treat cookies with and
+        # without the Secure flag as distinct entries — omitting Secure on an
+        # HTTPS deployment would silently fail to delete the stale cookie.
         from streamlit import config as st_config
 
         base_path: str | None = st_config.get_option("server.baseUrlPath")
         cookie_path = ("/" + base_path.strip("/")) if base_path else "/"
+        secure = bool(st_config.get_option("server.sslCertFile"))
 
         delete_headers = [
-            (b"set-cookie", _build_delete_cookie_header(name, cookie_path))
+            (b"set-cookie", _build_delete_cookie_header(name, cookie_path, secure=secure))
             for name in names_to_delete
         ]
 

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -232,6 +232,50 @@ def _get_signed_cookie_with_chunks(
     return get_cookie_with_chunks(get_single_cookie, cookie_name)
 
 
+def _has_unverifiable_auth_cookie(cookies: dict[str, str]) -> bool:
+    """Return True if any auth cookie is present but fails signature verification.
+
+    This detects the Tornado→Starlette upgrade regression (GitHub #15407): a
+    browser that was logged-in under the old Tornado backend (≤1.56) carries
+    cookies signed with Tornado's HMAC scheme, which ``decode_signed_value``
+    (itsdangerous) cannot verify.  The cookie value is non-empty, but decoding
+    returns ``None``.
+
+    Distinguishing "present but unverifiable" from "absent" is important:
+
+    * **Absent** — the user is simply not logged in; proceed normally.
+    * **Present but unverifiable** — the cookie is stale/incompatible; the
+      browser should drop it and reload so the HTTP middleware
+      (``InvalidAuthCookieMiddleware``) can clear it and let the login flow
+      restart cleanly.
+
+    Parameters
+    ----------
+    cookies
+        The WebSocket request cookies as a ``{name: value}`` mapping.
+
+    Returns
+    -------
+    bool
+        ``True`` if at least one auth cookie exists but cannot be verified.
+    """
+    secret = get_cookie_secret()
+    if not secret:
+        return False
+
+    for cookie_name in (USER_COOKIE_NAME, TOKENS_COOKIE_NAME):
+        raw_value = cookies.get(cookie_name)
+        if raw_value is None:
+            continue
+        signed_bytes = raw_value.encode("latin-1")
+        decoded = starlette_app_utils.decode_signed_value(secret, cookie_name, signed_bytes)
+        if decoded is None:
+            # Cookie is present but unverifiable — stale signature scheme.
+            return True
+
+    return False
+
+
 class StarletteClientContext(ClientContext):
     """Starlette-specific implementation of ClientContext.
 
@@ -393,6 +437,34 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                 "Rejecting WebSocket connection from disallowed origin: %s", origin
             )
             await websocket.close(code=1008)  # 1008 = Policy Violation
+            return
+
+        # Detect stale auth cookies from the old Tornado backend (≤1.56) before
+        # accepting the connection.  If a cookie is present but cannot be verified
+        # with the current itsdangerous scheme, the browser still holds a cookie
+        # that was signed by Tornado's incompatible HMAC format (regression #15407).
+        #
+        # Closing before accept() lets the frontend enter its PINGING_SERVER
+        # retry loop, which issues HTTP health-check requests.  Those HTTP
+        # requests pass through InvalidAuthCookieMiddleware, which injects
+        # Set-Cookie delete headers that clear the stale cookies.  The subsequent
+        # WebSocket reconnect then arrives with no auth cookies at all, allowing
+        # the login flow to restart cleanly.
+        #
+        # We use close code 1012 (Service Restart) rather than 1008 (Policy
+        # Violation) because this is a transient, self-healing condition — not a
+        # permanent access denial.  The frontend treats both codes identically
+        # (both trigger PINGING_SERVER), but 1012 is semantically more accurate
+        # and less alarming in browser developer tools.
+        if _has_unverifiable_auth_cookie(dict(websocket.cookies)):
+            _LOGGER.warning(
+                "WebSocket connection rejected: auth cookie(s) are present but "
+                "cannot be verified — they were likely signed by the old Tornado "
+                "backend (Streamlit ≤1.56). The browser will reload and the "
+                "InvalidAuthCookieMiddleware will clear the stale cookies on the "
+                "next HTTP request so the login flow can restart. (Issue #15407)"
+            )
+            await websocket.close(code=1012)  # 1012 = Service Restart (transient)
             return
 
         subprotocol, xsrf_token, existing_session_id = _parse_subprotocols(

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -451,6 +451,13 @@ def create_websocket_handler(runtime: Runtime) -> Any:
         # WebSocket reconnect then arrives with no auth cookies at all, allowing
         # the login flow to restart cleanly.
         #
+        # The frontend FSM (WebsocketConnection.tsx) guarantees this ordering:
+        # CONNECTED → (error/closed) → PINGING_SERVER → (ping succeeded) → CONNECTING
+        # PINGING_SERVER always fires doInitPings(), which hits /_stcore/health over
+        # HTTP *before* a new WebSocket connection is attempted.  This means
+        # InvalidAuthCookieMiddleware is guaranteed to run and clear the stale
+        # cookies in between the 1012 close and the next WebSocket reconnect.
+        #
         # We use close code 1012 (Service Restart) rather than 1008 (Policy
         # Violation) because this is a transient, self-healing condition — not a
         # permanent access denial.  The frontend treats both codes identically

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -292,7 +292,8 @@ def test_create_streamlit_middleware_uses_selective_gzip() -> None:
     """The Streamlit middleware stack should use the selective gzip wrapper."""
     middleware_list = create_streamlit_middleware()
 
-    assert middleware_list[2].cls is SelectiveGZipMiddleware
+    assert any(m.cls is SelectiveGZipMiddleware for m in middleware_list)
+
 
 
 def test_selective_gzip_skips_static_like_paths() -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware_test.py
@@ -1,0 +1,309 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for starlette_invalid_auth_cookie_middleware module.
+
+These tests cover the regression introduced in Streamlit 1.57.0 (GitHub #15407):
+when upgrading from the Tornado backend (≤1.56) to the Starlette backend (≥1.57),
+browsers that were previously logged-in continue to send auth cookies signed by
+Tornado's scheme.  The new Starlette server cannot verify those cookies; without
+the middleware, the app is stuck on the loading screen until the cookies expire.
+"""
+
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from streamlit.web.server.starlette.starlette_app_utils import create_signed_value
+from streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware import (
+    InvalidAuthCookieMiddleware,
+    _cookie_names_to_clear,
+)
+from streamlit.web.server.starlette.starlette_server_config import (
+    TOKENS_COOKIE_NAME,
+    USER_COOKIE_NAME,
+)
+
+if TYPE_CHECKING:
+    pass
+
+_COOKIE_SECRET = "test-cookie-secret"
+_TORNADO_LIKE_VALUE = "2|fake|tornado|signed|cookie|value"  # Unverifiable by Starlette
+
+
+def _make_app() -> Starlette:
+    """Build a minimal Starlette app with InvalidAuthCookieMiddleware for testing."""
+
+    async def root(_request):  # type: ignore[no-untyped-def]
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/", root, methods=["GET"])])
+    app.add_middleware(InvalidAuthCookieMiddleware)
+    return app
+
+
+def _valid_cookie(name: str, value: str = '{"is_logged_in": true}') -> str:
+    """Return a properly signed cookie value (Starlette / itsdangerous scheme)."""
+    signed: bytes = create_signed_value(_COOKIE_SECRET, name, value)
+    return signed.decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _cookie_names_to_clear unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCookieNamesToClear:
+    """Tests for the _cookie_names_to_clear helper."""
+
+    def test_no_auth_cookies_present(self) -> None:
+        """Returns an empty list when no auth cookies are in the request."""
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            result = _cookie_names_to_clear({})
+        assert result == []
+
+    def test_valid_user_cookie_not_cleared(self) -> None:
+        """A properly signed user cookie must NOT be scheduled for deletion."""
+        cookie_value = _valid_cookie(USER_COOKIE_NAME)
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            result = _cookie_names_to_clear({USER_COOKIE_NAME: cookie_value})
+        assert USER_COOKIE_NAME not in result
+
+    def test_invalid_user_cookie_scheduled_for_deletion(self) -> None:
+        """An unverifiable user cookie (e.g. Tornado-signed) is scheduled for deletion."""
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            result = _cookie_names_to_clear({USER_COOKIE_NAME: _TORNADO_LIKE_VALUE})
+        assert USER_COOKIE_NAME in result
+
+    def test_invalid_tokens_cookie_scheduled_for_deletion(self) -> None:
+        """An unverifiable tokens cookie is scheduled for deletion."""
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            result = _cookie_names_to_clear({TOKENS_COOKIE_NAME: _TORNADO_LIKE_VALUE})
+        assert TOKENS_COOKIE_NAME in result
+
+    def test_both_invalid_cookies_scheduled(self) -> None:
+        """Both user and tokens cookies, when invalid, are both scheduled."""
+        cookies = {
+            USER_COOKIE_NAME: _TORNADO_LIKE_VALUE,
+            TOKENS_COOKIE_NAME: _TORNADO_LIKE_VALUE,
+        }
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            result = _cookie_names_to_clear(cookies)
+        assert USER_COOKIE_NAME in result
+        assert TOKENS_COOKIE_NAME in result
+
+    def test_chunk_cookies_included_when_base_is_invalid(self) -> None:
+        """Chunk cookies are also cleared when their base cookie is invalid."""
+        cookies = {
+            USER_COOKIE_NAME: _TORNADO_LIKE_VALUE,
+            f"{USER_COOKIE_NAME}_1": "chunk1",
+            f"{USER_COOKIE_NAME}_2": "chunk2",
+        }
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            result = _cookie_names_to_clear(cookies)
+        assert USER_COOKIE_NAME in result
+        assert f"{USER_COOKIE_NAME}_1" in result
+        assert f"{USER_COOKIE_NAME}_2" in result
+
+    def test_no_secret_returns_empty(self) -> None:
+        """When no cookie secret is configured, no cookies are cleared."""
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value="",
+        ):
+            result = _cookie_names_to_clear({USER_COOKIE_NAME: _TORNADO_LIKE_VALUE})
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via Starlette TestClient
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidAuthCookieMiddleware:
+    """Integration tests for InvalidAuthCookieMiddleware."""
+
+    def test_response_200_without_any_cookies(self) -> None:
+        """Requests without auth cookies are served normally."""
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            response = client.get("/")
+        assert response.status_code == 200
+        # No Set-Cookie header should be added
+        set_cookie_headers = [
+            v
+            for k, v in response.headers.items()
+            if k.lower() == "set-cookie" and "streamlit_user" in v
+        ]
+        assert set_cookie_headers == []
+
+    def test_valid_cookies_not_cleared(self) -> None:
+        """Valid (Starlette-signed) auth cookies are not cleared."""
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            response = client.get(
+                "/",
+                cookies={USER_COOKIE_NAME: _valid_cookie(USER_COOKIE_NAME)},
+            )
+        assert response.status_code == 200
+        # Middleware should not add a delete directive for valid cookies
+        all_set_cookie: list[str] = response.headers.get_list("set-cookie")
+        for header in all_set_cookie:
+            # A delete directive has Max-Age=0; valid cookies must not be deleted
+            assert not ("Max-Age=0" in header and USER_COOKIE_NAME in header)
+
+    def test_invalid_user_cookie_cleared_in_response(self) -> None:
+        """An unverifiable user cookie triggers a Set-Cookie delete directive."""
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            response = client.get(
+                "/",
+                cookies={USER_COOKIE_NAME: _TORNADO_LIKE_VALUE},
+            )
+        assert response.status_code == 200
+
+        # Find all Set-Cookie headers
+        set_cookie_raw = response.headers.get("set-cookie", "")
+        # TestClient may merge; iterate over raw headers
+        all_set_cookie: list[str] = response.headers.get_list("set-cookie")
+
+        # At least one header should delete _streamlit_user with Max-Age=0
+        delete_headers = [h for h in all_set_cookie if USER_COOKIE_NAME in h and "Max-Age=0" in h]
+        assert delete_headers, (
+            f"Expected a Set-Cookie delete directive for {USER_COOKIE_NAME!r} "
+            f"but got: {all_set_cookie}"
+        )
+
+    def test_invalid_tokens_cookie_cleared_in_response(self) -> None:
+        """An unverifiable tokens cookie triggers a Set-Cookie delete directive."""
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            response = client.get(
+                "/",
+                cookies={TOKENS_COOKIE_NAME: _TORNADO_LIKE_VALUE},
+            )
+        assert response.status_code == 200
+
+        all_set_cookie: list[str] = response.headers.get_list("set-cookie")
+
+        delete_headers = [h for h in all_set_cookie if TOKENS_COOKIE_NAME in h and "Max-Age=0" in h]
+        assert delete_headers, (
+            f"Expected a Set-Cookie delete directive for {TOKENS_COOKIE_NAME!r} "
+            f"but got: {all_set_cookie}"
+        )
+
+    def test_websocket_scope_not_affected(self) -> None:
+        """Middleware does not interfere with WebSocket connections."""
+        from starlette.routing import WebSocketRoute
+
+        async def ws_endpoint(websocket):  # type: ignore[no-untyped-def]
+            await websocket.accept()
+            await websocket.send_text("hello")
+            await websocket.close()
+
+        app = Starlette(routes=[Route("/", lambda r: PlainTextResponse("ok")), WebSocketRoute("/ws", ws_endpoint)])
+        app.add_middleware(InvalidAuthCookieMiddleware)
+
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            with TestClient(app) as client:
+                with client.websocket_connect("/ws") as ws:
+                    data = ws.receive_text()
+            assert data == "hello"
+
+    def test_regression_15407_tornado_cookies_cleared_on_first_request(
+        self,
+    ) -> None:
+        """Regression test for GitHub #15407.
+
+        Browsers upgrading from Tornado (<=1.56) to Starlette (>=1.57) retain
+        auth cookies signed by Tornado's scheme.  On the very first request after
+        the upgrade, the middleware must clear those cookies so the login flow can
+        restart cleanly — instead of leaving the app stuck on the loading screen.
+        """
+        # Simulate a Tornado-signed cookie value (unverifiable by itsdangerous)
+        tornado_signed = "2|deadbeef|badc0ffee|1700000000"  # fake Tornado format
+
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ):
+            response = client.get(
+                "/",
+                cookies={
+                    USER_COOKIE_NAME: tornado_signed,
+                    TOKENS_COOKIE_NAME: tornado_signed,
+                },
+            )
+
+        assert response.status_code == 200
+
+        all_set_cookie: list[str] = response.headers.get_list("set-cookie")
+
+        user_deleted = any(
+            USER_COOKIE_NAME in h and "Max-Age=0" in h for h in all_set_cookie
+        )
+        tokens_deleted = any(
+            TOKENS_COOKIE_NAME in h and "Max-Age=0" in h for h in all_set_cookie
+        )
+
+        assert user_deleted, (
+            "Expected middleware to clear the stale Tornado-signed user cookie. "
+            f"Set-Cookie headers seen: {all_set_cookie}"
+        )
+        assert tokens_deleted, (
+            "Expected middleware to clear the stale Tornado-signed tokens cookie. "
+            f"Set-Cookie headers seen: {all_set_cookie}"
+        )

--- a/lib/tests/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_invalid_auth_cookie_middleware_test.py
@@ -307,3 +307,66 @@ class TestInvalidAuthCookieMiddleware:
             "Expected middleware to clear the stale Tornado-signed tokens cookie. "
             f"Set-Cookie headers seen: {all_set_cookie}"
         )
+
+    def test_secure_flag_present_on_https_deployment(self) -> None:
+        """Delete directives include the Secure flag when sslCertFile is configured.
+
+        On HTTPS deployments the original cookies were set with Secure=True.
+        Browsers treat Secure and non-Secure cookies as distinct entries, so
+        a delete directive without Secure will silently fail to remove the
+        stale cookie.
+        """
+        from streamlit.testing.v1.util import patch_config_options
+
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ), patch_config_options({"server.sslCertFile": "/etc/ssl/server.crt"}):
+            response = client.get(
+                "/",
+                cookies={USER_COOKIE_NAME: _TORNADO_LIKE_VALUE},
+            )
+
+        assert response.status_code == 200
+        all_set_cookie: list[str] = response.headers.get_list("set-cookie")
+
+        secure_delete = [
+            h for h in all_set_cookie
+            if USER_COOKIE_NAME in h and "Max-Age=0" in h and "Secure" in h
+        ]
+        assert secure_delete, (
+            "Expected a Secure delete directive for the stale cookie on an HTTPS "
+            f"deployment, but got: {all_set_cookie}"
+        )
+
+    def test_no_secure_flag_on_http_deployment(self) -> None:
+        """Delete directives omit the Secure flag when no sslCertFile is configured.
+
+        On plain-HTTP deployments the original cookies were set without Secure.
+        Adding Secure to the delete directive would target a different cookie
+        entry and leave the actual stale cookie untouched.
+        """
+        from streamlit.testing.v1.util import patch_config_options
+
+        client = TestClient(_make_app())
+        with patch(
+            "streamlit.web.server.starlette.starlette_invalid_auth_cookie_middleware.get_cookie_secret",
+            return_value=_COOKIE_SECRET,
+        ), patch_config_options({"server.sslCertFile": ""}):
+            response = client.get(
+                "/",
+                cookies={USER_COOKIE_NAME: _TORNADO_LIKE_VALUE},
+            )
+
+        assert response.status_code == 200
+        all_set_cookie: list[str] = response.headers.get_list("set-cookie")
+
+        non_secure_delete = [
+            h for h in all_set_cookie
+            if USER_COOKIE_NAME in h and "Max-Age=0" in h and "Secure" not in h
+        ]
+        assert non_secure_delete, (
+            "Expected a non-Secure delete directive for the stale cookie on an HTTP "
+            f"deployment, but got: {all_set_cookie}"
+        )

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -694,3 +694,237 @@ class TestStarletteSessionClientClientContext:
 
         # Cleanup
         await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Tests for _has_unverifiable_auth_cookie and WebSocket stale-cookie
+# early-exit (GitHub issue #15407)
+# ---------------------------------------------------------------------------
+
+from streamlit.web.server.starlette.starlette_websocket import (
+    _has_unverifiable_auth_cookie,
+)
+from streamlit.web.server.starlette.starlette_server_config import (
+    TOKENS_COOKIE_NAME,
+    USER_COOKIE_NAME,
+)
+
+
+class TestHasUnverifiableAuthCookie:
+    """Tests for _has_unverifiable_auth_cookie (regression #15407).
+
+    Verifies that the helper correctly distinguishes between:
+    - No auth cookies present (user is logged out) → False
+    - Valid Starlette-signed cookies present → False
+    - Cookies present but signed by the old Tornado backend → True
+    """
+
+    def test_returns_false_when_no_auth_cookies(self) -> None:
+        """No auth cookies → not a stale-cookie situation."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            assert _has_unverifiable_auth_cookie({}) is False
+            assert _has_unverifiable_auth_cookie({"unrelated_cookie": "value"}) is False
+
+    def test_returns_false_for_valid_user_cookie(self) -> None:
+        """A properly signed user cookie must NOT trigger the stale-cookie path."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            signed = starlette_app_utils.create_signed_value(
+                "test-secret", USER_COOKIE_NAME, '{"is_logged_in": true}'
+            )
+            cookies = {USER_COOKIE_NAME: signed.decode("utf-8")}
+            assert _has_unverifiable_auth_cookie(cookies) is False
+
+    def test_returns_false_for_valid_tokens_cookie(self) -> None:
+        """A properly signed tokens cookie must NOT trigger the stale-cookie path."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            signed = starlette_app_utils.create_signed_value(
+                "test-secret", TOKENS_COOKIE_NAME, '{"access_token": "tok"}'
+            )
+            cookies = {TOKENS_COOKIE_NAME: signed.decode("utf-8")}
+            assert _has_unverifiable_auth_cookie(cookies) is False
+
+    def test_returns_true_for_tornado_style_user_cookie(self) -> None:
+        """A Tornado-signed (unverifiable) user cookie returns True."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            tornado_cookie = "2|deadbeef|badc0ffee|1700000000"
+            cookies = {USER_COOKIE_NAME: tornado_cookie}
+            assert _has_unverifiable_auth_cookie(cookies) is True
+
+    def test_returns_true_for_tornado_style_tokens_cookie(self) -> None:
+        """A Tornado-signed (unverifiable) tokens cookie returns True."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            tornado_cookie = "2|deadbeef|badc0ffee|1700000000"
+            cookies = {TOKENS_COOKIE_NAME: tornado_cookie}
+            assert _has_unverifiable_auth_cookie(cookies) is True
+
+    def test_returns_true_when_any_cookie_is_invalid(self) -> None:
+        """Returns True as soon as the first unverifiable cookie is found."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            valid_signed = starlette_app_utils.create_signed_value(
+                "test-secret", USER_COOKIE_NAME, '{"is_logged_in": true}'
+            )
+            cookies = {
+                USER_COOKIE_NAME: valid_signed.decode("utf-8"),
+                TOKENS_COOKIE_NAME: "2|bad|tornado|cookie",
+            }
+            assert _has_unverifiable_auth_cookie(cookies) is True
+
+    def test_returns_false_when_no_secret_configured(self) -> None:
+        """When no cookie secret is set, the check is skipped entirely."""
+        with patch_config_options({"server.cookieSecret": ""}):
+            cookies = {USER_COOKIE_NAME: "any-value"}
+            assert _has_unverifiable_auth_cookie(cookies) is False
+
+
+class TestWebSocketStaleAuthCookieRejection:
+    """Integration tests for the stale-cookie early-exit in the WebSocket handler.
+
+    Verifies that when a WebSocket arrives carrying unverifiable auth cookies
+    (regression #15407), the server closes the connection before starting a
+    session, allowing the reconnect loop's HTTP health-check requests to trigger
+    InvalidAuthCookieMiddleware and clear the stale cookies.
+    """
+
+    @pytest.mark.anyio
+    async def test_websocket_closed_with_1012_for_stale_cookies(self) -> None:
+        """WebSocket with unverifiable auth cookies is closed with code 1012."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            mock_runtime = MagicMock()
+            handler = create_websocket_handler(mock_runtime)
+
+            mock_websocket = MagicMock()
+            mock_websocket.cookies = {USER_COOKIE_NAME: "2|bad|tornado|cookie"}
+            mock_websocket.headers.get.return_value = "http://localhost"
+            mock_websocket.close = AsyncMock()
+
+            with patch(
+                "streamlit.web.server.starlette.starlette_websocket._is_origin_allowed",
+                return_value=True,
+            ):
+                await handler(mock_websocket)
+
+        # Must be closed with 1012 (Service Restart) — NOT accepted
+        mock_websocket.close.assert_called_once_with(code=1012)
+        mock_websocket.accept.assert_not_called()
+        # No session should be created
+        mock_runtime.connect_session.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_websocket_not_closed_when_no_auth_cookies(self) -> None:
+        """WebSocket with no auth cookies proceeds normally (no stale-cookie close)."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            mock_runtime = MagicMock()
+            mock_runtime.connect_session.return_value = "session-123"
+            handler = create_websocket_handler(mock_runtime)
+
+            mock_websocket = MagicMock()
+            mock_websocket.cookies = {}
+            mock_websocket.headers.get.side_effect = lambda key, default=None: {
+                "Origin": "http://localhost",
+                "Sec-WebSocket-Protocol": "streamlit",
+            }.get(key, default)
+            mock_websocket.headers.__iter__ = MagicMock(return_value=iter([]))
+            mock_websocket.accept = AsyncMock()
+            mock_websocket.receive_bytes = AsyncMock(
+                side_effect=Exception("stop the loop")
+            )
+            mock_websocket.close = AsyncMock()
+
+            with patch(
+                "streamlit.web.server.starlette.starlette_websocket._is_origin_allowed",
+                return_value=True,
+            ):
+                with patch(
+                    "streamlit.web.server.starlette.starlette_websocket.is_xsrf_enabled",
+                    return_value=False,
+                ):
+                    try:
+                        await handler(mock_websocket)
+                    except Exception:
+                        pass  # Expected: receive_bytes raises to stop the loop
+
+        # The connection must have been accepted (not closed early)
+        mock_websocket.accept.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_websocket_not_closed_for_valid_cookies(self) -> None:
+        """WebSocket with valid Starlette-signed cookies proceeds normally."""
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            mock_runtime = MagicMock()
+            mock_runtime.connect_session.return_value = "session-456"
+            handler = create_websocket_handler(mock_runtime)
+
+            valid_signed = starlette_app_utils.create_signed_value(
+                "test-secret", USER_COOKIE_NAME, '{"is_logged_in": true}'
+            ).decode("utf-8")
+
+            mock_websocket = MagicMock()
+            mock_websocket.cookies = {USER_COOKIE_NAME: valid_signed}
+            mock_websocket.headers.get.side_effect = lambda key, default=None: {
+                "Origin": "http://localhost",
+                "Sec-WebSocket-Protocol": "streamlit",
+            }.get(key, default)
+            mock_websocket.headers.__iter__ = MagicMock(return_value=iter([]))
+            mock_websocket.accept = AsyncMock()
+            mock_websocket.receive_bytes = AsyncMock(
+                side_effect=Exception("stop the loop")
+            )
+            mock_websocket.close = AsyncMock()
+
+            with patch(
+                "streamlit.web.server.starlette.starlette_websocket._is_origin_allowed",
+                return_value=True,
+            ):
+                with patch(
+                    "streamlit.web.server.starlette.starlette_websocket.is_xsrf_enabled",
+                    return_value=False,
+                ):
+                    try:
+                        await handler(mock_websocket)
+                    except Exception:
+                        pass  # Expected stop
+
+        # Valid cookies → connection accepted, no premature close with 1012
+        mock_websocket.accept.assert_called_once()
+        for call in mock_websocket.close.call_args_list:
+            assert call.kwargs.get("code") != 1012, (
+                "Valid cookies should not trigger a 1012 close"
+            )
+
+    @pytest.mark.anyio
+    async def test_regression_15407_websocket_stale_tornado_cookies(self) -> None:
+        """Regression test for GitHub #15407 — WebSocket path.
+
+        When upgrading from Tornado (<=1.56) to Starlette (>=1.57), browsers
+        carry auth cookies signed by Tornado's incompatible scheme.  The WebSocket
+        handler must detect these stale cookies and close the connection before
+        starting a session, so the reconnect loop's HTTP health-check requests
+        can trigger InvalidAuthCookieMiddleware to clear them.
+        """
+        with patch_config_options({"server.cookieSecret": "test-secret"}):
+            mock_runtime = MagicMock()
+            handler = create_websocket_handler(mock_runtime)
+
+            # Simulate cookies from a Tornado-signed session (unverifiable format)
+            mock_websocket = MagicMock()
+            mock_websocket.cookies = {
+                USER_COOKIE_NAME: "2|deadbeef|badc0ffee|1700000000",
+                TOKENS_COOKIE_NAME: "2|cafebabe|feedface|1700000001",
+            }
+            mock_websocket.headers.get.return_value = "http://localhost"
+            mock_websocket.close = AsyncMock()
+            mock_websocket.accept = AsyncMock()
+
+            with patch(
+                "streamlit.web.server.starlette.starlette_websocket._is_origin_allowed",
+                return_value=True,
+            ):
+                await handler(mock_websocket)
+
+        # Connection must be rejected before session creation
+        mock_websocket.accept.assert_not_called()
+        mock_runtime.connect_session.assert_not_called()
+        mock_websocket.close.assert_called_once_with(code=1012)


### PR DESCRIPTION
## Problem
Browsers upgrading from Streamlit <=1.56 (Tornado backend) to >=1.57
(Starlette backend) retain auth cookies signed with Tornado's HMAC
scheme. The new Starlette backend cannot verify these cookies, leaving
the app stuck on the loading/login screen for up to 30 days.

## Changes
- Add `InvalidAuthCookieMiddleware` to the Starlette middleware stack;
  injects `Set-Cookie: Max-Age=0` delete directives for any auth cookie
  that is present but fails itsdangerous signature verification
- Add `Secure` flag to delete directives on HTTPS deployments
  (`server.sslCertFile`) so browsers correctly remove Secure-flagged cookies
- Add `_has_unverifiable_auth_cookie()` to `starlette_websocket.py`;
  closes WebSocket connections with code 1012 before `accept()` when stale
  cookies are detected, allowing the frontend PINGING_SERVER retry loop
  to trigger the middleware and clear cookies via HTTP
- Fix `test_create_streamlit_middleware_uses_selective_gzip` to use a
  class lookup instead of a hardcoded index

## Testing
- 15/15 new and existing middleware tests passing
- Full starlette test suite passing

Fixes #15407