### PR TITLE
[docs] Add parallel fragment guidance to developing-with-streamlit skill

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -87,7 +87,7 @@ Use this routing table to select reference(s). **Always read the reference file*
 
 | User Need | Reference to Read |
 |-----------|-------------------|
-| **App is slow, reruns take too long, or data loads repeatedly** — caching strategies (`st.cache_data`, `st.cache_resource`), `st.fragment` for partial reruns, and avoiding unnecessary recomputation | read `references/performance.md` |
+| **App is slow, reruns take too long, or data loads repeatedly** — caching strategies (`st.cache_data`, `st.cache_resource`), `st.fragment` for partial reruns, `parallel=True` for concurrent fragment execution, and avoiding unnecessary recomputation | read `references/performance.md` |
 | **Building a dashboard with KPIs, metrics, and charts** — composing `st.metric`, charts, and data tables into clean dashboard layouts with columns and containers | read `references/dashboards.md` |
 | **Making an app look polished** — icons (Material Symbols), spacing, color accents, visual hierarchy, and small design touches that elevate quality | read `references/design.md` |
 | **Choosing the right selection widget** — when to use `st.selectbox` vs `st.radio` vs `st.pills` vs `st.segmented_control` vs `st.multiselect`, including modern replacements for deprecated patterns | read `references/selection-widgets.md` |

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -87,7 +87,7 @@ Use this routing table to select reference(s). **Always read the reference file*
 
 | User Need | Reference to Read |
 |-----------|-------------------|
-| **App is slow, reruns take too long, or data loads repeatedly** — caching strategies (`st.cache_data`, `st.cache_resource`), `st.fragment` for partial reruns, `parallel=True` for concurrent fragment execution, and avoiding unnecessary recomputation | read `references/performance.md` |
+| **App is slow, reruns take too long, data loads repeatedly, or work is recomputed unnecessarily** — caching strategies (`st.cache_data`, `st.cache_resource`), `st.fragment` for partial reruns, and (optionally) `parallel=True` when independent fragments can run concurrently | read `references/performance.md` |
 | **Building a dashboard with KPIs, metrics, and charts** — composing `st.metric`, charts, and data tables into clean dashboard layouts with columns and containers | read `references/dashboards.md` |
 | **Making an app look polished** — icons (Material Symbols), spacing, color accents, visual hierarchy, and small design touches that elevate quality | read `references/design.md` |
 | **Choosing the right selection widget** — when to use `st.selectbox` vs `st.radio` vs `st.pills` vs `st.segmented_control` vs `st.multiselect`, including modern replacements for deprecated patterns | read `references/selection-widgets.md` |

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -158,7 +158,7 @@ orders()
 - Each parallel fragment should write to its own Session State keys
 - Avoid unsynchronized mutations of shared mutable objects across fragments
 
-Note: with `run_every`, only the initial full-app run uses parallel execution; subsequent timer-triggered reruns execute sequentially.
+Note: `parallel=True` applies to full-app reruns; `run_every` triggers fragment-scoped reruns, which execute sequentially.
 
 ## Forms to batch interactions
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -158,14 +158,7 @@ These restrictions only apply during the concurrent initial run. After a widget 
 - Avoid unsynchronized mutations of shared mutable objects across fragments
 - `@st.cache_data` and `@st.cache_resource` are thread-safe and work normally
 
-**Combining with `run_every`:**
-```python
-@st.fragment(parallel=True, run_every="30s")
-def live_revenue():
-    st.metric("Revenue", query_revenue())
-```
-
-The initial run executes in parallel; subsequent `run_every` reruns are sequential (single fragment at a time).
+Note: with `run_every`, only the initial full-app run uses parallel execution; subsequent timer-triggered reruns execute sequentially.
 
 ## Forms to batch interactions
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -107,6 +107,69 @@ auto_refresh_metrics()
 
 Use for: live metrics, refresh buttons, interactive charts that don't affect global state.
 
