### PR TITLE
Fix deprecation numpy: using a specific unit of measurement

### DIFF
--- a/e2e_playwright/shared/data_mocks.py
+++ b/e2e_playwright/shared/data_mocks.py
@@ -281,7 +281,7 @@ DATETIME_TYPES_DF = pd.DataFrame(
                 [
                     pd.Timestamp(random_date()),
                     np.datetime64("2022-03-11T17:13:00")
-                    - np.random.randint(400000, 1500000),
+                    - np.timedelta64(np.random.randint(400000, 1500000), "s"),
                     pd.to_datetime(10, unit="s"),
                 ]
             )


### PR DESCRIPTION
## Describe your changes
Fix: 
```
shared/data_mocks.py:283
  /home/quant/PycharmProjects/streamlit/e2e_playwright/shared/data_mocks.py:283: DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
    np.datetime64("2022-03-11T17:13:00")
```

To trigger a warning, run the test:

`make run-e2e-test e2e_playwright/st_data_editor_input_data_test.py
`


## Testing Plan

- No tests are needed; existing tests should cover this change.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
