### PR TITLE
[fix] Reject non-finite float values from URL params

### DIFF
--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 import numbers
 from dataclasses import dataclass
 from textwrap import dedent
@@ -86,7 +87,11 @@ class NumberInputSerde:
             # a no-op for frontend values since the UI enforces bounds.
             # Returning the default triggers _seed_widget_from_url's
             # "deserialized == default" check, which clears the URL param.
-            if val < self.min_value or val > self.max_value:
+            if (
+                (self.data_type == NumberInputProto.FLOAT and not math.isfinite(val))
+                or val < self.min_value
+                or val > self.max_value
+            ):
                 return self.value
 
         return val

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
@@ -209,7 +210,7 @@ class SliderSerde:
                 # accepted as-is. Consider snapping to the nearest valid step
                 # for consistency with the UI.
                 for v in val:
-                    if v < self.min_value or v > self.max_value:
+                    if not math.isfinite(v) or v < self.min_value or v > self.max_value:
                         val = self.value
                         break
         else:

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -813,3 +813,16 @@ def test_serde_resets_out_of_range_to_default(ui_value, expected):
         value=50, data_type=NumberInput.INT, min_value=0, max_value=100
     )
     assert serde.deserialize(ui_value) == expected
+
+
+@pytest.mark.parametrize(
+    "ui_value",
+    [float("nan"), float("inf"), -float("inf")],
+    ids=["nan", "positive_inf", "negative_inf"],
+)
+def test_serde_resets_non_finite_float_to_default(ui_value):
+    """Test that NumberInputSerde.deserialize resets non-finite floats to default."""
+    serde = NumberInputSerde(
+        value=0.5, data_type=NumberInput.FLOAT, min_value=0.0, max_value=1.0
+    )
+    assert serde.deserialize(ui_value) == 0.5

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -820,7 +820,7 @@ def test_serde_resets_out_of_range_to_default(ui_value, expected):
     [float("nan"), float("inf"), -float("inf")],
     ids=["nan", "positive_inf", "negative_inf"],
 )
-def test_serde_resets_non_finite_float_to_default(ui_value):
+def test_serde_resets_non_finite_float_to_default(ui_value: float) -> None:
     """Test that NumberInputSerde.deserialize resets non-finite floats to default."""
     serde = NumberInputSerde(
         value=0.5, data_type=NumberInput.FLOAT, min_value=0.0, max_value=1.0

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -655,6 +655,24 @@ def _make_int_serde(
     )
 
 
+def _make_float_serde(
+    value: list[float],
+    *,
+    single_value: bool = True,
+    min_value: float = 0.0,
+    max_value: float = 1.0,
+) -> SliderSerde:
+    """Construct a ``SliderSerde`` for FLOAT data with the provided defaults."""
+    return SliderSerde(
+        value=value,
+        data_type=SliderProto.FLOAT,
+        single_value=single_value,
+        orig_tz=None,
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+
 def test_slider_serde_deserialize_returns_default_when_ui_value_none() -> None:
     """A None ui_value falls back to the default."""
     assert _make_int_serde(value=[42]).deserialize(None) == 42
@@ -690,6 +708,19 @@ def test_slider_serde_deserialize_resets_out_of_range(
     """Out-of-range ui_values revert to the default."""
     serde = _make_int_serde(value=[20], min_value=10, max_value=100)
     assert serde.deserialize(ui_value) == 20
+
+
+@pytest.mark.parametrize(
+    "ui_value",
+    [[float("nan")], [float("inf")], [-float("inf")]],
+    ids=["nan", "positive_inf", "negative_inf"],
+)
+def test_slider_serde_deserialize_resets_non_finite_value(
+    ui_value: list[float],
+) -> None:
+    """Non-finite float ui_values revert to the default."""
+    serde = _make_float_serde(value=[0.5])
+    assert serde.deserialize(ui_value) == 0.5
 
 
 def test_slider_serde_deserialize_passes_through_in_range_value() -> None:

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -723,6 +723,19 @@ def test_slider_serde_deserialize_resets_non_finite_value(
     assert serde.deserialize(ui_value) == 0.5
 
 
+@pytest.mark.parametrize(
+    "ui_value",
+    [[float("nan"), 0.8], [0.2, float("inf")], [-float("inf"), float("nan")]],
+    ids=["nan_first", "inf_second", "both_non_finite"],
+)
+def test_slider_serde_deserialize_resets_non_finite_value_range(
+    ui_value: list[float],
+) -> None:
+    """Non-finite float values in a range slider revert to the default."""
+    serde = _make_float_serde(value=[0.2, 0.8], single_value=False)
+    assert serde.deserialize(ui_value) == (0.2, 0.8)
+
+
 def test_slider_serde_deserialize_passes_through_in_range_value() -> None:
     """In-range ui_values are returned and converted to the slider's data type."""
     serde = _make_int_serde(value=[20])


### PR DESCRIPTION
## Describe your changes

Fixes an input-validation flaw (CWE-1284) where a crafted URL query param could seed a non-finite float into `st.number_input` and `st.slider`.

- `NaN` bypassed the min/max bounds check because every comparison with `NaN` returns `False`, so the non-finite value was accepted as the widget value instead of being rejected.
- Non-finite floats (`NaN`, `inf`, `-inf`) now fall back to the widget default, which also clears the offending URL param via the existing `deserialized == default` path.

## GitHub Issue Link (if applicable)

## Testing Plan

- `lib/tests/streamlit/elements/number_input_test.py` — verifies FLOAT `st.number_input` resets `NaN`/`inf`/`-inf` to the default.
- `lib/tests/streamlit/elements/slider_test.py` — verifies FLOAT `st.slider` resets `NaN`/`inf`/`-inf` to the default.

Made with [Cursor](https://cursor.com)