### PR TITLE
[feature] Add `server.xsrfCookieSameSite` config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1020,13 +1020,16 @@ _create_option(
     "server.xsrfCookieSameSite",
     description="""
         Controls the SameSite attribute of the cookie Streamlit uses for
-        Cross-Site Request Forgery (XSRF) protection. This only affects the
-        XSRF cookie; authentication cookies always use SameSite=Lax.
+        Cross-Site Request Forgery (XSRF) protection. This only has an effect
+        when XSRF protection is enabled (via ``server.enableXsrfProtection`` or
+        an ``[auth]`` section in your secrets); otherwise no XSRF cookie is set.
+        It does not affect authentication cookies, which always use
+        SameSite=Lax.
 
         Allowed values:
         - "lax" (default): The XSRF cookie is sent on same-site requests and
           top-level cross-site navigations. This is the recommended, secure
-          default and matches the previous behavior.
+          default.
         - "strict": The XSRF cookie is only sent on same-site requests.
         - "none": The XSRF cookie is sent on all requests, including cross-site
           requests. This is required when embedding a Streamlit app in an

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2933,14 +2933,37 @@ If cross origin resource sharing is required, please disable server.enableXsrfPr
             """
         )
 
-    # Validate the XSRF cookie SameSite value.
+    # Validate the XSRF cookie SameSite value. We explicitly require a string
+    # so that a non-string value (e.g. a None from TOML "null") is rejected
+    # instead of being coerced via str() into a valid-looking "none".
     xsrf_cookie_same_site = get_option("server.xsrfCookieSameSite")
-    if str(xsrf_cookie_same_site).lower() not in {"lax", "strict", "none"}:
+    if not isinstance(
+        xsrf_cookie_same_site, str
+    ) or xsrf_cookie_same_site.lower() not in {"lax", "strict", "none"}:
         raise RuntimeError(
             "Invalid value for config option server.xsrfCookieSameSite: "
             f'"{xsrf_cookie_same_site}". '
             'Valid values are "lax", "strict", and "none".'
         )
+
+    # Warn about combinations where SameSite="none" silently has no effect or
+    # requires additional setup, to avoid hard-to-debug misconfigurations.
+    if xsrf_cookie_same_site.lower() == "none":
+        if not get_option("server.enableXsrfProtection"):
+            logger.warning(
+                "The config option 'server.xsrfCookieSameSite=\"none\"' has no "
+                "effect because 'server.enableXsrfProtection' is false, so no "
+                "XSRF cookie is set."
+            )
+        elif not get_option("server.sslCertFile"):
+            logger.warning(
+                "The config option 'server.xsrfCookieSameSite=\"none\"' marks "
+                "the XSRF cookie as 'Secure', so your app must be served over "
+                "HTTPS (either directly via 'server.sslCertFile' or through a "
+                "TLS-terminating proxy). Otherwise, browsers will drop the "
+                "cookie and cross-origin embedding (e.g. st.file_uploader in an "
+                "iframe) will not work."
+            )
 
 
 def _set_development_mode() -> None:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2949,11 +2949,18 @@ If cross origin resource sharing is required, please disable server.enableXsrfPr
     # Warn about combinations where SameSite="none" silently has no effect or
     # requires additional setup, to avoid hard-to-debug misconfigurations.
     if xsrf_cookie_same_site.lower() == "none":
