### PR TITLE
Fix: `st.pills` & `st.segmented_control` callback

### DIFF
--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -213,10 +213,11 @@ if st.toggle("Update pills props"):
         # mango is at index 0 here, default is index 1 (papaya)
         options=["mango", "papaya", "grape", "apple"],
         selection_mode="single",
-        # Changing format_func is allowed, but selection is based on the
-        # formatted string labels. If the formatted label changes (e.g.,
-        # "Apple" vs "APPLE"), previously selected options may become
-        # unselected.
+        # format_func can be changed dynamically. When the *same* raw options are
+        # kept and only the display labels change, the selection falls back to the
+        # default (not deselected entirely). When options change AND format_func
+        # produces a label that no longer matches the old selection, the same
+        # fallback-to-default behaviour applies.
         format_func=lambda x: x.capitalize(),
     )
     st.write("Updated pills value:", dyn_val)
@@ -319,3 +320,43 @@ not_required = st.pills(
     key="pills_not_required",
 )
 st.text(f"not_required: {not_required}")
+
+# --- Dynamic format_func (gh-15493 regression) ---
+# Regression test: changing format_func (e.g. a language switch) with the same
+# raw options must NOT trigger the on_change callback and must keep the pill
+# visually selected at the correct (translated) label.
+
+st.header("Pills - dynamic format_func")
+
+_fmt_map = {
+    "en": {"A": "apple", "B": "orange"},
+    "es": {"A": "manzana", "B": "naranja"},
+}
+_lang = st.session_state.get("dynamic_fmt_lang", "en")
+_fmt = _fmt_map[_lang]
+
+if "dynamic_fmt_callback_count" not in st.session_state:
+    st.session_state["dynamic_fmt_callback_count"] = 0
+
+
+def _on_dynamic_fmt_change() -> None:
+    st.session_state["dynamic_fmt_callback_count"] += 1
+    st.session_state["dynamic_fmt_last_value"] = st.session_state["dynamic_fmt_pills"]
+
+
+dynamic_fmt_val = st.pills(
+    "Dynamic format_func pills",
+    options=["A", "B"],
+    format_func=lambda x: _fmt[x],
+    default="A",
+    key="dynamic_fmt_pills",
+    on_change=_on_dynamic_fmt_change,
+)
+st.text(f"dynamic_fmt_pills value: {dynamic_fmt_val}")
+st.text(f"dynamic_fmt_callback_count: {st.session_state['dynamic_fmt_callback_count']}")
+st.text(
+    f"dynamic_fmt_last_value: {st.session_state.get('dynamic_fmt_last_value', 'none')}"
+)
+
+if st.button("Switch to ES", key="switch_to_es_btn"):
+    st.session_state["dynamic_fmt_lang"] = "es"

