### PR TITLE
[fix] Escape HTML in pydeck chart tooltip interpolation

### DIFF
--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx
@@ -197,6 +197,83 @@ describe("useDeckGl", () => {
         expect(result.html).toBe(expected)
       }
     )
+
+    it.each([
+      {
+        description: "direct object properties",
+        object: {
+          siteName: "A & B",
+          notes: `<img src=x onerror="alert('xss')">`,
+        },
+        expected:
+          "<b>A &amp; B</b><br/>&lt;img src=x onerror=&quot;alert(&#x27;xss&#x27;)&quot;&gt;",
+      },
+      {
+        description: "nested properties field",
+        object: {
+          properties: {
+            siteName: "A & B",
+            notes: "<svg onload=alert(1)>",
+          },
+        },
+        expected: "<b>A &amp; B</b><br/>&lt;svg onload=alert(1)&gt;",
+      },
+      {
+        // Guards against `$` sequences (e.g. `` $` ``) in interpolated values
+        // being treated as `String.prototype.replace` patterns.
+        description: "values containing `$` replacement patterns",
+        object: {
+          siteName: "x",
+          notes: "a$`b",
+        },
+        expected: "<b>x</b><br/>a$`b",
+      },
+    ])(
+      "should escape interpolated html tooltip values from $description",
+      ({ object, expected }) => {
+        const {
+          result: { current },
+        } = renderHook(hookProps => useDeckGl(hookProps), {
+          initialProps: getUseDeckGlProps({
+            tooltip: JSON.stringify({
+              html: "<b>{siteName}</b><br/>{notes}",
+            }),
+          }),
+        })
+
+        const result = current.createTooltip({ object } as PickingInfo)
+
+        if (result === null || typeof result !== "object") {
+          throw new Error("Expected result to be an object")
+        }
+
+        expect(result.html).toBe(expected)
+      }
+    )
+
+    it("should preserve unescaped values in text tooltips", () => {
+      const {
+        result: { current },
+      } = renderHook(hookProps => useDeckGl(hookProps), {
+        initialProps: getUseDeckGlProps({
+          tooltip: JSON.stringify({
+            text: "{notes}",
+          }),
+        }),
+      })
+
+      const result = current.createTooltip({
+        object: {
+          notes: "<b>plain text</b>",
+        },
+      } as PickingInfo)
+
+      if (result === null || typeof result !== "object") {
+        throw new Error("Expected result to be an object")
+      }
+
+      expect(result.text).toBe("<b>plain text</b>")
+    })
   })
 
   describe("deck memo behavior", () => {

--- a/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
+++ b/frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.tsx
@@ -77,6 +77,30 @@ type UseDeckGlShape = {
   width: number | string
 }
 
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#x27;",
+}
+
+/**
+ * Escapes HTML-significant characters in a value so it can be safely embedded
+ * as text content or a quoted attribute value in an HTML tooltip template.
+ *
+ * This prevents XSS from untrusted data values interpolated into `tooltip.html`.
+ * It is only safe for element content and quoted attribute contexts. Values must
+ * not be placed by the template into unquoted attributes, URL attributes such as
+ * `href`/`src` (where a `javascript:` scheme would survive escaping), or inside
+ * `<script>`/`<style>` blocks.
+ *
+ * @param {unknown} value - The value to coerce to a string and escape.
+ * @returns {string} - The HTML-escaped string.
+ */
+const escapeHtml = (value: unknown): string =>
+  String(value).replace(/[&<>"']/g, char => HTML_ESCAPE_MAP[char])
+
 export type UseDeckGlProps = Omit<DeckGLProps, "width"> & {
   isLightTheme: boolean
   theme: EmotionTheme
@@ -99,22 +123,37 @@ export const EMPTY_STATE: DeckGlElementState = {
  *
  * @param {PickingInfo} info - The object containing the data to interpolate into the string.
  * @param {string} body - The string containing placeholders in the format `{variable}`.
+ * @param {boolean} shouldEscapeHtml - Whether interpolated values should be HTML-escaped.
+ *   Enable this when `body` is rendered as HTML (see {@link escapeHtml} for the
+ *   contexts in which escaping is safe).
  * @returns {string} - The interpolated string with placeholders replaced by actual values.
  */
-const interpolate = (info: PickingInfo, body: string): string => {
+const interpolate = (
+  info: PickingInfo,
+  body: string,
+  shouldEscapeHtml = false
+): string => {
   const matchedVariables = body.match(/{(.*?)}/g)
   if (matchedVariables) {
     matchedVariables.forEach((match: string) => {
       const variable = match.substring(1, match.length - 1)
 
+      let rawValue: unknown
       if (Object.hasOwn(info.object, variable)) {
-        body = body.replace(match, info.object[variable])
+        rawValue = info.object[variable]
       } else if (
         Object.hasOwn(info.object, "properties") &&
         Object.hasOwn(info.object.properties, variable)
       ) {
-        body = body.replace(match, info.object.properties[variable])
+        rawValue = info.object.properties[variable]
+      } else {
+        return
       }
+
+      const value = shouldEscapeHtml ? escapeHtml(rawValue) : String(rawValue)
+      // Use a replacer function so `$` sequences in the value are inserted
+      // literally rather than treated as replacement patterns.
+      body = body.replace(match, () => value)
     })
   }
   return body
@@ -574,7 +613,7 @@ export const useDeckGl = (props: UseDeckGlProps): UseDeckGlShape => {
       const parsedTooltip = JSON5.parse(tooltip)
 
       if (parsedTooltip.html) {
-        parsedTooltip.html = interpolate(info, parsedTooltip.html)
+        parsedTooltip.html = interpolate(info, parsedTooltip.html, true)
       } else {
         parsedTooltip.text = interpolate(info, parsedTooltip.text)
       }


### PR DESCRIPTION
## Describe your changes

HTML-escapes interpolated data values when building pydeck (`st.pydeck_chart`) HTML tooltips, preventing XSS from untrusted values injected into `tooltip.html` templates.

- Interpolated values from both `object` and `object.properties` now flow through a single HTML-escaping step for the `html` tooltip path.
- Plain-text tooltips (`tooltip.text`) are intentionally left unescaped (rendered as text, not HTML).
- Behavioral change: HTML embedded in data values that previously rendered inside `tooltip.html` now displays as escaped literal text. Template-authored markup is unaffected.

Escaping is safe for element content and quoted-attribute contexts; templates should not place untrusted data into unquoted attributes, URL attributes (`href`/`src`), or `<script>`/`<style>` blocks (documented in code).

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Unit Tests (JS): `frontend/lib/src/components/elements/DeckGlJsonChart/useDeckGl.test.tsx` — covers escaping of direct and nested (`properties`) values for HTML tooltips, non-escaping of text tooltips, preserved behavior for unknown placeholders, and literal insertion of `$` replacement patterns.
- No E2E tests: the change is pure client-side string escaping validated by unit tests at the exact render input.

Made with [Cursor](https://cursor.com)