-        if not get_option("server.enableXsrfProtection"):
+        # is_xsrf_enabled() mirrors the runtime check used when setting the
+        # cookie: XSRF protection (and thus the XSRF cookie) can also be enabled
+        # implicitly by an [auth] section in secrets, not just by
+        # server.enableXsrfProtection. Import locally to avoid a circular import.
+        from streamlit.web.server.server_util import is_xsrf_enabled
+
+        if not is_xsrf_enabled():
             logger.warning(
                 "The config option 'server.xsrfCookieSameSite=\"none\"' has no "
-                "effect because 'server.enableXsrfProtection' is false, so no "
-                "XSRF cookie is set."
+                "effect because XSRF protection is disabled, so no XSRF cookie "
+                "is set. Enable it via 'server.enableXsrfProtection' or an "
+                "[auth] section in your secrets."
             )
         elif not get_option("server.sslCertFile"):
             logger.warning(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2952,10 +2952,10 @@ If cross origin resource sharing is required, please disable server.enableXsrfPr
     # Warn about combinations where SameSite="none" silently has no effect or
     # requires additional setup, to avoid hard-to-debug misconfigurations.
     if xsrf_cookie_same_site.lower() == "none":
-        # is_xsrf_enabled() mirrors the runtime check used when setting the
-        # cookie: XSRF protection (and thus the XSRF cookie) can also be enabled
-        # implicitly by an [auth] section in secrets, not just by
-        # server.enableXsrfProtection. Import locally to avoid a circular import.
+        # XSRF protection can also be enabled implicitly by an [auth] section
+        # in secrets, not just server.enableXsrfProtection — use
+        # is_xsrf_enabled() to check both paths. Imported locally to avoid
+        # a circular import.
         from streamlit.web.server.server_util import is_xsrf_enabled
 
         if not is_xsrf_enabled():

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1017,6 +1017,36 @@ _create_option(
 )
 
 _create_option(
+    "server.xsrfCookieSameSite",
+    description="""
+        Controls the SameSite attribute of the cookie Streamlit uses for
+        Cross-Site Request Forgery (XSRF) protection. This only affects the
+        XSRF cookie; authentication cookies always use SameSite=Lax.
+
+        Allowed values:
+        - "lax" (default): The XSRF cookie is sent on same-site requests and
+          top-level cross-site navigations. This is the recommended, secure
+          default and matches the previous behavior.
+        - "strict": The XSRF cookie is only sent on same-site requests.
+        - "none": The XSRF cookie is sent on all requests, including cross-site
+          requests. This is required when embedding a Streamlit app in an
+          iframe hosted on a different origin (for example, to make
+          ``st.file_uploader`` work inside a cross-origin iframe). Browsers
+          only accept ``SameSite=None`` cookies that also have the ``Secure``
+          attribute, so Streamlit sets ``Secure`` automatically in this case.
+          This means your app must be served over HTTPS (either directly or via
+          a TLS-terminating proxy), otherwise browsers will drop the cookie.
+
+        Note: Setting this to "none" relaxes the browser's SameSite-based CSRF
+        mitigation, so protection then relies on Streamlit's XSRF token
+        validation together with the CORS origin allowlist. Only use "none" if
+        you understand this tradeoff.
+    """,
+    default_val="lax",
+    type_=str,
+)
+
+_create_option(
     "server.maxUploadSize",
     description="""
         Max size, in megabytes, for files uploaded with the file_uploader.
@@ -2901,6 +2931,15 @@ cross-origin resource sharing.
 
 If cross origin resource sharing is required, please disable server.enableXsrfProtection.
             """
+        )
+
+    # Validate the XSRF cookie SameSite value.
+    xsrf_cookie_same_site = get_option("server.xsrfCookieSameSite")
+    if str(xsrf_cookie_same_site).lower() not in {"lax", "strict", "none"}:
+        raise RuntimeError(
+            "Invalid value for config option server.xsrfCookieSameSite: "
+            f'"{xsrf_cookie_same_site}". '
+            'Valid values are "lax", "strict", and "none".'
         )
 
 

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -93,6 +93,14 @@ _ROUTE_UPLOAD_FILE: Final = f"{BASE_ROUTE_UPLOAD_FILE}/{{session_id}}/{{file_id}
 _ROUTE_COMPONENTS_V1: Final = f"{BASE_ROUTE_COMPONENT}/{{path:path}}"
 _ROUTE_COMPONENTS_V2: Final = f"{BASE_ROUTE_CORE}/bidi-components/{{path:path}}"
 
+# Mapping of the (lowercase) server.xsrfCookieSameSite config values to their
+# canonical Set-Cookie "SameSite" attribute values.
+_SAME_SITE_HEADER_VALUES: Final = {
+    "lax": "Lax",
+    "strict": "Strict",
+    "none": "None",
+}
+
 # App static files
 _ROUTE_APP_STATIC: Final = "app/static/{path:path}"
 
@@ -207,7 +215,9 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
     bytes and timestamp are preserved. Otherwise, a new token is generated.
 
     The cookie is only set if XSRF protection is enabled in the configuration.
-    The Secure flag is added when SSL is configured.
+    The SameSite attribute is controlled by server.xsrfCookieSameSite. The
+    Secure flag is added when SSL is configured, and is always added when
+    SameSite is "none" (browsers require Secure for SameSite=None).
 
     Note: The XSRF cookie intentionally does NOT have the HttpOnly flag. This
     is required for the double-submit cookie pattern: JavaScript reads the
@@ -238,11 +248,20 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
         token_bytes, timestamp
     )
 
