### PR TITLE
[fix] Validate StreamlitPage source matches registered page (#10572)

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Literal, NoReturn
 import streamlit as st
 from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.file_util import get_main_script_directory, normalize_path_join
-from streamlit.navigation.page import StreamlitPage
+from streamlit.navigation.page import StreamlitPage, _validate_registered_page
 from streamlit.runtime.fragment import _check_not_parallel_worker
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
@@ -302,6 +302,7 @@ def switch_page(  # type: ignore[misc]
                 "Cannot use st.switch_page with external URL pages. "
                 "Use st.page_link instead to create a link to external pages."
             )
+        _validate_registered_page(page)
         page_script_hash = page._script_hash
     else:
         # Convert Path to string if necessary

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -48,7 +48,7 @@ from streamlit.errors import (
     StreamlitPageNotFoundError,
 )
 from streamlit.file_util import get_main_script_directory, normalize_path_join
-from streamlit.navigation.page import StreamlitPage
+from streamlit.navigation.page import StreamlitPage, _validate_registered_page
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.ButtonLikeIconPosition_pb2 import (
     ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
@@ -1566,6 +1566,7 @@ class ButtonMixin:
                     "page_link", page_link_proto, layout_config=layout_config
                 )
 
+            _validate_registered_page(page)
             page_link_proto.page_script_hash = page._script_hash
             page_link_proto.page = page.url_path
         else:

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -28,50 +28,6 @@ from streamlit.url_util import is_url
 from streamlit.util import calc_hash
 
 
-def _validate_registered_page(page: StreamlitPage) -> None:
-    """Validate that a ``StreamlitPage`` matches what was registered with
-    ``st.navigation``.
-
-    Page hashes are derived solely from ``url_path``, so two ``StreamlitPage``
-    objects sharing a ``url_path`` collide even when their underlying source
-    differs. Without this check, ``st.switch_page`` and ``st.page_link`` would
-    silently route to the registered page rather than surfacing the mismatch.
-
-    If no page with the same hash is registered, validation is skipped so apps
-    that haven't called ``st.navigation`` are unaffected.
-    """
-    if page.is_external:
-        return
-
-    ctx = get_script_run_ctx()
-    if not ctx:
-        return
-
-    registered = ctx.pages_manager.get_pages().get(page._script_hash)
-    if registered is None:
-        return
-
-    registered_script_path = registered.get("script_path", "")
-    if isinstance(page._page, Path):
-        if str(page._page) != registered_script_path:
-            registered_source = registered_script_path or "a callable"
-            raise StreamlitAPIException(
-                f"The page references `{page._page}`, but a different page is "
-                f"registered with `st.navigation` for URL pathname "
-                f"`/{page.url_path}` (`{registered_source}`). Pass the page "
-                "object returned by `st.navigation` or re-create the page "
-                "with the matching source."
-            )
-    elif callable(page._page) and registered_script_path:
-        raise StreamlitAPIException(
-            f"The page is a callable, but a file-based page "
-            f"(`{registered_script_path}`) is registered with `st.navigation` "
-            f"for URL pathname `/{page.url_path}`. Pass the page object "
-            "returned by `st.navigation` or re-create the page with the "
-            "matching source."
-        )
-
-
 def _sanitize_url_path(title: str) -> str:
     """Sanitize a title string to be used as a URL path.
 
@@ -540,3 +496,47 @@ class StreamlitPage:
     @property
     def _script_hash(self) -> str:
         return calc_hash(self._url_path)
+
+
+def _validate_registered_page(page: StreamlitPage) -> None:
+    """Validate that a ``StreamlitPage`` matches what was registered with
+    ``st.navigation``.
+
+    Page hashes are derived solely from ``url_path``, so two ``StreamlitPage``
+    objects sharing a ``url_path`` collide even when their underlying source
+    differs. Without this check, ``st.switch_page`` and ``st.page_link`` would
+    silently route to the registered page rather than surfacing the mismatch.
+
+    If no page with the same hash is registered, validation is skipped so apps
+    that haven't called ``st.navigation`` are unaffected.
+    """
+    if page.is_external:
+        return
+
+    ctx = get_script_run_ctx()
+    if not ctx:
+        return
+
+    registered = ctx.pages_manager.get_pages().get(page._script_hash)
+    if registered is None:
+        return
+
+    registered_script_path = registered.get("script_path", "")
+    if isinstance(page._page, Path):
+        if str(page._page) != registered_script_path:
+            registered_source = registered_script_path or "a callable"
+            raise StreamlitAPIException(
+                f"The page references `{page._page}`, but a different page is "
+                f"registered with `st.navigation` for URL pathname "
+                f"`/{page.url_path}` (`{registered_source}`). Pass the page "
+                "object returned by `st.navigation` or re-create the page "
+                "with the matching source."
+            )
+    elif callable(page._page) and registered_script_path:
+        raise StreamlitAPIException(
+            f"The page is a callable, but a file-based page "
+            f"(`{registered_script_path}`) is registered with `st.navigation` "
+            f"for URL pathname `/{page.url_path}`. Pass the page object "
+            "returned by `st.navigation` or re-create the page with the "
+            "matching source."
+        )

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -540,3 +540,6 @@ def _validate_registered_page(page: StreamlitPage) -> None:
             "returned by `st.navigation` or re-create the page with the "
             "matching source."
         )
+    # Callable-vs-callable collisions fall through intentionally: PageInfo
+    # only stores an empty script_path for callables, so we have no identity
+    # to compare the two functions against.

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -28,6 +28,50 @@ from streamlit.url_util import is_url
 from streamlit.util import calc_hash
 
 
+def _validate_registered_page(page: StreamlitPage) -> None:
+    """Validate that a ``StreamlitPage`` matches what was registered with
+    ``st.navigation``.
+
+    Page hashes are derived solely from ``url_path``, so two ``StreamlitPage``
+    objects sharing a ``url_path`` collide even when their underlying source
+    differs. Without this check, ``st.switch_page`` and ``st.page_link`` would
+    silently route to the registered page rather than surfacing the mismatch.
+
+    If no page with the same hash is registered, validation is skipped so apps
+    that haven't called ``st.navigation`` are unaffected.
+    """
+    if page.is_external:
+        return
+
+    ctx = get_script_run_ctx()
+    if not ctx:
+        return
+
+    registered = ctx.pages_manager.get_pages().get(page._script_hash)
+    if registered is None:
+        return
+
+    registered_script_path = registered.get("script_path", "")
+    if isinstance(page._page, Path):
+        if str(page._page) != registered_script_path:
+            registered_source = registered_script_path or "a callable"
+            raise StreamlitAPIException(
+                f"The page references `{page._page}`, but a different page is "
+                f"registered with `st.navigation` for URL pathname "
+                f"`/{page.url_path}` (`{registered_source}`). Pass the page "
+                "object returned by `st.navigation` or re-create the page "
+                "with the matching source."
+            )
+    elif callable(page._page) and registered_script_path:
+        raise StreamlitAPIException(
+            f"The page is a callable, but a file-based page "
+            f"(`{registered_script_path}`) is registered with `st.navigation` "
+            f"for URL pathname `/{page.url_path}`. Pass the page object "
+            "returned by `st.navigation` or re-create the page with the "
+            "matching source."
+        )
+
+
 def _sanitize_url_path(title: str) -> str:
     """Sanitize a title string to be used as a URL path.
 

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -27,6 +27,7 @@ from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.navigation.page import StreamlitPage
 from streamlit.runtime.scriptrunner import RerunData
 from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
 class NewFragmentIdQueueTest(unittest.TestCase):
@@ -408,3 +409,70 @@ def test_st_switch_page_string_path_unknown_page_raises(
         switch_page("missing.py")
 
     ctx.script_requests.request_rerun.assert_not_called()
+
+
+@patch("pathlib.Path.is_file", MagicMock(return_value=True))
+class SwitchPageStreamlitPageValidationTest(DeltaGeneratorTestCase):
+    """Test that ``st.switch_page`` validates a passed ``StreamlitPage`` against
+    pages registered with ``st.navigation`` and raises when the source does not
+    match the registered page sharing the same URL pathname.
+
+    Regression coverage for https://github.com/streamlit/streamlit/issues/10572.
+    """
+
+    def test_streamlit_page_with_mismatched_file_path_raises(self) -> None:
+        """Switching to a ``StreamlitPage`` whose file path does not match the
+        page registered under the same ``url_path`` raises."""
+        import streamlit as st
+
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        bad_page = st.Page("other.py", url_path="foo")
+        with pytest.raises(StreamlitAPIException, match=r"different page is "):
+            st.switch_page(bad_page)
+
+    def test_streamlit_page_with_inferred_url_path_mismatch_raises(self) -> None:
+        """Switching to ``st.Page("foo.py")`` (url_path inferred as ``foo``)
+        raises when a different file is registered under ``url_path="foo"``."""
+        import streamlit as st
+
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        with pytest.raises(StreamlitAPIException, match=r"different page is "):
+            st.switch_page(st.Page("foo.py"))
+
+    def test_streamlit_page_callable_with_file_registered_raises(self) -> None:
+        """Switching to a callable-based ``StreamlitPage`` raises when the
+        registered page sharing its ``url_path`` is file-based."""
+        import streamlit as st
+
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        def some_callable() -> None:
+            pass
+
+        with pytest.raises(StreamlitAPIException, match=r"is a callable"):
+            st.switch_page(st.Page(some_callable, url_path="foo"))
+
+    def test_streamlit_page_matching_source_does_not_raise(self) -> None:
+        """A ``StreamlitPage`` whose source matches the registered page is
+        accepted by validation (no ``StreamlitAPIException`` raised)."""
+        import streamlit as st
+
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        matching = st.Page("page1.py", url_path="foo")
+        # Validation passes — the rerun side effect is harmless for this test.
+        st.switch_page(matching)
+
+    def test_streamlit_page_unregistered_url_path_does_not_raise(self) -> None:
+        """If no page with the given ``url_path`` is registered (no hash
+        collision), validation is skipped — preserving previous behavior for
+        apps that don't use ``st.navigation``."""
+        import streamlit as st
+
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        # url_path "bar" is not registered; hash lookup misses, so the
+        # validator silently passes and the rerun side effect proceeds.
+        st.switch_page(st.Page("other.py", url_path="bar"))

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -252,26 +252,21 @@ class PageLinkTest(DeltaGeneratorTestCase):
 
         assert 'The value "   " is not a valid emoji' in str(exc_info.value)
 
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_st_page_with_mismatched_file_path_raises(self):
+        """Linking to an ``st.Page`` whose file path does not match the page
+        registered under the same ``url_path`` raises.
 
-@patch("pathlib.Path.is_file", MagicMock(return_value=True))
-class PageLinkStreamlitPageValidationTest(DeltaGeneratorTestCase):
-    """Test that ``st.page_link`` validates a passed ``StreamlitPage`` against
-    pages registered with ``st.navigation`` and raises when the source does not
-    match the registered page sharing the same URL pathname.
-
-    Regression coverage for https://github.com/streamlit/streamlit/issues/10572.
-    """
-
-    def test_streamlit_page_with_mismatched_file_path_raises(self) -> None:
-        """Linking to a ``StreamlitPage`` whose file path does not match the
-        page registered under the same ``url_path`` raises."""
+        Regression coverage for https://github.com/streamlit/streamlit/issues/10572.
+        """
         st.navigation([st.Page("page1.py", url_path="foo")])
 
         bad_page = st.Page("other.py", url_path="foo")
         with pytest.raises(StreamlitAPIException, match=r"different page is "):
             st.page_link(bad_page)
 
-    def test_streamlit_page_with_inferred_url_path_mismatch_raises(self) -> None:
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_st_page_with_inferred_url_path_mismatch_raises(self):
         """Linking to ``st.Page("foo.py")`` (url_path inferred as ``foo``)
         raises when a different file is registered under ``url_path="foo"``."""
         st.navigation([st.Page("page1.py", url_path="foo")])
@@ -279,9 +274,10 @@ class PageLinkStreamlitPageValidationTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException, match=r"different page is "):
             st.page_link(st.Page("foo.py"))
 
-    def test_streamlit_page_callable_with_file_registered_raises(self) -> None:
-        """Linking to a callable-based ``StreamlitPage`` raises when the
-        registered page sharing its ``url_path`` is file-based."""
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_st_page_callable_with_file_registered_raises(self):
+        """Linking to a callable-based ``st.Page`` raises when the registered
+        page sharing its ``url_path`` is file-based."""
         st.navigation([st.Page("page1.py", url_path="foo")])
 
         def some_callable() -> None:
@@ -290,15 +286,17 @@ class PageLinkStreamlitPageValidationTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException, match=r"is a callable"):
             st.page_link(st.Page(some_callable, url_path="foo"))
 
