### PR TITLE
[chore] Set MPLBACKEND=Agg for pytest in make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,16 @@ python-format:
 .PHONY: python-tests
 # Run Python unit tests.
 python-tests:
-	uv run pytest -c lib/pyproject.toml -v -l \
+	@# MPLBACKEND=Agg avoids matplotlib crashing the interpreter on macOS (its default 'macosx' backend must run on the main thread).
+	MPLBACKEND=Agg uv run pytest -c lib/pyproject.toml -v -l \
 		-m "not performance" \
 		lib/tests/
 
 .PHONY: python-performance-tests
 # Run Python performance tests.
 python-performance-tests:
-	uv run pytest -c lib/pyproject.toml -v -l \
+	@# MPLBACKEND=Agg avoids matplotlib crashing the interpreter on macOS (its default 'macosx' backend must run on the main thread).
+	MPLBACKEND=Agg uv run pytest -c lib/pyproject.toml -v -l \
 		-m "performance" \
 		--benchmark-autosave \
 		--benchmark-storage file://.benchmarks/pytest \
@@ -212,7 +214,8 @@ python-performance-tests:
 .PHONY: python-integration-tests
 # Run Python integration tests. Requires `uv sync --group integration` to be run first.
 python-integration-tests:
-	uv run pytest -c lib/pyproject.toml -v -l \
+	@# MPLBACKEND=Agg avoids matplotlib crashing the interpreter on macOS (its default 'macosx' backend must run on the main thread).
+	MPLBACKEND=Agg uv run pytest -c lib/pyproject.toml -v -l \
 		--require-integration \
 		lib/tests/
 

--- a/Makefile
+++ b/Makefile
@@ -759,7 +759,7 @@ check:
 	if [ -n "$$PY_TESTS" ] && [ "$$FAST_CHECK" != "true" ]; then \
 		echo "=== Python: tests (pytest) ===" && \
 		echo "Running: $$PY_TESTS" && \
-		uv run pytest -c lib/pyproject.toml -v $$PY_TESTS && \
+		MPLBACKEND=Agg uv run pytest -c lib/pyproject.toml -v $$PY_TESTS && \
 		echo "" || { \
 			kill $$FE_PID 2>/dev/null; \
 			[ -n "$$E2E_PID" ] && kill $$E2E_PID 2>/dev/null; \


### PR DESCRIPTION
## Describe your changes

Forces the non-interactive `Agg` matplotlib backend when running Python unit tests via `make check`.

- On macOS, matplotlib's default (`macosx`) backend can crash the interpreter when initialized off the main thread during tests, making `make check` unreliable.
- `lib/streamlit/__init__.py` already sets `MPLBACKEND=Agg`, but it only takes effect once Streamlit is imported; setting it on the pytest invocation guarantees the safe backend before any matplotlib import can occur.

## Testing Plan

- No additional tests needed: this is a dev-tooling change to the `make check` target and does not affect Streamlit runtime behavior. Verified locally on macOS that `lib/tests/streamlit/elements/pyplot_test.py` passes under the updated command.

Made with [Cursor](https://cursor.com)