### PR TITLE
Allow required multi-select button groups

### DIFF
--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -636,6 +636,57 @@ describe("ButtonGroup required parameter", () => {
     expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(1)
   })
 
+  it("prevents clearing the last selection when required=true in multi-select mode", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
+      options: simpleOptions,
+      default: [0],
+      required: true,
+    })
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    render(<ButtonGroup {...props} />)
+
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(1)
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
+      props.element,
+      ["apple"],
+      { fromUi: false },
+      undefined
+    )
+
+    const buttons = getButtonGroupButtons()
+
+    await user.click(buttons[0])
+
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledTimes(1)
+  })
+
+  it("allows changing selections when required=true in multi-select mode", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      clickMode: ButtonGroupProto.ClickMode.MULTI_SELECT,
+      options: simpleOptions,
+      default: [0],
+      required: true,
+    })
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    render(<ButtonGroup {...props} />)
+
+    const buttons = getButtonGroupButtons()
+
+    await user.click(buttons[1])
+
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
+      props.element,
+      ["apple", "banana"],
+      { fromUi: true },
+      undefined
+    )
+  })
+
   it("allows changing selection when required=true in single-select mode", async () => {
     const user = userEvent.setup()
     const props = getProps({

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -278,7 +278,7 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
         selectedKeys={selectedKeys}
         onSelectionChange={handleSelectionChange}
         isDisabled={disabled}
-        disallowEmptySelection={required && selectionMode === "single"}
+        disallowEmptySelection={required}
         aria-label={element.label}
         $isPills={isPills}
         $containerWidth={containerWidth}

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -428,12 +428,8 @@ class ButtonGroupMixin:
 
         required : bool
             Whether a selection is required. If this is ``True`` and
-            ``selection_mode="single"``, users cannot deselect an option once
-            one is selected. Clicking an already-selected option does nothing.
-            The default is ``False``.
-
-            If ``required=True`` is used with ``selection_mode="multi"``, an
-            exception is raised.
+            users have selected at least one option, they cannot clear all
+            selections. The default is ``False``.
 
         format_func : function
             Function to modify the display of the options. It receives
@@ -752,12 +748,8 @@ class ButtonGroupMixin:
 
         required : bool
             Whether a selection is required. If this is ``True`` and
-            ``selection_mode="single"``, users cannot deselect an option once
-            one is selected. Clicking an already-selected option does nothing.
-            The default is ``False``.
-
-            If ``required=True`` is used with ``selection_mode="multi"``, an
-            exception is raised.
+            users have selected at least one option, they cannot clear all
+            selections. The default is ``False``.
 
         format_func : function
             Function to modify the display of the options. It receives
@@ -946,13 +938,6 @@ class ButtonGroupMixin:
         bind: BindOption = None,
     ) -> list[V] | V | None:
         maybe_raise_label_warnings(label, label_visibility)
-
-        # Validate required with multi-select
-        if required and selection_mode == "multi":
-            raise StreamlitAPIException(
-                "The `required` argument cannot be used with `selection_mode='multi'`. "
-                "The `required` parameter is only supported for single-select mode."
-            )
 
         # Use str as default format_func
         actual_format_func: Callable[[Any], str] = format_func or str

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -1332,15 +1332,13 @@ class RequiredParameterTest(DeltaGeneratorTestCase):
         assert c.default == [1]
 
     @parameterized.expand([(st.pills,), (st.segmented_control,)])
-    def test_required_with_multi_select_raises_exception(
-        self, command: Callable[..., Any]
-    ):
-        """Test that required=True with selection_mode='multi' raises an exception."""
-        with pytest.raises(
-            StreamlitAPIException,
-            match=r"cannot be used with.*selection_mode='multi'",
-        ):
-            command("label", ["a", "b", "c"], selection_mode="multi", required=True)
+    def test_required_with_multi_select_allowed(self, command: Callable[..., Any]):
+        """Test that required=True with selection_mode='multi' is allowed."""
+        command("label", ["a", "b", "c"], selection_mode="multi", required=True)
+
+        c = self.get_delta_from_queue().new_element.button_group
+        assert c.required is True
+        assert c.click_mode == ButtonGroupProto.ClickMode.MULTI_SELECT
 
     @parameterized.expand([(st.pills,), (st.segmented_control,)])
     def test_required_false_with_multi_select_allowed(

--- a/lib/tests/streamlit/typing/pills_types.py
+++ b/lib/tests/streamlit/typing/pills_types.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
         int | None,  # Explicitly None default still returns V | None
     )
 
-    # Note: required=True with selection_mode="multi" is invalid and raises
-    # StreamlitAPIException at runtime. This combination cannot be caught at
-    # type-check time because the overload fallback accepts it. The validation
-    # is enforced in _internal_button_group() at runtime.
+    assert_type(
+        pills("foo", options, selection_mode="multi", required=True),
+        list[int],
+    )

--- a/lib/tests/streamlit/typing/segmented_control_types.py
+++ b/lib/tests/streamlit/typing/segmented_control_types.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
         int | None,  # Explicitly None default still returns V | None
     )
 
-    # Note: required=True with selection_mode="multi" is invalid and raises
-    # StreamlitAPIException at runtime. This combination cannot be caught at
-    # type-check time because the overload fallback accepts it. The validation
-    # is enforced in _internal_button_group() at runtime.
+    assert_type(
+        segmented_control("foo", options, selection_mode="multi", required=True),
+        list[int],
+    )


### PR DESCRIPTION
## Describe your changes

Allows `required=True` for `st.pills` and `st.segmented_control` when `selection_mode="multi"`.

With this change, multi-select button groups can still start empty, but once the user selects at least one option, the frontend prevents clearing the final selected option.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

Closes #14900

## Testing Plan

- Unit Tests (JS and/or Python)
  - Updated Python button group tests to allow `required=True` with multi-select mode.
  - Added frontend ButtonGroup tests for required multi-select behavior.
  - Updated typing tests for `st.pills` and `st.segmented_control`.

- E2E Tests
  - Not run.

- Any manual testing needed?
  - Not run locally. Verified with:
    - `git diff --check`
    - `python -m py_compile lib/streamlit/elements/widgets/button_group.py lib/tests/streamlit/elements/button_group_test.py lib/tests/streamlit/typing/pills_types.py lib/tests/streamlit/typing/segmented_control_types.py`

Could not run pytest/Vitest locally because this fresh checkout does not have `pytest`, `yarn`, or frontend `node_modules` installed.