### PR TITLE
Feature: Internal page navigation support to st.image

### DIFF
--- a/e2e_playwright/st_image_navigation.py
+++ b/e2e_playwright/st_image_navigation.py
@@ -1,0 +1,37 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import streamlit as st
+
+
+def main_page() -> None:
+    st.header("Main Page")
+    st.image(
+        "https://streamlit.io/images/brand/streamlit-logo-secondary-colormark-darktext.png",
+        caption="Click to go to Details",
+        link="page_details",
+    )
+
+
+def details_page() -> None:
+    st.header("Details Page")
+    st.write("Success! Internal navigation via st.image worked.")
+
+
+page_main = st.Page(main_page, title="Home", url_path="page_home")
+page_details = st.Page(details_page, title="Details", url_path="page_details")
+
+pg = st.navigation([page_main, page_details])
+pg.run()

--- a/e2e_playwright/st_image_navigation_test.py
+++ b/e2e_playwright/st_image_navigation_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.shared.app_utils import get_image
+
+
+def test_image_internal_link_navigates_to_page(app: Page) -> None:
+    """Clicking an image with an internal link navigates to the correct page."""
+    linked_image = get_image(app, "Click to go to Details")
+    link_wrapper = linked_image.get_by_test_id("stImageLink")
+
+    expect(link_wrapper).to_be_visible()
+    # Internal links must NOT open in a new tab
+    expect(link_wrapper).not_to_have_attribute("target", "_blank")
+
+    link_wrapper.click()
+
+    expect(app).to_have_url(re.compile(r"/page_details$"))
+    expect(app.get_by_text("Details Page")).to_be_visible()
+    expect(app.get_by_text("Success! Internal navigation via st.image worked.")).to_be_visible()

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -19,6 +19,7 @@ import { fireEvent, screen } from "@testing-library/react"
 import { ImageList as ImageListProto, streamlit } from "@streamlit/protobuf"
 
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
+import { NavigationContext } from "~lib/components/core/NavigationContext"
 import { mockEndpoints } from "~lib/mocks/mocks"
 import { render, renderWithContexts } from "~lib/test_util"
 
