### PR TITLE
[feature] Add AppTest support for download_button and image

### DIFF
--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1404,6 +1404,9 @@ class ButtonMixin:
             value_type="trigger_value",
         )
 
+        if ctx:
+            save_for_app_testing(ctx, element_id, button_state.value)
+
         layout_config = create_layout_config(width=width, allow_content_width=True)
         self.dg._enqueue(
             "download_button", download_button_proto, layout_config=layout_config

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -51,6 +51,7 @@ from streamlit.testing.v1.element_tree import (
     DateInput,
     DateTimeInput,
     Divider,
+    DownloadButton,
     ElementList,
     ElementTree,
     Error,
@@ -59,6 +60,7 @@ from streamlit.testing.v1.element_tree import (
     Feedback,
     FileUploader,
     Header,
+    Image,
     Info,
     Json,
     Latex,
@@ -709,6 +711,20 @@ class AppTest:
         return self._tree.divider
 
     @property
+    def download_button(self) -> WidgetList[DownloadButton]:
+        """Sequence of all ``st.download_button`` widgets.
+
+        Returns
+        -------
+        WidgetList of DownloadButton
+            Sequence of all ``st.download_button`` widgets. Individual widgets
+            can be accessed from a WidgetList by index (order on the page) or
+            key. For example, ``at.download_button[0]`` for the first widget or
+            ``at.download_button(key="my_key")`` for a widget with a given key.
+        """
+        return self._tree.download_button
+
+    @property
     def error(self) -> ElementList[Error]:
         """Sequence of all ``st.error`` elements.
 
@@ -791,6 +807,20 @@ class AppTest:
             extension of the Element class.
         """
         return self._tree.header
+
+    @property
+    def image(self) -> ElementList[Image]:
+        """Sequence of all ``st.image`` elements.
+
+        Returns
+        -------
+        ElementList of Image
+            Sequence of all ``st.image`` elements. Individual elements can be
+            accessed from an ElementList by index (order on the page). For
+            example, ``at.image[0]`` for the first element. Image is an
+            extension of the Element class.
+        """
+        return self._tree.image
 
     @property
     def info(self) -> ElementList[Info]:

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -67,12 +67,16 @@ if TYPE_CHECKING:
     from streamlit.proto.Dataframe_pb2 import Dataframe as DataframeProto
     from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
     from streamlit.proto.DateTimeInput_pb2 import DateTimeInput as DateTimeInputProto
+    from streamlit.proto.DownloadButton_pb2 import (
+        DownloadButton as DownloadButtonProto,
+    )
     from streamlit.proto.Element_pb2 import Element as ElementProto
     from streamlit.proto.Exception_pb2 import Exception as ExceptionProto
     from streamlit.proto.Feedback_pb2 import Feedback as FeedbackProto
     from streamlit.proto.FileUploader_pb2 import FileUploader as FileUploaderProto
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
     from streamlit.proto.Heading_pb2 import Heading as HeadingProto
+    from streamlit.proto.Image_pb2 import ImageList as ImageListProto
     from streamlit.proto.Json_pb2 import Json as JsonProto
     from streamlit.proto.MenuButton_pb2 import MenuButton as MenuButtonProto
     from streamlit.proto.Metric_pb2 import Metric as MetricProto
@@ -349,6 +353,48 @@ class Button(Widget):
 
 
 @dataclass(repr=False)
+class DownloadButton(Widget):
+    """A representation of ``st.download_button``."""
+
+    _value: bool
+
+    proto: DownloadButtonProto = field(repr=False)
+    label: str
+    help: str
+    form_id: str
+
+    def __init__(self, proto: DownloadButtonProto, root: ElementTree) -> None:
+        super().__init__(proto, root)
+        self._value = False
+        self.type = "download_button"
+
+    @property
+    def _widget_state(self) -> WidgetState:
+        ws = WidgetState()
+        ws.id = self.id
+        ws.trigger_value = self._value
+        return ws
+
+    @property
+    def value(self) -> bool:
+        """The value of the download button. (bool)"""  # noqa: D400
+        if self._value:
+            return self._value
+        state = self.root.session_state
+        assert state
+        return cast("bool", state[TESTING_KEY][self.id])
+
+    def set_value(self, v: bool) -> DownloadButton:
+        """Set the value of the download button."""
+        self._value = v
+        return self
+
+    def click(self) -> DownloadButton:
+        """Set the value of the download button to True."""
+        return self.set_value(True)
+
+
+@dataclass(repr=False)
 class ChatInput(Widget):
     """A representation of ``st.chat_input``."""
 
@@ -621,6 +667,30 @@ class Subheader(HeadingBase):
 class Title(HeadingBase):
     def __init__(self, proto: HeadingProto, root: ElementTree) -> None:
         super().__init__(proto, root, "title")
+
+
+@dataclass(repr=False)
+class Image(Element):
+    """A representation of ``st.image``."""
+
+    proto: ImageListProto = field(repr=False)
+    key: None
+
+    def __init__(self, proto: ImageListProto, root: ElementTree) -> None:
+        self.proto = proto
+        self.key = None
+        self.root = root
+        self.type = "image"
+
+    @property
+    def value(self) -> list[str]:
+        """The image URLs for this element."""
+        return [img.url for img in self.proto.imgs]
+
+    @property
+    def captions(self) -> list[str]:
+        """The image captions for this element."""
+        return [img.caption for img in self.proto.imgs]
 
 
 @dataclass(repr=False)
@@ -2015,6 +2085,10 @@ class Block:
         return ElementList(self.get("divider"))  # type: ignore
 
     @property
+    def download_button(self) -> WidgetList[DownloadButton]:
+        return WidgetList(self.get("download_button"))  # type: ignore
+
+    @property
     def error(self) -> ElementList[Error]:
         return ElementList(self.get("error"))  # type: ignore
 
@@ -2037,6 +2111,10 @@ class Block:
     @property
     def header(self) -> ElementList[Header]:
         return ElementList(self.get("header"))  # type: ignore
+
+    @property
+    def image(self) -> ElementList[Image]:
+        return ElementList(self.get("image"))  # type: ignore
 
     @property
     def info(self) -> ElementList[Info]:
@@ -2490,6 +2568,8 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                 new_node = DateInput(elt.date_input, root=root)
             elif ty == "date_time_input":
                 new_node = DateTimeInput(elt.date_time_input, root=root)
+            elif ty == "download_button":
+                new_node = DownloadButton(elt.download_button, root=root)
             elif ty == "exception":
                 new_node = Exception(elt.exception, root=root)
             elif ty == "feedback":
@@ -2505,6 +2585,8 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                     new_node = Subheader(elt.heading, root=root)
                 else:
                     raise ValueError(f"Unknown heading type with tag {elt.heading.tag}")
+            elif ty == "imgs":
+                new_node = Image(elt.imgs, root=root)
             elif ty == "json":
                 new_node = Json(elt.json, root=root)
             elif ty == "markdown":

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -119,6 +119,35 @@ def test_button():
     repr(sr.button[0])
 
 
+def test_download_button():
+    def script():
+        import streamlit as st
+
+        clicked = st.download_button(
+            "Download",
+            data="contents",
+            file_name="example.txt",
+            mime="text/plain",
+            key="download",
+        )
+        st.write(clicked)
+
+    at = AppTest.from_function(script).run()
+    assert at.download_button[0].label == "Download"
+    assert at.download_button(key="download").value is False
+    assert at.markdown[0].value == "`False`"
+
+    at.download_button[0].click().run()
+    assert at.download_button[0].value is True
+    assert at.markdown[0].value == "`True`"
+
+    at.run()
+    assert at.download_button[0].value is False
+    assert at.markdown[0].value == "`False`"
+
+    repr(at.download_button[0])
+
+
 def test_chat():
     def script():
         import streamlit as st
@@ -201,6 +230,35 @@ def test_columns():
     assert at.columns[1].radio[0].value == "a"
 
     repr(at.columns[0])
+
+
+def test_image():
+    def script():
+        import streamlit as st
+
+        st.image("https://example.com/image.png", caption="A caption")
+        st.image(
+            [
+                "https://example.com/first.png",
+                "https://example.com/second.png",
+            ],
+            caption=["First", "Second"],
+        )
+        st.image("https://example.com/no_caption.png")
+
+    at = AppTest.from_function(script).run()
+    assert at.image.len == 3
+    assert at.image[0].value == ["https://example.com/image.png"]
+    assert at.image[0].captions == ["A caption"]
+    assert at.image[1].value == [
+        "https://example.com/first.png",
+        "https://example.com/second.png",
+    ]
+    assert at.image[1].captions == ["First", "Second"]
+    assert at.image[2].value == ["https://example.com/no_caption.png"]
+    assert at.image[2].captions == [""]
+
+    repr(at.image[0])
 
 
 def test_dataframe():


### PR DESCRIPTION
## Describe your changes

Adds AppTest (`st.testing.v1`) support for two previously unsupported elements:

- `at.download_button` — new `DownloadButton` widget (mirrors `Button`; supports `.value`, `.set_value()`, `.click()`). The download button trigger value is now saved for app testing so it is recoverable across reruns.
- `at.image` — new `Image` element exposing `.value` (image URLs) and `.captions`.

## GitHub Issue Link (if applicable)

- Closes #9003

## Testing Plan

- `lib/tests/streamlit/testing/element_tree_test.py` — `test_download_button` (label, default/click/rerun-reset trigger behavior, key lookup) and `test_image` (single/multi image URLs, captions, and the no-caption default case)