### PR TITLE
[fix] Keep selectbox selection with identity-based format_func

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
+
 import pandas as pd
 
 import streamlit as st
@@ -228,6 +230,28 @@ v23 = st.selectbox(
     filter_mode=None,
 )
 st.write("value 23:", v23)
+
+
+# Regression test for https://github.com/streamlit/streamlit/issues/15618:
+# custom-class options with a format_func that depends on object identity
+# (here a dict lookup) must not revert the selection on rerun.
+@dataclass(frozen=True)
+class _Choice:
+    id: int
+    name: str
+
+
+_choice_a = _Choice(1, "one")
+_choice_b = _Choice(2, "two")
+_choice_labels = {_choice_a: "I", _choice_b: "II"}
+
+v24 = st.selectbox(
+    "selectbox 24 (custom objects with identity-dependent format_func)",
+    [_choice_a, _choice_b],
+    format_func=lambda choice: f"{_choice_labels[choice]} ({choice.name})",
+    key="selectbox_24",
+)
+st.write("value 24:", v24.name)
 
 # --- Bound widgets (query-params) ---
 

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -168,15 +168,8 @@ def test_keeps_selection_with_identity_dependent_format_func(app: Page):
     option class is redefined every rerun, so a format_func that looks options up
     in a dict used to raise on the stored deepcopy and revert the selection.
     """
-    selectbox_input = get_selectbox_input(
-        app, "selectbox 24 (custom objects with identity-dependent format_func)"
-    )
-
-    selectbox_input.click()
-    app.get_by_test_id("stSelectboxVirtualDropdown").get_by_role("option").nth(
-        1
-    ).click()
-    wait_for_app_run(app)
+    label = "selectbox 24 (custom objects with identity-dependent format_func)"
+    select_selectbox_option(app, label, "II (two)")
 
     # The selection must reflect the second option, not revert to the first.
     expect_markdown(app, "value 24: two")

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
+from e2e_playwright.conftest import rerun_app, wait_for_app_loaded, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from e2e_playwright.conftest import ImageCompareFunction
 
 
-NUM_SELECTBOXES = 26
+NUM_SELECTBOXES = 27
 
 
 def get_selectbox_input(
@@ -159,6 +159,31 @@ def test_handles_option_selection(app: Page, assert_snapshot: ImageCompareFuncti
     selection_dropdown.get_by_role("option").nth(1).click()
     # Check that selection worked:
     expect_markdown(app, "value 4: e2e/scripts/st_warning.py")
+
+
+def test_keeps_selection_with_identity_dependent_format_func(app: Page):
+    """Test that custom-object selections persist with an identity-dependent format_func.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15618. The
+    option class is redefined every rerun, so a format_func that looks options up
+    in a dict used to raise on the stored deepcopy and revert the selection.
+    """
+    selectbox_input = get_selectbox_input(
+        app, "selectbox 24 (custom objects with identity-dependent format_func)"
+    )
+
+    selectbox_input.click()
+    app.get_by_test_id("stSelectboxVirtualDropdown").get_by_role("option").nth(
+        1
+    ).click()
+    wait_for_app_run(app)
+
+    # The selection must reflect the second option, not revert to the first.
+    expect_markdown(app, "value 24: two")
+
+    # It must also survive a fresh rerun (where the bug originally triggered).
+    rerun_app(app)
+    expect_markdown(app, "value 24: two")
 
 
 def test_handles_option_selection_via_typing(app: Page):

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -376,10 +376,18 @@ def validate_and_sync_value_with_options(
         formatted_value = format_func(current_value)
     except Exception:
         # format_func raised on the current value. A non-string value reaching
-        # this point is a still-valid selection whose format_func depends on
-        # object identity/class (e.g. a dict lookup) and that was stored as a
-        # deepcopy from an earlier run, so keep it. Only a leftover raw string
-        # (from an option that no longer exists) is treated as invalid.
+        # this point is treated as a still-valid selection whose format_func
+        # depends on object identity/class (e.g. a dict lookup) and that was
+        # stored as a deepcopy from an earlier run, so keep it. Only a leftover
+        # raw string (from an option that no longer exists) is treated as
+        # invalid.
+        #
+        # Note the intentional asymmetry: this keeps the value even if it is no
+        # longer a member of the current options (e.g. the options were replaced
+        # with a different data model whose format_func can't handle the old
+        # type). Preserving a likely-valid selection is preferred over silently
+        # resetting it, so the caller may receive a value not in the current
+        # options.
         if not isinstance(current_value, str):
             return current_value, False
     else:
@@ -449,10 +457,16 @@ def validate_and_sync_multiselect_value_with_options(
         try:
             formatted_value = format_func(value)
         except Exception:
-            # A non-string value that can't be formatted is a still-valid
-            # selection whose format_func depends on object identity/class and
-            # was stored as a deepcopy from an earlier run, so keep it. A
-            # leftover raw string (from a removed option) is filtered out.
+            # A non-string value that can't be formatted is treated as a
+            # still-valid selection whose format_func depends on object
+            # identity/class and was stored as a deepcopy from an earlier run,
+            # so keep it. A leftover raw string (from a removed option) is
+            # filtered out.
+            #
+            # Note the intentional asymmetry: a kept value may no longer be a
+            # member of the current options (e.g. the options were replaced with
+            # a different data model). Preserving a likely-valid selection is
+            # preferred over silently dropping it.
             if not isinstance(value, str):
                 valid_values.append(value)
             continue
@@ -513,10 +527,15 @@ def validate_and_sync_range_value_with_options(
         try:
             formatted = format_func(val)
         except Exception:
-            # A non-string value that can't be formatted is a still-valid
-            # selection whose format_func depends on object identity/class and
-            # was stored as a deepcopy from an earlier run. A leftover raw
-            # string (from a removed option) is invalid.
+            # A non-string value that can't be formatted is treated as a
+            # still-valid selection whose format_func depends on object
+            # identity/class and was stored as a deepcopy from an earlier run. A
+            # leftover raw string (from a removed option) is invalid.
+            #
+            # Note the intentional asymmetry: a kept value may no longer be a
+            # member of the current options (e.g. the options were replaced with
+            # a different data model). Preserving a likely-valid selection is
+            # preferred over silently resetting it.
             return not isinstance(val, str)
         return formatted in formatted_options_set
 

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -374,10 +374,17 @@ def validate_and_sync_value_with_options(
     formatted_options_set = {format_func(o) for o in opt}
     try:
         formatted_value = format_func(current_value)
+    except Exception:
+        # format_func raised on the current value. A non-string value reaching
+        # this point is a still-valid selection whose format_func depends on
+        # object identity/class (e.g. a dict lookup) and that was stored as a
+        # deepcopy from an earlier run, so keep it. Only a leftover raw string
+        # (from an option that no longer exists) is treated as invalid.
+        if not isinstance(current_value, str):
+            return current_value, False
+    else:
         if formatted_value in formatted_options_set:
             return current_value, False
-    except Exception:  # noqa: S110
-        pass  # format_func failed - value is invalid, fall through to reset
 
     # Value not in options - reset to default
     if default_index is not None and len(opt) > 0:
@@ -441,11 +448,13 @@ def validate_and_sync_multiselect_value_with_options(
     for value in current_values:
         try:
             formatted_value = format_func(value)
-        except Exception:  # noqa: S112
-            # format_func failed on this value (e.g., a string value from a previous
-            # session when format_func expects an object with specific attributes).
-            # In this case, the value is definitely not valid since the current options
-            # can be formatted successfully.
+        except Exception:
+            # A non-string value that can't be formatted is a still-valid
+            # selection whose format_func depends on object identity/class and
+            # was stored as a deepcopy from an earlier run, so keep it. A
+            # leftover raw string (from a removed option) is filtered out.
+            if not isinstance(value, str):
+                valid_values.append(value)
             continue
 
         if formatted_value in formatted_options_set:
@@ -502,9 +511,14 @@ def validate_and_sync_range_value_with_options(
     def is_valid(val: Any) -> bool:
         """Check if a value exists in options via format_func comparison."""
         try:
-            return format_func(val) in formatted_options_set
+            formatted = format_func(val)
         except Exception:
-            return False
+            # A non-string value that can't be formatted is a still-valid
+            # selection whose format_func depends on object identity/class and
+            # was stored as a deepcopy from an earlier run. A leftover raw
+            # string (from a removed option) is invalid.
+            return not isinstance(val, str)
+        return formatted in formatted_options_set
 
     def get_default_range() -> tuple[T, T]:
         """Get the default range value."""

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -596,6 +596,53 @@ class TestValidateAndSyncValueWithOptions(unittest.TestCase):
         assert value is deepcopied_value
         assert needs_reset is False
 
+    def test_format_func_raising_on_object_keeps_value(self):
+        """A non-string value whose format_func raises is kept, not reset.
+
+        Reproduces https://github.com/streamlit/streamlit/issues/15618 where a
+        stale deepcopy from a previous run makes an identity-dependent
+        format_func raise, which previously reset the selection to the default.
+        """
+
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        options = [MyOption("a"), MyOption("b")]
+        # A separate object simulates a stale value from a previous run; the
+        # dict lookup below raises because it is keyed on the current options.
+        stale_value = MyOption("b")
+        lookup = {options[0]: "A", options[1]: "B"}
+
+        def format_func(x: Any) -> str:
+            return lookup[x]
+
+        value, needs_reset = validate_and_sync_value_with_options(
+            stale_value, options, 0, None, format_func=format_func
+        )
+
+        assert value is stale_value
+        assert needs_reset is False
+
+    def test_format_func_raising_on_string_resets_to_default(self):
+        """A leftover string whose format_func raises still resets to default."""
+
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        options = [MyOption("a"), MyOption("b")]
+
+        def format_func(x: Any) -> str:
+            return x.value
+
+        value, needs_reset = validate_and_sync_value_with_options(
+            "leftover_string", options, 0, None, format_func=format_func
+        )
+
+        assert value is options[0]
+        assert needs_reset is True
+
 
 class TestValidateAndSyncRangeValueWithOptions(unittest.TestCase):
     """Test class for validate_and_sync_range_value_with_options utility function."""
@@ -769,6 +816,35 @@ class TestValidateAndSyncRangeValueWithOptions(unittest.TestCase):
         # Should reset to default because first value is invalid
         assert value == (original_options[0], original_options[2])
         assert needs_reset is True
+
+    def test_format_func_raising_on_objects_keeps_range(self) -> None:
+        """A range of non-string values whose format_func raises is kept.
+
+        Range analogue of https://github.com/streamlit/streamlit/issues/15618.
+        """
+
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        options = [MyOption("a"), MyOption("b"), MyOption("c")]
+        stale_start = MyOption("a")
+        stale_end = MyOption("c")
+        lookup = {opt: opt.value for opt in options}
+
+        def format_func(x: Any) -> str:
+            return lookup[x]
+
+        value, needs_reset = validate_and_sync_range_value_with_options(
+            (stale_start, stale_end),
+            options,
+            [0],
+            None,
+            format_func=format_func,
+        )
+
+        assert value == (stale_start, stale_end)
+        assert needs_reset is False
 
 
 class TestValidateAndSyncMultiselectValueWithOptions(unittest.TestCase):
@@ -963,3 +1039,30 @@ class TestValidateMultiselectWithCustomObjects(unittest.TestCase):
         assert len(values) == 1
         assert values[0].value == "b"
         assert needs_reset is True
+
+    def test_format_func_raising_on_object_keeps_value(self):
+        """Non-string values whose format_func raises are kept, not filtered.
+
+        Multiselect analogue of https://github.com/streamlit/streamlit/issues/15618.
+        """
+
+        class MyOption:  # noqa: B903
+            def __init__(self, value: str):
+                self.value = value
+
+        options = [MyOption("a"), MyOption("b")]
+        stale_value = MyOption("b")
+        lookup = {options[0]: "A", options[1]: "B"}
+
+        def format_func(x):
+            return lookup[x]
+
+        values, needs_reset = validate_and_sync_multiselect_value_with_options(
+            [stale_value],
+            options,
+            None,
+            format_func=format_func,
+        )
+
+        assert values == [stale_value]
+        assert needs_reset is False

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -580,6 +580,44 @@ def test_selectbox_preserves_custom_value_with_accept_new_options():
     assert at.text[0].value == "Selected: B"
 
 
+def test_selectbox_keeps_selection_with_identity_dependent_format_func():
+    """Selection persists when format_func does an identity-dependent lookup.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15618.
+    The option class is defined at module scope (redefined every rerun), so the
+    stored deepcopy is an instance of a previous run's class. A format_func that
+    looks the option up in a dict keyed on the current options raises for that
+    stale instance, which previously reset the selection to the first option.
+    """
+
+    def script():
+        from dataclasses import dataclass
+
+        import streamlit as st
+
+        @dataclass(frozen=True)
+        class MyDataClass:
+            id: int
+            name: str
+
+        a = MyDataClass(1, "one")
+        b = MyDataClass(2, "two")
+        lookup = {a: "I", b: "II"}
+
+        def format_func(option: MyDataClass) -> str:
+            _ = lookup[option]
+            return option.name
+
+        selected = st.selectbox("selectbox", [a, b], format_func=format_func, key="sb")
+        st.text(f"Selected: {selected.name}")
+
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "Selected: one"
+
+    at = at.selectbox[0].set_value("two").run()
+    assert at.text[0].value == "Selected: two"
+
+
 def test_selectbox_enum_coercion():
     """Test E2E Enum Coercion on a selectbox.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

