### PR TITLE
[refactor] Use frozenset for cached_message_hashes

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -457,7 +457,7 @@ class AppSession:
                 page_name=client_state.page_name,
                 fragment_id=fragment_id or None,
                 is_auto_rerun=client_state.is_auto_rerun,
-                cached_message_hashes=set(client_state.cached_message_hashes),
+                cached_message_hashes=frozenset(client_state.cached_message_hashes),
                 context_info=client_state.context_info,
             )
         else:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -58,7 +58,7 @@ class RerunData:
     # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
     # Hashes of messages that are cached in the client browser:
-    cached_message_hashes: set[str] = field(default_factory=set)
+    cached_message_hashes: frozenset[str] = field(default_factory=frozenset)
     # context_info is used to store information from the user browser (e.g. timezone)
     context_info: ContextInfo | None = None
 

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -204,7 +204,7 @@ class ScriptRunContext:
     on_script_error: OnScriptErrorHandler | None = None
 
     # Hashes of messages that are cached in the client browser:
-    cached_message_hashes: set[str] = field(default_factory=set)
+    cached_message_hashes: frozenset[str] = field(default_factory=frozenset)
     context_info: ContextInfo | None = None
     gather_usage_stats: bool = False
     command_tracking_deactivated: bool = False
@@ -251,7 +251,7 @@ class ScriptRunContext:
         query_string: str = "",
         page_script_hash: str = "",
         fragment_ids_this_run: list[str] | None = None,
-        cached_message_hashes: set[str] | None = None,
+        cached_message_hashes: frozenset[str] | None = None,
         context_info: ContextInfo | None = None,
         # Checked by fragment workers to cease execution.
         yield_check: Callable[[], None] = lambda: None,
@@ -290,7 +290,7 @@ class ScriptRunContext:
         self.fragment_ids_this_run = fragment_ids_this_run
         self.new_fragment_ids.clear()
         self.has_dialog_opened = False
-        self.cached_message_hashes = cached_message_hashes or set()
+        self.cached_message_hashes = frozenset(cached_message_hashes or ())
 
         in_cached_function.set(False)
 

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -163,7 +163,7 @@ def test_st_switch_page_applies_query_params(patched_get_script_run_ctx):
     """Test that providing query_params sets them before rerunning."""
     ctx = MagicMock()
     ctx.query_string = ""
-    ctx.cached_message_hashes = set()
+    ctx.cached_message_hashes = frozenset()
     ctx.context_info = {"foo": "bar"}
     ctx.script_requests = MagicMock()
     ctx.session_state = MagicMock()
@@ -203,7 +203,7 @@ def test_st_switch_page_applies_iterable_query_params(patched_get_script_run_ctx
     """Test that tuple-based query_params are accepted."""
     ctx = MagicMock()
     ctx.query_string = ""
-    ctx.cached_message_hashes = set()
+    ctx.cached_message_hashes = frozenset()
     ctx.context_info = {}
     ctx.script_requests = MagicMock()
     ctx.session_state = MagicMock()
@@ -250,7 +250,7 @@ def test_st_switch_page_rejects_invalid_query_params(patched_get_script_run_ctx)
     ctx.session_state = MagicMock()
     ctx.script_requests = MagicMock()
     ctx.query_string = ""
-    ctx.cached_message_hashes = set()
+    ctx.cached_message_hashes = frozenset()
     ctx.context_info = {}
 
     query_params_cm = MagicMock()

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 def _create_script_run_context(
     fake_enqueue: Callable[[ForwardMsg], None],
     pages_manager: PagesManager | None = None,
-    cached_message_hashes: set[str] | None = None,
+    cached_message_hashes: frozenset[str] | None = None,
 ):
     return ScriptRunContext(
         session_id="TestSessionID",
@@ -58,7 +58,7 @@ def _create_script_run_context(
         user_info={"email": "test@example.com"},
         fragment_storage=MemoryFragmentStorage(),
         pages_manager=pages_manager or PagesManager(""),
-        cached_message_hashes=cached_message_hashes or set(),
+        cached_message_hashes=cached_message_hashes or frozenset(),
     )
 
 
@@ -186,7 +186,7 @@ class ScriptRunContextTest(unittest.TestCase):
             populate_hash_if_needed(cacheable_msg)
             assert bool(cacheable_msg.hash)
             ctx = _create_script_run_context(
-                fake_enqueue, cached_message_hashes={cacheable_msg.hash}
+                fake_enqueue, cached_message_hashes=frozenset({cacheable_msg.hash})
             )
             add_script_run_ctx(ctx=ctx)
             enqueue_message(cacheable_msg)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

`ScriptRunContext.cached_message_hashes` is written once at `ctx.reset()` and only read (via `in`) during `enqueue()`. Switching the type from `set[str]` to `frozenset[str]` makes the write-once/read-many contract explicit at the type level, preventing accidental mutation after initialization with zero runtime overhead.

- Field type and default factory updated across the chain: `RerunData` (`script_requests.py`) → `app_session.py` → `script_runner.py` → `ScriptRunContext` (`script_run_context.py`).
- `reset()` and the `app_session.py` client-state construction now wrap incoming values with `frozenset()`.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional tests are needed: purely a type-level change with no behavior change; existing unit tests for `scriptrunner_utils`, `script_requests`, `app_session`, and `execution_control` cover the affected paths and were updated to use `frozenset`.
- Unit Tests (JS and/or Python): Python unit tests updated/passing.
- E2E Tests: N/A
- Any manual testing needed? N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e42b626d-503e-42d8-9634-e1a59c04b7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e42b626d-503e-42d8-9634-e1a59c04b7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

