### PR TITLE
Add chart-escalation guidance to data-display reference

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -54,23 +54,21 @@ st.altair_chart(chart)
 
 ## Charts native can't do — escalate
 
-Native charts share a single y-axis and can't express every shape. When the request needs something they can't do, escalate to Altair or Plotly instead of forcing a native chart to approximate it. The most common trigger is **two series on very different scales** (e.g. revenue in the thousands vs. a 0–100% rate), which needs a **secondary y-axis** — on a single `st.line_chart` the smaller series flattens against the bottom. Other cases: combo charts (bars + line), pie/donut, treemaps, sankey.
+Native charts share a single y-axis and can't express every shape. When the request needs something they can't do, escalate to **Altair** (bundled with Streamlit — no extra install) rather than forcing a native chart to approximate it; reach for Plotly only if your app already uses it. The most common trigger is **two series on very different scales** (e.g. revenue in the thousands vs. a 0–100% rate), which needs a **secondary y-axis** — on a single `st.line_chart` the smaller series flattens against the bottom. Other cases: combo charts (bars + line), pie/donut, treemaps, sankey.
 
 ```python
 # BAD: both series on one axis — margin (0-100) is invisible next to revenue (thousands)
 st.line_chart(df, x="month", y=["revenue", "margin"])
 
-# GOOD: secondary axis with Plotly
-import plotly.graph_objects as go
-from plotly.subplots import make_subplots
+# GOOD: secondary axis in Altair — two layered marks with independent y-scales
+import altair as alt
 
-fig = make_subplots(specs=[[{"secondary_y": True}]])
-fig.add_bar(x=df["month"], y=df["revenue"], name="Revenue")
-fig.add_scatter(x=df["month"], y=df["margin"], name="Margin (%)", secondary_y=True)
-st.plotly_chart(fig)
+base = alt.Chart(df).encode(x="month:O")
+revenue = base.mark_bar().encode(y=alt.Y("revenue:Q", title="Revenue"))
+margin = base.mark_line(color="red").encode(y=alt.Y("margin:Q", title="Margin (%)"))
+chart = alt.layer(revenue, margin).resolve_scale(y="independent")
+st.altair_chart(chart)
 ```
-
-Altair expresses the same with two layered marks and `resolve_scale(y="independent")`.
 
 ## Deprecated: `use_container_width`
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -52,6 +52,26 @@ st.altair_chart(chart)
 - Interactive tooltips
 - Layered visualizations
 
+## Charts native can't do — escalate
+
+Native charts share a single y-axis and can't express every shape. When the request needs something they can't do, escalate to Altair or Plotly instead of forcing a native chart to approximate it. The most common trigger is **two series on very different scales** (e.g. revenue in the thousands vs. a 0–100% rate), which needs a **secondary y-axis** — on a single `st.line_chart` the smaller series flattens against the bottom. Other cases: combo charts (bars + line), pie/donut, treemaps, sankey.
+
+```python
+# BAD: both series on one axis — margin (0-100) is invisible next to revenue (thousands)
+st.line_chart(df, x="month", y=["revenue", "margin"])
+
+# GOOD: secondary axis with Plotly
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+fig = make_subplots(specs=[[{"secondary_y": True}]])
+fig.add_bar(x=df["month"], y=df["revenue"], name="Revenue")
+fig.add_scatter(x=df["month"], y=df["margin"], name="Margin (%)", secondary_y=True)
+st.plotly_chart(fig)
+```
+
+Altair expresses the same with two layered marks and `resolve_scale(y="independent")`.
+
 ## Deprecated: `use_container_width`
 
 **Do not use `use_container_width`.** It is deprecated — Streamlit elements now stretch to fill their container by default. Use the `width` parameter instead: `width="stretch"` (equivalent to `use_container_width=True`) or `width="content"` (equivalent to `use_container_width=False`). Remove `use_container_width` when you see it, and never add it to new code.


### PR DESCRIPTION
## What
Adds a "Charts native can't do — escalate" section to `references/data-display.md`.

It explains when to move off a native single-axis chart (`st.line_chart`/`st.bar_chart`) to Altair or Plotly — most commonly two series on very different scales needing a secondary y-axis — with a BAD/GOOD example.

## Why
Two series with clashing scales (e.g. revenue in the thousands vs. a 0–100% rate) on one native chart share a single y-axis, so the smaller series flattens to nothing. This gives the agent the escalation pattern.

Split out of #15531 into one PR per skill, stacked. (No `SKILL.md` row — `data-display.md` already has a routing entry.) Draft.
