### PR TITLE
[docs] Add shimmer directive to Markdown skill reference

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/markdown.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/markdown.md
@@ -1,7 +1,7 @@
 
 # Using Markdown in Streamlit
 
-Streamlit supports Markdown throughout its API—in `st.markdown()`, widget labels, help tooltips, metrics, `st.table()` cells, and more. Beyond standard GitHub-flavored Markdown, Streamlit adds colored text, badges, icons, and LaTeX.
+Streamlit supports Markdown throughout its API—in `st.markdown()`, widget labels, help tooltips, metrics, `st.table()` cells, and more. Beyond standard GitHub-flavored Markdown, Streamlit adds colored text, badges, icons, shimmer text, and LaTeX.
 
 ## Quick reference
 
@@ -27,6 +27,7 @@ Streamlit supports Markdown throughout its API—in `st.markdown()`, widget labe
 | Colored text | `:color[text]` | `:red[Error]` | ✓ |
 | Colored background | `:color-background[text]` | `:blue-background[Info]` | ✓ |
 | Badge | `:color-badge[text]` | `:green-badge[Success]` | ✓ |
+| Shimmer | `:shimmer[text]` | `:shimmer[Loading...]` | ✓ |
 | Small text | `:small[text]` | `:small[footnote]` | ✓ |
 | LaTeX (inline) | `$formula$` | `$ax^2 + bx + c$` | ✓ |
 | LaTeX (block) | `$$formula$$` | `$$\int_0^1 x^2 dx$$` | ✗ |

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/markdown.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/markdown.md
@@ -27,7 +27,7 @@ Streamlit supports Markdown throughout its API—in `st.markdown()`, widget labe
 | Colored text | `:color[text]` | `:red[Error]` | ✓ |
 | Colored background | `:color-background[text]` | `:blue-background[Info]` | ✓ |
 | Badge | `:color-badge[text]` | `:green-badge[Success]` | ✓ |
-| Shimmer | `:shimmer[text]` | `:shimmer[Loading...]` | ✓ |
+| Shimmer animation | `:shimmer[text]` | `:shimmer[Loading...]` | ✓ |
 | Small text | `:small[text]` | `:small[footnote]` | ✓ |
 | LaTeX (inline) | `$formula$` | `$ax^2 + bx + c$` | ✓ |
 | LaTeX (block) | `$$formula$$` | `$$\int_0^1 x^2 dx$$` | ✗ |


### PR DESCRIPTION
## Describe your changes

Adds the already-implemented `:shimmer[text]` directive to the `developing-with-streamlit` Markdown reference so the agent skill docs stay in sync with the supported Markdown syntax.

- Added a `Shimmer` row (`:shimmer[text]`) to the quick-reference table
- Mentioned shimmer text in the intro sentence alongside colored text, badges, and icons

## GitHub Issue Link (if applicable)

## Testing Plan

- Documentation-only change to an internal agent skill reference; no behavior changes, so no additional tests are needed.

Made with [Cursor](https://cursor.com)