### PR TITLE
Add download_filename support for st.dataframe (backend + frontend)

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -504,7 +504,10 @@ function DataFrame({
     getCellContent,
     columns,
     numRows,
-    enforceDownloadInNewTab
+    enforceDownloadInNewTab,
+    // Optional filename provided by the Python API (proto field: download_filename)
+    // Falls back to a timestamped suggestion when undefined.
+    element.downloadFilename
   )
 
   const { onCellEdited, onPaste, onRowAppended, onDelete, validateCell } =

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
@@ -191,6 +191,60 @@ describe("useDataExporter hook", () => {
     })
   })
 
+  it("uses provided downloadFilename with .csv suffix when missing", async () => {
+    const { result } = renderHook(() => {
+      return useDataExporter(
+        getCellContentMock,
+        MOCK_COLUMNS,
+        NUM_ROWS,
+        false,
+        "monthly-report"
+      )
+    })
+
+    if (typeof result.current.exportToCsv !== "function") {
+      throw new Error("exportToCsv is expected to be a function")
+    }
+
+    result.current.exportToCsv()
+
+    await waitFor(() => {
+      expect(showSaveFilePicker).toBeCalledTimes(1)
+    })
+    expect(showSaveFilePicker).toBeCalledWith({
+      excludeAcceptAllOption: false,
+      suggestedName: "monthly-report.csv",
+      types: [{ accept: { "text/csv": [".csv"] } }],
+    })
+  })
+
+  it("uses provided downloadFilename unchanged when it already includes .csv", async () => {
+    const { result } = renderHook(() => {
+      return useDataExporter(
+        getCellContentMock,
+        MOCK_COLUMNS,
+        NUM_ROWS,
+        false,
+        "monthly-report.csv"
+      )
+    })
+
+    if (typeof result.current.exportToCsv !== "function") {
+      throw new Error("exportToCsv is expected to be a function")
+    }
+
+    result.current.exportToCsv()
+
+    await waitFor(() => {
+      expect(showSaveFilePicker).toBeCalledTimes(1)
+    })
+    expect(showSaveFilePicker).toBeCalledWith({
+      excludeAcceptAllOption: false,
+      suggestedName: "monthly-report.csv",
+      types: [{ accept: { "text/csv": [".csv"] } }],
+    })
+  })
+
   it("does nothing when user cancels file picker (AbortError)", async () => {
     // Mock the file picker to throw an AbortError
     vi.mocked(showSaveFilePicker).mockRejectedValueOnce(

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -129,6 +129,10 @@ async function writeCsv(
  * @param getCellContent - The cell content getter compatible with glide-data-grid.
  * @param columns - The columns of the table.
  * @param numRows - The number of rows of the current state.
+ * @param enforceDownloadInNewTab - Whether to force the download to open in a new browser tab.
+ * @param downloadFilename - Optional filename for the exported CSV. If the
+ *   value does not end with `.csv` (case-insensitive), the extension is added
+ *   automatically.
  *
  * @returns a callback to trigger the data download as CSV.
  */
@@ -136,11 +140,17 @@ function useDataExporter(
   getCellContent: DataEditorProps["getCellContent"],
   columns: BaseColumn[],
   numRows: number,
-  enforceDownloadInNewTab: boolean
+  enforceDownloadInNewTab: boolean,
+  downloadFilename?: string
 ): DataExporterReturn {
   const exportToCsv = useCallback(async () => {
     const timestamp = new Date().toISOString().slice(0, 16).replace(":", "-")
     const suggestedName = `${timestamp}_export.csv`
+    const finalFilename = downloadFilename
+      ? downloadFilename.toLowerCase().endsWith(".csv")
+        ? downloadFilename
+        : `${downloadFilename}.csv`
+      : suggestedName
     try {
       // Lazy import to prevent weird breakage in some niche cases
       // (e.g. usage within the replay.io browser). The package works well
@@ -150,7 +160,7 @@ function useDataExporter(
       const nativeFileSystemAdapter =
         await import("native-file-system-adapter")
       const fileHandle = await nativeFileSystemAdapter.showSaveFilePicker({
-        suggestedName,
+        suggestedName: finalFilename,
         types: [{ accept: { "text/csv": [".csv"] } }],
         excludeAcceptAllOption: false,
       })
@@ -195,7 +205,7 @@ function useDataExporter(
         const link = createDownloadLinkElement({
           enforceDownloadInNewTab,
           url,
-          filename: suggestedName,
+          filename: finalFilename,
         })
 
         link.style.display = "none"
@@ -208,7 +218,13 @@ function useDataExporter(
         LOG.error("Failed to export data as CSV", e)
       }
     }
-  }, [columns, numRows, getCellContent, enforceDownloadInNewTab])
+  }, [
+    columns,
+    numRows,
+    getCellContent,
+    enforceDownloadInNewTab,
+    downloadFilename,
+  ])
 
   return {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -491,6 +491,7 @@ class ArrowMixin:
         selection_default: DataframeState | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
+        download_filename: str | None = None,
     ) -> DeltaGenerator: ...
 
     @overload
@@ -510,6 +511,7 @@ class ArrowMixin:
         selection_default: DataframeState | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
+        download_filename: str | None = None,
     ) -> DataframeState: ...
 
     @gather_metrics("dataframe")
@@ -529,6 +531,7 @@ class ArrowMixin:
         selection_default: DataframeState | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
+        download_filename: str | None = None,
     ) -> DeltaGenerator | DataframeState:
         """Display a dataframe as an interactive table.
 
@@ -744,6 +747,14 @@ class ArrowMixin:
             leave a cell empty, use an empty string (``""``). Other common
             values are ``"null"``, ``"NaN"`` and ``"-"``.
 
+        download_filename : str or None
+            Optional filename to use when the user exports the dataframe as
+            CSV. If provided, Streamlit will suggest this filename in the
+            download dialog. If the filename does not end with
+            ``".csv"`` (case-insensitive), Streamlit will append the extension
+            automatically. If ``None`` (default), Streamlit generates a
+            timestamp-based default filename.
+
         Returns
         -------
         element or dict
@@ -937,6 +948,10 @@ class ArrowMixin:
 
         if placeholder is not None:
             proto.placeholder = placeholder
+
+        # Optional: set download filename for CSV export from the frontend toolbar
+        if download_filename is not None:
+            proto.download_filename = download_filename
 
         proto.editing_mode = DataframeProto.EditingMode.READ_ONLY
 

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -170,6 +170,14 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.dataframe
         assert proto.placeholder == "-"
 
+    def test_download_filename_parameter(self):
+        """Test that a download filename is stored in the dataframe proto."""
+        st.dataframe(pd.DataFrame(), download_filename="report")
+
+        proto = self.get_delta_from_queue().new_element.dataframe
+        assert proto.HasField("download_filename")
+        assert proto.download_filename == "report"
+
     def test_uuid(self):
         df = mock_data_frame()
         styler = df.style

--- a/proto/streamlit/proto/Dataframe.proto
+++ b/proto/streamlit/proto/Dataframe.proto
@@ -55,6 +55,10 @@ message Dataframe {
   // so a single widget ID per column is sufficient to handle clicks on any row.
   map<string, string> button_click_widgets = 13;
 
+  // Optional filename to use for CSV downloads from the DataFrame toolbar.
+  // If not set, the frontend will generate a timestamped default filename.
+  optional string download_filename = 14;
+
   // Available editing modes:
   enum EditingMode {
     READ_ONLY = 0; // Read-only table.


### PR DESCRIPTION
## Fixes Issue - #15648 

Summary:
- Implements `download_filename` support for `st.dataframe` in the backend protobuf payload.
- Adds a backend unit test to verify `download_filename` is transmitted in the protobuf.
- Updates frontend data exporter to use the backend-provided filename and append `.csv` when missing.
- Adds frontend unit tests to cover filename behavior for CSV export.

What changed:
- `lib/tests/streamlit/elements/arrow_dataframe_test.py`
- `frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts`
- `frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts`

Testing performed:
- Backend: `PYTHONPATH=lib python -m pytest lib/tests/streamlit/elements/arrow_dataframe_test.py -q` → 195 passed
- Frontend: `cd frontend && npx corepack yarn workspace @streamlit/lib exec vitest run src/components/widgets/DataFrame/hooks/useDataExporter.test.ts` → 19 passed
- Frontend broader DataFrame suite: `cd frontend && npx corepack yarn workspace @streamlit/lib exec vitest run src/components/widgets/DataFrame` → passed
- Local formatting/lint: `cd frontend && npx corepack yarn workspace @streamlit/lib run format` and lint checks completed.

Notes:
- No existing PR was found for issue #15648.
- Branch pushed to fork: `MoiyadKayda/streamlit` branch `feature/add-download-filename`.
- Draft PR base: `develop`.
- CI may still need to validate the full frontend suite and protobuf generation artifacts.
