### PR TITLE
[fix] Clear stale fragment elements on outside-container shrink

### DIFF
--- a/e2e_playwright/st_fragment_basics.py
+++ b/e2e_playwright/st_fragment_basics.py
@@ -189,3 +189,31 @@ def nested_fragment():
 
 
 nested_fragment()
+
+
+# A fragment writing a variable number of elements into an outside container,
+# with a main-script footer after the fragment. Shrinking the count must garbage-
+# collect the removed elements (no stale rows), while growing must not overwrite
+# the footer.
+shrink_container = st.container(key="shrink_container")
+with shrink_container:
+    st.markdown("shrink header")
+
+if "shrink_count" not in st.session_state:
+    st.session_state.shrink_count = 5
+
+
+@st.fragment
+def shrink_fragment():
+    if st.button("shrink rows", key="shrink_rows"):
+        st.session_state.shrink_count = 2
+    if st.button("grow rows", key="grow_rows"):
+        st.session_state.shrink_count = 5
+    with shrink_container:
+        for i in range(st.session_state.shrink_count):
+            st.markdown(f"shrink row {i}")
+
+
+shrink_fragment()
+with shrink_container:
+    st.markdown("shrink footer")

--- a/e2e_playwright/st_fragment_basics_test.py
+++ b/e2e_playwright/st_fragment_basics_test.py
@@ -393,6 +393,40 @@ def test_fragment_nested_container_in_outside_container(app: Page):
     expect_no_exception(app)
 
 
