### PR TITLE
[feature] Support OpenAI Responses API streams in st.write_stream

### DIFF
--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -55,6 +55,12 @@ HELP_TYPES: Final[tuple[type[Any], ...]] = (
     types.ModuleType,
 )
 
+# OpenAI Responses API stream event types that carry user-visible text.
+# Other event types (lifecycle, tool-call, etc.) are protocol metadata.
+_OPENAI_RESPONSE_TEXT_EVENT_TYPES: Final = frozenset(
+    {"response.output_text.delta", "response.refusal.delta"}
+)
+
 
 class StreamingOutput(list[Any]):  # noqa: FURB189
     pass
@@ -85,6 +91,9 @@ class WriteMixin:
             If you pass an async generator, Streamlit will internally convert
             it to a sync generator. If the generator depends on a cached object
             with async references, this can raise an error.
+
+            Streamlit natively parses OpenAI streams (both the Chat
+            Completions API and the Responses API) and LangChain streams.
 
             .. note::
                 To use additional LLM libraries, you can create a wrapper to
@@ -219,6 +228,22 @@ class WriteMixin:
                     raise StreamlitAPIException(
                         "Failed to parse the OpenAI ChatCompletionChunk. "
                         "The most likely cause is a change of the chunk object structure "
+                        "due to a recent OpenAI update. You might be able to fix this "
+                        "by downgrading the OpenAI library or upgrading Streamlit. Also, "
+                        "please report this issue to: https://github.com/streamlit/streamlit/issues."
+                    ) from err
+
+            elif type_util.is_openai_response_event(chunk):
+                # Try to convert OpenAI Responses API stream events to a string.
+                try:
+                    if chunk.type in _OPENAI_RESPONSE_TEXT_EVENT_TYPES:
+                        chunk = chunk.delta or ""  # noqa: PLW2901
+                    else:
+                        chunk = ""  # noqa: PLW2901
+                except AttributeError as err:
+                    raise StreamlitAPIException(
+                        "Failed to parse the OpenAI Response stream event. "
+                        "The most likely cause is a change of the event object structure "
                         "due to a recent OpenAI update. You might be able to fix this "
                         "by downgrading the OpenAI library or upgrading Streamlit. Also, "
                         "please report this issue to: https://github.com/streamlit/streamlit/issues."

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -219,11 +219,19 @@ def is_keras_model(obj: object) -> bool:
 
 # We use a regex here to allow potential changes in the module path in the future.
 _OPENAI_CHUNK_RE: Final = re.compile(r"^openai\..+\.ChatCompletionChunk$")
+_OPENAI_RESPONSE_EVENT_RE: Final = re.compile(
+    r"^openai\.types\.responses\..+\.Response.+Event$"
+)
 
 
 def is_openai_chunk(obj: object) -> bool:
     """True if input looks like an OpenAI chat completion chunk."""
     return is_type(obj, _OPENAI_CHUNK_RE)
+
+
+def is_openai_response_event(obj: object) -> bool:
+    """True if input looks like an OpenAI Responses API stream event."""
+    return is_type(obj, _OPENAI_RESPONSE_EVENT_RE)
 
 
 def is_plotly_chart(obj: object) -> TypeGuard[Figure | list[Any] | dict[str, Any]]:

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -219,9 +219,9 @@ def is_keras_model(obj: object) -> bool:
 
 # We use a regex here to allow potential changes in the module path in the future.
 _OPENAI_CHUNK_RE: Final = re.compile(r"^openai\..+\.ChatCompletionChunk$")
-_OPENAI_RESPONSE_EVENT_RE: Final = re.compile(
-    r"^openai\.types\.responses\..+\.Response.+Event$"
-)
+# Only anchor to the `openai` package and the `Response...Event` class name so
+# detection survives potential future restructuring of the intermediate module path.
+_OPENAI_RESPONSE_EVENT_RE: Final = re.compile(r"^openai\..+\.Response.+Event$")
 
 
 def is_openai_chunk(obj: object) -> bool:

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -514,6 +514,43 @@ class StreamlitStreamTest(unittest.TestCase):
         stream_return = st.write_stream(openai_stream)
         assert stream_return == "Hello World"
 
+    def test_with_openai_response_events(self):
+        """Test st.write_stream with OpenAI Responses API stream events."""
+
+        def openai_response_stream():
+            yield _openai_response_event("ResponseCreatedEvent", "response.created")
+            yield _openai_response_event(
+                "ResponseTextDeltaEvent",
+                "response.output_text.delta",
+                delta="Hello ",
+            )
+            yield _openai_response_event(
+                "ResponseWebSearchCallInProgressEvent",
+                "response.web_search_call.in_progress",
+            )
+            yield _openai_response_event(
+                "ResponseTextDeltaEvent",
+                "response.output_text.delta",
+                delta="World",
+            )
+            yield _openai_response_event("ResponseCompletedEvent", "response.completed")
+
+        stream_return = st.write_stream(openai_response_stream)
+        assert stream_return == "Hello World"
+
+    def test_with_openai_response_refusal_delta_event(self):
+        """Test st.write_stream with OpenAI Responses API refusal deltas."""
+
+        def openai_response_stream():
+            yield _openai_response_event(
+                "ResponseRefusalDeltaEvent",
+                "response.refusal.delta",
+                delta="I can't help with that.",
+            )
+
+        stream_return = st.write_stream(openai_response_stream)
+        assert stream_return == "I can't help with that."
+
     def test_with_generator_text(self):
         """Test st.write_stream with generator text content."""
 
@@ -808,13 +845,33 @@ def _broken_langchain_ai_message_chunk() -> Any:
     return cls()
 
 
+def _openai_response_event(name: str, event_type: str, **attrs: Any) -> Any:
+    """Instance whose type FQN matches OpenAI Responses API stream events."""
+    cls = type(name, (), {})
+    cls.__module__ = f"openai.types.responses.{name.lower()}"
+    event = cls()
+    event.type = event_type
+    for attr, value in attrs.items():
+        setattr(event, attr, value)
+    return event
+
+
+def _broken_openai_response_event() -> Any:
+    """Instance whose type FQN matches OpenAI Response stream event checks."""
+    return _openai_response_event(
+        "ResponseTextDeltaEvent",
+        "response.output_text.delta",
+    )
+
+
 @pytest.mark.parametrize(
     ("make_chunk", "match_substr"),
     [
         (_broken_openai_chat_completion_chunk, "Failed to parse the OpenAI"),
+        (_broken_openai_response_event, "Failed to parse the OpenAI Response"),
         (_broken_langchain_ai_message_chunk, "Failed to parse the LangChain"),
     ],
-    ids=["openai", "langchain"],
+    ids=["openai-chat-completion", "openai-response", "langchain"],
 )
 def test_write_stream_chunk_attribute_error_raises(
     make_chunk: Callable[[], Any], match_substr: str

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import dataclasses
+import re
 import time
 import unittest
 from collections import namedtuple
@@ -848,7 +849,10 @@ def _broken_langchain_ai_message_chunk() -> Any:
 def _openai_response_event(name: str, event_type: str, **attrs: Any) -> Any:
     """Instance whose type FQN matches OpenAI Responses API stream events."""
     cls = type(name, (), {})
-    cls.__module__ = f"openai.types.responses.{name.lower()}"
+    # Mirror the SDK's snake_case module naming (e.g. ResponseTextDeltaEvent ->
+    # openai.types.responses.response_text_delta_event).
+    snake_case_name = re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+    cls.__module__ = f"openai.types.responses.{snake_case_name}"
     event = cls()
     event.type = event_type
     for attr, value in attrs.items():


### PR DESCRIPTION
## Describe your changes

Adds native support for the OpenAI Responses API streaming events to `st.write_stream` (previously only the Chat Completions API was handled).

- `st.write_stream` now extracts user-visible text from `response.output_text.delta` and `response.refusal.delta` events and ignores lifecycle/tool-call events (which are protocol metadata).
- Detection uses a new `type_util.is_openai_response_event` helper that matches the event type FQN, mirroring the existing `is_openai_chunk` approach so it works without importing `openai`.
- A malformed event raises a clear `StreamlitAPIException` pointing at a likely OpenAI version mismatch, consistent with the existing Chat Completions / LangChain handling.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/11061

## Testing Plan

- `lib/tests/streamlit/write_test.py` — Covers mixed Responses API streams (lifecycle + text deltas), refusal deltas, and the `AttributeError` -> `StreamlitAPIException` path.
- No E2E test added: the new logic is pure in-process text extraction, consistent with the existing OpenAI Chat Completions path which is also unit-test only.

Made with [Cursor](https://cursor.com)