### PR TITLE
[fix] Keep selectbox selection when format_func depends on object identity

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+from dataclasses import dataclass
+
 import pandas as pd
 
 import streamlit as st
@@ -228,6 +231,28 @@ v23 = st.selectbox(
     filter_mode=None,
 )
 st.write("value 23:", v23)
+
+
+# Regression test for https://github.com/streamlit/streamlit/issues/15618:
+# custom-class options with a format_func that depends on object identity
+# (here a dict lookup) must not revert the selection on rerun.
+@dataclass(frozen=True)
+class _Choice:
+    id: int
+    name: str
+
+
+_choice_a = _Choice(1, "one")
+_choice_b = _Choice(2, "two")
+_choice_labels = {_choice_a: "I", _choice_b: "II"}
+
+v24 = st.selectbox(
+    "selectbox 24 (custom objects with identity-dependent format_func)",
+    [_choice_a, _choice_b],
+    format_func=lambda choice: f"{_choice_labels[choice]} ({choice.name})",
+    key="selectbox_24",
+)
+st.write("value 24:", v24.name)
 
 # --- Bound widgets (query-params) ---
 

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
+from e2e_playwright.conftest import rerun_app, wait_for_app_loaded, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from e2e_playwright.conftest import ImageCompareFunction
 
 
-NUM_SELECTBOXES = 26
+NUM_SELECTBOXES = 27
 
 
 def get_selectbox_input(
@@ -159,6 +159,24 @@ def test_handles_option_selection(app: Page, assert_snapshot: ImageCompareFuncti
     selection_dropdown.get_by_role("option").nth(1).click()
     # Check that selection worked:
     expect_markdown(app, "value 4: e2e/scripts/st_warning.py")
+
+
+def test_keeps_selection_with_identity_dependent_format_func(app: Page):
+    """Test that custom-object selections persist with an identity-dependent format_func.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15618. The
+    option class is redefined every rerun, so a format_func that looks options up
+    in a dict used to raise on the stored value and revert the selection.
+    """
+    label = "selectbox 24 (custom objects with identity-dependent format_func)"
+    select_selectbox_option(app, label, "II (two)")
+
+    # The selection must reflect the second option, not revert to the first.
+    expect_markdown(app, "value 24: two")
+
+    # It must also survive a fresh rerun (where the bug originally triggered).
+    rerun_app(app)
+    expect_markdown(app, "value 24: two")
 
 
 def test_handles_option_selection_via_typing(app: Page):

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -395,38 +395,36 @@ def validate_and_sync_value_with_options(
 
 
 def resolve_value_against_options(
-    serialized_value: str | None,
     current_value: T | None,
     opt: Sequence[T],
     formatted_option_to_option_index: dict[str, int],
     default_index: int | None,
     key: str | int | None,
     format_func: Callable[[Any], str] = str,
+    incoming_serialized_value: str | None = None,
 ) -> tuple[T | None, bool]:
-    """Validate the current selection using its serialized label.
+    """Validate the current value against options, resetting if it's invalid.
 
-    Unlike :func:`validate_and_sync_value_with_options`, this does not re-run
-    ``format_func`` on ``current_value`` to decide membership. Instead it uses
-    ``serialized_value`` -- the widget's canonical formatted label, recovered
-    from the stored widget state -- and looks it up directly in
-    ``formatted_option_to_option_index``. On a hit, the matching *current*
-    option instance is returned (never a stale deepcopy). On a miss, the value
-    is reset to the default.
+    Membership is decided primarily by ``format_func``: the value is valid if
+    its formatted label is among the options. This preserves correct behavior
+    when ``format_func`` changes between runs or when the value was set
+    programmatically.
 
-    This avoids the failure mode where ``format_func`` performs an identity- or
-    class-dependent operation (e.g. a dict lookup) and raises when handed a
-    value that was deepcopied from an earlier run.
+    If ``format_func`` raises on ``current_value`` -- which happens when it
+    performs an identity- or class-dependent operation (e.g. a dict lookup) and
+    the value is a deepcopy stored from an earlier run -- the stored wire label
+    ``incoming_serialized_value`` is used instead to decide membership. On a
+    match, the matching *current* option instance is returned so the value
+    always belongs to the current run rather than a stale deepcopy.
 
-    Falls back to :func:`validate_and_sync_value_with_options` when no
-    serialized label is available (e.g. the first render, or a programmatic
-    ``st.session_state`` assignment that stored an object directly).
+    Has the same session-state side effect as
+    :func:`validate_and_sync_value_with_options`: when the value is reset and a
+    key is provided, session state is updated with the new value.
 
     Parameters
     ----------
-    serialized_value
-        The widget's stored formatted label, or ``None`` if unavailable.
     current_value
-        The current widget value (used for the empty check and fallback).
+        The current widget value to validate.
     opt
         The sequence of valid options.
     formatted_option_to_option_index
@@ -436,7 +434,10 @@ def resolve_value_against_options(
     key
         The widget key for session state updates.
     format_func
-        Only used by the fallback path.
+        Function to format options for comparison.
+    incoming_serialized_value
+        The widget's stored wire label, used as a fallback identity when
+        ``format_func`` raises on ``current_value``. ``None`` if unavailable.
 
     Returns
     -------
@@ -446,20 +447,24 @@ def resolve_value_against_options(
     if current_value is None:
         return current_value, False
 
-    if serialized_value is None:
-        # No label to validate against (first render or programmatic set) -
-        # fall back to the format_func-based comparison.
-        return validate_and_sync_value_with_options(
-            current_value, opt, default_index, key, format_func
+    try:
+        formatted_value = format_func(current_value)
+        if formatted_value in formatted_option_to_option_index:
+            return current_value, False
+    except Exception:
+        # format_func can't handle the stored value (e.g. it's identity- or
+        # class-dependent and the value is a deepcopy from an earlier run). Use
+        # the stored wire label as the identity instead, and return the current
+        # option instance so we never hand back a stale deepcopy.
+        option_index = (
+            formatted_option_to_option_index.get(incoming_serialized_value)
+            if incoming_serialized_value is not None
+            else None
         )
+        if option_index is not None and 0 <= option_index < len(opt):
+            return opt[option_index], False
 
-    option_index = formatted_option_to_option_index.get(serialized_value)
-    if option_index is not None and 0 <= option_index < len(opt):
-        # The label maps to a current option. Return that instance so the value
-        # always belongs to the current run, never a stale deepcopy.
-        return opt[option_index], False
-
-    # Label is not among the current options - reset to default.
+    # Value not in options - reset to default.
     if default_index is not None and len(opt) > 0:
         new_value: T | None = opt[default_index]
     else:

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -394,6 +394,83 @@ def validate_and_sync_value_with_options(
     return new_value, True
 
 
+def resolve_value_against_options(
+    serialized_value: str | None,
+    current_value: T | None,
+    opt: Sequence[T],
+    formatted_option_to_option_index: dict[str, int],
+    default_index: int | None,
+    key: str | int | None,
+    format_func: Callable[[Any], str] = str,
+) -> tuple[T | None, bool]:
+    """Validate the current selection using its serialized label.
+
+    Unlike :func:`validate_and_sync_value_with_options`, this does not re-run
+    ``format_func`` on ``current_value`` to decide membership. Instead it uses
+    ``serialized_value`` -- the widget's canonical formatted label, recovered
+    from the stored widget state -- and looks it up directly in
+    ``formatted_option_to_option_index``. On a hit, the matching *current*
+    option instance is returned (never a stale deepcopy). On a miss, the value
+    is reset to the default.
+
+    This avoids the failure mode where ``format_func`` performs an identity- or
+    class-dependent operation (e.g. a dict lookup) and raises when handed a
+    value that was deepcopied from an earlier run.
+
+    Falls back to :func:`validate_and_sync_value_with_options` when no
+    serialized label is available (e.g. the first render, or a programmatic
+    ``st.session_state`` assignment that stored an object directly).
+
+    Parameters
+    ----------
+    serialized_value
+        The widget's stored formatted label, or ``None`` if unavailable.
+    current_value
+        The current widget value (used for the empty check and fallback).
+    opt
+        The sequence of valid options.
+    formatted_option_to_option_index
+        Mapping from formatted option labels to their index in ``opt``.
+    default_index
+        The default index to reset to if the value is invalid.
+    key
+        The widget key for session state updates.
+    format_func
+        Only used by the fallback path.
+
+    Returns
+    -------
+    tuple[T | None, bool]
+        A tuple of (validated_value, value_was_reset).
+    """
+    if current_value is None:
+        return current_value, False
+
+    if serialized_value is None:
+        # No label to validate against (first render or programmatic set) -
+        # fall back to the format_func-based comparison.
+        return validate_and_sync_value_with_options(
+            current_value, opt, default_index, key, format_func
+        )
+
+    option_index = formatted_option_to_option_index.get(serialized_value)
+    if option_index is not None and 0 <= option_index < len(opt):
+        # The label maps to a current option. Return that instance so the value
+        # always belongs to the current run, never a stale deepcopy.
+        return opt[option_index], False
+
+    # Label is not among the current options - reset to default.
+    if default_index is not None and len(opt) > 0:
+        new_value: T | None = opt[default_index]
+    else:
+        new_value = None
+
+    if key is not None:
+        get_session_state().reset_state_value(str(key), new_value)
+
+    return new_value, True
+
+
 def validate_and_sync_multiselect_value_with_options(
     current_values: list[T] | list[T | str],
     opt: Sequence[T],

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from enum import Enum, EnumMeta
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, overload
 
@@ -24,13 +25,14 @@ from streamlit.proto.SelectWidgetFilterMode_pb2 import (
     SelectWidgetFilterMode as ProtoSelectWidgetFilterMode,
 )
 from streamlit.runtime.state import get_session_state
-from streamlit.runtime.state.common import RegisterWidgetResult
 from streamlit.type_util import (
     check_python_comparable,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
+
+    from streamlit.runtime.state.common import RegisterWidgetResult
 
 _LOGGER: Final = logger.get_logger(__name__)
 
@@ -250,9 +252,11 @@ def maybe_coerce_enum(
         if coerce_class is None:
             return register_widget_result
 
-    return RegisterWidgetResult(
-        _coerce_enum(register_widget_result.value, coerce_class),
-        register_widget_result.value_changed,
+    # Use replace so other fields (e.g. incoming_serialized_value) are preserved
+    # rather than dropped when only the value is coerced.
+    return replace(
+        register_widget_result,
+        value=_coerce_enum(register_widget_result.value, coerce_class),
     )
 
 
@@ -297,12 +301,13 @@ def maybe_coerce_enum_sequence(
         if coerce_class is None:
             return register_widget_result
 
-    # Return a new RegisterWidgetResult with the coerced enum values sequence
-    return RegisterWidgetResult(
-        type(register_widget_result.value)(
+    # Return a new RegisterWidgetResult with the coerced enum values sequence.
+    # Use replace so other fields (e.g. incoming_serialized_value) are preserved.
+    return replace(
+        register_widget_result,
+        value=type(register_widget_result.value)(
             _coerce_enum(val, coerce_class) for val in register_widget_result.value
         ),
-        register_widget_result.value_changed,
     )
 
 

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -403,7 +403,8 @@ def resolve_value_against_options(
     format_func: Callable[[Any], str] = str,
     incoming_serialized_value: str | None = None,
 ) -> tuple[T | None, bool]:
-    """Validate the current value against options, resetting if it's invalid.
+    """Like :func:`validate_and_sync_value_with_options`, but falls back to the
+    stored wire label when ``format_func`` raises on the current value.
 
     Membership is decided primarily by ``format_func``: the value is valid if
     its formatted label is among the options. This preserves correct behavior
@@ -434,7 +435,8 @@ def resolve_value_against_options(
     key
         The widget key for session state updates.
     format_func
-        Function to format options for comparison.
+        Used to compute the value's label for membership. May raise on a stale
+        value, which triggers the wire-label fallback.
     incoming_serialized_value
         The widget's stored wire label, used as a fallback identity when
         ``format_func`` raises on ``current_value``. ``None`` if unavailable.

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -685,25 +685,6 @@ class SelectboxMixin:
             default_option_index=index,
             format_func=format_func,
         )
-
-        # Recover the selection's canonical formatted label from the stored
-        # widget state *before* register_widget swaps in this run's serializer.
-        # Serializing here uses the previous run's serializer, which is
-        # consistent with the stored value, so it yields the correct label even
-        # when the option classes were redefined this run. This lets validation
-        # avoid re-running format_func on a value that may be a deepcopy from an
-        # earlier run (see resolve_value_against_options).
-        stored_serialized_label: str | None = None
-        if not accept_new_options:
-            stored_proto = get_session_state().get_serialized_widget_value(
-                selectbox_proto.id
-            )
-            if (
-                stored_proto is not None
-                and stored_proto.WhichOneof("value") == "string_value"
-            ):
-                stored_serialized_label = stored_proto.string_value
-
         widget_state = register_widget(
             selectbox_proto.id,
             on_change_handler=on_change,
@@ -736,12 +717,13 @@ class SelectboxMixin:
             )
         else:
             # Validate the current value against the new options using its
-            # serialized label instead of re-running format_func on the stored
-            # value. If the label is no longer among the options, reset to
-            # default. This handles dynamic option changes and avoids reverting
-            # the selection when format_func depends on object identity/class.
+            # serialized label (recovered during register_widget) instead of
+            # re-running format_func on the stored value. If the label is no
+            # longer among the options, reset to default. This handles dynamic
+            # option changes and avoids reverting the selection when format_func
+            # depends on object identity/class.
             current_value, value_needs_reset = resolve_value_against_options(
-                stored_serialized_label,
+                widget_state.serialized_value,
                 widget_state.value,
                 opt,
                 formatted_option_to_option_index,

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -707,12 +707,9 @@ class SelectboxMixin:
             current_value = widget_state.value
             value_needs_reset = False
         else:
-            # Validate the current value against the new options. Membership is
-            # decided by format_func; if format_func raises on the stored value
-            # (e.g. it depends on object identity/class and the value is a
-            # deepcopy from an earlier run), the stored wire label captured during
-            # register_widget is used as a fallback identity instead. This handles
-            # dynamic option changes without reverting the selection.
+            # Reset the selection only if the stored value no longer matches any
+            # option; see resolve_value_against_options for the format_func and
+            # wire-label fallback logic.
             current_value, value_needs_reset = resolve_value_against_options(
                 widget_state.value,
                 opt,

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -717,13 +717,13 @@ class SelectboxMixin:
             )
         else:
             # Validate the current value against the new options using its
-            # serialized label (recovered during register_widget) instead of
-            # re-running format_func on the stored value. If the label is no
+            # incoming serialized label (captured during register_widget) instead
+            # of re-running format_func on the stored value. If the label is no
             # longer among the options, reset to default. This handles dynamic
             # option changes and avoids reverting the selection when format_func
             # depends on object identity/class.
             current_value, value_needs_reset = resolve_value_against_options(
-                widget_state.serialized_value,
+                widget_state.incoming_serialized_value,
                 widget_state.value,
                 opt,
                 formatted_option_to_option_index,

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+from enum import Enum
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -36,6 +37,7 @@ from streamlit.elements.lib.options_selector_utils import (
     SelectWidgetFilterMode,
     create_mappings,
     maybe_coerce_enum,
+    resolve_value_against_options,
     validate_and_sync_value_with_options,
     validate_select_widget_filter_mode,
 )
@@ -683,6 +685,25 @@ class SelectboxMixin:
             default_option_index=index,
             format_func=format_func,
         )
+
+        # Recover the selection's canonical formatted label from the stored
+        # widget state *before* register_widget swaps in this run's serializer.
+        # Serializing here uses the previous run's serializer, which is
+        # consistent with the stored value, so it yields the correct label even
+        # when the option classes were redefined this run. This lets validation
+        # avoid re-running format_func on a value that may be a deepcopy from an
+        # earlier run (see resolve_value_against_options).
+        stored_serialized_label: str | None = None
+        if not accept_new_options:
+            stored_proto = get_session_state().get_serialized_widget_value(
+                selectbox_proto.id
+            )
+            if (
+                stored_proto is not None
+                and stored_proto.WhichOneof("value") == "string_value"
+            ):
+                stored_serialized_label = stored_proto.string_value
+
         widget_state = register_widget(
             selectbox_proto.id,
             on_change_handler=on_change,
@@ -706,13 +727,27 @@ class SelectboxMixin:
         if accept_new_options:
             current_value = widget_state.value
             value_needs_reset = False
-        else:
-            # Validate the current value against the new options.
-            # If the value is no longer valid (not in options), reset to default.
-            # This handles the case where options change dynamically and the
-            # previously selected value is no longer available.
+        elif isinstance(widget_state.value, Enum):
+            # Enum values are governed by runner.enumCoercion (already applied
+            # above via maybe_coerce_enum); keep the format_func-based validation
+            # so that coercion="off" still returns the stored value as-is.
             current_value, value_needs_reset = validate_and_sync_value_with_options(
                 widget_state.value, opt, index, key, format_func
+            )
+        else:
+            # Validate the current value against the new options using its
+            # serialized label instead of re-running format_func on the stored
+            # value. If the label is no longer among the options, reset to
+            # default. This handles dynamic option changes and avoids reverting
+            # the selection when format_func depends on object identity/class.
+            current_value, value_needs_reset = resolve_value_against_options(
+                stored_serialized_label,
+                widget_state.value,
+                opt,
+                formatted_option_to_option_index,
+                index,
+                key,
+                format_func,
             )
 
         if value_needs_reset or widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-from enum import Enum
 from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
@@ -38,7 +37,6 @@ from streamlit.elements.lib.options_selector_utils import (
     create_mappings,
     maybe_coerce_enum,
     resolve_value_against_options,
-    validate_and_sync_value_with_options,
     validate_select_widget_filter_mode,
 )
 from streamlit.elements.lib.policies import (
@@ -708,28 +706,21 @@ class SelectboxMixin:
         if accept_new_options:
             current_value = widget_state.value
             value_needs_reset = False
-        elif isinstance(widget_state.value, Enum):
-            # Enum values are governed by runner.enumCoercion (already applied
-            # above via maybe_coerce_enum); keep the format_func-based validation
-            # so that coercion="off" still returns the stored value as-is.
-            current_value, value_needs_reset = validate_and_sync_value_with_options(
-                widget_state.value, opt, index, key, format_func
-            )
         else:
-            # Validate the current value against the new options using its
-            # incoming serialized label (captured during register_widget) instead
-            # of re-running format_func on the stored value. If the label is no
-            # longer among the options, reset to default. This handles dynamic
-            # option changes and avoids reverting the selection when format_func
-            # depends on object identity/class.
+            # Validate the current value against the new options. Membership is
+            # decided by format_func; if format_func raises on the stored value
+            # (e.g. it depends on object identity/class and the value is a
+            # deepcopy from an earlier run), the stored wire label captured during
+            # register_widget is used as a fallback identity instead. This handles
+            # dynamic option changes without reverting the selection.
             current_value, value_needs_reset = resolve_value_against_options(
-                widget_state.incoming_serialized_value,
                 widget_state.value,
                 opt,
                 formatted_option_to_option_index,
                 index,
                 key,
                 format_func,
+                widget_state.incoming_serialized_value,
             )
 
         if value_needs_reset or widget_state.value_changed:

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -207,19 +207,20 @@ class RegisterWidgetResult(Generic[T_co]):
         returned from the frontend.
 
         Implies an update to the frontend is needed.
-    serialized_value : str or None
-        For string-valued widgets, the widget's stored wire value (its
-        serialized label) captured *before* this run's serializer was
-        registered. This is consistent with the stored value even when the
-        script redefined option classes between runs, so widgets can validate a
-        selection against the current options without re-running a potentially
-        identity-dependent ``format_func`` on a stale value. ``None`` for
-        non-string widgets or when no stored value exists yet.
+    incoming_serialized_value : str or None
+        The widget's serialized (wire) value as it was stored coming into this
+        run, captured before this run's serializer was applied. For string-valued
+        widgets this is the value the frontend currently holds, in serialized
+        form. It is ``None`` for non-string widgets and when the widget has no
+        stored value yet. Because it is the value's own wire form (not re-derived
+        from the deserialized ``value``), widgets can use it to reconcile a
+        stored value against freshly computed state without depending on the
+        deserialized value being current.
     """
 
     value: T_co
     value_changed: bool
-    serialized_value: str | None = None
+    incoming_serialized_value: str | None = None
 
     @classmethod
     def failure(

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -208,14 +208,12 @@ class RegisterWidgetResult(Generic[T_co]):
 
         Implies an update to the frontend is needed.
     incoming_serialized_value : str or None
-        The widget's serialized (wire) value as it was stored coming into this
-        run, captured before this run's serializer was applied. For string-valued
-        widgets this is the value the frontend currently holds, in serialized
-        form. It is ``None`` for non-string widgets and when the widget has no
-        stored value yet. Because it is the value's own wire form (not re-derived
-        from the deserialized ``value``), widgets can use it to reconcile a
-        stored value against freshly computed state without depending on the
-        deserialized value being current.
+        The widget's stored serialized (wire) value as it entered this run,
+        captured before this run's serializer was applied. ``None`` for
+        non-string widgets or when no value is stored yet. Because it's the raw
+        wire form (not re-derived from the deserialized ``value``), callers can
+        reconcile a stored value against freshly computed state even when the
+        deserialized value is stale.
     """
 
     value: T_co

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -207,10 +207,19 @@ class RegisterWidgetResult(Generic[T_co]):
         returned from the frontend.
 
         Implies an update to the frontend is needed.
+    serialized_value : str or None
+        For string-valued widgets, the widget's stored wire value (its
+        serialized label) captured *before* this run's serializer was
+        registered. This is consistent with the stored value even when the
+        script redefined option classes between runs, so widgets can validate a
+        selection against the current options without re-running a potentially
+        identity-dependent ``format_func`` on a stale value. ``None`` for
+        non-string widgets or when no stored value exists yet.
     """
 
     value: T_co
     value_changed: bool
+    serialized_value: str | None = None
 
     @classmethod
     def failure(

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -80,11 +80,6 @@ class SafeSessionState:
         with self._lock:
             return self._state.get_widget_states()
 
-    def get_serialized_widget_value(self, widget_id: str) -> WidgetStateProto | None:
-        """Return the serialized protobuf value for a widget, or None."""
-        with self._lock:
-            return self._state.get_serialized_widget_value(widget_id)
-
     def is_new_state_value(self, user_key: str) -> bool:
         with self._lock:
             return self._state.is_new_state_value(user_key)

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -80,6 +80,11 @@ class SafeSessionState:
         with self._lock:
             return self._state.get_widget_states()
 
+    def get_serialized_widget_value(self, widget_id: str) -> WidgetStateProto | None:
+        """Return the serialized protobuf value for a widget, or None."""
+        with self._lock:
+            return self._state.get_serialized_widget_value(widget_id)
+
     def is_new_state_value(self, user_key: str) -> bool:
         with self._lock:
             return self._state.is_new_state_value(user_key)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -984,22 +984,6 @@ class SessionState:
         """Return a list of serialized widget values for each widget with a value."""
         return self._new_widget_state.as_widget_states()
 
-    def get_serialized_widget_value(self, widget_id: str) -> WidgetStateProto | None:
-        """Return the serialized protobuf value for a widget, or None.
-
-        The value is serialized with the widget's currently-registered
-        serializer, which is consistent with the stored value even when a later
-        run has redefined option classes. This lets callers recover a widget's
-        canonical wire value (e.g. a select widget's formatted label) without
-        re-running a potentially identity-dependent format_func on a value that
-        was stored during an earlier run.
-
-        Must be called before the widget is re-registered this run (i.e. before
-        the metadata is swapped to the current run's serializer) to recover the
-        previous run's label.
-        """
-        return self._new_widget_state.get_serialized(widget_id)
-
     def _get_widget_id(self, k: str) -> str:
         """Turns a value that might be a widget id or a user provided key into
         an appropriate widget id.
@@ -1023,6 +1007,20 @@ class SessionState:
             if the frontend needs to be updated with the current value.
         """
         widget_id = metadata.id
+
+        # Capture the stored wire value *before* swapping in this run's
+        # serializer. For string widgets this recovers the canonical label using
+        # the previous run's serializer (consistent with the stored value), so
+        # widgets can validate against current options without re-running a
+        # potentially identity-dependent format_func on a stale value.
+        prior_serialized_value: str | None = None
+        if metadata.value_type == "string_value":
+            prior_proto = self._new_widget_state.get_serialized(widget_id)
+            if (
+                prior_proto is not None
+                and prior_proto.WhichOneof("value") == "string_value"
+            ):
+                prior_serialized_value = prior_proto.string_value
 
         self._set_widget_metadata(metadata)
         if user_key is not None:
@@ -1122,7 +1120,9 @@ class SessionState:
             user_key is not None and self.is_new_state_value(user_key)
         ) or restored_bound_value
 
-        return RegisterWidgetResult(widget_value, widget_value_changed)
+        return RegisterWidgetResult(
+            widget_value, widget_value_changed, prior_serialized_value
+        )
 
     def _handle_query_param_binding(
         self, metadata: WidgetMetadata[T], user_key: str, widget_id: str

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -984,6 +984,22 @@ class SessionState:
         """Return a list of serialized widget values for each widget with a value."""
         return self._new_widget_state.as_widget_states()
 
+    def get_serialized_widget_value(self, widget_id: str) -> WidgetStateProto | None:
+        """Return the serialized protobuf value for a widget, or None.
+
+        The value is serialized with the widget's currently-registered
+        serializer, which is consistent with the stored value even when a later
+        run has redefined option classes. This lets callers recover a widget's
+        canonical wire value (e.g. a select widget's formatted label) without
+        re-running a potentially identity-dependent format_func on a value that
+        was stored during an earlier run.
+
+        Must be called before the widget is re-registered this run (i.e. before
+        the metadata is swapped to the current run's serializer) to recover the
+        previous run's label.
+        """
+        return self._new_widget_state.get_serialized(widget_id)
+
     def _get_widget_id(self, k: str) -> str:
         """Turns a value that might be a widget id or a user provided key into
         an appropriate widget id.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1009,18 +1009,18 @@ class SessionState:
         widget_id = metadata.id
 
         # Capture the stored wire value *before* swapping in this run's
-        # serializer. For string widgets this recovers the canonical label using
-        # the previous run's serializer (consistent with the stored value), so
-        # widgets can validate against current options without re-running a
-        # potentially identity-dependent format_func on a stale value.
-        prior_serialized_value: str | None = None
+        # serializer, so it reflects the value as it was actually stored (using
+        # the serializer it was stored with). For string widgets we expose this
+        # so callers can reconcile a stored value against freshly computed state
+        # without re-deriving it from the deserialized value.
+        incoming_serialized_value: str | None = None
         if metadata.value_type == "string_value":
-            prior_proto = self._new_widget_state.get_serialized(widget_id)
+            stored_proto = self._new_widget_state.get_serialized(widget_id)
             if (
-                prior_proto is not None
-                and prior_proto.WhichOneof("value") == "string_value"
+                stored_proto is not None
+                and stored_proto.WhichOneof("value") == "string_value"
             ):
-                prior_serialized_value = prior_proto.string_value
+                incoming_serialized_value = stored_proto.string_value
 
         self._set_widget_metadata(metadata)
         if user_key is not None:
@@ -1121,7 +1121,9 @@ class SessionState:
         ) or restored_bound_value
 
         return RegisterWidgetResult(
-            widget_value, widget_value_changed, prior_serialized_value
+            widget_value,
+            widget_value_changed,
+            incoming_serialized_value=incoming_serialized_value,
         )
 
     def _handle_query_param_binding(

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -30,6 +30,7 @@ from streamlit.elements.lib.options_selector_utils import (
     index_,
     maybe_coerce_enum,
     maybe_coerce_enum_sequence,
+    resolve_value_against_options,
     validate_and_sync_multiselect_value_with_options,
     validate_and_sync_range_value_with_options,
     validate_and_sync_value_with_options,
@@ -963,3 +964,75 @@ class TestValidateMultiselectWithCustomObjects(unittest.TestCase):
         assert len(values) == 1
         assert values[0].value == "b"
         assert needs_reset is True
+
+
+class TestResolveValueAgainstOptions:
+    """Tests for the label-based resolver used by the selectbox (Option B)."""
+
+    def test_none_value_returns_unchanged(self) -> None:
+        """A None current value is returned as-is without a reset."""
+        value, reset = resolve_value_against_options(
+            None, None, ["a", "b"], {"a": 0, "b": 1}, 0, None
+        )
+        assert value is None
+        assert reset is False
+
+    def test_label_in_options_returns_current_instance(self) -> None:
+        """A serialized label that maps returns the current option instance.
+
+        The returned object must be the current option (by identity), not the
+        passed-in (potentially stale) ``current_value``.
+        """
+
+        class Stale:  # noqa: B903
+            def __init__(self, name: str):
+                self.name = name
+
+        options = ["A", "B"]
+        stale = Stale("b")
+        value, reset = resolve_value_against_options(
+            "b", stale, options, {"a": 0, "b": 1}, 0, None
+        )
+        assert value is options[1]
+        assert reset is False
+
+    def test_label_not_in_options_resets_to_default(self) -> None:
+        """A label that is no longer among the options resets to the default.
+
+        Covers the model-swap case: the stored value belongs to a different
+        data model, so its label is absent from the new options.
+        """
+
+        class Stale:  # noqa: B903
+            def __init__(self, name: str):
+                self.name = name
+
+        options = ["X", "Y"]
+        stale = Stale("a")
+        value, reset = resolve_value_against_options(
+            "a", stale, options, {"x": 0, "y": 1}, 0, None
+        )
+        assert value == "X"
+        assert reset is True
+        # The stale object must not be returned.
+        assert value is not stale
+
+    def test_no_default_index_resets_to_none(self) -> None:
+        """When the label is invalid and there is no default index, reset to None."""
+        value, reset = resolve_value_against_options(
+            "missing", "missing", ["a", "b"], {"a": 0, "b": 1}, None, None
+        )
+        assert value is None
+        assert reset is True
+
+    def test_missing_serialized_label_falls_back_to_format_func(self) -> None:
+        """With no serialized label, validation falls back to format_func.
+
+        The fallback path keeps a value whose format_func output is in options.
+        """
+        options = ["a", "b", "c"]
+        value, reset = resolve_value_against_options(
+            None, "b", options, {"a": 0, "b": 1, "c": 2}, 0, None
+        )
+        assert value == "b"
+        assert reset is False

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -447,6 +447,34 @@ class TestEnumCoercion:
             is tuple_result
         )
 
+    def test_maybe_coerce_enum_preserves_incoming_serialized_value(self):
+        """Coercing an Enum value must not drop other RegisterWidgetResult fields.
+
+        Otherwise the wire label needed for the identity-dependent format_func
+        fallback is lost for Enum selectboxes.
+        """
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+
+        result = RegisterWidgetResult(EnumA.A, False, incoming_serialized_value="A")
+        coerced = maybe_coerce_enum(result, EnumA, list(EnumA))
+        assert coerced.value is EnumA.A
+        assert coerced.incoming_serialized_value == "A"
+
+    def test_maybe_coerce_enum_sequence_preserves_incoming_serialized_value(self):
+        """Coercing an Enum sequence must not drop other RegisterWidgetResult fields."""
+
+        class EnumA(enum.Enum):
+            A = enum.auto()
+            B = enum.auto()
+
+        result = RegisterWidgetResult([EnumA.A], False, incoming_serialized_value="A")
+        coerced = maybe_coerce_enum_sequence(result, EnumA, list(EnumA))
+        assert coerced.value == [EnumA.A]
+        assert coerced.incoming_serialized_value == "A"
+
 
 class TestCreateMappings:
     """Test class for create_mappings utility function."""

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -967,21 +967,41 @@ class TestValidateMultiselectWithCustomObjects(unittest.TestCase):
 
 
 class TestResolveValueAgainstOptions:
-    """Tests for the label-based resolver used by the selectbox (Option B)."""
+    """Tests for the selectbox value resolver (format_func with wire-label fallback)."""
 
     def test_none_value_returns_unchanged(self) -> None:
         """A None current value is returned as-is without a reset."""
         value, reset = resolve_value_against_options(
-            None, None, ["a", "b"], {"a": 0, "b": 1}, 0, None
+            None, ["a", "b"], {"a": 0, "b": 1}, 0, None
         )
         assert value is None
         assert reset is False
 
-    def test_label_in_options_returns_current_instance(self) -> None:
-        """A serialized label that maps returns the current option instance.
+    def test_value_in_options_is_kept(self) -> None:
+        """A value whose format_func label is in options is kept (no reset)."""
+        options = ["a", "b", "c"]
+        value, reset = resolve_value_against_options(
+            "b", options, {"a": 0, "b": 1, "c": 2}, 0, None
+        )
+        assert value == "b"
+        assert reset is False
 
-        The returned object must be the current option (by identity), not the
-        passed-in (potentially stale) ``current_value``.
+    def test_value_not_in_options_resets_to_default(self) -> None:
+        """A value whose label is no longer among the options resets to default."""
+        options = ["a", "b", "c"]
+        value, reset = resolve_value_against_options(
+            "z", options, {"a": 0, "b": 1, "c": 2}, 0, None
+        )
+        assert value == "a"
+        assert reset is True
+
+    def test_format_func_raises_wire_label_in_options_returns_current_instance(
+        self,
+    ) -> None:
+        """When format_func raises, a matching wire label keeps the selection.
+
+        The returned object must be the current option instance, not the
+        passed-in (potentially stale) value.
         """
 
         class Stale:  # noqa: B903
@@ -990,17 +1010,28 @@ class TestResolveValueAgainstOptions:
 
         options = ["A", "B"]
         stale = Stale("b")
+        lookup: dict[Any, str] = {}  # empty -> format_func raises KeyError
+
+        def format_func(x: Any) -> str:
+            return lookup[x]
+
         value, reset = resolve_value_against_options(
-            "b", stale, options, {"a": 0, "b": 1}, 0, None
+            stale,
+            options,
+            {"a": 0, "b": 1},
+            0,
+            None,
+            format_func,
+            incoming_serialized_value="b",
         )
         assert value is options[1]
         assert reset is False
 
-    def test_label_not_in_options_resets_to_default(self) -> None:
-        """A label that is no longer among the options resets to the default.
+    def test_format_func_raises_wire_label_not_in_options_resets(self) -> None:
+        """When format_func raises and the wire label is absent, reset to default.
 
         Covers the model-swap case: the stored value belongs to a different
-        data model, so its label is absent from the new options.
+        data model, so neither format_func nor its label match the new options.
         """
 
         class Stale:  # noqa: B903
@@ -1009,30 +1040,36 @@ class TestResolveValueAgainstOptions:
 
         options = ["X", "Y"]
         stale = Stale("a")
+        lookup: dict[Any, str] = {}
+
+        def format_func(x: Any) -> str:
+            return lookup[x]
+
         value, reset = resolve_value_against_options(
-            "a", stale, options, {"x": 0, "y": 1}, 0, None
+            stale,
+            options,
+            {"x": 0, "y": 1},
+            0,
+            None,
+            format_func,
+            incoming_serialized_value="a",
         )
         assert value == "X"
         assert reset is True
-        # The stale object must not be returned.
         assert value is not stale
 
-    def test_no_default_index_resets_to_none(self) -> None:
-        """When the label is invalid and there is no default index, reset to None."""
+    def test_format_func_raises_without_wire_label_resets(self) -> None:
+        """When format_func raises and no wire label is available, reset."""
+
+        class Stale:  # noqa: B903
+            def __init__(self, name: str):
+                self.name = name
+
+        def format_func(x: Any) -> str:
+            return x.missing_attr
+
         value, reset = resolve_value_against_options(
-            "missing", "missing", ["a", "b"], {"a": 0, "b": 1}, None, None
+            Stale("a"), ["X", "Y"], {"x": 0, "y": 1}, None, None, format_func
         )
         assert value is None
         assert reset is True
-
-    def test_missing_serialized_label_falls_back_to_format_func(self) -> None:
-        """With no serialized label, validation falls back to format_func.
-
-        The fallback path keeps a value whose format_func output is in options.
-        """
-        options = ["a", "b", "c"]
-        value, reset = resolve_value_against_options(
-            None, "b", options, {"a": 0, "b": 1, "c": 2}, 0, None
-        )
-        assert value == "b"
-        assert reset is False

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -663,6 +663,40 @@ def test_selectbox_keeps_selection_with_identity_dependent_format_func():
     assert at.text[0].value == "Selected: two"
 
 
+def test_selectbox_keeps_enum_selection_with_identity_dependent_format_func():
+    """Enum options keep their selection with an identity-dependent format_func.
+
+    Regression test for the gap where ``maybe_coerce_enum`` dropped the stored
+    wire label. With ``runner.enumCoercion="off"`` the stored value is a stale
+    enum member, so an identity-dependent ``format_func`` raises; the wire label
+    must still be available to keep the selection instead of resetting.
+    """
+
+    def script():
+        from enum import Enum
+
+        import streamlit as st
+
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+
+        labels = {Color.RED: "I", Color.GREEN: "II"}
+
+        def format_func(color: Color) -> str:
+            return labels[color]
+
+        selected = st.selectbox("color", list(Color), format_func=format_func, key="c")
+        st.text(f"Selected: {selected.name}")
+
+    with patch_config_options({"runner.enumCoercion": "off"}):
+        at = AppTest.from_function(script).run()
+        assert at.text[0].value == "Selected: RED"
+
+        at = at.selectbox[0].set_value("II").run()
+        assert at.text[0].value == "Selected: GREEN"
+
+
 def test_None_session_state_value_retained():
     def script():
         import streamlit as st

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -624,6 +624,45 @@ def test_selectbox_enum_coercion():
         test_enum()
 
 
+def test_selectbox_keeps_selection_with_identity_dependent_format_func():
+    """Selection persists when format_func does an identity-dependent lookup.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15618.
+    The option class is defined at module scope (redefined every rerun), so the
+    stored value is an instance of a previous run's class. A format_func that
+    looks the option up in a dict keyed on the current options would raise for
+    that stale instance; the label-based resolver avoids calling format_func on
+    the stored value and keeps the selection.
+    """
+
+    def script():
+        from dataclasses import dataclass
+
+        import streamlit as st
+
+        @dataclass(frozen=True)
+        class MyDataClass:
+            id: int
+            name: str
+
+        a = MyDataClass(1, "one")
+        b = MyDataClass(2, "two")
+        lookup = {a: "I", b: "II"}
+
+        def format_func(option: MyDataClass) -> str:
+            _ = lookup[option]
+            return option.name
+
+        selected = st.selectbox("selectbox", [a, b], format_func=format_func, key="sb")
+        st.text(f"Selected: {selected.name}")
+
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "Selected: one"
+
+    at = at.selectbox[0].set_value("two").run()
+    assert at.text[0].value == "Selected: two"
+
+
 def test_None_session_state_value_retained():
     def script():
         import streamlit as st


### PR DESCRIPTION
## Describe your changes

Fixes a bug where a `st.selectbox` with custom-object options reverts to the
first option whenever a `format_func` performs an identity- or class-dependent
operation (e.g. a dict lookup keyed on the option).

**Root cause:** Streamlit deepcopies the stored widget value across reruns, and
when option classes are redefined each run, the stored value is an instance of a
*previous* run's class. Validation called `format_func` on that stale instance to
check option membership; an identity-dependent `format_func` (like `x[option]`)
raises on the stale instance, so validation treated the value as invalid and
reset the selection to the default.

**Fix:** Selectbox now resolves the stored value against the current options by
its serialized *wire label* when `format_func` raises, instead of relying solely
on `format_func`:

- `RegisterWidgetResult` now carries `incoming_serialized_value` — the widget's
  stored serialized (wire) value, captured in `register_widget` before this run's
  serializer is applied.
- New `resolve_value_against_options` helper validates by `format_func` first and,
  if it raises, falls back to matching the stored wire label against the options.
  On a match it returns the *current* option instance (never the stale deepcopy).
- `selectbox` uses this helper, passing the captured wire label.

When neither `format_func` nor the wire label matches (e.g. options were swapped
to a different data model), the selection still resets to the default as before.

An alternative fix was prepared here: https://github.com/streamlit/streamlit/pull/15624
It was not chosen because it could lead to retaining invalid values in the edge case where the options list is updated. 

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/15618

## Testing Plan

- **Unit tests (Python):** `TestResolveValueAgainstOptions` covers the resolver
  directly (value in options, reset, `format_func` raising with/without a matching
  wire label, and no wire label available). A new `selectbox_test.py` case asserts
  the selection persists with an identity-dependent `format_func`.
- **E2E test:** new `st_selectbox.py` case (selectbox 24) plus
  `test_keeps_selection_with_identity_dependent_format_func`, which verifies the
  selection survives both an interaction and a fresh rerun.
