### PR TITLE
[fix] Ignore browser prefetch on OAuth callback

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -60,6 +60,7 @@ _ROUTE_AUTH_LOGOUT: Final = "auth/logout"
 _ROUTE_OAUTH_CALLBACK: Final = "oauth2callback"
 _AUTH_COOKIE_SAMESITE: Final = "lax"
 _AUTH_COOKIE_NAMES: Final = (USER_COOKIE_NAME, TOKENS_COOKIE_NAME)
+_PREFETCH_REQUEST_HEADERS: Final = ("sec-purpose", "purpose", "x-moz")
 
 
 def _normalize_nested_config(value: Any) -> Any:
@@ -148,6 +149,22 @@ async def _redirect_to_base(base_url: str) -> RedirectResponse:
     from starlette.responses import RedirectResponse
 
     return RedirectResponse(make_url_path(base_url, "/"), status_code=302)
+
+
+def _is_browser_prefetch_request(request: Request) -> bool:
+    """Return whether the request is marked as speculative browser prefetch."""
+    return any(
+        "prefetch" in request.headers.get(header_name, "").lower()
+        for header_name in _PREFETCH_REQUEST_HEADERS
+    )
+
+
+def _set_auth_response_headers(response: Response) -> Response:
+    """Set defensive headers on authentication route responses."""
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Vary"] = "Sec-Purpose, Purpose, X-Moz"
+    return response
 
 
 def _get_cookie_path() -> str:
@@ -552,6 +569,15 @@ async def _auth_logout(request: Request, base_url: str) -> Response:
 async def _auth_callback(request: Request, base_url: str) -> Response:
     """Handle the OAuth callback from the authentication provider."""
 
+    if _is_browser_prefetch_request(request):
+        # OAuth authorization codes are single-use. Some mobile browsers can make
+        # speculative requests with prefetch headers; exchanging the code for that
+        # request can consume it before the user's real navigation arrives.
+        from starlette.responses import Response
+
+        _LOGGER.info("Ignoring OAuth callback request marked as browser prefetch.")
+        return Response(status_code=204)
+
     state = request.query_params.get("state")
     provider = _get_provider_by_state(request, state)
     origin = _get_origin_from_secrets()
@@ -624,13 +650,16 @@ def create_auth_routes(base_url: str) -> list[Route]:
     from starlette.routing import Route
 
     async def login(request: Request) -> Response:
-        return await _auth_login(request, base_url)
+        response = await _auth_login(request, base_url)
+        return _set_auth_response_headers(response)
 
     async def logout(request: Request) -> Response:
-        return await _auth_logout(request, base_url)
+        response = await _auth_logout(request, base_url)
+        return _set_auth_response_headers(response)
 
     async def callback(request: Request) -> Response:
-        return await _auth_callback(request, base_url)
+        response = await _auth_callback(request, base_url)
+        return _set_auth_response_headers(response)
 
     return [
         Route(make_url_path(base_url, _ROUTE_AUTH_LOGIN), login, methods=["GET"]),

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -16,10 +16,11 @@ from __future__ import annotations
 
 import asyncio
 from http.cookies import SimpleCookie
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
+import pytest
 from authlib.integrations import starlette_client
 from starlette.applications import Starlette
 from starlette.middleware.sessions import SessionMiddleware
@@ -42,9 +43,6 @@ from streamlit.web.server.starlette.starlette_server_config import (
     USER_COOKIE_NAME,
 )
 from tests.testutil import patch_config_options
-
-if TYPE_CHECKING:
-    import pytest
 
 TORNADO_SIGNED_USER_COOKIE = (
     "2|1:0|10:1780515959|15:_streamlit_user|68:"
@@ -125,6 +123,30 @@ def test_redirect_without_provider(monkeypatch: pytest.MonkeyPatch) -> None:
         assert response.text == "ok"
 
 
+def test_login_sets_defensive_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that login responses are not cacheable."""
+    _patch_login_with_dummy_client(monkeypatch)
+
+    with TestClient(_build_app()) as client:
+        response = client.get("/auth/login?provider=dummy", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Vary"] == "Sec-Purpose, Purpose, X-Moz"
+
+
+def test_logout_sets_defensive_headers() -> None:
+    """Test that logout responses are not cacheable."""
+    with TestClient(_build_app()) as client:
+        response = client.get("/auth/logout", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Vary"] == "Sec-Purpose, Purpose, X-Moz"
+
+
 def test_logout_clears_cookie() -> None:
     """Test that logout clears the auth cookie and redirects to root."""
     with TestClient(_build_app()) as client:
@@ -196,6 +218,44 @@ def test_callback_missing_provider_redirects(monkeypatch: pytest.MonkeyPatch) ->
         response = client.get("/oauth2callback?state=abc", follow_redirects=False)
         assert response.status_code == 302
         assert response.headers["location"].endswith("/")
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "Sec-Purpose",
+        "Purpose",
+        "X-Moz",
+    ],
+)
+def test_callback_prefetch_does_not_exchange_token(
+    header_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that speculative callback requests do not consume OAuth codes."""
+
+    def _raise_if_called(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Prefetch callback should not inspect OAuth state")
+
+    monkeypatch.setattr(
+        starlette_auth_routes,
+        "_get_provider_by_state",
+        _raise_if_called,
+    )
+
+    app = Starlette(routes=create_auth_routes(""))
+    with TestClient(app) as client:
+        response = client.get(
+            "/oauth2callback?state=abc&code=single-use-code",
+            headers={header_name: "prefetch"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 204
+    assert response.content == b""
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Vary"] == "Sec-Purpose, Purpose, X-Moz"
 
 
 @patch_config_options({"server.cookieSecret": "test-secret"})


### PR DESCRIPTION
## Describe your changes

Some browsers (e.g. Opera mobile) issue a speculative *prefetch* request to the OAuth callback URL before the user's real navigation. Because OAuth authorization codes are single-use, the prefetch consumes the code and the subsequent real callback fails with `invalid_grant: Invalid authorization code`.

- Detect speculative prefetch requests via `Sec-Purpose`/`Purpose`/`X-Moz` headers and short-circuit the callback with a `204` before any code exchange, so the code stays valid for the real navigation.
- Set `Cache-Control: no-store`, `Pragma: no-cache`, and `Vary` on all auth route responses (login/logout/callback) to prevent intermediaries from caching cookie-setting auth responses.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

- Closes #15568

## Testing Plan

- `lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py` — Covers prefetch short-circuit (no code exchange, `204` response) across all prefetch headers, and defensive cache headers on login/logout/callback responses.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)