### PR TITLE
docs: add WSL2 development notes to CONTRIBUTING.md (#11559)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,15 @@ $ sudo apt-get install -y ripgrep
 
 Streamlit's development setup is pretty Mac- and Linux-centric. If you're doing Streamlit development on Windows, we suggest using our [devcontainer](./.devcontainer) via Github Codespaces or locally via VS Code. Alternatively, you can also spin up a Linux VM (e.g. via [VirtualBox](https://www.virtualbox.org/), which is free); or your own Linux Docker image; or using Microsoft's WSL ("Windows Subsystem for Linux").
 
+##### Notes on WSL2
+
+If you choose WSL2, follow the [Ubuntu](#ubuntu) instructions above from inside your WSL distro, with a few extra notes:
+
+- **Keep the checkout inside the WSL filesystem.** Clone into your Linux home directory (e.g. `~/src/streamlit`), not under `/mnt/c/`. Building and running `yarn` across the `/mnt/c` boundary is significantly slower and CRLF line endings on the Windows side can break shell scripts invoked by `make`.
+- **Use `nvm` to install the Node version pinned in [`.nvmrc`](./.nvmrc).** The Node packaged with most Ubuntu releases is too old.
+- **Enable Corepack before running `make`.** `corepack enable` is enough; Corepack will pick up the `yarn` version pinned by [`frontend/package.json`](./frontend/package.json)'s `packageManager` field on first use.
+- **Run `make all-dev` once before any `make frontend-*` target.** `make all-dev` is what runs `yarn install` and populates `frontend/.yarn/`; without it, frontend targets will fail with errors like _"Couldn't find the node_modules state file"_.
+
 ### 2. Grab the code
 
 _(You probably already know how to do this, but just in case...)_


### PR DESCRIPTION

## Summary

Closes #11559.

The original report — `make frontend-dev` failing under WSL2 with _"Couldn't find the node_modules state file"_ — no longer reproduces on `develop`: `frontend-dev` is now just `cd frontend/ ; yarn start` (no `frontend-dependencies` dep), and `make all-dev` → `frontend-init` runs `yarn install --immutable` as part of the documented setup path. So the bug as written is stale (as @wyattscarpenter also noted in the thread).

What is *not* fixed is the underlying confusion: `CONTRIBUTING.md`'s `#### Windows` section is a single sentence that suggests WSL as an option but gives no guidance, so a WSL2 user can easily skip `make all-dev` and run `make frontend-*` straight away — which is exactly the failure mode the issue describes.

This PR adds a `##### Notes on WSL2` subsection right under `#### Windows` covering the four things that actually trip people up:

- Keep the checkout inside the WSL filesystem (not `/mnt/c/`) — yarn 4 across the mount boundary is slow and CRLF line endings break shell scripts invoked by `make`.
- Install Node via `nvm` matching `.nvmrc` (Ubuntu's default `node` is too old).
- `corepack enable` before running `make` — Corepack picks up the yarn version from `frontend/package.json`'s `packageManager` field automatically.
- Run `make all-dev` once before any `make frontend-*` target. This is the specific guardrail that would have prevented the original report.

## Files changed

- `CONTRIBUTING.md` — +9 lines, no deletions.

Diff is docs-only, +9/-0.

## Testing

- Verified `grep -rn 'all-devel' .` returns no matches on `develop` — no rename cleanup needed.
- Verified Makefile state matches what the new docs claim: `all-dev` at line 52, `frontend-init` at line 222 (runs `corepack enable yarn && corepack install && yarn install --immutable`), `frontend-dev` at line 271 (just `cd frontend/ ; yarn start`).
- Verified the pinned yarn version reference: `frontend/package.json` line 52 has `"packageManager": "yarn@4.13.0"`, so `corepack enable` plus running any yarn command in the repo is sufficient — no manual `corepack prepare yarn@... --activate` step needed.
- Did **not** spin up a fresh WSL2 environment end-to-end. The four bullets are all directly verifiable against repo state (`.nvmrc`, `Makefile`, `frontend/package.json`); the `/mnt/c` performance + CRLF guidance is consistent with Microsoft's own WSL filesystem guidance and the general yarn-4-on-Windows pattern. Flagging this explicitly for maintainer review — happy to drop the perf bullet if you'd rather keep the docs change minimal.

## Ready-to-PR checklist

- [x] Issue actually addressed (root cause, not symptom) — yes, fills the documentation gap that produced the original failure
- [x] Diff < 50 lines — 9 lines added, 0 removed
- [x] Docs-only, so no test changes needed
- [x] Style matches existing CONTRIBUTING.md sections (matching `####` / `#####` heading hierarchy, bold-label bullet pattern used elsewhere)
- [x] No `NO-AI` / `no-ai-contributions` policy on `streamlit/streamlit` (checked CONTRIBUTING.md — there is an explicit "Expectations for AI-assisted contributions" section that welcomes them with author-ownership caveats)
- [x] Repo is active (recent commits on `develop`)
- [x] Issue is unassigned, no "I'll take this" claim in the comment thread
- [x] Commit message follows repo's `<type>: <subject>` convention seen in `git log`

## Notes for Chris before shipping

- Worth a quick eyeball at the rendered preview on the branch before flipping the PR out of draft — GitHub renders `#####` as quite small, and if maintainers would rather see `####` plus an italic intro line, that's a one-line tweak.
- Issue author (`@daniftw`) is non-responsive in the thread; `@wyattscarpenter` already said the bug doesn't repro. The PR description above explicitly credits that observation and reframes the fix as documentation, which is the honest framing — but if you'd rather close the issue with a comment instead of merging a docs PR, that's also a defensible call. The docs gap is real either way.
- `gh` is not authed on this machine right now (`gh auth status` says not logged in). `scripts/ship.sh` will fail at the `gh api user --jq .login` step until you `gh auth login`.
