### PR TITLE
[feature] Add OTLP format to the /_stcore/metrics endpoint

### DIFF
--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -114,6 +114,16 @@ class Stat(Protocol):
     def marshall_metric_proto(self, metric: MetricProto) -> None:
         """Fill an OpenMetrics `Metric` protobuf object."""
 
+    def to_otlp_data_point(
+        self, time_unix_nano: int, start_time_unix_nano: int
+    ) -> dict[str, Any]:
+        """Return this stat as an OTLP `NumberDataPoint` dict.
+
+        The dict matches the proto3 JSON encoding of the OTLP NumberDataPoint
+        message, so int64 fields (timestamps and integer values) are encoded as
+        strings.
+        """
+
 
 # TODO(vdonato): Could we use GaugeStat below and get rid of this class?
 # We'd have to make some minor changes to use the other class, but overall the
@@ -171,6 +181,20 @@ class CacheStat(NamedTuple):
 
         metric_point = metric.metric_points.add()
         metric_point.gauge_value.int_value = self.byte_length
+
+    def to_otlp_data_point(
+        self, time_unix_nano: int, start_time_unix_nano: int
+    ) -> dict[str, Any]:
+        """Return this cache stat as an OTLP `NumberDataPoint` dict."""
+        return {
+            "attributes": [
+                {"key": "cache_type", "value": {"stringValue": self.category_name}},
+                {"key": "cache", "value": {"stringValue": self.cache_name}},
+            ],
+            "startTimeUnixNano": str(start_time_unix_nano),
+            "timeUnixNano": str(time_unix_nano),
+            "asInt": str(self.byte_length),
+        }
 
 
 def group_cache_stats(stats: list[CacheStat]) -> list[CacheStat]:
@@ -239,6 +263,17 @@ class CounterStat(NamedTuple):
         metric_point = metric.metric_points.add()
         metric_point.counter_value.int_value = self.value
 
