### PR TITLE
[feature] Add server.maxWidgetStateSize config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1072,6 +1072,17 @@ _create_option(
 )
 
 _create_option(
+    "server.maxWidgetStateSize",
+    description="""
+        Max size, in megabytes, of client-sent WebSocket messages and aggregate
+        widget state accepted for a single script rerun.
+    """,
+    visibility="hidden",
+    default_val=25,
+    type_=int,
+)
+
+_create_option(
     "server.enableArrowTruncation",
     description="""
         Enable automatically truncating all data structures that get serialized

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -86,7 +86,7 @@ setting the config option `server.maxWidgetStateSize`.
 [Click here to learn more about config options](https://docs.streamlit.io/develop/api-reference/configuration/config.toml).
 
 _Note that increasing the limit may lead to long loading times and large memory consumption
-of the client's browser and the Streamlit server._
+of the Streamlit server._
 """
         ).strip("\n")
 
@@ -149,7 +149,13 @@ def get_max_message_size_bytes() -> int:
 
 
 def get_max_widget_state_size_bytes() -> int:
-    """Returns the max client-sent widget state size in bytes."""
+    """Returns the max client-sent message size in bytes.
+
+    This limit is applied both to raw inbound WebSocket frames in the Starlette
+    handler and to the aggregate widget state protobuf in the runtime layer.
+
+    This will lazyload the value from the config and store it in the global symbol table.
+    """
     global _max_widget_state_size_bytes  # noqa: PLW0603
 
     if _max_widget_state_size_bytes is None:

--- a/lib/streamlit/runtime/runtime_util.py
+++ b/lib/streamlit/runtime/runtime_util.py
@@ -66,6 +66,31 @@ of the client's browser and the Streamlit server._
         ).strip("\n")
 
 
+class WidgetStateSizeError(MarkdownFormattedException):
+    """Exception raised when client-sent widget state is larger than the limit."""
+
+    def __init__(self, failed_msg_size: int) -> None:
+        msg = self._get_message(failed_msg_size)
+        super().__init__(msg)
+
+    def _get_message(self, failed_msg_size: int) -> str:
+        # This needs to have zero indentation otherwise the markdown will render incorrectly.
+        return (
+            f"""
+**Widget state of size {failed_msg_size / 1e6:.1f} MB exceeds the widget state size limit of
+{get_max_widget_state_size_bytes() / 1e6} MB.**
+
+This can happen when a widget or custom component sends a large value to Streamlit.
+Please decrease the amount of data sent from the browser, or increase the limit by
+setting the config option `server.maxWidgetStateSize`.
+[Click here to learn more about config options](https://docs.streamlit.io/develop/api-reference/configuration/config.toml).
+
+_Note that increasing the limit may lead to long loading times and large memory consumption
+of the client's browser and the Streamlit server._
+"""
+        ).strip("\n")
+
+
 class BadDurationStringError(StreamlitAPIException):
     """Raised when a bad duration argument string is passed."""
 
@@ -107,6 +132,7 @@ def serialize_forward_msg(msg: ForwardMsg) -> bytes:
 # This needs to be initialized lazily to avoid calling config.get_option() and
 # thus initializing config options when this file is first imported.
 _max_message_size_bytes: int | None = None
+_max_widget_state_size_bytes: int | None = None
 
 
 def get_max_message_size_bytes() -> int:
@@ -120,3 +146,15 @@ def get_max_message_size_bytes() -> int:
         _max_message_size_bytes = config.get_option("server.maxMessageSize") * int(1e6)
 
     return cast("int", _max_message_size_bytes)
+
+
+def get_max_widget_state_size_bytes() -> int:
+    """Returns the max client-sent widget state size in bytes."""
+    global _max_widget_state_size_bytes  # noqa: PLW0603
+
+    if _max_widget_state_size_bytes is None:
+        _max_widget_state_size_bytes = config.get_option(
+            "server.maxWidgetStateSize"
+        ) * int(1e6)
+
+    return cast("int", _max_widget_state_size_bytes)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -39,6 +39,10 @@ from streamlit.errors import StreamlitAPIException, UnserializableSessionStateEr
 from streamlit.logger import get_logger
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
+from streamlit.runtime.runtime_util import (
+    WidgetStateSizeError,
+    get_max_widget_state_size_bytes,
+)
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     ThreadState,
     get_script_run_ctx,
