### PR TITLE
[refactor] Add canShowColumnStatistics dataframe capability

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -230,6 +230,7 @@ function DataFrame({
     canSort,
     canSearch,
     canExportCsv,
+    canShowColumnStatistics,
     canEdit,
     canAddRows,
     canDeleteRows,
@@ -1207,7 +1208,7 @@ function DataFrame({
             left={showMenu.headerBounds.x + showMenu.headerBounds.width}
             column={originalColumns[showMenu.columnIdx]}
             data={data}
-            isEditable={editingMode !== DataframeProto.EditingMode.READ_ONLY}
+            canShowColumnStatistics={canShowColumnStatistics}
             onCloseMenu={() => setShowMenu(undefined)}
             onSortColumn={
               canSort

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts
@@ -116,6 +116,45 @@ describe("useDataFrameCapabilities", () => {
     })
   })
 
+  describe("canShowColumnStatistics", () => {
+    it("returns true for normal read-only tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities(defaultParams)
+      )
+      expect(result.current.canShowColumnStatistics).toBe(true)
+    })
+
+    it.each([
+      ["DYNAMIC editing mode", { editingMode: DYNAMIC }],
+      ["ADD_ONLY editing mode", { editingMode: ADD_ONLY }],
+      ["DELETE_ONLY editing mode", { editingMode: DELETE_ONLY }],
+      ["FIXED editing mode", { editingMode: FIXED }],
+      ["empty tables", { numDataRows: 0 }],
+    ])("returns false for %s", (_description, overrides) => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, ...overrides })
+      )
+      expect(result.current.canShowColumnStatistics).toBe(false)
+    })
+
+    it("returns true for large tables", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({
+          ...defaultParams,
+          numDataRows: LARGE_TABLE_ROWS_THRESHOLD + 1,
+        })
+      )
+      expect(result.current.canShowColumnStatistics).toBe(true)
+    })
+
+    it("is not affected by the disabled flag", () => {
+      const { result } = renderHook(() =>
+        useDataFrameCapabilities({ ...defaultParams, disabled: true })
+      )
+      expect(result.current.canShowColumnStatistics).toBe(true)
+    })
+  })
+
   describe("canEdit", () => {
     it("returns false for READ_ONLY mode", () => {
       const { result } = renderHook(() =>

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.ts
@@ -29,6 +29,13 @@ interface DataFrameCapabilities {
   canSearch: boolean
   /** Whether CSV export is enabled. */
   canExportCsv: boolean
+  /**
+   * Whether the column statistics submenu can be shown. Only enabled for
+   * read-only, non-empty tables: statistics are derived from the original data
+   * and would be stale for edited tables (e.g. st.data_editor), and are
+   * meaningless for empty tables.
+   */
+  canShowColumnStatistics: boolean
   /** Whether cell editing is enabled. */
   canEdit: boolean
   /** Whether adding rows is enabled. */
@@ -117,6 +124,8 @@ function useDataFrameCapabilities({
 
     const canExportCsv = !isLargeTable && !isEmptyTable
 
+    const canShowColumnStatistics = !isEmptyTable && editingMode === READ_ONLY
+
     const canEdit = !isEmptyTable && editingMode !== READ_ONLY && !disabled
 
     const canAddRows =
@@ -139,6 +148,7 @@ function useDataFrameCapabilities({
       canSort,
       canSearch,
       canExportCsv,
+      canShowColumnStatistics,
       canEdit,
       canAddRows,
       canDeleteRows,

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
@@ -386,11 +386,13 @@ describe("DataFrame ColumnMenu", () => {
       expect(screen.getByText("Statistics")).toBeVisible()
     })
 
-    it("does not render 'Statistics' when isEditable is true", () => {
-      // Statistics are hidden for editable tables (st.data_editor) because
-      // they would show stale data from the original Quiver, not the edits.
+    it("does not render 'Statistics' when column statistics are disabled", () => {
       render(
-        <ColumnMenu {...defaultProps} data={mockQuiver} isEditable={true} />
+        <ColumnMenu
+          {...defaultProps}
+          data={mockQuiver}
+          canShowColumnStatistics={false}
+        />
       )
 
       expect(screen.queryByText("Statistics")).not.toBeInTheDocument()

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.tsx
@@ -59,10 +59,8 @@ export interface ColumnMenuProps {
   // may not have Quiver data bound initially. Statistics menu is only shown
   // when data is available.
   data?: Quiver
-  // Whether the table is in an editable mode (st.data_editor).
-  // Statistics menu is hidden for editable tables since the displayed stats
-  // would reflect the original data, not the user's edits.
-  isEditable?: boolean
+  // Whether column statistics are enabled for this table. Defaults to true.
+  canShowColumnStatistics?: boolean
   // Callback used to instruct the parent to close the menu
   onCloseMenu: () => void
   // Callback to sort column
@@ -96,7 +94,7 @@ function ColumnMenu({
   onHideColumn,
   column,
   data,
-  isEditable,
+  canShowColumnStatistics = true,
   onChangeFormat,
   onAutosize,
 }: ColumnMenuProps): ReactElement {
@@ -286,51 +284,53 @@ function ColumnMenu({
                 <StyledMenuDivider />
               </>
             )}
-            {data && !isEditable && supportsStatistics(column.kind) && (
-              <StatisticsMenu
-                column={column}
-                data={data}
-                isOpen={statsMenuOpen}
-                onOpenChange={handleStatsOpenChange}
-              >
-                <StyledMenuListItem
-                  onFocus={() => handleStatsOpenChange(true)}
-                  onBlur={e => {
-                    if (pointerDownRef.current) return
-                    const related = e.relatedTarget
-                    if (
-                      related?.closest(
-                        '[data-testid="stDataFrameStatisticsMenu"]'
-                      )
-                    ) {
-                      return
-                    }
-                    setStatsMenuOpen(false)
-                  }}
-                  isActive={statsMenuOpen}
-                  hasSubmenu={true}
-                  role="menuitem"
-                  // The statistics popover is a read-only informational panel
-                  // (no focus management/focus lock), so "true" is more accurate
-                  // than "dialog", which implies a focusable dialog widget.
-                  aria-haspopup="true"
-                  aria-expanded={statsMenuOpen}
-                  tabIndex={0}
+            {canShowColumnStatistics &&
+              data &&
+              supportsStatistics(column.kind) && (
+                <StatisticsMenu
+                  column={column}
+                  data={data}
+                  isOpen={statsMenuOpen}
+                  onOpenChange={handleStatsOpenChange}
                 >
-                  <div>
+                  <StyledMenuListItem
+                    onFocus={() => handleStatsOpenChange(true)}
+                    onBlur={e => {
+                      if (pointerDownRef.current) return
+                      const related = e.relatedTarget
+                      if (
+                        related?.closest(
+                          '[data-testid="stDataFrameStatisticsMenu"]'
+                        )
+                      ) {
+                        return
+                      }
+                      setStatsMenuOpen(false)
+                    }}
+                    isActive={statsMenuOpen}
+                    hasSubmenu={true}
+                    role="menuitem"
+                    // The statistics popover is a read-only informational panel
+                    // (no focus management/focus lock), so "true" is more accurate
+                    // than "dialog", which implies a focusable dialog widget.
+                    aria-haspopup="true"
+                    aria-expanded={statsMenuOpen}
+                    tabIndex={0}
+                  >
+                    <div>
+                      <DynamicIcon
+                        size="base"
+                        iconValue=":material/bar_chart:"
+                      />
+                      Statistics
+                    </div>
                     <DynamicIcon
                       size="base"
-                      iconValue=":material/bar_chart:"
+                      iconValue=":material/chevron_right:"
                     />
-                    Statistics
-                  </div>
-                  <DynamicIcon
-                    size="base"
-                    iconValue=":material/chevron_right:"
-                  />
-                </StyledMenuListItem>
-              </StatisticsMenu>
-            )}
+                  </StyledMenuListItem>
+                </StatisticsMenu>
+              )}
             {onChangeFormat && (
               <FormattingMenu
                 columnKind={column.kind}


### PR DESCRIPTION
## Describe your changes

Centralizes the "show column Statistics submenu" decision in the dataframe's `useDataFrameCapabilities` hook as a new `canShowColumnStatistics` capability (`!isEmptyTable && editingMode === READ_ONLY`).

- `ColumnMenu` no longer takes an `isEditable` prop; it now receives a `canShowColumnStatistics` prop (default `true`) and is agnostic to editability.
- `DataFrame` passes the capability through, keeping all feature decisions in one place alongside `canSort`, `canSearch`, `canExportCsv`, etc.

Behavior is preserved: the previous condition `data && !isEditable && supportsStatistics(...)` is equivalent to the new gate (the extra `!isEmptyTable` term is a no-op since the header menu only opens for non-empty tables).

## Testing Plan

- Unit Tests (JS): `frontend/lib/src/components/widgets/DataFrame/hooks/useDataFrameCapabilities.test.ts` covers `canShowColumnStatistics` across editing modes, empty/large tables, and the `disabled` flag; `frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx` covers default-on and disabled behavior of the Statistics submenu.
- Existing E2E coverage for the statistics submenu (`e2e_playwright/st_dataframe_interactions_test.py`) remains valid; no new E2E needed for this behavior-preserving refactor.

Made with [Cursor](https://cursor.com)