### PR TITLE
[chore] Extend mega tester app coverage

### DIFF
--- a/e2e_playwright/mega_tester_app.py
+++ b/e2e_playwright/mega_tester_app.py
@@ -243,6 +243,28 @@ def _render_data_display(
         "text/csv",
     )
 
+    if hasattr(st, "pagination"):
+        st.subheader("Paginated sample rows")
+        paginated_df = pd.DataFrame(
+            {
+                "item": [f"Item {idx}" for idx in range(1, 26)],
+                "value": np.arange(10, 260, 10),
+            }
+        )
+        page_size = 5
+        total_pages = (len(paginated_df) + page_size - 1) // page_size
+        page = st.pagination(
+            total_pages,
+            key="mega_sample_pagination",
+            disabled=disabled,
+        )
+        start_idx = (page - 1) * page_size
+        st.dataframe(
+            paginated_df.iloc[start_idx : start_idx + page_size],
+            width="stretch",
+        )
+        st.caption(f"Showing page {page} of {total_pages}")
+
     if hasattr(st, "column_config"):
         st.subheader("Column config matrix")
         column_config_df = pd.DataFrame(
@@ -484,6 +506,14 @@ def _render_charts(minor_version: int) -> None:
         }
     """)
 
+    if hasattr(st, "mermaid_chart"):
+        st.mermaid_chart("""
+            flowchart LR
+                User[User input] --> Script[Python script]
+                Script --> Delta[Delta protocol]
+                Delta --> Browser[Browser render]
+        """)
+
 
 def _render_custom_ui(minor_version: int) -> None:
     st.header("Custom UI elements")
@@ -624,6 +654,18 @@ def _render_inputs(minor_version: int, help_text: str | None, disabled: bool) ->
             help=help_text,
             disabled=disabled,
         )
+
+    if hasattr(st, "menu_button"):
+        selected_action = st.menu_button(
+            "Menu button",
+            ["Export CSV", "Refresh cache", "Archive record"],
+            key="menu_button",
+            help=help_text,
+            icon=":material/more_vert:",
+            disabled=disabled,
+        )
+        if selected_action is not None:
+            st.write(f"Menu button selected: {selected_action}")
 
     st.checkbox("Checkbox", key="checkbox", help=help_text, disabled=disabled)
     toggle_value = st.toggle("Toggle", key="toggle", help=help_text, disabled=disabled)
@@ -885,8 +927,10 @@ def _render_text_elements(minor_version: int, help_text: str | None) -> None:
     st.markdown("Markdown", help=help_text)
     st.markdown(
         "Markdown features: **bold** *italic* ~strikethrough~ [link](https://streamlit.io) "
-        "`code` $a=b$ 🐶 :cat: :material/home: :streamlit: <- -> <-> -- >= <= ~= :small[small] $$a = b$$"
+        "`code` $a=b$ 🐶 :cat: :material/home: :streamlit: <- -> <-> -- >= <= ~= "
+        ":small[small] :shimmer[shimmer] $$a = b$$"
     )
+    st.markdown("Shimmer status: :shimmer[Loading generated summary...]")
     st.markdown("""
 Text colors:
 

