### PR TITLE
[skills] Note st.status state constraint and render-on-load guidance

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
@@ -128,6 +128,8 @@ with st.chat_message("assistant"):
 
 - Keep `type="step"` containers consecutive. Any other element between them—including an invisible `st.empty()`—starts a new timeline segment.
 - A step with no content also ends the timeline, which is useful to split a chain into segments—not as a dummy "done" node before the answer.
+- `state` must be `"running"` (default), `"complete"`, or `"error"`—any other value raises an error, including via `status.update(state=...)`.
+- Put the status where the work runs so its steps appear as the task runs. Don't gate it behind a button whose only job is to launch the task—running it in response to real input, for example `if prompt := st.chat_input(...)`, is the normal case.
 
 ## Chat message avatars
 


### PR DESCRIPTION
## What

Adds two bullets to the "Thinking and agent steps" section of `references/chat-ui.md`: the valid set for `state`, and guidance to put the status where the work runs rather than behind a button whose only job is to launch the task.

## Why this PR shrank

It originally added a full "Agent reasoning / status indicators" section plus a `SKILL.md` routing row, to fix a misroute where the skill pulled agents toward status *badges* in `design.md` (`:material/` icons + `st.info`/`st.success`) instead of `st.status`. In a 10-trial run the skill arm scored 1/5 on "uses `st.status`" against 5/5 for the no-skill baseline — the skill was making agents worse here.

#16558 (merged 2026-08-21) has since added a "Thinking and agent steps" section covering `type="compact"`, `type="step"`, `:shimmer[...]` running labels, and step nesting, and updated the `SKILL.md` routing row to name agentic UIs. That closes the misroute this PR was opened for.

The original diff is therefore redundant, and in two places now conflicts with `develop`: it enumerated `type` as `"default"`/`"compact"` (predating `type="step"`), and it treated `st.expander` as always-wrong for this pattern, which `develop` now explicitly sanctions for static replay.

What remains is the two facts #16558 does not cover. Both were part of the already-approved diff, so this is a strict reduction of it. Dropping the `SKILL.md` row also resolves the two review comments asking for `type="compact"` to come out of that row, and matches `lib/streamlit/.agents/skills/AGENTS.md` ("create a new reference page and corresponding `SKILL.md` routing entry only when explicitly instructed").

## Correction carried in

The earlier wording said an invalid `state` raises `StreamlitAPIException`. Source raises `StreamlitValueError`, which is a subclass of it — so the old text was true but named the wrong concrete type. The bullet now states the valid set without naming a class, which stays correct across refactors.

## Testing

Docs-only, no code paths touched. The `state` claim is verified against `lib/streamlit/elements/lib/mutable_status_container.py`: `States: TypeAlias = Literal["running", "complete", "error"]`, enforced in both the `status()` constructor and `StatusContainer.update()`. Confirmed `references/chat-ui.md` has no bundled mirror needing the same edit.

## Superseded eval

The paired eval (`status-compact-for-agents`) was retired in cortex PR #3142.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent skill reference; no runtime code paths.
> 
> **Overview**
> Adds two bullets under **Thinking and agent steps** in `chat-ui.md`.
> 
> The first documents that `st.status` `state` (including `status.update(state=...)`) must be `"running"`, `"complete"`, or `"error"`, and that any other value raises an error.
> 
> The second advises placing the status where the work actually runs so steps show live—e.g. on `st.chat_input`—instead of hiding it behind a button whose only purpose is to start the task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd446b7b247c6b790d0662a5a517f828ef841ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->