### PR TITLE
[spec] Avatar element

### DIFF
--- a/specs/2026-06-12-avatar/product-spec.md
+++ b/specs/2026-06-12-avatar/product-spec.md
@@ -79,7 +79,7 @@ st.avatar("https://avatars.githubusercontent.com/u/1673013")
 | `image` | `str \| Image \| None` | `None` | The avatar content. Accepts the same image inputs as `st.image` (URL, local path, `PIL.Image`, NumPy array, bytes/`BytesIO`), **plus** a single emoji (e.g. `"🦖"`) or a Material icon (e.g. `":material/person:"`)—matching `st.chat_message`'s `avatar`. If `None`, falls back to initials derived from `label`, or a generic person icon when no label is given. |
 | `label` | `str \| None` | `None` | Primary text shown to the right of the avatar (typically a name). Supports markdown. |
 | `caption` | `str \| None` | `None` | Secondary text shown below the label (typically a role or status). Supports markdown and renders in the muted caption style used elsewhere in Streamlit. |
-| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar. Semantic sizes map to fixed pixel values (`small` ≈ 24px, `medium` ≈ 40px, `large` ≈ 64px; exact values TBD with design). An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIError` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
+| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar image only. Semantic sizes map to rem-based values (`small` ≈ 1.5rem, `medium` ≈ 2.5rem, `large` ≈ 4rem; exact values TBD with design) so they scale with the root font size. An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIError` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
 | `border` | `bool` | `False` | If `True`, draws a subtle border around the avatar (useful for light images on light backgrounds). |
 | `on_click` | `"ignore" \| "rerun" \| Callable[[], None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
 | `key` | `str \| None` | `None` | Unique key for the element. Required when multiple clickable avatars would otherwise share identical parameters. |
@@ -108,21 +108,16 @@ st.avatar(None, label="Jane Doe")      # initials avatar → "JD"
 This keeps a single, consistent mental model: the thing you'd pass as a chat avatar is the
 thing you pass to `st.avatar`.
 
-> **Delta vs. the reference component:** the `streamlit-extras` avatar accepts images only
-> and renders `label`/`caption` as plain text. The emoji/Material-icon inputs, the
-> `image=None` initials fallback, and markdown in `label`/`caption` are native enhancements
-> proposed here to align with `st.chat_message` and Streamlit's "markdown everywhere"
-> convention. All can be trimmed if we want to ship the smallest possible v1. The image
-> handling itself reuses the same internals the reference relies on (`image_to_url`).
-
 ### Behavior
 
 - The avatar always renders as a circle, cropping non-square images to a centered square
   (`object-fit: cover`).
+- `size` controls only the circular avatar image; it does not scale the label, caption,
+  spacing, or other surrounding element layout.
 - When `label` and/or `caption` are provided, they render in a row to the right of the
   avatar, vertically centered against it. With no text, only the circle is shown.
 - `label` and `caption` are each constrained to a single line and truncate with an ellipsis
-  when they overflow; the full text is shown on hover (matching the reference component).
+  when they overflow; the full text is shown on hover.
 - Emoji and icon avatars render centered on a themed neutral background; initials avatars
   show 1–2 uppercase letters derived from `label`. Initials are derived from the
   *plain-text* form of `label` (markdown syntax, links, emoji, and Material icons are
@@ -132,15 +127,14 @@ thing you pass to `st.avatar`.
 - The element sizes to its content (the circle plus any text). Place avatars side by side
   with `st.container(horizontal=True)`—no `multiple`/grouping parameter is needed
   (composition over configuration).
-- `label` and `caption` support Streamlit markdown (bold, italics, links, code, emoji,
-  Material icons), consistent with other text-bearing elements.
+- `label` and `caption` support Streamlit markdown, with the same restrictions used across
+  other labels.
 
 ### Interactivity
 
-The `streamlit-extras` version supports `on_click` and returns a `bool`. For a native
-command this is the main open design question, because enabling clicks changes `st.avatar`
-from a display element into a widget (conditional return type, requires `key`). Two
-options:
+The main open design question is whether `st.avatar` should support click interaction,
+because enabling clicks changes it from a display element into a widget (conditional return
+type, requires `key`). Two options:
 
 **Option 1: Clickable widget** ✅ PREFERRED
 
@@ -153,11 +147,10 @@ if st.avatar("profile.jpg", label="Jane Smith", on_click="rerun", key="profile")
 ```
 
 A clickable avatar should be keyboard-accessible: expose it as a button (`role="button"`,
-focusable, activatable with Enter/Space) with an `aria-label` derived from `label`—the
-reference component already does this.
+focusable, activatable with Enter/Space) with an `aria-label` derived from `label`.
 
-- Pros: Matches the reference API; enables clickable profiles (open a dialog, navigate to a
-  detail view) directly; `on_click="ignore"` keeps the common display-only case a one-liner.
+- Pros: Enables clickable profiles (open a dialog, navigate to a detail view) directly;
+  `on_click="ignore"` keeps the common display-only case a one-liner.
 - Cons: Mixed return type (display vs. widget); adds `key`/callback surface to the API.
 
 **Option 2: Display-only in v1**