+    def to_otlp_data_point(
+        self, time_unix_nano: int, start_time_unix_nano: int
+    ) -> dict[str, Any]:
+        """Return this counter stat as an OTLP `NumberDataPoint` dict."""
+        return _build_otlp_number_data_point(
+            value=self.value,
+            labels=self.labels,
+            time_unix_nano=time_unix_nano,
+            start_time_unix_nano=start_time_unix_nano,
+        )
+
 
 class GaugeStat(NamedTuple):
     """A gauge stat.
@@ -283,6 +318,17 @@ class GaugeStat(NamedTuple):
         metric_point = metric.metric_points.add()
         metric_point.gauge_value.int_value = self.value
 
+    def to_otlp_data_point(
+        self, time_unix_nano: int, start_time_unix_nano: int
+    ) -> dict[str, Any]:
+        """Return this gauge stat as an OTLP `NumberDataPoint` dict."""
+        return _build_otlp_number_data_point(
+            value=self.value,
+            labels=self.labels,
+            time_unix_nano=time_unix_nano,
+            start_time_unix_nano=start_time_unix_nano,
+        )
+
 
 def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
     """Convert a metric type string to its corresponding proto enum value."""
@@ -307,6 +353,128 @@ def metric_type_string_to_proto(type_string: str) -> MetricType.ValueType:
         "summary": SUMMARY,
     }
     return type_map.get(type_string, UNKNOWN)
+
+
+# OTLP `AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE`. Streamlit's
+# counters are cumulative (monotonically increasing for the life of the server).
+_OTLP_AGGREGATION_TEMPORALITY_CUMULATIVE: Final = 2
+
+
+def _labels_to_otlp_attributes(
+    labels: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    """Convert a label mapping to a list of OTLP `KeyValue` dicts.
+
+    Labels are sorted by key so the output is deterministic.
+    """
+    return [
+        {"key": name, "value": {"stringValue": value}}
+        for name, value in sorted(labels.items())
+    ]
+
+
+def _build_otlp_number_data_point(
+    *,
+    value: int,
+    labels: Mapping[str, str] | None,
+    time_unix_nano: int,
+    start_time_unix_nano: int,
+) -> dict[str, Any]:
+    """Build an OTLP `NumberDataPoint` dict for an integer-valued stat."""
+    data_point: dict[str, Any] = {
+        "startTimeUnixNano": str(start_time_unix_nano),
+        "timeUnixNano": str(time_unix_nano),
+        "asInt": str(value),
+    }
+    if labels:
+        data_point["attributes"] = _labels_to_otlp_attributes(labels)
+    return data_point
+
+
+def stats_to_otlp_dict(
+    stats_by_family: Mapping[str, Sequence[Stat]],
+    *,
+    time_unix_nano: int,
+    start_time_unix_nano: int,
+    resource_attributes: Mapping[str, str] | None = None,
+    scope_name: str = "streamlit",
+    scope_version: str = "",
+) -> dict[str, Any]:
+    """Convert stats to an OTLP `MetricsData` dict (proto3 JSON encoding).
+
+    The returned dict matches the JSON representation of the OTLP
+    ``MetricsData`` / ``ExportMetricsServiceRequest`` message and can be
+    forwarded to an OTLP/HTTP receiver with ``Content-Type: application/json``.
+    int64 fields (timestamps and integer values) are encoded as strings, as
+    required by the proto3 JSON mapping.
+
+    Parameters
+    ----------
+    stats_by_family : Mapping[str, Sequence[Stat]]
+        Stats grouped by metric family name, as returned by
+        ``StatsManager.get_stats``.
+    time_unix_nano : int
+        The time of the observation, in nanoseconds since the Unix epoch.
+    start_time_unix_nano : int
+        The time the metrics started being collected (e.g. server start), in
+        nanoseconds since the Unix epoch. Used as the start time for cumulative
+        sums.
+    resource_attributes : Mapping[str, str] | None
+        Optional attributes describing the resource (e.g. ``service.name``).
+    scope_name : str
+        The instrumentation scope name.
+    scope_version : str
+        The instrumentation scope version (e.g. the Streamlit version).
+    """
+    metrics: list[dict[str, Any]] = []
+
+    for stats in stats_by_family.values():
+        if not stats:
+            continue
+
+        # All stats in a family share the same family_name, type, unit, and
+        # help, so the first one provides the family-level metadata.
+        first_stat = stats[0]
+        data_points = [
+            stat.to_otlp_data_point(time_unix_nano, start_time_unix_nano)
+            for stat in stats
+        ]
+
+        metric: dict[str, Any] = {"name": first_stat.family_name}
+        if first_stat.unit:
+            metric["unit"] = first_stat.unit
+        if first_stat.help:
+            metric["description"] = first_stat.help
+
+        if first_stat.type == "counter":
+            # OTLP counter names omit the Prometheus-only "_total" suffix.
+            metric["sum"] = {
+                "dataPoints": data_points,
+                "aggregationTemporality": _OTLP_AGGREGATION_TEMPORALITY_CUMULATIVE,
+                "isMonotonic": True,
+            }
+        else:
+            # Gauges (and any unrecognized type) map to an OTLP gauge.
+            metric["gauge"] = {"dataPoints": data_points}
+
+        metrics.append(metric)
+
+    scope: dict[str, Any] = {"name": scope_name}
+    if scope_version:
+        scope["version"] = scope_version
+
+    resource: dict[str, Any] = {}
+    if resource_attributes:
+        resource["attributes"] = _labels_to_otlp_attributes(resource_attributes)
+
+    return {
+        "resourceMetrics": [
+            {
+                "resource": resource,
+                "scopeMetrics": [{"scope": scope, "metrics": metrics}],
+            }
+        ]
+    }
 
 
 @runtime_checkable

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import TYPE_CHECKING, Final
 from urllib.parse import quote
 
@@ -60,6 +61,11 @@ if TYPE_CHECKING:
     from streamlit.runtime.stats import Stat
 
 _LOGGER: Final = get_logger(__name__)
+
+# Approximate process/server start time, captured when this module is first
+# imported (during server startup). Used as the start time for cumulative OTLP
+# sums so a counter's accumulation window is stable across scrapes.
+_SERVER_START_TIME_UNIX_NANO: Final = time.time_ns()
 
 # Route path constants (without base URL prefix)
 # These define the canonical paths for all Starlette server endpoints.
@@ -158,6 +164,28 @@ def _stats_to_proto(
             stat.marshall_metric_proto(metric_proto)
 
     return metric_set
+
+
+def _stats_to_otlp_response(
+    stats_by_family: Mapping[str, Sequence[Stat]],
+) -> Response:
+    """Build a JSON response with stats encoded as OTLP `MetricsData`.
+
+    The body is OTLP/HTTP JSON and can be forwarded as-is to an OTLP receiver.
+    """
+    from starlette.responses import JSONResponse
+
+    from streamlit.runtime.stats import stats_to_otlp_dict
+    from streamlit.version import STREAMLIT_VERSION_STRING
+
+    otlp_data = stats_to_otlp_dict(
+        stats_by_family,
+        time_unix_nano=time.time_ns(),
+        start_time_unix_nano=_SERVER_START_TIME_UNIX_NANO,
+        resource_attributes={"service.name": "streamlit"},
+        scope_version=STREAMLIT_VERSION_STRING,
+    )
+    return JSONResponse(otlp_data)
 
 
 def _with_base(path: str, base_url: str | None = None) -> str:
@@ -445,8 +473,9 @@ def create_metrics_routes(runtime: Runtime, base_url: str | None) -> list[BaseRo
     async def _metrics_endpoint(request: Request) -> Response:
         requested_families = request.query_params.getlist("families")
         stats = runtime.stats_mgr.get_stats(family_names=requested_families or None)
-        accept = request.headers.get("Accept", "")
-        if "application/x-protobuf" in accept:
+        if request.query_params.get("format") == "otlp":
+            response = _stats_to_otlp_response(stats)
+        elif "application/x-protobuf" in request.headers.get("Accept", ""):
             payload = _stats_to_proto(stats).SerializeToString()
             response = Response(payload, media_type="application/x-protobuf")
         else:

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -33,6 +33,7 @@ from streamlit.proto.openmetrics_data_model_pb2 import (
 )
 from streamlit.runtime.stats import (
     CACHE_MEMORY_FAMILY,
+    USER_SESSION_EVENTS_FAMILY,
     CacheStat,
     CounterStat,
     GaugeStat,
@@ -647,4 +648,39 @@ def test_stats_to_otlp_dict_is_json_serializable() -> None:
     )
 
     # Should not raise, and should round-trip unchanged.
+    assert json.loads(json.dumps(result)) == result
+
+
+def test_stats_to_otlp_dict_user_session_events_preserves_special_label_values() -> (
+    None
+):
+    """The user_session_events family carries user-controlled identity labels
+    (e.g. email) on the unauthenticated metrics endpoint. Unlike the text format
+    (which must escape them), the OTLP JSON body relies on JSON encoding to carry
+    special characters verbatim without breaking the payload.
+    """
+    stats = {
+        USER_SESSION_EVENTS_FAMILY: [
+            CounterStat(
+                family_name=USER_SESSION_EVENTS_FAMILY,
+                value=3,
+                labels={"email": 'a"b\\c\nd', "type": "connect"},
+            )
+        ]
+    }
+
+    result = stats_to_otlp_dict(
+        stats, time_unix_nano=_TIME_NS, start_time_unix_nano=_START_TIME_NS
+    )
+
+    metric = result["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+    # Emitted as a cumulative monotonic sum, like any other counter family.
+    assert metric["name"] == USER_SESSION_EVENTS_FAMILY
+    assert metric["sum"]["isMonotonic"] is True
+    data_point = metric["sum"]["dataPoints"][0]
+    # The raw value is preserved in the attribute (no text-format escaping).
+    assert {"key": "email", "value": {"stringValue": 'a"b\\c\nd'}} in data_point[
+        "attributes"
+    ]
+    # The body must survive JSON serialization with the value intact.
     assert json.loads(json.dumps(result)) == result

--- a/lib/tests/streamlit/runtime/stats_test.py
+++ b/lib/tests/streamlit/runtime/stats_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -40,6 +41,7 @@ from streamlit.runtime.stats import (
     group_cache_stats,
     metric_type_string_to_proto,
     safe_sizeof,
+    stats_to_otlp_dict,
 )
 
 if TYPE_CHECKING:
@@ -490,3 +492,159 @@ class SafeSizeofTest(unittest.TestCase):
             side_effect=ReferenceError("weakly-referenced object no longer exists"),
         ):
             assert safe_sizeof(object()) == 0
+
+
+# Fixed timestamps (in nanoseconds) used by the OTLP serialization tests.
+_TIME_NS = 1_700_000_000_000_000_000
+_START_TIME_NS = 1_699_999_000_000_000_000
+
+
+def test_cache_stat_to_otlp_data_point() -> None:
+    """CacheStat.to_otlp_data_point encodes cache labels and int64 fields as strings."""
+    stat = CacheStat("st.cache_data", "my_func", 512)
+
+    data_point = stat.to_otlp_data_point(_TIME_NS, _START_TIME_NS)
+
+    assert data_point == {
+        "attributes": [
+            {"key": "cache_type", "value": {"stringValue": "st.cache_data"}},
+            {"key": "cache", "value": {"stringValue": "my_func"}},
+        ],
+        "startTimeUnixNano": str(_START_TIME_NS),
+        "timeUnixNano": str(_TIME_NS),
+        "asInt": "512",
+    }
+
+
+def test_counter_stat_to_otlp_data_point_sorts_labels() -> None:
+    """CounterStat.to_otlp_data_point emits attributes sorted by key."""
+    stat = CounterStat(
+        family_name="my_counter",
+        value=5,
+        labels={"z_label": "z_val", "a_label": "a_val"},
+    )
+
+    data_point = stat.to_otlp_data_point(_TIME_NS, _START_TIME_NS)
+
+    assert data_point["asInt"] == "5"
+    assert data_point["attributes"] == [
+        {"key": "a_label", "value": {"stringValue": "a_val"}},
+        {"key": "z_label", "value": {"stringValue": "z_val"}},
+    ]
+
+
+def test_gauge_stat_to_otlp_data_point_without_labels_omits_attributes() -> None:
+    """GaugeStat.to_otlp_data_point omits the attributes key when there are no labels."""
+    stat = GaugeStat(family_name="active_sessions", value=3)
+
+    data_point = stat.to_otlp_data_point(_TIME_NS, _START_TIME_NS)
+
+    assert "attributes" not in data_point
+    assert data_point["asInt"] == "3"
+
+
+def test_stats_to_otlp_dict_maps_gauge_family() -> None:
+    """A gauge family is serialized as an OTLP gauge metric."""
+    stats = {CACHE_MEMORY_FAMILY: [CacheStat("st.cache_data", "my_func", 512)]}
+
+    result = stats_to_otlp_dict(
+        stats, time_unix_nano=_TIME_NS, start_time_unix_nano=_START_TIME_NS
+    )
+
+    metrics = result["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+    assert len(metrics) == 1
+    metric = metrics[0]
+    assert metric["name"] == CACHE_MEMORY_FAMILY
+    assert metric["unit"] == "bytes"
+    assert metric["description"] == "Total memory consumed by a cache."
+    # Gauges have no aggregation temporality / monotonic fields.
+    assert "gauge" in metric
+    assert "sum" not in metric
+    assert metric["gauge"]["dataPoints"][0]["asInt"] == "512"
+
+
+def test_stats_to_otlp_dict_maps_counter_family_as_cumulative_sum() -> None:
+    """A counter family is serialized as a cumulative, monotonic OTLP sum."""
+    stats = {
+        "session_events": [
+            CounterStat(family_name="session_events", value=10, labels={"type": "x"})
+        ]
+    }
+
+    result = stats_to_otlp_dict(
+        stats, time_unix_nano=_TIME_NS, start_time_unix_nano=_START_TIME_NS
+    )
+
+    metric = result["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+    # OTLP counter names must NOT carry the Prometheus-only "_total" suffix.
+    assert metric["name"] == "session_events"
+    assert "gauge" not in metric
+    sum_data = metric["sum"]
+    assert sum_data["isMonotonic"] is True
+    # 2 == AGGREGATION_TEMPORALITY_CUMULATIVE.
+    assert sum_data["aggregationTemporality"] == 2
+    assert sum_data["dataPoints"][0]["asInt"] == "10"
+
+
+def test_stats_to_otlp_dict_skips_empty_families() -> None:
+    """Families with no stats are omitted from the output."""
+    stats = {
+        "active_sessions": [GaugeStat(family_name="active_sessions", value=3)],
+        "empty_family": [],
+    }
+
+    result = stats_to_otlp_dict(
+        stats, time_unix_nano=_TIME_NS, start_time_unix_nano=_START_TIME_NS
+    )
+
+    metrics = result["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+    names = {metric["name"] for metric in metrics}
+    assert names == {"active_sessions"}
+
+
+def test_stats_to_otlp_dict_includes_resource_and_scope_metadata() -> None:
+    """Resource attributes and a non-empty scope version are included."""
+    stats = {"active_sessions": [GaugeStat(family_name="active_sessions", value=1)]}
+
+    result = stats_to_otlp_dict(
+        stats,
+        time_unix_nano=_TIME_NS,
+        start_time_unix_nano=_START_TIME_NS,
+        resource_attributes={"service.name": "streamlit"},
+        scope_version="1.2.3",
+    )
+
+    resource_metrics = result["resourceMetrics"][0]
+    assert resource_metrics["resource"]["attributes"] == [
+        {"key": "service.name", "value": {"stringValue": "streamlit"}}
+    ]
+    scope = resource_metrics["scopeMetrics"][0]["scope"]
+    assert scope == {"name": "streamlit", "version": "1.2.3"}
+
+
+def test_stats_to_otlp_dict_omits_scope_version_when_empty() -> None:
+    """An empty scope version is not emitted as a key."""
+    stats = {"active_sessions": [GaugeStat(family_name="active_sessions", value=1)]}
+
+    result = stats_to_otlp_dict(
+        stats, time_unix_nano=_TIME_NS, start_time_unix_nano=_START_TIME_NS
+    )
+
+    scope = result["resourceMetrics"][0]["scopeMetrics"][0]["scope"]
+    assert "version" not in scope
+    assert result["resourceMetrics"][0]["resource"] == {}
+
+
+def test_stats_to_otlp_dict_is_json_serializable() -> None:
+    """The OTLP dict round-trips through JSON (the forwarded OTLP/HTTP body)."""
+    stats = {
+        CACHE_MEMORY_FAMILY: [CacheStat("st.cache_data", "my_func", 512)],
+        "session_events": [CounterStat(family_name="session_events", value=10)],
+    }
+
+    result = stats_to_otlp_dict(
+        stats, time_unix_nano=_TIME_NS, start_time_unix_nano=_START_TIME_NS
+    )
+
+    # Should not raise, and should round-trip unchanged.
+    assert json.loads(json.dumps(result)) == result

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -555,6 +555,20 @@ def test_metrics_endpoint_otlp_format_respects_family_filter(
     assert names == {"session_events"}
 
 
+def test_metrics_endpoint_otlp_format_takes_precedence_over_accept_header(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """?format=otlp wins over an Accept: application/x-protobuf header."""
+    client, _ = starlette_client
+    response = client.get(
+        "/_stcore/metrics?format=otlp",
+        headers={"Accept": "application/x-protobuf"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    assert "resourceMetrics" in response.json()
+
+
 def test_media_endpoint_serves_file(
     starlette_client: tuple[TestClient, _DummyRuntime],
 ) -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -520,6 +520,41 @@ def test_metrics_endpoint_protobuf_uses_canonical_family_name(
     assert "session_duration_seconds_total" not in family_names
 
 
+def test_metrics_endpoint_otlp_format(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """?format=otlp returns the stats as OTLP/HTTP JSON."""
+    client, _ = starlette_client
+    response = client.get("/_stcore/metrics?format=otlp")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+
+    metrics = response.json()["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+    metrics_by_name = {metric["name"]: metric for metric in metrics}
+
+    # Gauge and counter map to the matching OTLP data types.
+    assert "gauge" in metrics_by_name["active_sessions"]
+    assert metrics_by_name["session_events"]["sum"]["isMonotonic"] is True
+    # OTLP counter names omit the Prometheus-only "_total" suffix.
+    assert "session_events" in metrics_by_name
+    assert "session_events_total" not in metrics_by_name
+    # int64 values are encoded as strings per proto3 JSON.
+    assert metrics_by_name["active_sessions"]["gauge"]["dataPoints"][0]["asInt"] == "3"
+
+
+def test_metrics_endpoint_otlp_format_respects_family_filter(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """?format=otlp honors the families filter just like the other formats."""
+    client, _ = starlette_client
+    response = client.get("/_stcore/metrics?format=otlp&families=session_events")
+    assert response.status_code == 200
+
+    metrics = response.json()["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+    names = {metric["name"] for metric in metrics}
+    assert names == {"session_events"}
+
+
 def test_media_endpoint_serves_file(
     starlette_client: tuple[TestClient, _DummyRuntime],
 ) -> None:


### PR DESCRIPTION

## Describe your changes

`GET /_stcore/metrics?format=otlp` returns the runtime stats as OTLP/HTTP JSON (`MetricsData`), so OTLP-only consumers (e.g. Snowflake SiS/SPCS observability) can scrape the existing pull endpoint and forward the body verbatim instead of converting it from Prometheus/OpenMetrics. Output with no `format` param is unchanged.

- Gauges map to OTLP gauges; counters map to cumulative, monotonic sums and drop the Prometheus-only `_total` suffix. int64 fields (timestamps, values) are encoded as strings, per the proto3 JSON mapping.
- Emits OTLP **JSON** with no new dependency (forwardable over OTLP/HTTP as `application/json`). Protobuf output via `opentelemetry-proto` is a deliberate follow-up, not included here.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python): OTLP serializer mapping (gauge/sum, label sorting, empty families, resource/scope metadata, JSON round-trip) and the `?format=otlp` endpoint behavior + family filter.
- [ ] E2E Tests: not added — this is a server response-format change with no UI surface; can follow up if desired.
- [ ] Any manual testing needed?


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
