### PR TITLE
Restore persisted widget value to the frontend on remount

### DIFF
--- a/e2e_playwright/widget_state_persistence_test.py
+++ b/e2e_playwright/widget_state_persistence_test.py
@@ -36,6 +36,13 @@ def _expect_value(app: Page, key: str, expected: str) -> None:
     expect(get_element_by_key(app, f"{key}_value")).to_have_text(f"{key}: {expected}")
 
 
+def _expect_input_value(app: Page, label: str, expected: str) -> None:
+    # Assert the value actually rendered in the widget UI, not just the
+    # st.session_state readout — a remounted widget must adopt the preserved
+    # value rather than fall back to its default.
+    expect(get_text_input(app, label).locator("input").first).to_have_value(expected)
+
+
 def _navigate(app: Page, page_name: str) -> None:
     app.get_by_test_id("stSidebarNav").get_by_text(page_name, exact=True).click()
     wait_for_app_run(app)
@@ -59,8 +66,47 @@ def test_persist_state_retains_value_when_not_rendered(app: Page) -> None:
     _expect_value(app, "plain_text", "UNSET")
 
 
+def test_persist_state_restores_widget_value_on_remount(app: Page) -> None:
+    """A persisted widget shows its value again after a hide/show cycle, and a
+    follow-up rerun does not reset it back to the default.
+    """
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Page-scoped", "page_value")
+    _fill_text_input(app, "Session-scoped", "session_value")
+
+    # Hide then show the widgets to force an unmount/remount.
+    click_checkbox(app, "Show widgets")
+    click_checkbox(app, "Show widgets")
+
+    # The remounted widgets must render the preserved values, not their default.
+    _expect_input_value(app, "Page-scoped", "page_value")
+    _expect_input_value(app, "Session-scoped", "session_value")
+
+    # A follow-up rerun must not clobber the restored values.
+    click_button(app, "Rerun")
+    _expect_input_value(app, "Page-scoped", "page_value")
+    _expect_input_value(app, "Session-scoped", "session_value")
+
+
+def test_session_scoped_value_restored_after_page_switch(app: Page) -> None:
+    """A persist_state="session" value survives an A -> B -> A page switch and
+    is restored on the re-rendered widget.
+    """
+    click_checkbox(app, "Show widgets")
+    _fill_text_input(app, "Session-scoped", "session_value")
+
+    _navigate(app, "Page 2")
+    expect(app.get_by_role("heading", name="Page 2")).to_be_visible()
+    _navigate(app, "Page 1")
+    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
+
+    _expect_input_value(app, "Session-scoped", "session_value")
+
+
 def test_page_scoped_value_does_not_leak_across_pages(app: Page) -> None:
-    """A persist_state="page" value is dropped after switching pages."""
+    """A persist_state="page" value is dropped after switching pages and is not
+    restored when returning to the originating page.
+    """
     click_checkbox(app, "Show widgets")
     _fill_text_input(app, "Page-scoped", "page_value")
 
@@ -70,6 +116,12 @@ def test_page_scoped_value_does_not_leak_across_pages(app: Page) -> None:
 
     # The page-scoped value from Page 1 must not carry over to Page 2.
     expect(get_element_by_key(app, "page_text_value")).not_to_contain_text("page_value")
+    _expect_input_value(app, "Page-scoped", "")
+
+    # Returning to Page 1 must not resurrect the dropped page-scoped value.
+    _navigate(app, "Page 1")
+    expect(app.get_by_role("heading", name="Page 1")).to_be_visible()
+    _expect_input_value(app, "Page-scoped", "")
 
 
 def test_persist_state_does_not_touch_query_params(app: Page) -> None:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -453,6 +453,11 @@ class SessionState:
     # time. Used to drop the value when the user navigates to a different page.
     _persisted_widget_pages: dict[str, str] = field(default_factory=dict)
 
