### PR TITLE
[docs] Add developing-with-streamlit skill authoring conventions to AGENTS.md

### DIFF
--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -18,6 +18,7 @@ rules/*
 !rules/typescript_tests.mdc
 !rules/python.mdc
 !rules/python_lib.mdc
+!rules/embedded_skills.mdc
 !rules/python_tests.mdc
 !rules/protobuf.mdc
 !rules/e2e_playwright.mdc

--- a/.cursor/rules/embedded_skills.mdc
+++ b/.cursor/rules/embedded_skills.mdc
@@ -1,0 +1,18 @@
+---
+description:
+globs: lib/streamlit/.agents/skills/**/*
+alwaysApply: false
+---
+
+<!-- Generated from lib/streamlit/.agents/skills/AGENTS.md. Edit that file instead, then run: uv run python scripts/generate_agent_rules.py -->
+
+# Authoring Embedded Agent Skills
+
+Streamlit embeds agent skills under `lib/streamlit/.agents/skills/` (e.g. `developing-with-streamlit/` — a routing `SKILL.md` plus topic reference files under `references/`). They ship with the library and are loaded from the user's installed Streamlit, so keep them up to date as new features land. When adding or editing guidance, follow these conventions:
+
+- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
+- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.form_submit_button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
+- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
+- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
+- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
+- **Bias toward concise guidance** — the smallest wording that lands the point.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -98,6 +98,17 @@ Selection of `make` commands for development (run in the repo root):
 - The main branch of this repository is `develop`.
 - For adding new elements, widgets, or features that span backend, frontend, and protobufs, see `wiki/new-feature-guide.md`.
 
+## Authoring the `developing-with-streamlit` skill
+
+The agent skill at `lib/streamlit/.agents/skills/developing-with-streamlit/` is a routing skill (`SKILL.md`) plus topic reference files under `references/`. When adding or editing guidance, follow these conventions (distilled from review feedback on the skill PRs):
+
+- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
+- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
+- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
+- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
+- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
+- **Bias toward concise guidance** — the smallest wording that lands the point.
+
 ## Testing Strategy
 
 - Most new user-facing features should be covered by both unit tests and E2E tests.

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -98,16 +98,9 @@ Selection of `make` commands for development (run in the repo root):
 - The main branch of this repository is `develop`.
 - For adding new elements, widgets, or features that span backend, frontend, and protobufs, see `wiki/new-feature-guide.md`.
 
-## Authoring the `developing-with-streamlit` skill
+## Embedded agent skills
 
-The agent skill at `lib/streamlit/.agents/skills/developing-with-streamlit/` is a routing skill (`SKILL.md`) plus topic reference files under `references/`. When adding or editing guidance, follow these conventions (distilled from review feedback on the skill PRs):
-
-- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
-- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
-- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
-- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
-- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
-- **Bias toward concise guidance** — the smallest wording that lands the point.
+We embed agent skills in the Streamlit library (`lib/streamlit/.agents/skills/`, e.g. `developing-with-streamlit`) that ship with the release to help users build Streamlit apps. Keep them up to date as new features land — see `lib/streamlit/.agents/skills/AGENTS.md` for authoring conventions.
 
 ## Testing Strategy
 

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -5,6 +5,7 @@ instructions/*
 !instructions/python.instructions.md
 !instructions/python_tests.instructions.md
 !instructions/python_lib.instructions.md
+!instructions/embedded_skills.instructions.md
 !instructions/protobuf.instructions.md
 !instructions/typescript.instructions.md
 !instructions/typescript_tests.instructions.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,16 +92,9 @@ Selection of `make` commands for development (run in the repo root):
 - The main branch of this repository is `develop`.
 - For adding new elements, widgets, or features that span backend, frontend, and protobufs, see `wiki/new-feature-guide.md`.
 
-## Authoring the `developing-with-streamlit` skill
+## Embedded agent skills
 
-The agent skill at `lib/streamlit/.agents/skills/developing-with-streamlit/` is a routing skill (`SKILL.md`) plus topic reference files under `references/`. When adding or editing guidance, follow these conventions (distilled from review feedback on the skill PRs):
-
-- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
-- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
-- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
-- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
-- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
-- **Bias toward concise guidance** — the smallest wording that lands the point.
+We embed agent skills in the Streamlit library (`lib/streamlit/.agents/skills/`, e.g. `developing-with-streamlit`) that ship with the release to help users build Streamlit apps. Keep them up to date as new features land — see `lib/streamlit/.agents/skills/AGENTS.md` for authoring conventions.
 
 ## Testing Strategy
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,17 @@ Selection of `make` commands for development (run in the repo root):
 - The main branch of this repository is `develop`.
 - For adding new elements, widgets, or features that span backend, frontend, and protobufs, see `wiki/new-feature-guide.md`.
 
+## Authoring the `developing-with-streamlit` skill
+
+The agent skill at `lib/streamlit/.agents/skills/developing-with-streamlit/` is a routing skill (`SKILL.md`) plus topic reference files under `references/`. When adding or editing guidance, follow these conventions (distilled from review feedback on the skill PRs):
+
+- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
+- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
+- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
+- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
+- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
+- **Bias toward concise guidance** — the smallest wording that lands the point.
+
 ## Testing Strategy
 
 - Most new user-facing features should be covered by both unit tests and E2E tests.

--- a/.github/instructions/embedded_skills.instructions.md
+++ b/.github/instructions/embedded_skills.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "lib/streamlit/.agents/skills/**/*"
+---
+
+<!-- Generated from lib/streamlit/.agents/skills/AGENTS.md. Edit that file instead, then run: uv run python scripts/generate_agent_rules.py -->
+
+# Authoring Embedded Agent Skills
+
+Streamlit embeds agent skills under `lib/streamlit/.agents/skills/` (e.g. `developing-with-streamlit/` — a routing `SKILL.md` plus topic reference files under `references/`). They ship with the library and are loaded from the user's installed Streamlit, so keep them up to date as new features land. When adding or editing guidance, follow these conventions:
+
+- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
+- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.form_submit_button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
+- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
+- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
+- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
+- **Bias toward concise guidance** — the smallest wording that lands the point.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,17 @@ Selection of `make` commands for development (run in the repo root):
 - The main branch of this repository is `develop`.
 - For adding new elements, widgets, or features that span backend, frontend, and protobufs, see `wiki/new-feature-guide.md`.
 
