### PR TITLE
Add authentication reference to developing-with-streamlit skill

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -107,6 +107,7 @@ Use this routing table to select reference(s). **Always read the reference file*
 | **Streamlit CLI and configuration** — `streamlit run`, `streamlit config`, looking up docstrings (`streamlit docs <command>`), `.streamlit/config.toml` (script-level and project-level), port settings, and server options | read `references/cli.md` |
 | **Advanced server configuration** — `st.App`, ASGI entry points, custom HTTP routes, middleware, lifespan hooks, programmatic secrets, exception handlers, and FastAPI/Starlette mounting | read `references/server-asgi.md` |
 | **Handling failures gracefully** — wrapping risky calls (APIs, queries, file/parse, input conversion) in `try/except`, showing `st.error`/`st.warning` + `st.stop()` instead of a raw traceback, and validating input | read `references/error-handling.md` |
+| **Requiring users to sign in** — `st.login`/`st.logout`/`st.user` with OIDC, gating on `st.user.is_logged_in`, and `[auth]` secrets configuration (not a hand-rolled password gate) | read `references/authentication.md` |
 
 **Fallback — "this widget doesn't exist in Streamlit":**
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -147,6 +147,7 @@ Use this routing table to select reference(s). **Always read the reference file*
 | **Environment and dependency setup** — Python environment management, installing packages, and configuring the development environment for Streamlit apps | read `references/environment-setup.md` |
 | **Streamlit CLI and configuration** — `streamlit run`, `streamlit config`, looking up docstrings (`streamlit docs <command>`), `.streamlit/config.toml` (script-level and project-level), port settings, and server options | read `references/cli.md` |
 | **Advanced server configuration** — `st.App`, ASGI entry points, custom HTTP routes, middleware, lifespan hooks, programmatic secrets, exception handlers, and FastAPI/Starlette mounting | read `references/server-asgi.md` |
