### PR TITLE
Clean up run_every auto-rerun timers per fragment

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3911,6 +3911,139 @@ describe("App", () => {
         },
       })
     })
+
+    it("does not accumulate duplicate timers when a fragment re-registers its auto-rerun", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBefore = connectionManager.sendMessage.mock.calls.length
+      act(() => {
+        // Register the same fragment twice, as happens when a run_every
+        // fragment re-renders.
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "myFragmentId",
+        })
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "myFragmentId",
+        })
+        vi.advanceTimersByTime(1000)
+      })
+
+      // Only one interval should be active despite two registrations; without
+      // deduping, two timers would each fire and send two messages per tick.
+      expect(
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        connectionManager.sendMessage.mock.calls.length - callsBefore
+      ).toBe(1)
+    })
+
+    it("stops a nested fragment's auto-rerun once it is removed, but keeps sibling timers", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // Full run: a top-level run_every fragment ("standalone") plus a nested
+      // run_every fragment ("nested") rendered inside a parent fragment.
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage(
+        "delta",
+        {
+          type: "addBlock",
+          addBlock: { vertical: {} },
+          fragmentId: "standalone",
+        },
+        { deltaPath: [0, 0] }
+      )
+      sendForwardMessage(
+        "delta",
+        { type: "addBlock", addBlock: { vertical: {} }, fragmentId: "parent" },
+        { deltaPath: [0, 1] }
+      )
+      sendForwardMessage(
+        "delta",
+        { type: "addBlock", addBlock: { vertical: {} }, fragmentId: "nested" },
+        { deltaPath: [0, 1, 0] }
+      )
+      sendForwardMessage("autoRerun", {
+        interval: 1.0,
+        fragmentId: "standalone",
+      })
+      sendForwardMessage("autoRerun", { interval: 1.0, fragmentId: "nested" })
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY
+      )
+
+      type SentRerun = { fragmentId?: string; isAutoRerun?: boolean }
+      const autoRerunFragmentIdsSince = (
+        fromIndex: number
+      ): (string | undefined)[] => {
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        const calls = connectionManager.sendMessage.mock.calls as Array<
+          [{ rerunScript?: SentRerun }]
+        >
+        return calls
+          .slice(fromIndex)
+          .map(call => call[0].rerunScript)
+          .filter((rerunScript): rerunScript is SentRerun =>
+            Boolean(rerunScript?.isAutoRerun)
+          )
+          .map(rerunScript => rerunScript.fragmentId)
+      }
+
+      // Both timers are active and tick.
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(new Set(autoRerunFragmentIdsSince(0))).toEqual(
+        new Set(["standalone", "nested"])
+      )
+
+      // Fragment-only rerun of the parent that no longer renders the nested
+      // fragment (mirrors unchecking a checkbox that hides it).
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBeforeHide = connectionManager.sendMessage.mock.calls.length
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        scriptRunId: "run_b",
+        fragmentIdsThisRun: ["parent"],
+      })
+      sendForwardMessage(
+        "delta",
+        { type: "addBlock", addBlock: { vertical: {} }, fragmentId: "parent" },
+        { deltaPath: [0, 1] }
+      )
+      sendForwardMessage(
+        "scriptFinished",
+        ForwardMsg.ScriptFinishedStatus.FINISHED_FRAGMENT_RUN_SUCCESSFULLY
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      const idsAfterHide = autoRerunFragmentIdsSince(callsBeforeHide)
+      // The standalone timer keeps ticking; the nested one has been cleared.
+      expect(idsAfterHide.length).toBeGreaterThan(0)
+      expect(idsAfterHide).not.toContain("nested")
+      expect(idsAfterHide.every(id => id === "standalone")).toBe(true)
+    })
   })
 
   describe("App.requestFileURLs", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -235,7 +235,6 @@ interface State {
   deployedAppMetadata: DeployedAppMetadata
   libConfig: LibConfig
   appConfig: AppConfig
-  autoReruns: NodeJS.Timeout[]
   inputsDisabled: boolean
   scriptChangedOnDisk: boolean
   // Whether the framework "install skills" nudge is currently shown. Set once
@@ -309,6 +308,15 @@ export class App extends PureComponent<Props, State> {
   // we have received a NewSession message after the latest rerun request.
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
+
+  // Active `run_every` auto-rerun interval timers, keyed by fragment id. These
+  // are imperative resources (setInterval handles), so they live outside of
+  // React state. Keying by fragment id lets us dedupe timers when a fragment
+  // re-registers and stop a fragment's timer once it is no longer rendered.
+  private readonly autoRerunIntervals: Map<
+    string,
+    ReturnType<typeof setInterval>
+  > = new Map()
 
   // Whether the skills-install nudge has been shown this page load.
   // `handleInitialization` re-runs on websocket reconnect, so this guards
@@ -385,7 +393,6 @@ export class App extends PureComponent<Props, State> {
       deployedAppMetadata: {},
       libConfig: {},
       appConfig: {},
-      autoReruns: [],
       inputsDisabled: false,
       navigationPosition: Navigation.Position.SIDEBAR,
       scriptChangedOnDisk: false,
@@ -922,7 +929,7 @@ export class App extends PureComponent<Props, State> {
         // Script is using fragments (fragments in last run or
         // fragment auto-reruns configured):
         this.state.fragmentIdsThisRun.length > 0 ||
-        this.state.autoReruns.length > 0
+        this.autoRerunIntervals.size > 0
       ) {
         LOG.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
@@ -1231,15 +1238,19 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleAutoRerun = (autoRerun: AutoRerun): void => {
+    const { fragmentId } = autoRerun
+
+    // A `run_every` fragment re-registers its auto-rerun every time it renders.
+    // Clear any existing timer for this fragment first so that repeated renders
+    // don't accumulate duplicate intervals (which would multiply the rerun rate
+    // and keep firing after the fragment is gone).
+    this.clearAutoRerunInterval(fragmentId)
+
     const intervalId = setInterval(() => {
-      this.widgetMgr.sendUpdateWidgetsMessage(autoRerun.fragmentId, true)
+      this.widgetMgr.sendUpdateWidgetsMessage(fragmentId, true)
     }, autoRerun.interval * 1000)
 
-    this.setState((prevState: State) => {
-      return {
-        autoReruns: [...prevState.autoReruns, intervalId],
-      }
-    })
+    this.autoRerunIntervals.set(fragmentId, intervalId)
   }
 
   /**
@@ -1847,7 +1858,8 @@ export class App extends PureComponent<Props, State> {
    * use useEffect and remove this suppress entirely.
    */
   private removeInactiveWidgetState(): void {
-    const { elements, blockIds } = this.state.elements.getActiveIds()
+    const { elements, blockIds, fragmentIds } =
+      this.state.elements.getActiveIds()
     const activeIds = new Set([
       ...Array.from(elements)
         .map(element => getElementId(element))
@@ -1855,6 +1867,9 @@ export class App extends PureComponent<Props, State> {
       ...blockIds,
     ])
     this.widgetMgr.removeInactive(activeIds)
+    // Stop auto-rerun timers for fragments that were pruned from the tree in
+    // this run (e.g. a nested `run_every` fragment hidden by its parent).
+    this.cleanupStaleAutoReruns(fragmentIds)
   }
 
   /**
@@ -1966,10 +1981,42 @@ export class App extends PureComponent<Props, State> {
    * lead to issues, e.g. when a new full app-rerun session is started or the active page changed.
    */
   cleanupAutoReruns = (): void => {
-    this.state.autoReruns.forEach((value: NodeJS.Timeout) => {
-      clearInterval(value)
+    this.autoRerunIntervals.forEach(intervalId => {
+      clearInterval(intervalId)
     })
-    this.setState({ autoReruns: [] })
+    this.autoRerunIntervals.clear()
+  }
+
+  /**
+   * Clear the auto-rerun interval for a single fragment, if one exists.
+   */
+  private clearAutoRerunInterval(fragmentId: string): void {
+    const intervalId = this.autoRerunIntervals.get(fragmentId)
+    if (intervalId !== undefined) {
+      clearInterval(intervalId)
+      this.autoRerunIntervals.delete(fragmentId)
+    }
+  }
+
+  /**
+   * Stop auto-rerun timers for fragments that are no longer rendered.
+   *
+   * A nested `run_every` fragment keeps its interval running on the frontend
+   * even after an ancestor stops rendering it, because a fragment-only rerun
+   * does not reset every timer (unlike a full rerun). Once such a fragment's
+   * subtree has been pruned from the render tree, its timer would otherwise
+   * keep sending stale auto-rerun requests. We therefore clear any timer whose
+   * fragment id is no longer present in the tree.
+   */
+  private cleanupStaleAutoReruns(activeFragmentIds: Set<string>): void {
+    if (this.autoRerunIntervals.size === 0) {
+      return
+    }
+    this.autoRerunIntervals.forEach((_intervalId, fragmentId) => {
+      if (!activeFragmentIds.has(fragmentId)) {
+        this.clearAutoRerunInterval(fragmentId)
+      }
+    })
   }
 
   /**

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -1445,6 +1445,31 @@ describe("AppRoot", () => {
     })
   })
 
+  describe("AppRoot.getActiveIds", () => {
+    it("returns fragment ids for fragments rendered in the tree", () => {
+      const blockDelta = makeProto(DeltaProto, {
+        addBlock: { vertical: {}, allowEmpty: true },
+        fragmentId: "my_fragment",
+      })
+      const elementDelta = makeProto(DeltaProto, {
+        newElement: { text: { body: "fragment_text" } },
+        fragmentId: "my_fragment",
+      })
+      const root = ROOT.applyDelta(
+        "session_id",
+        blockDelta,
+        forwardMsgMetadata([0, 2])
+      ).applyDelta("session_id", elementDelta, forwardMsgMetadata([0, 2, 0]))
+
+      const { fragmentIds } = root.getActiveIds()
+      expect(fragmentIds.has("my_fragment")).toBe(true)
+    })
+
+    it("returns an empty fragment id set when nothing uses fragments", () => {
+      expect(ROOT.getActiveIds().fragmentIds.size).toBe(0)
+    })
+  })
+
   describe("AppRoot.getElements", () => {
     it("returns all elements using ElementsSetVisitor", () => {
       // We have elements at main.[0] and main.[1, 0]

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -392,14 +392,17 @@ export class AppRoot {
   }
 
   /**
-   * Return all active element IDs and block IDs in the tree.
+   * Return all active element IDs, block IDs, and fragment IDs in the tree.
    * Block IDs are collected from blocks that have a stable identity
    * (e.g. keyed layout containers), and are needed to prevent
-   * elementStates entries from being garbage-collected.
+   * elementStates entries from being garbage-collected. Fragment IDs identify
+   * the fragments that are currently rendered, which is used to detect
+   * fragments that have been removed (e.g. to stop orphaned auto-rerun timers).
    */
   public getActiveIds(): {
     elements: Set<Element>
     blockIds: Set<string>
+    fragmentIds: Set<string>
   } {
     const visitor = new ElementsSetVisitor()
 
@@ -408,7 +411,11 @@ export class AppRoot {
     this.event.accept(visitor)
     this.bottom.accept(visitor)
 
-    return { elements: visitor.elements, blockIds: visitor.blockIds }
+    return {
+      elements: visitor.elements,
+      blockIds: visitor.blockIds,
+      fragmentIds: visitor.fragmentIds,
+    }
   }
 
   private addElement(

--- a/frontend/lib/src/render-tree/test-utils.ts
+++ b/frontend/lib/src/render-tree/test-utils.ts
@@ -38,7 +38,8 @@ export const FAKE_SCRIPT_HASH = "fake_script_hash"
 export function text(
   textArg: string,
   scriptRunId = NO_SCRIPT_RUN_ID,
-  elementHash?: string
+  elementHash?: string,
+  fragmentId?: string
 ): ElementNode {
   const element = makeProto(Element, { text: { body: textArg } })
   return new ElementNode(
@@ -46,7 +47,7 @@ export function text(
     ForwardMsgMetadata.create(),
     scriptRunId,
     FAKE_SCRIPT_HASH,
-    undefined,
+    fragmentId,
     elementHash
   )
 }
@@ -80,13 +81,15 @@ export function textInput(
 /** Create a BlockNode with the given properties. */
 export function block(
   children: AppNode[] = [],
-  scriptRunId = NO_SCRIPT_RUN_ID
+  scriptRunId = NO_SCRIPT_RUN_ID,
+  fragmentId?: string
 ): BlockNode {
   return new BlockNode(
     FAKE_SCRIPT_HASH,
     children,
     makeProto(BlockProto, {}),
-    scriptRunId
+    scriptRunId,
+    fragmentId
   )
 }
 

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.test.ts
@@ -232,6 +232,41 @@ describe("ElementsSetVisitor", () => {
     })
   })
 
+  describe("fragmentIds collection", () => {
+    it("collects fragment ids from block and element nodes", () => {
+      const fragmentElement = text("child", undefined, undefined, "fragment1")
+      const fragmentBlock = block([fragmentElement], undefined, "fragment2")
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(fragmentBlock)
+
+      expect(visitor.fragmentIds.size).toBe(2)
+      expect(visitor.fragmentIds.has("fragment1")).toBe(true)
+      expect(visitor.fragmentIds.has("fragment2")).toBe(true)
+    })
+
+    it("does not collect fragment ids from nodes without a fragment id", () => {
+      const noFragmentBlock = block([text("child")])
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(noFragmentBlock)
+
+      expect(visitor.fragmentIds.size).toBe(0)
+    })
+
+    it("deduplicates repeated fragment ids", () => {
+      const child1 = text("child1", undefined, undefined, "fragment1")
+      const child2 = text("child2", undefined, undefined, "fragment1")
+      const fragmentBlock = block([child1, child2], undefined, "fragment1")
+      const visitor = new ElementsSetVisitor()
+
+      visitor.visitBlockNode(fragmentBlock)
+
+      expect(visitor.fragmentIds.size).toBe(1)
+      expect(visitor.fragmentIds.has("fragment1")).toBe(true)
+    })
+  })
+
   describe("performance and mutability", () => {
     it("uses the same set instance throughout", () => {
       const element1 = text("first")

--- a/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ElementsSetVisitor.ts
@@ -23,13 +23,16 @@ import { TransientNode } from "~lib/render-tree/TransientNode"
 import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.interface"
 
 /**
- * A visitor that collects all Elements and stable block IDs from an AppNode
- * tree.
+ * A visitor that collects all Elements, stable block IDs, and active fragment
+ * IDs from an AppNode tree.
  *
  * - `elements`: all Element protos found in ElementNodes.
  * - `blockIds`: IDs from BlockNodes that have a stable identity (e.g. keyed
  *   layout containers). These are used to prevent `elementStates` entries
  *   from being garbage-collected.
+ * - `fragmentIds`: IDs of every fragment that currently has a node in the tree.
+ *   These are used to detect fragments that are no longer rendered (e.g. to
+ *   stop orphaned `run_every` auto-rerun timers).
  *
  * This visitor uses mutable Sets for performance, accumulating results
  * as it traverses the tree. The visitor methods return the element Set
@@ -42,25 +45,34 @@ import type { AppNodeVisitor } from "~lib/render-tree/visitors/AppNodeVisitor.in
  * rootNode.accept(visitor)
  * const elements = visitor.elements
  * const blockIds = visitor.blockIds
+ * const fragmentIds = visitor.fragmentIds
  * ```
  */
 export class ElementsSetVisitor implements AppNodeVisitor<Set<Element>> {
   public readonly elements: Set<Element>
   public readonly blockIds: Set<string>
+  public readonly fragmentIds: Set<string>
 
   constructor() {
     this.elements = new Set<Element>()
     this.blockIds = new Set<string>()
+    this.fragmentIds = new Set<string>()
   }
 
   visitElementNode(node: ElementNode): Set<Element> {
     this.elements.add(node.element)
+    if (node.fragmentId) {
+      this.fragmentIds.add(node.fragmentId)
+    }
     return this.elements
   }
 
   visitBlockNode(node: BlockNode): Set<Element> {
     if (node.deltaBlock?.id) {
       this.blockIds.add(node.deltaBlock.id)
+    }
+    if (node.fragmentId) {
+      this.fragmentIds.add(node.fragmentId)
     }
     for (const child of node.children) {
       child.accept(this)


### PR DESCRIPTION
## Describe your changes

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
