### PR TITLE
[docs] Add security warnings to component and iframe docstrings

### DIFF
--- a/lib/streamlit/components/v2/__init__.py
+++ b/lib/streamlit/components/v2/__init__.py
@@ -124,7 +124,7 @@ def _create_component_callable(
         Inline JavaScript (string) or a string path/glob to a file under
         ``asset_dir``; see :func:`_register_component` for path validation semantics.
     isolate_styles : bool
-        Whether to sandbox the component's styles in a shadow root.
+        Whether to isolate the component's styles in a shadow root.
         Defaults to True.
 
     Returns
@@ -218,6 +218,16 @@ def component(
     are provided, the component renders as an empty element without raising
     an error.
 
+    .. warning::
+        Components are trusted code. Streamlit does not sanitize the ``html``,
+        ``css``, or ``js`` content passed to this function. HTML may include
+        ``<script>`` tags, and JavaScript executes with normal app-page DOM
+        privileges. Never pass untrusted or user-provided content to ``html``,
+        ``css``, or ``js``, including content from widgets, query parameters,
+        databases, uploaded files, LLM output, or other external sources.
+        Sanitize or escape untrusted data before a component renders it as
+        HTML.
+
     If your component is defined in an installed package, you can declare an
     asset directory (``asset_dir``) through ``pyproject.toml`` files in the
     package. This allows you to serve component assets and reference them by
@@ -259,6 +269,9 @@ def component(
         - A path or glob to an HTML file, relative to the component's
           asset directory.
 
+        This is trusted component content. Streamlit does not sanitize it, and
+        any scripts in the HTML can execute in the app page.
+
         If any HTML depends on data passed at mount time, use a placeholder
         element and populate it via JavaScript. Alternatively, you can append
         a new element to the parent. For more information, see Example 2.
@@ -277,13 +290,19 @@ def component(
         - A path or glob to a JS file, relative to the component's
           asset directory.
 
+        This is trusted component code. It executes with normal app-page DOM
+        privileges.
+
     isolate_styles : bool
-        Whether to sandbox the component styles in a shadow root. If this is
+        Whether to isolate the component styles in a shadow root. If this is
         ``True`` (default), the component's HTML is mounted inside a shadow DOM
         and, in your component's JavaScript, ``parentElement`` returns a
         ``ShadowRoot``. If this is ``False``, the component's HTML is mounted
         directly into the app's DOM tree, and ``parentElement`` returns a
         regular ``HTMLElement``.
+
+        This is style isolation only. It is not a security boundary and does
+        not sandbox the component's JavaScript.
 
     Returns
     -------
@@ -350,11 +369,11 @@ def component(
 
     .. warning::
 
-        If you directly modify the inner HTML of the parent element, you will
-        overwrite the HTML and CSS passed to the component. Instead, create a
-        new child element and set its inner HTML. You can create the
-        placeholder dynamically in JavaScript or include it in the ``html``
-        parameter.
+        Only render trusted HTML this way. If you directly modify the inner
+        HTML of the parent element, you will overwrite the HTML and CSS passed
+        to the component. Instead, create a new child element and set its
+        inner HTML. You can create the placeholder dynamically in JavaScript
+        or include it in the ``html`` parameter.
 
     .. code-block:: python
 

--- a/lib/streamlit/components/v2/bidi_component/main.py
+++ b/lib/streamlit/components/v2/bidi_component/main.py
@@ -293,7 +293,7 @@ class BidiComponentMixin:
             If this is omitted, a key will be generated based on the
             component's execution sequence.
         isolate_styles
-            Whether to sandbox the component's styles in a shadow root.
+            Whether to isolate the component's styles in a shadow root.
             Defaults to True.
         data
             Data to pass to the component. This can be any JSON-serializable

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -266,12 +266,13 @@ class IframeMixin:
         iframe. It auto-detects the input type and handles it appropriately.
 
         .. warning::
-            HTML strings and local HTML files are embedded as-is in an iframe
-            that allows JavaScript execution and same-origin access to the
-            Streamlit app. Never pass untrusted HTML from users, query
-            parameters, databases, uploaded files, LLM output, or other
-            external sources to ``st.iframe``. Use ``st.html`` for sanitized
-            HTML snippets that don't need full iframe behavior.
+            HTML strings, local HTML files, and same-origin relative URLs are
+            embedded as-is in an iframe that allows JavaScript execution and
+            same-origin access to the Streamlit app. Never pass untrusted HTML
+            or untrusted ``src`` values from users, query parameters, databases,
+            uploaded files, LLM output, or other external sources to
+            ``st.iframe``. Use ``st.html`` for sanitized HTML snippets that
+            don't need full iframe behavior.
 
         Parameters
         ----------

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -172,6 +172,14 @@ class IframeMixin:
         If you want to insert HTML text into your app without an iframe, try
         ``st.html`` instead.
 
+        .. warning::
+            The HTML string is embedded as-is in an iframe that allows
+            JavaScript execution and same-origin access to the Streamlit app.
+            Never pass untrusted HTML from users, query parameters, databases,
+            uploaded files, LLM output, or other external sources to this
+            function. Use ``st.html`` for sanitized HTML snippets that don't
+            need full iframe behavior.
+
         .. deprecated::
             ``st.components.v1.html`` is deprecated and will be removed in a
             future release. Please use ``st.iframe`` instead, which provides
@@ -256,6 +264,14 @@ class IframeMixin:
 
         ``st.iframe`` embeds external URLs, HTML content, or local files in an
         iframe. It auto-detects the input type and handles it appropriately.
+
+        .. warning::
+            HTML strings and local HTML files are embedded as-is in an iframe
+            that allows JavaScript execution and same-origin access to the
+            Streamlit app. Never pass untrusted HTML from users, query
+            parameters, databases, uploaded files, LLM output, or other
+            external sources to ``st.iframe``. Use ``st.html`` for sanitized
+            HTML snippets that don't need full iframe behavior.
 
         Parameters
         ----------


### PR DESCRIPTION
## Describe your changes

Adds security warnings to the docstrings of trusted-content APIs so users understand that these APIs do not sanitize input and must not receive untrusted data.

- `st.iframe` / `st.components.v1.html`: warn that HTML strings and local HTML files are embedded as-is in an iframe with JS execution and same-origin access; recommend `st.html` for untrusted/sanitized content.
- `st.components.v2.component`: warn that `html`, `css`, and `js` are trusted code that is not sanitized and executes with normal app-page DOM privileges.
- Clarify that `isolate_styles` provides style isolation only, not a security boundary, and reword "sandbox" to "isolate" to avoid implying a security guarantee.

## GitHub Issue Link (if applicable)

## Testing Plan

- Documentation-only changes (docstrings). No behavior modifications, so no additional tests are needed.

Made with [Cursor](https://cursor.com)