### PR TITLE
[fix] Prevent resetting page title on rerun

### DIFF
--- a/frontend/app/src/util/AppNavigation.test.ts
+++ b/frontend/app/src/util/AppNavigation.test.ts
@@ -138,6 +138,19 @@ describe("AppNavigation", () => {
     expect(newState.hideSidebarNav).toEqual(false)
   })
 
+  it("does not reset the document title on new session", () => {
+    const previousTitle = document.title
+    document.title = "Callback Test"
+
+    try {
+      appNavigation.handleNewSession(generateNewSession())
+
+      expect(document.title).toBe("Callback Test")
+    } finally {
+      document.title = previousTitle
+    }
+  })
+
   it("continues to set hideSidebarNav on new session", () => {
     const cleanAppNavigation = new AppNavigation(
       hostCommunicationMgr,

--- a/frontend/app/src/util/AppNavigation.ts
+++ b/frontend/app/src/util/AppNavigation.ts
@@ -106,9 +106,6 @@ export class AppNavigation {
       this.hideSidebarNav = newSession.config?.hideSidebarNav ?? null
     }
 
-    // We do not know the page name, so use an empty string version
-    document.title = getTitle("")
-
     return [
       {
         // Set current page script hash to handle SPA case


### PR DESCRIPTION
## Describe your changes

The page title was reset to the default (`"Streamlit"`) on every new session message (rerun). `AppNavigation.handleNewSession` unconditionally set `document.title = getTitle("")`, which caused the title to flicker back to the default until the subsequent `Navigation` message re-applied the configured title.

This is especially noticeable when a slow callback or inline blocking operation is running: the configured page title disappears for the duration of the run.

This PR removes the unnecessary reset in `handleNewSession`. The page title is still correctly set in `handleNavigation`, guarded by the sticky `isPageTitleSet` flag, so the configured title is preserved across reruns.

Repro:

```python
import time

import streamlit as st

st.set_page_config(page_title="Callback Test")
st.title("Callback Test")


def _sleep_and_show_spinner():
    time.sleep(3)


st.button("Sleep in callback", on_click=_sleep_and_show_spinner)

if st.button("Sleep inline"):
    time.sleep(3)
```

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS): Added a test asserting `handleNewSession` does not reset `document.title`.

Made with [Cursor](https://cursor.com)