### PR TITLE
[feature] Support pasting files into st.chat_input

### DIFF
--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -28,6 +28,7 @@ import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import {
   createDirectoryFiles,
   createFileWithPath,
+  createTestFile,
   render,
 } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -88,6 +89,21 @@ const mockChatInputValue = (text: string): IChatInputValue => {
     },
   }
 }
+
+const mockClipboardData = ({
+  files = [],
+  items = [],
+  text = "",
+}: {
+  files?: File[]
+  items?: Partial<DataTransferItem>[]
+  text?: string
+}): DataTransfer =>
+  ({
+    files,
+    items,
+    getData: vi.fn(() => text),
+  }) as unknown as DataTransfer
 
 const createMockWaveformController = (): WaveformController => ({
   state: "idle",
@@ -579,6 +595,155 @@ describe("ChatInput widget", () => {
 
     const submitButton = screen.getByTestId("stChatInputSubmitButton")
     expect(submitButton).toBeEnabled()
+  })
+
+  it("uploads pasted files when file uploads are enabled", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      acceptFile: ChatInputProto.AcceptFile.SINGLE,
+      maxUploadSizeMb: 50,
+    })
+    render(<ChatInput {...props} />)
+
+    const file = createTestFile("pasted.txt", "clipboard content")
+    const textarea = screen.getByTestId("stChatInputTextArea")
+
+    await user.click(textarea)
+    await user.paste(mockClipboardData({ files: [file] }))
+
+    await waitFor(() => {
+      expect(props.uploadClient.uploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({ id: props.element.id }),
+        file.name,
+        file,
+        expect.any(Function),
+        expect.any(AbortSignal)
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stFileChipName")).toHaveTextContent(
+        "pasted.txt"
+      )
+    })
+  })
+
+  it("uploads only the first pasted file in single-file mode", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      acceptFile: ChatInputProto.AcceptFile.SINGLE,
+      maxUploadSizeMb: 50,
+    })
+    render(<ChatInput {...props} />)
+
+    const firstFile = createTestFile("first.txt", "first content")
+    const secondFile = createTestFile("second.txt", "second content")
+    const textarea = screen.getByTestId("stChatInputTextArea")
+
+    await user.click(textarea)
+    await user.paste(mockClipboardData({ files: [firstFile, secondFile] }))
+
+    await waitFor(() => {
+      expect(props.uploadClient.uploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({ id: props.element.id }),
+        firstFile.name,
+        firstFile,
+        expect.any(Function),
+        expect.any(AbortSignal)
+      )
+    })
+
+    expect(props.uploadClient.uploadFile).not.toHaveBeenCalledWith(
+      expect.anything(),
+      secondFile.name,
+      secondFile,
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it("does not upload pasted files when file uploads are disabled", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    render(<ChatInput {...props} />)
+
+    const file = createTestFile("ignored.txt")
+    const textarea = screen.getByTestId("stChatInputTextArea")
+
+    await user.click(textarea)
+    await user.paste(mockClipboardData({ files: [file] }))
+
+    expect(props.uploadClient.fetchFileURLs).not.toHaveBeenCalled()
+    expect(props.uploadClient.uploadFile).not.toHaveBeenCalled()
+  })
+
+  it("uploads pasted files from clipboard items", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      acceptFile: ChatInputProto.AcceptFile.SINGLE,
+      maxUploadSizeMb: 50,
+    })
+    render(<ChatInput {...props} />)
+
+    const file = createTestFile("pasted-from-item.png")
+    const textarea = screen.getByTestId("stChatInputTextArea")
+
+    await user.click(textarea)
+    await user.paste(
+      mockClipboardData({
+        items: [
+          {
+            kind: "file",
+            getAsFile: vi.fn(() => file),
+          },
+        ],
+      })
+    )
+
+    await waitFor(() => {
+      expect(props.uploadClient.uploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({ id: props.element.id }),
+        file.name,
+        file,
+        expect.any(Function),
+        expect.any(AbortSignal)
+      )
+    })
+  })
+
+  it("does not upload when clipboard has no files", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      acceptFile: ChatInputProto.AcceptFile.SINGLE,
+      maxUploadSizeMb: 50,
+    })
+    render(<ChatInput {...props} />)
+
+    const textarea = screen.getByTestId("stChatInputTextArea")
+
+    await user.click(textarea)
+    await user.paste(mockClipboardData({}))
+
+    expect(props.uploadClient.fetchFileURLs).not.toHaveBeenCalled()
+    expect(props.uploadClient.uploadFile).not.toHaveBeenCalled()
+  })
+
+  it("preserves text paste behavior when file uploads are enabled", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      acceptFile: ChatInputProto.AcceptFile.SINGLE,
+      maxUploadSizeMb: 50,
+    })
+    render(<ChatInput {...props} />)
+
+    const textarea = screen.getByTestId("stChatInputTextArea")
+
+    await user.click(textarea)
+    await user.paste("pasted text")
+
+    expect(textarea).toHaveTextContent("pasted text")
+    expect(props.uploadClient.fetchFileURLs).not.toHaveBeenCalled()
+    expect(props.uploadClient.uploadFile).not.toHaveBeenCalled()
   })
 
   it("displays directory upload instructions correctly", () => {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -462,15 +462,19 @@ function ChatInput({
         return
       }
 
+      if (!e.clipboardData) {
+        return
+      }
+
       const pastedFiles = getPastedFiles(e.clipboardData)
       if (pastedFiles.length === 0) {
         return
       }
 
       e.preventDefault()
-      dropHandler(pastedFiles, [])
+      dropHandlerRef.current?.(pastedFiles, [])
     },
-    [acceptFile, disabled, dropHandler]
+    [acceptFile, disabled]
   )
 
   const { getRootProps, getInputProps } = useDropzone({

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.tsx
@@ -16,6 +16,7 @@
 
 import {
   ChangeEvent,
+  ClipboardEvent,
   KeyboardEvent,
   memo,
   useCallback,
@@ -76,6 +77,7 @@ import ChatFileUploadButton from "./fileUpload/ChatFileUploadButton"
 import ChatFileUploadDropzone from "./fileUpload/ChatFileUploadDropzone"
 import { createDropHandler } from "./fileUpload/createDropHandler"
 import { createUploadFileHandler } from "./fileUpload/createFileUploadHandler"
+import { getPastedFiles } from "./fileUpload/fileUploadUtils"
 import {
   StyledChatAudioWave,
   StyledChatInput,
@@ -453,6 +455,23 @@ function ChatInput({
 
   // Store dropHandler in ref for retry functionality
   dropHandlerRef.current = dropHandler
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent<HTMLTextAreaElement>): void => {
+      if (disabled || acceptFile === AcceptFileValue.None) {
+        return
+      }
+
+      const pastedFiles = getPastedFiles(e.clipboardData)
+      if (pastedFiles.length === 0) {
+        return
+      }
+
+      e.preventDefault()
+      dropHandler(pastedFiles, [])
+    },
+    [acceptFile, disabled, dropHandler]
+  )
 
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: dropHandler,
@@ -835,6 +854,7 @@ function ChatInput({
                 placeholder={placeholder}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 aria-label={placeholder}
                 disabled={disabled}
                 rows={1}

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.test.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.test.ts
@@ -210,6 +210,46 @@ describe("createDropHandler", () => {
     expect(params.deleteExistingFiles).toHaveBeenCalledTimes(1)
   })
 
+  it("keeps only the first file and rejects the rest in single-file mode when multiple files bypass react-dropzone", () => {
+    const fetchFileURLs = vi.fn().mockResolvedValue([] as IFileURLs[])
+    const params = createMockParams({
+      acceptMultipleFiles: false,
+      uploadClient: { fetchFileURLs } as unknown as FileUploadClient,
+    })
+    const handler = createDropHandler(params)
+    const firstFile = createTestFile("first.txt")
+    const secondFile = createTestFile("second.txt")
+
+    handler([firstFile, secondFile], [])
+
+    expect(fetchFileURLs).toHaveBeenCalledWith([firstFile])
+    expect(getRejectedFileInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: secondFile,
+        errors: expect.arrayContaining([
+          expect.objectContaining({ code: FileErrorCode.TooManyFiles }),
+        ]),
+      }),
+      expect.any(Number),
+      params.maxFileSize
+    )
+  })
+
+  it("keeps all files in multi-file mode when several bypass react-dropzone", () => {
+    const fetchFileURLs = vi.fn().mockResolvedValue([] as IFileURLs[])
+    const params = createMockParams({
+      acceptMultipleFiles: true,
+      uploadClient: { fetchFileURLs } as unknown as FileUploadClient,
+    })
+    const handler = createDropHandler(params)
+    const firstFile = createTestFile("first.txt")
+    const secondFile = createTestFile("second.txt")
+
+    handler([firstFile, secondFile], [])
+
+    expect(fetchFileURLs).toHaveBeenCalledWith([firstFile, secondFile])
+  })
+
   it("calls uploadClient.fetchFileURLs with accepted files", async () => {
     const file = createTestFile("up.txt")
     const fileURLs = FileURLsProto.create({})

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/createDropHandler.ts
@@ -137,6 +137,26 @@ export const createDropHandler =
       }
     }
 
+    // When uploads bypass react-dropzone (e.g. pasting multiple files), more
+    // than one valid file can reach here even in single-file mode. Keep the
+    // first file and reject the rest, mirroring the drag-and-drop behavior.
+    if (!acceptMultipleFiles && acceptedFiles.length > 1) {
+      const [firstFile, ...extraFiles] = acceptedFiles
+      acceptedFiles = [firstFile]
+      rejectedFiles = [
+        ...rejectedFiles,
+        ...extraFiles.map(file => ({
+          file,
+          errors: [
+            {
+              code: FileErrorCode.TooManyFiles,
+              message: "Only one file is allowed.",
+            },
+          ],
+        })),
+      ]
+    }
+
     if (!acceptMultipleFiles && acceptedFiles.length > 0) {
       deleteExistingFiles()
     }

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.test.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.test.ts
@@ -22,6 +22,7 @@ import { AcceptFileValue } from "~lib/util/utils"
 
 import {
   configureFileInputProps,
+  getPastedFiles,
   getUploadDescription,
   validateFileType,
 } from "./fileUploadUtils"
@@ -185,6 +186,55 @@ describe("fileUploadUtils", () => {
       [AcceptFileValue.None, "a file"],
     ])("returns correct description for %s", (acceptFile, expected) => {
       expect(getUploadDescription(acceptFile)).toBe(expected)
+    })
+  })
+
+  describe("getPastedFiles", () => {
+    it("returns files from clipboard data", () => {
+      const file = createTestFile("pasted.txt")
+      const clipboardData = {
+        files: [file],
+        items: [],
+      } as unknown as DataTransfer
+
+      expect(getPastedFiles(clipboardData)).toEqual([file])
+    })
+
+    it("falls back to file items when files are unavailable", () => {
+      const file = createTestFile("clipboard.png")
+      const clipboardData = {
+        files: [],
+        items: [
+          {
+            kind: "string",
+            getAsFile: vi.fn(),
+          },
+          {
+            kind: "file",
+            getAsFile: vi.fn(() => file),
+          },
+        ],
+      } as unknown as DataTransfer
+
+      expect(getPastedFiles(clipboardData)).toEqual([file])
+    })
+
+    it("ignores clipboard items without files", () => {
+      const clipboardData = {
+        files: [],
+        items: [
+          {
+            kind: "string",
+            getAsFile: vi.fn(),
+          },
+          {
+            kind: "file",
+            getAsFile: vi.fn(() => null),
+          },
+        ],
+      } as unknown as DataTransfer
+
+      expect(getPastedFiles(clipboardData)).toEqual([])
     })
   })
 

--- a/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.ts
+++ b/frontend/lib/src/components/widgets/ChatInput/fileUpload/fileUploadUtils.ts
@@ -56,6 +56,24 @@ export const validateFileType = (
 }
 
 /**
+ * Extracts files from clipboard data on a paste event.
+ *
+ * Prefers `clipboardData.files`, falling back to file-kind `items` (e.g. when
+ * pasting an image where the file is only exposed via the items API).
+ */
+export const getPastedFiles = (clipboardData: DataTransfer): File[] => {
+  const files = Array.from(clipboardData.files)
+  if (files.length > 0) {
+    return files
+  }
+
+  return Array.from(clipboardData.items)
+    .filter(item => item.kind === "file")
+    .map(item => item.getAsFile())
+    .filter((file): file is File => file !== null)
+}
+
+/**
  * Gets a human-readable description for the upload type.
  */
 export const getUploadDescription = (acceptFile: AcceptFileValue): string => {


### PR DESCRIPTION
## Describe your changes

Pasting files (including images) into `st.chat_input` now uploads them, matching the existing drag-and-drop and file-picker behavior.

- Added an `onPaste` handler to the chat input textarea that extracts files from the clipboard and routes them through the existing validated upload pipeline (`dropHandler` → `filterFiles` → `uploadClient`). Pasting is a no-op when uploads are disabled or `accept_file` is not set.
- New `getPastedFiles` util reads `clipboardData.files`, falling back to file-kind `items` (e.g. pasted images).
- Fixed the single-file cap: `createDropHandler` now keeps only the first file and rejects the rest for any path that bypasses react-dropzone (paste), so pasting multiple files in single-file mode no longer uploads all of them.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

- Closes #10307

## Testing Plan

- Unit Tests (JS): `ChatInput.test.tsx`, `fileUpload/fileUploadUtils.test.ts`, and `fileUpload/createDropHandler.test.ts` cover paste-to-upload (files + clipboard items), the disabled/empty-clipboard no-ops, text-paste preservation, and the single-file truncation.
- No E2E test added: simulating real clipboard `DataTransfer`/paste events in Playwright is unreliable, and the change reuses the already-covered upload pipeline. The behavior is fully covered by the unit/integration tests above.