### PR TITLE
[fix] Stabilize flaky widget_state border snapshot test

### DIFF
--- a/e2e_playwright/widget_state.py
+++ b/e2e_playwright/widget_state.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import time
 
 import streamlit as st
@@ -79,7 +80,12 @@ with st.container(key="widget_container"):
         st.text_input("st.text_input", disabled=disabled)
         st.text_area("st.text_area", disabled=disabled)
     with col3:
-        st.time_input("st.time_input", disabled=disabled)
-        st.date_input("st.date_input", disabled=disabled)
+        # Use fixed value/date so the snapshot is deterministic. The defaults
+        # ("now"/"today") render the current time/date, which changes between
+        # runs and causes flaky snapshot mismatches.
+        st.time_input("st.time_input", value=datetime.time(4, 45), disabled=disabled)
+        st.date_input(
+            "st.date_input", value=datetime.date(2026, 6, 3), disabled=disabled
+        )
         st.chat_input("st.chat_input", disabled=disabled)
         st.audio_input("st.audio_input", disabled=disabled)


### PR DESCRIPTION
## Describe your changes

Fixes intermittent snapshot mismatches in `test_show_widget_border_when_enabled` (and the sibling `_when_disabled` test) in `widget_state_test.py`.

The snapshotted container included `st.time_input` and `st.date_input` using their non-deterministic defaults (`"now"` / `"today"`). The time display changes every minute, so the committed baseline drifts from later CI runs (the reported `~0.21%` pixel diff matched changed time digits). This is confirmed by the three committed `_when_enabled` baselines each showing a different time (chromium `04:45`, firefox `04:50`, webkit `04:44`).

- Pass fixed `value` to `st.time_input` (`04:45`) and `st.date_input` (`2026/06/03`) so rendering is deterministic.

## Testing Plan

- Documentation/test-only change; no library behavior modified.
- `e2e_playwright/widget_state_test.py` — existing border snapshot tests now render deterministically (verified stable across repeated local chromium runs).
- Note: the Linux `firefox`/`webkit` baselines (and `_when_disabled`) need regeneration via the `update-snapshots` label since the hardcoded time differs from their originally captured times.

Made with [Cursor](https://cursor.com)