+    same_site = _SAME_SITE_HEADER_VALUES.get(
+        str(config.get_option("server.xsrfCookieSameSite")).lower(), "Lax"
+    )
+    # Browsers only accept SameSite=None cookies that are also Secure, so force
+    # Secure in that case. This is what lets the XSRF cookie (and therefore
+    # st.file_uploader) work when the app is embedded in a cross-origin iframe.
+    secure = bool(config.get_option("server.sslCertFile")) or same_site == "None"
+
     _set_unquoted_cookie(
         response,
         XSRF_COOKIE_NAME,
         cookie_value,
-        secure=bool(config.get_option("server.sslCertFile")),
+        same_site=same_site,
+        secure=secure,
     )
 
 
@@ -251,6 +270,7 @@ def _set_unquoted_cookie(
     cookie_name: str,
     cookie_value: str,
     *,
+    same_site: str = "Lax",
     secure: bool,
 ) -> None:
     """Set a cookie without URL-encoding or quoting the value.
@@ -263,8 +283,10 @@ def _set_unquoted_cookie(
 
     Cookie flags set:
     - Path=/: Available to all paths
-    - SameSite=Lax: Protects against CSRF while allowing top-level navigations
-    - Secure (conditional): Added when SSL is configured
+    - SameSite: Controlled by the `same_site` argument. "Lax" (the default)
+      protects against CSRF while allowing top-level navigations; "None" enables
+      cross-origin (iframe) usage and requires Secure.
+    - Secure (conditional): Added when SSL is configured or `secure` is True.
 
     HttpOnly is intentionally NOT set for XSRF cookies because JavaScript must
     read the cookie value to include it in request headers (double-submit pattern).
@@ -277,6 +299,9 @@ def _set_unquoted_cookie(
         The name of the cookie.
     cookie_value
         The raw cookie value (will not be URL-encoded or quoted).
+    same_site
+        The SameSite attribute value to use (e.g. "Lax", "Strict", or "None").
+        Defaults to "Lax".
     secure
         Whether to add the Secure flag (should be True when using HTTPS).
     """
@@ -285,7 +310,7 @@ def _set_unquoted_cookie(
         [
             f"{cookie_name}={cookie_value}",
             "Path=/",
-            "SameSite=Lax",
+            f"SameSite={same_site}",
             *(["Secure"] if secure else []),
         ]
     )

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -248,8 +248,14 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
         token_bytes, timestamp
     )
 
+    # Only normalize actual strings; any unexpected value (e.g. None) falls
+    # back to the safe "Lax" default rather than being coerced into "none".
+    xsrf_cookie_same_site = config.get_option("server.xsrfCookieSameSite")
     same_site = _SAME_SITE_HEADER_VALUES.get(
-        str(config.get_option("server.xsrfCookieSameSite")).lower(), "Lax"
+        xsrf_cookie_same_site.lower()
+        if isinstance(xsrf_cookie_same_site, str)
+        else "lax",
+        "Lax",
     )
     # Browsers only accept SameSite=None cookies that are also Secure, so force
     # Secure in that case. This is what lets the XSRF cookie (and therefore

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -257,9 +257,8 @@ def _ensure_xsrf_cookie(request: Request, response: Response) -> None:
         else "lax",
         "Lax",
     )