+## Authoring the `developing-with-streamlit` skill
+
+The agent skill at `lib/streamlit/.agents/skills/developing-with-streamlit/` is a routing skill (`SKILL.md`) plus topic reference files under `references/`. When adding or editing guidance, follow these conventions (distilled from review feedback on the skill PRs):
+
+- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
+- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
+- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
+- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
+- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
+- **Bias toward concise guidance** — the smallest wording that lands the point.
+
 ## Testing Strategy
 
 - Most new user-facing features should be covered by both unit tests and E2E tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,16 +90,9 @@ Selection of `make` commands for development (run in the repo root):
 - The main branch of this repository is `develop`.
 - For adding new elements, widgets, or features that span backend, frontend, and protobufs, see `wiki/new-feature-guide.md`.
 
-## Authoring the `developing-with-streamlit` skill
+## Embedded agent skills
 
-The agent skill at `lib/streamlit/.agents/skills/developing-with-streamlit/` is a routing skill (`SKILL.md`) plus topic reference files under `references/`. When adding or editing guidance, follow these conventions (distilled from review feedback on the skill PRs):
-
-- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
-- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
-- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
-- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
-- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
-- **Bias toward concise guidance** — the smallest wording that lands the point.
+We embed agent skills in the Streamlit library (`lib/streamlit/.agents/skills/`, e.g. `developing-with-streamlit`) that ship with the release to help users build Streamlit apps. Keep them up to date as new features land — see `lib/streamlit/.agents/skills/AGENTS.md` for authoring conventions.
 
 ## Testing Strategy
 

--- a/lib/streamlit/.agents/skills/AGENTS.md
+++ b/lib/streamlit/.agents/skills/AGENTS.md
@@ -1,0 +1,10 @@
+# Authoring Embedded Agent Skills
+
+Streamlit embeds agent skills under `lib/streamlit/.agents/skills/` (e.g. `developing-with-streamlit/` — a routing `SKILL.md` plus topic reference files under `references/`). They ship with the library and are loaded from the user's installed Streamlit, so keep them up to date as new features land. When adding or editing guidance, follow these conventions:
+
+- **Earn the section.** Add a dedicated reference section *and* a `SKILL.md` routing row only for features that are common, easy to misuse, or post-training-cutoff (so an un-guided agent would miss or misuse them). Niche or advanced features get a single sentence in an existing section, or rely on the API-reference + changelog for discovery — not a prominent new section.
+- **Group references by widget semantics.** Selection widgets hold a value picked from a set; value-entry/input widgets collect a typed value; trigger widgets (`st.button`, `st.form_submit_button`, `st.menu_button`, `st.download_button`, `st.link_button`) fire once and hold no persistent value. Put each widget in the bucket that matches its semantics; don't shoehorn a trigger into selection/input.
+- **Don't version-stamp.** Avoid "as of 1.x" annotations — the skill ships bundled with the Streamlit release, so it is already versioned with the code. For support/compatibility lists, state the *exceptions* ("not supported on …") rather than enumerating the supported set, so new additions are covered by default.
+- **Steer to the native API and name the anti-pattern it replaces.** Prefer explicit elements over `st.write`/magic; prefer Altair over Plotly for complex charts (Altair is bundled, no extra install); match message severity to the situation (a not-yet-filled input is a neutral `st.info` prompt, not a warning).
+- **Keep routing and links in sync.** When you add, move, or remove a reference, update the `SKILL.md` routing row and verify every `references/*.md` link resolves. Avoid hard links between references that live in different PR branches/stacks — they dangle until both merge.
+- **Bias toward concise guidance** — the smallest wording that lands the point.

