### PR TITLE
[fix] Sanitize dangerous Graphviz link URLs

### DIFF
--- a/e2e_playwright/st_graphviz_chart.py
+++ b/e2e_playwright/st_graphviz_chart.py
@@ -130,3 +130,11 @@ st.subheader("Combined Width and Height")
 
 st.write("width=300, height=150")
 st.graphviz_chart(dot_code, width=300, height=150)
+
+st.subheader("Dangerous link sanitization")
+
+# Node with a dangerous javascript: URL. The frontend must neutralize this to
+# "#" after rendering to prevent XSS when the link is clicked.
+malicious_graph = graphviz.Digraph("malicious")
+malicious_graph.node("ClickMe", URL="javascript:alert('xss')")
+st.graphviz_chart(malicious_graph)

--- a/e2e_playwright/st_graphviz_chart_test.py
+++ b/e2e_playwright/st_graphviz_chart_test.py
@@ -66,7 +66,7 @@ def test_initial_setup(app: Page):
     """Initial setup: ensure charts are loaded."""
     expect(
         app.get_by_test_id("stGraphVizChart").locator("svg > g > title")
-    ).to_have_count(14)
+    ).to_have_count(15)
 
 
 def test_shows_left_and_right_graph(app: Page):
@@ -262,3 +262,29 @@ def test_width_height_combined(app: Page, assert_snapshot: ImageCompareFunction)
         combined_chart.locator("svg"),
         name="st_graphviz_chart_width_height_combined",
     )
+
+
+def test_sanitizes_dangerous_link_urls(app: Page):
+    """Test that dangerous javascript: link URLs are neutralized to '#'.
+
+    This relies on real-browser URL normalization that jsdom cannot fully
+    replicate, so it complements the frontend unit tests.
+    """
+    malicious_chart = app.get_by_test_id("stGraphVizChart").nth(14)
+    link = malicious_chart.locator("a").first
+    expect(link).to_be_attached()
+
+    def link_is_sanitized() -> bool:
+        # Graphviz may emit the link target as "href" and/or "xlink:href"
+        # depending on version; all present values must be neutralized to "#".
+        values = [
+            value
+            for value in (
+                link.get_attribute("href"),
+                link.get_attribute("xlink:href"),
+            )
+            if value is not None
+        ]
+        return len(values) > 0 and all(value == "#" for value in values)
+
+    wait_until(app, link_is_sanitized)

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx
@@ -23,7 +23,11 @@ import { GraphVizChart as GraphVizChartProto } from "@streamlit/protobuf"
 import * as UseResizeObserver from "~lib/hooks/useResizeObserver"
 import { render } from "~lib/test_util"
 
