### PR TITLE
[fix] Stabilize fullscreen wait in st_image e2e test on webkit

### DIFF
--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -223,23 +223,18 @@ def set_fullscreen(image_wrapper: Locator, open: bool):
     )
     expect(fullscreen_button).to_be_visible()
     fullscreen_button.click()
-    # Wait for the fullscreen CSS transition to complete by checking position style
-    # The stFullScreenFrame element (grandparent of stImage, parent of image_wrapper)
-    # becomes position:fixed when open.
-    # Use an extended timeout because webkit can take noticeably longer than the
-    # default 5s expect timeout to finish the fullscreen transition when the
-    # machine is under load (e.g. the full parallel CI suite), which otherwise
-    # leaves the frame still reporting position:static and flakes the assertion.
-    fullscreen_frame = image_wrapper.locator("..")
-    transition_timeout = 15000
-    if open:
-        expect(fullscreen_frame).to_have_css(
-            "position", "fixed", timeout=transition_timeout
-        )
-    else:
-        expect(fullscreen_frame).to_have_css(
-            "position", "static", timeout=transition_timeout
-        )
+    # Confirm the fullscreen state actually toggled by waiting for the toolbar
+    # button to flip to its opposite label. The button label and the
+    # stFullScreenFrame's `position: fixed` style are driven by the same
+    # `isExpanded` React state, so once the label flips the frame is already in
+    # the expected layout. This mirrors the fullscreen helpers in
+    # st_graphviz_chart_test.py and avoids relying on the CSS `position` value
+    # settling, which can lag past the default expect timeout on webkit under
+    # load (e.g. the full parallel CI suite) and flake the test.
+    toggled_button = image_wrapper.get_by_role(
+        "button", name="Close fullscreen" if open else "Fullscreen"
+    )
+    expect(toggled_button).to_be_visible()
 
 
 # SVGs without width or height are not rendered correctly in Firefox

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -225,12 +225,21 @@ def set_fullscreen(image_wrapper: Locator, open: bool):
     fullscreen_button.click()
     # Wait for the fullscreen CSS transition to complete by checking position style
     # The stFullScreenFrame element (grandparent of stImage, parent of image_wrapper)
-    # becomes position:fixed when open
+    # becomes position:fixed when open.
+    # Use an extended timeout because webkit can take noticeably longer than the
+    # default 5s expect timeout to finish the fullscreen transition when the
+    # machine is under load (e.g. the full parallel CI suite), which otherwise
+    # leaves the frame still reporting position:static and flakes the assertion.
     fullscreen_frame = image_wrapper.locator("..")
+    transition_timeout = 15000
     if open:
-        expect(fullscreen_frame).to_have_css("position", "fixed")
+        expect(fullscreen_frame).to_have_css(
+            "position", "fixed", timeout=transition_timeout
+        )
     else:
-        expect(fullscreen_frame).to_have_css("position", "static")
+        expect(fullscreen_frame).to_have_css(
+            "position", "static", timeout=transition_timeout
+        )
 
 
 # SVGs without width or height are not rendered correctly in Firefox

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -223,14 +223,8 @@ def set_fullscreen(image_wrapper: Locator, open: bool):
     )
     expect(fullscreen_button).to_be_visible()
     fullscreen_button.click()
-    # Confirm the fullscreen state actually toggled by waiting for the toolbar
-    # button to flip to its opposite label. The button label and the
-    # stFullScreenFrame's `position: fixed` style are driven by the same
-    # `isExpanded` React state, so once the label flips the frame is already in
-    # the expected layout. This mirrors the fullscreen helpers in
-    # st_graphviz_chart_test.py and avoids relying on the CSS `position` value
-    # settling, which can lag past the default expect timeout on webkit under
-    # load (e.g. the full parallel CI suite) and flake the test.
+    # Wait for the toolbar button to flip to its opposite label, which confirms
+    # the fullscreen state has finished toggling before we take a snapshot.
     toggled_button = image_wrapper.get_by_role(
         "button", name="Close fullscreen" if open else "Fullscreen"
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Fixes an intermittent `playwright-e2e-tests` failure on webkit in the tests that use the shared `set_fullscreen` helper in `e2e_playwright/st_image_test.py`:

- `test_svg_viewbox_only[webkit]`
- `test_width_stretch_fullscreen[webkit]`

Both failed the same way: `expect(fullscreen_frame).to_have_css("position", "fixed")` timed out at the default 5s with the `stFullScreenFrame` still reporting `static`.

**Root cause:** After clicking the fullscreen button, the helper polled `stFullScreenFrame` for `position: fixed`. That style is applied from the `isExpanded` React state (not a CSS animation), so the wait was really gated on the click → re-render cycle, which can exceed the 5s timeout on webkit under CI load.

**Fix:** In `set_fullscreen`, wait for the toolbar button to flip its label (`Fullscreen` ⇄ `Close fullscreen`) instead of polling the CSS `position` value. This is a semantic signal that the fullscreen state has finished toggling, matches the fullscreen helpers already used in `st_graphviz_chart_test.py`, and needs no custom timeout. Test intent is unchanged and `@pytest.mark.skip_browser("firefox")` is preserved.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- E2E Tests: The flake could not be reproduced locally in isolation (25/25 passes) nor under simulated CPU contention (12/12 passes), consistent with it being CI-parallel-load specific. After the fix, `test_svg_viewbox_only` passes 10/10 on webkit, and `test_width_stretch_fullscreen` passes on webkit and chromium.
- No unit tests needed — change is limited to an e2e test helper's wait strategy.
- Manual testing: not required.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e5a7571-6ed6-4639-91a8-3ff4a0fafb01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e5a7571-6ed6-4639-91a8-3ff4a0fafb01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

