### PR TITLE
[fragmentOutsideWrites][feature] Add per-fragment outside wrapper registry

### DIFF
--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -21,6 +21,7 @@ import { screen } from "@testing-library/react"
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
 import { BlockNode } from "~lib/AppNode"
+import { text } from "~lib/render-tree/test-utils"
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -338,5 +339,56 @@ describe("BlockNodeRenderer CSS key class placement", () => {
 
     const innerBlock = screen.getByTestId("stVerticalBlock")
     expect(innerBlock.className).not.toContain("st-key-")
+  })
+})
+
+describe("BlockNodeRenderer transparent blocks", () => {
+  const widgetMgr = new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+
+  function makeBlockNodeComponent(node: BlockNode): ReactElement {
+    return (
+      <BlockNodeRenderer
+        node={node}
+        scriptRunId=""
+        scriptRunState={ScriptRunState.NOT_RUNNING}
+        widgetsDisabled={false}
+        widgetMgr={widgetMgr}
+        // @ts-expect-error
+        uploadClient={undefined}
+      />
+    )
+  }
+
+  it("renders children directly with no wrapping container", () => {
+    const node = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [text("transparent child")],
+      new BlockProto({ allowEmpty: true, transparent: {} })
+    )
+
+    renderWithContexts(makeBlockNodeComponent(node))
+
+    expect(screen.getByText("transparent child")).toBeVisible()
+
+    expect(screen.queryByTestId("stVerticalBlock")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stLayoutWrapper")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stExpander")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stColumn")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("stHorizontalBlock")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing when empty even with allowEmpty", () => {
+    const node = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [],
+      new BlockProto({ allowEmpty: true, transparent: {} })
+    )
+
+    const { container } = renderWithContexts(makeBlockNodeComponent(node))
+
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -16,7 +16,7 @@
 
 import { ReactElement } from "react"
 
-import { screen } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
 
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
@@ -390,5 +390,40 @@ describe("BlockNodeRenderer transparent blocks", () => {
     const { container } = renderWithContexts(makeBlockNodeComponent(node))
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it("nested block inside transparent wrapper inherits parent layout", () => {
+    const column = makeColumn(0.5)
+    const transparentBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [column],
+      new BlockProto({ allowEmpty: true, transparent: {} })
+    )
+    const horizontalBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [transparentBlock],
+      new BlockProto({
+        allowEmpty: true,
+        flexContainer: {
+          gapConfig: { gapSize: streamlit.GapSize.SMALL },
+          direction: BlockProto.FlexContainer.Direction.HORIZONTAL,
+        },
+      })
+    )
+    const root = makeVerticalBlock([horizontalBlock])
+
+    renderWithContexts(makeVerticalBlockComponent(root))
+
+    const hBlock = screen.getByTestId("stHorizontalBlock")
+    expect(hBlock).toHaveAttribute("direction", "row")
+
+    // Column renders as a flex child of the horizontal block —
+    // the transparent wrapper contributes no intervening DOM.
+    const columnEl = within(hBlock).getByTestId("stColumn")
+    expect(columnEl).toBeVisible()
+
+    // Only the root and the column's inner vertical block exist;
+    // the transparent wrapper does not add another.
+    expect(screen.getAllByTestId("stVerticalBlock")).toHaveLength(2)
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -392,7 +392,7 @@ describe("BlockNodeRenderer transparent blocks", () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it("nested block inside transparent wrapper inherits parent layout", () => {
+  it("column inside transparent wrapper renders directly in parent horizontal block", () => {
     const column = makeColumn(0.5)
     const transparentBlock = new BlockNode(
       FAKE_SCRIPT_HASH,
@@ -414,16 +414,14 @@ describe("BlockNodeRenderer transparent blocks", () => {
 
     renderWithContexts(makeVerticalBlockComponent(root))
 
-    const hBlock = screen.getByTestId("stHorizontalBlock")
-    expect(hBlock).toHaveAttribute("direction", "row")
+    const horizontalBlockEl = screen.getByTestId("stHorizontalBlock")
+    expect(horizontalBlockEl).toHaveAttribute("direction", "row")
 
-    // Column renders as a flex child of the horizontal block —
-    // the transparent wrapper contributes no intervening DOM.
-    const columnEl = within(hBlock).getByTestId("stColumn")
+    // Column is a direct descendant of the horizontal block — no transparent wrapper DOM.
+    const columnEl = within(horizontalBlockEl).getByTestId("stColumn")
     expect(columnEl).toBeVisible()
 
-    // Only the root and the column's inner vertical block exist;
-    // the transparent wrapper does not add another.
+    // Transparent wrapper adds no extra stVerticalBlock.
     expect(screen.getAllByTestId("stVerticalBlock")).toHaveLength(2)
   })
 })

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -287,6 +287,18 @@ export const BlockNodeRenderer = (
     notNullOrUndefined(node.deltaBlock.dialog) ||
     notNullOrUndefined(node.deltaBlock.popover)
 
+  // Transparent blocks reserve a slot in the element tree for backend cursor
+  // bookkeeping but have zero visual or DOM footprint. Render children directly;
+  // they inherit direction, width, and flex context from the outside container.
+  if (node.deltaBlock.transparent) {
+    return (
+      <ChildRenderer
+        {...childProps}
+        disableFullscreenMode={disableFullscreenMode}
+      />
+    )
+  }
+
   let containerElement: ReactElement | undefined
   // Whether the CSS key class (st-key-*) is applied on StyledLayoutWrapper.
   // Gating this per container so we can analyze each one to confirm that

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -287,9 +287,8 @@ export const BlockNodeRenderer = (
     notNullOrUndefined(node.deltaBlock.dialog) ||
     notNullOrUndefined(node.deltaBlock.popover)
 
-  // Transparent blocks reserve a slot in the element tree for backend cursor
-  // bookkeeping but have zero visual or DOM footprint. Render children directly;
-  // they inherit direction, width, and flex context from the outside container.
+  // Transparent blocks group elements in the backend tree without adding DOM.
+  // Children render directly in the parent's flex context.
   if (node.deltaBlock.transparent) {
     return (
       <ChildRenderer

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -315,8 +315,8 @@ class DeltaGenerator(
         self._parent = parent
         self._block_type = block_type
 
-        # The fragment that created this container, used for per-fragment
-        # wrapper eviction. None when created outside any fragment.
+        # Tracks which fragment's scope created this container. Used to clear
+        # cached outside-write wrappers when that fragment reruns.
         self._creating_fragment_id: str | None = None
 
         # If this an `st.form` block, this will get filled in.

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -315,6 +315,10 @@ class DeltaGenerator(
         self._parent = parent
         self._block_type = block_type
 
+        # The fragment that created this container, used for per-fragment
+        # wrapper eviction. None when created outside any fragment.
+        self._creating_fragment_id: str | None = None
+
         # If this an `st.form` block, this will get filled in.
         self._form_data: FormData | None = None
 
@@ -406,6 +410,7 @@ class DeltaGenerator(
             block_type=self._block_type,
         )
         dg._form_data = deepcopy(self._form_data)
+        dg._creating_fragment_id = self._creating_fragment_id
         return dg
 
     @property

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -60,12 +60,15 @@ class _OutsideWrapper:
     """A cached implicit wrapper interposed between an outside container and a
     fragment's writes. ``creation_delta_path`` and ``block_proto`` are retained
     so the wrapper's ``add_block`` delta can be re-emitted on each fragment
-    rerun.
+    rerun. ``creating_fragment_id`` is the fragment whose scope created the
+    outside container (``None`` for the main script); it drives per-fragment
+    eviction when that scope reruns.
     """
 
     delta_generator: DeltaGenerator
     creation_delta_path: list[int]
     block_proto: Block_pb2.Block
+    creating_fragment_id: str | None
 
 
 def _check_not_parallel_worker(api_name: str) -> None:
@@ -205,6 +208,14 @@ class FragmentStorage(Protocol):
         """Return all wrapper records belonging to the given fragment."""
         raise NotImplementedError
 
+    @abstractmethod
+    def evict_outside_wrappers_created_by(self, fragment_id: str) -> None:
+        """Drop every wrapper whose outside container was created by the given
+        fragment's scope. Called when that fragment reruns and is about to rebuild
+        those containers.
+        """
+        raise NotImplementedError
+
 
 # NOTE: Ideally, we'd like to add a MemoryFragmentStorageStatProvider implementation to
 # keep track of memory usage due to fragments, but doing something like this ends up
@@ -249,6 +260,11 @@ class MemoryFragmentStorage(FragmentStorage):
         del self._fragments[fragment_id]
         self._parent_by_id.pop(fragment_id, None)
         self._registration_sequence_by_id.pop(fragment_id, None)
+        self._outside_wrappers = {
+            key: wrapper
+            for key, wrapper in self._outside_wrappers.items()
+            if key[0] != fragment_id
+        }
 
     def clear(self, new_fragment_ids: frozenset[str] | None = None) -> None:
         with self._lock:
@@ -375,6 +391,14 @@ class MemoryFragmentStorage(FragmentStorage):
                 ), wrapper in self._outside_wrappers.items()
                 if stored_fragment_id == fragment_id
             ]
+
+    def evict_outside_wrappers_created_by(self, fragment_id: str) -> None:
+        with self._lock:
+            self._outside_wrappers = {
+                key: wrapper
+                for key, wrapper in self._outside_wrappers.items()
+                if wrapper.creating_fragment_id != fragment_id
+            }
 
     def __deepcopy__(self, memo: dict[int, object]) -> NoReturn:
         raise TypeError(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -264,9 +264,7 @@ class MemoryFragmentStorage(FragmentStorage):
             seen_ids.add(parent_id)
             current = parent_id
 
-    def _remove(
-        self, fragment_id: str, *, evict_wrappers: bool = True
-    ) -> None:
+    def _remove(self, fragment_id: str, *, evict_wrappers: bool = True) -> None:
         del self._fragments[fragment_id]
         self._parent_by_id.pop(fragment_id, None)
         self._registration_sequence_by_id.pop(fragment_id, None)

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -41,7 +41,6 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ThreadState,
     get_script_run_ctx,
 )
-from streamlit.runtime.outside_container_wrapper import OutsideContainerWrapper
 from streamlit.time_util import time_to_seconds
 from streamlit.type_util import get_object_name
 from streamlit.util import calc_hash
@@ -50,6 +49,7 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.runtime.outside_container_wrapper import OutsideContainerWrapper
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -57,12 +57,20 @@ _LOGGER: Final = get_logger(__name__)
 
 @dataclass
 class _OutsideWrapper:
-    """A cached implicit wrapper interposed between an outside container and a
-    fragment's writes. ``creation_delta_path`` and ``block_proto`` are retained
-    so the wrapper's ``add_block`` delta can be re-emitted on each fragment
-    rerun. ``creating_fragment_id`` is the fragment whose scope created the
-    outside container (``None`` for the main script); it drives per-fragment
-    eviction when that scope reruns.
+    """Cached implicit wrapper between an outside container and a fragment's writes.
+
+    Attributes
+    ----------
+    delta_generator : DeltaGenerator
+        The wrapper DeltaGenerator that the fragment writes into.
+    creation_delta_path : list[int]
+        The delta path at which the wrapper was originally created, retained so
+        the wrapper's ``add_block`` delta can be re-emitted on each fragment rerun.
+    block_proto : Block_pb2.Block
+        The Block proto for the wrapper, also retained for re-emission.
+    creating_fragment_id : str | None
+        The fragment whose scope created the outside container (``None`` for the
+        main script). Drives per-fragment eviction when that scope reruns.
     """
 
     delta_generator: DeltaGenerator

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -264,15 +264,18 @@ class MemoryFragmentStorage(FragmentStorage):
             seen_ids.add(parent_id)
             current = parent_id
 
-    def _remove(self, fragment_id: str) -> None:
+    def _remove(
+        self, fragment_id: str, *, evict_wrappers: bool = True
+    ) -> None:
         del self._fragments[fragment_id]
         self._parent_by_id.pop(fragment_id, None)
         self._registration_sequence_by_id.pop(fragment_id, None)
-        self._outside_wrappers = {
-            key: wrapper
-            for key, wrapper in self._outside_wrappers.items()
-            if key[0] != fragment_id
-        }
+        if evict_wrappers:
+            self._outside_wrappers = {
+                key: wrapper
+                for key, wrapper in self._outside_wrappers.items()
+                if key[0] != fragment_id
+            }
 
     def clear(self, new_fragment_ids: frozenset[str] | None = None) -> None:
         with self._lock:
@@ -281,8 +284,13 @@ class MemoryFragmentStorage(FragmentStorage):
 
             for fragment_id in list(self._fragments):
                 if fragment_id not in new_fragment_ids:
-                    self._remove(fragment_id)
+                    self._remove(fragment_id, evict_wrappers=False)
 
+            # Drop ALL wrappers unconditionally, including those belonging to
+            # fragments that survived the loop above. On a full app rerun the
+            # main script recreates outside containers as new DG objects, so
+            # every wrapper record — even one for a retained fragment — holds a
+            # stale DG with an already-advanced cursor.
             self._outside_wrappers.clear()
 
     def lookup(self, key: str) -> Fragment:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -20,6 +20,7 @@ import threading
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
 from copy import deepcopy
+from dataclasses import dataclass
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypeVar, overload
 
@@ -49,8 +50,22 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from streamlit.delta_generator import DeltaGenerator
+    from streamlit.proto import Block_pb2
 
 _LOGGER: Final = get_logger(__name__)
+
+
+@dataclass
+class _OutsideWrapper:
+    """A cached implicit wrapper interposed between an outside container and a
+    fragment's writes. ``creation_delta_path`` and ``block_proto`` are retained
+    so the wrapper's ``add_block`` delta can be re-emitted on each fragment
+    rerun.
+    """
+
+    delta_generator: DeltaGenerator
+    creation_delta_path: list[int]
+    block_proto: Block_pb2.Block
 
 
 def _check_not_parallel_worker(api_name: str) -> None:
@@ -171,6 +186,25 @@ class FragmentStorage(Protocol):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def register_outside_wrapper(
+        self, fragment_id: str, container_id: str, wrapper: _OutsideWrapper
+    ) -> None:
+        """Store the implicit wrapper for a (fragment, outside container) pair."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_outside_wrapper(
+        self, fragment_id: str, container_id: str
+    ) -> _OutsideWrapper | None:
+        """Return the cached wrapper for a (fragment, outside container) pair."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def outside_wrappers_for(self, fragment_id: str) -> list[_OutsideWrapper]:
+        """Return all wrapper records belonging to the given fragment."""
+        raise NotImplementedError
+
 
 # NOTE: Ideally, we'd like to add a MemoryFragmentStorageStatProvider implementation to
 # keep track of memory usage due to fragments, but doing something like this ends up
@@ -192,6 +226,7 @@ class MemoryFragmentStorage(FragmentStorage):
         self._parent_by_id: dict[str, str | None] = {}
         self._registration_sequence_by_id: dict[str, int] = {}
         self._registration_sequence = 0
+        self._outside_wrappers: dict[tuple[str, str], _OutsideWrapper] = {}
 
     def _iter_ancestor_ids(self, fragment_id: str) -> Iterator[str]:
         """Yield ancestors from the immediate parent outward.
@@ -223,6 +258,8 @@ class MemoryFragmentStorage(FragmentStorage):
             for fragment_id in list(self._fragments):
                 if fragment_id not in new_fragment_ids:
                     self._remove(fragment_id)
+
+            self._outside_wrappers.clear()
 
     def lookup(self, key: str) -> Fragment:
         try:
@@ -315,6 +352,29 @@ class MemoryFragmentStorage(FragmentStorage):
     def contains(self, key: str) -> bool:
         with self._lock:
             return key in self._fragments
+
+    def register_outside_wrapper(
+        self, fragment_id: str, container_id: str, wrapper: _OutsideWrapper
+    ) -> None:
+        with self._lock:
+            self._outside_wrappers[fragment_id, container_id] = wrapper
+
+    def get_outside_wrapper(
+        self, fragment_id: str, container_id: str
+    ) -> _OutsideWrapper | None:
+        with self._lock:
+            return self._outside_wrappers.get((fragment_id, container_id))
+
+    def outside_wrappers_for(self, fragment_id: str) -> list[_OutsideWrapper]:
+        with self._lock:
+            return [
+                wrapper
+                for (
+                    stored_fragment_id,
+                    _container_id,
+                ), wrapper in self._outside_wrappers.items()
+                if stored_fragment_id == fragment_id
+            ]
 
     def __deepcopy__(self, memo: dict[int, object]) -> NoReturn:
         raise TypeError(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -41,7 +41,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ThreadState,
     get_script_run_ctx,
 )
-from streamlit.runtime.outside_wrapper import _OutsideWrapper
+from streamlit.runtime.outside_container_wrapper import OutsideContainerWrapper
 from streamlit.time_util import time_to_seconds
 from streamlit.type_util import get_object_name
 from streamlit.util import calc_hash
@@ -174,7 +174,7 @@ class FragmentStorage(Protocol):
 
     @abstractmethod
     def register_outside_wrapper(
-        self, fragment_id: str, container_id: str, wrapper: _OutsideWrapper
+        self, fragment_id: str, container_id: str, wrapper: OutsideContainerWrapper
     ) -> None:
         """Store the implicit wrapper for a (fragment, outside container) pair."""
         raise NotImplementedError
@@ -182,12 +182,12 @@ class FragmentStorage(Protocol):
     @abstractmethod
     def get_outside_wrapper(
         self, fragment_id: str, container_id: str
-    ) -> _OutsideWrapper | None:
+    ) -> OutsideContainerWrapper | None:
         """Return the cached wrapper for a (fragment, outside container) pair."""
         raise NotImplementedError
 
     @abstractmethod
-    def outside_wrappers_for(self, fragment_id: str) -> list[_OutsideWrapper]:
+    def outside_wrappers_for(self, fragment_id: str) -> list[OutsideContainerWrapper]:
         """Return all wrapper records belonging to the given fragment."""
         raise NotImplementedError
 
@@ -220,7 +220,7 @@ class MemoryFragmentStorage(FragmentStorage):
         self._parent_by_id: dict[str, str | None] = {}
         self._registration_sequence_by_id: dict[str, int] = {}
         self._registration_sequence = 0
-        self._outside_wrappers: dict[tuple[str, str], _OutsideWrapper] = {}
+        self._outside_wrappers: dict[tuple[str, str], OutsideContainerWrapper] = {}
 
     def _iter_ancestor_ids(self, fragment_id: str) -> Iterator[str]:
         """Yield ancestors from the immediate parent outward.
@@ -359,18 +359,18 @@ class MemoryFragmentStorage(FragmentStorage):
             return key in self._fragments
 
     def register_outside_wrapper(
-        self, fragment_id: str, container_id: str, wrapper: _OutsideWrapper
+        self, fragment_id: str, container_id: str, wrapper: OutsideContainerWrapper
     ) -> None:
         with self._lock:
             self._outside_wrappers[fragment_id, container_id] = wrapper
 
     def get_outside_wrapper(
         self, fragment_id: str, container_id: str
-    ) -> _OutsideWrapper | None:
+    ) -> OutsideContainerWrapper | None:
         with self._lock:
             return self._outside_wrappers.get((fragment_id, container_id))
 
-    def outside_wrappers_for(self, fragment_id: str) -> list[_OutsideWrapper]:
+    def outside_wrappers_for(self, fragment_id: str) -> list[OutsideContainerWrapper]:
         with self._lock:
             return [
                 wrapper

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -20,7 +20,6 @@ import threading
 from abc import abstractmethod
 from collections.abc import Callable, Iterator
 from copy import deepcopy
-from dataclasses import dataclass
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypeVar, overload
 
@@ -42,6 +41,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ThreadState,
     get_script_run_ctx,
 )
+from streamlit.runtime.outside_wrapper import _OutsideWrapper
 from streamlit.time_util import time_to_seconds
 from streamlit.type_util import get_object_name
 from streamlit.util import calc_hash
@@ -50,33 +50,8 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.proto import Block_pb2
 
 _LOGGER: Final = get_logger(__name__)
-
-
-@dataclass
-class _OutsideWrapper:
-    """Cached implicit wrapper between an outside container and a fragment's writes.
-
-    Attributes
-    ----------
-    delta_generator : DeltaGenerator
-        The wrapper DeltaGenerator that the fragment writes into.
-    creation_delta_path : list[int]
-        The delta path at which the wrapper was originally created, retained so
-        the wrapper's ``add_block`` delta can be re-emitted on each fragment rerun.
-    block_proto : Block_pb2.Block
-        The Block proto for the wrapper, also retained for re-emission.
-    creating_fragment_id : str | None
-        The fragment whose scope created the outside container (``None`` for the
-        main script). Drives per-fragment eviction when that scope reruns.
-    """
-
-    delta_generator: DeltaGenerator
-    creation_delta_path: list[int]
-    block_proto: Block_pb2.Block
-    creating_fragment_id: str | None
 
 
 def _check_not_parallel_worker(api_name: str) -> None:

--- a/lib/streamlit/runtime/outside_container_wrapper.py
+++ b/lib/streamlit/runtime/outside_container_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/streamlit/runtime/outside_container_wrapper.py
+++ b/lib/streamlit/runtime/outside_container_wrapper.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class _OutsideWrapper:
+class OutsideContainerWrapper:
     """Cached implicit wrapper between an outside container and a fragment's writes.
 
     Attributes

--- a/lib/streamlit/runtime/outside_wrapper.py
+++ b/lib/streamlit/runtime/outside_wrapper.py
@@ -1,0 +1,46 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.proto import Block_pb2
+
+
+@dataclass
+class _OutsideWrapper:
+    """Cached implicit wrapper between an outside container and a fragment's writes.
+
+    Attributes
+    ----------
+    delta_generator : DeltaGenerator
+        The wrapper DeltaGenerator that the fragment writes into.
+    creation_delta_path : list[int]
+        The delta path at which the wrapper was originally created, retained so
+        the wrapper's ``add_block`` delta can be re-emitted on each fragment rerun.
+    block_proto : Block_pb2.Block
+        The Block proto for the wrapper, also retained for re-emission.
+    creating_fragment_id : str | None
+        The fragment whose scope created the outside container (``None`` for the
+        main script). Drives per-fragment eviction when that scope reruns.
+    """
+
+    delta_generator: DeltaGenerator
+    creation_delta_path: list[int]
+    block_proto: Block_pb2.Block
+    creating_fragment_id: str | None

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -1305,3 +1305,24 @@ class ParallelWorkerExternalContainerWriteTest(DeltaGeneratorTestCase):
             assert result is not None
         finally:
             ThreadState.update(is_parallel_worker=False, delta_path=())
+
+
+class CreatingFragmentIdDeepCopyTest(DeltaGeneratorTestCase):
+    """Tests that _creating_fragment_id survives deepcopy."""
+
+    def test_creating_fragment_id_survives_deepcopy(self) -> None:
+        """A stamped container keeps its _creating_fragment_id through deepcopy."""
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+        dg._creating_fragment_id = "my_fragment"
+
+        copied = deepcopy(dg)
+
+        assert copied._creating_fragment_id == "my_fragment"
+
+    def test_creating_fragment_id_none_survives_deepcopy(self) -> None:
+        """A container with no creating fragment stays None through deepcopy."""
+        dg = DeltaGenerator(root_container=RootContainer.MAIN)
+
+        copied = deepcopy(dg)
+
+        assert copied._creating_fragment_id is None

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -1308,10 +1308,11 @@ class ParallelWorkerExternalContainerWriteTest(DeltaGeneratorTestCase):
 
 
 class CreatingFragmentIdDeepCopyTest(DeltaGeneratorTestCase):
-    """Tests that _creating_fragment_id survives deepcopy."""
+    """Deepcopy must preserve fragment-origin metadata so cached wrappers
+    can evict correctly after a container is copied during fragment reruns."""
 
     def test_creating_fragment_id_survives_deepcopy(self) -> None:
-        """A stamped container keeps its _creating_fragment_id through deepcopy."""
+        """A container with _creating_fragment_id set keeps it through deepcopy."""
         dg = DeltaGenerator(root_container=RootContainer.MAIN)
         dg._creating_fragment_id = "my_fragment"
 
@@ -1319,7 +1320,7 @@ class CreatingFragmentIdDeepCopyTest(DeltaGeneratorTestCase):
 
         assert copied._creating_fragment_id == "my_fragment"
 
-    def test_creating_fragment_id_none_survives_deepcopy(self) -> None:
+    def test_unset_creating_fragment_id_stays_none_through_deepcopy(self) -> None:
         """A container with no creating fragment stays None through deepcopy."""
         dg = DeltaGenerator(root_container=RootContainer.MAIN)
 

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -138,6 +138,15 @@ class MemoryFragmentStorageTest(unittest.TestCase):
         with pytest.raises(FragmentStorageKeyError):
             self._storage.delete("nonexistent_key")
 
+    def test_delete_evicts_fragment_wrappers(self):
+        """delete() evicts all wrappers belonging to the deleted fragment."""
+        wrapper = self._make_wrapper("dg-1")
+        self._storage.register_outside_wrapper("some_key", "container", wrapper)
+
+        self._storage.delete("some_key")
+
+        assert self._storage.outside_wrappers_for("some_key") == []
+
     def test_clear(self):
         self._set_fragment("some_other_key", value="some_other_fragment")
         assert len(self._storage._fragments) == 2

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -34,12 +34,14 @@ from streamlit.errors import (
     StreamlitAPIException,
     StreamlitFragmentWidgetsNotAllowedOutsideError,
 )
+from streamlit.proto.Block_pb2 import Block
 from streamlit.runtime.fragment import (
     FragmentStorage,
     MemoryFragmentStorage,
     _check_not_parallel_worker,
     _dispatch_parallel_fragment,
     _fragment,
+    _OutsideWrapper,
     _run_parallel_fragment,
     fragment,
 )
@@ -152,6 +154,49 @@ class MemoryFragmentStorageTest(unittest.TestCase):
         assert len(self._storage._fragments) == 1
         assert self._storage._fragments["some_key"] == "some_fragment"
         assert "some_other_key" not in self._storage._parent_by_id
+
+    def _make_wrapper(self, dg_id: str) -> _OutsideWrapper:
+        delta_generator = MagicMock()
+        delta_generator._id = dg_id
+        return _OutsideWrapper(
+            delta_generator=delta_generator,
+            creation_delta_path=[0, 1],
+            block_proto=Block(),
+        )
+
+    def test_register_and_get_outside_wrapper(self):
+        """register_outside_wrapper then get_outside_wrapper returns the record."""
+        wrapper = self._make_wrapper("dg-1")
+        self._storage.register_outside_wrapper("frag", "container", wrapper)
+
+        assert self._storage.get_outside_wrapper("frag", "container") is wrapper
+
+    def test_get_outside_wrapper_missing_returns_none(self):
+        """A missing (fragment, container) key returns None."""
+        assert self._storage.get_outside_wrapper("frag", "container") is None
+
+    def test_outside_wrappers_for_isolates_fragments(self):
+        """outside_wrappers_for returns only the matching fragment's records."""
+        wrapper_a = self._make_wrapper("dg-a")
+        wrapper_b = self._make_wrapper("dg-b")
+        self._storage.register_outside_wrapper("frag_a", "container", wrapper_a)
+        self._storage.register_outside_wrapper("frag_b", "container", wrapper_b)
+
+        wrappers_a = self._storage.outside_wrappers_for("frag_a")
+        assert [w.delta_generator._id for w in wrappers_a] == ["dg-a"]
+        assert self._storage.outside_wrappers_for("frag_b") == [wrapper_b]
+        assert self._storage.outside_wrappers_for("missing") == []
+
+    def test_clear_drops_outside_wrappers_even_when_fragment_retained(self):
+        """clear() empties wrappers even when the fragment id is retained."""
+        wrapper = self._make_wrapper("dg-1")
+        self._storage.register_outside_wrapper("some_key", "container", wrapper)
+
+        self._storage.clear(new_fragment_ids=frozenset({"some_key"}))
+
+        # The fragment closure survives, but its wrapper does not.
+        assert self._storage.contains("some_key")
+        assert self._storage._outside_wrappers == {}
 
     def test_clear_stale_descendants_removes_orphan_nested(self):
         """Descendants of root not re-registered this run are removed."""

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -44,7 +44,7 @@ from streamlit.runtime.fragment import (
     _run_parallel_fragment,
     fragment,
 )
-from streamlit.runtime.outside_wrapper import _OutsideWrapper
+from streamlit.runtime.outside_container_wrapper import OutsideContainerWrapper
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,
@@ -157,10 +157,10 @@ class MemoryFragmentStorageTest(unittest.TestCase):
 
     def _make_wrapper(
         self, dg_id: str, *, creating_fragment_id: str | None = None
-    ) -> _OutsideWrapper:
+    ) -> OutsideContainerWrapper:
         delta_generator = MagicMock()
         delta_generator._id = dg_id
-        return _OutsideWrapper(
+        return OutsideContainerWrapper(
             delta_generator=delta_generator,
             creation_delta_path=[0, 1],
             block_proto=Block(),

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -41,10 +41,10 @@ from streamlit.runtime.fragment import (
     _check_not_parallel_worker,
     _dispatch_parallel_fragment,
     _fragment,
-    _OutsideWrapper,
     _run_parallel_fragment,
     fragment,
 )
+from streamlit.runtime.outside_wrapper import _OutsideWrapper
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -1245,6 +1245,10 @@ def test_fragment_decorator_handles_pep649_annotations() -> None:
         ("order_fragment_ids", ([],), {}),
         ("delete", ("key",), {}),
         ("contains", ("key",), {}),
+        ("register_outside_wrapper", ("frag", "container", object()), {}),
+        ("get_outside_wrapper", ("frag", "container"), {}),
+        ("outside_wrappers_for", ("frag",), {}),
+        ("evict_outside_wrappers_created_by", ("frag",), {}),
     ],
 )
 def test_fragment_storage_abstract_methods_raise_not_implemented(

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -155,21 +155,26 @@ class MemoryFragmentStorageTest(unittest.TestCase):
         assert self._storage._fragments["some_key"] == "some_fragment"
         assert "some_other_key" not in self._storage._parent_by_id
 
-    def _make_wrapper(self, dg_id: str) -> _OutsideWrapper:
+    def _make_wrapper(
+        self, dg_id: str, *, creating_fragment_id: str | None = None
+    ) -> _OutsideWrapper:
         delta_generator = MagicMock()
         delta_generator._id = dg_id
         return _OutsideWrapper(
             delta_generator=delta_generator,
             creation_delta_path=[0, 1],
             block_proto=Block(),
+            creating_fragment_id=creating_fragment_id,
         )
 
     def test_register_and_get_outside_wrapper(self):
         """register_outside_wrapper then get_outside_wrapper returns the record."""
-        wrapper = self._make_wrapper("dg-1")
+        wrapper = self._make_wrapper("dg-1", creating_fragment_id="creator")
         self._storage.register_outside_wrapper("frag", "container", wrapper)
 
-        assert self._storage.get_outside_wrapper("frag", "container") is wrapper
+        stored = self._storage.get_outside_wrapper("frag", "container")
+        assert stored is wrapper
+        assert stored.creating_fragment_id == "creator"
 
     def test_get_outside_wrapper_missing_returns_none(self):
         """A missing (fragment, container) key returns None."""
@@ -197,6 +202,37 @@ class MemoryFragmentStorageTest(unittest.TestCase):
         # The fragment closure survives, but its wrapper does not.
         assert self._storage.contains("some_key")
         assert self._storage._outside_wrappers == {}
+
+    def test_evict_outside_wrappers_created_by_filters_on_creating_fragment(self):
+        """evict_outside_wrappers_created_by drops only records created by the id."""
+        created_by_a = self._make_wrapper("dg-a", creating_fragment_id="creator_a")
+        created_by_b = self._make_wrapper("dg-b", creating_fragment_id="creator_b")
+        main_script = self._make_wrapper("dg-main", creating_fragment_id=None)
+        self._storage.register_outside_wrapper("writer", "container_a", created_by_a)
+        self._storage.register_outside_wrapper("writer", "container_b", created_by_b)
+        self._storage.register_outside_wrapper("writer", "container_main", main_script)
+
+        self._storage.evict_outside_wrappers_created_by("creator_a")
+
+        remaining = self._storage.outside_wrappers_for("writer")
+        assert created_by_a not in remaining
+        assert created_by_b in remaining
+        assert main_script in remaining
+
+    def test_remove_drops_removed_fragments_own_wrappers(self):
+        """Removing a fragment drops its own wrappers, even stable-root ones."""
+        self._set_fragment("outer")
+        self._set_fragment("inner", parent_fragment_id="outer")
+        inner_wrapper = self._make_wrapper("dg-inner", creating_fragment_id=None)
+        outer_wrapper = self._make_wrapper("dg-outer", creating_fragment_id=None)
+        self._storage.register_outside_wrapper("inner", "container", inner_wrapper)
+        self._storage.register_outside_wrapper("outer", "container", outer_wrapper)
+
+        self._storage.clear_stale_descendants("outer", frozenset({"outer"}))
+
+        assert not self._storage.contains("inner")
+        assert self._storage.outside_wrappers_for("inner") == []
+        assert self._storage.outside_wrappers_for("outer") == [outer_wrapper]
 
     def test_clear_stale_descendants_removes_orphan_nested(self):
         """Descendants of root not re-registered this run are removed."""

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -184,10 +184,8 @@ message Block {
     AvatarType avatar_type = 3;
   }
 
-  // A layout-transparent wrapper block with no visual treatment (no padding,
-  // border, or gap). Renders as a plain unstyled grouping with no DOM node of
-  // its own. Used to group elements into a single tree node without affecting
-  // the user-visible layout.
+  // A layout-transparent wrapper block. Produces no DOM node — children
+  // render directly in the parent container's flex context.
   message Transparent {}
 
   // Next ID: 18

--- a/proto/streamlit/proto/Block.proto
+++ b/proto/streamlit/proto/Block.proto
@@ -33,6 +33,7 @@ message Block {
     Popover popover = 10;
     Dialog dialog = 11;
     FlexContainer flex_container = 13;
+    Transparent transparent = 17;
   }
 
   bool allow_empty = 8;
@@ -183,5 +184,11 @@ message Block {
     AvatarType avatar_type = 3;
   }
 
-  // Next ID: 17
+  // A layout-transparent wrapper block with no visual treatment (no padding,
+  // border, or gap). Renders as a plain unstyled grouping with no DOM node of
+  // its own. Used to group elements into a single tree node without affecting
+  // the user-visible layout.
+  message Transparent {}
+
+  // Next ID: 18
 }


### PR DESCRIPTION
## Describe your changes

**PR 2 of the "outside container writes" stack**, stacked on PR #15541.

Adds a per-fragment wrapper registry to `FragmentStorage` — a lookup table that maps `(fragment_id, container_id)` pairs to cached wrapper records. This allows a fragment to reuse the same implicit wrapper when it writes to the same outside container across reruns. **No callers yet** — PR 3 will consume it.

- New `OutsideContainerWrapper` dataclass (in its own module) holds the wrapper's `DeltaGenerator`, its original delta path, and the block proto — everything needed to replay the wrapper's block message on each fragment rerun.
- `FragmentStorage` gains three accessors: `register_outside_wrapper`, `get_outside_wrapper`, `outside_wrappers_for`, plus `evict_outside_wrappers_created_by` for per-fragment cleanup.
- `MemoryFragmentStorage` implements them under the existing lock, keyed by `(fragment_id, container_id)`.
- `clear()` drops **all** wrappers unconditionally (even retained fragments) because a full app rerun recreates outside containers as new DeltaGenerator objects, invalidating cached entries.
- `delete()` evicts the deleted fragment's wrappers via `_remove(evict_wrappers=True)`.
- `DeltaGenerator` gains `_creating_fragment_id`, preserved through `__deepcopy__`, to track which fragment created a container (used for wrapper eviction in later PRs).

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

## Testing Plan

- Registry round-trip: register then retrieve returns the same record; missing key returns `None`.
- Per-fragment isolation: wrappers for one fragment don't appear in another's lookup.
- `clear()` empties wrappers even when the fragment closure is retained via `new_fragment_ids`.
- `delete()` evicts the deleted fragment's own wrappers.
- `evict_outside_wrappers_created_by` filters only records matching the creating fragment.
- `_creating_fragment_id` survives `deepcopy` (both set and unset).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.