### PR TITLE
[feature] Add resolution parameter to st.camera_input

### DIFF
--- a/e2e_playwright/st_camera_input.py
+++ b/e2e_playwright/st_camera_input.py
@@ -25,7 +25,14 @@ y = st.camera_input("Label2", help="help2", disabled=True)
 st.camera_input("Width Stretch", width="stretch", key="camera_stretch", disabled=True)
 st.camera_input("Width 300px", width=300, key="camera_300px", disabled=True)
 
-st.camera_input("720p Resolution", resolution="720p", key="camera_720p")
+camera_720p_value = st.camera_input(
+    "720p Resolution", resolution="720p", key="camera_720p"
+)
+if camera_720p_value is not None:
+    from PIL import Image
+
+    captured = Image.open(camera_720p_value)
+    st.markdown(f"720p captured height: {captured.height}")
 
 if st.toggle("Update camera input props"):
     cam_val = st.camera_input(

--- a/e2e_playwright/st_camera_input.py
+++ b/e2e_playwright/st_camera_input.py
@@ -25,6 +25,8 @@ y = st.camera_input("Label2", help="help2", disabled=True)
 st.camera_input("Width Stretch", width="stretch", key="camera_stretch", disabled=True)
 st.camera_input("Width 300px", width=300, key="camera_300px", disabled=True)
 
+st.camera_input("720p Resolution", resolution="720p", key="camera_720p")
+
 if st.toggle("Update camera input props"):
     cam_val = st.camera_input(
         "Updated dynamic camera input",

--- a/e2e_playwright/st_camera_input_test.py
+++ b/e2e_playwright/st_camera_input_test.py
@@ -26,7 +26,7 @@ from e2e_playwright.shared.app_utils import (
     get_element_by_key,
 )
 
-NUM_CAMERA_INPUT_WIDGETS = 5
+NUM_CAMERA_INPUT_WIDGETS = 6
 
 
 def check_dimensions_func(camera_input: Locator) -> Callable[[], bool]:
@@ -134,6 +134,21 @@ def test_take_photo_button_styling(app: Page):
     expect(take_photo_button).to_have_css("color", "rgba(49, 51, 63, 0.4)")
     expect(take_photo_button).to_have_css("border-color", "rgba(49, 51, 63, 0.2)")
     expect(take_photo_button).to_have_css("background-color", "rgb(255, 255, 255)")
+
+
+@pytest.mark.only_browser("chromium")
+def test_captures_photo_with_720p_resolution(app: Page):
+    """Test that a camera input with resolution='720p' captures a photo."""
+    camera = get_element_by_key(app, "camera_720p").get_by_test_id("stCameraInput")
+    take_photo_button = camera.get_by_test_id("stCameraInputButton").first
+    # Wait until the fake video stream is ready (button becomes enabled)
+    expect(take_photo_button).to_be_enabled()
+    # Capture a photo
+    take_photo_button.click()
+    # Verify a photo was captured (Clear photo button appears)
+    expect(camera.get_by_text("Clear photo")).to_be_visible()
+    # Verify no error occurred (widget still visible)
+    expect(camera).to_be_visible()
 
 
 def test_check_top_level_class(app: Page):

--- a/e2e_playwright/st_camera_input_test.py
+++ b/e2e_playwright/st_camera_input_test.py
@@ -138,7 +138,14 @@ def test_take_photo_button_styling(app: Page):
 
 @pytest.mark.only_browser("chromium")
 def test_captures_photo_with_720p_resolution(app: Page):
-    """Test that a camera input with resolution='720p' captures a photo."""
+    """A resolution='720p' capture is encoded at the requested 720px height.
+
+    The app script opens the uploaded file and writes its pixel height, so this
+    asserts the dimensions of the actual captured image (not just the on-screen
+    preview). The Chromium fake camera streams 1280x720 for an ideal-720 height
+    request, and ``forceScreenshotSourceSize`` makes the screenshot use the
+    stream's intrinsic size.
+    """
     camera = get_element_by_key(app, "camera_720p").get_by_test_id("stCameraInput")
     take_photo_button = camera.get_by_test_id("stCameraInputButton").first
     # Wait until the fake video stream is ready (button becomes enabled)
@@ -147,8 +154,8 @@ def test_captures_photo_with_720p_resolution(app: Page):
     take_photo_button.click()
     # Verify a photo was captured (Clear photo button appears)
     expect(camera.get_by_text("Clear photo")).to_be_visible()
-    # Verify no error occurred (widget still visible)
-    expect(camera).to_be_visible()
+    # The captured JPEG is encoded at the requested 720px height.
+    expect_prefixed_markdown(app, "720p captured height:", "720")
 
 
 def test_check_top_level_class(app: Page):

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -642,4 +642,22 @@ describe("CameraInput widget", () => {
       expect(screen.getByTestId("stCameraInputWebcamComponent")).toBeVisible()
     })
   })