@@ -635,6 +639,10 @@ class SessionState:
 
     def set_widgets_from_proto(self, widget_states: WidgetStatesProto) -> None:
         """Set the value of all widgets represented in the given WidgetStatesProto."""
+        widget_states_size = widget_states.ByteSize()
+        if widget_states_size > get_max_widget_state_size_bytes():
+            raise WidgetStateSizeError(widget_states_size)
+
         for state in widget_states.widgets:
             self._new_widget_state.set_widget_from_proto(state)
 

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -26,7 +26,10 @@ from streamlit import config
 from streamlit.auth_util import get_cookie_with_chunks, get_expose_tokens_config
 from streamlit.logger import get_logger
 from streamlit.proto.BackMsg_pb2 import BackMsg
-from streamlit.runtime.runtime_util import serialize_forward_msg
+from streamlit.runtime.runtime_util import (
+    get_max_widget_state_size_bytes,
+    serialize_forward_msg,
+)
 from streamlit.runtime.session_manager import (
     ClientContext,
     SessionClient,
@@ -467,6 +470,17 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                         "WebSocket text frames are not supported; connection closed. "
                         "Expected binary protobufs."
                     )
+
+                max_client_msg_size = get_max_widget_state_size_bytes()
+                if len(data) > max_client_msg_size:
+                    _LOGGER.warning(
+                        "Client WebSocket message size %s exceeds the limit of %s; "
+                        "closing connection.",
+                        len(data),
+                        max_client_msg_size,
+                    )
+                    await websocket.close(code=1009)  # 1009 = Message Too Big
+                    break
 
                 back_msg = BackMsg()
                 try:

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -471,11 +471,16 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                         "Expected binary protobufs."
                     )
 
+                # The same config value bounds both the raw inbound frame here and
+                # the parsed aggregate widget state in the runtime layer. Applied to
+                # the raw BackMsg frame, this transport check is slightly stricter
+                # than the runtime check (the frame includes the BackMsg envelope),
+                # which is an intentional defense-in-depth tradeoff.
                 max_client_msg_size = get_max_widget_state_size_bytes()
                 if len(data) > max_client_msg_size:
                     _LOGGER.warning(
-                        "Client WebSocket message size %s exceeds the limit of %s; "
-                        "closing connection.",
+                        "Client WebSocket message size %s bytes exceeds the limit of "
+                        "%s bytes; closing connection.",
                         len(data),
                         max_client_msg_size,
                     )

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -799,6 +799,7 @@ class ConfigTest(unittest.TestCase):
                 "server.headless",
                 "server.maxMessageSize",
                 "server.maxUploadSize",
+                "server.maxWidgetStateSize",
                 "server.port",
                 "server.runOnSave",
                 "server.scriptHealthCheckEnabled",
@@ -1678,6 +1679,9 @@ class ConfigLoadingTest(unittest.TestCase):
 
     def test_max_message_size_default_values(self):
         assert config.get_option("server.maxMessageSize") == 200
