### PR TITLE
[chore] Update Claude Opus model to 4-8 in AI workflows

### DIFF
--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
         description: "Model to use for flaky test fixing"
         required: false
         type: string
-        default: "claude-opus-4-7-thinking-xhigh"
+        default: "claude-opus-4-8-thinking-xhigh"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
   TOP_N: ${{ inputs.top_n || 10 }}
   DAYS: ${{ inputs.days || 4 }}
 

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -14,12 +14,12 @@ on:
         description: "Model to use for the triage"
         required: false
         type: string
-        default: "claude-opus-4-7-thinking-xhigh"
+        default: "claude-opus-4-8-thinking-xhigh"
 
 # Computed issue number and model for use in jobs
 env:
   ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-  MODEL: ${{ github.event.inputs.model || 'claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ github.event.inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
 
 jobs:
   # Job 1: AI performs the triage analysis with READ-ONLY access

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -14,11 +14,11 @@ on:
         description: "Model to use for QA testing"
         required: false
         type: string
-        default: "claude-opus-4-7-thinking-xhigh"
+        default: "claude-opus-4-8-thinking-xhigh"
 
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ github.event.inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
 
 jobs:
   check-secrets:

--- a/.github/workflows/ai-test-coverage.yml
+++ b/.github/workflows/ai-test-coverage.yml
@@ -11,7 +11,7 @@ on:
         description: "Model to use for coverage improvement"
         required: false
         type: string
-        default: "claude-opus-4-7-thinking-xhigh"
+        default: "claude-opus-4-8-thinking-xhigh"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -19,7 +19,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
 
 jobs:
   check-secrets:

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -15,7 +15,7 @@ on:
         description: "Model to use for documentation review"
         required: false
         type: string
-        default: "claude-opus-4-7-thinking-xhigh"
+        default: "claude-opus-4-8-thinking-xhigh"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -23,7 +23,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'claude-opus-4-7-thinking-xhigh' }}
+  MODEL: ${{ inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
   PR_NUMBER: ${{ inputs.pr_number || '' }}
 
 jobs:


### PR DESCRIPTION
## Describe your changes

Bumps the default Claude model from `claude-opus-4-7-thinking-xhigh` to `claude-opus-4-8-thinking-xhigh` across the AI automation workflows (flaky-test fixing, issue triage, QA testing, test coverage, and docs updates).

## GitHub Issue Link (if applicable)

## Testing Plan

- No tests needed: CI/CD workflow config change only (model string default), no runtime behavior in the Streamlit library.

Made with [Cursor](https://cursor.com)