+### Parallel fragments
+
+Use `parallel=True` to run independent fragments concurrently during full app reruns. Each parallel fragment is dispatched to a thread pool, so multiple slow operations overlap instead of running sequentially.
+
+```python
+# BAD: Three slow queries run sequentially (~9s total)
+@st.fragment
+def revenue():
+    st.metric("Revenue", query_revenue())  # ~3s
+
+@st.fragment
+def users():
+    st.metric("Users", query_users())  # ~3s
+
+@st.fragment
+def orders():
+    st.metric("Orders", query_orders())  # ~3s
+
+# GOOD: Three slow queries run concurrently (~3s total)
+@st.fragment(parallel=True)
+def revenue():
+    st.metric("Revenue", query_revenue())
+
+@st.fragment(parallel=True)
+def users():
+    st.metric("Users", query_users())
+
+@st.fragment(parallel=True)
+def orders():
+    st.metric("Orders", query_orders())
+```
+
+**When to use `parallel=True`:**
+- Independent, slow operations (DB queries, API calls, model inference)
+- Multiple fragments that don't depend on each other's output
+- Dashboards with several data sources that each take 1s+
+
+**When NOT to use:**
+- Fast fragments (overhead of threading outweighs benefit)
+- Fragments that depend on each other's Session State writes
+- Fragments that need `st.dialog`, `st.switch_page`, or writing to external containers
+
+**Restrictions during parallel execution (initial page load only):**
+- `st.dialog` — raises error
+- `st.switch_page` — raises error
+- Writing to containers created outside the fragment — raises error
+
+These restrictions only apply during the concurrent initial run. After a widget interaction triggers a fragment rerun, the fragment runs sequentially and all APIs work normally.
+
+**Thread safety rules:**
+- Each parallel fragment should write to its own Session State keys
+- Avoid unsynchronized mutations of shared mutable objects across fragments
+- `@st.cache_data` and `@st.cache_resource` are thread-safe and work normally
+
+**Combining with `run_every`:**
+```python
+@st.fragment(parallel=True, run_every="30s")
+def live_revenue():
+    st.metric("Revenue", query_revenue())
+```
+
+The initial run executes in parallel; subsequent `run_every` reruns are sequential (single fragment at a time).
+
 ## Forms to batch interactions
 
 By default, every widget interaction triggers a full rerun. Use `st.form` to batch multiple inputs and only rerun on submit.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -142,7 +142,6 @@ def orders():
 **When to use `parallel=True`:**
 - Independent, slow operations (DB queries, API calls, model inference)
 - Multiple fragments that don't depend on each other's output
-- Dashboards with several data sources that each take 1s+
 
 **When NOT to use:**
 - Fragments that depend on each other's Session State writes

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -125,6 +125,10 @@ def users():
 def orders():
     st.metric("Orders", query_orders())  # ~3s
 
+revenue()
+users()
+orders()
+
 # GOOD: Three slow queries run concurrently (~3s total)
 @st.fragment(parallel=True)
 def revenue():
@@ -137,6 +141,10 @@ def users():
 @st.fragment(parallel=True)
 def orders():
     st.metric("Orders", query_orders())
+
+revenue()
+users()
+orders()
 ```
 
 **When to use `parallel=True`:**

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -149,7 +149,6 @@ def orders():
 **Thread safety rules:**
 - Each parallel fragment should write to its own Session State keys
 - Avoid unsynchronized mutations of shared mutable objects across fragments
-- `@st.cache_data` and `@st.cache_resource` are thread-safe and work normally
 
 Note: with `run_every`, only the initial full-app run uses parallel execution; subsequent timer-triggered reruns execute sequentially.
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -146,13 +146,6 @@ def orders():
 **When NOT to use:**
 - Fragments that depend on each other's Session State writes
 
-**Restrictions during parallel execution (initial page load only):**
-- `st.dialog` — raises error
-- `st.switch_page` — raises error
-- Writing to containers created outside the fragment — raises error
-
-These restrictions only apply during the concurrent initial run. After a widget interaction triggers a fragment rerun, the fragment runs sequentially and all APIs work normally.
-
 **Thread safety rules:**
 - Each parallel fragment should write to its own Session State keys
 - Avoid unsynchronized mutations of shared mutable objects across fragments

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -145,9 +145,7 @@ def orders():
 - Dashboards with several data sources that each take 1s+
 
 **When NOT to use:**
-- Fast fragments (overhead of threading outweighs benefit)
 - Fragments that depend on each other's Session State writes
-- Fragments that need `st.dialog`, `st.switch_page`, or writing to external containers
 
 **Restrictions during parallel execution (initial page load only):**
 - `st.dialog` — raises error


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Adds `parallel=True` fragment guidance to the `developing-with-streamlit` agent skill's performance reference.

- New "Parallel fragments" subsection in `references/performance.md` covering when to use, restrictions, thread safety, and `run_every` interaction
- Updated SKILL.md routing table to mention parallel/concurrent fragment execution

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Documentation-only change (markdown files); no additional tests needed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a0c76f6-2b54-495c-ae35-9e396878234c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0c76f6-2b54-495c-ae35-9e396878234c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