+def test_fragment_shrink_clears_stale_outside_elements(app: Page):
+    """A fragment that reruns with fewer elements in an outside container must
+    garbage-collect the removed elements, while growth keeps the footer in place.
+    """
+    container = get_element_by_key(app, "shrink_container")
+    markdowns = container.get_by_test_id("stMarkdown")
+    # header + 5 rows + footer.
+    expect(markdowns).to_have_count(7)
+    expect(markdowns.first).to_have_text("shrink header")
+    expect(markdowns.last).to_have_text("shrink footer")
+    expect(markdowns.filter(has_text="shrink row 4")).to_have_count(1)
+
+    click_button(app, "shrink rows")
+
+    # header + 2 rows + footer; rows 2-4 must be gone (the stale-on-shrink bug).
+    expect(markdowns).to_have_count(4)
+    expect(markdowns.first).to_have_text("shrink header")
+    expect(markdowns.last).to_have_text("shrink footer")
+    expect(markdowns.filter(has_text="shrink row 0")).to_have_count(1)
+    expect(markdowns.filter(has_text="shrink row 1")).to_have_count(1)
+    expect(markdowns.filter(has_text="shrink row 2")).to_have_count(0)
+    expect(markdowns.filter(has_text="shrink row 4")).to_have_count(0)
+
+    click_button(app, "grow rows")
+
+    # Growing back must restore all rows without overwriting the footer.
+    expect(markdowns).to_have_count(7)
+    expect(markdowns.first).to_have_text("shrink header")
+    expect(markdowns.last).to_have_text("shrink footer")
+    expect(markdowns.filter(has_text="shrink row 4")).to_have_count(1)
+
+    expect_no_exception(app)
+
+
 def test_outside_container_transparent_wrapper(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -418,18 +418,30 @@ def _reset_outside_wrappers(
     Re-emitting sends a fresh add_block delta so the frontend doesn't garbage-
     collect the wrapper as stale. Resetting the cursor returns its index to 0 so
     the fragment's children overwrite in place instead of accumulating.
+
+    The re-emission is stamped with ``fragment_id`` so the wrapper block carries
+    the rerunning fragment's id on the frontend. ``ClearStaleNodeVisitor`` relies
+    on that id (together with the refreshed ``scriptRunId``) to recognize the
+    wrapper as fragment-modified and garbage-collect children that weren't
+    re-emitted this run — otherwise a fragment that shrinks its element count
+    leaves stale children behind.
     """
     from streamlit.cursor import RunningCursor
     from streamlit.delta_generator import _enqueue_add_block
 
-    for wrapper in fragment_storage.outside_wrappers_for(fragment_id):
-        _enqueue_add_block(wrapper.creation_delta_path, wrapper.block_proto)
+    # Stamp the re-emitted add_block deltas with the writing fragment's id (see
+    # enqueue_message), matching the children the fragment writes into the
+    # wrapper. Without this, the wrapper block loses its fragment_id on rerun and
+    # stale children survive ClearStaleNodeVisitor.
+    with ThreadState.scoped(fragment_id=fragment_id):
+        for wrapper in fragment_storage.outside_wrappers_for(fragment_id):
+            _enqueue_add_block(wrapper.creation_delta_path, wrapper.block_proto)
 
-        wrapper_cursor = wrapper.delta_generator._cursor
-        if not isinstance(wrapper_cursor, RunningCursor):
-            # LockedCursor (st.empty wrappers) always points at index 0.
-            continue
-        wrapper_cursor.reset()
+            wrapper_cursor = wrapper.delta_generator._cursor
+            if not isinstance(wrapper_cursor, RunningCursor):
+                # LockedCursor (st.empty wrappers) always points at index 0.
+                continue
+            wrapper_cursor.reset()
 
 
 def _fragment(

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -550,6 +550,11 @@ def test_shallow_copy_raises_type_error() -> None:
 class ResetOutsideWrappersTest(unittest.TestCase):
     """Tests for _reset_outside_wrappers, called before a fragment reruns."""
 
+    def setUp(self) -> None:
+        # _reset_outside_wrappers re-emits add_block deltas under
+        # ThreadState.scoped(), which reads the current FragmentThreadState.
+        ThreadState.initialize()
+
     def _make_wrapper(
         self,
         cursor: object,
@@ -671,6 +676,35 @@ class ResetOutsideWrappersTest(unittest.TestCase):
         # P reruns and rebuilds the container, so F's wrapper is evicted.
         storage.evict_outside_wrappers_created_by("P")
         assert storage.outside_wrappers_for("F") == []
+
+    def test_reemission_is_stamped_with_writing_fragment_id(self) -> None:
+        """The wrapper re-emission runs with the writing fragment's id set on
+        ThreadState, so enqueue_message stamps the add_block delta with it.
+
+        Without this stamp the re-emitted wrapper block loses its fragment_id on
+        the frontend, and ClearStaleNodeVisitor can no longer garbage-collect
+        children that weren't re-emitted (the stale-on-shrink bug).
+        """
+        storage = MemoryFragmentStorage()
+        wrapper = self._make_wrapper(
+            RunningCursor(RootContainer.MAIN), creation_delta_path=[0, 3]
+        )
+        storage.register_outside_wrapper("frag", "container", wrapper)
+
+        seen_fragment_ids: list[str | None] = []
+
+        def _capture(*_args: object, **_kwargs: object) -> None:
+            seen_fragment_ids.append(ThreadState.get().fragment_id)
+
+        with patch(
+            "streamlit.delta_generator._enqueue_add_block", side_effect=_capture
+        ):
+            _reset_outside_wrappers(storage, "frag")
+
+        assert seen_fragment_ids == ["frag"]
+        # The scope is restored after re-emission, so the surrounding thread
+        # state is left untouched.
+        assert ThreadState.get().fragment_id is None
 
 
 class FragmentTest(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

When a `@st.fragment` writes into a container declared outside its scope and then reruns with **fewer** elements, the removed elements were not garbage-collected — stale elements stayed visible. Growth and in-scope fragment writes were unaffected.

**Root cause.** Fragment outside-writes are redirected through an implicit `Transparent` wrapper block. On a standalone fragment rerun, `_reset_outside_wrappers` re-emits each wrapper's `add_block` delta so the frontend refreshes its `scriptRunId`. That re-emission happened **outside** the `ThreadState.scoped(fragment_id=...)` context, so `enqueue_message` did not stamp the delta with a `fragment_id`. The re-emitted wrapper `BlockNode` therefore lost its `fragmentId` on the frontend. `ClearStaleNodeVisitor` only recurses into a block's children to drop stale ones when the block's `fragmentId` is in `fragmentIdsThisRun` and its `scriptRunId` matches the current run; with the wrapper's `fragmentId` cleared, that branch never fired and children that weren't re-emitted survived.

The initial full run was fine because the wrapper is created while the fragment body runs under the scoped `fragment_id`; only the rerun re-emission dropped the stamp. In-scope fragment containers were unaffected because they are recreated inside that scope on every rerun.

**The fix.** Wrap the re-emission loop in `_reset_outside_wrappers` with `ThreadState.scoped(fragment_id=fragment_id)`, matching the stamp on the children the fragment writes into the wrapper. This applies uniformly to captured `st.container()`, `st.sidebar`, and `st.bottom`.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Unit Tests (Python):** Added `test_reemission_is_stamped_with_writing_fragment_id` asserting the re-emission runs with the writing fragment's id on `ThreadState` and restores prior state. Existing `_reset_outside_wrappers` tests gained a `ThreadState` setup.
- **E2E Tests:** Added `test_fragment_shrink_clears_stale_outside_elements` (with a `shrink_fragment` scenario in `st_fragment_basics.py`) covering shrink (removed rows disappear) and re-growth (footer slot preserved).
- **Manual testing:** Verified against the minimal repro with `make debug` + Playwright — confirmed the bug reproduces without the fix (8 rows remain after shrink) and is resolved with it (only 3 rows, footer intact).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-534cbcf9-6894-4650-b58f-579f2166cc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-534cbcf9-6894-4650-b58f-579f2166cc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

