### PR TITLE
[chore] Pin pytest to 9.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,8 @@ dev = [
 test = [
   "streamlit",
   # Testing infrastructure dependencies:
-  "pytest>=8.3.5",
+  # pytest >= 9.1.0 is causing issues and is not yet supported.
+  "pytest==9.0.3",
   "pytest-cov",
   "hypothesis>=6.17.4",
   "parameterized",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ test = [
   "streamlit",
   # Testing infrastructure dependencies:
   # pytest >= 9.1.0 is causing issues and is not yet supported.
-  "pytest==9.0.3",
+  "pytest>=9.0.3,<9.1.0",
   "pytest-cov",
   "hypothesis>=6.17.4",
   "parameterized",


### PR DESCRIPTION
## Describe your changes

Pins the `pytest` test dependency to `9.0.3` (was `>=8.3.5`).

- `pytest >= 9.1.0` introduces breaking changes that aren't yet supported, so the version is pinned to avoid unexpected CI breakage.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Covered by existing CI test suite (no behavior change to the library itself)

Made with [Cursor](https://cursor.com)