### PR TITLE
[feature] Add list support to programmatic secrets

### DIFF
--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -51,7 +51,9 @@ def _validate_secrets_value(value: Any, path: str = "") -> None:
     value
         The value to validate.
     path
-        The dotted path to this value (for error messages).
+        The path to this value (for error messages). Dict keys use dotted
+        notation (e.g. ``outer.inner``) and list elements use bracket indexing
+        (e.g. ``outer.inner[2]``).
 
     Raises
     ------
@@ -447,6 +449,8 @@ class Secrets(Mapping[str, Any]):
         programmatic_secrets
             A dictionary of secrets to merge. Supported value types are:
             ``str``, ``int``, ``float``, ``bool``, ``list``, and nested ``dict``.
+            Lists and dicts are validated recursively, so their elements must
+            themselves be supported secrets types.
 
         Raises
         ------

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -34,8 +34,10 @@ from streamlit.logger import get_logger
 _LOGGER: Final = get_logger(__name__)
 
 # Type alias for programmatic secrets values.
-# Supported types: str, int, float, bool, and nested dicts.
-SecretsValue = str | int | float | bool | dict[str, "SecretsValue"]
+# Supported types: str, int, float, bool, lists, and nested dicts.
+SecretsValue = (
+    str | int | float | bool | list["SecretsValue"] | dict[str, "SecretsValue"]
+)
 
 # Allowed scalar types for secrets values
 _ALLOWED_SCALAR_TYPES: Final[frozenset[type]] = frozenset({str, int, float, bool})
@@ -66,6 +68,10 @@ def _validate_secrets_value(value: Any, path: str = "") -> None:
                 )
             nested_path = f"{path}.{key}" if path else key
             _validate_secrets_value(nested_value, nested_path)
+    elif isinstance(value, list):
+        for index, nested_value in enumerate(value):
+            nested_path = f"{path}[{index}]" if path else f"[{index}]"
+            _validate_secrets_value(nested_value, nested_path)
     # Use type() instead of isinstance() because bool is a subclass of int,
     # and we need to distinguish them for os.environ promotion (bool excluded).
     elif type(value) not in _ALLOWED_SCALAR_TYPES:
@@ -73,7 +79,7 @@ def _validate_secrets_value(value: Any, path: str = "") -> None:
         path_info = f" at '{path}'" if path else ""
         raise TypeError(
             f"Unsupported type '{type_name}'{path_info} in secrets. "
-            f"Allowed types are: str, int, float, bool, and nested dicts."
+            f"Allowed types are: str, int, float, bool, lists, and nested dicts."
         )
 
 
@@ -440,7 +446,7 @@ class Secrets(Mapping[str, Any]):
         ----------
         programmatic_secrets
             A dictionary of secrets to merge. Supported value types are:
-            ``str``, ``int``, ``float``, ``bool``, and nested ``dict``.
+            ``str``, ``int``, ``float``, ``bool``, ``list``, and nested ``dict``.
 
         Raises
         ------

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -272,9 +272,9 @@ class App:
         or another ASGI server, they resolve relative to the current working directory.
     secrets : Mapping[str, SecretsValue] | None
         A dictionary of secrets to make available via ``st.secrets``. Supported
-        value types are: ``str``, ``int``, ``float``, ``bool``, and nested ``dict``.
-        When provided, these secrets are shallow-merged with file-based secrets
-        (programmatic secrets override file-based secrets at the top level).
+        value types are: ``str``, ``int``, ``float``, ``bool``, ``list``, and nested
+        ``dict``. When provided, these secrets are shallow-merged with file-based
+        secrets (programmatic secrets override file-based secrets at the top level).
         Unsupported types raise ``TypeError`` at construction.
     lifespan : Callable[[App], AbstractAsyncContextManager[dict[str, Any] | None]] | None
         Async context manager for startup/shutdown logic. The context manager

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -273,9 +273,11 @@ class App:
     secrets : Mapping[str, SecretsValue] | None
         A dictionary of secrets to make available via ``st.secrets``. Supported
         value types are: ``str``, ``int``, ``float``, ``bool``, ``list``, and nested
-        ``dict``. When provided, these secrets are shallow-merged with file-based
-        secrets (programmatic secrets override file-based secrets at the top level).
-        Unsupported types raise ``TypeError`` at construction.
+        ``dict``. Lists and dicts are validated recursively, so their elements
+        must themselves be supported secrets types. When provided, these secrets
+        are shallow-merged with file-based secrets (programmatic secrets override
+        file-based secrets at the top level). Unsupported types raise
+        ``TypeError`` at construction.
     lifespan : Callable[[App], AbstractAsyncContextManager[dict[str, Any] | None]] | None
         Async context manager for startup/shutdown logic. The context manager
         receives the App instance and can yield a dictionary of state that will

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -731,6 +731,14 @@ class TestValidateSecretsValue:
             pytest.param(3.14, id="float"),
             pytest.param(True, id="bool_true"),
             pytest.param(False, id="bool_false"),
