### PR TITLE
Fix: sync widgetMgr to fix tab.open lazy loading

### DIFF
--- a/e2e_playwright/st_tabs.py
+++ b/e2e_playwright/st_tabs.py
@@ -135,17 +135,32 @@ with col3:
 
 prog_tabs = st.tabs(["Alpha", "Beta", "Gamma"], key="prog_tabs", on_change="rerun")
 
+if "prog_tab_counts" not in st.session_state:
+    st.session_state.prog_tab_counts = {"Alpha": 0, "Beta": 0, "Gamma": 0}
+
 if prog_tabs[0].open:
     with prog_tabs[0]:
         st.write("Alpha tab content")
+        if st.button("Increment Alpha", key="inc_alpha"):
+            st.session_state.prog_tab_counts["Alpha"] += 1
 
 if prog_tabs[1].open:
     with prog_tabs[1]:
         st.write("Beta tab content")
+        if st.button("Increment Beta", key="inc_beta"):
+            st.session_state.prog_tab_counts["Beta"] += 1
 
 if prog_tabs[2].open:
     with prog_tabs[2]:
         st.write("Gamma tab content")
+        if st.button("Increment Gamma", key="inc_gamma"):
+            st.session_state.prog_tab_counts["Gamma"] += 1
+
+st.write(
+    f"Prog tab counts - Alpha: {st.session_state.prog_tab_counts['Alpha']}, "
+    f"Beta: {st.session_state.prog_tab_counts['Beta']}, "
+    f"Gamma: {st.session_state.prog_tab_counts['Gamma']}"
+)
 # Key-only (no on_change) — should NOT trigger reruns on tab switch
 # ============================================================================
 

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -213,19 +213,16 @@ def test_programmatic_nav_preserves_lazy_loading(app: Page):
 
     # Step 1: interact with a widget while in Alpha (sets widgetMgr to "Alpha")
     click_button(app, "Increment Alpha")
-    wait_for_app_run(app)
     expect(counts_text).to_contain_text("Alpha: 1")
 
     # Step 2: programmatic nav to Beta via session_state
     click_button(app, "Go to Beta")
-    wait_for_app_run(app)
     expect(prog_tabs.get_by_text("Beta tab content")).to_be_visible()
     expect(prog_tabs.get_by_text("Alpha tab content")).not_to_be_visible()
 
     # Step 3: interact with widget inside Beta — before the fix this silently
     # failed because the stale widgetMgr value caused tab.open=False for Beta
     click_button(app, "Increment Beta")
-    wait_for_app_run(app)
     expect(counts_text).to_contain_text("Beta: 1")
     # Alpha must not have re-executed
     expect(counts_text).to_contain_text("Alpha: 1")

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -200,6 +200,37 @@ def test_dynamic_tabs_programmatic_control(app: Page):
     expect(prog_tabs.get_by_text("Beta tab content")).not_to_be_visible()
 
 