--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -360,3 +360,4 @@ st.text(
 
 if st.button("Switch to ES", key="switch_to_es_btn"):
     st.session_state["dynamic_fmt_lang"] = "es"
+    st.rerun()

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -349,7 +349,7 @@ def test_dynamic_format_func_preserves_selection_and_suppresses_callback(
 
     # Step 1: EN mode - "apple" is selected, no callback yet
     apple_btn = get_pill_button(dynamic_fmt_section, "apple")
-    expect(apple_btn).to_have_attribute("data-selected", "")
+    expect(apple_btn).to_have_attribute("data-selected", "true")
     expect_text(app, "dynamic_fmt_pills value: A")
     expect_text(app, "dynamic_fmt_callback_count: 0")
 
@@ -358,7 +358,7 @@ def test_dynamic_format_func_preserves_selection_and_suppresses_callback(
 
     # "manzana" (translated "apple") must be selected - no deselection flash
     manzana_btn = get_pill_button(dynamic_fmt_section, "manzana")
-    expect(manzana_btn).to_have_attribute("data-selected", "")
+    expect(manzana_btn).to_have_attribute("data-selected", "true")
     # Negative assertion: "apple" must not appear in the widget (labels changed)
     expect(dynamic_fmt_section).not_to_contain_text("apple")
     # Primary bug fix: callback must NOT have fired
@@ -374,7 +374,7 @@ def test_dynamic_format_func_preserves_selection_and_suppresses_callback(
     expect_text(app, "dynamic_fmt_last_value: B")
     expect_text(app, "dynamic_fmt_pills value: B")
     naranja_btn = get_pill_button(dynamic_fmt_section, "naranja")
-    expect(naranja_btn).to_have_attribute("data-selected", "")
+    expect(naranja_btn).to_have_attribute("data-selected", "true")
 
 
 # --- Query parameter binding tests ---

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -323,6 +323,60 @@ def test_dynamic_pills_props(app: Page, assert_snapshot: ImageCompareFunction):
     expect_prefixed_markdown(app, "Initial pills value:", "mango")
 
 
+# --- Dynamic format_func tests (gh-15493 regression) ---
+
+
+def test_dynamic_format_func_preserves_selection_and_suppresses_callback(
+    app: Page,
+):
+    """Changing format_func alone must not fire on_change or deselect the pill.
+
+    Regression test for gh-15493: when format_func changes (e.g. a language
+    switch) with the same raw options, the on_change callback must NOT fire and
+    the pill must remain visually selected at the new translated label.
+
+    Steps
+    -----
+    1. EN mode: verify "apple" pill is selected, callback_count == 0.
+    2. Click "Switch to ES": same raw options, format_func now maps A -> manzana.
+       - Pill must show "manzana" as selected (visual fix).
+       - callback_count must still be 0 (primary bug fix).
+    3. Click "naranja" (option B): callback fires once, value must be "B" (raw
+       option key), not the formatted string "naranja".
+    """
+    dynamic_fmt_section = get_element_by_key(app, "dynamic_fmt_pills")
+    expect(dynamic_fmt_section).to_be_visible()
+
+    # Step 1: EN mode - "apple" is selected, no callback yet
+    apple_btn = get_pill_button(dynamic_fmt_section, "apple")
+    expect(apple_btn).to_have_attribute("data-selected", "")
+    expect_text(app, "dynamic_fmt_pills value: A")
+    expect_text(app, "dynamic_fmt_callback_count: 0")
+
+    # Step 2: switch to ES by clicking the button - format_func changes, options don't
+    click_button(app, "Switch to ES")
+
+    # "manzana" (translated "apple") must be selected - no deselection flash
+    manzana_btn = get_pill_button(dynamic_fmt_section, "manzana")
+    expect(manzana_btn).to_have_attribute("data-selected", "")
+    # Negative assertion: "apple" must not appear in the widget (labels changed)
+    expect(dynamic_fmt_section).not_to_contain_text("apple")
+    # Primary bug fix: callback must NOT have fired
+    expect_text(app, "dynamic_fmt_callback_count: 0")
+    expect_text(app, "dynamic_fmt_pills value: A")
+
+    # Step 3: user selects "naranja" (option B) - callback should fire once
+    get_pill_button(dynamic_fmt_section, "naranja").click()
+    wait_for_app_run(app)
+
+    expect_text(app, "dynamic_fmt_callback_count: 1")
+    # The callback value must be the original option key "B", not the display string
+    expect_text(app, "dynamic_fmt_last_value: B")
+    expect_text(app, "dynamic_fmt_pills value: B")
+    naranja_btn = get_pill_button(dynamic_fmt_section, "naranja")
+    expect(naranja_btn).to_have_attribute("data-selected", "")
+
+
 # --- Query parameter binding tests ---
 
 

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -491,7 +491,7 @@ describe("ButtonGroup widget", () => {
     )
   })
 
-  it("resets to default when options change and stored value is stale", async () => {
+  it("resets to default when options change and stored value is stale", () => {
     // Simulate EN options: "apple" and "orange"
     const enOptions = [
       ButtonGroupProto.Option.create({ content: "apple" }),

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.test.tsx
@@ -490,6 +490,70 @@ describe("ButtonGroup widget", () => {
       undefined
     )
   })
+
+  it("resets to default when options change and stored value is stale", async () => {
+    // Simulate EN options: "apple" and "orange"
+    const enOptions = [
+      ButtonGroupProto.Option.create({ content: "apple" }),
+      ButtonGroupProto.Option.create({ content: "orange" }),
+    ]
+    // Simulate ES options: "manzana" and "naranja" (same raw keys, new display strings)
+    const esOptions = [
+      ButtonGroupProto.Option.create({ content: "manzana" }),
+      ButtonGroupProto.Option.create({ content: "naranja" }),
+    ]
+
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg: vi.fn(),
+      formsDataChanged: vi.fn(),
+    })
+
+    const enElement = ButtonGroupProto.create({
+      id: "fruit-widget",
+      clickMode: ButtonGroupProto.ClickMode.SINGLE_SELECT,
+      default: [0], // first option is the default ("apple" / "manzana")
+      disabled: false,
+      options: enOptions,
+      style: ButtonGroupProto.Style.PILLS,
+    })
+
+    // Pre-populate widgetMgr with the EN-formatted selection so the component
+    // starts with a stale value when it next renders with ES options.
+    widgetMgr.setStringArrayValue(
+      enElement,
+      ["apple"],
+      { fromUi: false },
+      undefined
+    )
+
+    const baseProps: Props = {
+      element: enElement,
+      disabled: false,
+      widgetMgr,
+      widthConfig: { useContent: true },
+    }
+
+    vi.spyOn(widgetMgr, "setStringArrayValue")
+
+    const { rerender } = render(<ButtonGroup {...baseProps} />)
+
+    // Re-render with ES options — the stored "apple" no longer matches any option
+    const esElement = ButtonGroupProto.create({
+      ...enElement,
+      options: esOptions,
+    })
+
+    rerender(<ButtonGroup {...baseProps} element={esElement} />)
+
+    // The stale-value effect should have fired and reset widgetMgr to the
+    // ES default (index 0 = "manzana") so the widget is visually consistent.
+    expect(widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+      esElement,
+      ["manzana"],
+      { fromUi: false },
+      undefined
+    )
+  })
 })
 
 describe("ButtonGroup query param binding", () => {

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -190,6 +190,16 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
   // default so the widget stays visually consistent. An explicit user
   // deselection always produces value=[], which short-circuits this guard
   // immediately, so we never auto-select over a deliberate empty selection.
+  //
+  // Safety for non-default selections: when format_func changes, the backend
+  // resolves the user's actual selection via session_state_fallback and sends
+  // it back serialised with the new format_func in rawValues (e.g. "naranja"
+  // for option "B" in ES mode). Because element props (options + rawValues)
+  // arrive as a single atomic proto update, useBasicWidgetState applies the
+  // corrected value before this effect runs. The validIndices guard above
+  // therefore fires an early return — the default reset path is only reached
+  // during the brief window before the first backend response (initial render),
+  // when no user selection yet exists and the default is correct.
   useEffect(() => {
     if (value.length === 0) return
     const validIndices = contentStringsToIndices(options, value)

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -186,26 +186,28 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
 
   // When options change and the currently stored value no longer matches any
   // option (e.g. because format_func changed dynamically due to a language
-  // switch, making the stored formatted strings stale), reset to the proto
-  // default so the widget stays visually consistent. An explicit user
-  // deselection always produces value=[], which short-circuits this guard
-  // immediately, so we never auto-select over a deliberate empty selection.
+  // switch, making the stored formatted strings stale), reset the widget so
+  // it stays visually consistent. An explicit user deselection always produces
+  // value=[], which short-circuits this guard immediately.
   //
-  // Safety for non-default selections: when format_func changes, the backend
-  // resolves the user's actual selection via session_state_fallback and sends
-  // it back serialised with the new format_func in rawValues (e.g. "naranja"
-  // for option "B" in ES mode). Because element props (options + rawValues)
-  // arrive as a single atomic proto update, useBasicWidgetState applies the
-  // corrected value before this effect runs. The validIndices guard above
-  // therefore fires an early return — the default reset path is only reached
-  // during the brief window before the first backend response (initial render),
-  // when no user selection yet exists and the default is correct.
+  // Reset target priority:
+  //   1. element.rawValues (non-empty) — the backend detected the stale wire
+  //      value via session_state_fallback and sent back the correct
+  //      serialization with set_value=True (e.g. "naranja" for option "B" in
+  //      ES mode). Using rawValues ensures non-default selections are preserved
+  //      and the widgetMgr stores the fresh label for the next rerun.
+  //   2. getDefaultStateFromProto — fallback for the brief window before the
+  //      first backend response, where only the proto default is known.
   useEffect(() => {
     if (value.length === 0) return
     const validIndices = contentStringsToIndices(options, value)
     if (validIndices.length > 0) return
+    const backendValue = getCurrStateFromProto(element)
     setValueWithSource({
-      value: getDefaultStateFromProto(element),
+      value:
+        backendValue.length > 0
+          ? backendValue
+          : getDefaultStateFromProto(element),
       fromUi: false,
     })
   }, [options, value, setValueWithSource, element])

--- a/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
+++ b/frontend/lib/src/components/widgets/ButtonGroup/ButtonGroup.tsx
@@ -184,6 +184,22 @@ function ButtonGroup(props: Readonly<Props>): ReactElement {
     }
   }, [required])
 
+  // When options change and the currently stored value no longer matches any
+  // option (e.g. because format_func changed dynamically due to a language
+  // switch, making the stored formatted strings stale), reset to the proto
+  // default so the widget stays visually consistent. An explicit user
+  // deselection always produces value=[], which short-circuits this guard
+  // immediately, so we never auto-select over a deliberate empty selection.
+  useEffect(() => {
+    if (value.length === 0) return
+    const validIndices = contentStringsToIndices(options, value)
+    if (validIndices.length > 0) return
+    setValueWithSource({
+      value: getDefaultStateFromProto(element),
+      fromUi: false,
+    })
+  }, [options, value, setValueWithSource, element])
+
   const selectionMode =
     clickMode === ButtonGroupProto.ClickMode.MULTI_SELECT
       ? "multiple"

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -230,6 +230,16 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
             # These are stale wire values from a previous format_func mapping
             # (e.g. a language switch). validate_and_sync_multiselect_value_with_options
             # applies the same filter for invalid canonical values.
+
+        # If ui_value was non-empty but every entry was stale (all dropped),
+        # fall back to the configured default so that _widget_changed sees no
+        # difference and suppresses the spurious on_change callback. This mirrors
+        # the single-select behaviour in _SingleSelectButtonGroupSerde.deserialize.
+        # When no default is configured, default_option_indices is [], which
+        # returns [] - matching the initial stored value and still suppressing
+        # the callback.
+        if not values and ui_value:
+            return [self.options[i] for i in self.default_option_indices]
         return values
 
 

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -127,7 +127,7 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
 
         return [formatted_value]
 
-    def deserialize(self, ui_value: list[str] | None) -> T | str | None:
+    def deserialize(self, ui_value: list[str] | None) -> T | None:
         """Deserialize from a list of strings to a single value."""
         if len(self.options) == 0:
             return None
@@ -149,8 +149,15 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         if option_index is not None:
             return self.options[option_index]
 
-        # Value not found in options - return as-is
-        return string_value
+        # Value not found in the current options mapping. This happens when options
+        # or format_func changes dynamically (e.g. a language switch): the frontend
+        # sends a stale wire value from the previous mapping that can't be resolved.
+        # Return the configured default so _widget_changed does not detect a spurious
+        # difference and fire an on_change callback with the formatted string instead
+        # of the original option value.
+        if self.default_option_index is not None:
+            return self.options[self.default_option_index]
+        return None
 
 
 class _MultiSelectButtonGroupSerde(Generic[T]):
@@ -219,9 +226,10 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
             option_index = self.formatted_option_to_option_index.get(v)
             if option_index is not None:
                 values.append(self.options[option_index])
-            else:
-                # Value not found in options - append as-is
-                values.append(v)
+            # Silently drop values not found in the current options mapping.
+            # These are stale wire values from a previous format_func mapping
+            # (e.g. a language switch). validate_and_sync_multiselect_value_with_options
+            # applies the same filter for invalid canonical values.
         return values
 
 

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -56,7 +56,7 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ButtonGroup_pb2 import ButtonGroup as ButtonGroupProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
-from streamlit.runtime.state import BindOption, register_widget
+from streamlit.runtime.state import BindOption, get_session_state, register_widget
 from streamlit.string_util import extract_leading_icon
 
 if TYPE_CHECKING:
@@ -91,6 +91,7 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
     formatted_option_to_option_index: dict[str, int]
     default_option_index: int | None
     format_func: Callable[[Any], str]
+    session_state_fallback: T | None
 
     def __init__(
         self,
@@ -100,12 +101,14 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         formatted_option_to_option_index: dict[str, int],
         default_option_index: int | None = None,
         format_func: Callable[[Any], str] = str,
+        session_state_fallback: T | None = None,
     ) -> None:
         self.options = options
         self.formatted_options = formatted_options
         self.formatted_option_to_option_index = formatted_option_to_option_index
         self.default_option_index = default_option_index
         self.format_func = format_func
+        self.session_state_fallback = session_state_fallback
 
     def serialize(self, v: T | str | None) -> list[str]:
         """Serialize single-select value to a list of strings for wire format."""
@@ -152,11 +155,13 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         # Value not found in the current options mapping. This happens when options
         # or format_func changes dynamically (e.g. a language switch): the frontend
         # sends a stale wire value from the previous mapping that can't be resolved.
-        # Return the configured default so _widget_changed does not detect a spurious
-        # difference and fire an on_change callback with the formatted string instead
-        # of the original option value.
+        # Return the configured default (or, when no default, the last known
+        # session-state value) so _widget_changed does not detect a spurious
+        # difference and fire an on_change callback.
         if self.default_option_index is not None:
             return self.options[self.default_option_index]
+        if self.session_state_fallback is not None:
+            return self.session_state_fallback
         return None
 
 
@@ -172,6 +177,7 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
     formatted_option_to_option_index: dict[str, int]
     default_option_indices: list[int]
     format_func: Callable[[Any], str]
+    session_state_fallback: list[T] | None
 
     def __init__(
         self,
@@ -181,12 +187,14 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
         formatted_option_to_option_index: dict[str, int],
         default_option_indices: list[int] | None = None,
         format_func: Callable[[Any], str] = str,
+        session_state_fallback: list[T] | None = None,
     ) -> None:
         self.options = options
         self.formatted_options = formatted_options
         self.formatted_option_to_option_index = formatted_option_to_option_index
         self.default_option_indices = default_option_indices or []
         self.format_func = format_func
+        self.session_state_fallback = session_state_fallback
 
     def serialize(self, value: list[T | str] | list[T] | None) -> list[str]:
         """Serialize multi-select values to list of strings for wire format."""
@@ -232,14 +240,15 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
             # applies the same filter for invalid canonical values.
 
         # If ui_value was non-empty but every entry was stale (all dropped),
-        # fall back to the configured default so that _widget_changed sees no
-        # difference and suppresses the spurious on_change callback. This mirrors
-        # the single-select behaviour in _SingleSelectButtonGroupSerde.deserialize.
-        # When no default is configured, default_option_indices is [], which
-        # returns [] - matching the initial stored value and still suppressing
-        # the callback.
+        # fall back to the configured default (or, when no default, the last
+        # known session-state value) so that _widget_changed sees no difference
+        # and suppresses the spurious on_change callback. This mirrors the
+        # single-select behaviour in _SingleSelectButtonGroupSerde.deserialize.
         if not values and ui_value:
-            return [self.options[i] for i in self.default_option_indices]
+            if self.default_option_indices:
+                return [self.options[i] for i in self.default_option_indices]
+            if self.session_state_fallback is not None:
+                return self.session_state_fallback
         return values
 
 
@@ -1014,6 +1023,31 @@ class ButtonGroupMixin:
             # behavior to mirror radio/selectbox/multiselect.
             formatted_option_to_option_index[formatted] = index
 
+        # Look up the currently-stored session-state value to use as a stale-wire
+        # fallback in the serde. When format_func changes dynamically and no default
+        # is configured, deserialize would otherwise return None/[] for stale wire
+        # values, causing _widget_changed to fire a spurious on_change callback.
+        # Using the last known valid value as a fallback keeps the comparison equal.
+        _ss_fallback_single: V | None = None
+        _ss_fallback_multi: list[V] | None = None
+        if key is not None:
+            try:
+                _ss = get_session_state()
+                if key in _ss:
+                    _ss_val = _ss[key]
+                    if selection_mode == "single":
+                        if _ss_val is not None and _ss_val in indexable_options:
+                            _ss_fallback_single = cast("V", _ss_val)
+                    elif isinstance(_ss_val, list):
+                        _valid = cast(
+                            "list[V]",
+                            [v for v in _ss_val if v in indexable_options],
+                        )
+                        if _valid:
+                            _ss_fallback_multi = _valid
+            except Exception:  # noqa: S110
+                pass  # Defensive: never let SS lookup break widget rendering
+
         # Create appropriate serde based on selection mode
         serializer: WidgetSerializer[Any]
         deserializer: WidgetDeserializer[Any]
@@ -1024,6 +1058,7 @@ class ButtonGroupMixin:
                 formatted_option_to_option_index=formatted_option_to_option_index,
                 default_option_indices=default_values,
                 format_func=actual_format_func,
+                session_state_fallback=_ss_fallback_multi,
             )
             serializer = multi_serde.serialize
             deserializer = multi_serde.deserialize
@@ -1034,6 +1069,7 @@ class ButtonGroupMixin:
                 formatted_option_to_option_index=formatted_option_to_option_index,
                 default_option_index=default_values[0] if default_values else None,
                 format_func=actual_format_func,
+                session_state_fallback=_ss_fallback_single,
             )
             serializer = single_serde.serialize
             deserializer = single_serde.deserialize

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -1037,21 +1037,21 @@ class ButtonGroupMixin:
         _ss_fallback_multi: list[V] | None = None
         if key is not None:
             try:
-                _ss = get_session_state()
-                if key in _ss:
-                    _ss_val = _ss[key]
-                    if selection_mode == "single":
-                        if _ss_val is not None and _ss_val in indexable_options:
-                            _ss_fallback_single = cast("V", _ss_val)
-                    elif isinstance(_ss_val, list):
-                        _valid = cast(
-                            "list[V]",
-                            [v for v in _ss_val if v in indexable_options],
-                        )
-                        if _valid:
-                            _ss_fallback_multi = _valid
+                # KeyError is raised if the key hasn't been set yet (first run).
+                # Any other exception is caught defensively to avoid breaking rendering.
+                _ss_val = get_session_state()[str(key)]
+                if selection_mode == "single":
+                    if _ss_val is not None and _ss_val in indexable_options:
+                        _ss_fallback_single = cast("V", _ss_val)
+                elif isinstance(_ss_val, list):
+                    _valid = cast(
+                        "list[V]",
+                        [v for v in _ss_val if v in indexable_options],
+                    )
+                    if _valid:
+                        _ss_fallback_multi = _valid
             except Exception:  # noqa: S110
-                pass  # Defensive: never let SS lookup break widget rendering
+                pass  # KeyError (key not yet set) or other SS error; safe to ignore
 
         # Create appropriate serde based on selection mode
         serializer: WidgetSerializer[Any]

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -1082,7 +1082,7 @@ class ButtonGroupMixin:
             ) -> list[V] | list[V | str]:
                 result_ = _multi_base(ui_value)
                 _stale_fallback_container[0] = multi_serde.used_session_state_fallback
-                return result_  # type: ignore[return-value]
+                return result_
 
             serializer = multi_serde.serialize
             deserializer = cast("WidgetDeserializer[Any]", _multi_deserialize)
@@ -1102,7 +1102,7 @@ class ButtonGroupMixin:
             ) -> V | None:
                 result_ = _single_base(ui_value)
                 _stale_fallback_container[0] = single_serde.used_session_state_fallback
-                return result_  # type: ignore[return-value]
+                return result_
 
             serializer = single_serde.serialize
             deserializer = cast("WidgetDeserializer[Any]", _single_deserialize)

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -155,13 +155,15 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         # Value not found in the current options mapping. This happens when options
         # or format_func changes dynamically (e.g. a language switch): the frontend
         # sends a stale wire value from the previous mapping that can't be resolved.
-        # Return the configured default (or, when no default, the last known
-        # session-state value) so _widget_changed does not detect a spurious
-        # difference and fire an on_change callback.
-        if self.default_option_index is not None:
-            return self.options[self.default_option_index]
+        # Prefer the last known session-state value (the user's live selection) over
+        # the configured default so _widget_changed does not detect a spurious
+        # difference and fire an on_change callback. The session-state value is
+        # always more accurate than the default because it reflects what the user
+        # actually had selected (e.g. user clicked "B" while default was "A").
         if self.session_state_fallback is not None:
             return self.session_state_fallback
+        if self.default_option_index is not None:
+            return self.options[self.default_option_index]
         return None
 
 
@@ -240,15 +242,18 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
             # applies the same filter for invalid canonical values.
 
         # If ui_value was non-empty but every entry was stale (all dropped),
-        # fall back to the configured default (or, when no default, the last
-        # known session-state value) so that _widget_changed sees no difference
-        # and suppresses the spurious on_change callback. This mirrors the
+        # fall back to the last known session-state value (the user's live
+        # selection) or, if none, to the configured default so that
+        # _widget_changed sees no difference and suppresses the spurious
+        # on_change callback. Session-state takes priority over the default
+        # because it reflects what the user actually had selected (e.g. user
+        # had ["A","B"] while default was only ["A"]). This mirrors the
         # single-select behaviour in _SingleSelectButtonGroupSerde.deserialize.
         if not values and ui_value:
-            if self.default_option_indices:
-                return [self.options[i] for i in self.default_option_indices]
             if self.session_state_fallback is not None:
                 return self.session_state_fallback
+            if self.default_option_indices:
+                return [self.options[i] for i in self.default_option_indices]
         return values
 
 

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -92,6 +92,7 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
     default_option_index: int | None
     format_func: Callable[[Any], str]
     session_state_fallback: T | None
+    used_session_state_fallback: bool
 
     def __init__(
         self,
@@ -109,6 +110,7 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         self.default_option_index = default_option_index
         self.format_func = format_func
         self.session_state_fallback = session_state_fallback
+        self.used_session_state_fallback = False
 
     def serialize(self, v: T | str | None) -> list[str]:
         """Serialize single-select value to a list of strings for wire format."""
@@ -161,6 +163,7 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         # always more accurate than the default because it reflects what the user
         # actually had selected (e.g. user clicked "B" while default was "A").
         if self.session_state_fallback is not None:
+            self.used_session_state_fallback = True
             return self.session_state_fallback
         if self.default_option_index is not None:
             return self.options[self.default_option_index]
@@ -180,6 +183,7 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
     default_option_indices: list[int]
     format_func: Callable[[Any], str]
     session_state_fallback: list[T] | None
+    used_session_state_fallback: bool
 
     def __init__(
         self,
@@ -197,6 +201,7 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
         self.default_option_indices = default_option_indices or []
         self.format_func = format_func
         self.session_state_fallback = session_state_fallback
+        self.used_session_state_fallback = False
 
     def serialize(self, value: list[T | str] | list[T] | None) -> list[str]:
         """Serialize multi-select values to list of strings for wire format."""
@@ -251,6 +256,7 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
         # single-select behaviour in _SingleSelectButtonGroupSerde.deserialize.
         if not values and ui_value:
             if self.session_state_fallback is not None:
+                self.used_session_state_fallback = True
                 return self.session_state_fallback
             if self.default_option_indices:
                 return [self.options[i] for i in self.default_option_indices]
@@ -1053,7 +1059,11 @@ class ButtonGroupMixin:
             except Exception:  # noqa: S110
                 pass  # KeyError (key not yet set) or other SS error; safe to ignore
 
-        # Create appropriate serde based on selection mode
+        # Create appropriate serde based on selection mode. A shared mutable
+        # container tracks whether the stale-wire fallback fired during
+        # deserialization so _button_group can force proto.set_value=True and
+        # send the fresh serialization to the frontend (see _button_group).
+        _stale_fallback_container: list[bool] = [False]
         serializer: WidgetSerializer[Any]
         deserializer: WidgetDeserializer[Any]
         if selection_mode == "multi":
@@ -1065,8 +1075,17 @@ class ButtonGroupMixin:
                 format_func=actual_format_func,
                 session_state_fallback=_ss_fallback_multi,
             )
+            _multi_base = multi_serde.deserialize
+
+            def _multi_deserialize(
+                ui_value: list[str] | None,
+            ) -> list[V] | list[V | str]:
+                result_ = _multi_base(ui_value)
+                _stale_fallback_container[0] = multi_serde.used_session_state_fallback
+                return result_  # type: ignore[return-value]
+
             serializer = multi_serde.serialize
-            deserializer = multi_serde.deserialize
+            deserializer = cast("WidgetDeserializer[Any]", _multi_deserialize)
         else:
             single_serde = _SingleSelectButtonGroupSerde[V](
                 indexable_options,
@@ -1076,8 +1095,17 @@ class ButtonGroupMixin:
                 format_func=actual_format_func,
                 session_state_fallback=_ss_fallback_single,
             )
+            _single_base = single_serde.deserialize
+
+            def _single_deserialize(
+                ui_value: list[str] | None,
+            ) -> V | None:
+                result_ = _single_base(ui_value)
+                _stale_fallback_container[0] = single_serde.used_session_state_fallback
+                return result_  # type: ignore[return-value]
+
             serializer = single_serde.serialize
-            deserializer = single_serde.deserialize
+            deserializer = cast("WidgetDeserializer[Any]", _single_deserialize)
 
         # Single call to _button_group with the appropriate serde
         result: RegisterWidgetResult[Any] = self._button_group(
@@ -1101,6 +1129,7 @@ class ButtonGroupMixin:
             options_format_func=actual_format_func,
             bind=bind,
             string_formatted_options=formatted_options,
+            stale_fallback_container=_stale_fallback_container,
         )
 
         # Handle return type based on selection mode
@@ -1138,6 +1167,7 @@ class ButtonGroupMixin:
         options_format_func: Callable[[Any], str] | None = None,
         bind: BindOption = None,
         string_formatted_options: list[str] | None = None,
+        stale_fallback_container: list[bool] | None = None,
     ) -> RegisterWidgetResult[T]:
         _maybe_raise_selection_mode_warning(selection_mode)
 
@@ -1259,10 +1289,24 @@ class ButtonGroupMixin:
                     )
                 )
 