@@ -134,6 +135,31 @@ describe("ImageList Element", () => {
 
       const caption = screen.getByTestId("stImageCaption")
       expect(caption).toHaveTextContent("Test caption")
+    })
+
+    it("handles internal links correctly by calling onPageChange without opening a new tab", () => {
+      const mockOnPageChange = vi.fn()
+
+      const props = getProps({
+        imgs: [{ caption: "Internal Image", url: "/media/mockImage1.jpeg" }],
+        link: "details",
+        isInternal: true,
+        pageScriptHash: "hash_123",
+      })
+
+      render(
+        <NavigationContext.Provider value={{ onPageChange: mockOnPageChange } as any}>
+          <ImageList {...props} />
+        </NavigationContext.Provider>
+      )
+
+      const link = screen.getByTestId("stImageLink")
+
+      expect(link).toHaveAttribute("target", "")
+
+      fireEvent.click(link)
+
+      expect(mockOnPageChange).toHaveBeenCalledWith("hash_123")
     })
   })
 

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -101,11 +101,12 @@ const Image = ({
   isInternal?: boolean
   pageScriptHash?: string
 }): ReactElement => {
-  const { onPageChange } = useContext(NavigationContext)
+  const navContext = useContext(NavigationContext)
+  const onPageChange = navContext?.onPageChange
   const crossOrigin = useCrossOriginAttribute(image.url)
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
-    if (isInternal && pageScriptHash) {
+    if (isInternal && pageScriptHash && onPageChange) {
       e.preventDefault()
       onPageChange(pageScriptHash)
     }

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CSSProperties, memo, ReactElement } from "react"
+import { CSSProperties, memo, ReactElement, useContext } from "react"
 
 import { getLogger } from "loglevel"
 
@@ -25,6 +25,7 @@ import {
 } from "@streamlit/protobuf"
 
 import { ElementFullscreenContext } from "~lib/components/shared/ElementFullscreen/ElementFullscreenContext"
+import { NavigationContext } from "~lib/components/core/NavigationContext"
 import withFullScreenWrapper from "~lib/components/shared/FullScreenWrapper/withFullScreenWrapper"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { StyledToolbarElementContainer } from "~lib/components/shared/Toolbar/styled-components"
@@ -87,6 +88,8 @@ const Image = ({
   handleImageError,
   shouldStretch,
   link,
+  isInternal,
+  pageScriptHash,
 }: {
   itemKey: string
   image: ImageProto
@@ -95,8 +98,18 @@ const Image = ({
   handleImageError: (e: React.SyntheticEvent<HTMLImageElement>) => void
   shouldStretch?: boolean
   link?: string
+  isInternal?: boolean
+  pageScriptHash?: string
 }): ReactElement => {
+  const { onPageChange } = useContext(NavigationContext)
   const crossOrigin = useCrossOriginAttribute(image.url)
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+    if (isInternal && pageScriptHash) {
+      e.preventDefault()
+      onPageChange(pageScriptHash)
+    }
+  }
 
   const imageElement = (
     <img
@@ -116,10 +129,11 @@ const Image = ({
       {link ? (
         <StyledImageLink
           href={link}
-          target="_blank"
+          target={isInternal ? "" : "_blank"}
           rel="noreferrer"
           aria-label={image.caption || link}
           data-testid="stImageLink"
+          onClick={handleClick}
         >
           {imageElement}
         </StyledImageLink>
@@ -228,6 +242,8 @@ function ImageList({
               handleImageError={handleImageError}
               shouldStretch={shouldStretch}
               link={element.imgs.length === 1 ? element.link : undefined}
+              isInternal={element.imgs.length === 1 ? element.isInternal : undefined}
+              pageScriptHash={element.imgs.length === 1 ? element.pageScriptHash : undefined}
             />
           )
         )}

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -249,27 +249,35 @@ class ImageMixin:
                     main_script_dir = get_main_script_directory(ctx.main_script_path)
                     requested_page = os.path.realpath(normalize_path_join(main_script_dir, link))
 
-                    page_found = False
+                    matched_page = None
+                    # Exact correspondence by script_path
                     for page_data in all_app_pages.values():
-                        if requested_page == page_data["script_path"]:
-                            page_found = True
-                            # Overwrite the link with the internal routing path
-                            image_list_proto.link = page_data["url_pathname"]
-                            image_list_proto.page_script_hash = page_data["page_script_hash"]
-                            break
-                        if link.strip("/") == page_data.get("url_pathname", "").strip("/"):
-                            page_found = True
-                            image_list_proto.link = page_data["url_pathname"]
-                            image_list_proto.page_script_hash = page_data["page_script_hash"]
+                        if requested_page == os.path.realpath(page_data.get("script_path", "")):
+                            matched_page = page_data
                             break
 
-                    if page_found:
+                    # Fallback to matching by url_pathname
+                    if matched_page is None:
+                        normalized_link = link.strip("/")
+                        for page_data in all_app_pages.values():
+                            page_url = page_data.get("url_pathname", "").strip("/")
+                            if normalized_link == page_url:
+                                matched_page = page_data
+                                break
+
+                    if matched_page is not None:
+                        url_pathname = matched_page["url_pathname"] or "/"
+                        image_list_proto.link = url_pathname
+                        image_list_proto.page_script_hash = matched_page["page_script_hash"]
                         image_list_proto.is_internal = True
                     else:
-                        raise StreamlitAPIException(
-                            f"Could not find internal page: '{link}'. "
-                            "Please provide a valid internal page path or an external URL."
-                        )
+                        # If page is not found, treat it as a standard relative link
+                        image_list_proto.link = link
+                        image_list_proto.is_internal = False
+                else:
+                    # If there is no script run context
+                    image_list_proto.link = link
+                    image_list_proto.is_internal = False
 
         return self.dg._enqueue("imgs", image_list_proto, layout_config=layout_config)
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -35,6 +35,10 @@ from streamlit.elements.lib.image_utils import (
 )
 from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.errors import StreamlitAPIException
+import os
+from streamlit.file_util import get_main_script_directory, normalize_path_join
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.url_util import is_url
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.runtime.metrics_util import gather_metrics
 
@@ -232,7 +236,35 @@ class ImageMixin:
                     "The `link` parameter is only supported when displaying a single image. "
                     f"You passed {len(image_list_proto.imgs)} images."
                 )
-            image_list_proto.link = link
+
+            # If it's a standard external link, behave normally
+            if is_url(link):
+                image_list_proto.link = link
+                image_list_proto.is_internal = False
+            else:
+                # It's not an external URL, so we treat it as an internal page path
+                ctx = get_script_run_ctx()
+                if ctx:
+                    all_app_pages = ctx.pages_manager.get_pages()
+                    main_script_dir = get_main_script_directory(ctx.main_script_path)
+                    requested_page = os.path.realpath(normalize_path_join(main_script_dir, link))
+
+                    page_found = False
+                    for page_data in all_app_pages.values():
+                        if requested_page == page_data["script_path"]:
+                            page_found = True
+                            # Overwrite the link with the internal routing path
+                            image_list_proto.link = page_data["url_pathname"]
+                            image_list_proto.page_script_hash = page_data["page_script_hash"]
+                            break
+
+                    if page_found:
+                        image_list_proto.is_internal = True
+                    else:
+                        raise StreamlitAPIException(
+                            f"Could not find internal page: '{link}'. "
+                            "Please provide a valid internal page path or an external URL."
+                        )
 
         return self.dg._enqueue("imgs", image_list_proto, layout_config=layout_config)
 

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -257,6 +257,11 @@ class ImageMixin:
                             image_list_proto.link = page_data["url_pathname"]
                             image_list_proto.page_script_hash = page_data["page_script_hash"]
                             break
+                        if link.strip("/") == page_data.get("url_pathname", "").strip("/"):
+                            page_found = True
+                            image_list_proto.link = page_data["url_pathname"]
+                            image_list_proto.page_script_hash = page_data["page_script_hash"]
+                            break
 
                     if page_found:
                         image_list_proto.is_internal = True

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -621,24 +621,6 @@ class ImageProtoTest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         assert el.imgs.link == ""
 
-    def test_st_image_with_relative_link(self):
-        """Test st.image with a relative link."""
-        img = Image.new("RGB", (64, 64), color="red")
-
-        st.image(img, link="/my_page")
-
-        el = self.get_delta_from_queue().new_element
-        assert el.imgs.link == "/my_page"
-
-    def test_st_image_with_link_no_scheme(self):
-        """Test st.image with a link without scheme."""
-        img = Image.new("RGB", (64, 64), color="red")
-
-        st.image(img, link="example.com/path")
-
-        el = self.get_delta_from_queue().new_element
-        assert el.imgs.link == "example.com/path"
-
     def test_st_image_link_with_multiple_images(self):
         """Test st.image with link and multiple images raises an error."""
         imgs = [
@@ -651,6 +633,49 @@ class ImageProtoTest(DeltaGeneratorTestCase):
 
         assert "single image" in str(exc_info.value)
         assert "2 images" in str(exc_info.value)
+
+    @mock.patch("streamlit.elements.image.get_script_run_ctx")
+    @mock.patch("streamlit.elements.image.get_main_script_directory")
+    def test_st_image_with_invalid_internal_link(self, mock_get_main_script_dir, mock_get_script_run_ctx):
+        """Testa se st.image dispara erro com um link interno inválido (Sad Path)."""
+        mock_ctx = mock.MagicMock()
+        mock_ctx.pages_manager.get_pages.return_value = {}
+        mock_get_script_run_ctx.return_value = mock_ctx
+        mock_get_main_script_dir.return_value = "/root"
+
+        img = Image.new("RGB", (64, 64), color="red")
+
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st.image(img, link="pages/invalid.py")
+
+        assert "Could not find internal page" in str(exc_info.value)
+
+    @mock.patch("streamlit.elements.image.get_script_run_ctx")
+    @mock.patch("streamlit.elements.image.get_main_script_directory")
+    @mock.patch("os.path.realpath")
+    def test_st_image_with_valid_internal_link(self, mock_realpath, mock_get_main_script_dir, mock_get_script_run_ctx):
+        """Testa se st.image configura as propriedades corretas para um link interno válido (Happy Path)."""
+        mock_ctx = mock.MagicMock()
+        mock_ctx.main_script_path = "/root/main.py"
+        mock_ctx.pages_manager.get_pages.return_value = {
+            "page_hash_123": {
+                "script_path": "/root/pages/details.py",
+                "url_pathname": "details",
+                "page_script_hash": "page_hash_123"
+            }
+        }
+        mock_get_script_run_ctx.return_value = mock_ctx
+        mock_get_main_script_dir.return_value = "/root"
+        mock_realpath.side_effect = lambda x: x
+
+        img = Image.new("RGB", (64, 64), color="red")
+
+        st.image(img, link="pages/details.py")
+
+        el = self.get_delta_from_queue().new_element
+        assert el.imgs.link == "details"
+        assert el.imgs.is_internal is True
+        assert el.imgs.page_script_hash == "page_hash_123"
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/elements/image_test.py
+++ b/lib/tests/streamlit/elements/image_test.py
@@ -645,16 +645,17 @@ class ImageProtoTest(DeltaGeneratorTestCase):
 
         img = Image.new("RGB", (64, 64), color="red")
 
-        with pytest.raises(StreamlitAPIException) as exc_info:
-            st.image(img, link="pages/invalid.py")
+        st.image(img, link="pages/invalid.py")
 
-        assert "Could not find internal page" in str(exc_info.value)
+        el = self.get_delta_from_queue().new_element
+        assert el.imgs.link == "pages/invalid.py"
+        assert el.imgs.is_internal is False
 
     @mock.patch("streamlit.elements.image.get_script_run_ctx")
     @mock.patch("streamlit.elements.image.get_main_script_directory")
     @mock.patch("os.path.realpath")
     def test_st_image_with_valid_internal_link(self, mock_realpath, mock_get_main_script_dir, mock_get_script_run_ctx):
-        """Testa se st.image configura as propriedades corretas para um link interno válido (Happy Path)."""
+        """Tests if st.image sets the correct properties for a valid internal link (Happy Path)."""
         mock_ctx = mock.MagicMock()
         mock_ctx.main_script_path = "/root/main.py"
         mock_ctx.pages_manager.get_pages.return_value = {

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -28,7 +28,7 @@ message Image {
 message ImageList {
   repeated Image imgs = 1;
 
-  // External URL to open when the image is clicked.
+  // URL to open when the image is clicked. Can be an external URL or an internal application path.
   // Only supported when there is exactly one image in the list.
   string link = 3;
 

--- a/proto/streamlit/proto/Image.proto
+++ b/proto/streamlit/proto/Image.proto
@@ -32,5 +32,11 @@ message ImageList {
   // Only supported when there is exactly one image in the list.
   string link = 3;
 
+  // Flag to indicate if the 'link' corresponds to an internal page navigation.
+  bool is_internal = 4;
+
+  // The unique hash of the internal page to navigate.
+  string page_script_hash = 5;
+
   reserved 2;
 }


### PR DESCRIPTION
## Describe your changes
This PR introduces support for internal Single Page Application (SPA) navigation directly through the `st.image` component, bringing its routing capabilities in line with `st.page_link`. 

Previously, passing a link to `st.image` would strictly open a new browser tab with `target="_blank"`. This PR updates the execution flow so that internal pages are recognized and routed smoothly without full page reloads.

**Implementation details:**
* **Protobuf (`Image.proto`):** Added `is_internal` boolean flag and `page_script_hash` string to pass routing context to the frontend.
* **Backend (`image.py`):** Added validation logic to resolve the provided `link` against the `pages_manager`. If a match is found, the hash is attached to the protobuf payload.
* **Frontend (`ImageList.tsx`):** Intercepts the click event. If `isInternal` is true, it prevents the default new-tab behavior and invokes the `NavigationContext`'s `onPageChange` hook for native SPA routing.

## Screenshot or video (only for visual changes)
N/A - Logic and routing behavior enhancement.

## GitHub Issue Link (if applicable)
Closes #14594

## Testing Plan
Added a comprehensive testing suite to validate the full stack:
- **Backend (Pytest):** Added unit tests for both the *Happy Path* (valid internal link correctly sets `page_script_hash` and `is_internal = True`) and the *Sad Path* (invalid internal link raises `StreamlitAPIException`).
- **Frontend (Jest & RTL):** Added tests in `ImageList.test.tsx` to verify that `onPageChange` is called with the correct hash and that the `target` attribute is stripped when `isInternal` is true.
- **E2E (Playwright):** Added a multi-page integration script (`st_image_navigation.py`) and a Playwright test (`st_image_navigation_test.py`) to simulate user clicks and verify URL matching and page rendering without a browser reload.

## Contribution License Agreement
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
