### PR TITLE
[fragmentOutsideWrites][feature] Add layout-transparent Block type

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -21,6 +21,7 @@ import { screen } from "@testing-library/react"
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
 import { BlockNode } from "~lib/AppNode"
+import { text } from "~lib/render-tree/test-utils"
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -338,5 +339,56 @@ describe("BlockNodeRenderer CSS key class placement", () => {
 
     const innerBlock = screen.getByTestId("stVerticalBlock")
     expect(innerBlock.className).not.toContain("st-key-")
+  })
+})
+
+describe("BlockNodeRenderer transparent blocks", () => {
+  const widgetMgr = new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+
+  function makeBlockNodeComponent(node: BlockNode): ReactElement {
+    return (
+      <BlockNodeRenderer
+        node={node}
+        scriptRunId=""
+        scriptRunState={ScriptRunState.NOT_RUNNING}
+        widgetsDisabled={false}
+        widgetMgr={widgetMgr}
+        // @ts-expect-error
+        uploadClient={undefined}
+      />
+    )
+  }
+
+  it("renders children directly with no wrapping container", () => {
+    const node = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [text("transparent child")],
+      new BlockProto({ allowEmpty: true, transparent: {} })
+    )
+
+    renderWithContexts(makeBlockNodeComponent(node))
+
+    expect(screen.getByText("transparent child")).toBeVisible()
+
+    expect(screen.queryByTestId("stVerticalBlock")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stLayoutWrapper")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stExpander")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stColumn")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stHorizontalBlock")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing when empty even with allowEmpty", () => {
+    const node = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true, transparent: {} })
+    )
+
+    const { container } = renderWithContexts(makeBlockNodeComponent(node))
+
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -16,7 +16,7 @@
 
 import { ReactElement } from "react"
 