+def test_programmatic_nav_preserves_lazy_loading(app: Page):
+    """Regression test for #15458: tab.open must stay True after programmatic
+    nav followed by a widget interaction in the new tab.
+    """
+    prog_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="Alpha"))
+        .first
+    )
+    counts_text = app.get_by_text("Prog tab counts -", exact=False)
+
+    # Step 1: interact with a widget while in Alpha (sets widgetMgr to "Alpha")
+    click_button(app, "Increment Alpha")
+    wait_for_app_run(app)
+    expect(counts_text).to_contain_text("Alpha: 1")
+
+    # Step 2: programmatic nav to Beta via session_state
+    click_button(app, "Go to Beta")
+    wait_for_app_run(app)
+    expect(prog_tabs.get_by_text("Beta tab content")).to_be_visible()
+    expect(prog_tabs.get_by_text("Alpha tab content")).not_to_be_visible()
+
+    # Step 3: interact with widget inside Beta — before the fix this silently
+    # failed because the stale widgetMgr value caused tab.open=False for Beta
+    click_button(app, "Increment Beta")
+    wait_for_app_run(app)
+    expect(counts_text).to_contain_text("Beta: 1")
+    # Alpha must not have re-executed
+    expect(counts_text).to_contain_text("Alpha: 1")
+
+
 def test_tabs_key_only_does_not_trigger_rerun(app: Page):
     """Test that tabs with key but no on_change does not trigger reruns."""
     rerun_text = app.get_by_text("Tabs key-only rerun count:")

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -389,7 +389,7 @@ describe("st.tabs", () => {
       // so subsequent reruns don't send a stale value and break tab.open (gh issue #15458).
       expect(setStringValueSpy).toHaveBeenCalledWith(
         { id: widgetId, formId: "" },
-        expect.any(String),
+        "Tab 2",
         { fromUi: false },
         undefined
       )

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -377,11 +377,29 @@ describe("st.tabs", () => {
         id: widgetId,
       }
 
+      const setStringValueSpy = vi.spyOn(widgetMgr, "setStringValue")
+
       rerender(<Tabs {...getProps({ node: updatedNode, widgetMgr })} />)
 
       tabs = screen.getAllByRole("tab")
       expect(tabs[2]).toHaveAttribute("aria-selected", "true")
       expect(tabs[0]).toHaveAttribute("aria-selected", "false")
+
+      // The widget manager must be updated with the new tab label and fromUi:false
+      // so subsequent reruns don't send a stale value and break tab.open (gh issue #15458).
+      expect(setStringValueSpy).toHaveBeenCalledWith(
+        { id: widgetId, formId: "" },
+        expect.any(String),
+        { fromUi: false },
+        undefined
+      )
+      // Must NOT use fromUi:true — that would schedule a spurious rerun
+      expect(setStringValueSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        { fromUi: true },
+        expect.anything()
+      )
     })
   })
 

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -200,11 +200,30 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
         if (newLabel) {
           setActiveTabKey(defaultTabIndex)
           activeTabNameRef.current = newLabel
+          // Keep the widget manager in sync with the backend-driven tab change.
+          // Without this, subsequent reruns would send a stale widget value that
+          // overrides session_state, making tab.open return False for the new tab.
+          // fromUi: false avoids scheduling a spurious rerun.
+          if (widgetId && widgetMgr) {
+            widgetMgr.setStringValue(
+              { id: widgetId, formId: "" },
+              newLabel,
+              { fromUi: false },
+              fragmentId
+            )
+          }
         }
         prevDefaultTabIndexRef.current = defaultTabIndex
       }
     }
-  }, [defaultTabIndex, isDynamic, allTabLabels])
+  }, [
+    defaultTabIndex,
+    isDynamic,
+    allTabLabels,
+    widgetId,
+    widgetMgr,
+    fragmentId,
+  ])
 
   // Reconciles active key & tab name when tab list changes.
   // When isPassivelyKeyed, also check elementStates so that the persisted


### PR DESCRIPTION
## Describe your changes
Fixes a regression introduced in #14332 where `tab.open` incorrectly returns `False` after navigating to a tab programmatically (via `st.session_state[key] = tab_label`), breaking lazy-loaded content guarded by `if tab.open:`.

When the backend sends a new `defaultTabIndex` after a programmatic tab switch, the sync effect added in #14332 correctly updates the frontend's visual display (`activeTabKey`) — but it did **not** update the widget manager's string value (`widgetMgr.setStringValue`).
On the _next_ user-initiated rerun (e.g. clicking a button inside the newly visible tab), the frontend sends the **stale** widget value to the backend. `register_widget` uses this stale frontend value, overriding the session state. `current_tab_label` points to the old tab, so `tab.open` returns `False` for the new tab and any lazy-guarded content silently skips execution. 
This affects all dynamic tabs (`on_change="rerun"`) that use programmatic
navigation, regardless of whether the user has ever clicked a tab header.

## GitHub Issue Link
Closes #15458 