-        if value_needs_reset or widget_state.value_changed:
+        # The stale-wire fallback fires when the frontend sends a formatted string
+        # from a previous format_func mapping (e.g. "orange" after switching to ES
+        # mode where the mapping no longer contains "orange"). The serde resolves the
+        # canonical value via session_state_fallback but neither value_needs_reset nor
+        # value_changed is True because the canonical value ("B") is unchanged.
+        # We must still send set_value=True with the NEW serialization ("naranja") so
+        # the frontend can update its displayed value; otherwise the stored stale wire
+        # value stays in widgetMgr and on the next rerun the backend would receive a
+        # fresh (non-stale) but wrong formatted string and fire a spurious on_change.
+        stale_fallback_used = (
+            stale_fallback_container is not None and stale_fallback_container[0]
+        )
+        if value_needs_reset or widget_state.value_changed or stale_fallback_used:
             # Always use string-based raw_values field
             value_for_serialization = (
-                current_value if value_needs_reset else widget_state.value
+                current_value
+                if (value_needs_reset or stale_fallback_used)
+                else widget_state.value
             )
             proto.raw_values[:] = serializer(cast("T", value_for_serialization))
             proto.set_value = True
@@ -1275,7 +1319,9 @@ class ButtonGroupMixin:
             "button_group",
             proto,
             layout_config=layout_config,