+| **Requiring users to sign in** — `st.login`/`st.logout`/`st.user` with OIDC, gating on `st.user.is_logged_in`, and `[auth]` secrets configuration (not a hand-rolled password gate) | read `references/authentication.md` |
 
 **Fallback — "this widget doesn't exist in Streamlit":**
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/authentication.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/authentication.md
@@ -1,0 +1,159 @@
+
+# Streamlit user authentication
+
+Add real user sign-in with `st.login`, `st.logout`, and `st.user`.
+
+## Don't roll your own password gate
+
+A `st.text_input(type="password")` compared against a hardcoded string (or a
+secret) is not authentication. It has no concept of user identity, the
+"password" is shared by everyone, and the gate is trivially bypassed. Use
+`st.login()` with a real OpenID Connect (OIDC) identity provider instead.
+
+```python
+# BAD — a fake gate, not authentication
+import streamlit as st
+
+if st.text_input("Password", type="password") != "hunter2":
+    st.stop()
+st.write("Secret dashboard")
+```
+
+```python
+# GOOD — real OIDC identity via st.login
+import streamlit as st
+
+if not st.user.is_logged_in:
+    st.login()
+    st.stop()
+
+st.write(f"Hello, {st.user.name}!")
+if st.button("Log out"):
+    st.logout()
+```
+
+**Why st.login:**
+- Real per-user identity from a trusted provider (Google, Microsoft, Okta, Auth0, …)
+- Signed identity cookie — can't be faked client-side
+- Streamlit enables CORS and XSRF protection automatically when auth is configured
+- `st.user` exposes verified claims (email, name, etc.); no password handling in your code
+
+## Requirements
+
+- **Streamlit >= 1.42** — this is when `st.login` / `st.logout` / `st.user` shipped.
+- **Authlib >= 1.3.2** — the auth flow depends on it. Install both with the extra:
+
+```shell
+pip install "streamlit[auth]"
+```
+
+This is app-level authentication. It is unrelated to `st.text_input(type="password")`,
+which is just a masked text field with no identity behind it.
+
+## Configure the provider in secrets.toml
+
+All auth config lives in an `[auth]` section of `.streamlit/secrets.toml`. Three
+keys are shared across every provider: `redirect_uri`, `cookie_secret`, and the
+per-provider `client_id`, `client_secret`, and `server_metadata_url`.
+
+```toml
+# .streamlit/secrets.toml
+[auth]
+redirect_uri = "http://localhost:8501/oauth2callback"
+cookie_secret = "a-strong-randomly-generated-secret"
+client_id = "xxx"
+client_secret = "xxx"
+server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"
+```
+
+- `redirect_uri` must be your app's absolute URL ending in `/oauth2callback`. For
+  local dev on the default port that's `http://localhost:8501/oauth2callback`.
+  Update it (in both secrets and your provider) when you deploy.
+- `cookie_secret` signs the identity cookie. Use a long, random value.
+- `client_id`, `client_secret`, and `server_metadata_url` come from your OIDC
+  provider's app registration.
+
+Never commit this file. Add it to `.gitignore`:
+
+```
+.streamlit/secrets.toml
+```
+
+## Gate the whole app
+
+The canonical pattern: bail out early when the user isn't signed in, then render
+protected content.
+
+```python
+import streamlit as st
+
+if not st.user.is_logged_in:
+    st.title("Please log in")
+    if st.button("Log in with Google"):
+        st.login()
+    st.stop()
+
+# Everything below only runs for authenticated users
+st.title("Dashboard")
+st.write(f"Signed in as {st.user.name} ({st.user.email})")
+
+with st.sidebar:
+    if st.button("Log out"):
+        st.logout()
+```
+
+`st.user.is_logged_in` is `True` only after a successful `st.login()`.
+`st.user.email`, `st.user.name`, and other fields are claims parsed from the
+provider's identity token (available claims vary by provider). `st.logout()`
+clears the identity cookie and starts a fresh session.
+
+## Multiple named providers
+
+Give users a choice of identity providers by adding `[auth.<provider>]` sections.
+Keep `redirect_uri` and `cookie_secret` in the shared `[auth]` section, and put
+each provider's credentials in its own section. The name is internal to your app
+and is passed to `st.login("<provider>")`.
+
+```toml
+# .streamlit/secrets.toml
+[auth]
+redirect_uri = "http://localhost:8501/oauth2callback"
+cookie_secret = "a-strong-randomly-generated-secret"
+
+[auth.google]
+client_id = "xxx"
+client_secret = "xxx"
+server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"
+
+[auth.microsoft]
+client_id = "xxx"
+client_secret = "xxx"
+server_metadata_url = "https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration"
+```
+
+```python
+import streamlit as st
+
+if not st.user.is_logged_in:
+    st.header("Log in:")
+    if st.button("Google"):
+        st.login("google")
+    if st.button("Microsoft"):
+        st.login("microsoft")
+    st.stop()
+
+st.write(f"Hello, {st.user.name}!")
+if st.button("Log out"):
+    st.logout()
+```
+
+Provider names can't contain underscores. Only OIDC providers are supported —
+generic OAuth 2.0 providers won't work.
+
+## References
+
+- [st.login](https://docs.streamlit.io/develop/api-reference/user/st.login)
+- [st.logout](https://docs.streamlit.io/develop/api-reference/user/st.logout)
+- [st.user](https://docs.streamlit.io/develop/api-reference/user/st.user)
+- [User authentication and information](https://docs.streamlit.io/develop/concepts/connections/authentication)
+- [st.secrets](https://docs.streamlit.io/develop/api-reference/connections/st.secrets)

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/authentication.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/authentication.md
@@ -35,13 +35,12 @@ if st.button("Log out"):
 **Why st.login:**
 - Real per-user identity from a trusted provider (Google, Microsoft, Okta, Auth0, …)
 - Signed identity cookie — can't be faked client-side
-- Streamlit enables CORS and XSRF protection automatically when auth is configured
+- Configuring `[auth]` turns on XSRF protection automatically
 - `st.user` exposes verified claims (email, name, etc.); no password handling in your code
 
 ## Requirements
 
-- **Streamlit >= 1.42** — this is when `st.login` / `st.logout` / `st.user` shipped.
-- **Authlib >= 1.3.2** — the auth flow depends on it. Install both with the extra:
+The auth flow needs the optional `auth` extra, which pulls in Authlib:
 
 ```shell
 pip install "streamlit[auth]"


### PR DESCRIPTION
## What

Adds `references/authentication.md` to the `developing-with-streamlit` skill, plus one `SKILL.md` routing row ("Requiring users to sign in").

The reference covers Streamlit's built-in OIDC auth: `st.login` / `st.logout` / `st.user`, gating an app on `st.user.is_logged_in`, `[auth]` secrets configuration (single and multiple named providers), and the `streamlit[auth]` extra.

## Why

Asked to gate an app, agents tend to hand-roll a password check — `st.text_input(type="password")` compared against a hardcoded string. That isn't authentication: there's no real identity, the "password" is shared by everyone, and the gate is trivially bypassed. This reference points at the real mechanism and names the anti-pattern explicitly so it gets rejected rather than reinvented.

## Still needed?

Re-checked against `develop` before refreshing this PR, since it sat for a while. Nothing has landed that covers it:

- No `authentication.md` reference exists, and `SKILL.md` has no sign-in routing row.
- `references/api-reference.md` has only one-line table entries for `st.login` and `st.logout` — no setup, no gating pattern, no secrets config.
- `references/multipage-apps.md` uses `st.user.is_logged_in` as one example condition for building a page list, which assumes auth is already configured.
- `references/server-asgi.md` mentions authentication once, as an example of what middleware can do. `references/snowflake-connection.md` covers Snowflake *connection* auth, which is a different thing.

## Changes since Lukas's approval

This PR was approved in June and is now rebased, so the two follow-up commits are worth a second look:

- **De-stacked.** Base moved from `nbellante/skill-chart-escalation` to `develop`, and the error-handling / chart-escalation commits are no longer on this branch. The diff is now exactly this PR's two files, and it no longer waits on #15601 or #15603 to merge. The routing row sits at the end of the table; if #15601 lands first, that's a one-line conflict.
- **Corrected an XSRF/CORS claim.** The reference previously said configuring auth turns on both CORS and XSRF protection. Only XSRF is implicit — `config.py` is explicit that `server.enableXsrfProtection` "does not enable `server.enableCORS`", and that Streamlit "does not set `server.enableCORS` to `true` for you".
- **Dropped version stamps.** `lib/streamlit/.agents/skills/AGENTS.md` (added to `develop` after this PR was written) forbids version stamps in the bundled skill, so the "Streamlit >= 1.42" / "Authlib >= 1.3.2" floors are gone; installing the `auth` extra is the actionable step.

## Testing

Docs-only, so no unit or e2e tests. Verified:

- `make check` passes; pre-commit hooks pass on both changed files.
- Every `references/*.md` link in `SKILL.md` resolves, and the new reference is routed to exactly once.
- All 4 Python examples parse (`ast.parse`) and both TOML examples parse (`tomllib`).
- Every documented API exists in this tree: `st.login` / `st.logout` / `st.user` are exported from `lib/streamlit/__init__.py`, `login(provider=None)` accepts the bare and named-provider forms both examples use, and `is_logged_in` is the documented gate.
- Factual claims re-checked against source: the `/oauth2callback` redirect suffix, the no-underscores rule for provider names, the `Authlib` dependency behind the `auth` extra, and the XSRF-only implicit behavior.

Not verified: no live OIDC provider was configured, so the flows are checked against source and docs rather than executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the bundled agent skill; no runtime or application code paths are modified.
> 
> **Overview**
> Adds agent skill documentation so **sign-in requests** route to built-in **OIDC auth** instead of ad-hoc password checks.
> 
> A new **`references/authentication.md`** explains `st.login` / `st.logout` / `st.user`, the `streamlit[auth]` extra, `[auth]` secrets (including multi-provider `[auth.<name>]`), and the early-exit gating pattern on `st.user.is_logged_in`. It explicitly rejects comparing `st.text_input(type="password")` to a hardcoded or secret value as “authentication.”
> 
> **`SKILL.md`** gains one routing-table row, **“Requiring users to sign in,”** pointing agents at that reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed3f2988e023879ef0d922bf47c5991eb54c4b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->