### PR TITLE
Remove widget default-value-when-set-via-session-state warning

### DIFF
--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -55,8 +55,6 @@ def check_callback_rules(dg: DeltaGenerator, on_change: WidgetCallback | None) -
         raise StreamlitInvalidFormCallbackError()
 
 
-_shown_default_value_warning: bool = False
-
 
 def check_session_state_rules(
     default_value: Any, key: str | None, writes_allowed: bool = True
@@ -72,8 +70,6 @@ def check_session_state_rules(
     StreamlitValueAssignmentNotAllowedError:
         Raised when writing is not allowed but session state contains a new value.
     """
-    global _shown_default_value_warning  # noqa: PLW0603
-
     if key is None or not runtime.exists():
         return
 
@@ -83,19 +79,6 @@ def check_session_state_rules(
 
     if not writes_allowed:
         raise StreamlitValueAssignmentNotAllowedError(key=key)
-
-    if (
-        default_value is not None
-        and not _shown_default_value_warning
-        and not config.get_option("global.disableWidgetStateDuplicationWarning")
-    ):
-        _LOGGER.warning(
-            'The widget with key "%s" was created with a default value but also had '
-            "its value set via the Session State API.",
-            key,
-            stack_info=True,
-        )
-        _shown_default_value_warning = True
 
 
 class CachedWidgetWarning(StreamlitAPIWarning):


### PR DESCRIPTION
## Describe your changes

Remove the warning that fires when a widget has both a default value
and a value set via the Session State API.

## GitHub Issue Link

Fixes #15544

## Background

As discussed in https://github.com/streamlit/streamlit/issues/15529#issuecomment-4692528726,
maintainer @lukasmasuch confirmed:
> It's fine to do that if it's intended.

The warning was acknowledged as needing removal ("I think I might have
removed this warning recently, but not 100% sure If I ever merged this PR").

## Changes

- Remove `_shown_default_value_warning` module-level flag
- Remove the warning block from `check_session_state_rules()`

## Testing Plan

The key validation and write-protection logic remains intact:
```python
import streamlit as st
st.session_state["key"] = 1
st.slider("slider", min_value=0, max_value=10, value=9, key="key")
```
No warning should be shown.

---
**Contribution License Agreement**

By submitting this pull request you agree that all past and future
contributions to this project are licensed under
the Apache License, Version 2.0 ([LICENSE](LICENSE)).