+    # For persist_state="page" values preserved while their widget is unmounted:
+    # the page script hash the value belongs to, keyed by user key. Lets a later
+    # registration on a different page drop the value instead of adopting it.
+    _persisted_page_value_pages: dict[str, str] = field(default_factory=dict)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -481,6 +486,7 @@ class SessionState:
         self._query_param_bound_widget_ids.clear()
         self._persisted_widget_ids.clear()
         self._persisted_widget_pages.clear()
+        self._persisted_page_value_pages.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -960,6 +966,15 @@ class SessionState:
                     bound_preserved[user_key] = self._getitem(key, user_key)
                 except KeyError:
                     bound_preserved[user_key] = self._old_state[key]
+                # Remember which page a "page"-scoped value belongs to so a
+                # later registration on a different page can drop it instead of
+                # adopting it.
+                if self._persisted_widget_ids.get(key) == "page":
+                    self._persisted_page_value_pages[user_key] = (
+                        self._persisted_widget_pages.get(key, ctx.page_script_hash)
+                    )
+                else:
+                    self._persisted_page_value_pages.pop(user_key, None)
 
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,
@@ -1017,6 +1032,13 @@ class SessionState:
             for wid, page_hash in self._persisted_widget_pages.items()
             if wid in wid_key_map
         }
+        # Keep origin-page records only while their value is still preserved
+        # under the user key in old state.
+        self._persisted_page_value_pages = {
+            key: page_hash
+            for key, page_hash in self._persisted_page_value_pages.items()
+            if key in self._old_state
+        }
 
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
@@ -1041,6 +1063,18 @@ class SessionState:
 
     def _set_key_widget_mapping(self, widget_id: str, user_key: str) -> None:
         self._key_id_mapper[user_key] = widget_id