-import GraphVizChart, { GraphVizChartProps, LOG } from "./GraphVizChart"
+import GraphVizChart, {
+  GraphVizChartProps,
+  LOG,
+  sanitizeGraphVizLinkUris,
+} from "./GraphVizChart"
 
 interface MockGraphvizChain {
   zoom: () => MockGraphvizChain
@@ -45,11 +49,43 @@ const createChainableMethods = (renderDotImpl?: Mock): MockGraphvizChain => {
     engine: () => chainable,
     renderDot:
       renderDotImpl ||
-      vi.fn().mockReturnValue({
-        on: vi.fn(),
+      vi.fn((_spec: string, callback?: () => void) => {
+        callback?.()
+
+        return {
+          on: vi.fn(),
+        }
       }),
   }
   return chainable
+}
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
+
+const appendSvgLink = (
+  container: Element,
+  attributes: Record<string, string>
+): SVGElement => {
+  const svg = document.createElementNS(SVG_NAMESPACE, "svg")
+  const link = document.createElementNS(SVG_NAMESPACE, "a")
+
+  Object.entries(attributes).forEach(([attributeName, attributeValue]) => {
+    if (attributeName === "xlink:href") {
+      link.setAttributeNS(XLINK_NAMESPACE, attributeName, attributeValue)
+    } else {
+      link.setAttribute(attributeName, attributeValue)
+    }
+  })
+
+  svg.appendChild(link)
+  container.appendChild(svg)
+
+  return link
+}
+
+const setupMockRenderDot = (renderDotImpl: Mock): void => {
+  ;(graphviz as Mock).mockReturnValue(createChainableMethods(renderDotImpl))
 }
 
 vi.mock("d3-graphviz", () => ({
@@ -106,8 +142,7 @@ describe("GraphVizChart Element", () => {
       }
     })
 
-    // Modify the graphviz mock to use the mockRenderDot
-    ;(graphviz as Mock).mockReturnValue(createChainableMethods(mockRenderDot))
+    setupMockRenderDot(mockRenderDot)
 
     const props = getProps({
       spec: "crash",
@@ -116,7 +151,7 @@ describe("GraphVizChart Element", () => {
     render(<GraphVizChart {...props} />)
 
     expect(logErrorSpy).toHaveBeenCalledTimes(1)
-    expect(mockRenderDot).toHaveBeenCalledWith("crash")
+    expect(mockRenderDot).toHaveBeenCalledWith("crash", expect.any(Function))
     expect(graphviz).toHaveBeenCalledTimes(1)
   })
 
@@ -129,5 +164,74 @@ describe("GraphVizChart Element", () => {
     expect(screen.getByTestId("stGraphVizChart")).toHaveStyle(
       "height: auto; width: auto"
     )
+  })
+
+  const renderWithSvgLink = (
+    attributes: Record<string, string>
+  ): Element | null => {
+    const mockRenderDot = vi.fn((_spec: string, callback?: () => void) => {
+      appendSvgLink(screen.getByTestId("stGraphVizChart"), attributes)
+
+      callback?.()
+
+      return {
+        on: vi.fn(),
+      }
+    })
+    setupMockRenderDot(mockRenderDot)
+
+    render(<GraphVizChart {...getProps()} />)
+
+    return screen.getByTestId("stGraphVizChart").querySelector("a")
+  }
+
+  it("sanitizes dangerous Graphviz link URLs after rendering", () => {
+    const link = renderWithSvgLink({
+      href: "vbscript:alert(1)",
+      "xlink:href": "\u0001java\nscript:alert(1)",
+    })
+
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute("href")).toBe("#")
+    expect(link?.getAttributeNS(XLINK_NAMESPACE, "href")).toBe("#")
+  })
+
+  it("preserves safe Graphviz link URLs", () => {
+    const link = renderWithSvgLink({
+      href: "#details",
+      "xlink:href": "https://streamlit.io",
+    })
+
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute("href")).toBe("#details")
+    expect(link?.getAttributeNS(XLINK_NAMESPACE, "href")).toBe(
+      "https://streamlit.io"
+    )
+  })
+
+  it("sanitizes rendered SVG links directly", () => {
+    const container = document.createElement("div")
+    const link = appendSvgLink(container, {
+      "xlink:href": "JAVASCRIPT:alert(1)",
+    })
+
+    sanitizeGraphVizLinkUris(container)
+
+    expect(link.getAttributeNS(XLINK_NAMESPACE, "href")).toBe("#")
+  })
+
+  it("sanitizes xlink:href set as a plain qualified attribute", () => {
+    const container = document.createElement("div")
+    const svg = document.createElementNS(SVG_NAMESPACE, "svg")
+    const link = document.createElementNS(SVG_NAMESPACE, "a")
+    // Set xlink:href by qualified name (no namespace) to exercise the
+    // getAttribute("xlink:href") branch.
+    link.setAttribute("xlink:href", "javascript:alert(1)")
+    svg.appendChild(link)
+    container.appendChild(svg)
+
+    sanitizeGraphVizLinkUris(container)
+
+    expect(link.getAttribute("xlink:href")).toBe("#")
   })
 })

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -74,7 +74,9 @@ function sanitizeNamespacedXlinkHref(element: Element): void {
  * regardless of environment (e.g. jsdom vs. a real browser SVG DOM).
  */
 export function sanitizeGraphVizLinkUris(container: Element): void {
-  container.querySelectorAll("*").forEach(element => {
+  // Graphviz link targets are exclusively on SVG `<a>` elements, so we only
+  // need to inspect those rather than walking every node in the SVG subtree.
+  container.querySelectorAll("a").forEach(element => {
     sanitizeLinkAttribute(element, "href")
     sanitizeLinkAttribute(element, "xlink:href")
     sanitizeNamespacedXlinkHref(element)

--- a/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
+++ b/frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.tsx
@@ -34,6 +34,7 @@ import { StyledToolbarElementContainer } from "~lib/components/shared/Toolbar/st
 import Toolbar from "~lib/components/shared/Toolbar/Toolbar"
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
+import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil"
 
 import { StyledGraphVizChart } from "./styled-components"
 
@@ -44,6 +45,41 @@ export interface GraphVizChartProps {
   heightConfig?: streamlit.IHeightConfig | null
 }
 export const LOG = getLogger("GraphVizChart")
+
+const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
+
+function sanitizeLinkAttribute(element: Element, attributeName: string): void {
+  const attributeValue = element.getAttribute(attributeName)
+
+  if (attributeValue !== null && isDangerousLinkUri(attributeValue)) {
+    element.setAttribute(attributeName, BLOCKED_LINK_URI)
+  }
+}
+
+function sanitizeNamespacedXlinkHref(element: Element): void {
+  const attributeValue = element.getAttributeNS(XLINK_NAMESPACE, "href")
+
+  if (attributeValue !== null && isDangerousLinkUri(attributeValue)) {
+    element.setAttributeNS(XLINK_NAMESPACE, "xlink:href", BLOCKED_LINK_URI)
+  }
+}
+
+/**
+ * Neutralizes dangerous link URIs in the rendered Graphviz SVG.
+ *
+ * Graphviz emits link targets as either `href` or `xlink:href`, and depending
+ * on how the SVG was parsed the latter may be reachable by qualified name
+ * (`getAttribute("xlink:href")`) and/or by namespace
+ * (`getAttributeNS(...)`). We handle all three to sanitize the value
+ * regardless of environment (e.g. jsdom vs. a real browser SVG DOM).
+ */
+export function sanitizeGraphVizLinkUris(container: Element): void {
+  container.querySelectorAll("*").forEach(element => {
+    sanitizeLinkAttribute(element, "href")
+    sanitizeLinkAttribute(element, "xlink:href")
+    sanitizeNamespacedXlinkHref(element)
+  })
+}
 
 function GraphVizChart({
   element,
@@ -89,7 +125,16 @@ function GraphVizChart({
         .fit(true)
         .scale(1)
         .engine(element.engine as Engine)
-        .renderDot(element.spec)
+        // Sanitize links once rendering completes. Graphviz inserts the SVG
+        // synchronously here, so there is only a negligible window (before this
+        // callback runs) where an unsanitized link could exist in the DOM.
+        .renderDot(element.spec, () => {
+          const chartElement = document.getElementById(chartId)
+
+          if (chartElement) {
+            sanitizeGraphVizLinkUris(chartElement)
+          }
+        })
     } catch (error) {
       LOG.error(error)
     }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -65,6 +65,7 @@ import {
 } from "~lib/theme/getColors"
 import type { EmotionTheme } from "~lib/theme/types"
 import { convertRemToPx } from "~lib/theme/utils"
+import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil"
 
 import {
   StyledHeadingActionElements,
@@ -263,15 +264,6 @@ export function createAnchorFromText(text: string | null): string {
   return xxhash.h32(text, 0xabcd).toString(16)
 }
 
-// Dangerous URL schemes that can execute arbitrary code when clicked
-const DANGEROUS_URL_SCHEMES = ["javascript:", "vbscript:"]
-
-// C0 control characters (U+0000-U+001F) that browsers silently strip from URLs
-// per the WHATWG URL spec. These must be removed before checking schemes to
-// prevent bypass attacks like "\x01javascript:alert(1)".
-// eslint-disable-next-line no-control-regex
-const C0_CONTROL_CHARS_REGEX = /[\x00-\x1F]/g
-
 /**
  * Transforms link URIs for markdown rendering.
  *
@@ -280,28 +272,12 @@ const C0_CONTROL_CHARS_REGEX = /[\x00-\x1F]/g
  * custom schemes that Streamlit users rely on (e.g., inline images, PDFs).
  * Only explicitly dangerous schemes (javascript:, vbscript:) are blocked.
  *
- * Note: data:text/html URLs can execute JavaScript but run in a sandboxed
- * null-origin context, making them less dangerous than javascript: URLs.
- *
- * Blocked URLs return "#" instead of "" to prevent navigation. An empty href
- * combined with target="_blank" would open the current page in a new tab.
+ * Blocked URLs return "#" (BLOCKED_LINK_URI) instead of "" to prevent
+ * navigation. An empty href combined with target="_blank" would open the
+ * current page in a new tab.
  */
 function transformLinkUri(href: string): string {
-  // Strip C0 control characters and whitespace, then lowercase for comparison.
-  // Browsers strip C0 chars per WHATWG URL spec, so we must normalize first
-  // to prevent bypass attacks like "\x01javascript:alert(1)".
-  const normalizedHref = href
-    .replace(C0_CONTROL_CHARS_REGEX, "")
-    .toLowerCase()
-    .trim()
-  if (
-    DANGEROUS_URL_SCHEMES.some(scheme => normalizedHref.startsWith(scheme))
-  ) {
-    // Return "#" instead of "" to prevent navigation. Empty href with
-    // target="_blank" would open the current page in a new tab.
-    return "#"
-  }
-  return href
+  return isDangerousLinkUri(href) ? BLOCKED_LINK_URI : href
 }
 
 // wrapping in `once` ensures we only scroll once

--- a/frontend/lib/src/util/UriUtil.test.ts
+++ b/frontend/lib/src/util/UriUtil.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { getCrossOriginAttribute, isValidOrigin } from "./UriUtil"
+import {
+  getCrossOriginAttribute,
+  isDangerousLinkUri,
+  isValidOrigin,
+} from "./UriUtil"
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
 vi.mock("@streamlit/utils", async () => {
@@ -25,6 +29,34 @@ vi.mock("@streamlit/utils", async () => {
       return globalThis.__mockStreamlitConfig
     },
   }
+})
+
+describe("isDangerousLinkUri", () => {
+  it.each([
+    "javascript:alert(1)",
+    "vbscript:msgbox(1)",
+    "JavaScript:alert(1)",
+    "VBScript:msgbox(1)",
+    "  javascript:alert(1)  ",
+    "\u0001javascript:alert(1)",
+    "java\nscript:alert(1)",
+    "java\tscript:alert(1)",
+  ])("returns true for dangerous URI %j", uri => {
+    expect(isDangerousLinkUri(uri)).toBe(true)
+  })
+
+  it.each([
+    "https://streamlit.io",
+    "http://example.com",
+    "#anchor",
+    "/relative/path",
+    "mailto:hello@streamlit.io",
+    "data:image/png;base64,abc",
+    "not-javascript:foo",
+    "",
+  ])("returns false for safe URI %j", uri => {
+    expect(isDangerousLinkUri(uri)).toBe(false)
+  })
 })
 
 describe("isValidOrigin", () => {

--- a/frontend/lib/src/util/UriUtil.ts
+++ b/frontend/lib/src/util/UriUtil.ts
@@ -21,6 +21,45 @@ import "urlpattern-polyfill"
 import { StreamlitConfig } from "@streamlit/utils"
 
 /**
+ * URI returned for blocked links. We use "#" instead of "" to prevent
+ * navigation: an empty href combined with target="_blank" would open the
+ * current page in a new tab.
+ */
+export const BLOCKED_LINK_URI = "#"
+
+/** Dangerous URL schemes that can execute arbitrary code when clicked. */
+const DANGEROUS_URL_SCHEMES = ["javascript:", "vbscript:"]
+
+// C0 control characters (U+0000-U+001F) that browsers silently strip from URLs
+// per the WHATWG URL spec. These must be removed before checking schemes to
+// prevent bypass attacks like "\x01javascript:alert(1)".
+// eslint-disable-next-line no-control-regex
+const C0_CONTROL_CHARS_REGEX = /[\x00-\x1F]/g
+
+/**
+ * Returns true if the given URI uses a dangerous scheme (javascript:,
+ * vbscript:) that can execute arbitrary code when clicked.
+ *
+ * We use a blocklist approach instead of an allowlist to preserve compatibility
+ * with data: URLs and other custom schemes that Streamlit users rely on (e.g.,
+ * inline images, PDFs). Note that data:text/html URLs can execute JavaScript
+ * but run in a sandboxed null-origin context, making them less dangerous than
+ * javascript: URLs.
+ *
+ * C0 control characters and surrounding whitespace are stripped before matching
+ * so that obfuscated values like "\x01javascript:" or "java\nscript:" (which
+ * browsers normalize before interpreting the scheme) are still detected.
+ */
+export function isDangerousLinkUri(uri: string): boolean {
+  const normalizedUri = uri
+    .replace(C0_CONTROL_CHARS_REGEX, "")
+    .toLowerCase()
+    .trim()
+
+  return DANGEROUS_URL_SCHEMES.some(scheme => normalizedUri.startsWith(scheme))
+}
+
+/**
  * Check if the given origin follows the allowed origin pattern, which could
  * include wildcards.
  *


### PR DESCRIPTION
## Describe your changes

Neutralizes dangerous link URIs (`javascript:` / `vbscript:` schemes, including forms obfuscated with C0 control characters like `java\nscript:`) in rendered Graphviz charts to prevent XSS when a user clicks a graph link.

- Sanitize `href` / `xlink:href` on the rendered SVG in a `renderDot` completion callback, replacing dangerous values with `#`.
- Extract the security-critical scheme-blocklist logic into a shared `isDangerousLinkUri` / `BLOCKED_LINK_URI` helper in `UriUtil`, now consumed by both `GraphVizChart` and `StreamlitMarkdown` (previously duplicated).

## GitHub Issue Link (if applicable)

SNOW-3715971

## Testing Plan

- `frontend/lib/src/util/UriUtil.test.ts` — Unit tests for `isDangerousLinkUri` (dangerous, obfuscated, and safe URIs).
- `frontend/lib/src/components/elements/GraphVizChart/GraphVizChart.test.tsx` — Unit tests covering dangerous vs. safe link sanitization across `href` and namespaced/qualified `xlink:href`.
- `e2e_playwright/st_graphviz_chart_test.py` — E2E test verifying real-browser normalization neutralizes a `javascript:` node URL to `#`.

Made with [Cursor](https://cursor.com)