### PR TITLE
[fix] Discover installed CCv2 components in AppTest

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -341,7 +341,11 @@ class AppTest:
             MemoryMediaFileStorage("/mock/media")
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
-        mock_runtime.bidi_component_registry = BidiComponentManager()
+        bidi_component_manager = BidiComponentManager()
+        bidi_component_manager.discover_and_register_components(
+            start_file_watching=False
+        )
+        mock_runtime.bidi_component_registry = bidi_component_manager
         Runtime._instance = mock_runtime
         script_cache = ScriptCache()
         # Reset to ensure st.navigation works correctly regardless of prior test state.

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -176,6 +176,9 @@ class AppTest:
         self.args = args
         self.kwargs = kwargs
         self._page_hash = ""
+        # Cache the discovered component manager so installed CCv2 components are
+        # only scanned once per AppTest instance instead of on every rerun.
+        self._bidi_component_manager: BidiComponentManager | None = None
 
         tree = ElementTree()
         tree._runner = self
@@ -341,11 +344,13 @@ class AppTest:
             MemoryMediaFileStorage("/mock/media")
         )
         mock_runtime.cache_storage_manager = MemoryCacheStorageManager()
-        bidi_component_manager = BidiComponentManager()
-        bidi_component_manager.discover_and_register_components(
-            start_file_watching=False
-        )
-        mock_runtime.bidi_component_registry = bidi_component_manager
+        if self._bidi_component_manager is None:
+            bidi_component_manager = BidiComponentManager()
+            bidi_component_manager.discover_and_register_components(
+                start_file_watching=False
+            )
+            self._bidi_component_manager = bidi_component_manager
+        mock_runtime.bidi_component_registry = self._bidi_component_manager
         Runtime._instance = mock_runtime
         script_cache = ScriptCache()
         # Reset to ensure st.navigation works correctly regardless of prior test state.

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -15,13 +15,19 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time
+from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentManifest
 from streamlit.elements.markdown import MARKDOWN_HORIZONTAL_RULE_EXPRESSION
 from streamlit.testing.v1.app_test import AppTest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_alert():
@@ -46,6 +52,43 @@ def test_alert():
     repr(at.info[0])
     repr(at.success[0])
     repr(at.warning[0])
+
+
+def test_app_test_discovers_installed_v2_components_with_file_backed_assets(
+    tmp_path: Path,
+):
+    package_root = tmp_path / "apptest_pkg"
+    asset_dir = package_root / "assets"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "style.css").write_text("#demo { color: purple; }")
+    (asset_dir / "script.js").write_text("console.log('loaded');")
+
+    manifest = ComponentManifest(
+        name="apptest_pkg",
+        version="0.0.1",
+        components=[ComponentConfig(name="demo", asset_dir="assets")],
+    )
+
+    def script():
+        import streamlit as st
+        from streamlit.components.v2 import component
+
+        component(
+            "apptest_pkg.demo",
+            html='<div id="demo">hi</div>',
+            css="style.css",
+            js="script.js",
+        )
+        st.success("Done")
+
+    with patch(
+        "streamlit.components.v2.manifest_scanner.scan_component_manifests",
+        return_value=[(manifest, package_root)],
+    ):
+        at = AppTest.from_function(script).run()
+
+    assert at.success[0].value == "Done"
+    assert not at.exception
 
 
 def test_button():

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -57,6 +57,7 @@ def test_alert():
 def test_app_test_discovers_installed_v2_components_with_file_backed_assets(
     tmp_path: Path,
 ):
+    """Installed CCv2 components with file-backed assets resolve under AppTest."""
     package_root = tmp_path / "apptest_pkg"
     asset_dir = package_root / "assets"
     asset_dir.mkdir(parents=True)
@@ -84,11 +85,16 @@ def test_app_test_discovers_installed_v2_components_with_file_backed_assets(
     with patch(
         "streamlit.components.v2.manifest_scanner.scan_component_manifests",
         return_value=[(manifest, package_root)],
-    ):
-        at = AppTest.from_function(script).run()
+    ) as scan_mock:
+        at = AppTest.from_function(script)
+        at.run()
+        # Rerun to ensure the discovered component manager is cached on the
+        # AppTest instance and components are not rescanned on every rerun.
+        at.run()
 
     assert at.success[0].value == "Done"
     assert not at.exception
+    assert scan_mock.call_count == 1
 
 
 def test_button():


### PR DESCRIPTION
## Describe your changes

`AppTest` constructs its own `BidiComponentManager` but never called `discover_and_register_components`, unlike the real `Runtime`. As a result, installed CCv2 components with file-backed JS/CSS assets (e.g. `streamlit-bokeh`) failed under `AppTest` with `StreamlitAPIException: ... must be declared in pyproject.toml with asset_dir`, while working under `streamlit run`.

- `AppTest._run()` now calls `discover_and_register_components(start_file_watching=False)` on the mock runtime's component manager, matching the existing `DeltaGeneratorTestCase` pattern, so installed v2 components resolve identically under test and under `streamlit run`.

## GitHub Issue Link (if applicable)

- Closes #15484

## Testing Plan

- [x] Unit Tests (Python): `lib/tests/streamlit/testing/element_tree_test.py` — added a test that an installed CCv2 component with file-backed CSS/JS assets resolves successfully under `AppTest`.

Made with [Cursor](https://cursor.com)