--- a/e2e_playwright/mega_tester_app.py
+++ b/e2e_playwright/mega_tester_app.py
@@ -261,7 +261,6 @@ def _render_data_display(
         start_idx = (page - 1) * page_size
         st.dataframe(
             paginated_df.iloc[start_idx : start_idx + page_size],
-            width="stretch",
         )
         st.caption(f"Showing page {page} of {total_pages}")
 

--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -28,6 +28,7 @@ from e2e_playwright.shared.app_utils import (
     expect_no_skeletons,
     fill_number_input,
     get_checkbox,
+    get_element_by_key,
     get_number_input,
     get_text_input,
     open_popover,
@@ -220,6 +221,15 @@ def test_mega_tester_app_renders_expected_content(app_target: AppTarget) -> None
     expect(
         app_target.get_by_role("button", name="Download data as CSV", exact=True)
     ).to_be_visible()
+    expect(
+        app_target.get_by_role("heading", name="Paginated sample rows", exact=True)
+    ).to_be_visible()
+    expect(
+        app_target.locator(".st-key-mega_sample_pagination")
+        .get_by_test_id("stPagination")
+        .first
+    ).to_be_visible()
+    expect(app_target.get_by_text("Showing page 1 of 5", exact=True)).to_be_visible()
     column_config_heading = app_target.get_by_role(
         "heading", name="Column config matrix", exact=True
     )
@@ -255,6 +265,7 @@ def test_mega_tester_app_renders_expected_content(app_target: AppTarget) -> None
     else:
         expect(plotly_charts).to_have_count(0)
     expect(app_target.get_by_test_id("stGraphVizChart").first).to_be_visible()
+    expect(app_target.get_by_test_id("stMermaidChart").first).to_be_visible()
 
     # Custom UI: verify HTML component iframe and unsafe markdown output.
     custom_html_iframe = app_target.locator(
@@ -279,6 +290,10 @@ def test_mega_tester_app_renders_expected_content(app_target: AppTarget) -> None
     expect(app_target.get_by_text("Success", exact=True)).to_be_visible()
     expect(app_target.get_by_text("Success with icon", exact=True)).to_be_visible()
     expect(
+        app_target.get_by_text("Loading generated summary...", exact=True)
+    ).to_be_visible()
+    expect(app_target.locator(".stMarkdownShimmer").first).to_be_visible()
+    expect(
         app_target.get_by_role("heading", name="Header with blue divider", exact=True)
     ).to_be_visible()
     expect(
@@ -301,6 +316,9 @@ def test_mega_tester_app_renders_expected_content(app_target: AppTarget) -> None
     ).to_be_visible()
     expect(
         app_target.get_by_role("button", name=re.compile(r"Button tertiary"))
+    ).to_be_visible()
+    expect(
+        app_target.get_by_test_id("stMenuButton").filter(has_text="Menu button").first
     ).to_be_visible()
     expect(app_target.get_by_text("Accept new options", exact=True)).to_be_visible()
     file_uploader_mode = app_target.get_by_text("File uploader mode", exact=True)
@@ -392,6 +410,26 @@ def test_mega_tester_app_interactions_validate_behavior(app: Page) -> None:
     expect(
         app.get_by_text("You pressed the tertiary button", exact=True)
     ).to_be_visible()
+
+    menu_button = (
+        app.get_by_test_id("stMenuButton").filter(has_text="Menu button").first
+    )
+    menu_button.get_by_test_id("stMenuButtonButton").first.click()
+    menu_body = app.get_by_test_id("stMenuButtonBody")
+    expect(menu_body).to_be_visible()
+    menu_body.get_by_text("Export CSV", exact=True).click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_text("Menu button selected: Export CSV", exact=True)
+    ).to_be_visible()
+
+    pagination = get_element_by_key(app, "mega_sample_pagination").get_by_test_id(
+        "stPagination"
+    )
+    expect(pagination).to_be_visible()
+    pagination.get_by_test_id("stPaginationNext").click()
+    wait_for_app_run(app)
+    expect(app.get_by_text("Showing page 2 of 5", exact=True)).to_be_visible()
 
     # Expander should hide content until opened.
     expect(app.get_by_text("Expander content", exact=True)).to_be_hidden()


### PR DESCRIPTION
## Describe your changes

Extends the mega tester app with examples for recently-added Streamlit features.

- Adds coverage for `st.mermaid_chart`, `st.pagination`, `st.menu_button`, and `:shimmer[]` markdown.
- Verifies rendering plus basic menu button and pagination interactions in the mega tester e2e test.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] `make check`
- [x] E2E Tests: `make run-e2e-test mega_tester_app_test.py`
- [ ] Unit Tests (JS and/or Python): not needed; e2e app/test-only change
- [ ] Any manual testing needed? No

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
