### PR TITLE
[feature] Add persist_state widget parameter

### DIFF
--- a/e2e_playwright/widget_state_persistence.py
+++ b/e2e_playwright/widget_state_persistence.py
@@ -35,9 +35,26 @@ def _render_widgets() -> None:
     st.button("Rerun", key="rerun")
 
 
+def _render_page_1_only_widgets() -> None:
+    # These widgets are rendered on Page 1 only. Page 2 never renders them, so
+    # a page-scoped value here must be dropped on the page switch even though no
+    # other page re-registers the widget.
+    if st.session_state.get("show"):
+        st.text_input("Page 1 page-scoped", key="p1_page_text", persist_state="page")
+        st.text_input(
+            "Page 1 session-scoped", key="p1_session_text", persist_state="session"
+        )
+        st.text_input("Page 1 not persisted", key="p1_plain_text")
+
+    _render_value("p1_page_text", "p1_page_text")
+    _render_value("p1_session_text", "p1_session_text")
+    _render_value("p1_plain_text", "p1_plain_text")
+
+
 def page_1() -> None:
     st.header("Page 1")
     _render_widgets()
+    _render_page_1_only_widgets()
 
 
 def page_2() -> None:

--- a/e2e_playwright/widget_state_persistence.py
+++ b/e2e_playwright/widget_state_persistence.py
@@ -32,6 +32,8 @@ def _render_widgets() -> None:
     _render_value("session_text", "session_text")
     _render_value("plain_text", "plain_text")
 
+    st.button("Rerun", key="rerun")
+
 
 def page_1() -> None:
     st.header("Page 1")

--- a/e2e_playwright/widget_state_persistence.py
+++ b/e2e_playwright/widget_state_persistence.py
@@ -40,11 +40,9 @@ def _render_page_1_only_widgets() -> None:
     # a page-scoped value here must be dropped on the page switch even though no
     # other page re-registers the widget.
     if st.session_state.get("show"):
-        st.text_input("Page 1 page-scoped", key="p1_page_text", persist_state="page")
-        st.text_input(
-            "Page 1 session-scoped", key="p1_session_text", persist_state="session"
-        )
-        st.text_input("Page 1 not persisted", key="p1_plain_text")
+        st.text_input("Solo page", key="p1_page_text", persist_state="page")
+        st.text_input("Solo session", key="p1_session_text", persist_state="session")
+        st.text_input("Solo plain", key="p1_plain_text")
 
     _render_value("p1_page_text", "p1_page_text")
     _render_value("p1_session_text", "p1_session_text")

--- a/e2e_playwright/widget_state_persistence.py
+++ b/e2e_playwright/widget_state_persistence.py
@@ -1,0 +1,54 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def _render_value(label: str, key: str) -> None:
+    """Always display a widget's current session_state value for assertions."""
+    value = st.session_state.get(key, "UNSET")
+    with st.container(key=f"{key}_value"):
+        st.write(f"{label}: {value}")
+
+
+def _render_widgets() -> None:
+    if st.session_state.get("show"):
+        st.text_input("Page-scoped", key="page_text", persist_state="page")
+        st.text_input("Session-scoped", key="session_text", persist_state="session")
+        st.text_input("Not persisted", key="plain_text")
+
+    _render_value("page_text", "page_text")
+    _render_value("session_text", "session_text")
+    _render_value("plain_text", "plain_text")
+
+
+def page_1() -> None:
+    st.header("Page 1")
+    _render_widgets()
+
+
+def page_2() -> None:
+    st.header("Page 2")
+    _render_widgets()
+
+
+st.sidebar.checkbox("Show widgets", key="show")
+
+pg = st.navigation(
+    [
+        st.Page(page_1, title="Page 1", url_path="page_1", default=True),
+        st.Page(page_2, title="Page 2", url_path="page_2"),
+    ]
+)
+pg.run()

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -48,37 +48,35 @@ def _navigate(app: Page, page_name: str) -> None:
     wait_for_app_run(app)
 
 
-def test_persist_state_retains_value_when_not_rendered(app: Page) -> None:
-    """page/session-scoped values survive unmounting; plain values reset."""
+def test_persist_state_survives_unmount_remount_on_same_page(app: Page) -> None:
+    """Single-page lifecycle for persist_state: persisted values survive an
+    unmount, are restored on the re-rendered widget, are not clobbered by a
+    follow-up rerun, and are never written to the URL. A non-persisted widget
+    resets, mirroring the default redisplay behavior covered in
+    widget_state_test.py.
+    """
     click_checkbox(app, "Show widgets")
     _fill_text_input(app, "Page-scoped", "page_value")
     _fill_text_input(app, "Session-scoped", "session_value")
     _fill_text_input(app, "Not persisted", "plain_value")
 
-    # Hide the widgets so they stop being rendered on the current page.
+    # persist_state is server-side only and must not add URL query params.
+    query_string = app.url.split("?", 1)[1] if "?" in app.url else ""
+    assert query_string == ""
+
+    # Hide the widgets so they stop being rendered, then rerun to settle the
+    # post-cleanup state for the value readouts.
     click_checkbox(app, "Show widgets")
-    # A follow-up rerun settles the post-cleanup state for the value readouts.
     click_button(app, "Rerun")
 
+    # Persisted values survive the unmount; the non-persisted one is dropped.
     _expect_value(app, "page_text", "page_value")
     _expect_value(app, "session_text", "session_value")
-    # The non-persisted widget loses its value once it stops being rendered.
     _expect_value(app, "plain_text", "UNSET")
 
-
-def test_persist_state_restores_widget_value_on_remount(app: Page) -> None:
-    """A persisted widget shows its value again after a hide/show cycle, and a
-    follow-up rerun does not reset it back to the default.
-    """
+    # Show the widgets again: the remounted widgets must render the preserved
+    # values, not their default.
     click_checkbox(app, "Show widgets")
-    _fill_text_input(app, "Page-scoped", "page_value")
-    _fill_text_input(app, "Session-scoped", "session_value")
-
-    # Hide then show the widgets to force an unmount/remount.
-    click_checkbox(app, "Show widgets")
-    click_checkbox(app, "Show widgets")
-
-    # The remounted widgets must render the preserved values, not their default.
     _expect_input_value(app, "Page-scoped", "page_value")
     _expect_input_value(app, "Session-scoped", "session_value")
 
@@ -159,13 +157,3 @@ def test_page_scoped_value_dropped_when_other_page_skips_widget(app: Page) -> No
     expect(get_element_by_key(app, "p1_plain_text_value")).not_to_contain_text(
         "plain_value"
     )
-
-
-def test_persist_state_does_not_touch_query_params(app: Page) -> None:
-    """persist_state is server-side only and must not add URL query params."""
-    click_checkbox(app, "Show widgets")
-    _fill_text_input(app, "Page-scoped", "page_value")
-    _fill_text_input(app, "Session-scoped", "session_value")
-
-    query_string = app.url.split("?", 1)[1] if "?" in app.url else ""
-    assert query_string == ""

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -130,28 +130,35 @@ def test_page_scoped_value_dropped_when_other_page_skips_widget(app: Page) -> No
     in the same flow is preserved and a non-persisted one is dropped.
     """
     click_checkbox(app, "Show widgets")
-    _fill_text_input(app, "Page 1 page-scoped", "page_value")
-    _fill_text_input(app, "Page 1 session-scoped", "session_value")
-    _fill_text_input(app, "Page 1 not persisted", "plain_value")
+    _fill_text_input(app, "Solo page", "page_value")
+    _fill_text_input(app, "Solo session", "session_value")
+    _fill_text_input(app, "Solo plain", "plain_value")
 
     # Page 2 does not render the Page 1-only widgets.
     _navigate(app, "Page 2")
     expect(app.get_by_role("heading", name="Page 2")).to_be_visible()
     # The Page 1-only widgets must not be present on Page 2.
-    expect(get_text_input(app, "Page 1 page-scoped")).to_have_count(0)
+    expect(
+        app.get_by_test_id("stTextInput").filter(has_text="Solo page")
+    ).to_have_count(0)
 
     _navigate(app, "Page 1")
     expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
 
-    # The page-scoped widget must fall back to its default on return.
-    _expect_input_value(app, "Page 1 page-scoped", "")
-    _expect_value(app, "p1_page_text", "UNSET")
+    # The page-scoped widget must fall back to its default on return, and its
+    # dropped value must not resurface in session_state.
+    _expect_input_value(app, "Solo page", "")
+    expect(get_element_by_key(app, "p1_page_text_value")).not_to_contain_text(
+        "page_value"
+    )
     # The session-scoped widget must keep its value across the page switch.
-    _expect_input_value(app, "Page 1 session-scoped", "session_value")
+    _expect_input_value(app, "Solo session", "session_value")
     _expect_value(app, "p1_session_text", "session_value")
     # The non-persisted widget is also dropped.
-    _expect_input_value(app, "Page 1 not persisted", "")
-    _expect_value(app, "p1_plain_text", "UNSET")
+    _expect_input_value(app, "Solo plain", "")
+    expect(get_element_by_key(app, "p1_plain_text_value")).not_to_contain_text(
+        "plain_value"
+    )
 
 
 def test_persist_state_does_not_touch_query_params(app: Page) -> None:

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -124,6 +124,36 @@ def test_page_scoped_value_does_not_leak_across_pages(app: Page) -> None:
     _expect_input_value(app, "Page-scoped", "")
 
 
+def test_page_scoped_value_dropped_when_other_page_skips_widget(app: Page) -> None:
+    """A persist_state="page" widget rendered on Page 1 only is dropped after an
+    A -> B -> A switch (Page 2 never renders it), while a session-scoped widget
+    in the same flow is preserved and a non-persisted one is dropped.
+    """
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Page 1 page-scoped", "page_value")
+    _fill_text_input(app, "Page 1 session-scoped", "session_value")
+    _fill_text_input(app, "Page 1 not persisted", "plain_value")
+
+    # Page 2 does not render the Page 1-only widgets.
+    _navigate(app, "Page 2")
+    expect(app.get_by_role("heading", name="Page 2")).to_be_visible()
+    # The Page 1-only widgets must not be present on Page 2.
+    expect(get_text_input(app, "Page 1 page-scoped")).to_have_count(0)
+
+    _navigate(app, "Page 1")
+    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
+
+    # The page-scoped widget must fall back to its default on return.
+    _expect_input_value(app, "Page 1 page-scoped", "")
+    _expect_value(app, "p1_page_text", "UNSET")
+    # The session-scoped widget must keep its value across the page switch.
+    _expect_input_value(app, "Page 1 session-scoped", "session_value")
+    _expect_value(app, "p1_session_text", "session_value")
+    # The non-persisted widget is also dropped.
+    _expect_input_value(app, "Page 1 not persisted", "")
+    _expect_value(app, "p1_plain_text", "UNSET")
+
+
 def test_persist_state_does_not_touch_query_params(app: Page) -> None:
     """persist_state is server-side only and must not add URL query params."""
     click_checkbox(app, "Show widgets")

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
@@ -61,8 +63,7 @@ def test_persist_state_survives_unmount_remount_on_same_page(app: Page) -> None:
     _fill_text_input(app, "Not persisted", "plain_value")
 
     # persist_state is server-side only and must not add URL query params.
-    query_string = app.url.split("?", 1)[1] if "?" in app.url else ""
-    assert query_string == ""
+    expect(app).not_to_have_url(re.compile(r"\?"))
 
     # Hide the widgets so they stop being rendered, then rerun to settle the
     # post-cleanup state for the value readouts.

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import wait_for_app_run
 from e2e_playwright.shared.app_utils import (
+    click_button,
     click_checkbox,
     get_element_by_key,
     get_text_input,
@@ -30,9 +31,9 @@ def _fill_text_input(app: Page, label: str, value: str) -> None:
 
 
 def _expect_value(app: Page, key: str, expected: str) -> None:
-    expect(get_element_by_key(app, f"{key}_value")).to_contain_text(
-        f"{key}: {expected}"
-    )
+    # The current st.session_state value is always written into a keyed
+    # container so it can be asserted regardless of whether the widget renders.
+    expect(get_element_by_key(app, f"{key}_value")).to_have_text(f"{key}: {expected}")
 
 
 def _navigate(app: Page, page_name: str) -> None:
@@ -40,58 +41,35 @@ def _navigate(app: Page, page_name: str) -> None:
     wait_for_app_run(app)
 
 
-def test_persist_state_when_not_rendered_on_same_page(app: Page) -> None:
+def test_persist_state_retains_value_when_not_rendered(app: Page) -> None:
     """page/session-scoped values survive unmounting; plain values reset."""
     click_checkbox(app, "Show widgets")
-
     _fill_text_input(app, "Page-scoped", "page_value")
     _fill_text_input(app, "Session-scoped", "session_value")
     _fill_text_input(app, "Not persisted", "plain_value")
 
     # Hide the widgets so they stop being rendered on the current page.
     click_checkbox(app, "Show widgets")
+    # A follow-up rerun settles the post-cleanup state for the value readouts.
+    click_button(app, "Rerun")
 
     _expect_value(app, "page_text", "page_value")
     _expect_value(app, "session_text", "session_value")
-    # The non-persisted widget loses its value once unmounted.
+    # The non-persisted widget loses its value once it stops being rendered.
     _expect_value(app, "plain_text", "UNSET")
 
-    # Re-rendering restores the persisted values into the inputs.
-    click_checkbox(app, "Show widgets")
-    expect(get_text_input(app, "Page-scoped").locator("input")).to_have_value(
-        "page_value"
-    )
-    expect(get_text_input(app, "Session-scoped").locator("input")).to_have_value(
-        "session_value"
-    )
-    expect(get_text_input(app, "Not persisted").locator("input")).to_have_value("")
 
-
-def test_session_scope_survives_page_switch_but_page_scope_does_not(
-    app: Page,
-) -> None:
-    """Across a page switch, only session-scoped values are preserved."""
+def test_page_scoped_value_does_not_leak_across_pages(app: Page) -> None:
+    """A persist_state="page" value is dropped after switching pages."""
     click_checkbox(app, "Show widgets")
     _fill_text_input(app, "Page-scoped", "page_value")
-    _fill_text_input(app, "Session-scoped", "session_value")
 
     _navigate(app, "Page 2")
     expect(app.get_by_role("heading", name="Page 2")).to_be_visible()
+    click_button(app, "Rerun")
 
-    # The session-scoped value is preserved on the new page; the page-scoped
-    # value is dropped and falls back to its default (empty) value.
-    expect(get_text_input(app, "Session-scoped").locator("input")).to_have_value(
-        "session_value"
-    )
-    expect(get_text_input(app, "Page-scoped").locator("input")).to_have_value("")
-
-    # Navigating back keeps the session value and still drops the page value.
-    _navigate(app, "Page 1")
-    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
-    expect(get_text_input(app, "Session-scoped").locator("input")).to_have_value(
-        "session_value"
-    )
-    expect(get_text_input(app, "Page-scoped").locator("input")).to_have_value("")
+    # The page-scoped value from Page 1 must not carry over to Page 2.
+    expect(get_element_by_key(app, "page_text_value")).not_to_contain_text("page_value")
 
 
 def test_persist_state_does_not_touch_query_params(app: Page) -> None:
@@ -100,4 +78,5 @@ def test_persist_state_does_not_touch_query_params(app: Page) -> None:
     _fill_text_input(app, "Page-scoped", "page_value")
     _fill_text_input(app, "Session-scoped", "session_value")
 
-    assert "?" not in app.url or app.url.split("?", 1)[1] == ""
+    query_string = app.url.split("?", 1)[1] if "?" in app.url else ""
+    assert query_string == ""

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -1,0 +1,103 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    click_checkbox,
+    get_element_by_key,
+    get_text_input,
+)
+
+
+def _fill_text_input(app: Page, label: str, value: str) -> None:
+    field = get_text_input(app, label).locator("input").first
+    field.fill(value)
+    field.press("Enter")
+    wait_for_app_run(app)
+
+
+def _expect_value(app: Page, key: str, expected: str) -> None:
+    expect(get_element_by_key(app, f"{key}_value")).to_contain_text(
+        f"{key}: {expected}"
+    )
+
+
+def _navigate(app: Page, page_name: str) -> None:
+    app.get_by_test_id("stSidebarNav").get_by_text(page_name, exact=True).click()
+    wait_for_app_run(app)
+
+
+def test_persist_state_when_not_rendered_on_same_page(app: Page) -> None:
+    """page/session-scoped values survive unmounting; plain values reset."""
+    click_checkbox(app, "Show widgets")
+
+    _fill_text_input(app, "Page-scoped", "page_value")
+    _fill_text_input(app, "Session-scoped", "session_value")
+    _fill_text_input(app, "Not persisted", "plain_value")
+
+    # Hide the widgets so they stop being rendered on the current page.
+    click_checkbox(app, "Show widgets")
+
+    _expect_value(app, "page_text", "page_value")
+    _expect_value(app, "session_text", "session_value")
+    # The non-persisted widget loses its value once unmounted.
+    _expect_value(app, "plain_text", "UNSET")
+
+    # Re-rendering restores the persisted values into the inputs.
+    click_checkbox(app, "Show widgets")
+    expect(get_text_input(app, "Page-scoped").locator("input")).to_have_value(
+        "page_value"
+    )
+    expect(get_text_input(app, "Session-scoped").locator("input")).to_have_value(
+        "session_value"
+    )
+    expect(get_text_input(app, "Not persisted").locator("input")).to_have_value("")
+
+
+def test_session_scope_survives_page_switch_but_page_scope_does_not(
+    app: Page,
+) -> None:
+    """Across a page switch, only session-scoped values are preserved."""
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Page-scoped", "page_value")
+    _fill_text_input(app, "Session-scoped", "session_value")
+
+    _navigate(app, "Page 2")
+    expect(app.get_by_role("heading", name="Page 2")).to_be_visible()
+
+    # The session-scoped value is preserved on the new page; the page-scoped
+    # value is dropped and falls back to its default (empty) value.
+    expect(get_text_input(app, "Session-scoped").locator("input")).to_have_value(
+        "session_value"
+    )
+    expect(get_text_input(app, "Page-scoped").locator("input")).to_have_value("")
+
+    # Navigating back keeps the session value and still drops the page value.
+    _navigate(app, "Page 1")
+    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
+    expect(get_text_input(app, "Session-scoped").locator("input")).to_have_value(
+        "session_value"
+    )
+    expect(get_text_input(app, "Page-scoped").locator("input")).to_have_value("")
+
+
+def test_persist_state_does_not_touch_query_params(app: Page) -> None:
+    """persist_state is server-side only and must not add URL query params."""
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Page-scoped", "page_value")
+    _fill_text_input(app, "Session-scoped", "session_value")
+
+    assert "?" not in app.url or app.url.split("?", 1)[1] == ""

--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -36,6 +36,13 @@ def _expect_value(app: Page, key: str, expected: str) -> None:
     expect(get_element_by_key(app, f"{key}_value")).to_have_text(f"{key}: {expected}")
 
 
+def _expect_input_value(app: Page, label: str, expected: str) -> None:
+    # Assert the value actually rendered in the widget UI, not just the
+    # st.session_state readout — a remounted widget must adopt the preserved
+    # value rather than fall back to its default.
+    expect(get_text_input(app, label).locator("input").first).to_have_value(expected)
+
+
 def _navigate(app: Page, page_name: str) -> None:
     app.get_by_test_id("stSidebarNav").get_by_text(page_name, exact=True).click()
     wait_for_app_run(app)
@@ -59,8 +66,47 @@ def test_persist_state_retains_value_when_not_rendered(app: Page) -> None:
     _expect_value(app, "plain_text", "UNSET")
 
 
+def test_persist_state_restores_widget_value_on_remount(app: Page) -> None:
+    """A persisted widget shows its value again after a hide/show cycle, and a
+    follow-up rerun does not reset it back to the default.
+    """
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Page-scoped", "page_value")
+    _fill_text_input(app, "Session-scoped", "session_value")
+
+    # Hide then show the widgets to force an unmount/remount.
+    click_checkbox(app, "Show widgets")
+    click_checkbox(app, "Show widgets")
+
+    # The remounted widgets must render the preserved values, not their default.
+    _expect_input_value(app, "Page-scoped", "page_value")
+    _expect_input_value(app, "Session-scoped", "session_value")
+
+    # A follow-up rerun must not clobber the restored values.
+    click_button(app, "Rerun")
+    _expect_input_value(app, "Page-scoped", "page_value")
+    _expect_input_value(app, "Session-scoped", "session_value")
+
+
+def test_session_scoped_value_restored_after_page_switch(app: Page) -> None:
+    """A persist_state="session" value survives an A -> B -> A page switch and
+    is restored on the re-rendered widget.
+    """
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Session-scoped", "session_value")
+
+    _navigate(app, "Page 2")
+    expect(app.get_by_role("heading", name="Page 2")).to_be_visible()
+    _navigate(app, "Page 1")
+    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
+
+    _expect_input_value(app, "Session-scoped", "session_value")
+
+
 def test_page_scoped_value_does_not_leak_across_pages(app: Page) -> None:
-    """A persist_state="page" value is dropped after switching pages."""
+    """A persist_state="page" value is dropped after switching pages and is not
+    restored when returning to the originating page.
+    """
     click_checkbox(app, "Show widgets")
     _fill_text_input(app, "Page-scoped", "page_value")
 
@@ -70,6 +116,12 @@ def test_page_scoped_value_does_not_leak_across_pages(app: Page) -> None:
 
     # The page-scoped value from Page 1 must not carry over to Page 2.
     expect(get_element_by_key(app, "page_text_value")).not_to_contain_text("page_value")
+    _expect_input_value(app, "Page-scoped", "")
+
+    # Returning to Page 1 must not resurrect the dropped page-scoped value.
+    _navigate(app, "Page 1")
+    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
+    _expect_input_value(app, "Page-scoped", "")
 
 
 def test_persist_state_does_not_touch_query_params(app: Page) -> None:

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -56,7 +56,12 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.ButtonGroup_pb2 import ButtonGroup as ButtonGroupProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
-from streamlit.runtime.state import BindOption, get_session_state, register_widget
+from streamlit.runtime.state import (
+    BindOption,
+    PersistStateOption,
+    get_session_state,
+    register_widget,
+)
 from streamlit.string_util import extract_leading_icon
 
 if TYPE_CHECKING:
@@ -331,6 +336,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> V: ...
     # 2. required=True without default -> V | None
     @overload
@@ -352,6 +358,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> V | None: ...
     # 3. Single-select (default, required=False) -> V | None
     @overload
@@ -373,6 +380,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> V | None: ...
     # 4. Multi-select -> list[V]
     @overload
@@ -394,6 +402,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[V]: ...
     @gather_metrics("pills")
     def pills(
@@ -414,6 +423,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[V] | V | None:
         r"""Display a pills widget.
 
