### PR TITLE
fix(auth): clear stale Tornado auth cookies after Starlette migration

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -556,14 +556,35 @@ def create_auth_routes(base_url: str) -> list[Route]:
 
     from starlette.routing import Route
 
+    def _clean_stale_cookies(request: Request, response: Response) -> None:
+        cookie_secret = get_cookie_secret()
+        for cookie_name in (USER_COOKIE_NAME, TOKENS_COOKIE_NAME):
+            cookie_value = request.cookies.get(cookie_name)
+            if cookie_value is not None:
+                signed_value = cookie_value.encode("latin-1")
+                if decode_signed_value(cookie_secret, cookie_name, signed_value) is None:
+                    has_set_cookie = any(
+                        cookie_name.encode() in v
+                        for k, v in response.raw_headers
+                        if k.lower() == b"set-cookie"
+                    )
+                    if not has_set_cookie:
+                        response.delete_cookie(cookie_name, path=_get_cookie_path())
+
     async def login(request: Request) -> Response:
-        return await _auth_login(request, base_url)
+        response = await _auth_login(request, base_url)
+        _clean_stale_cookies(request, response)
+        return response
 
     async def logout(request: Request) -> Response:
-        return await _auth_logout(request, base_url)
+        response = await _auth_logout(request, base_url)
+        _clean_stale_cookies(request, response)
+        return response
 
     async def callback(request: Request) -> Response:
-        return await _auth_callback(request, base_url)
+        response = await _auth_callback(request, base_url)
+        _clean_stale_cookies(request, response)
+        return response
 
     return [
         Route(make_url_path(base_url, _ROUTE_AUTH_LOGIN), login, methods=["GET"]),

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -551,39 +551,48 @@ async def _auth_callback(request: Request, base_url: str) -> Response:
     return response
 
 
+def _clean_stale_cookies(
+    request: Request, response: Response, cookie_secret: str
+) -> None:
+    for cookie_name in (USER_COOKIE_NAME, TOKENS_COOKIE_NAME):
+        cookie_value = request.cookies.get(cookie_name)
+        if cookie_value is not None:
+            try:
+                signed_value = cookie_value.encode("latin-1")
+                if decode_signed_value(cookie_secret, cookie_name, signed_value) is not None:
+                    continue
+            except UnicodeEncodeError:
+                pass
+
+            has_set_cookie = any(
+                v.startswith(cookie_name.encode() + b"=")
+                for k, v in response.raw_headers
+                if k.lower() == b"set-cookie"
+            )
+            if not has_set_cookie:
+                response.delete_cookie(cookie_name, path=_get_cookie_path())
+
+
 def create_auth_routes(base_url: str) -> list[Route]:
     """Create all authentication related routes for the Starlette app."""
 
     from starlette.routing import Route
 
-    def _clean_stale_cookies(request: Request, response: Response) -> None:
-        cookie_secret = get_cookie_secret()
-        for cookie_name in (USER_COOKIE_NAME, TOKENS_COOKIE_NAME):
-            cookie_value = request.cookies.get(cookie_name)
-            if cookie_value is not None:
-                signed_value = cookie_value.encode("latin-1")
-                if decode_signed_value(cookie_secret, cookie_name, signed_value) is None:
-                    has_set_cookie = any(
-                        cookie_name.encode() in v
-                        for k, v in response.raw_headers
-                        if k.lower() == b"set-cookie"
-                    )
-                    if not has_set_cookie:
-                        response.delete_cookie(cookie_name, path=_get_cookie_path())
+    cookie_secret = get_cookie_secret()
 
     async def login(request: Request) -> Response:
         response = await _auth_login(request, base_url)
-        _clean_stale_cookies(request, response)
+        _clean_stale_cookies(request, response, cookie_secret)
         return response
 
     async def logout(request: Request) -> Response:
         response = await _auth_logout(request, base_url)
-        _clean_stale_cookies(request, response)
+        _clean_stale_cookies(request, response, cookie_secret)
         return response
 
     async def callback(request: Request) -> Response:
         response = await _auth_callback(request, base_url)
-        _clean_stale_cookies(request, response)
+        _clean_stale_cookies(request, response, cookie_secret)
         return response
 
     return [


### PR DESCRIPTION
## Describe your changes
This PR fixes a regression introduced during the Tornado to Starlette migration where legacy auth cookies (`_streamlit_user` and `_streamlit_user_tokens`) prevent apps from loading.

**The Issue:** When an old Tornado-signed cookie fails signature verification in the new Starlette backend (`decode_signed_value` returns `None`), the server simply ignores it instead of clearing it. This causes the browser to continually re-send the stale cookies, resulting in an infinite loading loop or broken page state for previously logged-in users.

**The Fix:**
I introduced a minimal, localized cleanup helper (`_clean_stale_cookies`) in `starlette_auth_routes.py`. It intercepts requests at the auth endpoints (`login`, `logout`, `callback`). If a stale cookie is present but fails verification, the server explicitly appends a `delete_cookie` header to the Starlette response to clear the client's state (unless a brand new valid cookie was already set during the same request).

## Screenshot or video (only for visual changes)
N/A (Backend authentication fix)

## GitHub Issue Link (if applicable)
Closes #15407

## Testing Plan
- **Explanation of why no additional tests are needed:** This is a localized patch strictly for HTTP response headers to clear invalid legacy client-side state. It does not alter the core auth logic.
- **Unit Tests:** Existing auth tests should pass as normal. 
- **Any manual testing needed?**
  Yes, to verify the migration fix:
  1. Run a Streamlit app using version `1.56.0` (Tornado backend).
  2. Authenticate/login so the Tornado-signed cookies are stored in the browser.
  3. Upgrade the environment to use this PR branch (Starlette backend).
  4. Reload the app. The legacy cookies should be explicitly deleted by the server, allowing the app to load normally without hanging.

---
**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.