### PR TITLE
[fix] Ignore dataframe Ctrl+F shortcut when search is disabled

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -146,6 +146,36 @@ describe("DataFrame widget", () => {
     )
   })
 
+  it("shows search when Cmd+F is pressed and search is enabled", () => {
+    render(<DataFrame {...props} />)
+
+    const event = {
+      ctrlKey: false,
+      metaKey: true,
+      key: "f",
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    }
+
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: false,
+      })
+    )
+
+    act(() => {
+      dataEditorMockFn.mock.lastCall?.[0].onKeyDown(event)
+    })
+
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: true,
+      })
+    )
+  })
+
   it("does not handle Ctrl+F when search is disabled", () => {
     render(<DataFrame {...getProps(EMPTY)} />)
 
@@ -163,6 +193,37 @@ describe("DataFrame widget", () => {
 
     expect(event.stopPropagation).not.toHaveBeenCalled()
     expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: false,
+      })
+    )
+  })
+
+  it("hides the search overlay when search becomes disabled while open", () => {
+    const { rerender } = render(<DataFrame {...props} />)
+
+    act(() => {
+      dataEditorMockFn.mock.lastCall?.[0].onKeyDown({
+        ctrlKey: true,
+        metaKey: false,
+        key: "f",
+        stopPropagation: vi.fn(),
+        preventDefault: vi.fn(),
+      })
+    })
+
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: true,
+      })
+    )
+
+    // The dataframe becomes empty, which disables search. The overlay must
+    // not stay stuck open since both the toolbar button and the keyboard
+    // shortcut are disabled in that case.
+    rerender(<DataFrame {...getProps(EMPTY)} />)
+
     expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
       expect.objectContaining({
         showSearch: false,

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -16,11 +16,12 @@
 
 import { forwardRef } from "react"
 
-import { screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 
 import { Dataframe as DataframeProto } from "@streamlit/protobuf"
 
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
+import { EMPTY } from "~lib/mocks/arrow/empty"
 import { TEN_BY_TEN } from "~lib/mocks/arrow/tenByTen"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -113,6 +114,60 @@ describe("DataFrame widget", () => {
     // Verify expected toolbar buttons: search, column visibility, download, fullscreen
     const toolbarButtons = screen.getAllByTestId("stElementToolbarButton")
     expect(toolbarButtons).toHaveLength(4)
+  })
+
+  it("shows search when Ctrl+F is pressed and search is enabled", () => {
+    render(<DataFrame {...props} />)
+
+    const event = {
+      ctrlKey: true,
+      metaKey: false,
+      key: "f",
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    }
+
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: false,
+      })
+    )
+
+    act(() => {
+      dataEditorMockFn.mock.lastCall?.[0].onKeyDown(event)
+    })
+
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: true,
+      })
+    )
+  })
+
+  it("does not handle Ctrl+F when search is disabled", () => {
+    render(<DataFrame {...getProps(EMPTY)} />)
+
+    const event = {
+      ctrlKey: true,
+      metaKey: false,
+      key: "f",
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn(),
+    }
+
+    act(() => {
+      dataEditorMockFn.mock.lastCall?.[0].onKeyDown(event)
+    })
+
+    expect(event.stopPropagation).not.toHaveBeenCalled()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(dataEditorMockFn.mock.lastCall?.[0]).toEqual(
+      expect.objectContaining({
+        showSearch: false,
+      })
+    )
   })
 
   it("should show column visibility button when all columns are visible", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -719,6 +719,13 @@ function DataFrame({
       ? true
       : false
 
+  // The search overlay may only be open while search is actually enabled.
+  // Deriving it from `canSearch` ensures the overlay is hidden (instead of
+  // getting stuck open) if the table becomes empty while search is active,
+  // since both the toolbar search button and the Ctrl/Cmd+F shortcut are
+  // disabled in that case.
+  const isSearchOpen = canSearch && showSearch
+
   return (
     <StyledResizableContainer
       className="stDataFrame"
@@ -987,8 +994,8 @@ function DataFrame({
               event.preventDefault()
             }
           }}
-          showSearch={showSearch}
-          searchResults={!showSearch ? [] : undefined}
+          showSearch={isSearchOpen}
+          searchResults={!isSearchOpen ? [] : undefined}
           onSearchClose={() => {
             setShowSearch(false)
             clearTooltip()

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -977,7 +977,11 @@ function DataFrame({
           // Search needs to be activated manually, to support search
           // via the toolbar:
           onKeyDown={event => {
-            if ((event.ctrlKey || event.metaKey) && event.key === "f") {
+            if (
+              canSearch &&
+              (event.ctrlKey || event.metaKey) &&
+              event.key === "f"
+            ) {
               setShowSearch(cv => !cv)
               event.stopPropagation()
               event.preventDefault()


### PR DESCRIPTION
## Describe your changes

The dataframe's `Ctrl+F`/`Cmd+F` keydown handler toggled the search overlay even when search was disabled (e.g. empty dataframes or when the search feature is not available). It now only handles the shortcut when `canSearch` is `true`, letting the event fall through to the browser's native find otherwise.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS): `DataFrame.test.tsx` covers `Ctrl+F` toggling search when enabled and being ignored (no `preventDefault`/`stopPropagation`) when disabled.

Made with [Cursor](https://cursor.com)