-            has_one_shot_effect=value_needs_reset or widget_state.value_changed,
+            has_one_shot_effect=value_needs_reset
+            or widget_state.value_changed
+            or stale_fallback_used,
         )
 
         # Return widget_state with possibly updated value

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -1481,6 +1481,128 @@ class TestDynamicFormatFuncCallback:
             f"with no selection change (callback_count={at.session_state['callback_count']})"
         )
 
+    def test_non_default_selection_callback_not_invoked_after_format_func_change(self):
+        """on_change must not fire when format_func changes and a non-default option is selected.
+
+        Regression test for gh-15493: when the user has selected a non-default
+        option (e.g. "B" while default="A") and format_func changes dynamically,
+        the deserialized value must remain "B" (via session_state_fallback) so
+        that _widget_changed("B", "B") suppresses the spurious callback.
+        """
+
+        def script():
+            import streamlit as st
+
+            lang = st.session_state.get("lang", "en")
+            fmt_en = {"A": "apple", "B": "orange"}
+            fmt_es = {"A": "manzana", "B": "naranja"}
+            fmt = fmt_en if lang == "en" else fmt_es
+
+            if "callback_count" not in st.session_state:
+                st.session_state["callback_count"] = 0
+
+            def on_change() -> None:
+                st.session_state["callback_count"] += 1
+
+            st.pills(
+                "Fruit",
+                ["A", "B"],
+                format_func=lambda x: fmt[x],
+                default="A",
+                key="fruit",
+                on_change=on_change,
+            )
+
+        # Initial EN run — "A" is selected by default, callback_count=0
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+        assert at.button_group("fruit").value == "A"
+        assert at.session_state["callback_count"] == 0
+
+        # User selects "B" (non-default) — callback fires once for the real user action
+        at.button_group("fruit").select("B").run()
+        assert not at.exception
+        assert at.button_group("fruit").value == "B"
+        assert at.session_state["callback_count"] == 1
+
+        # Switch language to ES — format_func changes, but the selection ("B") is unchanged
+        at.session_state["callback_count"] = 0
+        at.session_state["lang"] = "es"
+        at = at.run()
+        assert not at.exception
+
+        # Callback must NOT fire — only the display string changed, not the selected value
+        assert at.session_state["callback_count"] == 0, (
+            "on_change fired unexpectedly after a format_func change with a "
+            f"non-default selection (callback_count={at.session_state['callback_count']})"
+        )
+        assert at.button_group("fruit").value == "B", (
+            "Selection must remain 'B' after format_func change, "
+            f"got {at.button_group('fruit').value!r}"
+        )
+
+    def test_multi_select_non_default_selection_callback_not_invoked_after_format_func_change(
+        self,
+    ):
+        """on_change must not fire for multi-select when a non-default combo is selected and
+        format_func changes.
+
+        When the user has selected ["A","B"] (while default is only ["A"]) and
+        format_func changes, session_state_fallback must return ["A","B"] so that
+        _widget_changed(["A","B"], ["A","B"]) suppresses the spurious callback.
+        """
+
+        def script():
+            import streamlit as st
+
+            lang = st.session_state.get("lang", "en")
+            fmt_en = {"A": "apple", "B": "orange"}
+            fmt_es = {"A": "manzana", "B": "naranja"}
+            fmt = fmt_en if lang == "en" else fmt_es
+
+            if "callback_count" not in st.session_state:
+                st.session_state["callback_count"] = 0
+
+            def on_change() -> None:
+                st.session_state["callback_count"] += 1
+
+            st.pills(
+                "Fruits",
+                ["A", "B"],
+                format_func=lambda x: fmt[x],
+                default=["A"],
+                selection_mode="multi",
+                key="fruits",
+                on_change=on_change,
+            )
+
+        # Initial EN run — ["A"] selected by default
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+        assert at.session_state["callback_count"] == 0
+
+        # User adds "B" to the selection — callback fires once for the real user action
+        at.button_group("fruits").select("B").run()
+        assert not at.exception
+        assert sorted(at.button_group("fruits").value) == ["A", "B"]
+        assert at.session_state["callback_count"] == 1
+
+        # Switch language to ES — format_func changes, selection is still ["A","B"]
+        at.session_state["callback_count"] = 0
+        at.session_state["lang"] = "es"
+        at = at.run()
+        assert not at.exception
+
+        # Callback must NOT fire — only the display strings changed, not the selection
+        assert at.session_state["callback_count"] == 0, (
+            "on_change fired unexpectedly after a multi-select format_func change "
+            f"with a non-default selection (callback_count={at.session_state['callback_count']})"
+        )
+        assert sorted(at.button_group("fruits").value) == ["A", "B"], (
+            "Selection must remain ['A','B'] after format_func change, "
+            f"got {at.button_group('fruits').value!r}"
+        )
+
     def test_single_select_no_default_callback_not_invoked_after_format_func_change(
         self,
     ):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -273,6 +273,33 @@ class TestButtonGroupSerde:
         res = serde.deserialize(["apple"])
         assert res == "A"  # The default option, not the raw "apple" string
 
