### PR TITLE
[fix] Reject spoofed host messages from child frames and scripts

### DIFF
--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -87,6 +87,9 @@ def is_expected_error(
 
 @pytest.fixture(scope="module")
 def app_server_extra_args() -> list[str]:
+    # Only used for local e2e server startup. In external SiS/host mode, the
+    # local server is not started and the platform host-config must provide the
+    # real allowed host origin.
     return ["--client.allowedOrigins", "http://localhost"]
 
 

--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -85,6 +85,30 @@ def is_expected_error(
     )
 
 
+@pytest.fixture(scope="module")
+def app_server_extra_args() -> list[str]:
+    return ["--client.allowedOrigins", "http://localhost"]
+
+
+def _send_host_message(
+    app_target: AppTarget, external_iframe_selector: str, message: dict[str, object]
+) -> None:
+    payload = {"stCommVersion": 1, **message}
+
+    if app_target.mode == "external_host":
+        iframe = app_target.page.locator(external_iframe_selector).first
+        iframe.evaluate(
+            "(iframe, payload) => iframe.contentWindow.postMessage(payload, '*')",
+            payload,
+        )
+        return
+
+    app_target.page.evaluate(
+        "payload => window.postMessage(payload, window.location.origin)",
+        payload,
+    )
+
+
 @pytest.mark.external_test(upload_test_assets=True)
 def test_no_console_errors(app_target: AppTarget, browser_name: str) -> None:
     """Test that the app does not log any console errors."""
@@ -340,6 +364,34 @@ def test_mega_tester_app_renders_expected_content(app_target: AppTarget) -> None
         expect(pdf_container.locator('[data-index="0"]').first).to_be_visible(
             timeout=30000
         )
+
+
+@pytest.mark.external_test(upload_test_assets=True)
+def test_host_communication_can_disable_and_enable_inputs(
+    app_target: AppTarget, external_iframe_selector: str
+) -> None:
+    if app_target.mode == "external_direct":
+        pytest.skip(
+            "Host communication requires a host page or same-window local mode."
+        )
+
+    button = app_target.locator(".st-key-button").get_by_role("button").first
+    button.scroll_into_view_if_needed()
+    expect(button).to_be_enabled()
+
+    _send_host_message(
+        app_target,
+        external_iframe_selector,
+        {"type": "SET_INPUTS_DISABLED", "disabled": True},
+    )
+    expect(button).to_be_disabled()
+
+    _send_host_message(
+        app_target,
+        external_iframe_selector,
+        {"type": "SET_INPUTS_DISABLED", "disabled": False},
+    )
+    expect(button).to_be_enabled()
 
 
 def test_mega_tester_app_interactions_validate_behavior(app: Page) -> None:

--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -93,6 +93,9 @@ def app_server_extra_args() -> list[str]:
 def _send_host_message(
     app_target: AppTarget, external_iframe_selector: str, message: dict[str, object]
 ) -> None:
+    # stCommVersion must match the frontend HOST_COMM_VERSION constant
+    # (frontend/lib/src/hostComm/HostCommunicationManager.tsx); bump this if
+    # that version ever changes.
     payload = {"stCommVersion": 1, **message}
 
     if app_target.mode == "external_host":

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4471,16 +4471,26 @@ describe("App", () => {
     function fireWindowPostMessage(
       message: DistributiveOmit<IHostToGuestMessage, "stCommVersion">
     ): void {
-      fireEvent(
-        window,
-        new MessageEvent("message", {
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+      // The manager registers `receiveHostMessage` as the window "message"
+      // listener and now only accepts trusted events originating from the
+      // direct parent frame. jsdom marks synthetically dispatched events as
+      // untrusted and does not allow overriding `isTrusted`, so we invoke the
+      // handler directly with an event that mimics a genuine host message
+      // (trusted and sourced from the parent frame).
+      act(() => {
+        hostCommunicationMgr.receiveHostMessage({
+          isTrusted: true,
+          source: window.parent,
+          origin: "https://devel.streamlit.test",
           data: {
             stCommVersion: HOST_COMM_VERSION,
             ...message,
           },
-          origin: "https://devel.streamlit.test",
-        })
-      )
+        } as unknown as MessageEvent)
+      })
     }
 
     it("sends SCRIPT_RUN_STATE_CHANGED signal to the host when the app is first rendered", () => {

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -16,6 +16,7 @@
 
 import "../../../utils/src/polyfills/index"
 
+import { getLogger } from "loglevel"
 import { MockInstance } from "vitest"
 
 import HostCommunicationManager, {
@@ -789,6 +790,46 @@ describe("HostCommunicationManager messaging", () => {
       // @ts-expect-error - props are private
       hostCommunicationMgr.props.fileUploadClientConfigChanged
     ).not.toHaveBeenCalled()
+  })
+
+  it("logs a debug message when a genuine host message is rejected by the guards", () => {
+    const debugSpy = vi
+      .spyOn(getLogger("HostCommunicationManager"), "debug")
+      .mockImplementation(() => {})
+
+    const message = new MessageEvent("message", {
+      data: {
+        stCommVersion: HOST_COMM_VERSION,
+        type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+        prefix: "https://evil.example/upload/",
+        headers: {
+          "X-Xsrftoken": "exfiltrated-token",
+        },
+      },
+      origin: "https://devel.streamlit.test",
+      source: window.parent,
+    })
+    dispatchEvent("message", message)
+
+    expect(debugSpy).toHaveBeenCalledOnce()
+    debugSpy.mockRestore()
+  })
+
+  it("does not log a debug message for non-host postMessages", () => {
+    const debugSpy = vi
+      .spyOn(getLogger("HostCommunicationManager"), "debug")
+      .mockImplementation(() => {})
+
+    dispatchEvent(
+      "message",
+      newHostMessageEvent({
+        data: { some: "unrelated-message" },
+        origin: "https://devel.streamlit.test",
+      })
+    )
+
+    expect(debugSpy).not.toHaveBeenCalled()
+    debugSpy.mockRestore()
   })
 
   it("can process a received RESTART_WEBSOCKET_CONNECTION message", () => {

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -55,6 +55,15 @@ function mockEventListeners(): MockEventListenersResult {
   }
 }
 
+/**
+ * Builds a trusted host `MessageEvent` originating from the direct parent
+ * frame, matching what the browser delivers for legitimate host messages.
+ *
+ * `isTrusted` is intentionally hard-coded and is not part of
+ * `MessageEventInit`, so callers cannot override it via `init`. Tests that
+ * need an untrusted (script-dispatched) event construct `new MessageEvent(...)`
+ * directly instead.
+ */
 function newHostMessageEvent(init: MessageEventInit): MessageEvent {
   return {
     data: init.data,
@@ -763,6 +772,11 @@ describe("HostCommunicationManager messaging", () => {
       origin: "https://devel.streamlit.test",
       source: window.parent,
     })
+    // Guard the test preconditions so it can only pass by exercising the
+    // `!event.isTrusted` check: a natively constructed event is untrusted while
+    // its source and origin are otherwise valid.
+    expect(message.isTrusted).toBe(false)
+    expect(message.source).toBe(window.parent)
     dispatchEvent("message", message)
 
     expect(

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -824,7 +824,16 @@ describe("HostCommunicationManager messaging", () => {
     })
     dispatchEvent("message", message)
 
-    expect(debugSpy).toHaveBeenCalledOnce()
+    // Args mirror the LOG.debug call: isTrusted, sourceIsParent, allowedOrigin,
+    // origin. The event is untrusted (script-constructed) but its source is the
+    // parent and its origin is allowed, so only the isTrusted guard fails.
+    expect(debugSpy).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("Ignoring host message"),
+      false,
+      true,
+      true,
+      "https://devel.streamlit.test"
+    )
     debugSpy.mockRestore()
   })
 
@@ -843,6 +852,44 @@ describe("HostCommunicationManager messaging", () => {
 
     expect(debugSpy).not.toHaveBeenCalled()
     debugSpy.mockRestore()
+  })
+
+  it("does not log a debug message for the guest's own self-posted messages", () => {
+    const debugSpy = vi
+      .spyOn(getLogger("HostCommunicationManager"), "debug")
+      .mockImplementation(() => {})
+
+    // Simulate being embedded so window.parent differs from window; otherwise
+    // jsdom makes window.parent === window and a self-post is indistinguishable
+    // from a top-level parent message.
+    const originalParent = window.parent
+    Object.defineProperty(window, "parent", {
+      value: { postMessage: vi.fn() },
+      configurable: true,
+    })
+
+    try {
+      // Mimics the GUEST_READY message the manager posts to its own window when
+      // embedded: a genuine host-versioned payload whose source is this window
+      // (not the parent). It is intentionally ignored and must not be logged.
+      const message = new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "GUEST_READY",
+        },
+        origin: "https://devel.streamlit.test",
+        source: window,
+      })
+      dispatchEvent("message", message)
+
+      expect(debugSpy).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(window, "parent", {
+        value: originalParent,
+        configurable: true,
+      })
+      debugSpy.mockRestore()
+    }
   })
 
   it("can process a received RESTART_WEBSOCKET_CONNECTION message", () => {

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -54,6 +54,16 @@ function mockEventListeners(): MockEventListenersResult {
   }
 }
 
+function newHostMessageEvent(init: MessageEventInit): MessageEvent {
+  return {
+    data: init.data,
+    isTrusted: true,
+    origin: init.origin ?? "",
+    source: window.parent,
+    ...init,
+  } as unknown as MessageEvent
+}
+
 describe("HostCommunicationManager messaging", () => {
   let hostCommunicationMgr: HostCommunicationManager
 
@@ -264,7 +274,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received CLOSE_MODAL message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "CLOSE_MODAL",
@@ -279,7 +289,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received STOP_SCRIPT message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "STOP_SCRIPT",
@@ -294,7 +304,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received RERUN_SCRIPT message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "RERUN_SCRIPT",
@@ -309,7 +319,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received CLEAR_CACHE message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "CLEAR_CACHE",
@@ -325,7 +335,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received PRINT_APP message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "PRINT_APP",
@@ -341,7 +351,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received REQUEST_PAGE_CHANGE message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "REQUEST_PAGE_CHANGE",
@@ -359,7 +369,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SEND_APP_HEARTBEAT message without ackTimeoutMilliseconds", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SEND_APP_HEARTBEAT",
@@ -375,7 +385,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SEND_APP_HEARTBEAT message with ackTimeoutMilliseconds", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SEND_APP_HEARTBEAT",
@@ -394,7 +404,7 @@ describe("HostCommunicationManager messaging", () => {
   it("treats negative ackTimeoutMilliseconds as 0", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SEND_APP_HEARTBEAT",
@@ -411,7 +421,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_INPUTS_DISABLED message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_INPUTS_DISABLED",
@@ -430,7 +440,7 @@ describe("HostCommunicationManager messaging", () => {
   it("should respond to SET_IS_OWNER message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_IS_OWNER",
@@ -448,7 +458,7 @@ describe("HostCommunicationManager messaging", () => {
   it("should respond to SET_MENU_ITEMS message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_MENU_ITEMS",
@@ -467,7 +477,7 @@ describe("HostCommunicationManager messaging", () => {
   it("should respond to SET_METADATA message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_METADATA",
@@ -490,7 +500,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_PAGE_LINK_BASE_URL message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_PAGE_LINK_BASE_URL",
@@ -509,7 +519,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_SIDEBAR_CHEVRON_DOWNSHIFT message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_SIDEBAR_CHEVRON_DOWNSHIFT",
@@ -528,7 +538,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_SIDEBAR_NAV_VISIBILITY message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_SIDEBAR_NAV_VISIBILITY",
@@ -547,7 +557,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_TOOLBAR_ITEMS message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_TOOLBAR_ITEMS",
@@ -582,7 +592,7 @@ describe("HostCommunicationManager messaging", () => {
 
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "UPDATE_HASH",
@@ -598,7 +608,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received UPDATE_FROM_QUERY_PARAMS message", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "UPDATE_FROM_QUERY_PARAMS",
@@ -625,7 +635,7 @@ describe("HostCommunicationManager messaging", () => {
     }
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_CUSTOM_THEME_CONFIG",
@@ -644,7 +654,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_CUSTOM_THEME_CONFIG message with a dark theme name", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_CUSTOM_THEME_CONFIG",
@@ -663,7 +673,7 @@ describe("HostCommunicationManager messaging", () => {
   it("can process a received SET_CUSTOM_THEME_CONFIG message with a light theme name", () => {
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "SET_CUSTOM_THEME_CONFIG",
@@ -680,7 +690,7 @@ describe("HostCommunicationManager messaging", () => {
   })
 
   it("can process a received SET_FILE_UPLOAD_CLIENT_CONFIG message", () => {
-    const message = new MessageEvent("message", {
+    const message = newHostMessageEvent({
       data: {
         stCommVersion: HOST_COMM_VERSION,
         type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
@@ -706,8 +716,83 @@ describe("HostCommunicationManager messaging", () => {
     })
   })
 
-  it("can process a received RESTART_WEBSOCKET_CONNECTION message", () => {
+  it("ignores messages from non-parent frames even when origin is allowed", () => {
+    const iframe = document.createElement("iframe")
+    document.body.appendChild(iframe)
+    const childWindow = iframe.contentWindow
+
+    if (!childWindow) {
+      throw new Error("Expected iframe contentWindow")
+    }
+
+    try {
+      const message = newHostMessageEvent({
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+          prefix: "https://evil.example/upload/",
+          headers: {
+            "X-Xsrftoken": "exfiltrated-token",
+          },
+        },
+        origin: "https://devel.streamlit.test",
+        source: childWindow,
+      })
+      dispatchEvent("message", message)
+
+      expect(
+        // @ts-expect-error - props are private
+        hostCommunicationMgr.props.fileUploadClientConfigChanged
+      ).not.toHaveBeenCalled()
+    } finally {
+      iframe.remove()
+    }
+  })
+
+  it("ignores script-dispatched host messages even when source and origin match", () => {
     const message = new MessageEvent("message", {
+      data: {
+        stCommVersion: HOST_COMM_VERSION,
+        type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+        prefix: "https://evil.example/upload/",
+        headers: {
+          "X-Xsrftoken": "exfiltrated-token",
+        },
+      },
+      origin: "https://devel.streamlit.test",
+      source: window.parent,
+    })
+    dispatchEvent("message", message)
+
+    expect(
+      // @ts-expect-error - props are private
+      hostCommunicationMgr.props.fileUploadClientConfigChanged
+    ).not.toHaveBeenCalled()
+  })
+
+  it("ignores host messages with a null source even when origin is allowed", () => {
+    const message = newHostMessageEvent({
+      data: {
+        stCommVersion: HOST_COMM_VERSION,
+        type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+        prefix: "https://evil.example/upload/",
+        headers: {
+          "X-Xsrftoken": "exfiltrated-token",
+        },
+      },
+      origin: "https://devel.streamlit.test",
+      source: null,
+    })
+    dispatchEvent("message", message)
+
+    expect(
+      // @ts-expect-error - props are private
+      hostCommunicationMgr.props.fileUploadClientConfigChanged
+    ).not.toHaveBeenCalled()
+  })
+
+  it("can process a received RESTART_WEBSOCKET_CONNECTION message", () => {
+    const message = newHostMessageEvent({
       data: {
         stCommVersion: HOST_COMM_VERSION,
         type: "RESTART_WEBSOCKET_CONNECTION",
@@ -723,7 +808,7 @@ describe("HostCommunicationManager messaging", () => {
   })
 
   it("can process a received TERMINATE_WEBSOCKET_CONNECTION message", () => {
-    const message = new MessageEvent("message", {
+    const message = newHostMessageEvent({
       data: {
         stCommVersion: HOST_COMM_VERSION,
         type: "TERMINATE_WEBSOCKET_CONNECTION",
@@ -783,7 +868,7 @@ describe("Test different origins", () => {
 
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "UPDATE_HASH",
@@ -804,7 +889,7 @@ describe("Test different origins", () => {
 
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "UPDATE_HASH",
@@ -825,7 +910,7 @@ describe("Test different origins", () => {
 
     dispatchEvent(
       "message",
-      new MessageEvent("message", {
+      newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
           type: "UPDATE_HASH",
@@ -900,7 +985,7 @@ describe("HostCommunicationManager external auth token handling", () => {
     setTimeout(() => {
       dispatchEvent(
         "message",
-        new MessageEvent("message", {
+        newHostMessageEvent({
           data: {
             stCommVersion: HOST_COMM_VERSION,
             type: "SET_AUTH_TOKEN",
@@ -931,7 +1016,7 @@ describe("HostCommunicationManager external auth token handling", () => {
     setTimeout(() => {
       dispatchEvent(
         "message",
-        new MessageEvent("message", {
+        newHostMessageEvent({
           data: {
             stCommVersion: HOST_COMM_VERSION,
             type: "SET_AUTH_TOKEN",

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -66,11 +66,10 @@ function mockEventListeners(): MockEventListenersResult {
  */
 function newHostMessageEvent(init: MessageEventInit): MessageEvent {
   return {
-    data: init.data,
-    isTrusted: true,
-    origin: init.origin ?? "",
+    origin: "",
     source: window.parent,
     ...init,
+    isTrusted: true,
   } as unknown as MessageEvent
 }
 

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -211,9 +211,12 @@ export default class HostCommunicationManager {
     const isFromParent = event.source === window.parent
     const isTrustedParentMessage = event.isTrusted && isFromParent
     const isHostMessage = message?.stCommVersion === HOST_COMM_VERSION
-    const isAllowedOrigin = this.allowedOrigins.some(allowed =>
-      isValidOrigin(allowed, event.origin)
-    )
+    // Only parse origins for genuine host messages; this global handler
+    // receives many unrelated postMessages and isValidOrigin allocates
+    // URL/URLPattern objects on every call.
+    const isAllowedOrigin =
+      isHostMessage &&
+      this.allowedOrigins.some(allowed => isValidOrigin(allowed, event.origin))
     // When embedded, the guest posts its own GUEST_READY to this window (see
     // openHostCommunication); that self-post is intentionally ignored here and
     // should not be logged as a dropped host message.

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -208,8 +208,8 @@ export default class HostCommunicationManager {
     // labeled as trusted, and only accept trusted postMessage events from the
     // direct parent frame so same-origin child iframes cannot spoof host
     // commands.
-    const isTrustedParentMessage =
-      event.isTrusted && event.source === window.parent
+    const isFromParent = event.source === window.parent
+    const isTrustedParentMessage = event.isTrusted && isFromParent
     const isHostMessage = message?.stCommVersion === HOST_COMM_VERSION
     const isAllowedOrigin = this.allowedOrigins.some(allowed =>
       isValidOrigin(allowed, event.origin)
@@ -225,7 +225,7 @@ export default class HostCommunicationManager {
         LOG.debug(
           "Ignoring host message: isTrusted=%s, sourceIsParent=%s, allowedOrigin=%s, origin=%s",
           event.isTrusted,
-          event.source === window.parent,
+          isFromParent,
           isAllowedOrigin,
           event.origin
         )

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -199,12 +199,15 @@ export default class HostCommunicationManager {
 
     // Messages coming from the parent frame of a deployed Streamlit app
     // may not be coming from a trusted source (even if we've set the CSP
-    // frame-anscestors header, it doesn't hurt to be extra safe). We avoid
+    // frame-ancestors header, it doesn't hurt to be extra safe). We avoid
     // processing messages received from origins we haven't explicitly
-    // labeled as trusted here to lower the probability that we end up
-    // processing malicious input.
+    // labeled as trusted, and only accept trusted postMessage events from the
+    // direct parent frame so same-origin child iframes cannot spoof host
+    // commands.
     if (
-      message.stCommVersion !== HOST_COMM_VERSION ||
+      !event.isTrusted ||
+      event.source !== window.parent ||
+      message?.stCommVersion !== HOST_COMM_VERSION ||
       !this.allowedOrigins.find(allowed =>
         isValidOrigin(allowed, event.origin)
       )

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -214,6 +214,10 @@ export default class HostCommunicationManager {
     const isAllowedOrigin = this.allowedOrigins.some(allowed =>
       isValidOrigin(allowed, event.origin)
     )
+    // When embedded, the guest posts its own GUEST_READY to this window (see
+    // openHostCommunication); that self-post is intentionally ignored here and
+    // should not be logged as a dropped host message.
+    const isSelfPost = event.source === window && window !== window.parent
 
     if (!isTrustedParentMessage || !isHostMessage || !isAllowedOrigin) {
       // Only log when the payload looks like a genuine host message so we
@@ -221,7 +225,7 @@ export default class HostCommunicationManager {
       // handler receives. This helps diagnose cases where a legitimate host's
       // messages are unexpectedly dropped (e.g. an intermediate iframe wrapper
       // posting from a non-direct-parent window).
-      if (isHostMessage) {
+      if (isHostMessage && !isSelfPost) {
         LOG.debug(
           "Ignoring host message: isTrusted=%s, sourceIsParent=%s, allowedOrigin=%s, origin=%s",
           event.isTrusted,

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { getLogger } from "loglevel"
+
 import { ICustomThemeConfig, WidgetStates } from "@streamlit/protobuf"
 
 import { PresetThemeName } from "~lib/theme/types"
@@ -28,6 +30,8 @@ import {
   IToolbarItem,
   VersionedMessage,
 } from "./types"
+
+const LOG = getLogger("HostCommunicationManager")
 
 export const HOST_COMM_VERSION = 1
 
@@ -204,14 +208,28 @@ export default class HostCommunicationManager {
     // labeled as trusted, and only accept trusted postMessage events from the
     // direct parent frame so same-origin child iframes cannot spoof host
     // commands.
-    if (
-      !event.isTrusted ||
-      event.source !== window.parent ||
-      message?.stCommVersion !== HOST_COMM_VERSION ||
-      !this.allowedOrigins.find(allowed =>
-        isValidOrigin(allowed, event.origin)
-      )
-    ) {
+    const isTrustedParentMessage =
+      event.isTrusted && event.source === window.parent
+    const isHostMessage = message?.stCommVersion === HOST_COMM_VERSION
+    const isAllowedOrigin = this.allowedOrigins.some(allowed =>
+      isValidOrigin(allowed, event.origin)
+    )
+
+    if (!isTrustedParentMessage || !isHostMessage || !isAllowedOrigin) {
+      // Only log when the payload looks like a genuine host message so we
+      // don't spam logs for the many unrelated postMessages this global
+      // handler receives. This helps diagnose cases where a legitimate host's
+      // messages are unexpectedly dropped (e.g. an intermediate iframe wrapper
+      // posting from a non-direct-parent window).
+      if (isHostMessage) {
+        LOG.debug(
+          "Ignoring host message: isTrusted=%s, sourceIsParent=%s, allowedOrigin=%s, origin=%s",
+          event.isTrusted,
+          event.source === window.parent,
+          isAllowedOrigin,
+          event.origin
+        )
+      }
       return
     }
 


### PR DESCRIPTION
## Describe your changes

Hardens `HostCommunicationManager.receiveHostMessage` against origin/source spoofing (CWE-346, Origin Validation Error). Previously the guard only checked the message version and that the event `origin` was in the allowlist. However, `event.origin` alone is not sufficient:

- A **same-origin child iframe** embedded inside the Streamlit app could `postMessage` upward with a matching (allowed) origin and spoof host commands.
- **Injected/synthetic scripts** running in the app window could `dispatchEvent` a fabricated `MessageEvent` that passes the origin check.

The fix adds two additional guards to the early-return gate:

- `!event.isTrusted` — rejects script-dispatched (synthetic) `postMessage` events.
- `event.source !== window.parent` — only accept messages coming from the direct parent frame (the frame Streamlit talks to via `window.parent.postMessage`), so nested/child frames cannot spoof host commands.

A concrete impact example: without this, a malicious child frame could send `SET_FILE_UPLOAD_CLIENT_CONFIG` to redirect uploads to an attacker endpoint and exfiltrate the XSRF token via injected headers.

## GitHub Issue Link (if applicable)

N/A (internal security hardening)

## Testing Plan

- Unit Tests (JS): Existing host-message tests were refactored to use a `newHostMessageEvent` helper (sets `isTrusted: true`, `source: window.parent`), so every existing test now doubles as a positive control proving legitimate parent messages still process. Added negative tests for: messages from a non-parent (child) frame with an allowed origin, script-dispatched events with matching source+origin, and messages with a `null` source.
- No behavior change is expected for standard single-level embeddings (SiS/Snowsight, Community Cloud direct iframe, `st.components` host embeds) where `event.source === window.parent`.

> [!NOTE]
> Open question for reviewers: this assumes all supported hosts post from the **direct parent** frame. Standard single-level embeddings relay through the direct parent and are unaffected, but if any host embeds Streamlit through an intermediate wrapper frame and posts directly from a non-direct-parent window, those messages would now be dropped. Worth confirming for Community Cloud's iframe topology. External e2e coverage of the embedded iframe host→guest command path (`@pytest.mark.external_test`) is recommended as follow-up.

Made with [Cursor](https://cursor.com)