-import { screen } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
 
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
@@ -390,5 +390,40 @@ describe("BlockNodeRenderer transparent blocks", () => {
     const { container } = renderWithContexts(makeBlockNodeComponent(node))
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it("nested block inside transparent wrapper inherits parent layout", () => {
+    const column = makeColumn(0.5)
+    const transparentBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [column],
+      new BlockProto({ allowEmpty: true, transparent: {} })
+    )
+    const horizontalBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [transparentBlock],
+      new BlockProto({
+        allowEmpty: true,
+        flexContainer: {
+          gapConfig: { gapSize: streamlit.GapSize.SMALL },
+          direction: BlockProto.FlexContainer.Direction.HORIZONTAL,
+        },
+      })
+    )
+    const root = makeVerticalBlock([horizontalBlock])
+
+    renderWithContexts(makeVerticalBlockComponent(root))
+
+    const hBlock = screen.getByTestId("stHorizontalBlock")
+    expect(hBlock).toHaveAttribute("direction", "row")
+
+    // Column renders as a flex child of the horizontal block —
+    // the transparent wrapper contributes no intervening DOM.
+    const columnEl = within(hBlock).getByTestId("stColumn")
+    expect(columnEl).toBeVisible()
+
+    // Only the root and the column's inner vertical block exist;
+    // the transparent wrapper does not add another.
+    expect(screen.getAllByTestId("stVerticalBlock")).toHaveLength(2)
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -392,7 +392,7 @@ describe("BlockNodeRenderer transparent blocks", () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it("nested block inside transparent wrapper inherits parent layout", () => {
+  it("column inside transparent wrapper renders directly in parent horizontal block", () => {
     const column = makeColumn(0.5)
     const transparentBlock = new BlockNode(
       FAKE_SCRIPT_HASH,
@@ -414,16 +414,14 @@ describe("BlockNodeRenderer transparent blocks", () => {
 
     renderWithContexts(makeVerticalBlockComponent(root))
 
-    const hBlock = screen.getByTestId("stHorizontalBlock")
-    expect(hBlock).toHaveAttribute("direction", "row")
+    const horizontalBlockEl = screen.getByTestId("stHorizontalBlock")
+    expect(horizontalBlockEl).toHaveAttribute("direction", "row")
 
-    // Column renders as a flex child of the horizontal block —
-    // the transparent wrapper contributes no intervening DOM.
-    const columnEl = within(hBlock).getByTestId("stColumn")
+    // Column is a direct descendant of the horizontal block — no transparent wrapper DOM.
+    const columnEl = within(horizontalBlockEl).getByTestId("stColumn")
     expect(columnEl).toBeVisible()
 
-    // Only the root and the column's inner vertical block exist;
-    // the transparent wrapper does not add another.
+    // Transparent wrapper adds no extra stVerticalBlock.
     expect(screen.getAllByTestId("stVerticalBlock")).toHaveLength(2)
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -287,6 +287,18 @@ export const BlockNodeRenderer = (
     notNullOrUndefined(node.deltaBlock.dialog) ||
     notNullOrUndefined(node.deltaBlock.popover)
 
+  // Transparent blocks reserve a slot in the element tree for backend cursor
+  // bookkeeping but have zero visual or DOM footprint. Render children directly;
+  // they inherit direction, width, and flex context from the outside container.
+  if (node.deltaBlock.transparent) {
+    return (
+      <ChildRenderer
+        {...childProps}
+        disableFullscreenMode={disableFullscreenMode}
+      />
+    )
+  }
+
   let containerElement: ReactElement | undefined
   // Whether the CSS key class (st-key-*) is applied on StyledLayoutWrapper.
   // Gating this per container so we can analyze each one to confirm that

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -287,9 +287,8 @@ export const BlockNodeRenderer = (
     notNullOrUndefined(node.deltaBlock.dialog) ||
     notNullOrUndefined(node.deltaBlock.popover)
 
-  // Transparent blocks reserve a slot in the element tree for backend cursor
-  // bookkeeping but have zero visual or DOM footprint. Render children directly;
-  // they inherit direction, width, and flex context from the outside container.
+  // Transparent blocks group elements in the backend tree without adding DOM.
+  // Children render directly in the parent's flex context.
   if (node.deltaBlock.transparent) {
     return (
       <ChildRenderer

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -184,10 +184,8 @@ message Block {
     AvatarType avatar_type = 3;
   }
 
-  // A layout-transparent wrapper block with no visual treatment (no padding,
-  // border, or gap). Renders as a plain unstyled grouping with no DOM node of
-  // its own. Used to group elements into a single tree node without affecting
-  // the user-visible layout.
+  // A layout-transparent wrapper block. Produces no DOM node — children
+  // render directly in the parent container's flex context.
   message Transparent {}
 
   // Next ID: 18

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -33,6 +33,7 @@ message Block {
     Popover popover = 10;
     Dialog dialog = 11;
     FlexContainer flex_container = 13;
+    Transparent transparent = 17;
   }
 
   bool allow_empty = 8;
@@ -183,5 +184,11 @@ message Block {
     AvatarType avatar_type = 3;
   }
 
-  // Next ID: 17
+  // A layout-transparent wrapper block with no visual treatment (no padding,
+  // border, or gap). Renders as a plain unstyled grouping with no DOM node of
+  // its own. Used to group elements into a single tree node without affecting
+  // the user-visible layout.
+  message Transparent {}
+
+  // Next ID: 18
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Adds a layout-transparent `Block` type to the protocol, rendered on the frontend with no DOM node of its own.

- New `Block.Transparent` proto message (field `transparent = 17`).
- `BlockNodeRenderer` returns children directly via a React fragment — no wrapping `<div>` — so they participate in the parent's flex layout (direction, width, gap). The transparent check runs before the flex-container path to ensure no wrapper div is added.

First PR in the "outside container writes" stack. Later PRs add the wrapper registry, detection/redirection, rerun reset, and lift the widget restriction. No backend behavior change — this PR only adds the proto message and frontend rendering.

## Screenshot or video (only for visual changes)

N/A — transparent blocks have no visual treatment.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS): `Block.test.tsx` asserts:
  - A transparent block renders its children directly with no `stVerticalBlock`, `stLayoutWrapper`, `stExpander`, `stColumn`, or `stHorizontalBlock` wrapper.
  - A transparent block renders nothing when empty (even with `allowEmpty`).
  - A column inside a transparent wrapper renders directly in the parent horizontal block with no extra DOM.
- E2E Tests: not needed — no user-facing surface yet; behavior is exercised in later PRs of the stack.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->