+
+    def _drop_widget_value(self, widget_id: str, user_key: str) -> bool:
+        """Forget any stored value for a widget, both by id and by user key.
+
+        Returns True if a value was removed. Values set during the current run
+        via ``_new_session_state`` represent the current run's intent and are
+        left untouched.
+        """
+        removed = self._new_widget_state.states.pop(widget_id, None) is not None
+        removed = self._old_state.pop(widget_id, None) is not None or removed
+        removed = self._old_state.pop(user_key, None) is not None or removed
+        return removed
 
     def register_widget(
         self, metadata: WidgetMetadata[T], user_key: str | None
@@ -1073,19 +1107,33 @@ class SessionState:
             self.query_params.unbind_and_clear_param(widget_id)
 
         # Track persist_state registrations (server-side only, no URL involved).
+        dropped_page_scoped_value = False
         if metadata.persist_state is not None and user_key is not None:
             self._persisted_widget_ids[widget_id] = metadata.persist_state
             if metadata.persist_state == "page":
                 ctx = get_script_run_ctx()
-                self._persisted_widget_pages[widget_id] = (
-                    ctx.page_script_hash if ctx is not None else ""
-                )
+                current_page_hash = ctx.page_script_hash if ctx is not None else ""
+                # A "page"-scoped value preserved while the widget was unmounted
+                # carries the page it belongs to. If the widget now mounts on a
+                # different page, the value must not leak across pages, so drop
+                # it before it is resolved.
+                origin_page_hash = self._persisted_page_value_pages.pop(user_key, None)
+                if (
+                    origin_page_hash is not None
+                    and origin_page_hash != current_page_hash
+                ):
+                    dropped_page_scoped_value = self._drop_widget_value(
+                        widget_id, user_key
+                    )
+                self._persisted_widget_pages[widget_id] = current_page_hash
             else:
                 self._persisted_widget_pages.pop(widget_id, None)
+                self._persisted_page_value_pages.pop(user_key, None)
         elif metadata.persist_state is None and user_key is not None:
             # Widget stopped persisting — drop any stale tracking.
             self._persisted_widget_ids.pop(widget_id, None)
             self._persisted_widget_pages.pop(widget_id, None)
+            self._persisted_page_value_pages.pop(user_key, None)
 
         if (
             widget_id not in self
@@ -1181,11 +1229,14 @@ class SessionState:
         # Also true when a preserved bound or persisted value was restored —
         # the frontend is rendering the widget for the first time on this page
         # and needs to be told to use the backend's resolved value instead of
-        # the widget's default.
+        # the widget's default. When a "page"-scoped value was dropped on a page
+        # switch, the frontend may still hold the old value for the reused widget
+        # id, so it must be told to fall back to the default as well.
         widget_value_changed = (
             (user_key is not None and self.is_new_state_value(user_key))
             or restored_bound_value
             or restored_persisted_value
+            or dropped_page_scoped_value
         )
 
         return RegisterWidgetResult(widget_value, widget_value_changed)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1158,15 +1158,35 @@ class SessionState:
             else:
                 self.query_params.discard_param_no_forward_msg(user_key)
 
+        # A persist_state widget that resolves to a non-default value carried
+        # over from a previous run (preserved while unmounted, or a programmatic
+        # set that has since been compacted into old state) must tell the
+        # frontend to adopt the backend value when the widget (re)mounts.
+        # Otherwise the freshly mounted widget renders at its default and the
+        # next rerun overwrites the preserved value with that default.
+        restored_persisted_value = False
+        if (
+            metadata.persist_state is not None
+            and user_key is not None
+            and not self.is_new_state_value(user_key)
+            and widget_id not in self._new_widget_state
+            and (widget_id in self._old_state or user_key in self._old_state)
+        ):
+            default_value = metadata.deserializer(None)
+            if widget_value != default_value:
+                restored_persisted_value = True
+
         # widget_value_changed indicates to the caller that the widget's
         # current value is different from what is in the frontend.
-        # Also true when a preserved bound value was restored to the URL —
+        # Also true when a preserved bound or persisted value was restored —
         # the frontend is rendering the widget for the first time on this page
         # and needs to be told to use the backend's resolved value instead of
         # the widget's default.
         widget_value_changed = (
-            user_key is not None and self.is_new_state_value(user_key)
-        ) or restored_bound_value
+            (user_key is not None and self.is_new_state_value(user_key))
+            or restored_bound_value
+            or restored_persisted_value
+        )
 
         return RegisterWidgetResult(widget_value, widget_value_changed)
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2260,6 +2260,61 @@ class PersistStatePreservationTest(DeltaGeneratorTestCase):
         assert self.session_state._persisted_widget_ids == {kept_widget_id: "session"}
         assert stale_widget_id not in self.session_state._persisted_widget_pages
 
+    def test_persist_state_page_drops_carried_value_on_remount_other_page(
+        self,
+    ) -> None:
+        """A "page" value preserved on one page is dropped when the widget
+        remounts on a different page, and the frontend is told to reset."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(set())
+
+        assert self.session_state._persisted_page_value_pages["my_widget"] == (
+            "page_1_hash"
+        )
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_2_hash"),
+        ):
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    def test_persist_state_page_keeps_carried_value_on_remount_same_page(
+        self,
+    ) -> None:
+        """A "page" value preserved on a page is kept when the widget remounts
+        on the same page."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(page_script_hash="page_1_hash"),
+        ):
+            self.session_state.register_widget(metadata, user_key="my_widget")
+            self.session_state._new_widget_state.set_from_value(
+                widget_id, "custom_value"
+            )
+            self.session_state._compact_state()
+            self.session_state._remove_stale_widgets(set())
+            result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
     @patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",
         return_value=MockScriptRunCtx(),

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -2442,6 +2442,84 @@ class RegisterWidgetValueChangedTest(DeltaGeneratorTestCase):
         assert result.value == "custom_value"
         assert result.value_changed is False
 
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_when_persisted_value_restored(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A remounted persist_state widget tells the frontend to adopt the
+        preserved value instead of the element default."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_persist_state_metadata(widget_id, "session")
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_false_for_non_persisted_remount(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A plain (persist_state=None) widget does not signal value_changed
+        on remount, so the restore behavior is specific to persisted widgets."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_persist_state_metadata(widget_id, None)
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value_changed is False
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_after_full_preserve_cycle(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """After a persist_state widget is preserved while unmounted, remounting
+        it returns value_changed=True so the frontend adopts the kept value."""
+        widget_id = "$$ID-hash-my_widget"
+        metadata = _create_persist_state_metadata(widget_id, "session")
+
+        self.session_state.register_widget(metadata, user_key="my_widget")
+        self.session_state._new_widget_state.set_from_value(widget_id, "custom_value")
+        self.session_state._compact_state()
+        self.session_state._remove_stale_widgets(set())
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_value_changed_true_for_programmatic_set_in_old_state(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A programmatic value compacted into old state under the user key is
+        pushed to a persisted widget on its first mount this run."""
+        widget_id = "$$ID-hash-my_widget"
+        self.session_state._old_state["my_widget"] = "custom_value"
+        self.session_state._set_key_widget_mapping(widget_id, "my_widget")
+        metadata = _create_persist_state_metadata(widget_id, "page")
+
+        result = self.session_state.register_widget(metadata, user_key="my_widget")
+
+        assert result.value == "custom_value"
+        assert result.value_changed is True
+
 
 class ConditionalRemountBoundBehaviorTest(DeltaGeneratorTestCase):
     """Tests conditional remount behavior for bound vs unbound widgets."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

The `persist_state` prototype (PR #15645) preserved a widget's value in `st.session_state` while the widget was unmounted, but it never told the **frontend** to adopt that value when the widget remounted. It only copied `bind="query-params"`' capture/re-inject machinery in `SessionState._remove_stale_widgets`, not the "frontend-push-on-mount" signal in `SessionState.register_widget`.

`bind` sets `RegisterWidgetResult(value_changed=True)` (via `restored_bound_value`) so a freshly mounted widget renders the backend's resolved value instead of its element default. `persist_state` widgets never set this flag, so on remount: the backend resolved to the preserved value, but the frontend mounted at the element default and the next rerun wrote that default back into `st.session_state`, destroying the preserved value.

This caused:
- **BUG-1** — preserved value not restored on same-page hide → show (both `"page"` and `"session"`).
- **BUG-2** — `persist_state="session"` lost across MPA page switches (A → B → A).
- **BUG-3** — programmatic `st.session_state[key] = value` (compacted into old state) not pushed to a remounted persisted widget.

## Fix

1. **Restore on remount** — In `SessionState.register_widget`, mirror the existing `restored_bound_value` handling: when a `persist_state` widget resolves to a non-default value that was carried over from a previous run (preserved while unmounted, or a programmatic set now in old state) and did not come from the frontend this run, set `widget_value_changed=True`. The element then sets `set_value`/`value` on the proto so the (re)mounted frontend adopts the backend value. The `bind`-only and `persist_state=None` paths are unchanged.

2. **Page-scope correctness on page switch** — Restoring on remount exposed a latent leak for `persist_state="page"`: during an MPA page transition there is an intermediate run still tagged with the old page where the page-scoped value is preserved under the user key, which the next page would then adopt. We now record the origin page of each preserved page-scoped value and, when the widget remounts on a different page, drop the carried value and tell the frontend to fall back to the default (the reused frontend widget id may still hold the old value). Same-page hide → show keeps the value as before.

## Tests

- **Unit** (`session_state_test.py`): re-registering a previously-preserved `persist_state` widget returns `value_changed=True` (direct, full preserve-cycle, and programmatic-old-state cases); a `persist_state=None` control returns `value_changed=False`; a `"page"`-scoped value is dropped (with `value_changed=True`) when remounting on a different page and kept when remounting on the same page.
- **E2E** (`widget_state_persistence_test.py`): assert the **rendered widget UI value** (not just the `st.session_state` readout) is restored after a hide → show cycle and that a follow-up rerun does not clobber it; `persist_state="session"` survives an A → B → A page switch; and `persist_state="page"` genuinely drops its value on page switch and does not resurrect it on return.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6b954e4-aeee-497a-a070-c2a803aaf626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6b954e4-aeee-497a-a070-c2a803aaf626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