-    # Browsers only accept SameSite=None cookies that are also Secure, so force
-    # Secure in that case. This is what lets the XSRF cookie (and therefore
-    # st.file_uploader) work when the app is embedded in a cross-origin iframe.
+    # Browsers reject SameSite=None cookies without the Secure flag, so force
+    # Secure in that case.
     secure = bool(config.get_option("server.sslCertFile")) or same_site == "None"
 
     _set_unquoted_cookie(

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -869,9 +869,10 @@ class ConfigTest(unittest.TestCase):
         assert "xsrfCookieSameSite" in warnings
         assert "HTTPS" in warnings
 
+    @patch("streamlit.web.server.server_util.is_xsrf_enabled", return_value=False)
     @patch("streamlit.logger.get_logger")
     def test_check_conflicts_xsrf_cookie_same_site_none_warns_when_xsrf_disabled(
-        self, get_logger
+        self, get_logger, _mock_is_xsrf_enabled
     ):
         """SameSite="none" with XSRF protection disabled must warn it has no effect."""
         config._set_option("server.xsrfCookieSameSite", "none", "test")
@@ -881,6 +882,27 @@ class ConfigTest(unittest.TestCase):
         warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
         assert "xsrfCookieSameSite" in warnings
         assert "no effect" in warnings
+
+    @patch("streamlit.web.server.server_util.is_xsrf_enabled", return_value=True)
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_xsrf_cookie_same_site_none_no_effect_respects_auth(
+        self, get_logger, _mock_is_xsrf_enabled
+    ):
+        """SameSite="none" must not warn "no effect" when XSRF is enabled via auth.
+
+        is_xsrf_enabled() can be True (e.g. via an [auth] secrets section) even
+        when server.enableXsrfProtection is false; the XSRF cookie is then still
+        set, so SameSite="none" does take effect.
+        """
+        config._set_option("server.xsrfCookieSameSite", "none", "test")
+        config._set_option("server.enableXsrfProtection", False, "test")
+        config._set_option("server.sslCertFile", None, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        assert "no effect" not in warnings
+        # It should still warn about the HTTPS/Secure requirement.
+        assert "HTTPS" in warnings
 
     def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -844,6 +844,44 @@ class ConfigTest(unittest.TestCase):
         ):
             config._check_conflicts()
 
+    def test_check_conflicts_xsrf_cookie_same_site_none_value(self):
+        """A None xsrfCookieSameSite value must be rejected, not coerced to "none"."""
+        config._set_option("server.xsrfCookieSameSite", None, "test")
+        with pytest.raises(
+            RuntimeError,
+            match=r"Invalid value for config option server.xsrfCookieSameSite",
+        ):
+            config._check_conflicts()
+
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_xsrf_cookie_same_site_none_warns_without_ssl(
+        self, get_logger
+    ):
+        """SameSite="none" without SSL must warn about the HTTPS requirement."""
+        config._set_option("server.xsrfCookieSameSite", "none", "test")
+        config._set_option("server.enableXsrfProtection", True, "test")
+        config._set_option("server.enableCORS", True, "test")
+        config._set_option("global.developmentMode", False, "test")
+        config._set_option("server.sslCertFile", None, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        assert "xsrfCookieSameSite" in warnings
+        assert "HTTPS" in warnings
+
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_xsrf_cookie_same_site_none_warns_when_xsrf_disabled(
+        self, get_logger
+    ):
+        """SameSite="none" with XSRF protection disabled must warn it has no effect."""
+        config._set_option("server.xsrfCookieSameSite", "none", "test")
+        config._set_option("server.enableXsrfProtection", False, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        assert "xsrfCookieSameSite" in warnings
+        assert "no effect" in warnings
+
     def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")
         config._set_option("browser.serverPort", 1234, "test")

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -844,7 +844,7 @@ class ConfigTest(unittest.TestCase):
         ):
             config._check_conflicts()
 
-    def test_check_conflicts_xsrf_cookie_same_site_none_value(self):
+    def test_check_conflicts_xsrf_cookie_same_site_rejects_python_none(self):
         """A None xsrfCookieSameSite value must be rejected, not coerced to "none"."""
         config._set_option("server.xsrfCookieSameSite", None, "test")
         with pytest.raises(
@@ -885,7 +885,7 @@ class ConfigTest(unittest.TestCase):
 
     @patch("streamlit.web.server.server_util.is_xsrf_enabled", return_value=True)
     @patch("streamlit.logger.get_logger")
-    def test_check_conflicts_xsrf_cookie_same_site_none_no_effect_respects_auth(
+    def test_check_conflicts_xsrf_cookie_same_site_none_skips_no_effect_warning_when_auth_enables_xsrf(
         self, get_logger, _mock_is_xsrf_enabled
     ):
         """SameSite="none" must not warn "no effect" when XSRF is enabled via auth.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -792,6 +792,7 @@ class ConfigTest(unittest.TestCase):
                 "server.enableWebsocketCompression",
                 "server.websocketPingInterval",
                 "server.enableXsrfProtection",
+                "server.xsrfCookieSameSite",
                 "server.fileWatcherType",
                 "server.folderWatchBlacklist",
                 "server.folderWatchList",
@@ -827,6 +828,21 @@ class ConfigTest(unittest.TestCase):
         mock_logger = get_logger()
         config._check_conflicts()
         mock_logger.warning.assert_called_once()
+
+    @parameterized.expand(["lax", "strict", "none", "Lax", "STRICT", "None"])
+    def test_check_conflicts_xsrf_cookie_same_site_valid(self, value):
+        """Valid (case-insensitive) xsrfCookieSameSite values must not raise."""
+        config._set_option("server.xsrfCookieSameSite", value, "test")
+        config._check_conflicts()
+
+    def test_check_conflicts_xsrf_cookie_same_site_invalid(self):
+        """An invalid xsrfCookieSameSite value must raise a clear error."""
+        config._set_option("server.xsrfCookieSameSite", "invalid", "test")
+        with pytest.raises(
+            RuntimeError,
+            match=r"Invalid value for config option server.xsrfCookieSameSite",
+        ):
+            config._check_conflicts()
 
     def test_check_conflicts_browser_serverport(self):
         config._set_option("global.developmentMode", True, "test")

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -207,6 +207,7 @@ class TestEnsureXsrfCookie:
         ]
         assert len(cookie_headers) == 1
         assert cookie_headers[0].startswith(f"{XSRF_COOKIE_NAME}=2|")
+        assert "SameSite=Lax" in cookie_headers[0]
         assert "Secure" not in cookie_headers[0]
 
     @patch_config_options(
@@ -255,6 +256,82 @@ class TestEnsureXsrfCookie:
         mock_decode.assert_called_once_with("existing_cookie_value")
         mock_generate.assert_called_once_with(existing_token, existing_timestamp)
 
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.sslCertFile": None,
+            "server.xsrfCookieSameSite": "none",
+        }
+    )
+    def test_same_site_none_forces_secure(self) -> None:
+        """SameSite=None must force the Secure flag even without SSL configured.
+
+        Browsers reject ``SameSite=None`` cookies that are not also ``Secure``,
+        so omitting Secure here would silently break cross-origin embedding.
+        """
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "SameSite=None" in cookie_headers[0]
+        assert "Secure" in cookie_headers[0]
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.sslCertFile": "/path/to/cert",
+            "server.xsrfCookieSameSite": "none",
+        }
+    )
+    def test_same_site_none_with_ssl_is_secure(self) -> None:
+        """SameSite=None combined with SSL still yields a single Secure flag."""
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "SameSite=None" in cookie_headers[0]
+        assert cookie_headers[0].count("Secure") == 1
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.sslCertFile": None,
+            "server.xsrfCookieSameSite": "strict",
+        }
+    )
+    def test_same_site_strict_does_not_force_secure(self) -> None:
+        """SameSite=Strict is reflected in the cookie without forcing Secure."""
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "SameSite=Strict" in cookie_headers[0]
+        assert "Secure" not in cookie_headers[0]
+
 
 class TestSetUnquotedCookie:
     """Tests for _set_unquoted_cookie function."""
@@ -277,6 +354,24 @@ class TestSetUnquotedCookie:
         assert "Path=/" in cookie_headers[0]
         assert "SameSite=Lax" in cookie_headers[0]
         assert "Secure" not in cookie_headers[0]
+
+    def test_sets_custom_same_site(self) -> None:
+        """Test that a custom SameSite value is reflected in the header."""
+
+        response = Response()
+
+        _set_unquoted_cookie(
+            response, "test_cookie", "value", same_site="None", secure=True
+        )
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "SameSite=None" in cookie_headers[0]
+        assert "Secure" in cookie_headers[0]
 
     def test_sets_secure_flag_when_requested(self) -> None:
         """Test that Secure flag is added when secure=True."""

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -384,7 +384,7 @@ class TestSetUnquotedCookie:
         assert "Secure" not in cookie_headers[0]
 
     def test_sets_custom_same_site(self) -> None:
-        """Test that a custom SameSite value is reflected in the header."""
+        """A custom SameSite value is reflected in the Set-Cookie header."""
 
         response = Response()
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -332,6 +332,34 @@ class TestEnsureXsrfCookie:
         assert "SameSite=Strict" in cookie_headers[0]
         assert "Secure" not in cookie_headers[0]
 
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.sslCertFile": None,
+            "server.xsrfCookieSameSite": None,
+        }
+    )
+    def test_non_string_same_site_falls_back_to_lax(self) -> None:
+        """A non-string SameSite value falls back to Lax without forcing Secure.
+
+        This guards against a None config (e.g. TOML null) being coerced into
+        SameSite=None with a forced Secure flag.
+        """
+        request = MagicMock()
+        request.cookies = {}
+        response = Response()
+
+        _ensure_xsrf_cookie(request, response)
+
+        cookie_headers = [
+            value.decode("latin-1")
+            for name, value in response.raw_headers
+            if name.lower() == b"set-cookie"
+        ]
+        assert len(cookie_headers) == 1
+        assert "SameSite=Lax" in cookie_headers[0]
+        assert "Secure" not in cookie_headers[0]
+
 
 class TestSetUnquotedCookie:
     """Tests for _set_unquoted_cookie function."""


### PR DESCRIPTION
## Describe your changes

Adds a new `server.xsrfCookieSameSite` config option (`"lax"` default, `"strict"`, `"none"`) controlling the `SameSite` attribute of the `_streamlit_xsrf` cookie.

- Setting `"none"` automatically forces the cookie's `Secure` flag (browsers reject `SameSite=None` without it), so the XSRF cookie is delivered in cross-origin iframe contexts. This unblocks `st.file_uploader` (and the authenticated WebSocket handshake) when a Streamlit app is embedded on a different origin over HTTPS.
- Default `"lax"` reproduces the previous hardcoded behavior byte-for-byte, so existing apps are unaffected. Invalid values are rejected at startup with a clear error.
- Scope is intentionally limited to the XSRF cookie; auth cookies still use `SameSite=Lax`.

## GitHub Issue Link (if applicable)

- Closes #9397
- Closes #5793 (cross-origin iframe facet; the auth-cookie and behind-proxy `Secure` aspects are out of scope here)
- Related #9719

## Testing Plan

- `lib/tests/streamlit/web/server/starlette/starlette_routes_test.py` — XSRF cookie header generation: default `SameSite=Lax` (no Secure), `none` forces Secure (with and without SSL), `strict` does not force Secure, and the `same_site` argument of `_set_unquoted_cookie`.
- `lib/tests/streamlit/config_test.py` — option is registered, and `_check_conflicts` validation accepts `lax`/`strict`/`none` (case-insensitive) and rejects invalid values.
- No frontend changes. E2E coverage for the cross-origin embedded upload flow is recommended as a follow-up (`@pytest.mark.external_test`) since it requires an HTTPS-capable embedded host harness.

Made with [Cursor](https://cursor.com)