### PR TITLE
[chore] Make /_stcore/metrics memory stats cheap by default

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -834,8 +834,11 @@ _create_option(
         calculate memory usage statistics for the /_stcore/metrics endpoint.
 
         This can be slow for large session state or cached resource objects. If
-        False, Streamlit reports fast proxy values for those objects, and the
-        memory statistics are likely to be incorrect as byte counts.
+        False (the default), Streamlit reports fast proxy values for those
+        objects: item counts (the number of cached entries or session-state
+        keys) rather than byte sizes. The cache_memory_bytes metric will
+        therefore reflect entry counts, not memory consumption, for those
+        objects.
     """,
     default_val=False,
     type_=bool,

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -827,6 +827,20 @@ _create_option(
     type_=str,
 )
 
+_create_option(
+    "server.enableExpensiveMemoryStats",
+    description="""
+        If True, Streamlit will use a recursive object graph traversal to
+        calculate memory usage statistics for the /_stcore/metrics endpoint.
+
+        This can be slow for large session state or cached resource objects. If
+        False, Streamlit reports fast proxy values for those objects, and the
+        memory statistics are likely to be incorrect as byte counts.
+    """,
+    default_val=False,
+    type_=bool,
+)
+
 
 @_create_option("server.cookieSecret", type_=str, sensitive=True)
 @util.memoize

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -33,6 +33,7 @@ from typing import (
 from typing_extensions import ParamSpec
 
 import streamlit as st
+from streamlit import config
 from streamlit.errors import StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
@@ -741,16 +742,24 @@ class ResourceCache(Cache[R]):
         if not cache_entries:
             return {}
 
-        from streamlit.runtime.stats import safe_sizeof
+        if config.get_option("server.enableExpensiveMemoryStats"):
+            from streamlit.runtime.stats import safe_sizeof
+
+            byte_lengths = [safe_sizeof(entry) for entry in cache_entries]
+        else:
+            # Use a cheap item-count proxy instead of traversing the cached
+            # resource objects, which can be very expensive.
+            byte_lengths = [len(cache_entries)]
 
         stats = [
             CacheStat(
                 category_name="st_cache_resource",
                 cache_name=self.display_name,
-                byte_length=safe_sizeof(entry),
+                byte_length=byte_length,
             )
-            for entry in cache_entries
+            for byte_length in byte_lengths
         ]
+
         # In general, get_stats methods need to be able to return only requested stat
         # families, but this method only returns a single family, and we're guaranteed
         # that it was one of those requested if we make it here.

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import threading
 import uuid
 from collections import defaultdict
 from typing import TYPE_CHECKING
@@ -38,6 +39,8 @@ class MemoryUploadedFileManager(UploadedFileManager):
     def __init__(self, upload_endpoint: str) -> None:
         self.file_storage: dict[str, dict[str, UploadedFileRec]] = defaultdict(dict)
         self.endpoint = upload_endpoint
+        self._total_bytes = 0
+        self._lock = threading.Lock()
 
     @property
     def stats_families(self) -> Sequence[str]:
@@ -61,19 +64,25 @@ class MemoryUploadedFileManager(UploadedFileManager):
             A list of URL UploadedFileRec instances, each instance contains information
             about uploaded file.
         """
-        session_storage = self.file_storage[session_id]
-        file_recs = []
+        with self._lock:
+            session_storage = self.file_storage[session_id]
+            file_recs = []
 
-        for file_id in file_ids:
-            file_rec = session_storage.get(file_id, None)
-            if file_rec is not None:
-                file_recs.append(file_rec)
+            for file_id in file_ids:
+                file_rec = session_storage.get(file_id, None)
+                if file_rec is not None:
+                    file_recs.append(file_rec)
 
-        return file_recs
+            return file_recs
 
     def remove_session_files(self, session_id: str) -> None:
         """Remove all files associated with a given session."""
-        self.file_storage.pop(session_id, None)
+        with self._lock:
+            session_storage = self.file_storage.pop(session_id, None)
+            if session_storage is not None:
+                self._total_bytes -= sum(
+                    len(file.data) for file in session_storage.values()
+                )
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -93,13 +102,22 @@ class MemoryUploadedFileManager(UploadedFileManager):
         file
             The file to add.
         """
+        with self._lock:
+            session_storage = self.file_storage[session_id]
+            old_file = session_storage.get(file.file_id)
+            if old_file is not None:
+                self._total_bytes -= len(old_file.data)
 
-        self.file_storage[session_id][file.file_id] = file
+            session_storage[file.file_id] = file
+            self._total_bytes += len(file.data)
 
     def remove_file(self, session_id: str, file_id: str) -> None:
         """Remove file with given file_id associated with a given session."""
-        session_storage = self.file_storage[session_id]
-        session_storage.pop(file_id, None)
+        with self._lock:
+            session_storage = self.file_storage[session_id]
+            file = session_storage.pop(file_id, None)
+            if file is not None:
+                self._total_bytes -= len(file.data)
 
     def get_upload_urls(
         self, session_id: str, file_names: Sequence[str]
@@ -124,25 +142,19 @@ class MemoryUploadedFileManager(UploadedFileManager):
 
         Safe to call from any thread.
         """
-        # Flatten all files into a single list
-        all_files: list[UploadedFileRec] = []
-        # Make copy of self.file_storage for thread safety, to be sure
-        # that main storage won't be changed form other thread
-        file_storage_copy = self.file_storage.copy()
+        with self._lock:
+            total_bytes = self._total_bytes
 
-        for session_storage in file_storage_copy.values():
-            all_files.extend(session_storage.values())
+        if total_bytes == 0:
+            return {}
 
-        stats: list[CacheStat] = [
+        stats = [
             CacheStat(
                 category_name="UploadedFileManager",
                 cache_name="",
-                byte_length=len(file.data),
+                byte_length=total_bytes,
             )
-            for file in all_files
         ]
-        if not stats:
-            return {}
         # In general, get_stats methods need to be able to return only requested stat
         # families, but this method only returns a single family, and we're guaranteed
         # that it was one of those requested if we make it here.

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -40,6 +40,7 @@ class MemoryUploadedFileManager(UploadedFileManager):
         self.file_storage: dict[str, dict[str, UploadedFileRec]] = defaultdict(dict)
         self.endpoint = upload_endpoint
         self._total_bytes = 0
+        self._file_count = 0
         self._lock = threading.Lock()
 
     @property
@@ -65,15 +66,17 @@ class MemoryUploadedFileManager(UploadedFileManager):
             about uploaded file.
         """
         with self._lock:
-            session_storage = self.file_storage[session_id]
-            file_recs = []
+            # Use `.get` instead of indexing so that reading files for an
+            # unknown session does not create an empty entry in the defaultdict.
+            session_storage = self.file_storage.get(session_id)
+            if session_storage is None:
+                return []
 
-            for file_id in file_ids:
-                file_rec = session_storage.get(file_id, None)
-                if file_rec is not None:
-                    file_recs.append(file_rec)
-
-            return file_recs
+            return [
+                file_rec
+                for file_id in file_ids
+                if (file_rec := session_storage.get(file_id)) is not None
+            ]
 
     def remove_session_files(self, session_id: str) -> None:
         """Remove all files associated with a given session."""
@@ -83,6 +86,7 @@ class MemoryUploadedFileManager(UploadedFileManager):
                 self._total_bytes -= sum(
                     len(file.data) for file in session_storage.values()
                 )
+                self._file_count -= len(session_storage)
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -107,6 +111,8 @@ class MemoryUploadedFileManager(UploadedFileManager):
             old_file = session_storage.get(file.file_id)
             if old_file is not None:
                 self._total_bytes -= len(old_file.data)
+            else:
+                self._file_count += 1
 
             session_storage[file.file_id] = file
             self._total_bytes += len(file.data)
@@ -114,10 +120,16 @@ class MemoryUploadedFileManager(UploadedFileManager):
     def remove_file(self, session_id: str, file_id: str) -> None:
         """Remove file with given file_id associated with a given session."""
         with self._lock:
-            session_storage = self.file_storage[session_id]
+            # Use `.get` instead of indexing so that removing a file for an
+            # unknown session does not create an empty entry in the defaultdict.
+            session_storage = self.file_storage.get(session_id)
+            if session_storage is None:
+                return
+
             file = session_storage.pop(file_id, None)
             if file is not None:
                 self._total_bytes -= len(file.data)
+                self._file_count -= 1
 
     def get_upload_urls(
         self, session_id: str, file_names: Sequence[str]
@@ -144,8 +156,12 @@ class MemoryUploadedFileManager(UploadedFileManager):
         """
         with self._lock:
             total_bytes = self._total_bytes
+            file_count = self._file_count
 
-        if total_bytes == 0:
+        # Emit a stat whenever any files are tracked, even if they are all
+        # zero-byte uploads (matching the previous per-file behavior). Gating on
+        # total_bytes alone would drop zero-byte uploads from the metrics.
+        if file_count == 0:
             return {}
 
         stats = [

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1281,9 +1281,16 @@ class SessionState:
     def get_stats(
         self, _family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
-        from streamlit.runtime.stats import safe_sizeof
+        if config.get_option("server.enableExpensiveMemoryStats"):
+            from streamlit.runtime.stats import safe_sizeof
 
-        stat = CacheStat("st_session_state", "", safe_sizeof(self))
+            byte_length = safe_sizeof(self)
+        else:
+            # Use a cheap item-count proxy instead of traversing the session
+            # state values, which can be very expensive.
+            byte_length = len(self)
+
+        stat = CacheStat("st_session_state", "", byte_length)
         # In general, get_stats methods need to be able to return only requested stat
         # families, but this method only returns a single family, and we're guaranteed
         # that it was one of those requested if we make it here.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -787,6 +787,7 @@ class ConfigTest(unittest.TestCase):
                 "server.disconnectedSessionTTL",
                 "server.enableArrowTruncation",
                 "server.enableCORS",
+                "server.enableExpensiveMemoryStats",
                 "server.enableStaticServing",
                 "server.enableWebsocketCompression",
                 "server.websocketPingInterval",

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import threading
 import unittest
-from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -33,24 +32,13 @@ from streamlit.runtime.caching import (
 from streamlit.runtime.caching.hashing import UserHashError
 from streamlit.runtime.scriptrunner import add_script_run_ctx
 from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
-from streamlit.vendor.pympler.asizeof import asizeof
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.element_mocks import (
     ELEMENT_PRODUCER,
     NON_WIDGET_ELEMENTS,
     WIDGET_ELEMENTS,
 )
-from tests.streamlit.runtime.caching.common_cache_test import (
-    as_cached_result as _as_cached_result,
-)
-from tests.testutil import create_mock_script_run_ctx
-
-if TYPE_CHECKING:
-    from streamlit.runtime.caching.cached_message_replay import CachedResult
-
-
-def as_cached_result(value: Any) -> CachedResult:
-    return _as_cached_result(value)
+from tests.testutil import create_mock_script_run_ctx, patch_config_options
 
 
 class CacheResourceTest(unittest.TestCase):
@@ -348,7 +336,7 @@ class CacheResourceStatsProviderTest(unittest.TestCase):
     def test_no_stats(self):
         assert get_resource_cache_stats_provider().get_stats() == {}
 
-    def test_multiple_stats(self):
+    def test_multiple_stats_use_fast_proxy_by_default(self):
         @st.cache_resource(show_spinner=False)
         def foo(count):
             return [3.14] * count
@@ -369,23 +357,62 @@ class CacheResourceStatsProviderTest(unittest.TestCase):
             CacheStat(
                 category_name="st_cache_resource",
                 cache_name=foo_cache_name,
-                byte_length=(
-                    get_byte_length(as_cached_result([3.14]))
-                    + get_byte_length(as_cached_result([3.14] * 53))
-                ),
+                byte_length=2,
             ),
             CacheStat(
                 category_name="st_cache_resource",
                 cache_name=bar_cache_name,
-                byte_length=get_byte_length(as_cached_result(bar())),
+                byte_length=1,
             ),
         ]
 
-        # The order of these is non-deterministic, so check Set equality
-        # instead of List equality
-        stats_dict = get_resource_cache_stats_provider().get_stats()
+        with patch(
+            "streamlit.runtime.stats.safe_sizeof",
+            side_effect=AssertionError("safe_sizeof should not be called"),
+        ):
+            stats_dict = get_resource_cache_stats_provider().get_stats()
+
         assert CACHE_MEMORY_FAMILY in stats_dict
         assert set(expected) == set(stats_dict[CACHE_MEMORY_FAMILY])
+
+    def test_multiple_stats(self):
+        with patch_config_options({"server.enableExpensiveMemoryStats": True}):
+
+            @st.cache_resource(show_spinner=False)
+            def foo(count):
+                return [3.14] * count
+
+            @st.cache_resource(show_spinner=False)
+            def bar():
+                return threading.Lock()
+
+            foo(1)
+            foo(53)
+            bar()
+            bar()
+
+            foo_cache_name = f"{foo.__module__}.{foo.__qualname__}"
+            bar_cache_name = f"{bar.__module__}.{bar.__qualname__}"
+
+            expected = [
+                CacheStat(
+                    category_name="st_cache_resource",
+                    cache_name=foo_cache_name,
+                    byte_length=84,
+                ),
+                CacheStat(
+                    category_name="st_cache_resource",
+                    cache_name=bar_cache_name,
+                    byte_length=42,
+                ),
+            ]
+
+            # The order of these is non-deterministic, so check Set equality
+            # instead of List equality
+            with patch("streamlit.runtime.stats.safe_sizeof", return_value=42):
+                stats_dict = get_resource_cache_stats_provider().get_stats()
+            assert CACHE_MEMORY_FAMILY in stats_dict
+            assert set(expected) == set(stats_dict[CACHE_MEMORY_FAMILY])
 
 
 class CacheResourceMessageReplayTest(DeltaGeneratorTestCase):
@@ -536,8 +563,3 @@ class CacheResourceMessageReplayTest(DeltaGeneratorTestCase):
             first_element.height_config.pixel_height
             == second_element.height_config.pixel_height
         ), "Height config should be identical between original and replayed elements"
-
-
-def get_byte_length(value: Any) -> int:
-    """Return the byte length of the pickled value."""
-    return asizeof(value)

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1166,38 +1166,56 @@ class IsStaleWidgetTests(unittest.TestCase):
 
 
 class SessionStateStatProviderTests(DeltaGeneratorTestCase):
+    def test_session_state_stats_use_fast_proxy_by_default(self):
+        state = _raw_session_state()
+
+        with patch(
+            "streamlit.runtime.stats.safe_sizeof",
+            side_effect=AssertionError("safe_sizeof should not be called"),
+        ):
+            stat = state.get_stats()[CACHE_MEMORY_FAMILY][0]
+            assert stat.category_name == "st_session_state"
+            assert stat.byte_length == 0
+
+            state["foo"] = 2
+            assert state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length == 1
+
+            st.checkbox("checkbox", key="checkbox")
+            assert state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length == 2
+
     def test_session_state_stats(self):
         # TODO: document the values used here. They're somewhat arbitrary -
         #  we don't care about actual byte values, but rather that our
         #  SessionState isn't getting unexpectedly massive.
-        state = _raw_session_state()
-        stat = state.get_stats()[CACHE_MEMORY_FAMILY][0]
-        assert stat.category_name == "st_session_state"
+        with patch_config_options({"server.enableExpensiveMemoryStats": True}):
+            state = _raw_session_state()
+            stat = state.get_stats()[CACHE_MEMORY_FAMILY][0]
+            assert stat.category_name == "st_session_state"
 
-        # The expected size of the session state in bytes.
-        # It composes of the session_state's fields.
-        expected_session_state_size_bytes = 3000
+            # The expected size of the session state in bytes.
+            # It composes of the session_state's fields.
+            expected_session_state_size_bytes = 3000
 
-        init_size = stat.byte_length
-        assert init_size < expected_session_state_size_bytes
+            init_size = stat.byte_length
+            assert init_size < expected_session_state_size_bytes
 
-        state["foo"] = 2
-        new_size = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
-        assert new_size > init_size
-        assert new_size < expected_session_state_size_bytes
+            state["foo"] = 2
+            new_size = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
+            assert new_size > init_size
+            assert new_size < expected_session_state_size_bytes
 
-        state["foo"] = 1
-        new_size_2 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
-        assert new_size_2 == new_size
+            state["foo"] = 1
+            new_size_2 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
+            assert new_size_2 == new_size
 
-        st.checkbox("checkbox", key="checkbox")
-        new_size_3 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
-        assert new_size_3 > new_size_2
-        assert new_size_3 - new_size_2 < expected_session_state_size_bytes
+            st.checkbox("checkbox", key="checkbox")
+            new_size_3 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
+            assert new_size_3 > new_size_2
+            assert new_size_3 - new_size_2 < expected_session_state_size_bytes
 
-        state._compact_state()
-        new_size_4 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
-        assert new_size_4 <= new_size_3
+            state._compact_state()
+            new_size_4 = state.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length
+            assert new_size_4 <= new_size_3
 
 
 def test_session_state_repr_includes_class_and_field_names() -> None:

--- a/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import unittest
 
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
-from streamlit.runtime.stats import CacheStat
+from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
 from streamlit.runtime.uploaded_file_manager import UploadedFileRec
 from tests.exception_capturing_thread import call_on_threads
 
@@ -106,6 +106,30 @@ class UploadedFileManagerTest(unittest.TestCase):
         )
         expected = {expected_stat.family_name: [expected_stat]}
         assert expected == self.mgr.get_stats()
+
+    def test_cache_stats_updates_on_file_replacement_and_removal(self):
+        replacement = UploadedFileRec(
+            file_id=FILE_1.file_id,
+            name="replacement",
+            type="type",
+            data=b"replacement",
+        )
+
+        self.mgr.add_file("session1", FILE_1)
+        self.mgr.add_file("session1", replacement)
+        self.mgr.add_file("session2", FILE_2)
+
+        stats = self.mgr.get_stats()
+        assert stats[CACHE_MEMORY_FAMILY][0].byte_length == len(replacement.data) + len(
+            FILE_2.data
+        )
+
+        self.mgr.remove_file("session2", FILE_2.file_id)
+        stats = self.mgr.get_stats()
+        assert stats[CACHE_MEMORY_FAMILY][0].byte_length == len(replacement.data)
+
+        self.mgr.remove_session_files("session1")
+        assert self.mgr.get_stats() == {}
 
 
 class UploadedFileManagerThreadingTest(unittest.TestCase):
@@ -208,3 +232,39 @@ class UploadedFileManagerThreadingTest(unittest.TestCase):
             assert len(session_files) == 0
 
         call_on_threads(remove_session_files, num_threads=self.NUM_THREADS)
+
+    def test_byte_accounting_is_thread_safe(self):
+        """The tracked total byte count stays consistent under concurrent
+        add/remove operations.
+        """
+        # Each thread adds a file and then removes a different thread's file, so
+        # adds and removes interleave on the shared byte counter.
+        for ii in range(self.NUM_THREADS):
+            self.mgr.add_file(
+                "session",
+                UploadedFileRec(
+                    file_id=f"seed_{ii}", name=f"seed_{ii}", type="type", data=b"123"
+                ),
+            )
+
+        def churn(index: int) -> None:
+            self.mgr.add_file(
+                "session",
+                UploadedFileRec(
+                    file_id=f"id_{index}",
+                    name=f"file_{index}",
+                    type="type",
+                    data=b"12345",
+                ),
+            )
+            self.mgr.remove_file("session", f"seed_{index}")
+
+        call_on_threads(churn, num_threads=self.NUM_THREADS)
+
+        expected_bytes = sum(
+            len(file.data) for file in self.mgr.file_storage["session"].values()
+        )
+        assert self.mgr._total_bytes == expected_bytes
+        assert (
+            self.mgr.get_stats()[CACHE_MEMORY_FAMILY][0].byte_length == expected_bytes
+        )

--- a/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
+++ b/lib/tests/streamlit/runtime/uploaded_file_manager_test.py
@@ -131,6 +131,23 @@ class UploadedFileManagerTest(unittest.TestCase):
         self.mgr.remove_session_files("session1")
         assert self.mgr.get_stats() == {}
 
+    def test_cache_stats_includes_zero_byte_uploads(self):
+        """Zero-byte uploads still produce a stat (not dropped from metrics)."""
+        empty_file = UploadedFileRec(
+            file_id="empty",
+            name="empty",
+            type="type",
+            data=b"",
+        )
+        self.mgr.add_file("session1", empty_file)
+
+        stats = self.mgr.get_stats()
+        assert stats[CACHE_MEMORY_FAMILY][0].byte_length == 0
+
+        # Removing the only file clears the stats again.
+        self.mgr.remove_file("session1", empty_file.file_id)
+        assert self.mgr.get_stats() == {}
+
 
 class UploadedFileManagerThreadingTest(unittest.TestCase):
     # The number of threads to run our tests on


### PR DESCRIPTION
## Describe your changes

Computing `/_stcore/metrics` memory stats currently runs a recursive object-graph traversal (`safe_sizeof`) over session state and `@st.cache_resource` entries, which can be very slow for large objects.

- Adds `server.enableExpensiveMemoryStats` config option (default `False`) to gate the recursive `safe_sizeof` traversal. When disabled, `st_session_state` and `st_cache_resource` report a cheap item-count proxy instead of exact byte sizes. Set to `True` to restore exact byte sizing.
- `MemoryUploadedFileManager` now tracks total bytes incrementally under a lock instead of re-summing all files on every `get_stats` call. Its stats remain exact byte totals (unaffected by the config option).

**Note:** With the default `False`, the `cache_memory_bytes` series for session state and cached resources changes meaning (item counts rather than bytes). `@st.cache_data` is intentionally unchanged since its stats are computed over already-pickled bytes.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/runtime/caching/cache_resource_api_test.py` — fast-proxy default path (asserts `safe_sizeof` not called) and expensive path behind config
  - `lib/tests/streamlit/runtime/state/session_state_test.py` — fast-proxy default and expensive path
  - `lib/tests/streamlit/runtime/uploaded_file_manager_test.py` — incremental byte accounting on replace/remove and under concurrency
  - `lib/tests/streamlit/config_test.py` — new config option registered

Made with [Cursor](https://cursor.com)