@@ -562,6 +572,16 @@ class ButtonGroupMixin:
             repeated parameters (e.g., ``?tags=Red&tags=Blue``) and duplicates
             are deduplicated.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         list of V, V, or None
@@ -632,6 +652,7 @@ class ButtonGroupMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            persist_state=persist_state,
         )
 
     # segmented_control overloads:
@@ -655,6 +676,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> V: ...
     # 2. required=True without default -> V | None
     @overload
@@ -676,6 +698,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> V | None: ...
     # 3. Single-select (default, required=False) -> V | None
     @overload
@@ -697,6 +720,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> V | None: ...
     # 4. Multi-select -> list[V]
     @overload
@@ -718,6 +742,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[V]: ...
 
     @gather_metrics("segmented_control")
@@ -739,6 +764,7 @@ class ButtonGroupMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[V] | V | None:
         r"""Display a segmented control widget.
 
@@ -887,6 +913,16 @@ class ButtonGroupMixin:
             repeated parameters (e.g., ``?tags=Red&tags=Blue``) and duplicates
             are deduplicated.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         list of V, V, or None
@@ -960,6 +996,7 @@ class ButtonGroupMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            persist_state=persist_state,
         )
 
     @gather_metrics("_internal_button_group")
@@ -982,6 +1019,7 @@ class ButtonGroupMixin:
         help: str | None = None,
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[V] | V | None:
         maybe_raise_label_warnings(label, label_visibility)
 
@@ -1128,6 +1166,7 @@ class ButtonGroupMixin:
             width=width,
             options_format_func=actual_format_func,
             bind=bind,
+            persist_state=persist_state,
             string_formatted_options=formatted_options,
             stale_fallback_container=_stale_fallback_container,
         )
@@ -1166,6 +1205,7 @@ class ButtonGroupMixin:
         width: Width = "content",
         options_format_func: Callable[[Any], str] | None = None,
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         string_formatted_options: list[str] | None = None,
         stale_fallback_container: list[bool] | None = None,
     ) -> RegisterWidgetResult[T]:
@@ -1259,6 +1299,7 @@ class ButtonGroupMixin:
             ctx=ctx,
             value_type="string_array_value",
             bind=bind,
+            persist_state=persist_state,
             clearable=True,
             formatted_options=string_formatted_options,
             max_array_length=1 if selection_mode == "single" else None,

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -580,7 +580,9 @@ class ButtonGroupMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------
@@ -921,7 +923,9 @@ class ButtonGroupMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -576,13 +576,16 @@ class ButtonGroupMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------
@@ -919,13 +922,16 @@ class ButtonGroupMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -39,6 +39,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -76,6 +77,7 @@ class CheckboxMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> bool:
         r"""Display a checkbox widget.
 
@@ -178,6 +180,16 @@ class CheckboxMixin:
             ``st.query_params``; it can only be programmatically changed
             through ``st.session_state``.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         bool
@@ -212,6 +224,7 @@ class CheckboxMixin:
             ctx=ctx,
             width=width,
             bind=bind,
+            persist_state=persist_state,
         )
 
     @gather_metrics("toggle")
@@ -229,6 +242,7 @@ class CheckboxMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> bool:
         r"""Display a toggle widget.
 
@@ -331,6 +345,16 @@ class CheckboxMixin:
             ``st.query_params``; it can only be programmatically changed
             through ``st.session_state``.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         bool
@@ -365,6 +389,7 @@ class CheckboxMixin:
             ctx=ctx,
             width=width,
             bind=bind,
+            persist_state=persist_state,
         )
 
     def _checkbox(
@@ -383,6 +408,7 @@ class CheckboxMixin:
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> bool:
         key = to_key(key)
 
@@ -437,6 +463,7 @@ class CheckboxMixin:
             ctx=ctx,
             value_type="bool_value",
             bind=bind,
+            persist_state=persist_state,
             # Checkbox/toggle is not clearable (always true or false)
             clearable=False,
         )

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -184,13 +184,16 @@ class CheckboxMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------
@@ -351,13 +354,16 @@ class CheckboxMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -188,7 +188,9 @@ class CheckboxMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------
@@ -353,7 +355,9 @@ class CheckboxMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -41,6 +41,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -96,6 +97,7 @@ class ColorPickerMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str:
         r"""Display a color picker widget.
 
@@ -200,6 +202,16 @@ class ColorPickerMixin:
             ``st.query_params``; it can only be programmatically changed
             through ``st.session_state``.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         str
@@ -230,6 +242,7 @@ class ColorPickerMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -247,6 +260,7 @@ class ColorPickerMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str:
         key = to_key(key)
@@ -325,6 +339,7 @@ like '#00FFAA' or '#000'.
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            persist_state=persist_state,
             # Color picker is not clearable (defaults to black)
             clearable=False,
         )

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -210,7 +210,9 @@ class ColorPickerMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -206,13 +206,16 @@ class ColorPickerMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -461,7 +461,9 @@ class MultiSelectMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -59,7 +59,7 @@ from streamlit.errors import (
 from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
-from streamlit.runtime.state import BindOption, register_widget
+from streamlit.runtime.state import BindOption, PersistStateOption, register_widget
 from streamlit.type_util import (
     is_iterable,
 )
@@ -211,6 +211,7 @@ class MultiSelectMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[T]: ...
 
     @overload
@@ -234,6 +235,7 @@ class MultiSelectMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[T | str]: ...
 
     @overload
@@ -257,6 +259,7 @@ class MultiSelectMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[T] | list[T | str]: ...
 
     @gather_metrics("multiselect")
@@ -280,6 +283,7 @@ class MultiSelectMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> list[T] | list[T | str]:
         r"""Display a multiselect widget.
         The multiselect widget starts as empty.
@@ -449,6 +453,16 @@ class MultiSelectMixin:
             are truncated. When ``accept_new_options`` is ``True``, any
             value is accepted.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         list
@@ -526,6 +540,7 @@ class MultiSelectMixin:
             filter_mode=filter_mode,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -549,6 +564,7 @@ class MultiSelectMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> list[T] | list[T | str]:
         key = to_key(key)
@@ -651,6 +667,7 @@ class MultiSelectMixin:
             ctx=ctx,
             value_type="string_array_value",
             bind=bind,
+            persist_state=persist_state,
             # Multiselect is always clearable: users can always remove all
             # selections, so ?key= (empty URL param) should clear to [].
             clearable=True,

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -457,13 +457,16 @@ class MultiSelectMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -48,6 +48,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -118,6 +119,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> int | IntOrNone: ...
 
     # If "max_value: int" is given and all other numerical inputs are
@@ -145,6 +147,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> int | IntOrNone: ...
 
     # If "value=int" is given and all other numerical inputs are "int"s
@@ -170,6 +173,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> int: ...
 
     # If "step=int" is given and all other numerical inputs are "int"s
@@ -197,6 +201,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> int | IntOrNone: ...
 
     # If all numerical inputs are floats (with value optionally being "min")
@@ -224,6 +229,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> float | FloatOrNone: ...
 
     @gather_metrics("number_input")
@@ -247,6 +253,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> Number | None:
         r"""Display a numeric input widget.
 
@@ -411,6 +418,16 @@ class NumberInputMixin:
             from the URL. If ``value`` is ``None``, an empty query
             parameter (e.g., ``?my_key=``) clears the widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         int or float or None
@@ -461,6 +478,7 @@ class NumberInputMixin:
             icon=icon,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -484,6 +502,7 @@ class NumberInputMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> Number | None:
         key = to_key(key)
@@ -686,6 +705,7 @@ class NumberInputMixin:
             ctx=ctx,
             value_type="double_value",
             bind=bind,
+            persist_state=persist_state,
             # Clearable when value=None: the widget can be in an empty state,
             # so ?key= (empty URL param) should clear the widget to None.
             clearable=(value is None),

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -422,13 +422,16 @@ class NumberInputMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -426,7 +426,9 @@ class NumberInputMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/pagination.py
+++ b/lib/streamlit/elements/widgets/pagination.py
@@ -163,7 +163,9 @@ class PaginationMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/pagination.py
+++ b/lib/streamlit/elements/widgets/pagination.py
@@ -30,7 +30,12 @@ from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Pagination_pb2 import Pagination as PaginationProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
-from streamlit.runtime.state import BindOption, get_session_state, register_widget
+from streamlit.runtime.state import (
+    BindOption,
+    PersistStateOption,
+    get_session_state,
+    register_widget,
+)
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -74,6 +79,7 @@ class PaginationMixin:
         kwargs: WidgetKwargs | None = None,
         disabled: bool = False,
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> int:
         r"""Display a pagination widget for navigating through pages of content.
 
@@ -149,6 +155,16 @@ class PaginationMixin:
             parameter name. This enables shareable URLs that preserve the
             widget's state. If ``bind`` is set, ``key`` is required.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         int
@@ -208,6 +224,7 @@ class PaginationMixin:
             kwargs=kwargs,
             disabled=disabled,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -224,6 +241,7 @@ class PaginationMixin:
         kwargs: WidgetKwargs | None,
         disabled: bool,
         bind: BindOption,
+        persist_state: PersistStateOption,
         ctx: ScriptRunContext | None,
     ) -> int:
 
@@ -301,6 +319,7 @@ class PaginationMixin:
             ctx=ctx,
             value_type="int_value",
             bind=bind,
+            persist_state=persist_state,
             # Pagination always has a valid page (1 to num_pages), never empty
             clearable=False,
         )

--- a/lib/streamlit/elements/widgets/pagination.py
+++ b/lib/streamlit/elements/widgets/pagination.py
@@ -159,13 +159,16 @@ class PaginationMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -362,7 +362,9 @@ class RadioMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -48,6 +48,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -156,6 +157,7 @@ class RadioMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> None: ...
 
     @overload
@@ -177,6 +179,7 @@ class RadioMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T: ...
 
     @overload
@@ -198,6 +201,7 @@ class RadioMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | None: ...
 
     @gather_metrics("radio")
@@ -219,6 +223,7 @@ class RadioMixin:
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | None:
         r"""Display a radio button widget.
 
@@ -349,6 +354,16 @@ class RadioMixin:
             from the URL. If ``index`` is ``None``, an empty query
             parameter (e.g., ``?my_key=``) clears the widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         any
@@ -412,6 +427,7 @@ class RadioMixin:
             captions=captions,
             label_visibility=label_visibility,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
             width=width,
         )
@@ -433,6 +449,7 @@ class RadioMixin:
         label_visibility: LabelVisibility = "visible",
         captions: Sequence[str] | None = None,
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
     ) -> T | None:
@@ -533,6 +550,7 @@ class RadioMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            persist_state=persist_state,
             # Clearable when index=None: the widget can be in an empty state,
             # so ?key= (empty URL param) should clear the widget to None.
             clearable=(index is None),

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -358,13 +358,16 @@ class RadioMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -351,13 +351,16 @@ class SelectSliderMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -355,7 +355,9 @@ class SelectSliderMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -54,6 +54,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -174,6 +175,7 @@ class SelectSliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> tuple[T, T]: ...
 
     @overload
@@ -193,6 +195,7 @@ class SelectSliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T: ...
 
     @gather_metrics("select_slider")
@@ -212,6 +215,7 @@ class SelectSliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | tuple[T, T]:
         r"""
         Display a slider widget to select items from a list.
@@ -343,6 +347,16 @@ class SelectSliderMixin:
             from the URL. Range select sliders use repeated parameters
             (e.g., ``?color=red&color=blue``).
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         any value or tuple of any value
@@ -409,6 +423,7 @@ class SelectSliderMixin:
             ctx=ctx,
             width=width,
             bind=bind,
+            persist_state=persist_state,
         )
 
     def _select_slider(
@@ -427,6 +442,7 @@ class SelectSliderMixin:
         ctx: ScriptRunContext | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | tuple[T, T]:
         key = to_key(key)
 
@@ -521,6 +537,7 @@ class SelectSliderMixin:
             ctx=ctx,
             value_type="string_array_value",
             bind=bind,
+            persist_state=persist_state,
             # Select sliders always have a value (no empty/cleared state in
             # the UI), so disallow empty URL params (e.g., ?key=).
             clearable=False,

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -497,7 +497,9 @@ class SelectboxMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -57,6 +57,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -190,6 +191,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> None: ...  # Returns None if options is empty and accept_new_options is False
 
     @overload
@@ -212,6 +214,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T: ...
 
     @overload
@@ -234,6 +237,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | str: ...
 
     @overload
@@ -256,6 +260,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | None: ...
 
     @overload
@@ -278,6 +283,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | str | None: ...
 
     @overload
@@ -300,6 +306,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | str | None: ...
 
     @gather_metrics("selectbox")
@@ -322,6 +329,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> T | str | None:
         r"""Display a select widget.
 