-    def test_streamlit_page_matching_source_does_not_raise(self) -> None:
-        """A ``StreamlitPage`` whose source matches the registered page is
-        accepted by validation."""
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_st_page_matching_source_does_not_raise(self):
+        """An ``st.Page`` whose source matches the registered page is accepted
+        by validation."""
         st.navigation([st.Page("page1.py", url_path="foo")])
 
         matching = st.Page("page1.py", url_path="foo")
         st.page_link(matching)
 
-    def test_streamlit_page_unregistered_url_path_does_not_raise(self) -> None:
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_st_page_unregistered_url_path_does_not_raise(self):
         """If no page with the given ``url_path`` is registered (no hash
         collision), validation is skipped — preserving previous behavior for
         apps that don't use ``st.navigation``."""

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -251,3 +251,57 @@ class PageLinkTest(DeltaGeneratorTestCase):
             st.page_link(page="https://example.com", label="Test", icon="   ")
 
         assert 'The value "   " is not a valid emoji' in str(exc_info.value)
+
+
+@patch("pathlib.Path.is_file", MagicMock(return_value=True))
+class PageLinkStreamlitPageValidationTest(DeltaGeneratorTestCase):
+    """Test that ``st.page_link`` validates a passed ``StreamlitPage`` against
+    pages registered with ``st.navigation`` and raises when the source does not
+    match the registered page sharing the same URL pathname.
+
+    Regression coverage for https://github.com/streamlit/streamlit/issues/10572.
+    """
+
+    def test_streamlit_page_with_mismatched_file_path_raises(self) -> None:
+        """Linking to a ``StreamlitPage`` whose file path does not match the
+        page registered under the same ``url_path`` raises."""
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        bad_page = st.Page("other.py", url_path="foo")
+        with pytest.raises(StreamlitAPIException, match=r"different page is "):
+            st.page_link(bad_page)
+
+    def test_streamlit_page_with_inferred_url_path_mismatch_raises(self) -> None:
+        """Linking to ``st.Page("foo.py")`` (url_path inferred as ``foo``)
+        raises when a different file is registered under ``url_path="foo"``."""
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        with pytest.raises(StreamlitAPIException, match=r"different page is "):
+            st.page_link(st.Page("foo.py"))
+
+    def test_streamlit_page_callable_with_file_registered_raises(self) -> None:
+        """Linking to a callable-based ``StreamlitPage`` raises when the
+        registered page sharing its ``url_path`` is file-based."""
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        def some_callable() -> None:
+            pass
+
+        with pytest.raises(StreamlitAPIException, match=r"is a callable"):
+            st.page_link(st.Page(some_callable, url_path="foo"))
+
+    def test_streamlit_page_matching_source_does_not_raise(self) -> None:
+        """A ``StreamlitPage`` whose source matches the registered page is
+        accepted by validation."""
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        matching = st.Page("page1.py", url_path="foo")
+        st.page_link(matching)
+
+    def test_streamlit_page_unregistered_url_path_does_not_raise(self) -> None:
+        """If no page with the given ``url_path`` is registered (no hash
+        collision), validation is skipped — preserving previous behavior for
+        apps that don't use ``st.navigation``."""
+        st.navigation([st.Page("page1.py", url_path="foo")])
+
+        st.page_link(st.Page("other.py", url_path="bar"))


