### PR TITLE
[fix] Explain multi-replica cause in invalid session upload error

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -662,7 +662,15 @@ def create_upload_routes(
         file_id = request.path_params["file_id"]
 
         if not runtime.is_active_session(session_id):
-            raise HTTPException(status_code=400, detail="Invalid session_id")
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Invalid session_id. This is likely caused by a multi-replica "
+                    "deployment without sticky sessions / session affinity. See "
+                    "https://docs.streamlit.io/develop/concepts/architecture/"
+                    "architecture#websockets-and-session-management"
+                ),
+            )
 
         max_size_bytes = (  # maxUploadSize is in megabytes
             config.get_option("server.maxUploadSize") * 1024 * 1024

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -640,6 +640,28 @@ def test_upload_put_adds_file(
     assert stored.data == b"payload"
 
 
+def test_upload_put_inactive_session_explains_session_affinity(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """Test that inactive session uploads explain multi-replica deployments."""
+    client, _ = starlette_client
+
+    response = client.put(
+        "_stcore/upload_file/inactive-session/fileid",
+        files={"file": ("foo.txt", b"payload", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "Invalid session_id" in response.text
+    assert "multi-replica deployment without sticky sessions / session affinity" in (
+        response.text
+    )
+    assert (
+        "https://docs.streamlit.io/develop/concepts/architecture/"
+        "architecture#websockets-and-session-management"
+    ) in response.text
+
+
 def test_upload_put_enforces_max_size(
     starlette_client: tuple[TestClient, _DummyRuntime],
 ) -> None:


### PR DESCRIPTION
## Describe your changes

- File uploads to an inactive session return HTTP 400 with the generic message `Invalid session_id`. This commonly happens in multi-replica deployments without sticky sessions / session affinity, where the upload HTTP request is routed to a different replica than the one holding the user's WebSocket session.
- Extend the error detail to explain this likely cause and link to the [architecture docs](https://docs.streamlit.io/develop/concepts/architecture/architecture#websockets-and-session-management) so users can self-diagnose and resolve it (e.g. by enabling session affinity).

## GitHub Issue Link (if applicable)

- Related: #4173
- Related: #9976

## Testing Plan

- [x] Unit Tests (Python): added `test_upload_put_inactive_session_explains_session_affinity` to verify the inactive-session upload response includes the explanation and docs link.

Made with [Cursor](https://cursor.com)