+            pytest.param(["id", "access"], id="list"),
+            pytest.param(
+                {"auth": {"expose_tokens": ["id", "access"]}}, id="nested_list"
+            ),
+            pytest.param(
+                {"sections": [{"name": "primary", "enabled": True}]},
+                id="list_of_dicts",
+            ),
             pytest.param({"level1": {"level2": {"value": "deep"}}}, id="nested_dict"),
             pytest.param(
                 {"mixed": {"str": "a", "int": 1, "float": 2.5, "bool": True}},
@@ -739,7 +747,7 @@ class TestValidateSecretsValue:
         ],
     )
     def test_valid_types_pass_validation(self, value: object) -> None:
-        """Valid scalar types and nested dicts pass validation."""
+        """Valid scalar, list, and nested dict types pass validation."""
         from streamlit.runtime.secrets import _validate_secrets_value
 
         # Should not raise
@@ -748,8 +756,8 @@ class TestValidateSecretsValue:
     @pytest.mark.parametrize(
         ("value", "expected_match"),
         [
-            pytest.param(["a", "b"], "Unsupported type 'list'", id="list"),
             pytest.param(None, "Unsupported type 'NoneType'", id="none"),
+            pytest.param(("a", "b"), "Unsupported type 'tuple'", id="tuple"),
         ],
     )
     def test_invalid_types_raise_typeerror(
@@ -761,12 +769,12 @@ class TestValidateSecretsValue:
         with pytest.raises(TypeError, match=expected_match):
             _validate_secrets_value(value, "key")
 
-    def test_invalid_nested_list_includes_path(self) -> None:
-        """Nested invalid types include the path in the error message."""
+    def test_invalid_nested_list_value_includes_path(self) -> None:
+        """Nested invalid list values include the indexed path in the error message."""
         from streamlit.runtime.secrets import _validate_secrets_value
 
-        with pytest.raises(TypeError, match=r"at 'key\.outer\.inner'"):
-            _validate_secrets_value({"outer": {"inner": [1, 2, 3]}}, "key")
+        with pytest.raises(TypeError, match=r"at 'key\.outer\.inner\[2\]'"):
+            _validate_secrets_value({"outer": {"inner": [1, "ok", None]}}, "key")
 
     def test_invalid_custom_object(self) -> None:
         """Custom objects raise TypeError."""
@@ -854,15 +862,41 @@ class TestMergeProgrammaticSecrets:
 
         assert os.environ[key] == expected_environ
 
-    def test_merge_does_not_promote_dicts_or_bools(self) -> None:
-        """Dict and bool values are not promoted to os.environ."""
+    def test_merge_does_not_promote_dicts_lists_or_bools(self) -> None:
+        """Dict, list, and bool values are not promoted to os.environ."""
         secrets = Secrets()
         secrets.merge_programmatic_secrets(
-            {"dict_key": {"nested": "value"}, "bool_key": True}
+            {
+                "dict_key": {"nested": "value"},
+                "list_key": ["id", "access"],
+                "bool_key": True,
+            }
         )
 
         assert "dict_key" not in os.environ
+        assert "list_key" not in os.environ
         assert "bool_key" not in os.environ
+
+    def test_merge_accepts_list_values(self) -> None:
+        """Programmatic secrets support list values like TOML arrays."""
+        secrets = Secrets()
+
+        secrets.merge_programmatic_secrets(
+            {"auth": {"expose_tokens": ["id", "access"]}}
+        )
+
+        assert secrets["auth"]["expose_tokens"] == ["id", "access"]
+
+    def test_merge_accepts_list_of_dicts(self) -> None:
+        """Lists of dicts round-trip through the store like TOML arrays of tables."""
+        secrets = Secrets()
+
+        secrets.merge_programmatic_secrets(
+            {"sections": [{"name": "primary", "enabled": True}]}
+        )
+
+        assert secrets["sections"][0]["name"] == "primary"
+        assert secrets["sections"][0]["enabled"] is True
 
     def test_merge_replaces_environ_on_override(self) -> None:
         """When overriding a key, the environ value is updated."""
@@ -891,8 +925,8 @@ class TestMergeProgrammaticSecrets:
         """Merging invalid types raises TypeError."""
         secrets = Secrets()
 
-        with pytest.raises(TypeError, match="Unsupported type 'list'"):
-            secrets.merge_programmatic_secrets({"bad": [1, 2, 3]})
+        with pytest.raises(TypeError, match="Unsupported type 'set'"):
+            secrets.merge_programmatic_secrets({"bad": {"unsupported"}})  # type: ignore[dict-item]
 
     def test_merge_validates_top_level_keys_are_strings(self) -> None:
         """Merging with non-string top-level keys raises TypeError."""

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -732,6 +732,7 @@ class TestValidateSecretsValue:
             pytest.param(True, id="bool_true"),
             pytest.param(False, id="bool_false"),
             pytest.param(["id", "access"], id="list"),
+            pytest.param([], id="empty_list"),
             pytest.param(
                 {"auth": {"expose_tokens": ["id", "access"]}}, id="nested_list"
             ),

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -2324,9 +2324,11 @@ class TestAppSecrets:
     @pytest.mark.parametrize(
         ("secrets", "expected_match"),
         [
-            pytest.param({"bad": [1, 2, 3]}, "Unsupported type 'list'", id="list"),
+            pytest.param({"bad": None}, "Unsupported type 'NoneType'", id="none"),
             pytest.param(
-                {"outer": {"inner": [1, 2]}}, r"at 'outer\.inner'", id="nested_list"
+                {"outer": {"inner": [1, None]}},
+                r"at 'outer\.inner\[1\]'",
+                id="nested_none_in_list",
             ),
             pytest.param(
                 {1: "value"}, r"Dictionary keys.*must be strings", id="int_key"
@@ -2371,6 +2373,7 @@ class TestAppSecrets:
             secrets={
                 "api_key": "secret123",
                 "database": {"host": "localhost", "port": 5432},
+                "auth": {"expose_tokens": ["id", "access"]},
             },
         )
 
@@ -2381,6 +2384,7 @@ class TestAppSecrets:
             assert secrets_singleton["api_key"] == "secret123"
             assert secrets_singleton["database"]["host"] == "localhost"
             assert secrets_singleton["database"]["port"] == 5432
+            assert secrets_singleton["auth"]["expose_tokens"] == ["id", "access"]
 
     @patch_config_options(
         {

--- a/specs/2026-04-15-app-secrets-param/product-spec.md
+++ b/specs/2026-04-15-app-secrets-param/product-spec.md
@@ -46,7 +46,7 @@ Add a `secrets` parameter to `st.App`:
 
 ```python
 # Type alias for documentation
-SecretsValue = str | int | float | bool | dict[str, "SecretsValue"]
+SecretsValue = str | int | float | bool | list["SecretsValue"] | dict[str, "SecretsValue"]
 
 class App:
     def __init__(
@@ -67,9 +67,10 @@ class App:
 - `secrets : Mapping[str, SecretsValue] | None`
   A dictionary of secrets to make available via `st.secrets`. Supported value types:
   - `str`, `int`, `float`, `bool` — scalar values
+  - `list[SecretsValue]` — lists of values (recursive)
   - `dict[str, SecretsValue]` — nested sections (recursive)
 
-  Unsupported types (e.g., `list`, `datetime`, custom objects) raise `TypeError` at `App`
+  Unsupported types (e.g., `datetime`, custom objects) raise `TypeError` at `App`
   construction.
 
   When provided, these secrets are **shallow-merged** with file-based secrets: entire top-level
@@ -86,8 +87,8 @@ class App:
    3. Script-level `.streamlit/secrets.toml` (located alongside the main script)
    4. `secrets` parameter passed to `st.App`
 
-2. **Type preservation:** Values retain their Python types (strings, ints, bools, nested dicts).
-   No TOML parsing required.
+2. **Type preservation:** Values retain their Python types (strings, ints, bools, lists, nested
+   dicts). No TOML parsing required.
 
 3. **Environment variable promotion:** Top-level string/int/float secrets are promoted to
    `os.environ` as strings (same behavior as file-based secrets). Note: `int` and `float` values


### PR DESCRIPTION
## Describe your changes

Extends programmatic secrets (`st.App(secrets=...)` / `merge_programmatic_secrets`) to accept `list` values, bringing them to parity with file-based TOML arrays. Lists may recursively contain any supported type.

- `SecretsValue` now includes `list["SecretsValue"]`; validation recurses into list elements and reports an indexed path (e.g. `key.outer.inner[2]`) on error.
- Lists are not promoted to `os.environ` (only top-level scalars are), consistent with existing behavior.

## GitHub Issue Link (if applicable)

<!-- N/A -->

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/runtime/secrets_test.py` — list / nested-list / list-of-dict validation, indexed error paths, env-var promotion exclusion, and store round-tripping
  - `lib/tests/streamlit/web/server/starlette/starlette_app_test.py` — list values via `App(...)` construction and retrieval through `st.secrets`

Made with [Cursor](https://cursor.com)