@@ -481,6 +489,16 @@ class SelectboxMixin:
             from the URL. If ``index`` is ``None``, an empty query
             parameter (e.g., ``?my_key=``) clears the widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         any
@@ -567,6 +585,7 @@ class SelectboxMixin:
             filter_mode=filter_mode,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -589,6 +608,7 @@ class SelectboxMixin:
         filter_mode: SelectWidgetFilterMode = "fuzzy",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> T | str | None:
         key = to_key(key)
@@ -693,6 +713,7 @@ class SelectboxMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            persist_state=persist_state,
             # Clearable when index=None: the widget can be in an empty state,
             # so ?key= (empty URL param) should clear the widget to None.
             clearable=(index is None),

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -493,13 +493,16 @@ class SelectboxMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -689,7 +689,9 @@ class SliderMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -54,6 +54,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -263,6 +264,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> int: ...
 
     # If min-value or max_value is provided and a numeric type, and value (if provided)
@@ -286,6 +288,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> SliderNumericT: ...
 
     # If value is provided and a sequence of numeric type,
@@ -309,6 +312,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> tuple[SliderNumericT, SliderNumericT]: ...
 
     # If value is provided positionally and a sequence of numeric type,
@@ -332,6 +336,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> tuple[SliderNumericT, SliderNumericT]: ...
 
     # If min-value is provided and a datelike type, and value (if provided)
@@ -355,6 +360,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> SliderDatelikeT: ...
 
     # If max-value is provided and a datelike type, and value (if provided)
@@ -378,6 +384,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> SliderDatelikeT: ...
 
     # If value is provided and a datelike type, return the same datelike type.
@@ -400,6 +407,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> SliderDatelikeT: ...
 
     # If value is provided and a sequence of datelike type,
@@ -425,6 +433,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> tuple[SliderDatelikeT, SliderDatelikeT]: ...
 
     # If value is provided positionally and a sequence of datelike type,
@@ -449,6 +458,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> tuple[SliderDatelikeT, SliderDatelikeT]: ...
 
     # https://github.com/python/mypy/issues/17614
@@ -471,6 +481,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> Any:
         r"""Display a slider widget.
 
@@ -670,6 +681,16 @@ class SliderMixin:
             from the URL. Range sliders use repeated parameters (e.g.,
             ``?price=10&price=90``).
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         int/float/date/time/datetime or tuple of int/float/date/time/datetime
@@ -734,6 +755,7 @@ class SliderMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -755,6 +777,7 @@ class SliderMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> SliderReturn:
         key = to_key(key)
@@ -1075,6 +1098,7 @@ class SliderMixin:
             ctx=ctx,
             value_type="double_array_value",
             bind=bind,
+            persist_state=persist_state,
             # Sliders always have a value (no empty/cleared state in the UI),
             # so disallow empty URL params (e.g., ?key=).
             clearable=False,

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -685,13 +685,16 @@ class SliderMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -309,7 +309,9 @@ class TextWidgetsMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------
@@ -694,7 +696,9 @@ class TextWidgetsMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -314,7 +314,10 @@ class TextWidgetsMixin:
             requires ``key`` to be set. If ``bind="query-params"`` is also set,
             the binding takes precedence: the value is stored in the URL, so it
             persists across page switches regardless of the ``persist_state``
-            scope.
+            scope. For example,
+            ``st.text_input("Name", key="name", persist_state="session")`` keeps
+            the entered text when the widget is hidden and shown again, or when
+            the user navigates to another page and back.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -305,13 +305,16 @@ class TextWidgetsMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------
@@ -692,13 +695,16 @@ class TextWidgetsMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -42,6 +42,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -106,6 +107,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str:
         pass
 
@@ -129,6 +131,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str | None:
         pass
 
@@ -152,6 +155,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str | None:
         r"""Display a single-line text input widget.
 
@@ -297,6 +301,16 @@ class TextWidgetsMixin:
             This can't be used with ``type="password"``. An empty
             query parameter (e.g., ``?my_key=``) clears the widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         str or None
@@ -333,6 +347,7 @@ class TextWidgetsMixin:
             icon=icon,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -355,6 +370,7 @@ class TextWidgetsMixin:
         icon: str | None = None,
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str | None:
         key = to_key(key)
@@ -453,6 +469,7 @@ class TextWidgetsMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            persist_state=persist_state,
             # Text input is clearable (empty string is a valid value)
             clearable=True,
         )
@@ -490,6 +507,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str:
         pass
 
@@ -511,6 +529,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str | None:
         pass
 
@@ -532,6 +551,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> str | None:
         r"""Display a multi-line text input widget.
 
@@ -666,6 +686,16 @@ class TextWidgetsMixin:
             An empty query parameter (e.g., ``?my_key=``) clears the
             widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         str or None
@@ -708,6 +738,7 @@ class TextWidgetsMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -728,6 +759,7 @@ class TextWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> str | None:
         key = to_key(key)
@@ -797,6 +829,7 @@ class TextWidgetsMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            persist_state=persist_state,
             # Text area is clearable (empty string is a valid value)
             clearable=True,
         )

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -840,13 +840,16 @@ class TimeWidgetsMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------
@@ -1223,13 +1226,16 @@ class TimeWidgetsMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------
@@ -1700,13 +1706,16 @@ class TimeWidgetsMixin:
             How long to preserve the widget's value when it isn't rendered.
             If this is ``None`` (default), the value is lost when the widget
             stops being rendered or the user switches pages. If this is
-            ``"page"``, the value is preserved while the widget isn't rendered
-            on the same page, but is cleared when the user switches pages. If
-            this is ``"session"``, the value is preserved for the entire
-            session, including across page switches. This requires ``key`` to
-            be set. If ``bind="query-params"`` is also set, the binding takes
-            precedence: the value is stored in the URL, so it persists across
-            page switches regardless of the ``persist_state`` scope.
+            ``"page"``, the value is preserved only while the user stays on the
+            page where the widget is defined (for example, while the widget is
+            conditionally hidden); it is discarded on a page switch and is not
+            restored if the user returns to the page. If this is ``"session"``,
+            the value is preserved for the entire session, including across
+            page switches, so it returns when the user navigates back. This
+            requires ``key`` to be set. If ``bind="query-params"`` is also set,
+            the binding takes precedence: the value is stored in the URL, so it
+            persists across page switches regardless of the ``persist_state``
+            scope.
 
         Returns
         -------

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -52,6 +52,7 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -672,6 +673,7 @@ class TimeWidgetsMixin:
         step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> time:
         pass
 
@@ -691,6 +693,7 @@ class TimeWidgetsMixin:
         step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> time | None:
         pass
 
@@ -710,6 +713,7 @@ class TimeWidgetsMixin:
         step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> time | None:
         r"""Display a time input widget.
 
@@ -832,6 +836,16 @@ class TimeWidgetsMixin:
             is ``None``, an empty query parameter (e.g., ``?my_key=``)
             clears the widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         datetime.time or None
@@ -881,6 +895,7 @@ class TimeWidgetsMixin:
             step=step,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -899,6 +914,7 @@ class TimeWidgetsMixin:
         step: int | timedelta = timedelta(minutes=DEFAULT_STEP_MINUTES),
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> time | None:
         key = to_key(key)
@@ -972,6 +988,7 @@ class TimeWidgetsMixin:
             ctx=ctx,
             value_type="string_value",
             bind=bind,
+            persist_state=persist_state,
             clearable=(parsed_time is None),
         )
 
@@ -1009,6 +1026,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> datetime | None: ...
 
     @overload
@@ -1030,6 +1048,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> datetime: ...
 
     @gather_metrics("datetime_input")
@@ -1051,6 +1070,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> datetime | None:
         r"""Display a date and time input widget.
 
@@ -1197,6 +1217,16 @@ class TimeWidgetsMixin:
             the URL. If ``value`` is ``None``, an empty query parameter
             (e.g., ``?my_key=``) clears the widget.
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         datetime.datetime or None
@@ -1252,6 +1282,7 @@ class TimeWidgetsMixin:
             label_visibility=label_visibility,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -1273,6 +1304,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> datetime | None:
         key = to_key(key)
@@ -1388,6 +1420,7 @@ class TimeWidgetsMixin:
             ctx=ctx,
             value_type="string_array_value",
             bind=bind,
+            persist_state=persist_state,
             clearable=(default_value is None),
         )
 
@@ -1440,6 +1473,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> date: ...
 
     @overload
@@ -1460,6 +1494,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> date | None: ...
 
     @overload
@@ -1482,6 +1517,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> DateWidgetRangeReturn: ...
 
     @gather_metrics("date_input")
@@ -1502,6 +1538,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
     ) -> DateWidgetReturn:
         r"""Display a date input widget.
 
@@ -1655,6 +1692,16 @@ class TimeWidgetsMixin:
             parameters (e.g.,
             ``?vacation=2025-01-01&vacation=2025-01-31``).
 
+        persist_state : "page", "session", or None
+            How long to preserve the widget's value when it isn't rendered.
+            If this is ``None`` (default), the value is lost when the widget
+            stops being rendered or the user switches pages. If this is
+            ``"page"``, the value is preserved while the widget isn't rendered
+            on the same page, but is cleared when the user switches pages. If
+            this is ``"session"``, the value is preserved for the entire
+            session, including across page switches. This requires ``key`` to
+            be set.
+
         Returns
         -------
         datetime.date or a tuple with 0-2 dates or None
@@ -1729,6 +1776,7 @@ class TimeWidgetsMixin:
             format=format,
             width=width,
             bind=bind,
+            persist_state=persist_state,
             ctx=ctx,
         )
 
@@ -1749,6 +1797,7 @@ class TimeWidgetsMixin:
         label_visibility: LabelVisibility = "visible",
         width: WidthWithoutContent = "stretch",
         bind: BindOption = None,
+        persist_state: PersistStateOption = None,
         ctx: ScriptRunContext | None = None,
     ) -> DateWidgetReturn:
         key = to_key(key)
@@ -1878,6 +1927,7 @@ class TimeWidgetsMixin:
             ctx=ctx,
             value_type="string_array_value",
             bind=bind,
+            persist_state=persist_state,
             clearable=(parsed_values.value is None),
         )
 

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -844,7 +844,9 @@ class TimeWidgetsMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------
@@ -1225,7 +1227,9 @@ class TimeWidgetsMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------
@@ -1700,7 +1704,9 @@ class TimeWidgetsMixin:
             on the same page, but is cleared when the user switches pages. If
             this is ``"session"``, the value is preserved for the entire
             session, including across page switches. This requires ``key`` to
-            be set.
+            be set. If ``bind="query-params"`` is also set, the binding takes
+            precedence: the value is stored in the URL, so it persists across
+            page switches regardless of the ``persist_state`` scope.
 
         Returns
         -------

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -315,6 +315,17 @@ class StreamlitInvalidBindValueError(LocalizableStreamlitException):
         )
 
 
+class StreamlitInvalidPersistStateError(LocalizableStreamlitException):
+    """Exception raised when an invalid value is specified for the persist_state parameter."""
+
+    def __init__(self, persist_state_value: Any) -> None:
+        super().__init__(
+            'Invalid `persist_state` value: "{persist_state_value}". '
+            'Supported values are: `"page"`, `"session"`, or `None`.',
+            persist_state_value=persist_state_value,
+        )
+
+
 # st.multiselect
 class StreamlitSelectionCountExceedsMaxError(LocalizableStreamlitException):
     """Exception raised when there are more default selections specified than the max allowable selections."""

