### PR TITLE
Extract `useHoverSubmenu` hook for `FormattingMenu` & `StatisticsMenu`

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/FormattingMenu.tsx
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useCallback, useEffect, useRef } from "react"
+import { memo, ReactElement } from "react"
 
 import { FloatingPortal } from "@floating-ui/react"
 
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
-import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
-import useTimeout from "~lib/hooks/useTimeout"
+import { useHoverSubmenu } from "~lib/hooks/useHoverSubmenu"
 
 import {
   StyledMenuList,
@@ -186,66 +185,11 @@ function FormattingMenu({
 }: FormattingMenuProps): ReactElement {
   const formats = COLUMN_KIND_FORMAT_MAPPING[columnKind] || []
 
-  // Note: FloatingPortal panels may render at (0,0) for one frame before
-  // floating-ui measures and positions them. A visibility:hidden guard until
-  // placement is stable would fix this, but no other overlay in the codebase
-  // (MenuButton, Popover, TopNav, ColorPicker) uses that pattern. If a flash
-  // is observed on slow machines, add `visibility: isPositioned ? 'visible' :
-  // 'hidden'` using useFloating's `isPositioned` return value.
-
-  // Refs to the anchor and panel DOM nodes — needed for the mouseover check.
-  const anchorRef = useRef<HTMLDivElement | null>(null)
-  const panelRef = useRef<HTMLDivElement | null>(null)
-
-  const { refs, floatingStyles } = useFloatingOverlay({
-    open: isOpen,
-    placement: "right",
-    offsetPx: 2,
+  const { floatingStyles, setAnchorRef, setFloatingRef } = useHoverSubmenu({
+    isOpen,
+    onOpenChange,
+    enabled: formats.length > 0,
   })
-
-  // Merge floating-ui's callback refs with our local refs.
-  const setAnchorRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      anchorRef.current = node
-      refs.setReference(node)
-    },
-    [refs]
-  )
-  const setPanelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      panelRef.current = node
-      refs.setFloating(node)
-    },
-    [refs]
-  )
-
-  const { clear: clearClose, restart: scheduleClose } = useTimeout(
-    () => onOpenChange(false),
-    150,
-    { autoStart: false }
-  )
-
-  // Document-level mouseover listener for reliable cross-browser hover detection.
-  // Element-level onPointerEnter is unreliable in WebKit with Playwright because
-  // synthetic click events don't always fire pointerenter on FloatingPortal elements
-  // when crossing portal boundaries. mouseover bubbles to document unconditionally,
-  // so it fires regardless of portal structure or browser engine.
-  useEffect(() => {
-    if (formats.length === 0) return
-    const handleMouseOver = (e: MouseEvent): void => {
-      const target = e.target as Element
-      if (anchorRef.current?.contains(target)) {
-        clearClose()
-        onOpenChange(true)
-      } else if (isOpen && panelRef.current?.contains(target)) {
-        clearClose()
-      } else if (isOpen) {
-        scheduleClose()
-      }
-    }
-    document.addEventListener("mouseover", handleMouseOver)
-    return () => document.removeEventListener("mouseover", handleMouseOver)
-  }, [isOpen, formats.length, clearClose, onOpenChange, scheduleClose])
 
   if (formats.length === 0) {
     // If there are no formats available for the column kind,
@@ -261,7 +205,7 @@ function FormattingMenu({
       {isOpen && (
         <FloatingPortal>
           <StyledSubMenuPanel
-            ref={setPanelRef}
+            ref={setFloatingRef}
             style={floatingStyles}
             data-testid="stDataFrameColumnFormattingMenu"
             tabIndex={-1}

--- a/frontend/lib/src/components/widgets/DataFrame/menus/StatisticsMenu.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/StatisticsMenu.tsx
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react"
+import { memo, ReactElement, useMemo } from "react"
 
 import { FloatingPortal } from "@floating-ui/react"
 
 import { BaseColumn } from "~lib/components/widgets/DataFrame/columns"
 import { getTimezone } from "~lib/dataframes/arrowTypeUtils"
 import { Quiver } from "~lib/dataframes/Quiver"
-import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
-import useTimeout from "~lib/hooks/useTimeout"
+import { useHoverSubmenu } from "~lib/hooks/useHoverSubmenu"
 
 import StatisticsChart from "./StatisticsChart"
 import {
@@ -283,58 +275,10 @@ function StatisticsMenu({
     return computeStatistics(column.kind, data, column.indexNumber, timezone)
   }, [isOpen, column.kind, column.indexNumber, column.arrowType, data])
 
-  // Refs to the anchor and panel DOM nodes — needed for the mouseover check.
-  const anchorRef = useRef<HTMLDivElement | null>(null)
-  const panelRef = useRef<HTMLDivElement | null>(null)
-
-  const { refs, floatingStyles } = useFloatingOverlay({
-    open: isOpen,
-    placement: "right",
-    offsetPx: 2,
+  const { floatingStyles, setAnchorRef, setFloatingRef } = useHoverSubmenu({
+    isOpen,
+    onOpenChange,
   })
-
-  // Merge floating-ui's callback refs with our local refs.
-  const setAnchorRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      anchorRef.current = node
-      refs.setReference(node)
-    },
-    [refs]
-  )
-  const setPanelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      panelRef.current = node
-      refs.setFloating(node)
-    },
-    [refs]
-  )
-
-  const { clear: clearClose, restart: scheduleClose } = useTimeout(
-    () => onOpenChange(false),
-    150,
-    { autoStart: false }
-  )
-
-  // Document-level mouseover listener for reliable cross-browser hover detection.
-  // Element-level onPointerEnter is unreliable in WebKit with Playwright because
-  // synthetic click events don't always fire pointerenter on FloatingPortal elements
-  // when crossing portal boundaries. mouseover bubbles to document unconditionally,
-  // so it fires regardless of portal structure or browser engine.
-  useEffect(() => {
-    const handleMouseOver = (e: MouseEvent): void => {
-      const target = e.target as Element
-      if (anchorRef.current?.contains(target)) {
-        clearClose()
-        onOpenChange(true)
-      } else if (isOpen && panelRef.current?.contains(target)) {
-        clearClose()
-      } else if (isOpen) {
-        scheduleClose()
-      }
-    }
-    document.addEventListener("mouseover", handleMouseOver)
-    return () => document.removeEventListener("mouseover", handleMouseOver)
-  }, [isOpen, clearClose, onOpenChange, scheduleClose])
 
   // Defensive fallback: parent ColumnMenu already guards this, but keep for safety.
   // This ensures the component renders nothing if called directly without the guard.
@@ -353,7 +297,7 @@ function StatisticsMenu({
               Allows keyboard users to navigate the parent column menu while
               viewing statistics. */}
           <StyledSubMenuPanel
-            ref={setPanelRef}
+            ref={setFloatingRef}
             style={floatingStyles}
             data-testid="stDataFrameStatisticsMenu"
           >

--- a/frontend/lib/src/hooks/useHoverSubmenu.ts
+++ b/frontend/lib/src/hooks/useHoverSubmenu.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type CSSProperties, useCallback, useEffect, useRef } from "react"
+
+import { type Placement } from "@floating-ui/react"
+
+import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
+import useTimeout from "~lib/hooks/useTimeout"
+
+interface UseHoverSubmenuOptions {
+  /** Whether the submenu is currently open. */
+  isOpen: boolean
+  /** Called when hover interactions change the open state. */
+  onOpenChange: (open: boolean) => void
+  /**
+   * When false, the mouseover listener is skipped entirely.
+   * Use `enabled === false` (not `!enabled`) so that omitting this prop
+   * (undefined) behaves as true.
+   */
+  enabled?: boolean
+  /** Close delay in milliseconds when the pointer leaves both anchor and panel. Defaults to 150. */
+  delayMs?: number
+  /** Floating-ui placement for the submenu panel. Defaults to "right". */
+  placement?: Placement
+  /** Pixel offset between anchor and panel. Defaults to 2. */
+  offsetPx?: number
+}
+
+interface UseHoverSubmenuReturn {
+  /** Floating-ui computed styles to apply to the panel element. */
+  floatingStyles: CSSProperties
+  /** Callback ref to attach to the anchor (trigger) element. */
+  setAnchorRef: (node: HTMLElement | null) => void
+  /** Callback ref to attach to the floating panel element. */
+  setFloatingRef: (node: HTMLElement | null) => void
+}
+
+/**
+ * Shared hook for hover-activated submenus (e.g. FormattingMenu, StatisticsMenu).
+ *
+ * Encapsulates:
+ * - Floating-ui positioning via `useFloatingOverlay`
+ * - Merged callback refs (floating-ui + local DOM refs for hit-testing)
+ * - Document-level `mouseover` listener for reliable cross-browser hover detection
+ * - Debounced close via `useTimeout`
+ *
+ * The `mouseover` approach is intentional: element-level `onPointerEnter` is
+ * unreliable in WebKit with Playwright because synthetic click events don't
+ * always fire `pointerenter` on FloatingPortal elements across portal boundaries.
+ * `mouseover` bubbles to `document` unconditionally.
+ */
+export function useHoverSubmenu({
+  isOpen,
+  onOpenChange,
+  enabled,
+  delayMs = 150,
+  placement = "right",
+  offsetPx = 2,
+}: UseHoverSubmenuOptions): UseHoverSubmenuReturn {
+  const anchorRef = useRef<HTMLElement | null>(null)
+  const panelRef = useRef<HTMLElement | null>(null)
+
+  const { refs, floatingStyles } = useFloatingOverlay({
+    open: isOpen,
+    placement,
+    offsetPx,
+  })
+
+  const setAnchorRef = useCallback(
+    (node: HTMLElement | null): void => {
+      anchorRef.current = node
+      refs.setReference(node)
+    },
+    [refs]
+  )
+
+  const setFloatingRef = useCallback(
+    (node: HTMLElement | null): void => {
+      panelRef.current = node
+      refs.setFloating(node)
+    },
+    [refs]
+  )
+
+  const { clear: clearClose, restart: scheduleClose } = useTimeout(
+    () => onOpenChange(false),
+    delayMs,
+    { autoStart: false }
+  )
+
+  // Document-level mouseover listener for reliable cross-browser hover detection.
+  // Element-level onPointerEnter is unreliable in WebKit with Playwright because
+  // synthetic click events don't always fire pointerenter on FloatingPortal elements
+  // when crossing portal boundaries. mouseover bubbles to document unconditionally,
+  // so it fires regardless of portal structure or browser engine.
+  useEffect(() => {
+    // enabled === false (explicit false) disables the listener.
+    // undefined (not provided) means enabled — do NOT use !enabled here.
+    if (enabled === false) return
+
+    const handleMouseOver = (e: MouseEvent): void => {
+      const target = e.target as Element
+      if (anchorRef.current?.contains(target)) {
+        clearClose()
+        onOpenChange(true)
+      } else if (isOpen && panelRef.current?.contains(target)) {
+        clearClose()
+      } else if (isOpen) {
+        scheduleClose()
+      }
+    }
+
+    document.addEventListener("mouseover", handleMouseOver)
+    return () => document.removeEventListener("mouseover", handleMouseOver)
+  }, [isOpen, enabled, clearClose, onOpenChange, scheduleClose])
+
+  return { floatingStyles, setAnchorRef, setFloatingRef }
+}

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -107,6 +107,7 @@ export { useCrossOriginAttribute } from "./hooks/useCrossOriginAttribute"
 export { useEmotionTheme } from "./hooks/useEmotionTheme"
 export { useExecuteWhenChanged } from "./hooks/useExecuteWhenChanged"
 export { useFloatingOverlay } from "./hooks/useFloatingOverlay"
+export { useHoverSubmenu } from "./hooks/useHoverSubmenu"
 export {
   ensureHotkeysFilterConfigured,
   isKeyboardEventFromEditableTarget,


### PR DESCRIPTION
## Describe your changes
Refactor: `FormattingMenu` and `StatisticsMenu` shared identical hover-gap + dual-ref boilerplate (~35 lines each). The new `useHoverSubmenu` hook encapsulates `floating-ui` positioning, merged callback refs, document-level mouseover detection, and debounced close via useTimeout.