+
+  describe("resolution height forwarding", () => {
+    it("forwards resolutionHeight to WebcamComponent when proto field is set", () => {
+      const props = getProps({ resolutionHeight: 720 })
+      render(<CameraInput {...props} />)
+
+      // WebcamComponent receives the resolutionHeight; it renders without error
+      expect(screen.getByTestId("stCameraInputWebcamComponent")).toBeVisible()
+    })
+
+    it("forwards undefined to WebcamComponent when proto field is absent", () => {
+      const props = getProps({})
+      render(<CameraInput {...props} />)
+
+      // WebcamComponent receives undefined resolutionHeight; renders normally
+      expect(screen.getByTestId("stCameraInputWebcamComponent")).toBeVisible()
+    })
+  })
 })

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -44,7 +44,7 @@ const webcamMock = vi.hoisted(() => ({
 
 vi.mock("react-webcam", () => {
   const MockWebcam = forwardRef((props, ref) => {
-    webcamMock.calls.push(props as Record<string, unknown>)
+    webcamMock.calls.push(props)
     useImperativeHandle(ref, () => {
       return {
         getScreenshot: () => "data:image/jpeg;base64,mocked-photo",

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.test.tsx
@@ -36,8 +36,15 @@ import { WidgetStateManager } from "~lib/WidgetStateManager"
 import CameraInput, { Props } from "./CameraInput"
 import { WebcamPermission } from "./WebcamComponent"
 
+// Records the props passed to the (mocked) react-webcam on each render so tests
+// can assert how CameraInput's props flow through WebcamComponent.
+const webcamMock = vi.hoisted(() => ({
+  calls: [] as Array<Record<string, unknown>>,
+}))
+
 vi.mock("react-webcam", () => {
-  const MockWebcam = forwardRef((_props, ref) => {
+  const MockWebcam = forwardRef((props, ref) => {
+    webcamMock.calls.push(props as Record<string, unknown>)
     useImperativeHandle(ref, () => {
       return {
         getScreenshot: () => "data:image/jpeg;base64,mocked-photo",
@@ -644,20 +651,37 @@ describe("CameraInput widget", () => {
   })
 
   describe("resolution height forwarding", () => {
-    it("forwards resolutionHeight to WebcamComponent when proto field is set", () => {
+    beforeEach(() => {
+      webcamMock.calls.length = 0
+    })
+
+    it("forwards resolutionHeight as a height-only capture constraint", () => {
       const props = getProps({ resolutionHeight: 720 })
       render(<CameraInput {...props} />)
 
-      // WebcamComponent receives the resolutionHeight; it renders without error
-      expect(screen.getByTestId("stCameraInputWebcamComponent")).toBeVisible()
+      // The proto field reaches WebcamComponent, which turns it into a
+      // height-only getUserMedia constraint and forces the screenshot to use
+      // the stream's intrinsic size.
+      const webcamProps = webcamMock.calls.at(-1)
+      expect(webcamProps?.forceScreenshotSourceSize).toBe(true)
+      expect(webcamProps?.videoConstraints).toMatchObject({
+        height: { ideal: 720 },
+      })
+      expect(webcamProps?.videoConstraints).not.toHaveProperty("width")
     })
 
-    it("forwards undefined to WebcamComponent when proto field is absent", () => {
+    it("omits the resolution constraint when the proto field is absent", () => {
       const props = getProps({})
       render(<CameraInput {...props} />)
 
-      // WebcamComponent receives undefined resolutionHeight; renders normally
-      expect(screen.getByTestId("stCameraInputWebcamComponent")).toBeVisible()
+      // Without a resolution, capture falls back to the display-width hint and
+      // the screenshot uses the displayed element size.
+      const webcamProps = webcamMock.calls.at(-1)
+      expect(webcamProps?.forceScreenshotSourceSize).toBe(false)
+      expect(webcamProps?.videoConstraints).toMatchObject({
+        width: { ideal: expect.any(Number) },
+      })
+      expect(webcamProps?.videoConstraints).not.toHaveProperty("height")
     })
   })
 })

--- a/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/CameraInput.tsx
@@ -662,6 +662,7 @@ const CameraInput = ({
           setClearPhotoInProgress={setClearPhotoInProgress}
           facingMode={facingMode}
           setFacingMode={handleSetFacingMode}
+          resolutionHeight={element.resolutionHeight ?? undefined}
           testOverride={testOverride}
         />
       )}

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.test.tsx
@@ -16,6 +16,7 @@
 
 import { act, screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
+import Webcam from "react-webcam"
 
 import { render } from "~lib/test_util"
 
@@ -191,5 +192,63 @@ describe("Test Webcam Component", () => {
     await user.click(screen.getByRole("button", { name: "Take Photo" }))
 
     expect(props.handleCapture).toHaveBeenCalled()
+  })
+})
+
+describe("WebcamComponent resolution constraints", () => {
+  beforeEach(() => {
+    vi.mocked(Webcam).mockClear()
+  })
+
+  const getProps = (props: Partial<Props> = {}): Props => ({
+    handleCapture: vi.fn(),
+    width: 500,
+    disabled: false,
+    setClearPhotoInProgress: vi.fn(),
+    clearPhotoInProgress: false,
+    facingMode: FacingMode.USER,
+    setFacingMode: vi.fn(),
+    testOverride: WebcamPermission.SUCCESS,
+    ...props,
+  })
+
+  const advanceDebounceTimer = (): void => {
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+  }
+
+  it("uses width ideal constraint and forceScreenshotSourceSize=false when no resolutionHeight", () => {
+    const props = getProps()
+    render(<WebcamComponent {...props} />)
+    advanceDebounceTimer()
+
+    const webcamCalls = vi.mocked(Webcam).mock.calls
+    expect(webcamCalls.length).toBeGreaterThan(0)
+    const webcamProps = webcamCalls[webcamCalls.length - 1][0] as Record<
+      string,
+      unknown
+    >
+    const constraints = webcamProps.videoConstraints as MediaTrackConstraints
+    expect(constraints).toMatchObject({ width: { ideal: expect.any(Number) } })
+    expect(constraints).not.toHaveProperty("height")
+    expect(webcamProps.forceScreenshotSourceSize).toBe(false)
+  })
+
+  it("uses height ideal constraint and forceScreenshotSourceSize=true when resolutionHeight is set", () => {
+    const props = getProps({ resolutionHeight: 1080 })
+    render(<WebcamComponent {...props} />)
+    advanceDebounceTimer()
+
+    const webcamCalls = vi.mocked(Webcam).mock.calls
+    expect(webcamCalls.length).toBeGreaterThan(0)
+    const webcamProps = webcamCalls[webcamCalls.length - 1][0] as Record<
+      string,
+      unknown
+    >
+    const constraints = webcamProps.videoConstraints as MediaTrackConstraints
+    expect(constraints).toMatchObject({ height: { ideal: 1080 } })
+    expect(constraints).not.toHaveProperty("width")
+    expect(webcamProps.forceScreenshotSourceSize).toBe(true)
   })
 })

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -31,7 +31,7 @@ import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import themeColors from "~lib/theme/emotionBaseTheme/themeColors"
 import { CAMERA_PERMISSION_URL } from "~lib/urls"
 import { isMobile } from "~lib/util/isMobile"
-import { debounce } from "~lib/util/utils"
+import { debounce, isNullOrUndefined } from "~lib/util/utils"
 
 import CameraInputButton from "./CameraInputButton"
 import {
@@ -50,6 +50,7 @@ export interface Props {
   setClearPhotoInProgress: (clearPhotoInProgress: boolean) => void
   facingMode: FacingMode
   setFacingMode: () => void
+  resolutionHeight?: number
   // Allow for unit testing
   testOverride?: WebcamPermission
 }
@@ -92,6 +93,7 @@ const WebcamComponent = ({
   setClearPhotoInProgress,
   facingMode,
   setFacingMode,
+  resolutionHeight,
   testOverride,
 }: Props): ReactElement => {
   const [webcamPermission, setWebcamPermissionState] = useState(
@@ -121,6 +123,14 @@ const WebcamComponent = ({
 
   const theme = useEmotionTheme()
 
+  // When a resolution is requested we constrain only height so the camera's
+  // native aspect ratio determines width; otherwise we hint the display width.
+  const videoConstraints: MediaTrackConstraints = isNullOrUndefined(
+    resolutionHeight
+  )
+    ? { width: { ideal: debouncedWidth }, facingMode }
+    : { height: { ideal: resolutionHeight }, facingMode }
+
   return (
     <StyledCameraInput data-testid="stCameraInputWebcamComponent">
       {webcamPermission !== WebcamPermission.SUCCESS &&
@@ -147,9 +157,9 @@ const WebcamComponent = ({
             ref={videoRef}
             screenshotFormat="image/jpeg"
             screenshotQuality={1}
+            // width/height size the on-screen preview only; the captured image size is
+            // governed by videoConstraints + forceScreenshotSourceSize.
             width={debouncedWidth}
-            // We keep Aspect ratio of container always equal 16 / 9.
-            // The aspect ration of video stream may be different depending on a camera.
             height={(debouncedWidth * 9) / 16}
             style={{
               borderRadius: `${theme.radii.default} ${theme.radii.default} 0 0`,
@@ -161,10 +171,8 @@ const WebcamComponent = ({
               setWebcamPermissionState(WebcamPermission.SUCCESS)
               setClearPhotoInProgress(false)
             }}
-            videoConstraints={{
-              width: { ideal: debouncedWidth },
-              facingMode,
-            }}
+            videoConstraints={videoConstraints}
+            forceScreenshotSourceSize={!isNullOrUndefined(resolutionHeight)}
           />
         )}
       </StyledBox>

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -19,6 +19,7 @@ import {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
@@ -125,11 +126,15 @@ const WebcamComponent = ({
 
   // When a resolution is requested we constrain only height so the camera's
   // native aspect ratio determines width; otherwise we hint the display width.
-  const videoConstraints: MediaTrackConstraints = isNullOrUndefined(
-    resolutionHeight
+  // Memoized so react-webcam only renegotiates the stream when an input changes,
+  // since it uses videoConstraints as a useEffect dependency.
+  const videoConstraints: MediaTrackConstraints = useMemo(
+    () =>
+      isNullOrUndefined(resolutionHeight)
+        ? { width: { ideal: debouncedWidth }, facingMode }
+        : { height: { ideal: resolutionHeight }, facingMode },
+    [resolutionHeight, debouncedWidth, facingMode]
   )
-    ? { width: { ideal: debouncedWidth }, facingMode }
-    : { height: { ideal: resolutionHeight }, facingMode }
 
   return (
     <StyledCameraInput data-testid="stCameraInputWebcamComponent">

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -160,6 +160,8 @@ const WebcamComponent = ({
             // width/height size the on-screen preview only; the captured image size is
             // governed by videoConstraints + forceScreenshotSourceSize.
             width={debouncedWidth}
+            // We keep Aspect ratio of container always equal 16 / 9.
+            // The aspect ration of video stream may be different depending on a camera.
             height={(debouncedWidth * 9) / 16}
             style={{
               borderRadius: `${theme.radii.default} ${theme.radii.default} 0 0`,

--- a/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
+++ b/frontend/lib/src/components/widgets/CameraInput/WebcamComponent.tsx
@@ -126,15 +126,21 @@ const WebcamComponent = ({
 
   // When a resolution is requested we constrain only height so the camera's
   // native aspect ratio determines width; otherwise we hint the display width.
-  // Memoized so react-webcam only renegotiates the stream when an input changes,
-  // since it uses videoConstraints as a useEffect dependency.
-  const videoConstraints: MediaTrackConstraints = useMemo(
-    () =>
-      isNullOrUndefined(resolutionHeight)
-        ? { width: { ideal: debouncedWidth }, facingMode }
-        : { height: { ideal: resolutionHeight }, facingMode },
-    [resolutionHeight, debouncedWidth, facingMode]
+  // Each branch is memoized separately so the selected reference only changes
+  // with the inputs it actually uses. This keeps react-webcam (which treats
+  // videoConstraints as a useEffect dependency) from renegotiating the stream
+  // on resize while a resolution preset is active, where debouncedWidth is unused.
+  const heightConstraints: MediaTrackConstraints = useMemo(
+    () => ({ height: { ideal: resolutionHeight }, facingMode }),
+    [resolutionHeight, facingMode]
   )
+  const widthConstraints: MediaTrackConstraints = useMemo(
+    () => ({ width: { ideal: debouncedWidth }, facingMode }),
+    [debouncedWidth, facingMode]
+  )
+  const videoConstraints = isNullOrUndefined(resolutionHeight)
+    ? widthConstraints
+    : heightConstraints
 
   return (
     <StyledCameraInput data-testid="stCameraInputWebcamComponent">

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
 
 from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction
 from streamlit.elements.lib.form_utils import current_form_id
@@ -33,6 +33,7 @@ from streamlit.elements.lib.utils import (
     to_key,
 )
 from streamlit.elements.widgets.file_uploader import _get_upload_files
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.CameraInput_pb2 import CameraInput as CameraInputProto
 from streamlit.proto.Common_pb2 import FileUploaderState as FileUploaderStateProto
 from streamlit.proto.Common_pb2 import UploadedFileInfo as UploadedFileInfoProto
@@ -51,6 +52,14 @@ if TYPE_CHECKING:
     from streamlit.elements.lib.layout_utils import WidthWithoutContent
 
 SomeUploadedSnapshotFile: TypeAlias = UploadedFile | DeletedFile | None
+
+CameraInputResolution: TypeAlias = Literal["480p", "720p", "1080p"]
+
+_RESOLUTION_TO_HEIGHT: Final[dict[str, int]] = {
+    "480p": 480,
+    "720p": 720,
+    "1080p": 1080,
+}
 
 
 @dataclass
@@ -95,6 +104,7 @@ class CameraInputMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
+        resolution: CameraInputResolution | None = None,
         width: WidthWithoutContent = "stretch",
     ) -> UploadedFile | None:
         r"""Display a widget that returns pictures from the user's webcam.
@@ -168,6 +178,23 @@ class CameraInputMixin:
             label, which can help keep the widget aligned with other widgets.
             If this is ``"collapsed"``, Streamlit displays no label or spacer.
 
+        resolution : "480p", "720p", "1080p", or None
+            The capture resolution to request from the user's camera. Resolution
+            presets set the target image height in pixels; the width is determined
+            by the camera's native aspect ratio. This can be one of the following:
+
+            - ``None`` (default): Streamlit captures at a resolution determined by
+              the widget's display size.
+            - ``"480p"``: Target a height of 480 pixels.
+            - ``"720p"``: Target a height of 720 pixels.
+            - ``"1080p"``: Target a height of 1080 pixels.
+
+            The value is a request, not a guarantee. Cameras support a fixed set of
+            resolutions, so the browser selects the closest supported resolution and
+            the returned image may differ from the requested height. If you need
+            exact dimensions, resize the captured image after capture (for example,
+            with ``PIL.Image.resize``).
+
         width : "stretch" or int
             The width of the camera input widget. This can be one of the
             following:
@@ -188,6 +215,8 @@ class CameraInputMixin:
 
         Examples
         --------
+        *Example 1:* Capture a photo and display it.
+
         >>> import streamlit as st
         >>>
         >>> enable = st.checkbox("Enable camera")
@@ -200,7 +229,22 @@ class CameraInputMixin:
            https://doc-camera-input.streamlit.app/
            height: 600px
 
+        *Example 2:* Capture a photo at 720p resolution.
+
+        >>> import streamlit as st
+        >>>
+        >>> picture = st.camera_input("Scan QR code", resolution="720p")
+        >>>
+        >>> if picture:
+        ...     st.image(picture)
+
         """
+        if resolution is not None and resolution not in _RESOLUTION_TO_HEIGHT:
+            raise StreamlitAPIException(
+                f"Invalid resolution: {resolution!r}. "
+                f"Must be one of {sorted(_RESOLUTION_TO_HEIGHT)}, or None."
+            )
+
         ctx = get_script_run_ctx()
         return self._camera_input(
             label=label,
@@ -211,6 +255,7 @@ class CameraInputMixin:
             kwargs=kwargs,
             disabled=disabled,
             label_visibility=label_visibility,
+            resolution=resolution,
             width=width,
             ctx=ctx,
         )
@@ -226,6 +271,7 @@ class CameraInputMixin:
         *,  # keyword-only arguments:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
+        resolution: CameraInputResolution | None = None,
         width: WidthWithoutContent = "stretch",
         ctx: ScriptRunContext | None = None,
     ) -> UploadedFile | None:
@@ -248,6 +294,7 @@ class CameraInputMixin:
             label=label,
             help=help,
             width=width,
+            resolution=resolution,
         )
 
         camera_input_proto = CameraInputProto()
@@ -258,6 +305,9 @@ class CameraInputMixin:
         camera_input_proto.label_visibility.value = get_label_visibility_proto_value(
             label_visibility
         )
+
+        if resolution is not None:
+            camera_input_proto.resolution_height = _RESOLUTION_TO_HEIGHT[resolution]
 
         if help is not None:
             camera_input_proto.help = dedent(help)

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -242,7 +242,7 @@ class CameraInputMixin:
         if resolution is not None and resolution not in _RESOLUTION_TO_HEIGHT:
             raise StreamlitAPIException(
                 f"Invalid resolution: {resolution!r}. "
-                f"Must be one of {sorted(_RESOLUTION_TO_HEIGHT)}, or None."
+                f"Must be one of {list(_RESOLUTION_TO_HEIGHT)}, or None."
             )
 
         ctx = get_script_run_ctx()

--- a/lib/tests/streamlit/elements/camera_input_test.py
+++ b/lib/tests/streamlit/elements/camera_input_test.py
@@ -33,6 +33,71 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
 
+class CameraInputResolutionTest(DeltaGeneratorTestCase):
+    def test_resolution_none_no_field(self):
+        """Test that resolution=None does not set resolution_height in proto."""
+        st.camera_input("the label", resolution=None)
+        c = self.get_delta_from_queue().new_element.camera_input
+        assert not c.HasField("resolution_height")
+
+    @parameterized.expand(
+        [
+            ("480p", 480),
+            ("720p", 720),
+            ("1080p", 1080),
+        ]
+    )
+    def test_resolution_preset_sets_height(self, resolution: str, expected_height: int):
+        """Test that each resolution preset maps to the correct pixel height."""
+        st.camera_input("the label", resolution=resolution)
+        c = self.get_delta_from_queue().new_element.camera_input
+        assert c.HasField("resolution_height")
+        assert c.resolution_height == expected_height
+
+    @parameterized.expand(
+        [
+            ("4k",),
+            (720,),
+            ("720",),
+        ]
+    )
+    def test_resolution_invalid_raises_exception(self, invalid_resolution):
+        """Test that an invalid resolution raises StreamlitAPIException and no element is enqueued."""
+        queue_length_before = len(self.forward_msg_queue._queue)
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st.camera_input("the label", resolution=invalid_resolution)
+        assert "Invalid resolution" in str(exc_info.value)
+        assert len(self.forward_msg_queue._queue) == queue_length_before
+
+    def test_stable_id_with_key_and_resolution(self):
+        """Test that when a key is provided, the widget ID is stable even when resolution changes."""
+        with patch(
+            "streamlit.elements.lib.utils._register_element_id",
+            return_value=MagicMock(),
+        ):
+            st.camera_input("Label", key="cam_key", resolution=None)
+            c1 = self.get_delta_from_queue().new_element.camera_input
+            id1 = c1.id
+
+            st.camera_input("Label", key="cam_key", resolution="720p")
+            c2 = self.get_delta_from_queue().new_element.camera_input
+            id2 = c2.id
+
+            assert id1 == id2
+
+    def test_id_changes_with_resolution_no_key(self):
+        """Test that without a key, changing resolution changes the auto-generated id."""
+        st.camera_input("Label", resolution=None)
+        c1 = self.get_delta_from_queue().new_element.camera_input
+        id1 = c1.id
+
+        st.camera_input("Label", resolution="720p")
+        c2 = self.get_delta_from_queue().new_element.camera_input
+        id2 = c2.id
+
+        assert id1 != id2
+
+
 class CameraInputTest(DeltaGeneratorTestCase):
     def test_just_label(self):
         """Test that it can be called with no other values."""

--- a/lib/tests/streamlit/typing/camera_input_types.py
+++ b/lib/tests/streamlit/typing/camera_input_types.py
@@ -84,6 +84,12 @@ if TYPE_CHECKING:
     )
     assert_type(camera_input("Take a picture", on_change=None), UploadedFile | None)
 
+    # Camera input with resolution parameter
+    assert_type(camera_input("Take a picture", resolution="480p"), UploadedFile | None)
+    assert_type(camera_input("Take a picture", resolution="720p"), UploadedFile | None)
+    assert_type(camera_input("Take a picture", resolution="1080p"), UploadedFile | None)
+    assert_type(camera_input("Take a picture", resolution=None), UploadedFile | None)
+
     # Camera input with all parameters combined
     assert_type(
         camera_input(
@@ -95,6 +101,7 @@ if TYPE_CHECKING:
             kwargs=None,
             disabled=False,
             label_visibility="visible",
+            resolution="720p",
             width="stretch",
         ),
         UploadedFile | None,

--- a/proto/streamlit/proto/CameraInput.proto
+++ b/proto/streamlit/proto/CameraInput.proto
@@ -25,4 +25,5 @@ message CameraInput {
   string form_id = 4;
   bool disabled = 5;
   LabelVisibility label_visibility = 6;
+  optional int32 resolution_height = 7;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Adds an optional keyword-only `resolution` parameter to `st.camera_input`. When set, the browser requests a capture at the specified height (via an `ideal` height constraint on `getUserMedia`), and the JPEG is encoded at the camera's actual stream resolution rather than the on-screen widget size.

- `"480p"`, `"720p"`, `"1080p"` — targets the corresponding pixel height; width follows the camera's native aspect ratio.
- `None` (default) — unchanged behavior; capture size matches the widget's display width.

Invalid values raise `StreamlitAPIException` at call time. The proto field `resolution_height` is omitted when `resolution=None`.

Frontend uses a height-only `ideal` constraint (avoids `OverconstrainedError`) and enables `forceScreenshotSourceSize` so the captured image uses the stream's intrinsic size rather than the preview box size.

## GitHub Issue Link (if applicable)

Closes #4320

## Testing Plan

- Unit Tests (JS and/or Python)
- E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589c0c1c-e2b7-4016-bcdf-5b64b0f104cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589c0c1c-e2b7-4016-bcdf-5b64b0f104cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