@@ -171,9 +164,9 @@ wrap it in a container or pair it with a nearby `st.button`.
 - Cons: No built-in click handling; clickable-profile patterns need a workaround until a
   fast-follow adds it.
 
-**Recommendation:** Ship Option 1 (clickable). It matches the reference API users already
-know and keeps the display-only case ergonomic via the `on_click="ignore"` default, while
-covering the profile/navigation use cases natively without a fast-follow.
+**Recommendation:** Ship Option 1 (clickable). It covers more avatar use cases, including
+interactive profile chips, user pickers, and navigation to detail views, while keeping the
+display-only case ergonomic via the `on_click="ignore"` default.
 
 ### Examples
 

--- a/specs/2026-06-12-avatar/product-spec.md
+++ b/specs/2026-06-12-avatar/product-spec.md
@@ -49,16 +49,23 @@ that capability is locked inside the chat element and can't be used standalone.
 
 ```python
 st.avatar(
-    image: str | Image | None = None,
+    image: str | AtomicImage | None = None,
     *,
     label: str | None = None,
     caption: str | None = None,
     size: Literal["small", "medium", "large"] | int = "medium",
     border: bool = False,
-    on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore",
+    on_click: Literal["ignore", "rerun"] | Callable[..., None] = "ignore",
+    args: tuple[Any, ...] | None = None,
+    kwargs: dict[str, Any] | None = None,
     key: str | None = None,
 ) -> DeltaGenerator | bool
 ```
+
+`AtomicImage` is the existing single-image type alias used by `st.logo` (PIL image, NumPy
+array, bytes/`BytesIO`); `str` additionally covers a URL, local path, emoji, or Material
+icon. `st.avatar` is reused for a single image, so it intentionally borrows `st.logo`'s
+`AtomicImage` rather than `st.image`'s list-capable `ImageOrImageList`.
 
 By default (`on_click="ignore"`) `st.avatar` behaves like a display element and returns
 a `DeltaGenerator`. When made clickable (`on_click="rerun"` or a callback), it returns a
@@ -76,20 +83,28 @@ st.avatar("https://avatars.githubusercontent.com/u/1673013")
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `image` | `str \| Image \| None` | `None` | The avatar content. Accepts the same image inputs as `st.image` (URL, local path, `PIL.Image`, NumPy array, bytes/`BytesIO`), **plus** a single emoji (e.g. `"🦖"`) or a Material icon (e.g. `":material/person:"`)—matching `st.chat_message`'s `avatar`. If `None`, falls back to initials derived from `label`, or a generic person icon when no label is given. |
+| `image` | `str \| AtomicImage \| None` | `None` | The avatar content. Accepts the same single-image inputs as `st.logo`'s `AtomicImage` (URL, local path, `PIL.Image`, NumPy array, bytes/`BytesIO`), **plus** a single emoji (e.g. `"🦖"`) or a Material icon (e.g. `":material/person:"`)—matching `st.chat_message`'s `avatar`. If `None`, falls back to initials derived from `label`, or a generic person icon when no label is given. |
 | `label` | `str \| None` | `None` | Primary text shown to the right of the avatar (typically a name). Supports markdown. |
 | `caption` | `str \| None` | `None` | Secondary text shown below the label (typically a role or status). Supports markdown and renders in the muted caption style used elsewhere in Streamlit. |
-| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar image only. Semantic sizes map to rem-based values (`small` ≈ 1.5rem, `medium` ≈ 2.5rem, `large` ≈ 4rem; exact values TBD with design) so they scale with the root font size. An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIError` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
+| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar image only. Semantic sizes map to rem-based values (`small` ≈ 1.5rem, `medium` ≈ 2.5rem, `large` ≈ 4rem; exact values TBD with design) so they scale with the root font size. An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIException` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
 | `border` | `bool` | `False` | If `True`, draws a subtle border around the avatar (useful for light images on light backgrounds). |
-| `on_click` | `"ignore" \| "rerun" \| Callable[[], None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
+| `on_click` | `"ignore" \| "rerun" \| Callable[..., None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun, receiving `args`/`kwargs`. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
+| `args` | `tuple[Any, ...] \| None` | `None` | An optional tuple of positional arguments passed to the `on_click` callback. Mirrors `st.button`'s `args` (Principle #11). |
+| `kwargs` | `dict[str, Any] \| None` | `None` | An optional dictionary of keyword arguments passed to the `on_click` callback. Mirrors `st.button`'s `kwargs` (Principle #11). |
 | `key` | `str \| None` | `None` | Unique key for the element. Required when multiple clickable avatars would otherwise share identical parameters. |
 
 ### Return value
 
-`st.avatar` returns a `DeltaGenerator` when `on_click="ignore"`, matching display elements
-like `st.image` and `st.logo`. When `on_click="rerun"` or a callback is provided,
-`st.avatar` returns a `bool`: `True` only on the rerun triggered by a click, and `False`
-otherwise.
+`st.avatar` returns a `DeltaGenerator` when `on_click="ignore"`, matching the display
+element `st.image`. (`st.logo` is also a display element but returns `None`; `st.avatar`
+returns a `DeltaGenerator` so the display-only call can be chained like other elements.)
+When `on_click="rerun"` or a callback is provided, `st.avatar` returns a `bool`: `True`
+only on the rerun triggered by a click, and `False` otherwise.
+
+Because the return type depends on the runtime value of `on_click`, the implementation will
+provide `@overload` stubs (as `st.download_button` and `st.link_button` already do) so that
+type checkers narrow the return type at call sites: `DeltaGenerator` for the
+`on_click="ignore"` default and `bool` for the clickable overloads.
 
 ### Content types
 
@@ -138,8 +153,10 @@ type, requires `key`). Two options:
 
 **Option 1: Clickable widget** ✅ PREFERRED
 