+    def test_single_select_deserialize_stale_value_session_fallback_beats_default(self):
+        """Session-state fallback takes priority over configured default for stale values.
+
+        When the user has selected a non-default option (e.g. "B" while default="A")
+        and format_func changes, the serde must return the user's live selection ("B"),
+        not the configured default ("A"). Returning the default would cause
+        _widget_changed("B", "A") to fire the spurious on_change callback.
+        """
+        options = ["A", "B"]
+        formatted_options = ["manzana", "naranja"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _SingleSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_option_index=0,  # default is "A"
+            format_func=lambda x: {"A": "manzana", "B": "naranja"}[x],
+            session_state_fallback="B",  # user had "B" selected (non-default)
+        )
+        # Frontend sends stale EN string "orange" (for "B"); should return "B", not "A"
+        res = serde.deserialize(["orange"])
+        assert res == "B", (
+            "Expected session_state_fallback ('B') to take priority over default ('A')"
+        )
+
     def test_single_select_deserialize_stale_value_no_default_returns_none(self):
         """Stale wire value without a configured default returns None."""
         options = ["A", "B", "C"]
@@ -311,6 +338,33 @@ class TestButtonGroupSerde:
         # "apple" is a stale EN string; "naranja" is valid in the ES mapping
         res = serde.deserialize(["apple", "naranja"])
         assert res == ["B"]  # Only the valid ES option is returned
