### PR TITLE
Fix RST in text status elements

### DIFF
--- a/lib/streamlit/elements/alert.py
+++ b/lib/streamlit/elements/alert.py
@@ -133,6 +133,9 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
         Examples
         --------
         >>> import streamlit as st
@@ -239,6 +242,9 @@ class AlertMixin:
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
 
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
+
         Examples
         --------
         >>> import streamlit as st
@@ -343,6 +349,9 @@ class AlertMixin:
 
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         Examples
         --------
@@ -449,6 +458,9 @@ class AlertMixin:
 
             See the ``body`` parameter of |st.markdown|_ for additional,
             supported Markdown directives.
+
+            .. |st.markdown| replace:: ``st.markdown``
+            .. _st.markdown: https://docs.streamlit.io/develop/api-reference/text/st.markdown
 
         Examples
         --------


### PR DESCRIPTION
## Describe your changes
RST parsing isn't global. Substitutions must (currently) be fully defined in place. This PR adds the missing link substitutions for `st.error`, `st.warning`, `st.info`, and `st.success` that was missing in their title parameter.

## Screenshot or video (only for visual changes)
Without the correction, the parsed RST would show an error message on the docs site:
<img width="1626" height="884" alt="image" src="https://github.com/user-attachments/assets/57ec7c4f-7b81-41b0-874e-0bc16dac8b42" />

## GitHub Issue Link (if applicable)
n/a
streamlit/docs#1483 fixes the docstrings for 1.57 and 1.58, post-release.

## Testing Plan
n/a - docs only.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
