### PR TITLE
Remove `Baseweb` for `TopNav`

### DIFF
--- a/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_top_nav_test.py
@@ -452,6 +452,36 @@ def test_mixed_empty_and_named_sections(app: Page):
     expect(app.get_by_test_id("stHeading").filter(has_text="Page 1")).to_be_visible()
 
 
+def test_top_nav_section_keyboard_and_aria(app: Page):
+    """Test keyboard dismissal and ARIA state for top nav section popovers.
+
+    Covers behavior introduced when replacing BaseWeb's popover with a custom
+    FloatingPortal + useEffect dismissal handler: Escape closes the popover and
+    returns focus to the trigger, and aria-expanded reflects open/closed state.
+    """
+    app.set_viewport_size({"width": 1280, "height": 800})
+
+    click_checkbox(app, "Test Sections")
+    wait_for_app_run(app)
+
+    section_trigger = app.get_by_test_id("stTopNavSection").first
+
+    # Trigger starts closed with correct ARIA state
+    expect(section_trigger).to_have_attribute("aria-expanded", "false")
+    expect(app.get_by_test_id("stTopNavPopover")).not_to_be_visible()
+
+    # Click to open — aria-expanded updates and popover appears
+    section_trigger.click()
+    expect(section_trigger).to_have_attribute("aria-expanded", "true")
+    expect(app.get_by_test_id("stTopNavPopover").first).to_be_visible()
+
+    # Escape closes the popover and returns focus to the trigger
+    app.keyboard.press("Escape")
+    expect(section_trigger).to_have_attribute("aria-expanded", "false")
+    expect(app.get_by_test_id("stTopNavPopover")).not_to_be_visible()
+    expect(section_trigger).to_be_focused()
+
+
 def test_mixed_sections_visual_regression(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -30,6 +30,7 @@
     "@emotion/react": "^11.13.5",
     "@emotion/serialize": "^1.1.3",
     "@emotion/styled": "^11.14.1",
+    "@floating-ui/react": "^0.27.19",
     "@streamlit/connection": "workspace:^",
     "@streamlit/lib": "workspace:^",
     "@streamlit/protobuf": "workspace:^",

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -1082,9 +1082,8 @@ describe("AppView element", () => {
       const header = screen.getByTestId("stHeader")
       expect(header).toBeInTheDocument()
       expect(header).not.toHaveStyle({ backgroundColor: "transparent" })
-      // Navigation should be present in the header
-      const allPage2Elements = screen.getAllByText("page2")
-      expect(allPage2Elements.length).toBeGreaterThan(0)
+      // Navigation should be present in the header — top nav section trigger is rendered
+      expect(screen.getByTestId("stTopNavSection")).toBeInTheDocument()
     })
 
     it("header shows logo and sidebar button in embed mode", () => {
@@ -1161,9 +1160,8 @@ describe("AppView element", () => {
       // Header should be visible
       expect(screen.getByTestId("stHeader")).toBeInTheDocument()
 
-      // Navigation should still be shown in embed mode
-      const allPage2Elements = screen.getAllByText("page2")
-      expect(allPage2Elements.length).toBeGreaterThan(0)
+      // Navigation should still be shown in embed mode — top nav section trigger is rendered
+      expect(screen.getByTestId("stTopNavSection")).toBeInTheDocument()
     })
 
     it("header does NOT show toolbar actions in embed mode without show_toolbar", () => {

--- a/frontend/app/src/components/Navigation/TopNavSection.tsx
+++ b/frontend/app/src/components/Navigation/TopNavSection.tsx
@@ -70,8 +70,9 @@ const TopNavSection = ({
   const theme = useEmotionTheme()
   const showSections = sections.length > 1
 
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const popoverRef = useRef<HTMLDivElement>(null)
+  // useRef<T | null>(null) gives MutableRefObject so .current is directly assignable.
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
 
   const { refs, floatingStyles } = useFloatingOverlay({
     open,
@@ -81,9 +82,7 @@ const TopNavSection = ({
 
   const setReferenceRef = useCallback(
     (node: HTMLButtonElement | null): void => {
-      ;(
-        triggerRef as React.MutableRefObject<HTMLButtonElement | null>
-      ).current = node
+      triggerRef.current = node
       refs.setReference(node)
     },
     [refs]
@@ -91,8 +90,7 @@ const TopNavSection = ({
 
   const setFloatingRef = useCallback(
     (node: HTMLDivElement | null): void => {
-      ;(popoverRef as React.MutableRefObject<HTMLDivElement | null>).current =
-        node
+      popoverRef.current = node
       refs.setFloating(node)
     },
     [refs]
@@ -103,7 +101,8 @@ const TopNavSection = ({
     if (!open) return
 
     const handlePointerDown = (e: PointerEvent): void => {
-      const target = e.target as Node
+      const target = e.target
+      if (!(target instanceof Node)) return
       if (
         !triggerRef.current?.contains(target) &&
         !popoverRef.current?.contains(target)
@@ -196,9 +195,11 @@ const TopNavSection = ({
     <>
       <StyledNavSection
         ref={setReferenceRef}
+        type="button"
         onClick={() => setOpen(prev => !prev)}
         isOpen={open}
         aria-expanded={open}
+        aria-haspopup="true"
         data-testid="stTopNavSection"
       >
         <StyledNavSectionText>

--- a/frontend/app/src/components/Navigation/TopNavSection.tsx
+++ b/frontend/app/src/components/Navigation/TopNavSection.tsx
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import { Fragment, useState } from "react"
+import { Fragment, useCallback, useEffect, useRef, useState } from "react"
 
 import {
   KeyboardArrowDown,
   KeyboardArrowUp,
 } from "@emotion-icons/material-outlined"
-import { PLACEMENT, TRIGGER_TYPE, Popover as UIPopover } from "baseui/popover"
+import { FloatingPortal } from "@floating-ui/react"
 
 import { StreamlitEndpoints } from "@streamlit/connection"
 import {
   convertRemToPx,
-  getPopoverContainerStyle,
   Icon,
   StreamlitMarkdown,
   useEmotionTheme,
+  useFloatingOverlay,
 } from "@streamlit/lib"
 import { IAppPage } from "@streamlit/protobuf"
 import { isNullOrUndefined } from "@streamlit/utils"
@@ -40,6 +40,7 @@ import {
   StyledNavSectionText,
   StyledPopoverContent,
   StyledSectionName,
+  StyledTopNavPopoverBody,
   StyledTopNavSidebarNavLinkContainer,
 } from "./styled-components"
 import { getExternalPageUrl, isExternalPage } from "./utils"
@@ -69,6 +70,65 @@ const TopNavSection = ({
   const theme = useEmotionTheme()
   const showSections = sections.length > 1
 
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  const { refs, floatingStyles } = useFloatingOverlay({
+    open,
+    placement: "bottom-start",
+    offsetPx: convertRemToPx(theme.spacing.twoXS),
+  })
+
+  const setReferenceRef = useCallback(
+    (node: HTMLButtonElement | null): void => {
+      ;(
+        triggerRef as React.MutableRefObject<HTMLButtonElement | null>
+      ).current = node
+      refs.setReference(node)
+    },
+    [refs]
+  )
+
+  const setFloatingRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      ;(popoverRef as React.MutableRefObject<HTMLDivElement | null>).current =
+        node
+      refs.setFloating(node)
+    },
+    [refs]
+  )
+
+  // Custom dismissal: outside-click and Escape via capture-phase listeners.
+  useEffect(() => {
+    if (!open) return
+
+    const handlePointerDown = (e: PointerEvent): void => {
+      const target = e.target as Node
+      if (
+        !triggerRef.current?.contains(target) &&
+        !popoverRef.current?.contains(target)
+      ) {
+        setOpen(false)
+      }
+    }
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        e.stopPropagation()
+        e.preventDefault()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown, true)
+    document.addEventListener("keydown", handleKeyDown, true)
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true)
+      document.removeEventListener("keydown", handleKeyDown, true)
+    }
+  }, [open])
+
   if (
     isNullOrUndefined(sections) ||
     sections.length === 0 ||
@@ -77,126 +137,103 @@ const TopNavSection = ({
     return null
   }
 
-  return (
-    <UIPopover
-      triggerType={TRIGGER_TYPE.click}
-      placement={PLACEMENT.bottomLeft}
-      content={() => (
-        <StyledPopoverContent data-testid="stTopNavPopover">
-          {sections.map((section, _sectionIndex) => {
-            const sectionName = section[0].sectionHeader
+  const popoverContent = sections.map((section, _sectionIndex) => {
+    const sectionName = section[0].sectionHeader
 
-            return section.map((item, index) => {
-              const isExternal = isExternalPage(item)
-              const handleClick = (e: React.MouseEvent): void => {
-                // External links are handled by the browser (target="_blank")
-                if (isExternal) {
-                  setOpen(false)
-                  return
-                }
-                e.preventDefault()
-                if (item.pageScriptHash) {
-                  handlePageChange(item.pageScriptHash)
-                }
-                setOpen(false)
-              }
+    return section.map((item, index) => {
+      const isExternal = isExternalPage(item)
+      const handleClick = (e: React.MouseEvent): void => {
+        // External links are handled by the browser (target="_blank")
+        if (isExternal) {
+          setOpen(false)
+          return
+        }
+        e.preventDefault()
+        if (item.pageScriptHash) {
+          handlePageChange(item.pageScriptHash)
+        }
+        setOpen(false)
+      }
 
-              // Convert potentially null pageName to string safely
-              const pageName = String(item.pageName || "")
+      // Convert potentially null pageName to string safely
+      const pageName = String(item.pageName || "")
 
-              return (
-                <Fragment key={`${item.pageScriptHash}-${pageName}`}>
-                  {index === 0 && showSections && (
-                    <StyledSectionName>
-                      <StreamlitMarkdown
-                        source={sectionName || ""}
-                        allowHTML={false}
-                        isLabel
-                        disableLinks
-                        truncate
-                        inheritFont
-                      />
-                    </StyledSectionName>
-                  )}
-                  <StyledTopNavSidebarNavLinkContainer>
-                    <SidebarNavLink
-                      icon={item.icon || null}
-                      isTopNav={true}
-                      isInDropdown={true}
-                      isActive={currentPageScriptHash === item.pageScriptHash}
-                      onClick={handleClick}
-                      pageUrl={endpoints.buildAppPageURL(
-                        pageLinkBaseUrl,
-                        item
-                      )}
-                      widgetsDisabled={widgetsDisabled}
-                      isExternal={isExternal}
-                      externalUrl={getExternalPageUrl(item)}
-                    >
-                      {pageName}
-                    </SidebarNavLink>
-                  </StyledTopNavSidebarNavLinkContainer>
-                </Fragment>
-              )
-            })
-          })}
-        </StyledPopoverContent>
-      )}
-      isOpen={open}
-      onClickOutside={() => setOpen(false)}
-      onClick={() => (open ? setOpen(false) : undefined)}
-      onEsc={() => setOpen(false)}
-      // Consistently render the content for smoother opening/closing
-      renderAll={true}
-      popoverMargin={convertRemToPx(theme.spacing.twoXS)}
-      overrides={{
-        Body: {
-          style: () => ({
-            ...getPopoverContainerStyle(theme),
-
-            marginRight: theme.spacing.lg,
-            marginBottom: theme.spacing.lg,
-
-            maxHeight: "70vh",
-            minWidth: "8rem",
-            overflow: "auto",
-            maxWidth: `calc(${theme.sizes.contentMaxWidth} - 2*${theme.spacing.lg})`,
-
-            [`@media (max-width: ${theme.breakpoints.sm})`]: {
-              maxWidth: `calc(100% - ${theme.spacing.threeXL})`,
-            },
-          }),
-        },
-      }}
-    >
-      <div>
-        <StyledNavSection
-          tabIndex={0}
-          onClick={() => setOpen(!open)}
-          isOpen={open}
-          data-testid="stTopNavSection"
-        >
-          <StyledNavSectionText>
-            <StreamlitMarkdown
-              source={title}
-              allowHTML={false}
-              isLabel
-              disableLinks
-              truncate
-              inheritFont
-            />
-          </StyledNavSectionText>
-          {!hideChevron && (
-            <StyledIconContainer>
-              <Icon
-                content={open ? KeyboardArrowUp : KeyboardArrowDown}
-                size="lg"
+      return (
+        <Fragment key={`${item.pageScriptHash}-${pageName}`}>
+          {index === 0 && showSections && (
+            <StyledSectionName>
+              <StreamlitMarkdown
+                source={sectionName || ""}
+                allowHTML={false}
+                isLabel
+                disableLinks
+                truncate
+                inheritFont
               />
-            </StyledIconContainer>
+            </StyledSectionName>
           )}
-        </StyledNavSection>
-      </div>
-    </UIPopover>
+          <StyledTopNavSidebarNavLinkContainer>
+            <SidebarNavLink
+              icon={item.icon || null}
+              isTopNav={true}
+              isInDropdown={true}
+              isActive={currentPageScriptHash === item.pageScriptHash}
+              onClick={handleClick}
+              pageUrl={endpoints.buildAppPageURL(pageLinkBaseUrl, item)}
+              widgetsDisabled={widgetsDisabled}
+              isExternal={isExternal}
+              externalUrl={getExternalPageUrl(item)}
+            >
+              {pageName}
+            </SidebarNavLink>
+          </StyledTopNavSidebarNavLinkContainer>
+        </Fragment>
+      )
+    })
+  })
+
+  return (
+    <>
+      <StyledNavSection
+        ref={setReferenceRef}
+        onClick={() => setOpen(prev => !prev)}
+        isOpen={open}
+        aria-expanded={open}
+        data-testid="stTopNavSection"
+      >
+        <StyledNavSectionText>
+          <StreamlitMarkdown
+            source={title}
+            allowHTML={false}
+            isLabel
+            disableLinks
+            truncate
+            inheritFont
+          />
+        </StyledNavSectionText>
+        {!hideChevron && (
+          <StyledIconContainer>
+            <Icon
+              content={open ? KeyboardArrowUp : KeyboardArrowDown}
+              size="lg"
+            />
+          </StyledIconContainer>
+        )}
+      </StyledNavSection>
+      {open && (
+        <FloatingPortal>
+          <StyledTopNavPopoverBody
+            ref={setFloatingRef}
+            style={floatingStyles}
+            data-testid="stTopNavPopoverBody"
+          >
+            <StyledPopoverContent data-testid="stTopNavPopover">
+              {popoverContent}
+            </StyledPopoverContent>
+          </StyledTopNavPopoverBody>
+        </FloatingPortal>
+      )}
+    </>
   )
 }
 

--- a/frontend/app/src/components/Navigation/styled-components.ts
+++ b/frontend/app/src/components/Navigation/styled-components.ts
@@ -314,13 +314,12 @@ export const StyledNavSection = styled.button<StyledNavSectionProps>(
 
 export const StyledTopNavPopoverBody = styled.div(({ theme }) => ({
   ...getPopoverContainerStyle(theme),
+  backgroundColor: theme.colors.bgColor,
   zIndex: getOverlayZIndex(theme),
   maxHeight: "70vh",
   minWidth: "8rem",
   overflow: "auto",
   maxWidth: `calc(${theme.sizes.contentMaxWidth} - 2*${theme.spacing.lg})`,
-  marginRight: theme.spacing.lg,
-  marginBottom: theme.spacing.lg,
   [`@media (max-width: ${theme.breakpoints.sm})`]: {
     maxWidth: `calc(100% - ${theme.spacing.threeXL})`,
   },

--- a/frontend/app/src/components/Navigation/styled-components.ts
+++ b/frontend/app/src/components/Navigation/styled-components.ts
@@ -17,7 +17,12 @@
 import styled from "@emotion/styled"
 import { transparentize } from "color2k"
 
-import { EmotionTheme, hasLightBackgroundColor } from "@streamlit/lib"
+import {
+  EmotionTheme,
+  getOverlayZIndex,
+  getPopoverContainerStyle,
+  hasLightBackgroundColor,
+} from "@streamlit/lib"
 
 /**
  * Returns the color of the text in the sidebar nav.
@@ -275,12 +280,17 @@ interface StyledNavSectionProps {
   isOpen: boolean
 }
 
-export const StyledNavSection = styled.div<StyledNavSectionProps>(
+export const StyledNavSection = styled.button<StyledNavSectionProps>(
   ({ theme, isOpen }) => ({
+    // Button CSS reset
+    border: "none",
+    background: "none",
+    font: "inherit",
+    cursor: "pointer",
+
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    cursor: "pointer",
     position: "relative",
     lineHeight: theme.lineHeights.menuItem,
     fontSize: theme.fontSizes.sm,
@@ -295,8 +305,26 @@ export const StyledNavSection = styled.div<StyledNavSectionProps>(
     "&:hover": {
       backgroundColor: theme.colors.darkenedBgMix15,
     },
+    "&:focus-visible": {
+      outline: "none",
+      boxShadow: theme.shadows.focusRingMuted,
+    },
   })
 )
+
+export const StyledTopNavPopoverBody = styled.div(({ theme }) => ({
+  ...getPopoverContainerStyle(theme),
+  zIndex: getOverlayZIndex(theme),
+  maxHeight: "70vh",
+  minWidth: "8rem",
+  overflow: "auto",
+  maxWidth: `calc(${theme.sizes.contentMaxWidth} - 2*${theme.spacing.lg})`,
+  marginRight: theme.spacing.lg,
+  marginBottom: theme.spacing.lg,
+  [`@media (max-width: ${theme.breakpoints.sm})`]: {
+    maxWidth: `calc(100% - ${theme.spacing.threeXL})`,
+  },
+}))
 
 export const StyledTopNavLinkContainer = styled.div(({ theme }) => ({
   marginRight: theme.spacing.twoXS,

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -63,7 +63,10 @@ export { toastQueue } from "./components/elements/Toast/toastQueue"
 export type { StreamlitToastContent } from "./components/elements/Toast/toastQueue"
 export { StreamlitToastItem } from "./components/elements/Toast/StreamlitToastItem"
 export { StyledToastRegion } from "./components/elements/Toast/styled-components"
-export { getPopoverContainerStyle } from "./components/shared/Base/styled-components"
+export {
+  getOverlayZIndex,
+  getPopoverContainerStyle,
+} from "./components/shared/Base/styled-components"
 export {
   default as BaseButton,
   BaseButtonKind,
@@ -103,6 +106,7 @@ export { useCopyToClipboard } from "./hooks/useCopyToClipboard"
 export { useCrossOriginAttribute } from "./hooks/useCrossOriginAttribute"
 export { useEmotionTheme } from "./hooks/useEmotionTheme"
 export { useExecuteWhenChanged } from "./hooks/useExecuteWhenChanged"
+export { useFloatingOverlay } from "./hooks/useFloatingOverlay"
 export {
   ensureHotkeysFilterConfigured,
   isKeyboardEventFromEditableTarget,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3642,6 +3642,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.5"
     "@emotion/serialize": "npm:^1.1.3"
     "@emotion/styled": "npm:^11.14.1"
+    "@floating-ui/react": "npm:^0.27.19"
     "@streamlit/connection": "workspace:^"
     "@streamlit/lib": "workspace:^"
     "@streamlit/protobuf": "workspace:^"


### PR DESCRIPTION
## Describe your changes
Replaces the last baseui/popover import in TopNavSection with @floating-ui/react + a custom useEffect dismissal handler, consistent with the refactor pattern established in MenuButton, Popover, Selectbox, and BaseColorPicker. Also establishes shared prerequisites (useFloatingOverlay and getOverlayZIndex exported from @streamlit/lib) that the MainMenu PR (PR 2/2) will depend on.

As a bonus this PR fixes a longstanding a11y issue: the section trigger was a `<div>` with `tabIndex={0}` acting as a button; it is now a semantic `<button>` with aria-expanded.

**Behavior changes:**
- **`renderAll` removed**: BaseWeb's renderAll={true} kept popover content always mounted for smoother transitions. Content now conditionally mounts (consistent with every other refactored overlay). Two AppView unit tests that were accidentally relying on hidden-but-mounted popover content are updated to use stTopNavSection instead.
- **Trigger element**: `<div>` with `tabIndex={0}` → `<button>`. All existing E2E test selectors (getByText, getByTestId, getByRole("link")) continue to work; the `<div>` → `<button>` change is transparent to them.

## Testing Plan
- All existing unit tests pass (3 TopNavSection tests, 66 AppView tests)
- New E2E test test_top_nav_section_keyboard_and_aria covers aria-expanded state transitions and Escape-key dismissal with focus return — behavior now handled by custom code rather than BaseWeb's onEsc prop
- Existing E2E tests (section open/close, page navigation, outside-click dismissal, markdown headers, mixed sections) continue to pass