`st.selectbox` (and `st.multiselect`/`st.select_slider`) silently reverted to the default option when an option was a custom-class instance and `format_func` performed an identity- or class-dependent operation (e.g. a dict lookup keyed on the option instances).

- In `validate_and_sync_value_with_options` (and the multiselect/range variants), a `format_func` exception on a non-string value is now treated as a still-valid selection and kept, instead of being reset/filtered. Leftover raw strings (from removed options) still reset as before.

**Root cause:** The deserialized widget value is cached and deepcopied across reruns, so for a script that redefines its option class each run, the stored selection is an instance of a *previous* run's class. A class-gated (`@dataclass`) or identity-based (plain class) `format_func` lookup then raises on it, and the broad `except Exception` in the validation helper reinterpreted that user-code error as "value not in options" and reset to the default index.

**Alternatives considered:**
- Let `format_func` exceptions propagate: not chosen because validation runs on every rerun over stored deepcopies, so it would crash previously-working apps and break the legitimate dynamic-options reset path.
- Fall back to `==`/`is` membership when `format_func` fails: not chosen because the stale deepcopy is a different class object, so equality is class-gated and identity fails after deepcopy — the value would still be wrongly reset.

Repro: https://issues.streamlit.app/?issue=gh-15618

## GitHub Issue Link (if applicable)

- Closes #15618

## Testing Plan

- [x] Unit Tests (Python)
- [x] E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6a1b8eb-3912-4ac9-9ca1-3462830348f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6a1b8eb-3912-4ac9-9ca1-3462830348f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

