### PR TITLE
[test] Guard server cookie names against Community Cloud cookie filtering

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_server_config.py
+++ b/lib/streamlit/web/server/starlette/starlette_server_config.py
@@ -23,8 +23,8 @@ from typing import Final
 # Community Cloud proxy, which only forwards an allowlist of known cookies to the
 # app. A new cookie that is filtered will work locally but silently break on
 # Community Cloud (e.g. st.login via `_streamlit_session`). The guard test in
-# `starlette_server_config_test.py` discovers these constants and will fail to
-# remind you.
+# `starlette_server_config_test.py` discovers these constants and will fail as a
+# reminder when they change.
 
 # Cookie name for storing signed user identity information.
 USER_COOKIE_NAME: Final = "_streamlit_user"

--- a/lib/streamlit/web/server/starlette/starlette_server_config.py
+++ b/lib/streamlit/web/server/starlette/starlette_server_config.py
@@ -18,6 +18,12 @@ from __future__ import annotations
 
 from typing import Final
 
+# IMPORTANT: When adding or renaming a cookie below, ensure it is not filtered
+# out by the Streamlit Community Cloud proxy, which only forwards an allowlist of
+# known cookies to the app. A new cookie that is filtered will work locally but
+# silently break on Community Cloud (e.g. st.login via `_streamlit_session`).
+# The guard test in `starlette_server_config_test.py` will fail to remind you.
+
 # Cookie name for storing signed user identity information.
 USER_COOKIE_NAME: Final = "_streamlit_user"
 # Cookie name for storing signed OAuth tokens (access_token, id_token).

--- a/lib/streamlit/web/server/starlette/starlette_server_config.py
+++ b/lib/streamlit/web/server/starlette/starlette_server_config.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 from typing import Final
 
-# IMPORTANT: When adding or renaming a cookie below, ensure it is not filtered
-# out by the Streamlit Community Cloud proxy, which only forwards an allowlist of
-# known cookies to the app. A new cookie that is filtered will work locally but
-# silently break on Community Cloud (e.g. st.login via `_streamlit_session`).
-# The guard test in `starlette_server_config_test.py` will fail to remind you.
+# IMPORTANT: Define every server cookie name here as a `*_COOKIE_NAME` constant,
+# and when adding or renaming one, ensure it is not filtered out by the Streamlit
+# Community Cloud proxy, which only forwards an allowlist of known cookies to the
+# app. A new cookie that is filtered will work locally but silently break on
+# Community Cloud (e.g. st.login via `_streamlit_session`). The guard test in
+# `starlette_server_config_test.py` discovers these constants and will fail to
+# remind you.
 
 # Cookie name for storing signed user identity information.
 USER_COOKIE_NAME: Final = "_streamlit_user"

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_config_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_config_test.py
@@ -28,6 +28,11 @@ def test_server_cookie_names_match_cloud_allowlist() -> None:
     Community Cloud -- this is exactly what broke ``st.login`` via
     ``_streamlit_session``.
 
+    To catch *added* cookies (not just renamed ones), this discovers every
+    ``*_COOKIE_NAME`` constant in ``starlette_server_config`` rather than listing
+    them by hand. This relies on the convention that all server cookie names are
+    defined there as ``*_COOKIE_NAME`` constants.
+
     If this test fails because you added or renamed a cookie, make sure the new
     cookie is allowlisted by the Community Cloud proxy, then update
     ``expected_cookie_names`` below to match.
@@ -37,10 +42,9 @@ def test_server_cookie_names_match_cloud_allowlist() -> None:
     the base name, so they are intentionally not listed here.
     """
     actual_cookie_names = {
-        starlette_server_config.USER_COOKIE_NAME,
-        starlette_server_config.TOKENS_COOKIE_NAME,
-        starlette_server_config.XSRF_COOKIE_NAME,
-        starlette_server_config.SESSION_COOKIE_NAME,
+        value
+        for name, value in vars(starlette_server_config).items()
+        if name.endswith("_COOKIE_NAME") and isinstance(value, str)
     }
 
     # Keep in sync with the Community Cloud proxy cookie allowlist.

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_config_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_config_test.py
@@ -1,0 +1,58 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for starlette_server_config."""
+
+from __future__ import annotations
+
+from streamlit.web.server.starlette import starlette_server_config
+
+
+def test_server_cookie_names_match_cloud_allowlist() -> None:
+    """Guard that fails when a server cookie is added or renamed.
+
+    The Streamlit Community Cloud proxy only forwards an allowlist of known
+    cookies to the app; any cookie not on it is stripped before the request
+    reaches the app. A new cookie therefore works locally but silently breaks on
+    Community Cloud -- this is exactly what broke ``st.login`` via
+    ``_streamlit_session``.
+
+    If this test fails because you added or renamed a cookie, make sure the new
+    cookie is allowlisted by the Community Cloud proxy, then update
+    ``expected_cookie_names`` below to match.
+
+    Note: this guards the base cookie *names*. Chunk suffixes
+    (``_streamlit_user_1`` etc.) are covered by the proxy's allowlist entry for
+    the base name, so they are intentionally not listed here.
+    """
+    actual_cookie_names = {
+        starlette_server_config.USER_COOKIE_NAME,
+        starlette_server_config.TOKENS_COOKIE_NAME,
+        starlette_server_config.XSRF_COOKIE_NAME,
+        starlette_server_config.SESSION_COOKIE_NAME,
+    }
+
+    # Keep in sync with the Community Cloud proxy cookie allowlist.
+    expected_cookie_names = {
+        "_streamlit_user",
+        "_streamlit_user_tokens",
+        "_streamlit_xsrf",
+        "_streamlit_session",
+    }
+
+    assert actual_cookie_names == expected_cookie_names, (
+        "Server cookie names changed. Ensure the new cookie is allowlisted by "
+        "the Streamlit Community Cloud proxy before updating this test, or it "
+        "will be stripped on Cloud."
+    )


### PR DESCRIPTION
## Describe your changes

The Streamlit Community Cloud proxy only forwards an allowlist of known cookies to the app; any cookie **not** on that allowlist is stripped from the request before it reaches the app pod. A newly added server cookie therefore works locally but **silently breaks on Community Cloud** — which is exactly what happened to `st.login` once the OAuth handshake started relying on the `_streamlit_session` cookie (issue #15455).

This PR adds a lightweight regression guard so the coupling is caught at PR time instead of in production:

- **Guard test** (`starlette_server_config_test.py`): asserts the set of server cookie names matches an explicit expected set. Adding or renaming a cookie fails the test with a message telling the developer to ensure the new cookie is allowlisted by the Community Cloud proxy first.
- **Comment** at the cookie-name definitions in `starlette_server_config.py` documenting the requirement.

No behavior change — this is test/documentation only. The actual Community Cloud allowlist update for `_streamlit_session` is handled separately in the Cloud infra repo.

### Cookie inventory (current Starlette server)

| Cookie | Type |
|---|---|
| `_streamlit_user` | chunked |
| `_streamlit_user_tokens` | chunked |
| `_streamlit_xsrf` | single |
| `_streamlit_session` | single |

## GitHub Issue Link (if applicable)

Related to #15455

## Testing Plan

- New unit test `test_server_cookie_names_match_cloud_allowlist` passes; lint/format clean.