+
+    def test_multi_select_deserialize_all_stale_session_fallback_beats_default(self):
+        """Session-state fallback takes priority over configured default for multi-select.
+
+        When the user has ["A","B"] selected (default is only ["A"]) and format_func
+        changes so all wire values go stale, the serde must return ["A","B"] (the live
+        selection), not ["A"] (the configured default). Returning the default would
+        cause _widget_changed(["A","B"], ["A"]) to fire a spurious on_change callback.
+        """
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+            default_option_indices=[0],  # default is ["A"]
+            session_state_fallback=["A", "B"],  # user had A+B selected
+        )
+        # Both wire values are stale EN strings; should return ["A","B"], not ["A"]
+        res = serde.deserialize(["apple", "orange"])
+        assert res == ["A", "B"], (
+            "Expected session_state_fallback (['A','B']) to take priority over default (['A'])"
+        )
 
     def test_multi_select_deserialize_all_stale_values_returns_default(self):
         """Multi-select with all stale values falls back to the configured default.

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -139,7 +139,13 @@ class TestButtonGroupSerde:
         assert res is None
 
     def test_single_select_deserialize_unknown_value(self):
-        """Test single-select deserialization of unknown value returns string as-is."""
+        """Test single-select deserialization of an unrecognised value returns None.
+
+        When the options mapping doesn't contain the received wire value (e.g.
+        a stale formatted string left over from a previous format_func), the
+        deserializer must not pass that raw string to session_state or callbacks.
+        Without a configured default, the correct fallback is None.
+        """
         options = ["apple", "banana", "cherry"]
         formatted_options = ["Apple", "Banana", "Cherry"]
         formatted_option_to_option_index = {
@@ -152,7 +158,7 @@ class TestButtonGroupSerde:
             format_func=lambda x: x.capitalize(),
         )
         res = serde.deserialize(["Unknown"])
-        assert res == "Unknown"
+        assert res is None
 
     def test_multi_select_serialize(self):
         """Test multi-select serialization returns list of formatted strings."""
@@ -220,7 +226,13 @@ class TestButtonGroupSerde:
         assert res == ["apple", "cherry"]
 
     def test_multi_select_deserialize_unknown_value(self):
-        """Test multi-select deserialization with unknown value includes it as-is."""
+        """Test multi-select deserialization with unknown value silently drops it.
+
+        Stale wire values that don't exist in the current options mapping (e.g.
+        formatted strings from a previous format_func) must be dropped rather
+        than passed through to session_state or callbacks. Known valid values in
+        the same list are still resolved correctly.
+        """
         options = ["apple", "banana", "cherry"]
         formatted_options = ["Apple", "Banana", "Cherry"]
         formatted_option_to_option_index = {
@@ -233,7 +245,94 @@ class TestButtonGroupSerde:
             format_func=lambda x: x.capitalize(),
         )
         res = serde.deserialize(["Apple", "Unknown"])
-        assert res == ["apple", "Unknown"]
+        assert res == ["apple"]
+
+    def test_single_select_deserialize_stale_value_returns_default(self):
+        """Stale wire value with a configured default returns the default option.
+
+        When format_func changes dynamically (e.g. language switch from EN to ES),
+        the frontend may still send the old EN-formatted string such as "apple".
+        With ES options the mapping has no "apple" entry, so the deserializer must
+        fall back to the configured default option to prevent _widget_changed from
+        seeing a spurious change and invoking on_change with the formatted string.
+        """
+        # Simulate ES-mode options: raw keys "A", "B" with ES display strings
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _SingleSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            default_option_index=0,  # "A" / "manzana" is the default
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+        )
+        # Frontend sends "apple" - a stale EN-formatted string
+        res = serde.deserialize(["apple"])
+        assert res == "A"  # The default option, not the raw "apple" string
+
+    def test_single_select_deserialize_stale_value_no_default_returns_none(self):
+        """Stale wire value without a configured default returns None."""
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _SingleSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            # No default_option_index configured
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+        )
+        res = serde.deserialize(["apple"])
+        assert res is None
+
+    def test_multi_select_deserialize_stale_values_are_dropped(self):
+        """Stale multi-select wire values are dropped; valid values are resolved.
+
+        When format_func changes dynamically, the frontend may send a mix of
+        stale formatted strings from the old mapping and strings that happen to
+        match the new mapping. Only the valid ones should survive.
+        """
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+        )
+        # "apple" is a stale EN string; "naranja" is valid in the ES mapping
+        res = serde.deserialize(["apple", "naranja"])
+        assert res == ["B"]  # Only the valid ES option is returned
+
+    def test_multi_select_deserialize_all_stale_values_returns_empty(self):
+        """Multi-select with all stale values returns an empty list.
+
+        If every value in the wire payload is stale (none match the current
+        options mapping), the result must be an empty list, not a list of raw
+        formatted strings.
+        """
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+        )
+        # Both values are stale EN strings; none match the ES mapping
+        res = serde.deserialize(["apple", "orange"])
+        assert res == []
 
 
 def get_command_matrix(
@@ -1200,6 +1299,99 @@ class TestButtonGroupAppTest:
         at.button_group("sc").select("y").run()
         assert at.button_group("sc").value == "y"
         assert not at.exception
+
+
+class TestDynamicFormatFuncCallback:
+    """Integration tests for on_change callback correctness with dynamic format_func.
+
+    Covers GitHub issue #15493: callbacks should receive the original option value,
+    not the formatted string, even when format_func changes between reruns.
+    """
+
+    def test_callback_not_invoked_after_format_func_change_same_selection(self):
+        """on_change must not fire when format_func changes but selection is unchanged.
+
+        When a language switch changes format_func so that the same underlying
+        option ("A") is now displayed as "manzana" instead of "apple", the widget
+        value hasn't actually changed. The on_change callback must therefore NOT
+        be invoked on the rerun that follows the language switch.
+        """
+
+        def script():
+            import streamlit as st
+
+            lang = st.session_state.get("lang", "en")
+            fmt_en = {"A": "apple", "B": "orange"}
+            fmt_es = {"A": "manzana", "B": "naranja"}
+            fmt = fmt_en if lang == "en" else fmt_es
+
+            if "callback_count" not in st.session_state:
+                st.session_state["callback_count"] = 0
+
+            def on_change() -> None:
+                st.session_state["callback_count"] += 1
+                st.session_state["last_callback_value"] = st.session_state["fruit"]
+
+            st.pills(
+                "Fruit",
+                ["A", "B"],
+                format_func=lambda x: fmt[x],
+                default="A",
+                key="fruit",
+                on_change=on_change,
+            )
+
+        # Initial EN run - widget shows "apple" selected, callback never called
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+        assert at.button_group("fruit").value == "A"
+        assert at.session_state["callback_count"] == 0
+
+        # Switch language to ES without changing the selection
+        at.session_state["lang"] = "es"
+        at = at.run()
+        assert not at.exception
+
+        # The on_change callback must not have fired - only the format changed
+        assert at.session_state["callback_count"] == 0, (
+            "on_change fired unexpectedly after a format_func change with no "
+            f"selection change (callback_count={at.session_state['callback_count']})"
+        )
+        assert at.button_group("fruit").value == "A"
+
+    def test_callback_invoked_with_original_option_when_user_changes_selection(self):
+        """on_change receives the original option value, not the formatted string."""
+
+        def script():
+            import streamlit as st
+
+            lang = st.session_state.get("lang", "es")
+            fmt_es = {"A": "manzana", "B": "naranja"}
+            fmt = fmt_es if lang == "es" else {"A": "apple", "B": "orange"}
+
+            if "last_callback_value" not in st.session_state:
+                st.session_state["last_callback_value"] = None
+
+            def on_change() -> None:
+                st.session_state["last_callback_value"] = st.session_state["fruit"]
+
+            st.pills(
+                "Fruit",
+                ["A", "B"],
+                format_func=lambda x: fmt[x],
+                default="A",
+                key="fruit",
+                on_change=on_change,
+            )
+
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+
+        # User clicks "naranja" (B) - callback should receive "B", not "naranja"
+        at.button_group("fruit").select("B").run()
+        assert not at.exception
+        assert at.session_state["last_callback_value"] == "B"
+        assert at.button_group("fruit").value == "B"
 
 
 class PillsBindQueryParamsTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -338,11 +338,11 @@ class TestButtonGroupSerde:
         assert res == ["A"]
 
     def test_multi_select_deserialize_all_stale_values_no_default_returns_empty(self):
-        """Multi-select with all stale values and no default returns [].
+        """Multi-select with all stale values, no default, and no session fallback returns [].
 
-        When no default is configured, default_option_indices is [], so the
-        fallback also returns [] - which matches the initial stored value (also
-        []) and therefore still suppresses a spurious on_change callback.
+        When no default is configured AND no session_state_fallback is provided,
+        the result is [] - same as the initial stored value when nothing was ever
+        selected, so _widget_changed([], []) produces no spurious callback.
         """
         options = ["A", "B", "C"]
         formatted_options = ["manzana", "naranja", "cereza"]
