### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -106,3 +106,12 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+These notes apply to the Cursor Cloud Agent VM. The startup update script runs `make init` (deps + protobufs) from this repo; the toolchain below is baked into the VM snapshot, so you normally don't need to reinstall anything.
+
+- **Node version gotcha:** This repo requires Node 24 (`.nvmrc`), but the VM has a daemon-provided `node` v22 at `/exec-daemon/node` that sits early in `PATH` and would otherwise shadow nvm. To fix this globally, Node 24 (`node`/`npm`/`npx`/`corepack`) and `uv`/`uvx` are symlinked into `/usr/local/cargo/bin` (the first `PATH` entry). If `node --version` ever shows v22, re-point those symlinks at `~/.nvm/versions/node/v24*/bin`.
+- **Don't use `make all-dev` / `pre-commit install` here.** Cursor sets `git config core.hooksPath`, so `pre-commit install` fails with "Cowardly refusing to install hooks with `core.hooksPath` set". Do **not** unset `core.hooksPath`. Use `make init` for dependency/protobuf refresh; pre-commit hooks are not needed for running, testing, or building.
+- **Running the app:** `make debug <script.py>` starts the Python backend + Vite dev server and prints the App URL (default `http://localhost:3001`, backend `http://localhost:8501`). Logs land in `work-tmp/debug/latest/{backend,frontend}.log`. The first `make debug` builds the non-app frontend workspace packages on demand (no full `make frontend` needed).
+- `protoc` is installed system-wide (apt) and the Makefile's "Python version is not detected / `python: command not found`" line is a harmless version-check warning — all Python runs go through `uv run`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,3 +100,12 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+These notes apply to the Cursor Cloud Agent VM. The startup update script runs `make init` (deps + protobufs) from this repo; the toolchain below is baked into the VM snapshot, so you normally don't need to reinstall anything.
+
+- **Node version gotcha:** This repo requires Node 24 (`.nvmrc`), but the VM has a daemon-provided `node` v22 at `/exec-daemon/node` that sits early in `PATH` and would otherwise shadow nvm. To fix this globally, Node 24 (`node`/`npm`/`npx`/`corepack`) and `uv`/`uvx` are symlinked into `/usr/local/cargo/bin` (the first `PATH` entry). If `node --version` ever shows v22, re-point those symlinks at `~/.nvm/versions/node/v24*/bin`.
+- **Don't use `make all-dev` / `pre-commit install` here.** Cursor sets `git config core.hooksPath`, so `pre-commit install` fails with "Cowardly refusing to install hooks with `core.hooksPath` set". Do **not** unset `core.hooksPath`. Use `make init` for dependency/protobuf refresh; pre-commit hooks are not needed for running, testing, or building.
+- **Running the app:** `make debug <script.py>` starts the Python backend + Vite dev server and prints the App URL (default `http://localhost:3001`, backend `http://localhost:8501`). Logs land in `work-tmp/debug/latest/{backend,frontend}.log`. The first `make debug` builds the non-app frontend workspace packages on demand (no full `make frontend` needed).
+- `protoc` is installed system-wide (apt) and the Makefile's "Python version is not detected / `python: command not found`" line is a harmless version-check warning — all Python runs go through `uv run`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,12 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+These notes apply to the Cursor Cloud Agent VM. The startup update script runs `make init` (deps + protobufs) from this repo; the toolchain below is baked into the VM snapshot, so you normally don't need to reinstall anything.
+
+- **Node version gotcha:** This repo requires Node 24 (`.nvmrc`), but the VM has a daemon-provided `node` v22 at `/exec-daemon/node` that sits early in `PATH` and would otherwise shadow nvm. To fix this globally, Node 24 (`node`/`npm`/`npx`/`corepack`) and `uv`/`uvx` are symlinked into `/usr/local/cargo/bin` (the first `PATH` entry). If `node --version` ever shows v22, re-point those symlinks at `~/.nvm/versions/node/v24*/bin`.
+- **Don't use `make all-dev` / `pre-commit install` here.** Cursor sets `git config core.hooksPath`, so `pre-commit install` fails with "Cowardly refusing to install hooks with `core.hooksPath` set". Do **not** unset `core.hooksPath`. Use `make init` for dependency/protobuf refresh; pre-commit hooks are not needed for running, testing, or building.
+- **Running the app:** `make debug <script.py>` starts the Python backend + Vite dev server and prints the App URL (default `http://localhost:3001`, backend `http://localhost:8501`). Logs land in `work-tmp/debug/latest/{backend,frontend}.log`. The first `make debug` builds the non-app frontend workspace packages on demand (no full `make frontend` needed).
+- `protoc` is installed system-wide (apt) and the Makefile's "Python version is not detected / `python: command not found`" line is a harmless version-check warning — all Python runs go through `uv run`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Sets up the Streamlit development environment for the Cursor Cloud Agent VM and documents the non-obvious, durable caveats discovered during setup.

This PR only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` (and the generated `.cursor/rules/overview.mdc` / `.github/copilot-instructions.md`, regenerated via `scripts/generate_agent_rules.py`). No application/library code is changed.

Key environment learnings captured for future agents:

- **Node version gotcha:** the repo requires Node 24 (`.nvmrc`), but a daemon-provided `node` v22 at `/exec-daemon/node` sits early in `PATH` and shadows nvm. Node 24 + `uv` are symlinked into `/usr/local/cargo/bin` (first `PATH` entry) so they resolve globally.
- **`pre-commit install` fails** because Cursor sets `git config core.hooksPath` ("Cowardly refusing to install hooks…"). Use `make init` (deps + protobufs) instead of `make all-dev`; do not unset `core.hooksPath`.
- **Running the app:** `make debug <script.py>` starts backend + Vite dev server (App URL `http://localhost:3001`, backend `:8501`).

The startup update script is configured to run `make init`.

## Screenshot or video (only for visual changes)

Verified end-to-end with a small app (button increments, text input, slider): "13 squared is 169" rendered correctly via the full Python backend + Vite frontend + protobuf/WebSocket stack.

[Streamlit dev app running after interaction](https://cursor.com/agents/bc-46cb17b3-0103-43de-a520-8860a6e9f443/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_after_interaction.png)

[page@a79cba15aee8f38caf16f07557e6c641.webm](https://cursor.com/agents/bc-46cb17b3-0103-43de-a520-8860a6e9f443/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvideo%2Fpage%40a79cba15aee8f38caf16f07557e6c641.webm)

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No additional tests needed: this is a docs-only change (`AGENTS.md` + generated rule files).
- Verified locally: `make python-lint` passes, a Python unit-test subset passes (`lib/tests/streamlit/string_util_test.py`, 101 passed), `make init` completes idempotently, and the app runs via `make debug` with a working hello-world interaction.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46cb17b3-0103-43de-a520-8860a6e9f443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46cb17b3-0103-43de-a520-8860a6e9f443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