+
+    def test_max_widget_state_size_default_values(self):
+        assert config.get_option("server.maxWidgetStateSize") == 25
 
     def test_config_options_removed_on_reparse(self):
         """Test that config options that are removed in a file are also removed

--- a/lib/tests/streamlit/runtime/runtime_util_test.py
+++ b/lib/tests/streamlit/runtime/runtime_util_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime import runtime_util
@@ -52,6 +53,8 @@ class RuntimeUtilTest(unittest.TestCase):
 
     def test_get_max_widget_state_size_bytes_reads_config(self):
         """The widget state size limit is derived from the config option in bytes."""
-        runtime_util._max_widget_state_size_bytes = None  # Reset cached value
-        with patch_config_options({"server.maxWidgetStateSize": 10}):
+        with (
+            patch.object(runtime_util, "_max_widget_state_size_bytes", None),
+            patch_config_options({"server.maxWidgetStateSize": 10}),
+        ):
             assert runtime_util.get_max_widget_state_size_bytes() == 10 * int(1e6)

--- a/lib/tests/streamlit/runtime/runtime_util_test.py
+++ b/lib/tests/streamlit/runtime/runtime_util_test.py
@@ -49,3 +49,9 @@ class RuntimeUtilTest(unittest.TestCase):
                 "exceeds the message size limit"
                 in deserialized_msg.delta.new_element.exception.message
             )
+
+    def test_get_max_widget_state_size_bytes_reads_config(self):
+        """The widget state size limit is derived from the config option in bytes."""
+        runtime_util._max_widget_state_size_bytes = None  # Reset cached value
+        with patch_config_options({"server.maxWidgetStateSize": 10}):
+            assert runtime_util.get_max_widget_state_size_bytes() == 10 * int(1e6)

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -886,6 +886,23 @@ class SessionStateMethodTests(unittest.TestCase):
             f"{GENERATED_ELEMENT_ID_PREFIX}-foo-None": Value("bar"),
         }
 
+    def test_set_widgets_from_proto_accepts_widget_state_at_limit(self):
+        """Widget state exactly at the size limit is accepted (boundary condition)."""
+        widget_state = WidgetStateProto()
+        widget_state.id = "boundary_widget"
+        widget_state.string_value = "x" * 1000
+        widget_states = WidgetStatesProto(widgets=[widget_state])
+
+        # Set the limit to exactly the serialized size so the boundary (==) passes.
+        with patch.object(
+            runtime_util,
+            "_max_widget_state_size_bytes",
+            widget_states.ByteSize(),
+        ):
+            self.session_state.set_widgets_from_proto(widget_states)
+
+        assert "boundary_widget" in self.session_state._new_widget_state.states
+
     def test_clear_state(self):
         # Sanity test
         keys = {"foo", "baz", "corge", f"{GENERATED_ELEMENT_ID_PREFIX}-foo-None"}

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -48,6 +48,9 @@ from streamlit.proto.Common_pb2 import (
     StringTriggerValue as StringTriggerValueProto,
 )
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
+from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
+from streamlit.runtime import runtime_util
+from streamlit.runtime.runtime_util import WidgetStateSizeError
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
 from streamlit.runtime.scriptrunner_utils.shared_run_state import SharedRunState
@@ -848,6 +851,40 @@ class SessionStateMethodTests(unittest.TestCase):
         session_state._compact_state()
         with pytest.raises(KeyError):
             wstates["baz"]
+
+    def test_set_widgets_from_proto_rejects_oversized_widget_state(self):
+        widget_state = WidgetStateProto()
+        widget_state.id = "large_widget"
+        widget_state.json_value = "x" * 1_100_000
+        widget_states = WidgetStatesProto(widgets=[widget_state])
+
+        with (
+            patch_config_options({"server.maxWidgetStateSize": 1}),
+            patch.object(runtime_util, "_max_widget_state_size_bytes", None),
+            pytest.raises(WidgetStateSizeError, match="widget state size limit"),
+        ):
+            self.session_state.set_widgets_from_proto(widget_states)
+
+        assert "large_widget" not in self.session_state._new_widget_state.states
+
+    def test_set_widgets_from_proto_rejects_oversized_aggregate_widget_state(self):
+        widget_states = WidgetStatesProto()
+        for idx in range(2):
+            widget_state = widget_states.widgets.add()
+            widget_state.id = f"large_widget_{idx}"
+            widget_state.string_value = "x" * 600_000
+
+        with (
+            patch_config_options({"server.maxWidgetStateSize": 1}),
+            patch.object(runtime_util, "_max_widget_state_size_bytes", None),
+            pytest.raises(WidgetStateSizeError, match="widget state size limit"),
+        ):
+            self.session_state.set_widgets_from_proto(widget_states)
+
+        assert self.session_state._new_widget_state.states == {
+            "baz": Value("qux2"),
+            f"{GENERATED_ELEMENT_ID_PREFIX}-foo-None": Value("bar"),
+        }
 
     def test_clear_state(self):
         # Sanity test

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from streamlit.runtime import runtime_util
 from streamlit.web.server.starlette import starlette_app_utils
 from streamlit.web.server.starlette.starlette_websocket import (
     StarletteClientContext,
@@ -502,6 +503,50 @@ class TestWebsocketHandlerUserInfoPrecedence:
         assert user_info["email"] == "header@example.com"
         # Cookie values that aren't overridden should still be present
         assert user_info["is_logged_in"] is True
+
+
+class TestWebsocketHandlerMessageSize:
+    """Tests for inbound WebSocket message size enforcement."""
+
+    @patch_config_options(
+        {
+            "server.enableCORS": False,
+            "server.enableXsrfProtection": False,
+            "server.maxWidgetStateSize": 1,
+        }
+    )
+    def test_closes_connection_for_oversized_client_message(self) -> None:
+        """Test that oversized client messages close the connection with code 1009."""
+        mock_websocket = MagicMock()
+        mock_websocket.headers = MagicMock()
+        mock_websocket.headers.get.return_value = None
+        mock_websocket.headers.getlist.return_value = []
+        mock_websocket.cookies = {}
+        mock_websocket.accept = AsyncMock()
+        mock_websocket.close = AsyncMock()
+        mock_websocket.receive_bytes = AsyncMock(return_value=b"x" * 1_100_000)
+
+        mock_runtime = MagicMock()
+        mock_runtime.connect_session = MagicMock(return_value="test-session-id")
+        mock_runtime.disconnect_session = MagicMock()
+        mock_runtime.handle_backmsg = MagicMock()
+
+        handler = create_websocket_handler(mock_runtime)
+        with (
+            patch.object(runtime_util, "_max_widget_state_size_bytes", None),
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.StarletteSessionClient"
+            ) as mock_client_class,
+        ):
+            mock_client = MagicMock()
+            mock_client.aclose = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            asyncio.run(handler(mock_websocket))
+
+        mock_websocket.close.assert_called_once_with(code=1009)
+        mock_runtime.handle_backmsg.assert_not_called()
+        mock_runtime.disconnect_session.assert_called_once_with("test-session-id")
 
 
 class TestGetSignedCookieWithChunks:


### PR DESCRIPTION
## Describe your changes

Adds a hidden `server.maxWidgetStateSize` config option (default 25 MB) that bounds how much data a client can send to the server per script rerun, hardening against oversized widget/custom-component payloads.

- **Transport layer:** oversized inbound WebSocket frames close the connection with code `1009` before the `BackMsg` is parsed (cheap, pre-parse DoS guard for the OSS server).
- **Runtime layer:** `SessionState.set_widgets_from_proto` raises a new `WidgetStateSizeError` for oversized aggregate widget state, providing transport-agnostic enforcement for runtimes that don't use the Starlette WebSocket handler.
- Mirrors the existing `server.maxMessageSize` / `MessageSizeError` pattern (lazy-cached getter, Markdown-formatted error).

## GitHub Issue Link (if applicable)

Internal: SNOW-3715967

## Testing Plan

- [x] Unit Tests (Python)
  - `config_test.py` — option registration + default value
  - `runtime_util_test.py` — `get_max_widget_state_size_bytes()`
  - `session_state_test.py` — rejects oversized single and aggregate widget state (and leaves state unmutated)
  - `starlette_websocket_test.py` — closes connection with `1009` for an oversized inbound frame
- [ ] E2E Tests — not added; the behavior is a transport-level connection close that is hard to exercise reliably in Playwright (see conversation note on external-test coverage)

Made with [Cursor](https://cursor.com)