@@ -358,6 +358,54 @@ class TestButtonGroupSerde:
         # Both values are stale EN strings; none match the ES mapping
         res = serde.deserialize(["apple", "orange"])
         assert res == []
+
+    def test_single_select_deserialize_stale_value_no_default_uses_session_fallback(
+        self,
+    ):
+        """Single-select with a stale value, no default, but an active session-state value.
+
+        When format_func changes and no default is configured, the serde falls back
+        to the session_state_fallback value so _widget_changed sees no difference
+        and suppresses the spurious on_change callback.
+        """
+        options = ["A", "B"]
+        formatted_options = ["manzana", "naranja"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _SingleSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "manzana", "B": "naranja"}[x],
+            session_state_fallback="A",  # user had "A" selected; no default
+        )
+        # Frontend sends stale EN string "apple"; should resolve to "A" via fallback
+        res = serde.deserialize(["apple"])
+        assert res == "A"
+
+    def test_multi_select_deserialize_all_stale_values_uses_session_fallback(self):
+        """Multi-select with all stale values uses session_state_fallback when no default.
+
+        When format_func changes, all selections go stale, and no default is
+        configured, the serde falls back to the last known session-state value so
+        that _widget_changed sees no difference and suppresses the spurious callback.
+        """
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+            session_state_fallback=["A", "B"],  # user had A+B selected; no default
+        )
+        # Both wire values are stale EN strings; none match the ES mapping
+        res = serde.deserialize(["apple", "orange"])
+        assert res == ["A", "B"]
 
 
 def get_command_matrix(
@@ -1468,6 +1516,64 @@ class TestDynamicFormatFuncCallback:
             "on_change fired unexpectedly after a multi-select format_func change "
             f"with no selection change (callback_count={at.session_state['callback_count']})"
         )
+
+    def test_single_select_no_default_callback_not_invoked_after_format_func_change(
+        self,
+    ):
+        """on_change must not fire for single-select with no default when format_func changes.
+
+        Regression test for gh-15493 (no-default path): when the user has manually
+        selected an option and format_func changes, the callback must NOT fire even
+        though no default was configured.
+        """
+
+        def script():
+            import streamlit as st
+
+            lang = st.session_state.get("lang", "en")
+            fmt_en = {"A": "apple", "B": "orange"}
+            fmt_es = {"A": "manzana", "B": "naranja"}
+            fmt = fmt_en if lang == "en" else fmt_es
+
+            if "callback_count" not in st.session_state:
+                st.session_state["callback_count"] = 0
+
+            def on_change() -> None:
+                st.session_state["callback_count"] += 1
+
+            st.pills(
+                "Fruit",
+                ["A", "B"],
+                format_func=lambda x: fmt[x],
+                # No default - user must manually select
+                key="fruit",
+                on_change=on_change,
+            )
+
+        # Initial run - nothing selected
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+
+        # User clicks option "A" in EN mode
+        at.button_group("fruit").select("A").run()
+        assert not at.exception
+        assert (
+            at.session_state["callback_count"] == 1
+        )  # callback fired for user selection
+        assert at.button_group("fruit").value == "A"
+
+        # Reset callback count, then switch language to ES
+        at.session_state["callback_count"] = 0
+        at.session_state["lang"] = "es"
+        at = at.run()
+        assert not at.exception
+
+        # The on_change callback must NOT have fired after the format_func change
+        assert at.session_state["callback_count"] == 0, (
+            "on_change fired unexpectedly after a no-default format_func change "
+            f"(callback_count={at.session_state['callback_count']})"
+        )
+        assert at.button_group("fruit").value == "A"
 
 
 class PillsBindQueryParamsTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -312,12 +312,37 @@ class TestButtonGroupSerde:
         res = serde.deserialize(["apple", "naranja"])
         assert res == ["B"]  # Only the valid ES option is returned
 
-    def test_multi_select_deserialize_all_stale_values_returns_empty(self):
-        """Multi-select with all stale values returns an empty list.
+    def test_multi_select_deserialize_all_stale_values_returns_default(self):
+        """Multi-select with all stale values falls back to the configured default.
 