-Add `on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore"` plus `key`, and
-return `DeltaGenerator` for the display-only case and `bool` for the clickable case.
+Add `on_click: Literal["ignore", "rerun"] | Callable[..., None] = "ignore"` plus `args`,
+`kwargs`, and `key`, and return `DeltaGenerator` for the display-only case and `bool` for
+the clickable case. The callback `args`/`kwargs` mirror `st.button` so callers can pass
+context (e.g. a user ID) without closures (Principle #11).
 
 ```python
 if st.avatar("profile.jpg", label="Jane Smith", on_click="rerun", key="profile"):
@@ -155,9 +172,9 @@ focusable, activatable with Enter/Space) with an `aria-label` derived from `labe
 
 **Option 2: Display-only in v1**
 
-Ship `st.avatar` as a pure display element (returns `DeltaGenerator`), matching `st.image`
-and `st.logo`. Users who need a clickable avatar compose with existing primitives, e.g.
-wrap it in a container or pair it with a nearby `st.button`.
+Ship `st.avatar` as a pure display element (returns `DeltaGenerator`), like `st.image`.
+Users who need a clickable avatar compose with existing primitives, e.g. wrap it in a
+container or pair it with a nearby `st.button`.
 
 - Pros: Simplest, smallest API; consistent return type with sibling display elements;
   avoids widget machinery (`key`, state, callbacks) for the 80% case.

--- a/specs/2026-06-12-avatar/product-spec.md
+++ b/specs/2026-06-12-avatar/product-spec.md
@@ -1,0 +1,281 @@
+---
+author: lukasmasuch
+created: 2026-06-12
+---
+
+# `st.avatar`
+
+## Summary
+
+Add a native `st.avatar` command that displays a circular avatar (an image, Material
+icon, or emoji) with an optional label and caption beside it. Avatars are a ubiquitous UI
+primitive for representing people and entities—user profiles, contact lists, team rosters,
+comment authors, and chat participants.
+
+## Problem
+
+Streamlit has no native way to render the single most common identity primitive on the
+web: a circular avatar. Users routinely build profile pages, member directories, team
+sections, leaderboards, and activity feeds, and today they have to hack it together.
+
+**Current workarounds:**
+
+- `st.image(url, width=48)` renders a *square* image. Making it circular requires injecting
+  CSS (`border-radius: 50%`) with `st.markdown(..., unsafe_allow_html=True)`, which is
+  brittle and breaks across theme/layout changes.
+- Hand-rolled `st.markdown` HTML blocks combining an `<img>` with name/role text, which
+  don't respect the theme, don't size consistently, and are hard to align.
+- The community [`streamlit-extras` avatar](https://arnaudmiribel.github.io/streamlit-extras/extras/avatar/)
+  component, which proves the demand but pulls in an extra dependency and renders inside an
+  iframe (extra height, no theme inheritance, layout quirks).
+
+Notably, Streamlit *already* renders circular avatars internally for `st.chat_message`, but
+that capability is locked inside the chat element and can't be used standalone.
+
+**Use cases:**
+
+- **User profile / account header** — show the signed-in user's picture, name, and role.
+- **Member directories & team pages** — a grid or row of avatars with names and titles.
+- **Comment / activity feeds** — author avatar next to each entry.
+- **Tables of people** — avatar + name in a "person" cell (composed alongside other elements).
+- **Leaderboards** — avatar + display name + rank/score.
+
+## Proposal
+
+### API
+
+```python
+st.avatar(
+    image: str | Image | None = None,
+    *,
+    label: str | None = None,
+    caption: str | None = None,
+    size: Literal["small", "medium", "large"] | int = "medium",
+    border: bool = False,
+    on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore",
+    key: str | None = None,
+) -> bool
+```
+
+By default (`on_click="ignore"`) `st.avatar` behaves like a display element and returns
+`False`. When made clickable (`on_click="rerun"` or a callback), it returns `True` on the
+rerun where it was clicked, matching `st.button`. This clickable-by-opt-in design is chosen
+over a display-only element—see [Interactivity](#interactivity) for the trade-offs.
+
+The simplest call is a single positional argument:
+
+```python
+st.avatar("https://avatars.githubusercontent.com/u/1673013")
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | `str \| Image \| None` | `None` | The avatar content. Accepts the same image inputs as `st.image` (URL, local path, `PIL.Image`, NumPy array, bytes/`BytesIO`), **plus** a single emoji (e.g. `"🦖"`) or a Material icon (e.g. `":material/person:"`)—matching `st.chat_message`'s `avatar`. If `None`, falls back to initials derived from `label`, or a generic person icon when no label is given. |
+| `label` | `str \| None` | `None` | Primary text shown to the right of the avatar (typically a name). Supports markdown. |
+| `caption` | `str \| None` | `None` | Secondary text shown below the label (typically a role or status). Supports markdown and renders in the muted caption style used elsewhere in Streamlit. |
+| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar. Semantic sizes map to fixed pixel values (`small` ≈ 24px, `medium` ≈ 40px, `large` ≈ 64px; exact values TBD with design). An `int` sets a custom diameter in pixels. |
+| `border` | `bool` | `False` | If `True`, draws a subtle border around the avatar (useful for light images on light backgrounds). |
+| `on_click` | `"ignore" \| "rerun" \| Callable[[], None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun. |
+| `key` | `str \| None` | `None` | Unique key for the element. Required when multiple clickable avatars would otherwise share identical parameters. |
+
+### Return value
+
+`st.avatar` returns a `bool`: `True` only on the rerun triggered by a click (when
+`on_click != "ignore"`), and `False` otherwise—including always when `on_click="ignore"`.
+
+### Content types
+
+`image` is intentionally flexible and mirrors how avatars are already specified in
+`st.chat_message`:
+
+```python
+st.avatar("https://.../photo.png")     # remote image
+st.avatar("profile.jpg")               # local file path
+st.avatar(pil_image)                   # PIL.Image, numpy array, or bytes
+st.avatar(":material/person:")         # Material icon
+st.avatar("🦖")                         # emoji
+st.avatar(None, label="Jane Doe")      # initials avatar → "JD"
+```
+
+This keeps a single, consistent mental model: the thing you'd pass as a chat avatar is the
+thing you pass to `st.avatar`.
+
+> **Delta vs. the reference component:** the `streamlit-extras` avatar accepts images only
+> and renders `label`/`caption` as plain text. The emoji/Material-icon inputs, the
+> `image=None` initials fallback, and markdown in `label`/`caption` are native enhancements
+> proposed here to align with `st.chat_message` and Streamlit's "markdown everywhere"
+> convention. All can be trimmed if we want to ship the smallest possible v1. The image
+> handling itself reuses the same internals the reference relies on (`image_to_url`).
+
+### Behavior
+
+- The avatar always renders as a circle, cropping non-square images to a centered square
+  (`object-fit: cover`).
+- When `label` and/or `caption` are provided, they render in a row to the right of the
+  avatar, vertically centered against it. With no text, only the circle is shown.
+- `label` and `caption` are each constrained to a single line and truncate with an ellipsis
+  when they overflow; the full text is shown on hover (matching the reference component).
+- Emoji and icon avatars render centered on a themed neutral background; initials avatars
+  show 1–2 uppercase letters derived from `label`.
+- The element sizes to its content (the circle plus any text). Place avatars side by side
+  with `st.container(horizontal=True)`—no `multiple`/grouping parameter is needed
+  (composition over configuration).
+- `label` and `caption` support Streamlit markdown (bold, italics, links, code, emoji,
+  Material icons), consistent with other text-bearing elements.
+
+### Interactivity
+
+The `streamlit-extras` version supports `on_click` and returns a `bool`. For a native
+command this is the main open design question, because it changes `st.avatar` from a
+display element into a widget (different return type, requires `key`). Two options:
+
+**Option 1: Clickable widget** ✅ PREFERRED
+
+Add `on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore"` plus `key`, and
+return `bool` (matching the extra and `st.button`).
+
+```python
+if st.avatar("profile.jpg", label="Jane Smith", on_click="rerun", key="profile"):
+    st.write("Profile clicked!")
+```
+
+A clickable avatar should be keyboard-accessible: expose it as a button (`role="button"`,
+focusable, activatable with Enter/Space) with an `aria-label` derived from `label`—the
+reference component already does this.
+
+- Pros: Matches the reference API; enables clickable profiles (open a dialog, navigate to a
+  detail view) directly; `on_click="ignore"` keeps the common display-only case a one-liner.
+- Cons: Mixed return type (display vs. widget); adds `key`/callback surface to the API.
+
+**Option 2: Display-only in v1**
+
+Ship `st.avatar` as a pure display element (returns `DeltaGenerator`), matching `st.image`
+and `st.logo`. Users who need a clickable avatar compose with existing primitives, e.g.
+wrap it in a container or pair it with a nearby `st.button`.
+
+- Pros: Simplest, smallest API; consistent return type with sibling display elements;
+  avoids widget machinery (`key`, state, callbacks) for the 80% case.
+- Cons: No built-in click handling; clickable-profile patterns need a workaround until a
+  fast-follow adds it.
+
+**Recommendation:** Ship Option 1 (clickable). It matches the reference API users already
+know and keeps the display-only case ergonomic via the `on_click="ignore"` default, while
+covering the profile/navigation use cases natively without a fast-follow.
+
+### Examples
+
+**Avatar with label and caption:**
+
+```python
+import streamlit as st
+
+st.avatar(
+    "https://avatars.githubusercontent.com/u/1673013",
+    label="Adrien Treuille",
+    caption="Co-founder",
+)
+```
+
+**A row of team members:**
+
+```python
+import streamlit as st
+
+with st.container(horizontal=True):
+    st.avatar("https://avatars.githubusercontent.com/u/1673013", label="Adrien", caption="Co-founder")
+    st.avatar("https://avatars.githubusercontent.com/u/690814", label="Thiago", caption="Co-founder")
+    st.avatar("https://avatars.githubusercontent.com/u/47222480", label="Amanda", caption="Co-founder")
+```
+
+**Different sizes:**
+
+```python
+import streamlit as st
+
+st.avatar("profile.jpg", size="small", label="Small")
+st.avatar("profile.jpg", size="medium", label="Medium")
+st.avatar("profile.jpg", size="large", label="Large")
+st.avatar("profile.jpg", size=96, label="Custom (96px)")
+```
+
+**Icon, emoji, and initials avatars (no photo needed):**
+
+```python
+import streamlit as st
+
+st.avatar(":material/person:", label="System", caption="Automated")
+st.avatar("🦖", label="Rex", caption="Mascot")
+st.avatar(None, label="Jane Doe", caption="No photo on file")  # renders "JD"
+```
+
+**Icon-only avatars in a row, with a border:**
+
+```python
+import streamlit as st
+
+with st.container(horizontal=True):
+    st.avatar("https://avatars.githubusercontent.com/u/1673013", size=40, border=True)
+    st.avatar("https://avatars.githubusercontent.com/u/690814", size=40, border=True)
+    st.avatar("🦖", size=40, border=True)
+```
+
+**Clickable avatar (open a profile dialog):**
+
+```python
+import streamlit as st
+
+if st.avatar("profile.jpg", label="Jane Smith", caption="Engineer", on_click="rerun", key="profile"):
+    show_profile_dialog("jane")
+```
+
+## Alternatives Considered
+
+### Alternative 1: Extend `st.image` with a `shape="circle"` parameter
+
+Rather than a new command, add `shape: Literal["rectangle", "rounded", "circle"]` (and
+maybe `caption` placement tweaks) to `st.image`.
+
+- Pros: Reuses `st.image`'s mature image handling; no new command (Extend Before Inventing).
+- Cons: `st.image` has no concept of a `label`/`caption`-beside-image layout, no emoji/icon
+  shortcut, and isn't semantically discoverable ("avatar" is a clear noun users search for).
+  Avatars are a distinct, common-enough use case to warrant their own command
+  (One Use Case, One Command). `st.image` and `st.avatar` can still share rendering
+  internals.
+
+**Rejected because** the layout (circle + adjacent text), the emoji/icon/initials inputs,
+and discoverability justify a dedicated command, even though it reuses `st.image`'s
+plumbing.
+
+### Alternative 2: Use `width` instead of a dedicated `size`
+
+Reuse the standard `width: "content" | "stretch" | int` parameter to control the circle.
+
+- Pros: Maximizes parameter consistency across the API.
+- Cons: An avatar is square and defined by a single diameter; `"stretch"` is meaningless for
+  a circle, and conflating the element's container width with the circle's diameter is
+  confusing. A semantic `size` (`small`/`medium`/`large`/int) mirrors `st.logo` and reads
+  better for avatars.
+
+**Rejected** in favor of `size`; a `width` parameter for the overall element can be added
+later if needed (see Out of Scope).
+
+## Out of Scope (Future Work)
+
+- **Status indicator** — an online/offline dot or small badge overlaid on the avatar.
+- **Avatar groups / stacking** — overlapping avatars with a `+N` overflow (e.g. "shared with").
+- **Shape variants** — `shape="square" | "rounded"` for non-circular avatars.
+- **Overall `width` parameter** — controlling the element's container width independently of `size`.
+- **Custom background / ring color** — theming for icon/initials avatars beyond the default.
+
+## Checklist
+
+| Item                       | ✅ or comment                                                       |
+|----------------------------|---------------------------------------------------------------------|
+| Works on SiS, Cloud, etc?  | ✅ Reuses existing image/icon rendering and the standard widget path |
+| No breaking API changes    | ✅ New, additive command                                            |
+| No new dependencies        | ✅ Reuses `st.image`/`st.chat_message` rendering internals          |
+| Metrics collected          | ✅ `st.avatar` via `gather_metrics`                                 |
+| Any security/legal impact? | ✅ Same image-handling surface as `st.image`; clicks use the existing widget/callback path |
+| Any docs changes needed?   | ✅ New command page + mention alongside `st.image` / `st.logo`      |

--- a/specs/2026-06-12-avatar/product-spec.md
+++ b/specs/2026-06-12-avatar/product-spec.md
@@ -55,6 +55,7 @@ st.avatar(
     caption: str | None = None,
     size: Literal["small", "medium", "large"] | int = "medium",
     border: bool = False,
+    link: str | None = None,
     on_click: Literal["ignore", "rerun"] | Callable[..., None] = "ignore",
     args: tuple[Any, ...] | None = None,
     kwargs: dict[str, Any] | None = None,
@@ -88,7 +89,8 @@ st.avatar("https://avatars.githubusercontent.com/u/1673013")
 | `caption` | `str \| None` | `None` | Secondary text shown below the label (typically a role or status). Supports markdown and renders in the muted caption style used elsewhere in Streamlit. |
 | `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar image only. Semantic sizes map to rem-based values (`small` ≈ 1.5rem, `medium` ≈ 2.5rem, `large` ≈ 4rem; exact values TBD with design) so they scale with the root font size. An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIException` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
 | `border` | `bool` | `False` | If `True`, draws a subtle border around the avatar (useful for light images on light backgrounds). |
-| `on_click` | `"ignore" \| "rerun" \| Callable[..., None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun, receiving `args`/`kwargs`. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
+| `link` | `str \| None` | `None` | The URL to open in a new tab when a user clicks the avatar. As with `st.image`, this can be an external URL like `"https://streamlit.io"` or a relative path like `"/my_page"`. If `None`, the avatar does not include a hyperlink. `link` and `on_click` can be used together. |
+| `on_click` | `"ignore" \| "rerun" \| Callable[..., None]` | `"ignore"` | Click behavior. `"ignore"` disables rerun and callback behavior; a configured `link` still opens. `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun, receiving `args`/`kwargs`. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
 | `args` | `tuple[Any, ...] \| None` | `None` | An optional tuple of positional arguments passed to the `on_click` callback. Mirrors `st.button`'s `args` (Principle #11). |
 | `kwargs` | `dict[str, Any] \| None` | `None` | An optional dictionary of keyword arguments passed to the `on_click` callback. Mirrors `st.button`'s `kwargs` (Principle #11). |
 | `key` | `str \| None` | `None` | Unique key for the element. Required when multiple clickable avatars would otherwise share identical parameters. |
@@ -99,7 +101,8 @@ st.avatar("https://avatars.githubusercontent.com/u/1673013")
 element `st.image`. (`st.logo` is also a display element but returns `None`; `st.avatar`
 returns a `DeltaGenerator` so the display-only call can be chained like other elements.)
 When `on_click="rerun"` or a callback is provided, `st.avatar` returns a `bool`: `True`
-only on the rerun triggered by a click, and `False` otherwise.
+only on the rerun triggered by a click, and `False` otherwise. Providing `link` does not
+change the return type.
 
 Because the return type depends on the runtime value of `on_click`, the implementation will
 provide `@overload` stubs (as `st.download_button` and `st.link_button` already do) so that
@@ -151,6 +154,12 @@ The main open design question is whether `st.avatar` should support click intera
 because enabling clicks changes it from a display element into a widget (conditional return
 type, requires `key`). Two options:
 
+`link` is independent of `on_click`, following the existing `st.link_button` pattern. With
+`on_click="ignore"`, clicking opens the link in a new tab without rerunning the app. With
+`on_click="rerun"` or a callback, the link opens and the configured rerun or callback also
+occurs. This lets an avatar navigate to a profile and optionally update app state from the
+same interaction.
+
 **Option 1: Clickable widget** ✅ PREFERRED
 
 Add `on_click: Literal["ignore", "rerun"] | Callable[..., None] = "ignore"` plus `args`,
@@ -163,8 +172,9 @@ if st.avatar("profile.jpg", label="Jane Smith", on_click="rerun", key="profile")
     st.write("Profile clicked!")
 ```
 
-A clickable avatar should be keyboard-accessible: expose it as a button (`role="button"`,
-focusable, activatable with Enter/Space) with an `aria-label` derived from `label`.
+A clickable avatar should be keyboard-accessible and have an accessible name derived from
+`label`. Link-only avatars should expose link semantics, while avatars with `on_click`
+behavior should follow the accessible interaction pattern used by `st.link_button`.
 
 - Pros: Enables clickable profiles (open a dialog, navigate to a detail view) directly;
   `on_click="ignore"` keeps the common display-only case a one-liner.
@@ -196,6 +206,18 @@ st.avatar(
     "https://avatars.githubusercontent.com/u/1673013",
     label="Adrien Treuille",
     caption="Co-founder",
+)
+```
+
+**Avatar linked to a profile:**
+
+```python
+import streamlit as st
+
+st.avatar(
+    "https://avatars.githubusercontent.com/u/1673013",
+    label="Adrien Treuille",
+    link="https://github.com/treuille",
 )
 ```
 
@@ -300,5 +322,5 @@ later if needed (see Out of Scope).
 | No breaking API changes    | ✅ New, additive command                                            |
 | No new dependencies        | ✅ Reuses `st.image`/`st.chat_message` rendering internals          |
 | Metrics collected          | ✅ `st.avatar` via `gather_metrics`                                 |
-| Any security/legal impact? | ✅ Same image-handling surface as `st.image`; clicks use the existing widget/callback path |
+| Any security/legal impact? | ✅ Same image/link-handling surface as `st.image`; clicks use the existing widget/callback path |
 | Any docs changes needed?   | ✅ New command page + mention alongside `st.image` / `st.logo`      |

--- a/specs/2026-06-12-avatar/product-spec.md
+++ b/specs/2026-06-12-avatar/product-spec.md
@@ -56,16 +56,15 @@ st.avatar(
     size: Literal["small", "medium", "large"] | int = "medium",
     border: bool = False,
     on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore",
-    disabled: bool = False,
-    help: str | None = None,
     key: str | None = None,
-) -> bool
+) -> DeltaGenerator | bool
 ```
 
 By default (`on_click="ignore"`) `st.avatar` behaves like a display element and returns
-`False`. When made clickable (`on_click="rerun"` or a callback), it returns `True` on the
-rerun where it was clicked, matching `st.button`. This clickable-by-opt-in design is chosen
-over a display-only element—see [Interactivity](#interactivity) for the trade-offs.
+a `DeltaGenerator`. When made clickable (`on_click="rerun"` or a callback), it returns a
+`bool`: `True` on the rerun where it was clicked and `False` otherwise, matching
+`st.button`. This clickable-by-opt-in design is chosen over a display-only element—see
+[Interactivity](#interactivity) for the trade-offs.
 
 The simplest call is a single positional argument:
 
@@ -83,14 +82,14 @@ st.avatar("https://avatars.githubusercontent.com/u/1673013")
 | `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar. Semantic sizes map to fixed pixel values (`small` ≈ 24px, `medium` ≈ 40px, `large` ≈ 64px; exact values TBD with design). An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIError` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
 | `border` | `bool` | `False` | If `True`, draws a subtle border around the avatar (useful for light images on light backgrounds). |
 | `on_click` | `"ignore" \| "rerun" \| Callable[[], None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
-| `disabled` | `bool` | `False` | If `True`, disables click interaction and renders the avatar in a muted/disabled state. Only meaningful when `on_click != "ignore"`. |
-| `help` | `str \| None` | `None` | An optional tooltip shown on hover. Supports markdown. |
 | `key` | `str \| None` | `None` | Unique key for the element. Required when multiple clickable avatars would otherwise share identical parameters. |
 
 ### Return value
 
-`st.avatar` returns a `bool`: `True` only on the rerun triggered by a click (when
-`on_click != "ignore"`), and `False` otherwise—including always when `on_click="ignore"`.
+`st.avatar` returns a `DeltaGenerator` when `on_click="ignore"`, matching display elements
+like `st.image` and `st.logo`. When `on_click="rerun"` or a callback is provided,
+`st.avatar` returns a `bool`: `True` only on the rerun triggered by a click, and `False`
+otherwise.
 
 ### Content types
 
@@ -139,15 +138,14 @@ thing you pass to `st.avatar`.
 ### Interactivity
 
 The `streamlit-extras` version supports `on_click` and returns a `bool`. For a native
-command this is the main open design question, because it changes `st.avatar` from a
-display element into a widget (different return type, requires `key`). Two options:
+command this is the main open design question, because enabling clicks changes `st.avatar`
+from a display element into a widget (conditional return type, requires `key`). Two
+options:
 
 **Option 1: Clickable widget** ✅ PREFERRED
 
 Add `on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore"` plus `key`, and
-return `bool` (matching the extra and `st.button`). For consistency with other interactive
-widgets (Principle #11: Patterns Are Sacred), a clickable avatar also accepts `disabled`
-and `help`, which behave identically to their `st.button` counterparts.
+return `DeltaGenerator` for the display-only case and `bool` for the clickable case.
 
 ```python
 if st.avatar("profile.jpg", label="Jane Smith", on_click="rerun", key="profile"):
@@ -280,6 +278,8 @@ later if needed (see Out of Scope).
 - **Avatar groups / stacking** — overlapping avatars with a `+N` overflow (e.g. "shared with").
 - **Shape variants** — `shape="square" | "rounded"` for non-circular avatars.
 - **Overall `width` parameter** — controlling the element's container width independently of `size`.
+- **Disabled state and help tooltip** — button-like widget affordances that can be added
+  later if the clickable use case needs them.
 - **Custom background / ring color** — theming for icon/initials avatars beyond the default.
 
 ## Checklist

--- a/specs/2026-06-12-avatar/product-spec.md
+++ b/specs/2026-06-12-avatar/product-spec.md
@@ -16,7 +16,10 @@ comment authors, and chat participants.
 
 Streamlit has no native way to render the single most common identity primitive on the
 web: a circular avatar. Users routinely build profile pages, member directories, team
-sections, leaderboards, and activity feeds, and today they have to hack it together.
+sections, leaderboards, and activity feeds, and today they have to hack it together. This
+has been requested directly in
+[#12475](https://github.com/streamlit/streamlit/issues/12475) (`st.avatar` to show a
+standalone avatar image).
 
 **Current workarounds:**
 
@@ -53,6 +56,8 @@ st.avatar(
     size: Literal["small", "medium", "large"] | int = "medium",
     border: bool = False,
     on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore",
+    disabled: bool = False,
+    help: str | None = None,
     key: str | None = None,
 ) -> bool
 ```
@@ -75,9 +80,11 @@ st.avatar("https://avatars.githubusercontent.com/u/1673013")
 | `image` | `str \| Image \| None` | `None` | The avatar content. Accepts the same image inputs as `st.image` (URL, local path, `PIL.Image`, NumPy array, bytes/`BytesIO`), **plus** a single emoji (e.g. `"🦖"`) or a Material icon (e.g. `":material/person:"`)—matching `st.chat_message`'s `avatar`. If `None`, falls back to initials derived from `label`, or a generic person icon when no label is given. |
 | `label` | `str \| None` | `None` | Primary text shown to the right of the avatar (typically a name). Supports markdown. |
 | `caption` | `str \| None` | `None` | Secondary text shown below the label (typically a role or status). Supports markdown and renders in the muted caption style used elsewhere in Streamlit. |
-| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar. Semantic sizes map to fixed pixel values (`small` ≈ 24px, `medium` ≈ 40px, `large` ≈ 64px; exact values TBD with design). An `int` sets a custom diameter in pixels. |
+| `size` | `"small" \| "medium" \| "large" \| int` | `"medium"` | Diameter of the circular avatar. Semantic sizes map to fixed pixel values (`small` ≈ 24px, `medium` ≈ 40px, `large` ≈ 64px; exact values TBD with design). An `int` sets a custom diameter in pixels and must be a positive value; non-positive values raise a `StreamlitAPIError` (Fail Fast). No upper bound is enforced, but very large values are clamped to the element's container width at render time. |
 | `border` | `bool` | `False` | If `True`, draws a subtle border around the avatar (useful for light images on light backgrounds). |
-| `on_click` | `"ignore" \| "rerun" \| Callable[[], None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun. |
+| `on_click` | `"ignore" \| "rerun" \| Callable[[], None]` | `"ignore"` | Click behavior. `"ignore"` disables click interaction (avatar is purely decorative). `"rerun"` triggers a rerun when clicked. A callable runs as a callback before the rerun. Follows the `st.button` click pattern (a click action), not the `on_change` value-change pattern. |
+| `disabled` | `bool` | `False` | If `True`, disables click interaction and renders the avatar in a muted/disabled state. Only meaningful when `on_click != "ignore"`. |
+| `help` | `str \| None` | `None` | An optional tooltip shown on hover. Supports markdown. |
 | `key` | `str \| None` | `None` | Unique key for the element. Required when multiple clickable avatars would otherwise share identical parameters. |
 
 ### Return value
@@ -118,7 +125,11 @@ thing you pass to `st.avatar`.
 - `label` and `caption` are each constrained to a single line and truncate with an ellipsis
   when they overflow; the full text is shown on hover (matching the reference component).
 - Emoji and icon avatars render centered on a themed neutral background; initials avatars
-  show 1–2 uppercase letters derived from `label`.
+  show 1–2 uppercase letters derived from `label`. Initials are derived from the
+  *plain-text* form of `label` (markdown syntax, links, emoji, and Material icons are
+  stripped first): the first letter of the first two whitespace-separated words, or the
+  first two letters of a single word. If no letters remain after stripping, the generic
+  person icon is shown instead.
 - The element sizes to its content (the circle plus any text). Place avatars side by side
   with `st.container(horizontal=True)`—no `multiple`/grouping parameter is needed
   (composition over configuration).
@@ -134,7 +145,9 @@ display element into a widget (different return type, requires `key`). Two optio
 **Option 1: Clickable widget** ✅ PREFERRED
 
 Add `on_click: Literal["ignore", "rerun"] | Callable[[], None] = "ignore"` plus `key`, and
-return `bool` (matching the extra and `st.button`).
+return `bool` (matching the extra and `st.button`). For consistency with other interactive
+widgets (Principle #11: Patterns Are Sacred), a clickable avatar also accepts `disabled`
+and `help`, which behave identically to their `st.button` counterparts.
 
 ```python
 if st.avatar("profile.jpg", label="Jane Smith", on_click="rerun", key="profile"):


### PR DESCRIPTION
## Describe your changes

- [Issue renderer
](https://issues.streamlit.app/spec_renderer?pr=15546)

Adds a product spec proposing a native `st.avatar` command for displaying a circular avatar (image, Material icon, or emoji) with an optional label and caption — inspired by the `streamlit-extras` avatar but aligned with native Streamlit API conventions.

- Proposes `st.avatar(image, *, label, caption, size, border, on_click, key)` with a clickable-by-opt-in design (`on_click="ignore"` default, returns `bool`)
- Uses a semantic `size` ("small"/"medium"/"large"/int) instead of raw pixel height, and accepts emoji/Material-icon/initials inputs to match `st.chat_message`
- Documents alternatives (extend `st.image` with `shape="circle"`, `width` vs `size`) and out-of-scope future work (status indicator, avatar groups, shape variants)

## GitHub Issue Link (if applicable)

- Related https://github.com/streamlit/streamlit/issues/12475

## Testing Plan

- [x] No tests — spec/design document only

Made with [Cursor](https://cursor.com)