--- a/lib/streamlit/.agents/skills/CLAUDE.md
+++ b/lib/streamlit/.agents/skills/CLAUDE.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/scripts/generate_agent_rules.py
+++ b/scripts/generate_agent_rules.py
@@ -108,6 +108,13 @@ AGENT_RULE_FILES: Final[list[AgentRuleFile]] = [
         "always_apply": False,
     },
     {
+        "cursor_mdc": ".cursor/rules/embedded_skills.mdc",
+        "github_copilot": ".github/instructions/embedded_skills.instructions.md",
+        "agents_md": "lib/streamlit/.agents/skills/AGENTS.md",
+        "globs": "lib/streamlit/.agents/skills/**/*",
+        "always_apply": False,
+    },
+    {
         "cursor_mdc": ".cursor/rules/python_tests.mdc",
         "github_copilot": ".github/instructions/python_tests.instructions.md",
         "agents_md": "lib/tests/AGENTS.md",


### PR DESCRIPTION
## What
Adds skill-authoring conventions for the embedded `developing-with-streamlit` skill. The detailed conventions live in a dedicated nested `lib/streamlit/.agents/skills/AGENTS.md` (co-located with the embedded skills), with a short high-level pointer in the root `AGENTS.md`.

## Why
The same review notes recurred across the developing-with-streamlit skill PR stacks (#15508–#15513, #15601–#15606). Codifying them in a tracked `AGENTS.md` (auto-mirrored to Cursor/Copilot rules + a sibling `CLAUDE.md`, and read by other agents directly) means future skill PRs don't re-litigate the same points. Nesting the file under the skills directory keeps the always-loaded root `AGENTS.md` lean while surfacing the guidance right when skill files are edited.

## Sources (the review feedback this distills)
- **Earn the section** — Lukas on #15508 ("the `title` feature is too unimportant to get such a prominent listing"), #15509 ("remove this section … not important enough as a feature"), #15513 ("fine to just mention `st.status` … `type=\"compact\"` seems a bit specific" / "can be removed … a bit more niche").
- **Group by widget semantics** — Lukas on #15511 ("`menu_button` doesn't fit well into the selection widgets group since it's a trigger widget … a dedicated `button-widgets` or `trigger-widgets` reference") and #15602 ("`button` (or any other trigger widgets) doesn't fit well into this collection").
- **No version stamps / invert support lists** — Maya on #15512 ("how are we handling drift … appending something like 'as of 1.58'?"), Lukas's reply ("list where it's *not* supported … assume that it's supported for all other widgets"), plus author self-review notes on #15508/#15510 ("version annotations don't work, remove it").
- **Native API / explicit over write+magic / Altair / severity** — Lukas on #15606 ("we always want agents to use explicit commands … instead of `st.write` and magic"), #15603 ("go with an altair example … we try to slightly nudge agents to prefer altair vs plotly"), #15601 ("it would show a big warning on the first app run … subpar UX"); Maya on #15513 ("the 'don't gate behind a button' guidance is slightly too broad").
- **Routing/links in sync** — learnings from restacking these PRs onto develop (stale SKILL.md routes and cross-stack reference links that dangled until merge).

## Review follow-ups (this revision)
- Per Lukas: moved the detailed conventions into the nested `lib/streamlit/.agents/skills/AGENTS.md` and left a 1–2 sentence pointer in the root; registered it in `generate_agent_rules.py` so the Cursor/Copilot mirrors + sibling `CLAUDE.md` generate.
- Per greptile (P2): added `st.form_submit_button` to the trigger-widget list.