### PR DESCRIPTION
## Summary

Fixes #10572. `st.switch_page` and `st.page_link` blindly trust `StreamlitPage._script_hash` (which is derived solely from `url_path`). When a user constructs a `StreamlitPage` that shares a `url_path` with a page registered via `st.navigation`, the hash collides and the request silently routes to the registered page — even when the source file or callable differs from what the user passed.

This PR adds a `_validate_registered_page` helper that, on a hash collision with a registered page, verifies the source matches:
- File-based pages must point at the same `script_path` as the registered page.
- Callable-based pages must not collide with a file-based registered page.

When no page with the given hash is registered (e.g., apps that don't use `st.navigation`), validation is skipped to preserve existing behavior. Two different callables sharing one `url_path` cannot currently be disambiguated — `PageInfo` only stores `script_path` (empty for callables) — so that edge case is out of scope.

## Test plan

- [x] Added 10 unit tests across `execution_control_test.py` and `page_link_test.py` covering: mismatched file path, inferred-url-path mismatch, callable-vs-file mismatch, matching source (positive), and unregistered url_path (skip).
- [x] All 150 tests in the four relevant test files pass (`execution_control_test`, `page_link_test`, `navigation_test`, `navigation/page_test`).
- [x] `make check` clean for lint/format/ty. (Pre-existing mypy error in `page_config.py` is unrelated.)