--- a/lib/streamlit/runtime/state/__init__.py
+++ b/lib/streamlit/runtime/state/__init__.py
@@ -14,6 +14,7 @@
 
 from streamlit.runtime.state.common import (
     BindOption,
+    PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
@@ -34,6 +35,7 @@ from streamlit.runtime.state.widgets import register_widget
 __all__ = [
     "SCRIPT_RUN_WITHOUT_ERRORS_KEY",
     "BindOption",
+    "PersistStateOption",
     "QueryParamsProxy",
     "SafeSessionState",
     "SessionState",

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -55,6 +55,11 @@ WidgetCallback: TypeAlias = Callable[..., None]
 # Currently only supports binding to query params
 BindOption: TypeAlias = Literal["query-params"] | None
 
+# Type for the persist_state parameter on widgets.
+# "page" keeps the widget value while it is not rendered on the same page.
+# "session" keeps it for the whole session, including across page switches.
+PersistStateOption: TypeAlias = Literal["page", "session"] | None
+
 # A deserializer receives the value from whatever field is set on the
 # WidgetState proto, and returns a regular python value. A serializer
 # receives a regular python value, and returns something suitable for
@@ -153,6 +158,11 @@ class WidgetMetadata(Generic[T]):
 
     # Optional binding for the widget's value to external state (e.g. query params)
     bind: BindOption = None
+
+    # Optional server-side persistence of the widget's value when it is not
+    # rendered. "page" keeps the value while on the same page; "session" keeps it
+    # for the whole session, including across page switches. None disables it.
+    persist_state: PersistStateOption = None
 
     # The list of valid formatted option strings for selection widgets.
     # When set, _seed_widget_from_url validates URL values against this list and

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -442,9 +442,9 @@ class SessionState:
     # stale-widget cleanup time.
     _query_param_bound_widget_ids: set[str] = field(default_factory=set)
 
-    # Widget IDs that registered with persist_state, mapped to their scope.
-    # Like _query_param_bound_widget_ids, this is a durable snapshot that
-    # survives the rerun sequencing of a multi-page app page transition.
+    # Widget IDs registered with persist_state, mapped to their scope. Like
+    # _query_param_bound_widget_ids, a durable snapshot that survives the rerun
+    # sequencing of a page transition.
     _persisted_widget_ids: dict[str, Literal["page", "session"]] = field(
         default_factory=dict
     )
@@ -458,10 +458,9 @@ class SessionState:
     # registration on a different page drop the value instead of adopting it.
     _persisted_page_value_pages: dict[str, str] = field(default_factory=dict)
 
-    # Widget IDs of persist_state="page" widgets whose value was dropped because
-    # the session navigated to a page that does not own the value. The frontend
-    # may still hold and resend the dropped value for the reused widget id, so
-    # the next registration must discard that value and fall back to the default.
+    # persist_state="page" widget IDs whose value was dropped on a page switch.
+    # The frontend may resend the stale value for the reused id, so the next
+    # registration must discard it and fall back to the default.
     _page_scoped_widget_ids_to_reset: set[str] = field(default_factory=set)
 
     def __repr__(self) -> str:
@@ -983,17 +982,11 @@ class SessionState:
                 else:
                     self._persisted_page_value_pages.pop(user_key, None)
 
-        # A stale "page"-scoped widget whose owned page differs from the current
-        # page is being dropped because of a page switch. Record the widget id so
-        # its next registration discards the value the frontend may still resend
-        # for the reused widget id, even if that registration happens back on the
-        # originating page.
-        #
-        # Widgets that also bind to query params are exempt: binding takes
-        # precedence over "page" scope, so the value must survive the page switch
-        # (the binding preservation path above keeps it under the user key, ready
-        # to be restored from the URL). Dropping it here would make the
-        # combination lose the value even though plain bind keeps it.
+        # A "page"-scoped widget on a page other than its origin is dropped on
+        # this page switch. Record the id so its next registration discards any
+        # value the frontend resends for the reused id (even back on the origin
+        # page). Bound widgets are exempt: binding takes precedence over "page"
+        # scope, so their value must survive the switch (restored from the URL).
         for wid, scope in self._persisted_widget_ids.items():
             if (
                 scope == "page"
@@ -1006,13 +999,11 @@ class SessionState:
                 )
             ):
                 self._page_scoped_widget_ids_to_reset.add(wid)
-                # If the widget was hidden on its origin page, its value is held
-                # under the user key in _old_state. The widget may never
-                # re-register on this page, so the registration-time reset would
-                # never run — drop the value now so it is not readable via
-                # st.session_state after the page switch, honoring the "page"
-                # scope guarantee. A programmatic set this run lives in
-                # _new_session_state and is intentionally left untouched.
+                # A value held under the user key (widget hidden on its origin
+                # page) may never reach the registration-time reset, so drop it
+                # now — otherwise it stays readable via st.session_state after
+                # the switch. A programmatic set this run lives in
+                # _new_session_state and is left untouched.
                 reset_user_key = wid_key_map.get(wid)
                 if reset_user_key is not None:
                     self._old_state.pop(reset_user_key, None)
@@ -1162,10 +1153,9 @@ class SessionState:
             self._query_param_bound_widget_ids.discard(widget_id)
             self.query_params.unbind_and_clear_param(widget_id)
 
-        # Track persist_state registrations (server-side only, no URL involved).
-        # When a widget also sets bind="query-params", binding takes precedence:
-        # the "page"-scope drops below are skipped for bound widgets so the value
-        # survives page switches (restored from the URL) regardless of scope.
+        # Track persist_state registrations (server-side only, no URL). When bind
+        # is also set it takes precedence: the "page"-scope drops below are
+        # skipped for bound widgets so the value survives page switches.
         dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
             self._persisted_widget_ids[widget_id] = metadata.persist_state
@@ -1175,10 +1165,9 @@ class SessionState:
                 # Binding takes precedence (see above): bound widgets skip the
                 # page-scope drops below but still clear stale page-tracking.
                 is_bound = metadata.bind == "query-params"
-                # A "page"-scoped value preserved while the widget was unmounted
-                # carries the page it belongs to. If the widget now mounts on a
-                # different page, the value must not leak across pages, so drop
-                # it before it is resolved.
+                # A preserved "page"-scoped value carries its origin page. If the
+                # widget now mounts on a different page, drop it before it
+                # resolves so it does not leak across pages.
                 origin_page_hash = self._persisted_page_value_pages.pop(user_key, None)
                 if (
                     not is_bound
@@ -1281,12 +1270,10 @@ class SessionState:
             else:
                 self.query_params.discard_param_no_forward_msg(user_key)
 
-        # A persist_state widget that resolves to a non-default value carried
-        # over from a previous run (preserved while unmounted, or a programmatic
-        # set that has since been compacted into old state) must tell the
-        # frontend to adopt the backend value when the widget (re)mounts.
-        # Otherwise the freshly mounted widget renders at its default and the
-        # next rerun overwrites the preserved value with that default.
+        # A persist_state widget resolving to a non-default value from a previous
+        # run (preserved while unmounted, or a compacted programmatic set) must
+        # tell the frontend to adopt the backend value on (re)mount. Otherwise it
+        # renders at its default and the next rerun overwrites the preserved value.
         restored_persisted_value = False
         if (
             metadata.persist_state is not None
@@ -1299,14 +1286,11 @@ class SessionState:
             if widget_value != default_value:
                 restored_persisted_value = True
 
-        # widget_value_changed indicates to the caller that the widget's
-        # current value is different from what is in the frontend.
-        # Also true when a preserved bound or persisted value was restored —
-        # the frontend is rendering the widget for the first time on this page
-        # and needs to be told to use the backend's resolved value instead of
-        # the widget's default. When a "page"-scoped value was dropped on a page
-        # switch, the frontend may still hold the old value for the reused widget
-        # id, so it must be told to fall back to the default as well.
+        # Tells the caller the widget's value differs from the frontend's. Also
+        # true when a preserved bound/persisted value was restored (the frontend
+        # must adopt the backend value instead of the default on first render),
+        # or when a "page"-scoped value was dropped on a page switch (the
+        # frontend must fall back to the default for the reused widget id).
         widget_value_changed = (
             (user_key is not None and self.is_new_state_value(user_key))
             or restored_bound_value

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -444,7 +444,7 @@ class SessionState:
 
     # Widget IDs that registered with persist_state, mapped to their scope.
     # Like _query_param_bound_widget_ids, this is a durable snapshot that
-    # survives MPA page-transition sequencing.
+    # survives the rerun sequencing of a multi-page app page transition.
     _persisted_widget_ids: dict[str, Literal["page", "session"]] = field(
         default_factory=dict
     )

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1172,10 +1172,8 @@ class SessionState:
             if metadata.persist_state == "page":
                 ctx = get_script_run_ctx()
                 current_page_hash = ctx.page_script_hash if ctx is not None else ""
-                # Binding takes precedence over "page" scope: a bound widget keeps
-                # its value across page switches (restored from the URL), so the
-                # page-scope drops below must not clobber it. Stale page-tracking
-                # is still cleared so it does not accumulate.
+                # Binding takes precedence (see above): bound widgets skip the
+                # page-scope drops below but still clear stale page-tracking.
                 is_bound = metadata.bind == "query-params"
                 # A "page"-scoped value preserved while the widget was unmounted
                 # carries the page it belongs to. If the widget now mounts on a

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -527,20 +527,34 @@ class PersistedWidgetTracker:
         user_key: str,
         scope: Literal["page", "session"],
         current_page: str,
-        is_bound: bool,
-    ) -> bool:
-        """Record a persist_state registration.
-
-        Returns True if the caller should drop the widget's stored value: a
-        "page"-scoped value resolving on a different page than it belongs to, or
-        one flagged for reset after a page switch. Bound widgets keep their value
-        (bind takes precedence) but still clear stale page-tracking.
+    ) -> None:
+        """Record a persist_state registration: the widget's scope and, for
+        "page" scope, the page it is mounting on. This is the durable snapshot
+        that later runs read; "session" scope needs no page, so any stale
+        page-tracking for the widget is cleared.
         """
         self._scopes[widget_id] = scope
-        if scope != "page":
+        if scope == "page":
+            self._widget_pages[widget_id] = current_page
+        else:
             self._widget_pages.pop(widget_id, None)
             self._value_pages.pop(user_key, None)
             self._pending_resets.discard(widget_id)
+
+    def take_pending_drop(
+        self, widget_id: str, user_key: str, current_page: str, is_bound: bool
+    ) -> bool:
+        """Resolve whether a just-registered widget's stored value must be
+        dropped, consuming the one-shot flags behind the decision. Call after
+        register().
+
+        Returns True when a "page"-scoped value must not survive: it belongs to a
+        different page than the one the widget is mounting on, or it was flagged
+        for reset after a page switch. Bound widgets are exempt (bind takes
+        precedence over "page" scope) but still clear the flags so they don't
+        linger. "session" scope never drops.
+        """
+        if self._scopes.get(widget_id) != "page":
             return False
 
         should_drop = False
@@ -556,7 +570,6 @@ class PersistedWidgetTracker:
             self._pending_resets.discard(widget_id)
             if not is_bound:
                 should_drop = True
-        self._widget_pages[widget_id] = current_page
         return should_drop
 
     def untrack(self, widget_id: str, user_key: str) -> None:
@@ -1267,20 +1280,22 @@ class SessionState:
             self._query_param_bound_widget_ids.discard(widget_id)
             self.query_params.unbind_and_clear_param(widget_id)
 
-        # Track persist_state registrations (server-side only, no URL). When bind
-        # is also set it takes precedence: the tracker still records the page but
-        # the value drop is skipped for bound widgets so it survives page switches.
+        # Keep persist_state tracking in sync (server-side only, no URL) and drop
+        # the stored value if the tracker says it's no longer valid for this page.
         dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
             ctx = get_script_run_ctx()
             current_page_hash = ctx.page_script_hash if ctx is not None else ""
-            if self._persist_tracker.register(
+            self._persist_tracker.register(
+                widget_id, user_key, metadata.persist_state, current_page_hash
+            )
+            should_drop = self._persist_tracker.take_pending_drop(
                 widget_id,
                 user_key,
-                metadata.persist_state,
                 current_page_hash,
                 is_bound=metadata.bind == "query-params",
-            ):
+            )
+            if should_drop:
                 dropped_page_scoped_value = self._drop_widget_value(widget_id, user_key)
         elif metadata.persist_state is None and user_key is not None:
             # Widget stopped persisting — drop any stale tracking.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -999,6 +999,16 @@ class SessionState:
                 )
             ):
                 self._page_scoped_widget_ids_to_reset.add(wid)
+                # If the widget was hidden on its origin page, its value is held
+                # under the user key in _old_state. The widget may never
+                # re-register on this page, so the registration-time reset would
+                # never run — drop the value now so it is not readable via
+                # st.session_state after the page switch, honoring the "page"
+                # scope guarantee. A programmatic set this run lives in
+                # _new_session_state and is intentionally left untouched.
+                user_key = wid_key_map.get(wid)
+                if user_key is not None:
+                    self._old_state.pop(user_key, None)
 
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -983,6 +983,15 @@ class SessionState:
         # Re-add preserved query-param-bound values under user keys.
         self._old_state.update(bound_preserved)
 
+        # When a widget remounts under a new id this run (e.g. after a page
+        # switch) but its user key was just preserved from a stale widget, seed
+        # the active widget's value directly. Otherwise the freshly defaulted
+        # new widget-id entry would shadow the preserved user-key value.
+        for user_key, value in bound_preserved.items():
+            active_id = self._key_id_mapper.get_id_from_key(user_key, None)
+            if active_id is not None and active_id in active_widget_ids:
+                self._new_widget_state.set_from_value(active_id, value)
+
         # Remove query param bindings and URL params for stale widgets.
         # For fragment runs, preserve widgets outside the running fragment(s).
         # Note: For MPA page transitions, query param filtering is performed

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -453,6 +453,11 @@ class SessionState:
     # time. Used to drop the value when the user navigates to a different page.
     _persisted_widget_pages: dict[str, str] = field(default_factory=dict)
 
+    # For persist_state="page" values preserved while their widget is unmounted:
+    # the page script hash the value belongs to, keyed by user key. Lets a later
+    # registration on a different page drop the value instead of adopting it.
+    _persisted_page_value_pages: dict[str, str] = field(default_factory=dict)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -481,6 +486,7 @@ class SessionState:
         self._query_param_bound_widget_ids.clear()
         self._persisted_widget_ids.clear()
         self._persisted_widget_pages.clear()
+        self._persisted_page_value_pages.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -960,6 +966,15 @@ class SessionState:
                     bound_preserved[user_key] = self._getitem(key, user_key)
                 except KeyError:
                     bound_preserved[user_key] = self._old_state[key]
+                # Remember which page a "page"-scoped value belongs to so a
+                # later registration on a different page can drop it instead of
+                # adopting it.
+                if self._persisted_widget_ids.get(key) == "page":
+                    self._persisted_page_value_pages[user_key] = (
+                        self._persisted_widget_pages.get(key, ctx.page_script_hash)
+                    )
+                else:
+                    self._persisted_page_value_pages.pop(user_key, None)
 
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,
@@ -1017,6 +1032,13 @@ class SessionState:
             for wid, page_hash in self._persisted_widget_pages.items()
             if wid in wid_key_map
         }
+        # Keep origin-page records only while their value is still preserved
+        # under the user key in old state.
+        self._persisted_page_value_pages = {
+            key: page_hash
+            for key, page_hash in self._persisted_page_value_pages.items()
+            if key in self._old_state
+        }
 
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
@@ -1041,6 +1063,18 @@ class SessionState:
 
     def _set_key_widget_mapping(self, widget_id: str, user_key: str) -> None:
         self._key_id_mapper[user_key] = widget_id
+
+    def _drop_widget_value(self, widget_id: str, user_key: str) -> bool:
+        """Forget any stored value for a widget, both by id and by user key.
+
+        Returns True if a value was removed. Values set during the current run
+        via ``_new_session_state`` represent the current run's intent and are
+        left untouched.
+        """
+        removed = self._new_widget_state.states.pop(widget_id, None) is not None
+        removed = self._old_state.pop(widget_id, None) is not None or removed
+        removed = self._old_state.pop(user_key, None) is not None or removed
+        return removed
 
     def register_widget(
         self, metadata: WidgetMetadata[T], user_key: str | None
@@ -1087,19 +1121,33 @@ class SessionState:
             self.query_params.unbind_and_clear_param(widget_id)
 
         # Track persist_state registrations (server-side only, no URL involved).
+        dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
             self._persisted_widget_ids[widget_id] = metadata.persist_state
             if metadata.persist_state == "page":
                 ctx = get_script_run_ctx()
-                self._persisted_widget_pages[widget_id] = (
-                    ctx.page_script_hash if ctx is not None else ""
-                )
+                current_page_hash = ctx.page_script_hash if ctx is not None else ""
+                # A "page"-scoped value preserved while the widget was unmounted
+                # carries the page it belongs to. If the widget now mounts on a
+                # different page, the value must not leak across pages, so drop
+                # it before it is resolved.
+                origin_page_hash = self._persisted_page_value_pages.pop(user_key, None)
+                if (
+                    origin_page_hash is not None
+                    and origin_page_hash != current_page_hash
+                ):
+                    dropped_page_scoped_value = self._drop_widget_value(
+                        widget_id, user_key
+                    )
+                self._persisted_widget_pages[widget_id] = current_page_hash
             else:
                 self._persisted_widget_pages.pop(widget_id, None)
+                self._persisted_page_value_pages.pop(user_key, None)
         elif metadata.persist_state is None and user_key is not None:
             # Widget stopped persisting — drop any stale tracking.
             self._persisted_widget_ids.pop(widget_id, None)
             self._persisted_widget_pages.pop(widget_id, None)
+            self._persisted_page_value_pages.pop(user_key, None)
 
         if (
             widget_id not in self
@@ -1172,15 +1220,38 @@ class SessionState:
             else:
                 self.query_params.discard_param_no_forward_msg(user_key)
 
+        # A persist_state widget that resolves to a non-default value carried
+        # over from a previous run (preserved while unmounted, or a programmatic
+        # set that has since been compacted into old state) must tell the
+        # frontend to adopt the backend value when the widget (re)mounts.
+        # Otherwise the freshly mounted widget renders at its default and the
+        # next rerun overwrites the preserved value with that default.
+        restored_persisted_value = False
+        if (
+            metadata.persist_state is not None
+            and user_key is not None
+            and not self.is_new_state_value(user_key)
+            and widget_id not in self._new_widget_state
+            and (widget_id in self._old_state or user_key in self._old_state)
+        ):
+            default_value = metadata.deserializer(None)
+            if widget_value != default_value:
+                restored_persisted_value = True
+
         # widget_value_changed indicates to the caller that the widget's
         # current value is different from what is in the frontend.
-        # Also true when a preserved bound value was restored to the URL —
+        # Also true when a preserved bound or persisted value was restored —
         # the frontend is rendering the widget for the first time on this page
         # and needs to be told to use the backend's resolved value instead of
-        # the widget's default.
+        # the widget's default. When a "page"-scoped value was dropped on a page
+        # switch, the frontend may still hold the old value for the reused widget
+        # id, so it must be told to fall back to the default as well.
         widget_value_changed = (
-            user_key is not None and self.is_new_state_value(user_key)
-        ) or restored_bound_value
+            (user_key is not None and self.is_new_state_value(user_key))
+            or restored_bound_value
+            or restored_persisted_value
+            or dropped_page_scoped_value
+        )
 
         return RegisterWidgetResult(
             widget_value,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -405,17 +405,15 @@ class KeyIdMapper:
 class PersistedWidgetTracker:
     """Tracks persist_state bookkeeping for keyed widgets.
 
-    Owns the rules for keeping a widget's value when it stops rendering, so the
-    logic lives in one place instead of being spread across SessionState.
-    "session" scope always preserves the value. "page" scope preserves it only
-    while the user stays on the widget's page and must be actively dropped on a
-    page switch — including telling a remounted widget to ignore a value the
-    frontend may resend for the reused id.
+    "session" scope always preserves a widget's value when it stops rendering.
+    "page" scope preserves it only while the user stays on the widget's page, and
+    drops it on a page switch — including telling a remounted widget to ignore a
+    value the frontend may resend for the reused id.
 
-    This tracker only records policy/metadata; SessionState performs the actual
-    value mutations. bind="query-params" is a separate feature that takes
-    precedence over "page" scope; the tracker is unaware of it and the caller
-    passes ``is_bound`` so bound widgets skip the drops.
+    The tracker only records policy; SessionState performs the actual value
+    mutations. bind="query-params" takes precedence over "page" scope: the
+    tracker is unaware of it, and the caller passes ``is_bound`` so bound widgets
+    skip the drops.
     """
 
     # Widget id -> scope it registered with. A durable snapshot that survives the

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1388,11 +1388,16 @@ class SessionState:
             if widget_value != default_value:
                 restored_persisted_value = True
 
-        # Tells the caller the widget's value differs from the frontend's. Also
-        # true when a preserved bound/persisted value was restored (the frontend
-        # must adopt the backend value instead of the default on first render),
-        # or when a "page"-scoped value was dropped on a page switch (the
-        # frontend must fall back to the default for the reused widget id).
+        # widget_value_changed indicates to the caller that the widget's current
+        # value is different from what is in the frontend. True when:
+        # - the value changed this run;
+        # - a bound value was restored to the URL — the frontend renders the
+        #   widget for the first time on this page and must use the backend's
+        #   resolved value instead of the widget's default;
+        # - a persisted value was restored from session state on (re)mount, for
+        #   the same reason;
+        # - a "page"-scoped value was dropped on a page switch, so the frontend
+        #   must fall back to the default for the reused widget id.
         widget_value_changed = (
             (user_key is not None and self.is_new_state_value(user_key))
             or restored_bound_value

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import pickle  # noqa: S403
 from collections.abc import (
+    Callable,
     Iterator,
     KeysView,
     Mapping,
@@ -472,18 +473,34 @@ class PersistedWidgetTracker:
         else:
             self._value_pages.pop(user_key, None)
 
-    def page_scoped_ids_off_page(self, current_page: str) -> list[str]:
-        """Page-scoped widget ids whose owning page differs from the current one
-        — the candidates to drop on a page switch.
-        """
-        return [
-            wid
-            for wid, scope in self._scopes.items()
-            if scope == "page" and self._widget_pages.get(wid) != current_page
-        ]
+    def mark_page_switch_drops(
+        self,
+        current_page: str,
+        user_key_for: Mapping[str, str],
+        is_exempt: Callable[[str], bool],
+        is_stale: Callable[[str], bool],
+    ) -> list[str]:
+        """Flag "page"-scoped widgets being dropped on this page switch and
+        return the user keys whose preserved value the caller should drop.
 
-    def mark_pending_reset(self, widget_id: str) -> None:
-        self._pending_resets.add(widget_id)
+        A widget qualifies when its owning page differs from the current one and
+        it is stale this run. Flagging it makes its next registration discard a
+        value the frontend may resend for the reused id. ``is_exempt`` skips
+        widgets that must survive the switch (bound widgets, which take
+        precedence over "page" scope); ``is_stale`` reports whether a widget is
+        absent from the current run.
+        """
+        dropped_user_keys: list[str] = []
+        for wid, scope in self._scopes.items():
+            if scope != "page" or self._widget_pages.get(wid) == current_page:
+                continue
+            if is_exempt(wid) or not is_stale(wid):
+                continue
+            self._pending_resets.add(wid)
+            user_key = user_key_for.get(wid)
+            if user_key is not None:
+                dropped_user_keys.append(user_key)
+        return dropped_user_keys
 
     def prune(
         self, live_widget_ids: KeysView[str], live_value_keys: Mapping[str, Any]
@@ -1104,26 +1121,23 @@ class SessionState:
                     key, user_key, ctx.page_script_hash
                 )
 
-        # A "page"-scoped widget on a page other than its origin is dropped on
-        # this page switch. Flag it so its next registration discards any value
-        # the frontend resends for the reused id (even back on the origin page).
-        # Bound widgets are exempt: binding takes precedence over "page" scope, so
-        # their value must survive the switch (restored from the URL).
-        for wid in self._persist_tracker.page_scoped_ids_off_page(ctx.page_script_hash):
-            if wid not in self._query_param_bound_widget_ids and _is_stale_widget(
+        # Drop "page"-scoped values being left behind on a page switch. The
+        # tracker flags each widget for a reset; here we also drop a value held
+        # under its user key (widget hidden on its origin page), which may never
+        # reach the registration-time reset and would otherwise stay readable via
+        # st.session_state after the switch. A programmatic set this run lives in
+        # _new_session_state and is left untouched.
+        for user_key in self._persist_tracker.mark_page_switch_drops(
+            ctx.page_script_hash,
+            wid_key_map,
+            is_exempt=lambda wid: wid in self._query_param_bound_widget_ids,
+            is_stale=lambda wid: _is_stale_widget(
                 self._new_widget_state.widget_metadata.get(wid),
                 active_widget_ids,
                 ctx.fragment_ids_this_run,
-            ):
-                self._persist_tracker.mark_pending_reset(wid)
-                # A value held under the user key (widget hidden on its origin
-                # page) may never reach the registration-time reset, so drop it
-                # now — otherwise it stays readable via st.session_state after
-                # the switch. A programmatic set this run lives in
-                # _new_session_state and is left untouched.
-                reset_user_key = wid_key_map.get(wid)
-                if reset_user_key is not None:
-                    self._old_state.pop(reset_user_key, None)
+            ),
+        ):
+            self._old_state.pop(user_key, None)
 
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1006,9 +1006,9 @@ class SessionState:
                 # st.session_state after the page switch, honoring the "page"
                 # scope guarantee. A programmatic set this run lives in
                 # _new_session_state and is intentionally left untouched.
-                user_key = wid_key_map.get(wid)
-                if user_key is not None:
-                    self._old_state.pop(user_key, None)
+                reset_user_key = wid_key_map.get(wid)
+                if reset_user_key is not None:
+                    self._old_state.pop(reset_user_key, None)
 
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1248,6 +1248,7 @@ class SessionState:
             if the frontend needs to be updated with the current value.
         """
         widget_id = metadata.id
+        ctx = get_script_run_ctx()
 
         # Capture the stored wire value *before* swapping in this run's
         # serializer, so it reflects the value as it was actually stored (using
@@ -1284,7 +1285,6 @@ class SessionState:
         # the stored value if the tracker says it's no longer valid for this page.
         dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
-            ctx = get_script_run_ctx()
             current_page_hash = ctx.page_script_hash if ctx is not None else ""
             self._persist_tracker.register(
                 widget_id, user_key, metadata.persist_state, current_page_hash
@@ -1376,6 +1376,8 @@ class SessionState:
         # run (preserved while unmounted, or a compacted programmatic set) must
         # tell the frontend to adopt the backend value on (re)mount. Otherwise it
         # renders at its default and the next rerun overwrites the preserved value.
+        # For a bind + persist_state widget this can overlap with
+        # restored_bound_value; that is harmless since both only feed the OR below.
         restored_persisted_value = False
         if (
             metadata.persist_state is not None

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -402,6 +402,157 @@ class KeyIdMapper:
 
 
 @dataclass(slots=True)
+class PersistedWidgetTracker:
+    """Tracks persist_state bookkeeping for keyed widgets.
+
+    Owns the rules for keeping a widget's value when it stops rendering, so the
+    logic lives in one place instead of being spread across SessionState.
+    "session" scope always preserves the value. "page" scope preserves it only
+    while the user stays on the widget's page and must be actively dropped on a
+    page switch — including telling a remounted widget to ignore a value the
+    frontend may resend for the reused id.
+
+    This tracker only records policy/metadata; SessionState performs the actual
+    value mutations. bind="query-params" is a separate feature that takes
+    precedence over "page" scope; the tracker is unaware of it and the caller
+    passes ``is_bound`` so bound widgets skip the drops.
+    """
+
+    # Widget id -> scope it registered with. A durable snapshot that survives the
+    # rerun sequencing of a page transition.
+    _scopes: dict[str, Literal["page", "session"]] = field(default_factory=dict)
+    # "page" widget id -> page hash where it last registered.
+    _widget_pages: dict[str, str] = field(default_factory=dict)
+    # "page" user key -> page hash a value preserved while unmounted belongs to.
+    _value_pages: dict[str, str] = field(default_factory=dict)
+    # "page" widget ids whose value was dropped on a page switch; the next
+    # registration must discard a frontend-resent value and reset to the default.
+    _pending_resets: set[str] = field(default_factory=set)
+
+    def clear(self) -> None:
+        self._scopes.clear()
+        self._widget_pages.clear()
+        self._value_pages.clear()
+        self._pending_resets.clear()
+
+    # --- Reads (also used by white-box tests) ------------------------------
+
+    def scope_of(self, widget_id: str) -> Literal["page", "session"] | None:
+        return self._scopes.get(widget_id)
+
+    def page_of(self, widget_id: str) -> str | None:
+        return self._widget_pages.get(widget_id)
+
+    def value_page_of(self, user_key: str) -> str | None:
+        return self._value_pages.get(user_key)
+
+    def has_pending_reset(self, widget_id: str) -> bool:
+        return widget_id in self._pending_resets
+
+    def should_preserve(self, widget_id: str, current_page: str) -> bool:
+        """True if a stale keyed widget's value should be carried forward."""
+        scope = self._scopes.get(widget_id)
+        if scope == "session":
+            return True
+        if scope == "page":
+            return self._widget_pages.get(widget_id) == current_page
+        return False
+
+    # --- Stale-cleanup hooks -----------------------------------------------
+
+    def note_preserved_value(
+        self, widget_id: str, user_key: str, current_page: str
+    ) -> None:
+        """Record (or clear) the origin page for a value carried forward while
+        its widget is unmounted, so a later registration on a different page can
+        drop it instead of adopting it.
+        """
+        if self._scopes.get(widget_id) == "page":
+            self._value_pages[user_key] = self._widget_pages.get(
+                widget_id, current_page
+            )
+        else:
+            self._value_pages.pop(user_key, None)
+
+    def page_scoped_ids_off_page(self, current_page: str) -> list[str]:
+        """Page-scoped widget ids whose owning page differs from the current one
+        — the candidates to drop on a page switch.
+        """
+        return [
+            wid
+            for wid, scope in self._scopes.items()
+            if scope == "page" and self._widget_pages.get(wid) != current_page
+        ]
+
+    def mark_pending_reset(self, widget_id: str) -> None:
+        self._pending_resets.add(widget_id)
+
+    def prune(
+        self, live_widget_ids: KeysView[str], live_value_keys: Mapping[str, Any]
+    ) -> None:
+        """Drop tracking for widgets/keys no longer present, preventing unbounded
+        growth across long sessions.
+        """
+        self._scopes = {w: s for w, s in self._scopes.items() if w in live_widget_ids}
+        self._widget_pages = {
+            w: p for w, p in self._widget_pages.items() if w in live_widget_ids
+        }
+        # Origin-page records are kept only while their value is still preserved
+        # under the user key in old state.
+        self._value_pages = {
+            k: p for k, p in self._value_pages.items() if k in live_value_keys
+        }
+        self._pending_resets.intersection_update(live_widget_ids)
+
+    # --- Registration ------------------------------------------------------
+
+    def register(
+        self,
+        widget_id: str,
+        user_key: str,
+        scope: Literal["page", "session"],
+        current_page: str,
+        is_bound: bool,
+    ) -> bool:
+        """Record a persist_state registration.
+
+        Returns True if the caller should drop the widget's stored value: a
+        "page"-scoped value resolving on a different page than it belongs to, or
+        one flagged for reset after a page switch. Bound widgets keep their value
+        (bind takes precedence) but still clear stale page-tracking.
+        """
+        self._scopes[widget_id] = scope
+        if scope != "page":
+            self._widget_pages.pop(widget_id, None)
+            self._value_pages.pop(user_key, None)
+            self._pending_resets.discard(widget_id)
+            return False
+
+        should_drop = False
+        # A preserved "page" value carries its origin page; drop it if the widget
+        # now mounts on a different page so it cannot leak across pages.
+        origin_page = self._value_pages.pop(user_key, None)
+        if not is_bound and origin_page is not None and origin_page != current_page:
+            should_drop = True
+        # The value was dropped on a page switch while this page skipped the
+        # widget: discard whatever the frontend resends so it falls back to the
+        # default, even back on the origin page.
+        if widget_id in self._pending_resets:
+            self._pending_resets.discard(widget_id)
+            if not is_bound:
+                should_drop = True
+        self._widget_pages[widget_id] = current_page
+        return should_drop
+
+    def untrack(self, widget_id: str, user_key: str) -> None:
+        """Forget all tracking for a widget that stopped persisting."""
+        self._scopes.pop(widget_id, None)
+        self._widget_pages.pop(widget_id, None)
+        self._value_pages.pop(user_key, None)
+        self._pending_resets.discard(widget_id)
+
+
+@dataclass(slots=True)
 class SessionState:
     """SessionState allows users to store values that persist between app
     reruns.
@@ -442,26 +593,12 @@ class SessionState:
     # stale-widget cleanup time.
     _query_param_bound_widget_ids: set[str] = field(default_factory=set)
 
-    # Widget IDs registered with persist_state, mapped to their scope. Like
-    # _query_param_bound_widget_ids, a durable snapshot that survives the rerun
-    # sequencing of a page transition.
-    _persisted_widget_ids: dict[str, Literal["page", "session"]] = field(
-        default_factory=dict
+    # All persist_state bookkeeping (both scopes) lives here. Like
+    # _query_param_bound_widget_ids, it is a durable snapshot that survives the
+    # rerun sequencing of a page transition.
+    _persist_tracker: PersistedWidgetTracker = field(
+        default_factory=PersistedWidgetTracker
     )
-
-    # For persist_state="page" widgets: the page script hash at registration
-    # time. Used to drop the value when the user navigates to a different page.
-    _persisted_widget_pages: dict[str, str] = field(default_factory=dict)
-
-    # For persist_state="page" values preserved while their widget is unmounted:
-    # the page script hash the value belongs to, keyed by user key. Lets a later
-    # registration on a different page drop the value instead of adopting it.
-    _persisted_page_value_pages: dict[str, str] = field(default_factory=dict)
-
-    # persist_state="page" widget IDs whose value was dropped on a page switch.
-    # The frontend may resend the stale value for the reused id, so the next
-    # registration must discard it and fall back to the default.
-    _page_scoped_widget_ids_to_reset: set[str] = field(default_factory=set)
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -489,10 +626,7 @@ class SessionState:
         self._new_widget_state.clear()
         self._key_id_mapper.clear()
         self._query_param_bound_widget_ids.clear()
-        self._persisted_widget_ids.clear()
-        self._persisted_widget_pages.clear()
-        self._persisted_page_value_pages.clear()
-        self._page_scoped_widget_ids_to_reset.clear()
+        self._persist_tracker.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -944,16 +1078,12 @@ class SessionState:
 
         def _should_preserve(widget_id: str) -> bool:
             """True if a stale keyed widget's value should be carried forward."""
-            if widget_id in self._query_param_bound_widget_ids:
-                return True
-            scope = self._persisted_widget_ids.get(widget_id)
-            if scope == "session":
-                return True
-            if scope == "page":
-                return (
-                    self._persisted_widget_pages.get(widget_id) == ctx.page_script_hash
+            return (
+                widget_id in self._query_param_bound_widget_ids
+                or self._persist_tracker.should_preserve(
+                    widget_id, ctx.page_script_hash
                 )
-            return False
+            )
 
         bound_preserved: dict[str, Any] = {}
         for key in self._old_state:
@@ -972,33 +1102,22 @@ class SessionState:
                     bound_preserved[user_key] = self._getitem(key, user_key)
                 except KeyError:
                     bound_preserved[user_key] = self._old_state[key]
-                # Remember which page a "page"-scoped value belongs to so a
-                # later registration on a different page can drop it instead of
-                # adopting it.
-                if self._persisted_widget_ids.get(key) == "page":
-                    self._persisted_page_value_pages[user_key] = (
-                        self._persisted_widget_pages.get(key, ctx.page_script_hash)
-                    )
-                else:
-                    self._persisted_page_value_pages.pop(user_key, None)
+                self._persist_tracker.note_preserved_value(
+                    key, user_key, ctx.page_script_hash
+                )
 
         # A "page"-scoped widget on a page other than its origin is dropped on
-        # this page switch. Record the id so its next registration discards any
-        # value the frontend resends for the reused id (even back on the origin
-        # page). Bound widgets are exempt: binding takes precedence over "page"
-        # scope, so their value must survive the switch (restored from the URL).
-        for wid, scope in self._persisted_widget_ids.items():
-            if (
-                scope == "page"
-                and wid not in self._query_param_bound_widget_ids
-                and self._persisted_widget_pages.get(wid) != ctx.page_script_hash
-                and _is_stale_widget(
-                    self._new_widget_state.widget_metadata.get(wid),
-                    active_widget_ids,
-                    ctx.fragment_ids_this_run,
-                )
+        # this page switch. Flag it so its next registration discards any value
+        # the frontend resends for the reused id (even back on the origin page).
+        # Bound widgets are exempt: binding takes precedence over "page" scope, so
+        # their value must survive the switch (restored from the URL).
+        for wid in self._persist_tracker.page_scoped_ids_off_page(ctx.page_script_hash):
+            if wid not in self._query_param_bound_widget_ids and _is_stale_widget(
+                self._new_widget_state.widget_metadata.get(wid),
+                active_widget_ids,
+                ctx.fragment_ids_this_run,
             ):
-                self._page_scoped_widget_ids_to_reset.add(wid)
+                self._persist_tracker.mark_pending_reset(wid)
                 # A value held under the user key (widget hidden on its origin
                 # page) may never reach the registration-time reset, so drop it
                 # now — otherwise it stays readable via st.session_state after
@@ -1054,24 +1173,7 @@ class SessionState:
         # This prevents unbounded growth across long sessions with many stale
         # widget IDs while preserving currently mapped keyed widgets.
         self._query_param_bound_widget_ids.intersection_update(wid_key_map.keys())
-        self._persisted_widget_ids = {
-            wid: scope
-            for wid, scope in self._persisted_widget_ids.items()
-            if wid in wid_key_map
-        }
-        self._persisted_widget_pages = {
-            wid: page_hash
-            for wid, page_hash in self._persisted_widget_pages.items()
-            if wid in wid_key_map
-        }
-        # Keep origin-page records only while their value is still preserved
-        # under the user key in old state.
-        self._persisted_page_value_pages = {
-            key: page_hash
-            for key, page_hash in self._persisted_page_value_pages.items()
-            if key in self._old_state
-        }
-        self._page_scoped_widget_ids_to_reset.intersection_update(wid_key_map.keys())
+        self._persist_tracker.prune(wid_key_map.keys(), self._old_state)
 
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
@@ -1154,50 +1256,23 @@ class SessionState:
             self.query_params.unbind_and_clear_param(widget_id)
 
         # Track persist_state registrations (server-side only, no URL). When bind
-        # is also set it takes precedence: the "page"-scope drops below are
-        # skipped for bound widgets so the value survives page switches.
+        # is also set it takes precedence: the tracker still records the page but
+        # the value drop is skipped for bound widgets so it survives page switches.
         dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
-            self._persisted_widget_ids[widget_id] = metadata.persist_state
-            if metadata.persist_state == "page":
-                ctx = get_script_run_ctx()
-                current_page_hash = ctx.page_script_hash if ctx is not None else ""
-                # Binding takes precedence (see above): bound widgets skip the
-                # page-scope drops below but still clear stale page-tracking.
-                is_bound = metadata.bind == "query-params"
-                # A preserved "page"-scoped value carries its origin page. If the
-                # widget now mounts on a different page, drop it before it
-                # resolves so it does not leak across pages.
-                origin_page_hash = self._persisted_page_value_pages.pop(user_key, None)
-                if (
-                    not is_bound
-                    and origin_page_hash is not None
-                    and origin_page_hash != current_page_hash
-                ):
-                    dropped_page_scoped_value = self._drop_widget_value(
-                        widget_id, user_key
-                    )
-                # The value was dropped on a page switch while this page did not
-                # render the widget. Discard any value the frontend resends so the
-                # widget falls back to its default, even back on its origin page.
-                if widget_id in self._page_scoped_widget_ids_to_reset:
-                    self._page_scoped_widget_ids_to_reset.discard(widget_id)
-                    if not is_bound:
-                        dropped_page_scoped_value = (
-                            self._drop_widget_value(widget_id, user_key)
-                            or dropped_page_scoped_value
-                        )
-                self._persisted_widget_pages[widget_id] = current_page_hash
-            else:
-                self._persisted_widget_pages.pop(widget_id, None)
-                self._persisted_page_value_pages.pop(user_key, None)
-                self._page_scoped_widget_ids_to_reset.discard(widget_id)
+            ctx = get_script_run_ctx()
+            current_page_hash = ctx.page_script_hash if ctx is not None else ""
+            if self._persist_tracker.register(
+                widget_id,
+                user_key,
+                metadata.persist_state,
+                current_page_hash,
+                is_bound=metadata.bind == "query-params",
+            ):
+                dropped_page_scoped_value = self._drop_widget_value(widget_id, user_key)
         elif metadata.persist_state is None and user_key is not None:
             # Widget stopped persisting — drop any stale tracking.
-            self._persisted_widget_ids.pop(widget_id, None)
-            self._persisted_widget_pages.pop(widget_id, None)
-            self._persisted_page_value_pages.pop(user_key, None)
-            self._page_scoped_widget_ids_to_reset.discard(widget_id)
+            self._persist_tracker.untrack(widget_id, user_key)
 
         if (
             widget_id not in self

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -29,6 +29,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
+    Literal,
     TypeAlias,
     cast,
 )
@@ -441,6 +442,17 @@ class SessionState:
     # stale-widget cleanup time.
     _query_param_bound_widget_ids: set[str] = field(default_factory=set)
 
+    # Widget IDs that registered with persist_state, mapped to their scope.
+    # Like _query_param_bound_widget_ids, this is a durable snapshot that
+    # survives MPA page-transition sequencing.
+    _persisted_widget_ids: dict[str, Literal["page", "session"]] = field(
+        default_factory=dict
+    )
+
+    # For persist_state="page" widgets: the page script hash at registration
+    # time. Used to drop the value when the user navigates to a different page.
+    _persisted_widget_pages: dict[str, str] = field(default_factory=dict)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -467,6 +479,8 @@ class SessionState:
         self._new_widget_state.clear()
         self._key_id_mapper.clear()
         self._query_param_bound_widget_ids.clear()
+        self._persisted_widget_ids.clear()
+        self._persisted_widget_pages.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -915,11 +929,25 @@ class SessionState:
         # (which holds the value from the previous compaction).  We must read it
         # through the full lookup chain before _new_widget_state is cleaned.
         wid_key_map = self._key_id_mapper.id_key_mapping
+
+        def _should_preserve(widget_id: str) -> bool:
+            """True if a stale keyed widget's value should be carried forward."""
+            if widget_id in self._query_param_bound_widget_ids:
+                return True
+            scope = self._persisted_widget_ids.get(widget_id)
+            if scope == "session":
+                return True
+            if scope == "page":
+                return (
+                    self._persisted_widget_pages.get(widget_id) == ctx.page_script_hash
+                )
+            return False
+
         bound_preserved: dict[str, Any] = {}
         for key in self._old_state:
             if (
                 is_element_id(key)
-                and key in self._query_param_bound_widget_ids
+                and _should_preserve(key)
                 and key in wid_key_map
                 and _is_stale_widget(
                     self._new_widget_state.widget_metadata.get(key),
@@ -970,6 +998,16 @@ class SessionState:
         # This prevents unbounded growth across long sessions with many stale
         # widget IDs while preserving currently mapped keyed widgets.
         self._query_param_bound_widget_ids.intersection_update(wid_key_map.keys())
+        self._persisted_widget_ids = {
+            wid: scope
+            for wid, scope in self._persisted_widget_ids.items()
+            if wid in wid_key_map
+        }
+        self._persisted_widget_pages = {
+            wid: page_hash
+            for wid, page_hash in self._persisted_widget_pages.items()
+            if wid in wid_key_map
+        }
 
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
@@ -1038,6 +1076,21 @@ class SessionState:
             # Widget stopped using bind — clean up any stale binding
             self._query_param_bound_widget_ids.discard(widget_id)
             self.query_params.unbind_and_clear_param(widget_id)
+
+        # Track persist_state registrations (server-side only, no URL involved).
+        if metadata.persist_state is not None and user_key is not None:
+            self._persisted_widget_ids[widget_id] = metadata.persist_state
+            if metadata.persist_state == "page":
+                ctx = get_script_run_ctx()
+                self._persisted_widget_pages[widget_id] = (
+                    ctx.page_script_hash if ctx is not None else ""
+                )
+            else:
+                self._persisted_widget_pages.pop(widget_id, None)
+        elif metadata.persist_state is None and user_key is not None:
+            # Widget stopped persisting — drop any stale tracking.
+            self._persisted_widget_ids.pop(widget_id, None)
+            self._persisted_widget_pages.pop(widget_id, None)
 
         if (
             widget_id not in self

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -988,9 +988,16 @@ class SessionState:
         # its next registration discards the value the frontend may still resend
         # for the reused widget id, even if that registration happens back on the
         # originating page.
+        #
+        # Widgets that also bind to query params are exempt: binding takes
+        # precedence over "page" scope, so the value must survive the page switch
+        # (the binding preservation path above keeps it under the user key, ready
+        # to be restored from the URL). Dropping it here would make the
+        # combination lose the value even though plain bind keeps it.
         for wid, scope in self._persisted_widget_ids.items():
             if (
                 scope == "page"
+                and wid not in self._query_param_bound_widget_ids
                 and self._persisted_widget_pages.get(wid) != ctx.page_script_hash
                 and _is_stale_widget(
                     self._new_widget_state.widget_metadata.get(wid),
@@ -1156,23 +1163,28 @@ class SessionState:
             self.query_params.unbind_and_clear_param(widget_id)
 
         # Track persist_state registrations (server-side only, no URL involved).
-        # When a widget also sets bind="query-params", the URL value seeded
-        # above into _new_session_state intentionally takes precedence: a
-        # "page"-scoped drop below cannot remove a URL-backed value, so a bound
-        # widget keeps its value across page switches regardless of scope.
+        # When a widget also sets bind="query-params", binding takes precedence:
+        # the "page"-scope drops below are skipped for bound widgets so the value
+        # survives page switches (restored from the URL) regardless of scope.
         dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
             self._persisted_widget_ids[widget_id] = metadata.persist_state
             if metadata.persist_state == "page":
                 ctx = get_script_run_ctx()
                 current_page_hash = ctx.page_script_hash if ctx is not None else ""
+                # Binding takes precedence over "page" scope: a bound widget keeps
+                # its value across page switches (restored from the URL), so the
+                # page-scope drops below must not clobber it. Stale page-tracking
+                # is still cleared so it does not accumulate.
+                is_bound = metadata.bind == "query-params"
                 # A "page"-scoped value preserved while the widget was unmounted
                 # carries the page it belongs to. If the widget now mounts on a
                 # different page, the value must not leak across pages, so drop
                 # it before it is resolved.
                 origin_page_hash = self._persisted_page_value_pages.pop(user_key, None)
                 if (
-                    origin_page_hash is not None
+                    not is_bound
+                    and origin_page_hash is not None
                     and origin_page_hash != current_page_hash
                 ):
                     dropped_page_scoped_value = self._drop_widget_value(
@@ -1183,10 +1195,11 @@ class SessionState:
                 # widget falls back to its default, even back on its origin page.
                 if widget_id in self._page_scoped_widget_ids_to_reset:
                     self._page_scoped_widget_ids_to_reset.discard(widget_id)
-                    dropped_page_scoped_value = (
-                        self._drop_widget_value(widget_id, user_key)
-                        or dropped_page_scoped_value
-                    )
+                    if not is_bound:
+                        dropped_page_scoped_value = (
+                            self._drop_widget_value(widget_id, user_key)
+                            or dropped_page_scoped_value
+                        )
                 self._persisted_widget_pages[widget_id] = current_page_hash
             else:
                 self._persisted_widget_pages.pop(widget_id, None)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1146,6 +1146,10 @@ class SessionState:
             self.query_params.unbind_and_clear_param(widget_id)
 
         # Track persist_state registrations (server-side only, no URL involved).
+        # When a widget also sets bind="query-params", the URL value seeded
+        # above into _new_session_state intentionally takes precedence: a
+        # "page"-scoped drop below cannot remove a URL-backed value, so a bound
+        # widget keeps its value across page switches regardless of scope.
         dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
             self._persisted_widget_ids[widget_id] = metadata.persist_state

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -422,7 +422,7 @@ class PersistedWidgetTracker:
     _scopes: dict[str, Literal["page", "session"]] = field(default_factory=dict)
     # "page" widget id -> page hash where it last registered.
     _widget_pages: dict[str, str] = field(default_factory=dict)
-    # "page" user key -> page hash a value preserved while unmounted belongs to.
+    # "page" user key -> origin page hash of a value preserved while unmounted.
     _value_pages: dict[str, str] = field(default_factory=dict)
     # "page" widget ids whose value was dropped on a page switch; the next
     # registration must discard a frontend-resent value and reset to the default.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1100,7 +1100,7 @@ class SessionState:
                 )
             )
 
-        bound_preserved: dict[str, Any] = {}
+        preserved_by_key: dict[str, Any] = {}
         for key in self._old_state:
             if (
                 is_element_id(key)
@@ -1114,9 +1114,9 @@ class SessionState:
             ):
                 user_key = wid_key_map[key]
                 try:
-                    bound_preserved[user_key] = self._getitem(key, user_key)
+                    preserved_by_key[user_key] = self._getitem(key, user_key)
                 except KeyError:
-                    bound_preserved[user_key] = self._old_state[key]
+                    preserved_by_key[user_key] = self._old_state[key]
                 self._persist_tracker.note_preserved_value(
                     key, user_key, ctx.page_script_hash
                 )
@@ -1157,15 +1157,15 @@ class SessionState:
             )
         }
 
-        # Re-add preserved query-param-bound values under user keys.
-        self._old_state.update(bound_preserved)
+        # Re-add the preserved values under their user keys.
+        self._old_state.update(preserved_by_key)
 
         # A keyed widget can remount under a new element id this run (e.g. after
         # a page switch) while its user key stays the same. The value was just
         # preserved under the user key, so copy it onto the new element id —
         # otherwise the default written for that id at registration shadows it,
         # since a value stored by element id outranks one stored by user key.
-        for user_key, value in bound_preserved.items():
+        for user_key, value in preserved_by_key.items():
             active_id = self._key_id_mapper.get_id_from_key(user_key, None)
             if active_id is not None and active_id in active_widget_ids:
                 self._new_widget_state.set_from_value(active_id, value)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -458,6 +458,12 @@ class SessionState:
     # registration on a different page drop the value instead of adopting it.
     _persisted_page_value_pages: dict[str, str] = field(default_factory=dict)
 
+    # Widget IDs of persist_state="page" widgets whose value was dropped because
+    # the session navigated to a page that does not own the value. The frontend
+    # may still hold and resend the dropped value for the reused widget id, so
+    # the next registration must discard that value and fall back to the default.
+    _page_scoped_widget_ids_to_reset: set[str] = field(default_factory=set)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -487,6 +493,7 @@ class SessionState:
         self._persisted_widget_ids.clear()
         self._persisted_widget_pages.clear()
         self._persisted_page_value_pages.clear()
+        self._page_scoped_widget_ids_to_reset.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -976,6 +983,23 @@ class SessionState:
                 else:
                     self._persisted_page_value_pages.pop(user_key, None)
 
+        # A stale "page"-scoped widget whose owned page differs from the current
+        # page is being dropped because of a page switch. Record the widget id so
+        # its next registration discards the value the frontend may still resend
+        # for the reused widget id, even if that registration happens back on the
+        # originating page.
+        for wid, scope in self._persisted_widget_ids.items():
+            if (
+                scope == "page"
+                and self._persisted_widget_pages.get(wid) != ctx.page_script_hash
+                and _is_stale_widget(
+                    self._new_widget_state.widget_metadata.get(wid),
+                    active_widget_ids,
+                    ctx.fragment_ids_this_run,
+                )
+            ):
+                self._page_scoped_widget_ids_to_reset.add(wid)
+
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,
             ctx.fragment_ids_this_run,
@@ -1039,6 +1063,7 @@ class SessionState:
             for key, page_hash in self._persisted_page_value_pages.items()
             if key in self._old_state
         }
+        self._page_scoped_widget_ids_to_reset.intersection_update(wid_key_map.keys())
 
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
@@ -1139,15 +1164,26 @@ class SessionState:
                     dropped_page_scoped_value = self._drop_widget_value(
                         widget_id, user_key
                     )
+                # The value was dropped on a page switch while this page did not
+                # render the widget. Discard any value the frontend resends so the
+                # widget falls back to its default, even back on its origin page.
+                if widget_id in self._page_scoped_widget_ids_to_reset:
+                    self._page_scoped_widget_ids_to_reset.discard(widget_id)
+                    dropped_page_scoped_value = (
+                        self._drop_widget_value(widget_id, user_key)
+                        or dropped_page_scoped_value
+                    )
                 self._persisted_widget_pages[widget_id] = current_page_hash
             else:
                 self._persisted_widget_pages.pop(widget_id, None)
                 self._persisted_page_value_pages.pop(user_key, None)
+                self._page_scoped_widget_ids_to_reset.discard(widget_id)
         elif metadata.persist_state is None and user_key is not None:
             # Widget stopped persisting — drop any stale tracking.
             self._persisted_widget_ids.pop(widget_id, None)
             self._persisted_widget_pages.pop(widget_id, None)
             self._persisted_page_value_pages.pop(user_key, None)
+            self._page_scoped_widget_ids_to_reset.discard(widget_id)
 
         if (
             widget_id not in self

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1121,12 +1121,11 @@ class SessionState:
                     key, user_key, ctx.page_script_hash
                 )
 
-        # Drop "page"-scoped values being left behind on a page switch. The
-        # tracker flags each widget for a reset; here we also drop a value held
-        # under its user key (widget hidden on its origin page), which may never
-        # reach the registration-time reset and would otherwise stay readable via
-        # st.session_state after the switch. A programmatic set this run lives in
-        # _new_session_state and is left untouched.
+        # A "page"-scoped value must not outlive a page switch. The widget may
+        # never re-register on the new page (that page might not render it), so
+        # we can't rely on the registration-time reset — drop any value left
+        # under its user key now, or it stays readable via st.session_state.
+        # (A set made this run lives in _new_session_state and is left untouched.)
         for user_key in self._persist_tracker.mark_page_switch_drops(
             ctx.page_script_hash,
             wid_key_map,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1160,10 +1160,11 @@ class SessionState:
         # Re-add preserved query-param-bound values under user keys.
         self._old_state.update(bound_preserved)
 
-        # When a widget remounts under a new id this run (e.g. after a page
-        # switch) but its user key was just preserved from a stale widget, seed
-        # the active widget's value directly. Otherwise the freshly defaulted
-        # new widget-id entry would shadow the preserved user-key value.
+        # A keyed widget can remount under a new element id this run (e.g. after
+        # a page switch) while its user key stays the same. The value was just
+        # preserved under the user key, so copy it onto the new element id —
+        # otherwise the default written for that id at registration shadows it,
+        # since a value stored by element id outranks one stored by user key.
         for user_key, value in bound_preserved.items():
             active_id = self._key_id_mapper.get_id_from_key(user_key, None)
             if active_id is not None and active_id in active_widget_ids:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -16,12 +16,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidBindValueError,
+    StreamlitInvalidPersistStateError,
+)
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ThreadState,
 )
 from streamlit.runtime.state.common import (
     BindOption,
+    PersistStateOption,
     RegisterWidgetResult,
     T,
     ValueFieldName,
@@ -52,6 +57,7 @@ def register_widget(
     value_type: ValueFieldName,
     presenter: WidgetValuePresenter | None = None,
     bind: BindOption = None,
+    persist_state: PersistStateOption = None,
     # For selection widgets with bind="query-params": the valid option strings
     # used to validate and filter URL values during seeding.
     formatted_options: list[str] | None = None,
@@ -96,6 +102,12 @@ def register_widget(
         Optional binding for the widget's value to external state.
         Currently only "query-params" is supported, which binds the widget
         value to a URL query parameter. Requires a user-provided key.
+    persist_state : "page", "session", or None
+        How long to preserve the widget's value when it isn't rendered. If
+        "page", the value is preserved while the widget isn't rendered on the
+        same page; if "session", it is preserved for the whole session,
+        including across page switches; if None, it is not preserved. Requires
+        a user-provided key.
     formatted_options : list[str] or None
         **Temporary** - will be removed once all selection widgets use string-based
         wire formats. Currently used for index-based widgets (pills, segmented_control,
@@ -156,6 +168,17 @@ def register_widget(
                 "This is required for correct empty value handling."
             )
 
+    # Validate persist_state value and key requirement.
+    if persist_state is not None:
+        if persist_state not in ("page", "session"):
+            raise StreamlitInvalidPersistStateError(persist_state)
+        if user_key_from_element_id(element_id) is None:
+            raise StreamlitAPIException(
+                "When using persist_state, the widget must have a unique 'key' "
+                "parameter specified so its value can be preserved across reruns "
+                "and page switches."
+            )
+
     # Create the widget's updated metadata, and register it with session_state.
     metadata = WidgetMetadata(
         element_id,
@@ -169,6 +192,7 @@ def register_widget(
         fragment_id=ThreadState.get().fragment_id if ctx else None,
         presenter=presenter,
         bind=bind,
+        persist_state=persist_state,
         formatted_options=formatted_options,
         clearable=clearable if clearable is not None else False,
         max_array_length=max_array_length,

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -170,7 +170,7 @@ def register_widget(
 
     # Validate persist_state value and key requirement.
     if persist_state is not None:
-        if persist_state not in ("page", "session"):
+        if persist_state not in {"page", "session"}:
             raise StreamlitInvalidPersistStateError(persist_state)
         if user_key_from_element_id(element_id) is None:
             raise StreamlitAPIException(

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -104,12 +104,15 @@ def register_widget(
         value to a URL query parameter. Requires a user-provided key.
     persist_state : "page", "session", or None
         How long to preserve the widget's value when it isn't rendered. If
-        "page", the value is preserved while the widget isn't rendered on the
-        same page; if "session", it is preserved for the whole session,
-        including across page switches; if None, it is not preserved. Requires
-        a user-provided key. If bind="query-params" is also set, the binding
-        takes precedence: the value is stored in the URL and therefore persists
-        across page switches regardless of the persist_state scope.
+        "page", the value is preserved only while the user stays on the page
+        where the widget is defined (for example, while it is conditionally
+        hidden); it is discarded on a page switch and not restored on return.
+        If "session", it is preserved for the whole session, including across
+        page switches, so it returns when the user navigates back. If None, it
+        is not preserved. Requires a user-provided key. If bind="query-params"
+        is also set, the binding takes precedence: the value is stored in the
+        URL and therefore persists across page switches regardless of the
+        persist_state scope.
     formatted_options : list[str] or None
         **Temporary** - will be removed once all selection widgets use string-based
         wire formats. Currently used for index-based widgets (pills, segmented_control,

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -107,7 +107,9 @@ def register_widget(
         "page", the value is preserved while the widget isn't rendered on the
         same page; if "session", it is preserved for the whole session,
         including across page switches; if None, it is not preserved. Requires
-        a user-provided key.
+        a user-provided key. If bind="query-params" is also set, the binding
+        takes precedence: the value is stored in the URL and therefore persists
+        across page switches regardless of the persist_state scope.
     formatted_options : list[str] or None
         **Temporary** - will be removed once all selection widgets use string-based
         wire formats. Currently used for index-based widgets (pills, segmented_control,

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -24,6 +24,7 @@ from streamlit.elements.lib.policies import _LOGGER
 from streamlit.errors import StreamlitAPIException, StreamlitInvalidBindValueError
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
+from streamlit.runtime.state.widgets import register_widget_from_metadata
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
@@ -420,3 +421,37 @@ hello
 
         assert "invalid-value" in str(exc.value)
         assert "query-params" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_persist_state_passed_to_metadata(
+        self, _name: str, widget_func: object
+    ) -> None:
+        """Test that persist_state is threaded onto the widget's WidgetMetadata."""
+        with patch(
+            "streamlit.runtime.state.widgets.register_widget_from_metadata",
+            wraps=register_widget_from_metadata,
+        ) as patched:
+            widget_func("the label", key="my_widget", persist_state="session")
+
+        metadata = patched.call_args[0][0]
+        assert metadata.persist_state == "session"
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_persist_state_without_key_raises(
+        self, _name: str, widget_func: object
+    ) -> None:
+        """Test that persist_state without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException) as exc:
+            widget_func("the label", persist_state="session")
+
+        assert "must have a unique 'key' parameter" in str(exc.value)

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -35,6 +35,7 @@ from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.proto.SelectWidgetFilterMode_pb2 import (
     SelectWidgetFilterMode as ProtoSelectWidgetFilterMode,
 )
+from streamlit.runtime.state.widgets import register_widget_from_metadata
 from streamlit.testing.v1.app_test import AppTest
 from streamlit.testing.v1.util import patch_config_options
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -993,6 +994,24 @@ class SelectboxBindQueryParamsTest(DeltaGeneratorTestCase):
         """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
         with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
             st.selectbox("the label", ["a", "b"], key="my_key", bind="invalid-value")
+
+    def test_persist_state_passed_to_metadata(self) -> None:
+        """Test that persist_state is threaded onto the widget's WidgetMetadata."""
+        with patch(
+            "streamlit.runtime.state.widgets.register_widget_from_metadata",
+            wraps=register_widget_from_metadata,
+        ) as patched:
+            st.selectbox(
+                "the label", ["a", "b", "c"], key="my_key", persist_state="session"
+            )
+
+        metadata = patched.call_args[0][0]
+        assert metadata.persist_state == "session"
+
+    def test_persist_state_without_key_raises(self) -> None:
+        """Test that persist_state without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.selectbox("the label", ["a", "b", "c"], persist_state="session")
 
     def test_bind_with_format_func(self):
         """Test that bind works with format_func."""

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -35,6 +35,7 @@ from streamlit.errors import (
 )
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
+from streamlit.runtime.state.widgets import register_widget_from_metadata
 from streamlit.testing.v1.app_test import AppTest
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
@@ -590,6 +591,22 @@ class SliderBindQueryParamsTest(DeltaGeneratorTestCase):
         """Test that an invalid bind value raises StreamlitInvalidBindValueError."""
         with pytest.raises(StreamlitInvalidBindValueError, match=r"invalid-value"):
             st.slider("the label", key="my_key", bind="invalid-value")
+
+    def test_persist_state_passed_to_metadata(self) -> None:
+        """Test that persist_state is threaded onto the widget's WidgetMetadata."""
+        with patch(
+            "streamlit.runtime.state.widgets.register_widget_from_metadata",
+            wraps=register_widget_from_metadata,
+        ) as patched:
+            st.slider("the label", key="my_key", persist_state="session")
+
+        metadata = patched.call_args[0][0]
+        assert metadata.persist_state == "session"
+
+    def test_persist_state_without_key_raises(self) -> None:
+        """Test that persist_state without a key raises an exception."""
+        with pytest.raises(StreamlitAPIException, match=r"must have a unique 'key'"):
+            st.slider("the label", persist_state="session")
 
     def test_bind_with_int_slider(self):
         """Test that bind works with integer slider."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -112,6 +112,7 @@ def _create_persist_state_metadata(
     persist_state: PersistStateOption,
     value_type: str = "string_value",
     bind: BindOption = None,
+    fragment_id: str | None = None,
 ) -> WidgetMetadata:
     """Helper to create widget metadata for persist_state tests."""
     return WidgetMetadata(
@@ -121,6 +122,7 @@ def _create_persist_state_metadata(
         value_type=value_type,
         bind=bind,
         persist_state=persist_state,
+        fragment_id=fragment_id,
     )
 
 
@@ -2435,6 +2437,78 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
 
         assert result.value == "custom_value"
         assert result.value_changed is True
+
+    def test_persist_state_session_preserved_during_fragment_rerun(self) -> None:
+        """A persist_state="session" widget inside a fragment keeps its value
+        when it stops rendering during a fragment-scoped rerun.
+
+        Cleanup runs with fragment_ids_this_run set, so the widget is only a
+        stale candidate because it belongs to the running fragment. persist_state
+        must preserve it just as it would on a full rerun.
+        """
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(
+            widget_id, "session", fragment_id="frag_1"
+        )
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(fragment_ids_this_run=["frag_1"]),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            # Widget no longer rendered during this fragment-only rerun.
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
+    def test_persist_state_none_dropped_during_fragment_rerun(self) -> None:
+        """A non-persisted widget inside the running fragment is still dropped on
+        a fragment-scoped rerun when it stops rendering (control for the
+        persisted case)."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, None, fragment_id="frag_1")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(fragment_ids_this_run=["frag_1"]),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert "my_widget" not in self.session_state._old_state
+
+    def test_persist_state_page_kept_during_fragment_rerun_same_page(self) -> None:
+        """A persist_state="page" widget keeps its value across a fragment rerun:
+        a fragment rerun stays on the same page, so the page-scope drop must not
+        fire."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(
+            widget_id, "page", fragment_id="frag_1"
+        )
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(
+                fragment_ids_this_run=["frag_1"], page_script_hash="page_1_hash"
+            ),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
 
     @patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -102,6 +102,23 @@ def _create_test_widget_metadata(
     )
 
 
+def _create_persist_state_metadata(
+    widget_id: str,
+    persist_state: str,
+    value_type: str = "string_value",
+    bind: str | None = None,
+) -> WidgetMetadata:
+    """Helper to create widget metadata for persist_state tests."""
+    return WidgetMetadata(
+        id=widget_id,
+        deserializer=lambda x: x if x is not None else "default",
+        serializer=lambda x: x,
+        value_type=value_type,
+        bind=bind,
+        persist_state=persist_state,
+    )
+
+
 class WStateTests(unittest.TestCase):
     def setUp(self):
         wstates = WStates()
@@ -1613,6 +1630,7 @@ class MockScriptRunCtx:
     """Mock script run context for testing."""
 
     fragment_ids_this_run: list[str] | None = None
+    page_script_hash: str = "page_1_hash"
 
 
 class HandleQueryParamBindingTest(DeltaGeneratorTestCase):
@@ -2121,6 +2139,146 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
         self.session_state._remove_stale_widgets(set())
 
         assert self.session_state._query_param_bound_widget_ids == {kept_widget_id}
+
+
+class PersistStatePreservationTest(DeltaGeneratorTestCase):
+    """Tests for persist_state value preservation during stale-widget cleanup."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_persist_state_session_preserves_stale_keyed_value(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A persist_state="session" widget keeps its value when not rendered."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "session")
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert widget_id not in self.session_state._old_state
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_persist_state_page_preserves_value_on_same_page(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A persist_state="page" widget keeps its value while on the same page."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        assert self.session_state._persisted_widget_pages[widget_id] == "page_1_hash"
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_persist_state_page_drops_value_on_page_switch(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A persist_state="page" widget loses its value on a different page."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        # Simulate navigation to a different page by recording a different hash.
+        self.session_state._persisted_widget_pages[widget_id] = "page_2_hash"
+        self.session_state._remove_stale_widgets(set())
+
+        assert widget_id not in self.session_state._old_state
+        assert "my_widget" not in self.session_state._old_state
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_persist_state_none_does_not_preserve(self, mock_ctx: MagicMock) -> None:
+        """A widget without persist_state loses its value when not rendered."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, None)
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert "my_widget" not in self.session_state._old_state
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_register_widget_tracks_persisted_ids(self, mock_ctx: MagicMock) -> None:
+        """Registration records persisted ids and clears them when persistence stops."""
+        widget_id = "$$ID-hash-my_widget"
+        page_metadata = _create_persist_state_metadata(widget_id, "page")
+
+        self.session_state.register_widget(page_metadata, user_key="my_widget")
+        assert self.session_state._persisted_widget_ids[widget_id] == "page"
+        assert widget_id in self.session_state._persisted_widget_pages
+
+        none_metadata = _create_persist_state_metadata(widget_id, None)
+        self.session_state.register_widget(none_metadata, user_key="my_widget")
+        assert widget_id not in self.session_state._persisted_widget_ids
+        assert widget_id not in self.session_state._persisted_widget_pages
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_prunes_unmapped_persisted_widget_ids(self, mock_ctx: MagicMock) -> None:
+        """Persisted ids without a key mapping are pruned during cleanup."""
+        kept_widget_id = "$$ID-hash-kept"
+        stale_widget_id = "$$ID-hash-stale"
+        self.session_state._set_key_widget_mapping(kept_widget_id, "kept")
+        self.session_state._persisted_widget_ids.update(
+            {kept_widget_id: "session", stale_widget_id: "session"}
+        )
+        self.session_state._persisted_widget_pages[stale_widget_id] = "page_1_hash"
+
+        self.session_state._remove_stale_widgets(set())
+
+        assert self.session_state._persisted_widget_ids == {kept_widget_id: "session"}
+        assert stale_widget_id not in self.session_state._persisted_widget_pages
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_persist_state_and_bind_combined_preserves(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A widget that is both bound and persisted is preserved (OR logic)."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(
+            widget_id, "session", bind="query-params"
+        )
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        assert self.session_state._old_state["my_widget"] == "custom_value"
 
 
 class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2341,6 +2341,58 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         assert result.value_changed is True
         assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
 
+    def test_persist_state_page_dropped_after_hide_then_page_switch(self) -> None:
+        """A "page" value preserved by hiding the widget on its origin page is
+        dropped on a subsequent page switch.
+
+        Without an eager drop the value would linger under the user key in
+        _old_state and stay readable via st.session_state on the new page (the
+        widget may never re-register there to trigger the registration-time
+        reset), contradicting the "page"-scope guarantee.
+        """
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        # Page 1: render, set value, then hide (value preserved under user key).
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(frozenset())
+
+        # The same-page hide preserves the value.
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
+        # Page 2: navigate to a page that does not render the widget.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            self.session_state._remove_stale_widgets(frozenset())
+
+        # The value is dropped on the page switch — not just at re-registration.
+        assert "my_widget" not in self.session_state._old_state
+        assert widget_id in self.session_state._page_scoped_widget_ids_to_reset
+
+        # Returning to the origin page still resolves to the default, even if the
+        # frontend resends the stale value for the reused widget id.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
     def test_persist_state_page_same_page_hide_not_marked_for_reset(self) -> None:
         """Hiding a "page" widget on its own page preserves the value and does
         not flag it for a frontend reset."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2186,7 +2186,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         metadata = _create_persist_state_metadata(widget_id, "page")
 
         self.session_state.register_widget(metadata, user_key="my_widget")
-        assert self.session_state._persisted_widget_pages[widget_id] == "page_1_hash"
+        assert self.session_state._persist_tracker.page_of(widget_id) == "page_1_hash"
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
         self.session_state._remove_stale_widgets(set())
@@ -2208,7 +2208,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
         # Simulate navigation to a different page by recording a different hash.
-        self.session_state._persisted_widget_pages[widget_id] = "page_2_hash"
+        self.session_state._persist_tracker._widget_pages[widget_id] = "page_2_hash"
         self.session_state._remove_stale_widgets(set())
 
         assert widget_id not in self.session_state._old_state
@@ -2240,13 +2240,13 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         page_metadata = _create_persist_state_metadata(widget_id, "page")
 
         self.session_state.register_widget(page_metadata, user_key="my_widget")
-        assert self.session_state._persisted_widget_ids[widget_id] == "page"
-        assert widget_id in self.session_state._persisted_widget_pages
+        assert self.session_state._persist_tracker.scope_of(widget_id) == "page"
+        assert self.session_state._persist_tracker.page_of(widget_id) is not None
 
         none_metadata = _create_persist_state_metadata(widget_id, None)
         self.session_state.register_widget(none_metadata, user_key="my_widget")
-        assert widget_id not in self.session_state._persisted_widget_ids
-        assert widget_id not in self.session_state._persisted_widget_pages
+        assert self.session_state._persist_tracker.scope_of(widget_id) is None
+        assert self.session_state._persist_tracker.page_of(widget_id) is None
 
     @patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",
@@ -2257,15 +2257,19 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         kept_widget_id = "$$ID-hash-kept"
         stale_widget_id = "$$ID-hash-stale"
         self.session_state._set_key_widget_mapping(kept_widget_id, "kept")
-        self.session_state._persisted_widget_ids.update(
+        self.session_state._persist_tracker._scopes.update(
             {kept_widget_id: "session", stale_widget_id: "session"}
         )
-        self.session_state._persisted_widget_pages[stale_widget_id] = "page_1_hash"
+        self.session_state._persist_tracker._widget_pages[stale_widget_id] = (
+            "page_1_hash"
+        )
 
         self.session_state._remove_stale_widgets(set())
 
-        assert self.session_state._persisted_widget_ids == {kept_widget_id: "session"}
-        assert stale_widget_id not in self.session_state._persisted_widget_pages
+        assert self.session_state._persist_tracker._scopes == {
+            kept_widget_id: "session"
+        }
+        assert self.session_state._persist_tracker.page_of(stale_widget_id) is None
 
     def test_persist_state_page_drops_carried_value_on_remount_other_page(
         self,
@@ -2286,7 +2290,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
             self.session_state._compact_state()
             self.session_state._remove_stale_widgets(set())
 
-        assert self.session_state._persisted_page_value_pages["my_widget"] == (
+        assert self.session_state._persist_tracker.value_page_of("my_widget") == (
             "page_1_hash"
         )
 
@@ -2325,7 +2329,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         ):
             self.session_state._remove_stale_widgets(frozenset())
 
-        assert widget_id in self.session_state._page_scoped_widget_ids_to_reset
+        assert self.session_state._persist_tracker.has_pending_reset(widget_id)
         assert "my_widget" not in self.session_state._old_state
 
         # Return to the origin page; the frontend resends the cached value for
@@ -2341,7 +2345,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
 
         assert result.value == "default"
         assert result.value_changed is True
-        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+        assert not self.session_state._persist_tracker.has_pending_reset(widget_id)
 
     def test_persist_state_page_dropped_after_hide_then_page_switch(self) -> None:
         """A "page" value preserved by hiding the widget on its origin page is
@@ -2379,7 +2383,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
 
         # The value is dropped on the page switch — not just at re-registration.
         assert "my_widget" not in self.session_state._old_state
-        assert widget_id in self.session_state._page_scoped_widget_ids_to_reset
+        assert self.session_state._persist_tracker.has_pending_reset(widget_id)
 
         # Returning to the origin page still resolves to the default, even if the
         # frontend resends the stale value for the reused widget id.
@@ -2412,7 +2416,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
             self.session_state._compact_state()
             self.session_state._remove_stale_widgets(frozenset())
 
-        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+        assert not self.session_state._persist_tracker.has_pending_reset(widget_id)
         assert self.session_state._old_state["my_widget"] == "custom_value"
 
     def test_persist_state_page_keeps_carried_value_on_remount_same_page(
@@ -2508,7 +2512,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
             self.session_state._remove_stale_widgets(frozenset())
 
         assert self.session_state._old_state["my_widget"] == "custom_value"
-        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+        assert not self.session_state._persist_tracker.has_pending_reset(widget_id)
 
     @patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",
@@ -2611,7 +2615,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         # Binding wins: the value is preserved and the widget is not flagged for
         # a reset (unlike a non-bound "page" widget, which would be dropped).
         assert self.session_state._old_state["my_widget"] == "custom_value"
-        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+        assert not self.session_state._persist_tracker.has_pending_reset(widget_id)
 
         # Return to the origin page with no URL value to seed: the widget still
         # resolves to the preserved bound value rather than the default.

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2292,6 +2292,70 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         assert result.value == "default"
         assert result.value_changed is True
 
+    def test_persist_state_page_drops_value_when_other_page_skips_widget(
+        self,
+    ) -> None:
+        """A "page" value is dropped after navigating to a page that does not
+        render the widget, and stays dropped when the widget remounts back on
+        its origin page even if the frontend resends the stale value."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+
+        # Navigate to a page that does not render the widget.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert widget_id in self.session_state._page_scoped_widget_ids_to_reset
+        assert "my_widget" not in self.session_state._old_state
+
+        # Return to the origin page; the frontend resends the cached value for
+        # the reused widget id, which must be discarded.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+
+    def test_persist_state_page_same_page_hide_not_marked_for_reset(self) -> None:
+        """Hiding a "page" widget on its own page preserves the value and does
+        not flag it for a frontend reset."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
     def test_persist_state_page_keeps_carried_value_on_remount_same_page(
         self,
     ) -> None:

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2496,6 +2496,59 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
 
         assert result.value == "custom_value"
 
+    def test_bind_value_survives_page_switch_without_url_seed(self) -> None:
+        """bind="query-params" + persist_state="page" keeps its value across a
+        page switch even when navigation dropped the URL param.
+
+        ``st.navigation`` links go to the bare page URL, so a bound widget's
+        query param is removed on a page switch and there is nothing to re-seed
+        on return. The value is held under the user key by the binding
+        preservation path, and binding takes precedence over "page" scope, so
+        the page-scope drop/reset must not clobber it. (Plain ``bind`` keeps the
+        value here; the combination must behave the same.)
+        """
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(
+            widget_id, "page", bind="query-params"
+        )
+
+        # Page 1 (origin): render, set value, then hide on the same page.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+
+        # Page 2: navigate to a page that does not render the widget. No query
+        # params are seeded, mirroring navigation dropping the URL param.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            self.session_state._remove_stale_widgets(frozenset())
+
+        # Binding wins: the value is preserved and the widget is not flagged for
+        # a reset (unlike a non-bound "page" widget, which would be dropped).
+        assert self.session_state._old_state["my_widget"] == "custom_value"
+        assert widget_id not in self.session_state._page_scoped_widget_ids_to_reset
+
+        # Return to the origin page with no URL value to seed: the widget still
+        # resolves to the preserved bound value rather than the default.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+
 
 class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
     """Tests for URL sync in register_widget for bound widgets."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2404,6 +2404,46 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
 
         assert self.session_state._old_state["my_widget"] == "custom_value"
 
+    def test_bind_takes_precedence_over_persist_state_page_on_page_switch(
+        self,
+    ) -> None:
+        """bind="query-params" wins over persist_state="page" on a page switch.
+
+        The two options are contradictory on page switch (binding stores the
+        value in the URL, which is global; "page" scope wants it dropped). By
+        design binding wins, so the URL value is restored on the new page
+        instead of being dropped.
+        """
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(
+            widget_id, "page", bind="query-params"
+        )
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(set())
+
+        # Binding keeps the value in the URL across the page switch, so it is
+        # present in the initial query params seen on the destination page.
+        self.session_state.query_params.set_initial_query_params(
+            "my_widget=custom_value"
+        )
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+
 
 class RegisterWidgetUrlSyncTest(DeltaGeneratorTestCase):
     """Tests for URL sync in register_widget for bound widgets."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2260,6 +2260,61 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         assert self.session_state._persisted_widget_ids == {kept_widget_id: "session"}
         assert stale_widget_id not in self.session_state._persisted_widget_pages
 
+    def test_persist_state_page_drops_carried_value_on_remount_other_page(
+        self,
+    ) -> None:
+        """A "page" value preserved on one page is dropped when the widget
+        remounts on a different page, and the frontend is told to reset."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(set())
+
+        assert self.session_state._persisted_page_value_pages["my_widget"] == (
+            "page_1_hash"
+        )
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    def test_persist_state_page_keeps_carried_value_on_remount_same_page(
+        self,
+    ) -> None:
+        """A "page" value preserved on a page is kept when the widget remounts
+        on the same page."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(set())
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
     @patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",
         return_value=MockScriptRunCtx(),
@@ -2441,6 +2496,84 @@ class RegisterWidgetValueChangedTest(DeltaGeneratorTestCase):
 
         assert result.value == "custom_value"
         assert result.value_changed is False
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_when_persisted_value_restored(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A remounted persist_state widget tells the frontend to adopt the
+        preserved value instead of the element default."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_persist_state_metadata(widget_id, "session")
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_false_for_non_persisted_remount(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A plain (persist_state=None) widget does not signal value_changed
+        on remount, so the restore behavior is specific to persisted widgets."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_persist_state_metadata(widget_id, None)
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value_changed is False
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_after_full_preserve_cycle(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """After a persist_state widget is preserved while unmounted, remounting
+        it returns value_changed=True so the frontend adopts the kept value."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "session")
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_for_programmatic_set_in_old_state(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A programmatic value compacted into old state under the user key is
+        pushed to a persisted widget on its first mount this run."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
 
 
 class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2193,23 +2193,29 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
 
         assert self.session_state._old_state["my_widget"] == "custom_value"
 
-    @patch(
-        "streamlit.runtime.state.session_state.get_script_run_ctx",
-        return_value=MockScriptRunCtx(),
-    )
-    def test_persist_state_page_drops_value_on_page_switch(
-        self, mock_ctx: MagicMock
-    ) -> None:
+    def test_persist_state_page_drops_value_on_page_switch(self) -> None:
         """A persist_state="page" widget loses its value on a different page."""
         widget_id = "$$ID-hash-my_widget"
         metadata = _create_persist_state_metadata(widget_id, "page")
 
-        self.session_state.register_widget(metadata, user_key="my_widget")
-        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
-        self.session_state._compact_state()
-        # Simulate navigation to a different page by recording a different hash.
-        self.session_state._persist_tracker._widget_pages[widget_id] = "page_2_hash"
-        self.session_state._remove_stale_widgets(set())
+        # Page 1: register and set the value (recording page_1 as its home).
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+
+        # Page 2: cleanup now runs under a different page, so the value belonging
+        # to page 1 must be dropped.
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            self.session_state._remove_stale_widgets(set())
 
         assert widget_id not in self.session_state._old_state
         assert "my_widget" not in self.session_state._old_state
@@ -2521,7 +2527,8 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
     def test_persist_state_and_bind_combined_preserves(
         self, mock_ctx: MagicMock
     ) -> None:
-        """A widget that is both bound and persisted is preserved (OR logic)."""
+        """A widget that is both bound and persisted is preserved, since either
+        feature alone would keep its value."""
         widget_id = "$$ID-hash-my_widget"
         metadata = _create_persist_state_metadata(
             widget_id, "session", bind="query-params"

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -52,7 +52,12 @@ from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
 from streamlit.runtime.scriptrunner_utils.shared_run_state import SharedRunState
 from streamlit.runtime.state import SessionState, get_session_state
-from streamlit.runtime.state.common import GENERATED_ELEMENT_ID_PREFIX, WidgetMetadata
+from streamlit.runtime.state.common import (
+    GENERATED_ELEMENT_ID_PREFIX,
+    BindOption,
+    PersistStateOption,
+    WidgetMetadata,
+)
 from streamlit.runtime.state.session_state import (
     KeyIdMapper,
     Serialized,
@@ -104,9 +109,9 @@ def _create_test_widget_metadata(
 
 def _create_persist_state_metadata(
     widget_id: str,
-    persist_state: str,
+    persist_state: PersistStateOption,
     value_type: str = "string_value",
-    bind: str | None = None,
+    bind: BindOption = None,
 ) -> WidgetMetadata:
     """Helper to create widget metadata for persist_state tests."""
     return WidgetMetadata(

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2071,7 +2071,7 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
         assert self.query_params.get_binding_for_widget(widget_id) is None
 
         # Cleanup should still preserve value under user key.
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
         assert widget_id not in self.session_state._old_state
         assert self.session_state._old_state["my_widget"] == "custom_value"
 
@@ -2093,7 +2093,7 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
         self.session_state.register_widget(metadata, user_key="my_widget")
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert widget_id not in self.session_state._old_state
         assert "my_widget" not in self.session_state._old_state
@@ -2125,7 +2125,7 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
         # Stale cleanup (MPA page change) — _old_state has "default" but
         # _new_widget_state has "user_value". Preservation should capture
         # "user_value".
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert widget_id not in self.session_state._old_state
         assert self.session_state._old_state["my_widget"] == "user_value"
@@ -2143,7 +2143,7 @@ class RemoveStaleWidgetsPreservationTest(DeltaGeneratorTestCase):
             {kept_widget_id, stale_widget_id}
         )
 
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert self.session_state._query_param_bound_widget_ids == {kept_widget_id}
 
@@ -2169,7 +2169,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         self.session_state.register_widget(metadata, user_key="my_widget")
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert widget_id not in self.session_state._old_state
         assert self.session_state._old_state["my_widget"] == "custom_value"
@@ -2189,7 +2189,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         assert self.session_state._persist_tracker.page_of(widget_id) == "page_1_hash"
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert self.session_state._old_state["my_widget"] == "custom_value"
 
@@ -2215,7 +2215,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
             "streamlit.runtime.state.session_state.get_script_run_ctx",
             return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
         ):
-            self.session_state._remove_stale_widgets(set())
+            self.session_state._remove_stale_widgets(frozenset())
 
         assert widget_id not in self.session_state._old_state
         assert "my_widget" not in self.session_state._old_state
@@ -2232,7 +2232,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         self.session_state.register_widget(metadata, user_key="my_widget")
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert "my_widget" not in self.session_state._old_state
 
@@ -2270,7 +2270,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
             "page_1_hash"
         )
 
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert self.session_state._persist_tracker._scopes == {
             kept_widget_id: "session"
@@ -2294,7 +2294,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
                 widget_id, "custom_value"
             )
             self.session_state._compact_state()
-            self.session_state._remove_stale_widgets(set())
+            self.session_state._remove_stale_widgets(frozenset())
 
         assert self.session_state._persist_tracker.value_page_of("my_widget") == (
             "page_1_hash"
@@ -2442,7 +2442,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
                 widget_id, "custom_value"
             )
             self.session_state._compact_state()
-            self.session_state._remove_stale_widgets(set())
+            self.session_state._remove_stale_widgets(frozenset())
             result = self.session_state.register_widget(metadata, user_key="my_widget")
 
         assert result.value == "custom_value"
@@ -2537,7 +2537,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         self.session_state.register_widget(metadata, user_key="my_widget")
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert self.session_state._old_state["my_widget"] == "custom_value"
 
@@ -2565,7 +2565,7 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
                 widget_id, "custom_value"
             )
             self.session_state._compact_state()
-            self.session_state._remove_stale_widgets(set())
+            self.session_state._remove_stale_widgets(frozenset())
 
         # Binding keeps the value in the URL across the page switch, so it is
         # present in the initial query params seen on the destination page.
@@ -2848,7 +2848,7 @@ class RegisterWidgetValueChangedTest(DeltaGeneratorTestCase):
         self.session_state.register_widget(metadata, user_key="my_widget")
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         result = self.session_state.register_widget(metadata, user_key="my_widget")
 
@@ -2900,7 +2900,7 @@ class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):
         self.query_params.set_with_no_forward_msg("my_widget", "custom_value")
 
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert "my_widget" in self.session_state._old_state
         assert "my_widget" not in self.query_params._query_params
@@ -2930,7 +2930,7 @@ class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):
         self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
 
         self.session_state._compact_state()
-        self.session_state._remove_stale_widgets(set())
+        self.session_state._remove_stale_widgets(frozenset())
 
         assert "my_widget" not in self.session_state._old_state
 

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -773,8 +773,8 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
             persist_state=None,
         )
         session_state = self.script_run_ctx.session_state._state
-        assert session_state._persisted_widget_ids == {}
-        assert session_state._persisted_widget_pages == {}
+        assert session_state._persist_tracker._scopes == {}
+        assert session_state._persist_tracker._widget_pages == {}
 
 
 @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -722,6 +722,58 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
         )
         assert result is not None
 
+    def test_register_widget_persist_state_requires_key(self) -> None:
+        """persist_state requires a user key so the value can be preserved."""
+        with pytest.raises(
+            errors.StreamlitAPIException, match="must have a unique 'key' parameter"
+        ):
+            register_widget(
+                element_id="$$ID-some_hash-None",  # No user key (ends with -None)
+                ctx=None,
+                on_change_handler=None,
+                args=None,
+                kwargs=None,
+                deserializer=lambda x: x,
+                serializer=lambda x: x,
+                value_type="string_value",
+                persist_state="session",
+            )
+
+    def test_register_widget_invalid_persist_state_raises(self) -> None:
+        """Invalid persist_state values raise StreamlitInvalidPersistStateError."""
+        with pytest.raises(
+            errors.StreamlitInvalidPersistStateError,
+            match="Invalid `persist_state` value",
+        ):
+            register_widget(
+                element_id="$$ID-some_hash-my_widget_key",
+                ctx=None,
+                on_change_handler=None,
+                args=None,
+                kwargs=None,
+                deserializer=lambda x: x if x is not None else "default",
+                serializer=lambda x: x,
+                value_type="string_value",
+                persist_state="forever",
+            )
+
+    def test_register_widget_persist_state_none_is_noop(self) -> None:
+        """persist_state=None does not record any persisted-id tracking."""
+        register_widget(
+            element_id="$$ID-some_hash-my_widget_key",
+            ctx=self.script_run_ctx,
+            on_change_handler=None,
+            args=None,
+            kwargs=None,
+            deserializer=lambda x: x if x is not None else "default",
+            serializer=lambda x: x,
+            value_type="string_value",
+            persist_state=None,
+        )
+        session_state = self.script_run_ctx.session_state._state
+        assert session_state._persisted_widget_ids == {}
+        assert session_state._persisted_widget_pages == {}
+
 
 @patch("streamlit.runtime.Runtime.exists", new=MagicMock(return_value=True))
 class WidgetUserKeyTests(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -346,6 +346,8 @@ EXCLUDED_KWARGS_FOR_ELEMENT_ID_COMPUTATION = {
     "key",
     # bind controls URL syncing, not widget identity
     "bind",
+    # persist_state controls server-side value retention, not widget identity
+    "persist_state",
 }
 
 

--- a/lib/tests/streamlit/typing/checkbox_types.py
+++ b/lib/tests/streamlit/typing/checkbox_types.py
@@ -51,6 +51,9 @@ if TYPE_CHECKING:
     assert_type(
         checkbox("Accept terms", key="bind_checkbox", bind="query-params"), bool
     )
+    assert_type(
+        checkbox("Accept terms", key="persist_checkbox", persist_state="session"), bool
+    )
 
     def my_callback() -> None:
         pass
@@ -111,6 +114,9 @@ if TYPE_CHECKING:
     assert_type(toggle("Enable feature", width="stretch"), bool)
     assert_type(toggle("Enable feature", width=150), bool)
     assert_type(toggle("Enable feature", key="bind_toggle", bind="query-params"), bool)
+    assert_type(
+        toggle("Enable feature", key="persist_toggle", persist_state="page"), bool
+    )
 
     assert_type(toggle("Enable feature", on_change=my_callback), bool)
     assert_type(

--- a/lib/tests/streamlit/typing/selectbox_types.py
+++ b/lib/tests/streamlit/typing/selectbox_types.py
@@ -81,3 +81,11 @@ if TYPE_CHECKING:
     assert_type(
         selectbox("foo", ["a", "b"], index=None, bind="query-params"), str | None
     )
+
+    # Check persist_state parameter
+    assert_type(selectbox("foo", ["a", "b"], persist_state="page"), str)
+    assert_type(selectbox("foo", [1, 2, 3], persist_state="session"), int)
+    assert_type(selectbox("foo", ["a", "b"], persist_state=None), str)
+    assert_type(
+        selectbox("foo", ["a", "b"], index=None, persist_state="session"), str | None
+    )

--- a/lib/tests/streamlit/typing/slider_types.py
+++ b/lib/tests/streamlit/typing/slider_types.py
@@ -377,3 +377,9 @@ if TYPE_CHECKING:
     assert_type(slider("foo", value=5.0, bind="query-params"), float)
     assert_type(slider("foo", bind=None), int)
     assert_type(slider("foo", value=(1, 10), bind="query-params"), tuple[int, int])
+
+    # Check persist_state parameter
+    assert_type(slider("foo", persist_state="page"), int)
+    assert_type(slider("foo", value=5.0, persist_state="session"), float)
+    assert_type(slider("foo", persist_state=None), int)
+    assert_type(slider("foo", value=(1, 10), persist_state="session"), tuple[int, int])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Adds a keyword-only `persist_state=None | "page" | "session"` parameter that preserves a keyed widget's value when it stops being rendered. Persistence is purely a server-side state decision: it reuses the existing `bind="query-params"` capture/re-inject machinery in `SessionState` with no URL involvement, so it needs no proto changes.

- `None` (default): current behavior — value is lost when the widget isn't rendered or on a page switch.
- `"page"`: keep the value while the widget isn't rendered on the **same page**; drop it on a page switch (not restored on return, and never leaks to another page that reuses the key).
- `"session"`: keep the value for the whole session, including across page switches.

Offered on the same 12 widgets that already support `bind`. When both are set, **`bind` takes precedence**: the value lives in the URL and survives page switches regardless of the `persist_state` scope.

A remounted widget gets a new id (e.g. after a page switch), so the preserved value is seeded directly onto the active widget during cleanup — otherwise the freshly-defaulted new-id entry would shadow the preserved user-key value.

Demo App: https://persist-widget-state.streamlit.app/
[Product Spec](https://github.com/streamlit/streamlit/blob/develop/specs/2026-01-06-query-param-binding-state-persistence/product-spec.md)

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Unit tests: `SessionState` preservation/pruning/tracking (including the page-switch drop, the same-page-hide control, fragment reruns, and `bind` precedence), `register_widget` validation, and element/typing passthrough.
- E2E (`e2e_playwright/widget_state_persistence_test.py`): same-page unmount/remount persistence, session restore across a page switch, page-scoped values not leaking across pages, and absence of query-param involvement.
- Manual testing: local testing performed. 
- QA agent run 15/15 tests pass (based on product spec).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->