-        If every value in the wire payload is stale (none match the current
-        options mapping), the result must be an empty list, not a list of raw
-        formatted strings.
+        When format_func changes (e.g. a language switch) and all wire values
+        are stale, the deserializer must return the configured default so that
+        _widget_changed sees no difference and suppresses the spurious on_change
+        callback - mirroring the single-select behaviour.
+        """
+        options = ["A", "B", "C"]
+        formatted_options = ["manzana", "naranja", "cereza"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
+            default_option_indices=[0],  # default is "A"
+        )
+        # Both wire values are stale EN strings; none match the ES mapping
+        res = serde.deserialize(["apple", "orange"])
+        # Should fall back to the default ("A") rather than returning []
+        assert res == ["A"]
+
+    def test_multi_select_deserialize_all_stale_values_no_default_returns_empty(self):
+        """Multi-select with all stale values and no default returns [].
+
+        When no default is configured, default_option_indices is [], so the
+        fallback also returns [] - which matches the initial stored value (also
+        []) and therefore still suppresses a spurious on_change callback.
         """
         options = ["A", "B", "C"]
         formatted_options = ["manzana", "naranja", "cereza"]
@@ -1392,6 +1417,57 @@ class TestDynamicFormatFuncCallback:
         assert not at.exception
         assert at.session_state["last_callback_value"] == "B"
         assert at.button_group("fruit").value == "B"
+
+    def test_multi_select_callback_not_invoked_after_format_func_change(self):
+        """on_change must not fire for multi-select when format_func changes but
+        selection is unchanged.
+
+        Regression test for gh-15493 (multi-select path): when a language switch
+        changes format_func so ["A", "B"] are now displayed as ["manzana", "naranja"]
+        instead of ["apple", "orange"], the widget value is unchanged. The on_change
+        callback must NOT fire on the rerun that follows the language switch.
+        """
+
+        def script():
+            import streamlit as st
+
+            lang = st.session_state.get("lang", "en")
+            fmt_en = {"A": "apple", "B": "orange"}
+            fmt_es = {"A": "manzana", "B": "naranja"}
+            fmt = fmt_en if lang == "en" else fmt_es
+
+            if "callback_count" not in st.session_state:
+                st.session_state["callback_count"] = 0
+
+            def on_change() -> None:
+                st.session_state["callback_count"] += 1
+                st.session_state["last_callback_value"] = st.session_state["fruits"]
+
+            st.pills(
+                "Fruits",
+                ["A", "B"],
+                format_func=lambda x: fmt[x],
+                default=["A", "B"],
+                selection_mode="multi",
+                key="fruits",
+                on_change=on_change,
+            )
+
+        # Initial EN run - ["A", "B"] selected, callback never called
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+        assert at.session_state["callback_count"] == 0
+
+        # Switch language to ES without changing the selection
+        at.session_state["lang"] = "es"
+        at = at.run()
+        assert not at.exception
+
+        # The on_change callback must not have fired - only the format changed
+        assert at.session_state["callback_count"] == 0, (
+            "on_change fired unexpectedly after a multi-select format_func change "
+            f"with no selection change (callback_count={at.session_state['callback_count']})"
+        )
 
 
 class PillsBindQueryParamsTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -247,32 +247,6 @@ class TestButtonGroupSerde:
         res = serde.deserialize(["Apple", "Unknown"])
         assert res == ["apple"]
 
-    def test_single_select_deserialize_stale_value_returns_default(self):
-        """Stale wire value with a configured default returns the default option.
-
-        When format_func changes dynamically (e.g. language switch from EN to ES),
-        the frontend may still send the old EN-formatted string such as "apple".
-        With ES options the mapping has no "apple" entry, so the deserializer must
-        fall back to the configured default option to prevent _widget_changed from
-        seeing a spurious change and invoking on_change with the formatted string.
-        """
-        # Simulate ES-mode options: raw keys "A", "B" with ES display strings
-        options = ["A", "B", "C"]
-        formatted_options = ["manzana", "naranja", "cereza"]
-        formatted_option_to_option_index = {
-            f: i for i, f in enumerate(formatted_options)
-        }
-        serde = _SingleSelectButtonGroupSerde[str](
-            options,
-            formatted_options=formatted_options,
-            formatted_option_to_option_index=formatted_option_to_option_index,
-            default_option_index=0,  # "A" / "manzana" is the default
-            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
-        )
-        # Frontend sends "apple" - a stale EN-formatted string
-        res = serde.deserialize(["apple"])
-        assert res == "A"  # The default option, not the raw "apple" string
-
     def test_single_select_deserialize_stale_value_session_fallback_beats_default(self):
         """Session-state fallback takes priority over configured default for stale values.
 
@@ -299,23 +273,6 @@ class TestButtonGroupSerde:
         assert res == "B", (
             "Expected session_state_fallback ('B') to take priority over default ('A')"
         )
-
-    def test_single_select_deserialize_stale_value_no_default_returns_none(self):
-        """Stale wire value without a configured default returns None."""
-        options = ["A", "B", "C"]
-        formatted_options = ["manzana", "naranja", "cereza"]
-        formatted_option_to_option_index = {
-            f: i for i, f in enumerate(formatted_options)
-        }
-        serde = _SingleSelectButtonGroupSerde[str](
-            options,
-            formatted_options=formatted_options,
-            formatted_option_to_option_index=formatted_option_to_option_index,
-            # No default_option_index configured
-            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
-        )
-        res = serde.deserialize(["apple"])
-        assert res is None
 
     def test_multi_select_deserialize_stale_values_are_dropped(self):
         """Stale multi-select wire values are dropped; valid values are resolved.
@@ -365,53 +322,6 @@ class TestButtonGroupSerde:
         assert res == ["A", "B"], (
             "Expected session_state_fallback (['A','B']) to take priority over default (['A'])"
         )
-
-    def test_multi_select_deserialize_all_stale_values_returns_default(self):
-        """Multi-select with all stale values falls back to the configured default.
-
-        When format_func changes (e.g. a language switch) and all wire values
-        are stale, the deserializer must return the configured default so that
-        _widget_changed sees no difference and suppresses the spurious on_change
-        callback - mirroring the single-select behaviour.
-        """
-        options = ["A", "B", "C"]
-        formatted_options = ["manzana", "naranja", "cereza"]
-        formatted_option_to_option_index = {
-            f: i for i, f in enumerate(formatted_options)
-        }
-        serde = _MultiSelectButtonGroupSerde[str](
-            options,
-            formatted_options=formatted_options,
-            formatted_option_to_option_index=formatted_option_to_option_index,
-            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
-            default_option_indices=[0],  # default is "A"
-        )
-        # Both wire values are stale EN strings; none match the ES mapping
-        res = serde.deserialize(["apple", "orange"])
-        # Should fall back to the default ("A") rather than returning []
-        assert res == ["A"]
-
-    def test_multi_select_deserialize_all_stale_values_no_default_returns_empty(self):
-        """Multi-select with all stale values, no default, and no session fallback returns [].
-
-        When no default is configured AND no session_state_fallback is provided,
-        the result is [] - same as the initial stored value when nothing was ever
-        selected, so _widget_changed([], []) produces no spurious callback.
-        """
-        options = ["A", "B", "C"]
-        formatted_options = ["manzana", "naranja", "cereza"]
-        formatted_option_to_option_index = {
-            f: i for i, f in enumerate(formatted_options)
-        }
-        serde = _MultiSelectButtonGroupSerde[str](
-            options,
-            formatted_options=formatted_options,
-            formatted_option_to_option_index=formatted_option_to_option_index,
-            format_func=lambda x: {"A": "manzana", "B": "naranja", "C": "cereza"}[x],
-        )
-        # Both values are stale EN strings; none match the ES mapping
-        res = serde.deserialize(["apple", "orange"])
-        assert res == []
 
     def test_single_select_deserialize_stale_value_no_default_uses_session_fallback(
         self,


### PR DESCRIPTION
## Describe your changes
Fixes a regression in `st.pills `and `st.segmented_control` where changing `format_func` dynamically (e.g. a language switch between app reruns) caused two problems:

- Primary bug — The on_change callback fired spuriously and received the formatted display string (e.g. "apple") instead of the original option value (e.g. "A"), violating the documented contract that `format_func` has no impact on the return value of the command.
- Secondary visual bug — After the `format_func` change the pill appeared deselected for one render cycle, even though the underlying selection had not changed.

## GitHub Issue Link (if applicable)
Closes #15493 

## Testing Plan
- Unit Tests (JS and/or Python): ✅ 
- E2E Tests: ✅ 