### PR TITLE
[chore] Reduce required Python dependencies

### DIFF
--- a/e2e_playwright/lazy_loaded_modules.py
+++ b/e2e_playwright/lazy_loaded_modules.py
@@ -34,7 +34,6 @@ lazy_loaded_modules = [
     "pyarrow",
     "pydeck",
     "rich",
-    "tenacity",
     # toml is automatically loaded if there is a secret.toml, config.toml or
     # a local credentials.toml file. So, we cannot test this here.
     # Internal modules:

--- a/e2e_playwright/lazy_loaded_modules_test.py
+++ b/e2e_playwright/lazy_loaded_modules_test.py
@@ -20,6 +20,6 @@ from playwright.sync_api import Page, expect
 def test_lazy_loaded_modules_are_not_imported(app: Page):
     """Test that lazy loaded modules are not imported when the page is loaded."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(15)
+    expect(markdown_elements).to_have_count(14)
     for element in markdown_elements.all():
         expect(element).to_have_text(re.compile(r".*not loaded.*"))

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -72,7 +72,6 @@ dependencies = [
   # doesn't tend to break the API on major version upgrades, so we don't put an
   # upper bound on it.
   "pyarrow>=7.0",
-  "requests>=2.27,<3",
   # Starting from Python 3.11, Python has built in support for reading TOML files.
   # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
   "toml>=0.10.1,<2",

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -57,10 +57,7 @@ dependencies = [
   # that cause st.line_chart and other built-in charts to fail rendering.
   # See: https://github.com/streamlit/streamlit/issues/12064
   "altair>=4.0,<7,!=5.4.0,!=5.4.1",
-  "blinker>=1.5.0,<2",
-  "cachetools>=5.5,<8",
   "click>=7.0,<9",
-  "gitpython>=3.0.7,<4,!=3.1.19",
   "numpy>=1.23,<3",
   # The "packaging" package isn't version-capped because they use calendar-based
   # versioning, i.e. "major" version increase != breaking changes
@@ -69,7 +66,6 @@ dependencies = [
   # the index dtype. Pandas 3.x requires Python >= 3.11.
   "pandas>=1.4.0,<4",
   "pillow>=7.1.0,<13",
-  "pydeck>=0.8.0b4,<1",
   # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
   "protobuf>=3.20,<8",
   # pyarrow is not semantically versioned, gets new major versions frequently, and
@@ -77,7 +73,6 @@ dependencies = [
   # upper bound on it.
   "pyarrow>=7.0",
   "requests>=2.27,<3",
-  "tenacity>=8.1.0,<10",
   # Starting from Python 3.11, Python has built in support for reading TOML files.
   # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
   "toml>=0.10.1,<2",
@@ -87,8 +82,6 @@ dependencies = [
   "starlette>=0.40.0",
   # ASGI server:
   "uvicorn>=0.30.0",
-  # Faster http parsing for Starlette server:
-  "httptools>=0.6.3",
   # Required by starlette:
   "anyio>=4.0.0",
   # Required for file-upload support:
@@ -120,6 +113,8 @@ charts = [
   # orjson speeds up large plotly figure processing by 5-10x:
   "orjson>=3.5.0",
 ]
+# Optional dependency required for st.pydeck_chart and the mapping demo:
+mapping = ["pydeck>=0.8.0b4,<1"]
 # Optional SQL connection dependency:
 sql = ["SQLAlchemy>=2.0.0"]
 # Optional dependency for better performance:
@@ -128,10 +123,12 @@ performance = [
   "orjson>=3.5.0",
   # uvloop speeds up the event loop:
   "uvloop>=0.15.2; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
+  # Faster HTTP parsing for the Starlette/uvicorn server (falls back to h11 when absent):
+  "httptools>=0.6.3",
 ]
 # Install all optional dependencies:
 all = [
-  "streamlit[auth,charts,snowflake,sql,pdf,performance]",
+  "streamlit[auth,charts,mapping,snowflake,sql,pdf,performance]",
   # Improved exception traceback formatting:
   "rich>=11.0.0",
 ]

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -27,11 +27,10 @@ from collections import OrderedDict
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from blinker import Signal
-
 from streamlit import config_util, development, env_util, file_util, util
 from streamlit.config_option import ConfigOption
 from streamlit.errors import StreamlitAPIException, StreamlitInvalidThemeSectionError
+from streamlit.signal_util import Signal
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/lib/streamlit/connections/retry_util.py
+++ b/lib/streamlit/connections/retry_util.py
@@ -1,0 +1,160 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A minimal retry helper for connection queries.
+
+This is a small, dependency-free replacement for the tiny subset of the
+``tenacity`` library that Streamlit's connection implementations rely on. The
+public names (``retry``, ``stop_after_attempt``, ``wait_fixed``,
+``retry_if_exception`` and ``retry_if_exception_type``) mirror ``tenacity`` so
+call sites remain unchanged apart from the import.
+
+The behavior deliberately matches ``tenacity`` for the options we use:
+
+- The wrapped function is attempted until ``stop`` returns ``True`` (based on
+  the attempt number) or a non-retryable exception is raised.
+- ``retry`` decides, based on the raised exception, whether another attempt
+  should be made. A raised exception for which ``retry`` returns ``False`` is
+  re-raised immediately without any further waiting.
+- ``after`` runs after every *retryable* failed attempt, including the final
+  attempt right before the error is re-raised. This matches ``tenacity``, where
+  the ``after`` callback is scheduled before the ``stop`` check.
+- ``wait`` determines how long to sleep between attempts.
+- With ``reraise=True`` (the only mode we use), the last exception is re-raised
+  once ``stop`` triggers. Otherwise a :class:`RetryError` is raised.
+"""
+
+from __future__ import annotations
+
+import functools
+import time
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_T = TypeVar("_T")
+
+
+class RetryCallState:
+    """State passed to the ``stop``/``wait``/``retry``/``after`` callbacks.
+
+    Only the attributes used by Streamlit's connections are provided:
+    ``attempt_number`` (1-based) and ``exception`` (the exception raised by the
+    most recent attempt, or ``None`` on success).
+    """
+
+    def __init__(self) -> None:
+        self.attempt_number: int = 1
+        self.exception: BaseException | None = None
+
+
+class RetryError(Exception):
+    """Raised when retries are exhausted and ``reraise`` is ``False``."""
+
+    def __init__(self, last_exception: BaseException | None) -> None:
+        self.last_exception = last_exception
+        super().__init__(last_exception)
+
+
+def stop_after_attempt(max_attempt_number: int) -> Callable[[RetryCallState], bool]:
+    """Stop once ``max_attempt_number`` attempts have been made."""
+
+    def _stop(retry_state: RetryCallState) -> bool:
+        return retry_state.attempt_number >= max_attempt_number
+
+    return _stop
+
+
+def wait_fixed(wait: float) -> Callable[[RetryCallState], float]:
+    """Wait a fixed number of seconds between attempts."""
+
+    def _wait(_retry_state: RetryCallState) -> float:
+        return wait
+
+    return _wait
+
+
+def retry_if_exception(
+    predicate: Callable[[BaseException], bool],
+) -> Callable[[RetryCallState], bool]:
+    """Retry only if the raised exception satisfies ``predicate``."""
+
+    def _retry(retry_state: RetryCallState) -> bool:
+        exception = retry_state.exception
+        if exception is None:
+            return False
+        return predicate(exception)
+
+    return _retry
+
+
+def retry_if_exception_type(
+    exception_types: type[BaseException] | tuple[type[BaseException], ...] = Exception,
+) -> Callable[[RetryCallState], bool]:
+    """Retry only if the raised exception is one of ``exception_types``."""
+    return retry_if_exception(lambda e: isinstance(e, exception_types))
+
+
+def retry(
+    *,
+    stop: Callable[[RetryCallState], bool],
+    wait: Callable[[RetryCallState], float],
+    retry: Callable[[RetryCallState], bool],
+    after: Callable[[RetryCallState], Any] | None = None,
+    reraise: bool = False,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Callable[[Callable[..., _T]], Callable[..., _T]]:
+    """Return a decorator that retries the wrapped function.
+
+    The parameters mirror the ``tenacity.retry`` keyword arguments that
+    Streamlit uses.
+    """
+
+    def decorator(fn: Callable[..., _T]) -> Callable[..., _T]:
+        @functools.wraps(fn)
+        def wrapped(*args: Any, **kwargs: Any) -> _T:
+            retry_state = RetryCallState()
+            while True:
+                try:
+                    result = fn(*args, **kwargs)
+                except BaseException as exc:
+                    retry_state.exception = exc
+                    if not retry(retry_state):
+                        # The exception is not retryable: re-raise immediately.
+                        raise
+                else:
+                    retry_state.exception = None
+                    if not retry(retry_state):
+                        # The call succeeded and should not be retried.
+                        return result
+
+                # A retryable outcome occurred. Run the `after` hook (e.g. to
+                # reset the connection) before deciding whether to stop.
+                if after is not None:
+                    after(retry_state)
+
+                sleep_seconds = wait(retry_state)
+
+                if stop(retry_state):
+                    if reraise and retry_state.exception is not None:
+                        raise retry_state.exception
+                    raise RetryError(retry_state.exception) from retry_state.exception
+
+                sleep(sleep_seconds)
+                retry_state.attempt_number += 1
+
+        return wrapped
+
+    return decorator

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -121,7 +121,12 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         >>> st.dataframe(df)
 
         """
-        from tenacity import retry, retry_if_exception, stop_after_attempt, wait_fixed
+        from streamlit.connections.retry_util import (
+            retry,
+            retry_if_exception,
+            stop_after_attempt,
+            wait_fixed,
+        )
 
         @retry(
             after=lambda _: self.reset(),

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -295,7 +295,8 @@ class SQLConnection(BaseConnection["Engine"]):
 
         from sqlalchemy import text
         from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
-        from tenacity import (
+
+        from streamlit.connections.retry_util import (
             retry,
             retry_if_exception_type,
             stop_after_attempt,

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -153,6 +153,10 @@ class GitRepo:
                 ["git", "-C", cwd or self._start_dir, *args],  # noqa: S607
                 capture_output=True,
                 text=True,
+                # Decode defensively: unusual bytes in git output (e.g. exotic
+                # filenames) must never raise UnicodeDecodeError and break the
+                # deploy dialog. This keeps the "degrades gracefully" contract.
+                errors="replace",
                 check=False,
                 timeout=_GIT_TIMEOUT,
                 # Never prompt for credentials; fail fast instead.

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -77,19 +77,26 @@ def _extract_github_repo_from_url(url: str) -> str | None:
     return f"{match.group(1)}/{match.group(2)}"
 
 
-def _parse_git_version(version_output: str) -> tuple[int, ...] | None:
-    """Parse a ``git --version`` string into a version tuple."""
+def _parse_git_version(version_output: str) -> tuple[int, int, int] | None:
+    """Parse a ``git --version`` string into a ``(major, minor, patch)`` tuple.
+
+    A missing patch component (e.g. ``git version 2.7``) is normalized to ``0``
+    so the result can be compared directly against ``_MIN_GIT_VERSION`` (a
+    two-element tuple like ``(2, 7)`` would otherwise compare as less than
+    ``(2, 7, 0)``).
+    """
     match = _GIT_VERSION_PATTERN.search(version_output)
     if match is None:
         return None
-    return tuple(int(part) for part in match.groups() if part is not None)
+    major, minor, patch = match.groups()
+    return (int(major), int(minor), int(patch) if patch is not None else 0)
 
 
 class GitRepo:
     def __init__(self, path: str) -> None:
-        # If we have a valid repo, git_version will be a tuple
-        # of 2+ ints: (major, minor[, patch]).
-        self.git_version: tuple[int, ...] | None = None
+        # If git is installed, git_version will be a 3-tuple of ints:
+        # (major, minor, patch). A missing patch component is normalized to 0.
+        self.git_version: tuple[int, int, int] | None = None
         self.module: str = ""
 
         # `git -C` needs a directory, but `path` may point at a file (e.g. the

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -12,17 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Lightweight git repository inspection.
+
+This uses the ``git`` command-line tool via :mod:`subprocess` instead of a
+third-party library (previously GitPython) so that Streamlit does not need an
+extra runtime dependency. Only the read-only information required by the
+"Deploy" button is collected; every operation degrades gracefully (returning
+``None``/empty results) when ``git`` is missing or the directory is not a
+repository.
+"""
+
 from __future__ import annotations
 
 import os
 import re
-from typing import TYPE_CHECKING, Final, cast
+import subprocess  # noqa: S404
+from typing import Final
 
 from streamlit import util
 from streamlit.logger import get_logger
-
-if TYPE_CHECKING:
-    from git import Commit, Remote, RemoteReference, Repo
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -32,10 +40,17 @@ _GITHUB_URL_PATTERN: Final = re.compile(
     r"github\.com(?::\d+)?[/:]([^/]+)/([^/]+?)(?:\.git)?/?$"
 )
 
+# Parser for the output of ``git --version`` (e.g. "git version 2.39.3").
+_GIT_VERSION_PATTERN: Final = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+
 # We don't support git < 2.7, because we can't get repo info without
 # talking to the remote server, which results in the user being prompted
 # for credentials.
 _MIN_GIT_VERSION: Final = (2, 7, 0)
+
+# Timeout (in seconds) applied to each git invocation so a hanging git process
+# (e.g. waiting for credentials) can never block the server indefinitely.
+_GIT_TIMEOUT: Final = 5
 
 
 def _extract_github_repo_from_url(url: str) -> str | None:
@@ -62,98 +77,158 @@ def _extract_github_repo_from_url(url: str) -> str | None:
     return f"{match.group(1)}/{match.group(2)}"
 
 
-class GitRepo:
-    repo: Repo | None
+def _parse_git_version(version_output: str) -> tuple[int, ...] | None:
+    """Parse a ``git --version`` string into a version tuple."""
+    match = _GIT_VERSION_PATTERN.search(version_output)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups() if part is not None)
 
+
+class GitRepo:
     def __init__(self, path: str) -> None:
         # If we have a valid repo, git_version will be a tuple
-        # of 3+ ints: (major, minor, patch, possible_additional_patch_number)
+        # of 2+ ints: (major, minor[, patch]).
         self.git_version: tuple[int, ...] | None = None
         self.module: str = ""
 
+        # `git -C` needs a directory, but `path` may point at a file (e.g. the
+        # main script). Fall back to its parent directory in that case.
+        self._start_dir: str = (
+            path if os.path.isdir(path) else os.path.dirname(os.path.abspath(path))
+        )
+        # The repository root. File listings run from here so they cover the
+        # whole repo with root-relative paths (matching prior GitPython behavior).
+        self._git_root: str | None = None
+        self.is_repo: bool = False
+
         try:
-            import git
+            version_output = self._run_git("--version")
+            if version_output is not None:
+                self.git_version = _parse_git_version(version_output)
 
-            self.repo = git.Repo(path, search_parent_directories=True)
-            self.git_version = self.repo.git.version_info
-
-            if self.git_version is not None and self.git_version >= _MIN_GIT_VERSION:
-                git_root = self.repo.git.rev_parse("--show-toplevel")
-                self.module = str(os.path.relpath(path, git_root))
+            git_root = self._run_git("rev-parse", "--show-toplevel")
+            if git_root is not None:
+                self.is_repo = True
+                self._git_root = git_root
+                if (
+                    self.git_version is not None
+                    and self.git_version >= _MIN_GIT_VERSION
+                ):
+                    self.module = str(os.path.relpath(path, git_root))
         except Exception:
             _LOGGER.debug(
                 "Did not find a git repo at %s. This is expected if this isn't a git repo, but could "
                 "also fail for other reasons: "
-                "1) git binary or GitPython not installed "
+                "1) git binary not installed "
                 "2) No .git folder "
                 "3) Corrupted .git folder "
                 "4) Path is invalid.",
                 path,
                 exc_info=True,
             )
-            self.repo = None
+            self.is_repo = False
 
     def __repr__(self) -> str:
         return util.repr_(self)
 
+    def _run_git(self, *args: str, cwd: str | None = None) -> str | None:
+        """Run a git command in the repo directory.
+
+        Runs in ``cwd`` if provided, otherwise in the starting directory.
+        Returns the stripped stdout on success, or ``None`` if git is not
+        installed, the command fails, or it times out.
+        """
+        try:
+            # `git` is intentionally resolved from PATH (S607) and the argument
+            # list is fixed with no shell interpolation (S603).
+            result = subprocess.run(  # noqa: S603
+                ["git", "-C", cwd or self._start_dir, *args],  # noqa: S607
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_GIT_TIMEOUT,
+                # Never prompt for credentials; fail fast instead.
+                env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+
     def is_valid(self) -> bool:
         """True if there's a git repo here, and git.version >= _MIN_GIT_VERSION."""
         return (
-            self.repo is not None
+            self.is_repo
             and self.git_version is not None
             and self.git_version >= _MIN_GIT_VERSION
         )
 
     @property
-    def tracking_branch(self) -> RemoteReference | None:
-        if self.repo is None or not self.is_valid():
+    def tracking_branch(self) -> str | None:
+        """The upstream tracking branch (e.g. ``origin/main``), or None."""
+        if not self.is_valid() or self.is_head_detached:
             return None
 
-        if self.is_head_detached:
-            return None
-
-        return self.repo.active_branch.tracking_branch()
+        return self._run_git(
+            "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
+        )
 
     @property
     def untracked_files(self) -> list[str] | None:
-        if self.repo is None or not self.is_valid():
+        if not self.is_valid():
             return None
 
-        return self.repo.untracked_files
+        output = self._run_git(
+            "ls-files", "--others", "--exclude-standard", cwd=self._git_root
+        )
+        if output is None:
+            return None
+        return output.splitlines() if output else []
 
     @property
     def is_head_detached(self) -> bool:
-        if self.repo is None or not self.is_valid():
+        if not self.is_valid():
             return False
 
-        return self.repo.head.is_detached
+        # `symbolic-ref -q HEAD` exits non-zero (returns None here) when HEAD is
+        # detached, and returns the ref name (e.g. "refs/heads/main") otherwise.
+        return self._run_git("symbolic-ref", "-q", "HEAD") is None
 
     @property
     def uncommitted_files(self) -> list[str] | None:
-        if self.repo is None or not self.is_valid():
+        if not self.is_valid():
             return None
 
-        return [cast("str", item.a_path) for item in self.repo.index.diff(None)]
+        # Unstaged changes (working tree vs. index), matching the previous
+        # GitPython `index.diff(None)` behavior (whole-repo, root-relative).
+        output = self._run_git("diff", "--name-only", cwd=self._git_root)
+        if output is None:
+            return None
+        return output.splitlines() if output else []
 
     @property
-    def ahead_commits(self) -> list[Commit] | None:
-        if self.repo is None or not self.is_valid():
+    def ahead_commits(self) -> list[str] | None:
+        if not self.is_valid():
             return None
 
-        try:
-            tracking_branch_info = self.get_tracking_branch_remote()
-            if tracking_branch_info is None:
-                return None
+        tracking_branch_info = self.get_tracking_branch_remote()
+        if tracking_branch_info is None:
+            return None
 
-            remote, branch_name = tracking_branch_info
-            remote_branch = f"{remote.name}/{branch_name}"
+        remote_name, branch_name = tracking_branch_info
+        remote_branch = f"{remote_name}/{branch_name}"
 
-            return list(self.repo.iter_commits(f"{remote_branch}..{branch_name}"))
-        except Exception:
+        output = self._run_git("rev-list", f"{remote_branch}..{branch_name}")
+        if output is None:
             return []
+        return output.splitlines() if output else []
 
-    def get_tracking_branch_remote(self) -> tuple[Remote, str] | None:
-        if self.repo is None or not self.is_valid():
+    def get_tracking_branch_remote(self) -> tuple[str, str] | None:
+        """Return the (remote_name, branch_name) for the tracking branch."""
+        if not self.is_valid():
             return None
 
         tracking_branch = self.tracking_branch
@@ -161,14 +236,22 @@ class GitRepo:
         if tracking_branch is None:
             return None
 
-        remote_name, *branch = tracking_branch.name.split("/")
+        remote_name, *branch = tracking_branch.split("/")
         branch_name = "/".join(branch)
 
-        try:
-            return self.repo.remote(remote_name), branch_name
-        except Exception:
-            _LOGGER.debug("Failed to resolve remote %s", remote_name, exc_info=True)
+        # Confirm the remote actually resolves to at least one URL.
+        if not self._get_remote_urls(remote_name):
+            _LOGGER.debug("Failed to resolve remote %s", remote_name)
             return None
+
+        return remote_name, branch_name
+
+    def _get_remote_urls(self, remote_name: str) -> list[str]:
+        """Return the configured fetch URLs for a remote (may be empty)."""
+        output = self._run_git("remote", "get-url", "--all", remote_name)
+        if output is None:
+            return []
+        return [line for line in output.splitlines() if line]
 
     def get_repo_info(self) -> tuple[str, str, str] | None:
         if not self.is_valid():
@@ -182,8 +265,8 @@ class GitRepo:
             _LOGGER.debug("No tracking remote branch found for the git repo.")
             return None
 
-        remote, branch = remote_info
-        remote_urls = list(remote.urls)
+        remote_name, branch = remote_info
+        remote_urls = self._get_remote_urls(remote_name)
         repo = None
         for url in remote_urls:
             repo = _extract_github_repo_from_url(url)

--- a/lib/streamlit/hello/mapping_demo.py
+++ b/lib/streamlit/hello/mapping_demo.py
@@ -15,13 +15,22 @@
 from urllib.error import URLError
 
 import pandas as pd
-import pydeck as pdk
 
 import streamlit as st
 from streamlit.hello.utils import show_code
 
 
 def mapping_demo() -> None:
+    try:
+        import pydeck as pdk
+    except ImportError:
+        st.error(
+            "This demo requires the **pydeck** package, which is an optional "
+            "dependency. Install it with `pip install pydeck` or "
+            "`pip install streamlit[mapping]`."
+        )
+        return
+
     @st.cache_data
     def from_data_file(filename: str) -> pd.DataFrame:
         url = (

--- a/lib/streamlit/net_util.py
+++ b/lib/streamlit/net_util.py
@@ -96,13 +96,12 @@ def get_internal_ip() -> str | None:
 
 
 def _make_blocking_http_get(url: str, timeout: float = 5) -> str | None:
-    import requests
+    import urllib.request
 
     try:
-        text = requests.get(url, timeout=timeout).text
-        if isinstance(text, str):
-            text = text.strip()
-        return text
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            text: str = response.read().decode("utf-8", errors="replace")
+        return text.strip()
     except Exception:
         return None
 

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -673,9 +673,7 @@ class ResourceCache(Cache[R]):
 
     @property
     def ttl_seconds(self) -> float:
-        # Wrap in float() so this type-checks across types-cachetools versions:
-        # 6.x types .ttl as float, while 7.0.0+ types it as Any.
-        return float(self._mem_cache.ttl)
+        return self._mem_cache.ttl
 
     def read_result(self, key: str) -> CachedResult[R]:
         """Read a value and associated messages from the cache.

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -17,8 +17,6 @@ import math
 import threading
 from typing import TYPE_CHECKING
 
-from cachetools import TTLCache
-
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
@@ -26,6 +24,7 @@ from streamlit.runtime.caching.storage.cache_storage_protocol import (
     CacheStorageContext,
     CacheStorageKeyNotFoundError,
 )
+from streamlit.runtime.caching.ttl_cache import TTLCache
 from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
 
 if TYPE_CHECKING:

--- a/lib/streamlit/runtime/caching/ttl_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cache.py
@@ -1,0 +1,177 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A minimal LRU + TTL cache.
+
+This is a small, purpose-built replacement for the subset of ``cachetools.TTLCache``
+that Streamlit relies on. It keeps the exact observable behavior Streamlit depends on
+while dropping the generality of the library (variable item sizes, pickling support,
+the re-entrant timer, and the multi-class hierarchy):
+
+- Items live for ``ttl`` seconds (measured with ``timer``); ``maxsize`` bounds the
+  number of entries. Both may be ``math.inf``.
+- **LRU on read and write:** reading or writing a key marks it most-recently-used, so
+  under ``maxsize`` pressure the least-recently-used entry is evicted first.
+- **Expire-before-write:** every write (and ``__len__``/``currsize`` access) first
+  drops already-expired entries, then applies ``maxsize`` eviction.
+- Expired entries are reported as absent by ``in``/``[]`` but are only actually removed
+  by :meth:`expire` (which returns them) or by eviction — never on read. This lets
+  subclasses (see ``TTLCleanupCache``) run release hooks at removal time.
+
+Thread-safety: this class is **not** internally synchronized. Callers that share an
+instance across threads must hold their own lock (as Streamlit's callers do).
+
+Two ordered maps are maintained: ``_data`` in access (LRU) order and ``_expiry`` in
+insertion/refresh order. Because the TTL is uniform per cache, insertion order equals
+expiration order, so expiry is an O(number-expired) sweep from the front of
+``_expiry`` while eviction pops the front (LRU) of ``_data``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, TypeVar, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
+
+
+class TTLCache(MutableMapping[_KT, _VT]):
+    """An LRU cache whose entries expire after a fixed time-to-live."""
+
+    def __init__(
+        self,
+        maxsize: float,
+        ttl: float,
+        timer: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Create a cache.
+
+        Parameters
+        ----------
+        maxsize
+            Maximum number of entries to hold (may be ``math.inf``).
+        ttl
+            Time-to-live for each entry, in ``timer`` units (may be ``math.inf``).
+        timer
+            Callable returning the current time. Defaults to ``time.monotonic``.
+        """
+        self._maxsize = maxsize
+        self._ttl = ttl
+        self._timer = timer
+        # Values, kept in least-recently-used order (reordered on read and write).
+        self._data: OrderedDict[_KT, _VT] = OrderedDict()
+        # Per-key expiration times, kept in insertion/refresh order. Since the TTL is
+        # uniform, this is also ascending-expiration order, so expiry sweeps the front.
+        self._expiry: OrderedDict[_KT, float] = OrderedDict()
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(maxsize={self._maxsize!r}, ttl={self._ttl!r}, "
+            f"currsize={len(self._data)!r})"
+        )
+
+    def __getitem__(self, key: _KT) -> _VT:
+        if key not in self._data:
+            raise KeyError(key)
+        # Mark as most-recently-used before the expiry check (matching cachetools).
+        self._data.move_to_end(key)
+        if not (self._timer() < self._expiry[key]):
+            # Expired: report as missing but leave the entry for expire()/eviction.
+            raise KeyError(key)
+        return self._data[key]
+
+    def __setitem__(self, key: _KT, value: _VT) -> None:
+        if self._maxsize < 1:
+            raise ValueError("value too large")
+        now = self._timer()
+        # Drop expired entries first (dispatches to subclass release hooks, if any).
+        self.expire(now)
+        if key not in self._data:
+            while len(self._data) >= self._maxsize:
+                self.popitem()
+        self._data[key] = value
+        self._data.move_to_end(key)
+        self._expiry[key] = now + self._ttl
+        self._expiry.move_to_end(key)
+
+    def __delitem__(self, key: _KT) -> None:
+        now = self._timer()
+        del self._data[key]
+        expire_at = self._expiry.pop(key)
+        # Matches cachetools: deleting an already-expired entry still removes it but
+        # raises KeyError to signal it was not "present".
+        if not (now < expire_at):
+            raise KeyError(key)
+
+    def __contains__(self, key: object) -> bool:
+        expire_at = self._expiry.get(cast("_KT", key))
+        return expire_at is not None and self._timer() < expire_at
+
+    def __iter__(self) -> Iterator[_KT]:
+        now = self._timer()
+        # Snapshot so callers can read values (which reorders _data) while iterating.
+        return iter([key for key, expire_at in self._expiry.items() if now < expire_at])
+
+    def __len__(self) -> int:
+        self.expire()
+        return len(self._data)
+
+    def expire(self, time: float | None = None) -> list[tuple[_KT, _VT]]:
+        """Remove and return all currently-expired ``(key, value)`` pairs."""
+        now = self._timer() if time is None else time
+        expired: list[tuple[_KT, _VT]] = []
+        while self._expiry:
+            key = next(iter(self._expiry))
+            if now < self._expiry[key]:
+                break
+            del self._expiry[key]
+            expired.append((key, self._data.pop(key)))
+        return expired
+
+    def popitem(self) -> tuple[_KT, _VT]:
+        """Remove and return the least-recently-used non-expired ``(key, value)``."""
+        self.expire()
+        try:
+            key = next(iter(self._data))
+        except StopIteration:
+            raise KeyError(f"{type(self).__name__} is empty") from None
+        value = self._data.pop(key)
+        del self._expiry[key]
+        return (key, value)
+
+    def clear(self) -> None:
+        self._data.clear()
+        self._expiry.clear()
+
+    @property
+    def maxsize(self) -> float:
+        """The maximum number of entries the cache can hold."""
+        return self._maxsize
+
+    @property
+    def ttl(self) -> float:
+        """The time-to-live for the cache's entries."""
+        return self._ttl
+
+    @property
+    def currsize(self) -> int:
+        """The current number of (non-expired) entries in the cache."""
+        self.expire()
+        return len(self._data)

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -17,13 +17,12 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-from cachetools import TTLCache
-
 # override is in typing after Python 3.12 and can be imported from there after 3.11
 # support is retired.
 from typing_extensions import override
 
 from streamlit.runtime.caching.cache_utils import OnRelease
+from streamlit.runtime.caching.ttl_cache import TTLCache
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -77,8 +76,8 @@ class TTLCleanupCache(TTLCache[K, V]):
 
     @override
     def clear(self) -> None:
-        # cachetools 7.0.2 makes clear() O(1) and bypasses popitem(). We clear
-        # via popitem() to preserve the behavior seen in cachetools <= 7.0.1.
+        # The base clear() empties the internal maps directly without running the
+        # release hook, so we pop each item via popitem() to invoke on_release.
         while True:
             try:
                 self.popitem()

--- a/lib/streamlit/runtime/credentials.py
+++ b/lib/streamlit/runtime/credentials.py
@@ -68,16 +68,17 @@ Collecting usage statistics. To deactivate, set browser.gatherUsageStats to fals
 
 def _send_email(email: str | None) -> None:
     """Send the user's email for metrics, if submitted."""
-    import requests
+    import urllib.request
 
     if email is None or "@" not in email:
         return
 
     metrics_url = ""
     try:
-        response_json = requests.get(
+        with urllib.request.urlopen(
             "https://data.streamlit.io/metrics.json", timeout=2
-        ).json()
+        ) as response:
+            response_json = json.loads(response.read().decode("utf-8"))
         metrics_url = response_json.get("url", "")
     except Exception:
         _LOGGER.exception("Failed to fetch metrics URL")
@@ -101,14 +102,16 @@ def _send_email(email: str | None) -> None:
         "userId": email,
     }
 
-    response = requests.post(
+    request = urllib.request.Request(  # noqa: S310
         metrics_url,
-        headers=headers,
         data=json.dumps(data).encode(),
-        timeout=10,
+        headers=headers,
+        method="POST",
     )
-
-    response.raise_for_status()
+    # urlopen raises urllib.error.HTTPError for non-2xx responses, mirroring
+    # requests' response.raise_for_status().
+    with urllib.request.urlopen(request, timeout=10):  # noqa: S310
+        pass
 
 
 class Credentials:
@@ -205,8 +208,6 @@ class Credentials:
 
     def save(self) -> None:
         """Save to toml file and send email."""
-        from requests.exceptions import RequestException
-
         if self.activation is None:
             return
 
@@ -223,7 +224,9 @@ class Credentials:
 
         try:
             _send_email(self.activation.email)
-        except RequestException:
+        except (OSError, ValueError):
+            # urllib raises URLError/HTTPError (OSError subclasses) on network or
+            # HTTP failures, and ValueError for a malformed metrics URL.
             _LOGGER.exception("Error saving email:")
 
     def activate(self, show_instructions: bool = True) -> None:

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cachetools import TTLCache
-
+from streamlit.runtime.caching.ttl_cache import TTLCache
 from streamlit.runtime.session_manager import SessionInfo, SessionStorage
 
 if TYPE_CHECKING:
@@ -28,8 +27,8 @@ class MemorySessionStorage(SessionStorage):
     """A SessionStorage that stores sessions in memory.
 
     At most maxsize sessions are stored with a TTL of ttl seconds. This class is really
-    just a thin wrapper around cachetools.TTLCache that complies with the SessionStorage
-    protocol.
+    just a thin wrapper around an in-memory ``TTLCache`` that complies with the
+    SessionStorage protocol.
     """
 
     # NOTE: The defaults for maxsize and ttl are chosen arbitrarily for now. These

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -23,8 +23,6 @@ from enum import Enum
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
-from blinker import Signal
-
 from streamlit import config, runtime, util
 from streamlit.errors import FragmentStorageKeyError
 from streamlit.logger import get_logger
@@ -59,6 +57,7 @@ from streamlit.runtime.state import (
     SafeSessionState,
     SessionState,
 )
+from streamlit.signal_util import Signal
 from streamlit.source_util import page_sort_key
 
 if TYPE_CHECKING:

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -24,12 +24,11 @@ from typing import (
     NoReturn,
 )
 
-from blinker import Signal
-
 import streamlit.watcher.path_watcher
 from streamlit import config, runtime
 from streamlit.errors import StreamlitMaxRetriesError, StreamlitSecretNotFoundError
 from streamlit.logger import get_logger
+from streamlit.signal_util import Signal
 
 _LOGGER: Final = get_logger(__name__)
 

--- a/lib/streamlit/signal_util.py
+++ b/lib/streamlit/signal_util.py
@@ -1,0 +1,243 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A tiny in-process signal (observer) implementation.
+
+This is a dependency-free replacement for the small subset of the ``blinker``
+library that Streamlit uses. The :class:`Signal` API mirrors ``blinker.Signal``
+closely enough that call sites only need to change their import:
+
+- ``connect(receiver, sender=ANY, weak=True)`` registers a receiver. As in
+  blinker, receivers are tracked with a :mod:`weakref` by default so they are
+  automatically disconnected when garbage collected. Bound methods are tracked
+  with :class:`weakref.WeakMethod` so the receiver stays alive exactly as long
+  as the object it is bound to.
+- ``send(sender=None, **kwargs)`` calls every receiver registered for ``sender``
+  or for :data:`ANY`, passing ``sender`` as the first positional argument along
+  with ``kwargs``. It returns a list of ``(receiver, return_value)`` tuples.
+- ``disconnect(receiver, sender=ANY)`` removes a receiver.
+- ``has_receivers_for(sender)`` reports whether a matching receiver exists.
+
+Receivers are identified by a stable identity (mirroring blinker's ``make_id``)
+so that connecting and later disconnecting the *same* callable works even though
+Python may create distinct bound-method objects for each attribute access.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import weakref
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Hashable
+
+
+class _Symbol:
+    """A constant, self-describing sentinel (nicer repr than ``object()``)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+ANY = _Symbol("ANY")
+"""Sentinel meaning "receiver is called for every sender"."""
+
+# Senders are keyed by their identity; ANY uses a fixed sentinel id that can
+# never collide with a real object's identity.
+_ANY_ID = 0
+
+
+def _make_id(obj: object) -> Hashable:
+    """Return a stable identifier for a receiver or sender.
+
+    Bound methods do not have a stable ``id()``, but the underlying function and
+    instance do, so we key on both. Strings and ints are used directly since
+    equal values hash equally.
+    """
+    if inspect.ismethod(obj):
+        return (id(obj.__func__), id(obj.__self__))
+    if isinstance(obj, (str, int)):
+        return obj
+    return id(obj)
+
+
+def _make_ref(
+    obj: Any, callback: Callable[[weakref.ref[Any]], None] | None = None
+) -> weakref.ref[Any]:
+    """Create a weak reference, using WeakMethod for bound methods."""
+    if inspect.ismethod(obj):
+        return weakref.WeakMethod(obj, callback)
+    return weakref.ref(obj, callback)
+
+
+class Signal:
+    """A notification emitter (a minimal ``blinker.Signal`` replacement)."""
+
+    ANY = ANY
+
+    def __init__(self, doc: str | None = None) -> None:
+        if doc:
+            self.__doc__ = doc
+
+        # Maps a receiver id to either the receiver itself (strong reference)
+        # or a weakref to it. Checking the truthiness of this dict is part of
+        # the public contract (``if signal.receivers:``).
+        self.receivers: dict[Hashable, weakref.ref[Any] | Callable[..., Any]] = {}
+        self._by_receiver: dict[Hashable, set[Hashable]] = defaultdict(set)
+        self._by_sender: dict[Hashable, set[Hashable]] = defaultdict(set)
+        self._weak_senders: dict[Hashable, weakref.ref[Any]] = {}
+
+    def connect(
+        self, receiver: Callable[..., Any], sender: Any = ANY, weak: bool = True
+    ) -> Callable[..., Any]:
+        """Connect ``receiver`` to be called when the signal is sent.
+
+        Parameters
+        ----------
+        receiver
+            The callable invoked on :meth:`send`, receiving ``sender`` as its
+            first positional argument plus any keyword arguments.
+        sender
+            Only call ``receiver`` when :meth:`send` is called with this sender.
+            :data:`ANY` (the default) matches every sender.
+        weak
+            Track the receiver with a weakref (the default). Set ``False`` when
+            connecting a function/closure that would otherwise be collected as
+            soon as the enclosing scope exits.
+        """
+        receiver_id = _make_id(receiver)
+        sender_id = _ANY_ID if sender is ANY else _make_id(sender)
+
+        if weak:
+            self.receivers[receiver_id] = _make_ref(
+                receiver, self._make_cleanup_receiver(receiver_id)
+            )
+        else:
+            self.receivers[receiver_id] = receiver
+
+        self._by_sender[sender_id].add(receiver_id)
+        self._by_receiver[receiver_id].add(sender_id)
+
+        if sender is not ANY and sender_id not in self._weak_senders:
+            try:
+                self._weak_senders[sender_id] = _make_ref(
+                    sender, self._make_cleanup_sender(sender_id)
+                )
+            except TypeError:
+                # The sender does not support weak references (e.g. str/int).
+                pass
+
+        return receiver
+
+    def send(self, sender: Any = None, **kwargs: Any) -> list[tuple[Any, Any]]:
+        """Call all receivers connected to ``sender`` or :data:`ANY`.
+
+        Returns a list of ``(receiver, return_value)`` tuples. Exceptions raised
+        by a receiver propagate to the caller.
+        """
+        return [
+            (receiver, receiver(sender, **kwargs))
+            for receiver in self.receivers_for(sender)
+        ]
+
+    def has_receivers_for(self, sender: Any) -> bool:
+        """Return whether any receiver would be called for ``sender``.
+
+        Does not verify that weakly referenced receivers are still alive; see
+        :meth:`receivers_for` for a stronger check.
+        """
+        if not self.receivers:
+            return False
+        if self._by_sender[_ANY_ID]:
+            return True
+        if sender is ANY:
+            return False
+        return _make_id(sender) in self._by_sender
+
+    def receivers_for(self, sender: Any) -> Generator[Callable[..., Any], None, None]:
+        """Yield the live receivers to call for ``sender`` (plus :data:`ANY`).
+
+        Weakly referenced receivers that have been collected are disconnected
+        and skipped.
+        """
+        if not self.receivers:
+            return
+
+        sender_id = _make_id(sender)
+
+        if sender_id in self._by_sender:
+            ids = self._by_sender[_ANY_ID] | self._by_sender[sender_id]
+        else:
+            ids = self._by_sender[_ANY_ID].copy()
+
+        for receiver_id in ids:
+            receiver = self.receivers.get(receiver_id)
+            if receiver is None:
+                continue
+
+            if isinstance(receiver, weakref.ref):
+                strong = receiver()
+                if strong is None:
+                    self._disconnect(receiver_id, _ANY_ID)
+                    continue
+                yield strong
+            else:
+                yield receiver
+
+    def disconnect(self, receiver: Callable[..., Any], sender: Any = ANY) -> None:
+        """Disconnect ``receiver`` (from ``sender``, or from all senders)."""
+        sender_id = _ANY_ID if sender is ANY else _make_id(sender)
+        receiver_id = _make_id(receiver)
+        self._disconnect(receiver_id, sender_id)
+
+    def _disconnect(self, receiver_id: Hashable, sender_id: Hashable) -> None:
+        if sender_id == _ANY_ID:
+            if self._by_receiver.pop(receiver_id, None) is not None:
+                for bucket in self._by_sender.values():
+                    bucket.discard(receiver_id)
+            self.receivers.pop(receiver_id, None)
+        else:
+            self._by_sender[sender_id].discard(receiver_id)
+            self._by_receiver[receiver_id].discard(sender_id)
+
+    def _make_cleanup_receiver(
+        self, receiver_id: Hashable
+    ) -> Callable[[weakref.ref[Any]], None]:
+        """Return a weakref callback that disconnects a collected receiver."""
+
+        def cleanup(_ref: weakref.ref[Any]) -> None:
+            # Disconnecting during interpreter shutdown can raise a spurious
+            # ignored exception, so skip cleanup in that case.
+            if not sys.is_finalizing():
+                self._disconnect(receiver_id, _ANY_ID)
+
+        return cleanup
+
+    def _make_cleanup_sender(
+        self, sender_id: Hashable
+    ) -> Callable[[weakref.ref[Any]], None]:
+        """Return a weakref callback that drops a collected sender's routing."""
+
+        def cleanup(_ref: weakref.ref[Any]) -> None:
+            self._weak_senders.pop(sender_id, None)
+            for receiver_id in self._by_sender.pop(sender_id, ()):
+                self._by_receiver[receiver_id].discard(sender_id)
+
+        return cleanup

--- a/lib/streamlit/signal_util.py
+++ b/lib/streamlit/signal_util.py
@@ -59,8 +59,10 @@ class _Symbol:
 ANY = _Symbol("ANY")
 """Sentinel meaning "receiver is called for every sender"."""
 
-# Senders are keyed by their identity; ANY uses a fixed sentinel id that can
-# never collide with a real object's identity.
+# Senders are keyed by their identity; ANY uses a fixed sentinel id. This relies
+# on senders never being the integer ``0`` (``_make_id`` returns ints unchanged),
+# which holds for Streamlit's usage where senders are objects or strings. This
+# mirrors blinker, which likewise reserves a fixed id for ANY.
 _ANY_ID = 0
 
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -58,13 +58,13 @@ import os
 import threading
 from typing import TYPE_CHECKING, Final, cast
 
-from blinker import ANY, Signal
 from typing_extensions import Self
 from watchdog import events
 from watchdog.observers import Observer
 
 from streamlit.errors import StreamlitMaxRetriesError
 from streamlit.logger import get_logger
+from streamlit.signal_util import ANY, Signal
 from streamlit.util import repr_
 from streamlit.watcher import util
 

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -116,15 +116,15 @@ def configurator_options(func: F) -> F:
 
 def _download_remote(main_script_path: str, url_path: str) -> None:
     """Fetch remote file at url_path to main_script_path."""
-    import requests
-    from requests.exceptions import RequestException
+    import urllib.request
 
     with open(main_script_path, "wb") as fp:
         try:
-            resp = requests.get(url_path, timeout=30)
-            resp.raise_for_status()
-            fp.write(resp.content)
-        except RequestException as e:
+            # urlopen raises urllib.error.HTTPError (an OSError) for non-2xx
+            # responses, mirroring the previous resp.raise_for_status() behavior.
+            with urllib.request.urlopen(url_path, timeout=30) as resp:  # noqa: S310
+                fp.write(resp.read())
+        except (OSError, ValueError) as e:
             raise click.BadParameter(f"Unable to fetch {url_path}.\n{e}")
 
 

--- a/lib/tests/streamlit/connections/retry_util_test.py
+++ b/lib/tests/streamlit/connections/retry_util_test.py
@@ -1,0 +1,230 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from streamlit.connections.retry_util import (
+    RetryError,
+    retry,
+    retry_if_exception,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_fixed,
+)
+
+
+def _no_sleep(_seconds: float) -> None:
+    """A sleep replacement that records nothing and never blocks."""
+
+
+def test_retryable_failure_exhausts_and_reraises_last_exception():
+    """A retryable error is attempted up to the stop limit, then re-raised."""
+    attempts = 0
+    afters = 0
+
+    def after(_state: object) -> None:
+        nonlocal afters
+        afters += 1
+
+    @retry(
+        after=after,
+        stop=stop_after_attempt(3),
+        reraise=True,
+        retry=retry_if_exception_type((ValueError,)),
+        wait=wait_fixed(0),
+        sleep=_no_sleep,
+    )
+    def always_fails() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        always_fails()
+
+    # Three attempts, and `after` runs after each retryable attempt (incl. the last).
+    assert attempts == 3
+    assert afters == 3
+
+
+def test_non_retryable_exception_raised_immediately_without_after():
+    """A non-matching exception is raised on the first attempt; `after` is skipped."""
+    attempts = 0
+    afters = 0
+
+    def after(_state: object) -> None:
+        nonlocal afters
+        afters += 1
+
+    @retry(
+        after=after,
+        stop=stop_after_attempt(3),
+        reraise=True,
+        retry=retry_if_exception_type((ValueError,)),
+        wait=wait_fixed(0),
+        sleep=_no_sleep,
+    )
+    def wrong_error() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise KeyError("nope")
+
+    with pytest.raises(KeyError):
+        wrong_error()
+
+    assert attempts == 1
+    assert afters == 0
+
+
+def test_eventual_success_returns_value():
+    """Retrying stops and returns as soon as the call succeeds."""
+    attempts = 0
+
+    @retry(
+        stop=stop_after_attempt(5),
+        reraise=True,
+        retry=retry_if_exception_type((ValueError,)),
+        wait=wait_fixed(0),
+        sleep=_no_sleep,
+    )
+    def succeeds_on_third() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ValueError("retry me")
+        return "ok"
+
+    assert succeeds_on_third() == "ok"
+    assert attempts == 3
+
+
+def test_success_first_try_does_not_sleep():
+    """A call that succeeds immediately never sleeps or waits."""
+    sleeps: list[float] = []
+
+    @retry(
+        stop=stop_after_attempt(3),
+        reraise=True,
+        retry=retry_if_exception_type((ValueError,)),
+        wait=wait_fixed(1),
+        sleep=sleeps.append,
+    )
+    def ok() -> int:
+        return 5
+
+    assert ok() == 5
+    assert sleeps == []
+
+
+def test_sleeps_between_attempts():
+    """The wait strategy determines the sleep duration between attempts."""
+    sleeps: list[float] = []
+
+    @retry(
+        stop=stop_after_attempt(3),
+        reraise=True,
+        retry=retry_if_exception_type((ValueError,)),
+        wait=wait_fixed(2),
+        sleep=sleeps.append,
+    )
+    def always_fails() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        always_fails()
+
+    # Two sleeps of 2s between the three attempts (no sleep after the final attempt).
+    assert sleeps == [2, 2]
+
+
+def test_reraise_false_raises_retry_error():
+    """With reraise=False, exhausted retries raise RetryError wrapping the last error."""
+
+    @retry(
+        stop=stop_after_attempt(2),
+        reraise=False,
+        retry=retry_if_exception_type((ValueError,)),
+        wait=wait_fixed(0),
+        sleep=_no_sleep,
+    )
+    def always_fails() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(RetryError) as exc_info:
+        always_fails()
+
+    assert isinstance(exc_info.value.last_exception, ValueError)
+
+
+def test_retry_if_exception_predicate():
+    """retry_if_exception only retries when the predicate matches the exception."""
+    attempts = 0
+
+    @retry(
+        stop=stop_after_attempt(3),
+        reraise=True,
+        retry=retry_if_exception(lambda e: getattr(e, "code", None) == 1),
+        wait=wait_fixed(0),
+        sleep=_no_sleep,
+    )
+    def fails_with_code() -> None:
+        nonlocal attempts
+        attempts += 1
+        err = RuntimeError("retryable")
+        err.code = 1  # type: ignore[attr-defined]
+        raise err
+
+    with pytest.raises(RuntimeError):
+        fails_with_code()
+    assert attempts == 3
+
+
+def test_retry_if_exception_predicate_no_match_fails_fast():
+    """retry_if_exception does not retry when the predicate rejects the exception."""
+    attempts = 0
+
+    @retry(
+        stop=stop_after_attempt(3),
+        reraise=True,
+        retry=retry_if_exception(lambda e: getattr(e, "code", None) == 1),
+        wait=wait_fixed(0),
+        sleep=_no_sleep,
+    )
+    def fails_with_other_code() -> None:
+        nonlocal attempts
+        attempts += 1
+        err = RuntimeError("not retryable")
+        err.code = 2  # type: ignore[attr-defined]
+        raise err
+
+    with pytest.raises(RuntimeError):
+        fails_with_other_code()
+    assert attempts == 1
+
+
+def test_stop_after_attempt_and_wait_fixed_helpers():
+    """The stop/wait strategy factories evaluate against the retry state."""
+    from streamlit.connections.retry_util import RetryCallState
+
+    state = RetryCallState()
+    stop = stop_after_attempt(3)
+    wait = wait_fixed(1.5)
+
+    state.attempt_number = 2
+    assert stop(state) is False
+    state.attempt_number = 3
+    assert stop(state) is True
+    assert wait(state) == 1.5

--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -106,7 +106,9 @@ def test_extract_github_repo_from_url(url: str, expected: str) -> None:
     [
         ("git version 2.39.3", (2, 39, 3)),
         ("git version 2.39.3 (Apple Git-145)", (2, 39, 3)),
-        ("git version 2.7", (2, 7)),
+        # A missing patch component is normalized to 0 so the version can be
+        # compared directly against _MIN_GIT_VERSION.
+        ("git version 2.7", (2, 7, 0)),
         ("not a version", None),
     ],
 )
@@ -135,6 +137,17 @@ class GitUtilTest(unittest.TestCase):
         with _mock_git_repo(git_version="git version 2.20.3") as repo:
             assert repo.is_valid()
             assert repo.git_version == (2, 20, 3)
+
+    def test_two_part_min_git_version_is_valid(self):
+        """A two-part git version at the minimum (e.g. "2.7") is still valid.
+
+        The patch component is normalized to 0 so it compares as
+        (2, 7, 0) >= _MIN_GIT_VERSION rather than the two-tuple (2, 7), which
+        would incorrectly sort below (2, 7, 0).
+        """
+        with _mock_git_repo(git_version="git version 2.7") as repo:
+            assert repo.is_valid()
+            assert repo.git_version == (2, 7, 0)
 
     def test_git_not_installed(self):
         """When git is not installed, all commands return None and the repo

--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -298,6 +298,8 @@ def test_run_git_builds_safe_command_and_strips_output() -> None:
         assert kwargs["timeout"] == git_util._GIT_TIMEOUT
         assert kwargs["check"] is False
         assert kwargs["capture_output"] is True
+        # Non-UTF-8 git output must be decoded defensively, never raising.
+        assert kwargs["errors"] == "replace"
         # Credential prompts are disabled so git can never block waiting for input.
         assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
 

--- a/lib/tests/streamlit/git_util_test.py
+++ b/lib/tests/streamlit/git_util_test.py
@@ -14,15 +14,20 @@
 
 from __future__ import annotations
 
+import subprocess
 import unittest
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from git.exc import InvalidGitRepositoryError
 
-from streamlit.git_util import GitRepo, _extract_github_repo_from_url
+from streamlit import git_util
+from streamlit.git_util import (
+    GitRepo,
+    _extract_github_repo_from_url,
+    _parse_git_version,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -32,71 +37,43 @@ if TYPE_CHECKING:
 def _mock_git_repo(
     *,
     module_path: str = "/repo",
+    git_version: str | None = "git version 2.20.3",
+    show_toplevel: str | None = "/repo",
     head_detached: bool = False,
-    tracking_branch_name: str | None = "origin/main",
+    upstream: str | None = "origin/main",
     remote_urls: Sequence[str] | None = ("https://github.com/owner/repo.git",),
-    remote_exception: Exception | None = None,
-    iter_commits: Sequence[object] | None = None,
-    iter_commits_exc: Exception | None = None,
-    untracked_files: Sequence[str] | None = None,
-    diff_paths: Sequence[str] | None = None,
+    untracked_files: Sequence[str] = (),
+    diff_paths: Sequence[str] = (),
+    rev_list: Sequence[str] | None = (),
 ) -> Iterator[GitRepo]:
-    """Context manager that yields a GitRepo with a mocked underlying git.Repo.
+    """Yield a GitRepo whose git CLI calls are mocked via canned responses.
 
-    Parameters mirror common setup needs across tests to reduce duplication.
+    Each key mirrors the exact arguments GitRepo passes to ``git`` so we can
+    exercise the subprocess-based implementation without a real repository.
     """
-    with patch("git.Repo") as repo_ctor:
-        mock_repo = repo_ctor.return_value
-        mock_repo.git.version_info = (2, 20, 3)
-        mock_repo.git.rev_parse.return_value = "/repo"
+    responses: dict[tuple[str, ...], str | None] = {
+        ("--version",): git_version,
+        ("rev-parse", "--show-toplevel"): show_toplevel,
+        ("symbolic-ref", "-q", "HEAD"): None if head_detached else "refs/heads/main",
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"): upstream,  # noqa: RUF027
+        ("ls-files", "--others", "--exclude-standard"): "\n".join(untracked_files),
+        ("diff", "--name-only"): "\n".join(diff_paths),
+    }
 
-        mock_repo.head = unittest.mock.Mock()
-        mock_repo.head.is_detached = head_detached
-
-        mock_repo.active_branch = unittest.mock.Mock()
-        if tracking_branch_name is not None and not head_detached:
-            tracking = unittest.mock.Mock()
-            tracking.name = tracking_branch_name
-            mock_repo.active_branch.tracking_branch.return_value = tracking
-        else:
-            mock_repo.active_branch.tracking_branch.return_value = None
-
-        remote = unittest.mock.Mock()
-        if remote_urls is not None:
-            remote.urls = list(remote_urls)
-        else:
-            remote.urls = []
-        # Name is used by ahead_commits
-        remote_name = (
-            tracking_branch_name.split("/")[0] if tracking_branch_name else "origin"
+    if upstream:
+        remote_name, *branch = upstream.split("/")
+        branch_name = "/".join(branch)
+        responses["remote", "get-url", "--all", remote_name] = (
+            "\n".join(remote_urls) if remote_urls else None
         )
-        remote.name = remote_name
+        responses["rev-list", f"{remote_name}/{branch_name}..{branch_name}"] = (
+            None if rev_list is None else "\n".join(rev_list)
+        )
 
-        if remote_exception is not None:
-            mock_repo.remote.side_effect = remote_exception
-        else:
-            mock_repo.remote.return_value = remote
+    def fake_run_git(self: GitRepo, *args: str, cwd: str | None = None) -> str | None:
+        return responses.get(tuple(args))
 
-        if iter_commits_exc is not None:
-            mock_repo.iter_commits.side_effect = iter_commits_exc
-        elif iter_commits is not None:
-            mock_repo.iter_commits.return_value = list(iter_commits)
-        else:
-            mock_repo.iter_commits.return_value = []
-
-        if untracked_files is not None:
-            mock_repo.untracked_files = list(untracked_files)
-
-        if diff_paths is not None:
-
-            class _DiffObj:  # noqa: B903
-                def __init__(self, path: str) -> None:
-                    self.a_path = path
-
-            mock_repo.index.diff.return_value = [_DiffObj(p) for p in diff_paths]
-        else:
-            mock_repo.index.diff.return_value = []
-
+    with patch.object(GitRepo, "_run_git", fake_run_git):
         yield GitRepo(module_path)
 
 
@@ -124,11 +101,24 @@ def test_extract_github_repo_from_url(url: str, expected: str) -> None:
     assert _extract_github_repo_from_url(url) == expected
 
 
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("git version 2.39.3", (2, 39, 3)),
+        ("git version 2.39.3 (Apple Git-145)", (2, 39, 3)),
+        ("git version 2.7", (2, 7)),
+        ("not a version", None),
+    ],
+)
+def test_parse_git_version(output: str, expected: tuple[int, ...] | None) -> None:
+    """Ensure git version strings are parsed into version tuples."""
+    assert _parse_git_version(output) == expected
+
+
 class GitUtilTest(unittest.TestCase):
     def test_git_repo_invalid(self):
-        with patch("git.Repo") as mock:
-            mock.side_effect = InvalidGitRepositoryError("Not a git repo")
-            repo = GitRepo(".")
+        """A directory that is not a git repo is not valid."""
+        with _mock_git_repo(show_toplevel=None) as repo:
             assert not repo.is_valid()
 
     def test_old_git_version(self):
@@ -136,28 +126,21 @@ class GitUtilTest(unittest.TestCase):
         prompt the user for credentials. We don't want to do this, so
         repo.is_valid() returns False for old gits.
         """
-        with (
-            patch("git.repo.base.Repo.GitCommandWrapperType") as git_mock,
-            patch("streamlit.git_util.os"),
-        ):
-            git_mock.return_value.version_info = (1, 6, 4)  # An old git version
-            repo = GitRepo(".")
+        with _mock_git_repo(git_version="git version 1.6.4") as repo:
             assert not repo.is_valid()
             assert repo.git_version == (1, 6, 4)
 
     def test_git_repo_valid(self):
-        with (
-            patch("git.repo.base.Repo.GitCommandWrapperType") as git_mock,
-            patch("streamlit.git_util.os"),
-        ):
-            git_mock.return_value.version_info = (2, 20, 3)  # A recent git version
-            repo = GitRepo(".")
+        """A directory with a recent git version and a repo root is valid."""
+        with _mock_git_repo(git_version="git version 2.20.3") as repo:
             assert repo.is_valid()
             assert repo.git_version == (2, 20, 3)
 
-    def test_gitpython_not_installed(self):
-        with patch.dict("sys.modules", {"git": None}):
-            repo = GitRepo(".")
+    def test_git_not_installed(self):
+        """When git is not installed, all commands return None and the repo
+        is not valid.
+        """
+        with _mock_git_repo(git_version=None, show_toplevel=None) as repo:
             assert not repo.is_valid()
 
     def test_get_repo_info_https_userinfo(self) -> None:
@@ -178,9 +161,7 @@ class GitUtilTest(unittest.TestCase):
 
     def test_get_repo_info_no_tracking_branch(self) -> None:
         """Return None when there is no tracking branch configured."""
-        with _mock_git_repo(
-            module_path="/repo/sub/module", tracking_branch_name=None
-        ) as gr:
+        with _mock_git_repo(module_path="/repo/sub/module", upstream=None) as gr:
             assert gr.get_repo_info() is None
 
     def test_get_repo_info_no_matching_remote_url(self) -> None:
@@ -198,7 +179,7 @@ class GitUtilTest(unittest.TestCase):
 
     def test_get_tracking_branch_remote_branch_with_slashes(self) -> None:
         """Branch names with slashes are preserved after the remote name segment."""
-        with _mock_git_repo(tracking_branch_name="origin/feature/foo/bar") as gr:
+        with _mock_git_repo(upstream="origin/feature/foo/bar") as gr:
             result = gr.get_tracking_branch_remote()
             assert result is not None
             _, branch = result
@@ -206,84 +187,60 @@ class GitUtilTest(unittest.TestCase):
 
     def test_get_tracking_branch_remote_missing_remote(self) -> None:
         """If the named remote cannot be resolved, return None."""
-        with _mock_git_repo(
-            tracking_branch_name="missing/main",
-            remote_exception=RuntimeError("remote not found"),
-        ) as gr:
+        with _mock_git_repo(upstream="missing/main", remote_urls=None) as gr:
             assert gr.get_tracking_branch_remote() is None
 
     def test_ahead_commits_success(self) -> None:
         """ahead_commits returns commits compared to the remote branch."""
-        commit1 = object()
-        commit2 = object()
-        with _mock_git_repo(iter_commits=(commit1, commit2)) as gr:
-            assert gr.ahead_commits == [commit1, commit2]
+        with _mock_git_repo(rev_list=("commit1", "commit2")) as gr:
+            assert gr.ahead_commits == ["commit1", "commit2"]
 
     def test_ahead_commits_no_tracking(self) -> None:
         """ahead_commits returns None when there's no tracking branch."""
-        with _mock_git_repo(tracking_branch_name=None) as gr:
+        with _mock_git_repo(upstream=None) as gr:
             assert gr.ahead_commits is None
 
-    def test_ahead_commits_iter_exception_returns_empty(self) -> None:
-        """On errors iterating commits, ahead_commits returns an empty list."""
-        with _mock_git_repo(iter_commits_exc=RuntimeError("boom")) as gr:
+    def test_ahead_commits_rev_list_failure_returns_empty(self) -> None:
+        """When rev-list fails (returns None), ahead_commits returns an empty list."""
+        with _mock_git_repo(rev_list=None) as gr:
             assert gr.ahead_commits == []
 
     def test_untracked_files_property(self) -> None:
         """untracked_files returns repo list when valid, else None."""
-        # valid repo
         with _mock_git_repo(untracked_files=("a.txt", "b.txt")) as gr:
             assert gr.untracked_files == ["a.txt", "b.txt"]
 
-        # invalid repo
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = Exception("no repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.untracked_files is None
 
     def test_uncommitted_files_property(self) -> None:
-        """uncommitted_files returns index.diff(None) a_path entries; None if invalid."""
-        # valid repo
+        """uncommitted_files returns diff --name-only entries; None if invalid."""
         with _mock_git_repo(diff_paths=("x.py", "y.py")) as gr:
             assert gr.uncommitted_files == ["x.py", "y.py"]
 
-        # invalid repo
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = Exception("no repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.uncommitted_files is None
 
     def test_is_head_detached_property(self) -> None:
-        """is_head_detached reflects repo.head.is_detached when valid; False if invalid."""
-        # valid repo - attached
+        """is_head_detached reflects HEAD state when valid; False if invalid."""
         with _mock_git_repo(head_detached=False) as gr:
             assert gr.is_head_detached is False
 
-        # valid repo - detached
         with _mock_git_repo(head_detached=True) as gr:
             assert gr.is_head_detached is True
 
-        # invalid repo
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = Exception("no repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.is_head_detached is False
 
     def test_tracking_branch_property(self) -> None:
         """tracking_branch returns None for invalid or detached HEAD; else value."""
-        # valid repo, attached head
         with _mock_git_repo() as gr:
-            # When not detached and tracking is configured, property should be truthy
             assert gr.tracking_branch is not None
 
-        # valid repo, detached head
         with _mock_git_repo(head_detached=True) as gr:
             assert gr.tracking_branch is None
 
-        # invalid repo
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = Exception("no repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.tracking_branch is None
 
     def test_repr_returns_string(self) -> None:
@@ -295,21 +252,77 @@ class GitUtilTest(unittest.TestCase):
 
     def test_get_repo_info_invalid_repo(self) -> None:
         """Verify get_repo_info returns None when repo is invalid."""
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = InvalidGitRepositoryError("Not a git repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.get_repo_info() is None
 
     def test_ahead_commits_invalid_repo(self) -> None:
         """Verify ahead_commits returns None when repo is invalid."""
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = InvalidGitRepositoryError("Not a git repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.ahead_commits is None
 
     def test_get_tracking_branch_remote_invalid_repo(self) -> None:
         """Verify get_tracking_branch_remote returns None when repo is invalid."""
-        with patch("git.Repo") as repo_ctor:
-            repo_ctor.side_effect = InvalidGitRepositoryError("Not a git repo")
-            gr = GitRepo("/repo")
+        with _mock_git_repo(show_toplevel=None) as gr:
             assert gr.get_tracking_branch_remote() is None
+
+
+# These tests exercise the actual subprocess boundary of `_run_git`, which the
+# `_mock_git_repo` helper above stubs out.
+
+
+def test_run_git_builds_safe_command_and_strips_output() -> None:
+    """_run_git runs a list-form git command with a timeout and no credential prompt."""
+    with patch("streamlit.git_util.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="  output \n")
+        repo = GitRepo("/some/dir")
+
+        mock_run.reset_mock()
+        result = repo._run_git("status", "--short")
+
+        assert result == "output"
+        (command,), kwargs = mock_run.call_args
+        assert command == ["git", "-C", repo._start_dir, "status", "--short"]
+        assert kwargs["timeout"] == git_util._GIT_TIMEOUT
+        assert kwargs["check"] is False
+        assert kwargs["capture_output"] is True
+        # Credential prompts are disabled so git can never block waiting for input.
+        assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_run_git_uses_provided_cwd() -> None:
+    """_run_git runs in the explicit cwd when one is given (whole-repo listings)."""
+    with patch("streamlit.git_util.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        repo = GitRepo("/some/dir")
+
+        mock_run.reset_mock()
+        repo._run_git("ls-files", cwd="/repo/root")
+
+        (command,), _kwargs = mock_run.call_args
+        assert command == ["git", "-C", "/repo/root", "ls-files"]
+
+
+def test_run_git_returns_none_on_nonzero_exit() -> None:
+    """A non-zero git exit code yields None."""
+    with patch("streamlit.git_util.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="whatever")
+        repo = GitRepo("/some/dir")
+        assert repo._run_git("status") is None
+
+
+def test_run_git_returns_none_when_git_missing() -> None:
+    """When the git binary is missing, _run_git returns None and the repo is invalid."""
+    with patch("streamlit.git_util.subprocess.run", side_effect=FileNotFoundError()):
+        repo = GitRepo("/some/dir")
+        assert not repo.is_valid()
+        assert repo._run_git("status") is None
+
+
+def test_run_git_returns_none_on_timeout() -> None:
+    """A git command that times out yields None rather than raising."""
+    with patch(
+        "streamlit.git_util.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="git", timeout=git_util._GIT_TIMEOUT),
+    ):
+        repo = GitRepo("/some/dir")
+        assert repo._run_git("status") is None

--- a/lib/tests/streamlit/net_util_test.py
+++ b/lib/tests/streamlit/net_util_test.py
@@ -15,12 +15,19 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import MagicMock
-
-import requests
-import requests_mock
+import urllib.error
+from unittest.mock import MagicMock, patch
 
 from streamlit import net_util
+
+
+def _mock_response(body: str) -> MagicMock:
+    """Build a urlopen return value usable as a context manager."""
+    response = MagicMock()
+    response.read.return_value = body.encode("utf-8")
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
 
 
 class UtilTest(unittest.TestCase):
@@ -29,30 +36,34 @@ class UtilTest(unittest.TestCase):
 
     def test_get_external_ip(self):
         # Test success
-        with requests_mock.mock() as m:
-            m.get(net_util._AWS_CHECK_IP, text="1.2.3.4")
+        with patch("urllib.request.urlopen", return_value=_mock_response("1.2.3.4")):
             assert net_util.get_external_ip() == "1.2.3.4"
 
         net_util._external_ip = None
 
         # Test failure
-        with requests_mock.mock() as m:
-            m.get(net_util._AWS_CHECK_IP, exc=requests.exceptions.ConnectTimeout)
-            assert None is net_util.get_external_ip()
+        with patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("timeout")
+        ):
+            assert net_util.get_external_ip() is None
 
     def test_get_external_ip_use_http_by_default(self):
-        with requests_mock.mock() as m:
-            m.get(net_util._AWS_CHECK_IP, text="1.2.3.4")
-            m.get(net_util._AWS_CHECK_IP_HTTPS, text="5.6.7.8")
+        mock_urlopen = MagicMock(return_value=_mock_response("1.2.3.4"))
+        with patch("urllib.request.urlopen", mock_urlopen):
             assert net_util.get_external_ip() == "1.2.3.4"
-            assert m.call_count == 1
+            # HTTPS fallback is not attempted when HTTP succeeds.
+            assert mock_urlopen.call_count == 1
 
     def test_get_external_ip_https_if_http_fails(self):
-        with requests_mock.mock() as m:
-            m.get(net_util._AWS_CHECK_IP, exc=requests.exceptions.ConnectTimeout)
-            m.get(net_util._AWS_CHECK_IP_HTTPS, text="5.6.7.8")
+        def side_effect(url: str, timeout: float | None = None) -> MagicMock:
+            if url == net_util._AWS_CHECK_IP:
+                raise urllib.error.URLError("timeout")
+            return _mock_response("5.6.7.8")
+
+        mock_urlopen = MagicMock(side_effect=side_effect)
+        with patch("urllib.request.urlopen", mock_urlopen):
             assert net_util.get_external_ip() == "5.6.7.8"
-            assert m.call_count == 2
+            assert mock_urlopen.call_count == 2
 
     def test_get_external_ip_html(self):
         # This tests the case where the external URL returns a web page.
@@ -64,67 +75,49 @@ class UtilTest(unittest.TestCase):
         </html>
         """
 
-        with requests_mock.mock() as m:
-            m.get(net_util._AWS_CHECK_IP, text=response_text)
-            assert None is net_util.get_external_ip()
+        with patch(
+            "urllib.request.urlopen", return_value=_mock_response(response_text)
+        ):
+            assert net_util.get_external_ip() is None
 
         net_util._external_ip = None
 
 
 def test_get_external_ip_uses_short_timeout(monkeypatch) -> None:
-    """Verify get_external_ip uses 1s timeout for both HTTP and HTTPS calls."""
-    # Reset cache to force new request
+    """Verify get_external_ip uses a 1s timeout for the HTTP call."""
+    # Reset cache to force a new request.
     monkeypatch.setattr(net_util, "_external_ip", None)
 
-    mock_get = MagicMock()
-    mock_response = MagicMock()
-    mock_response.text = "1.2.3.4"
-    mock_get.return_value = mock_response
-
-    monkeypatch.setattr("requests.get", mock_get)
+    mock_urlopen = MagicMock(return_value=_mock_response("1.2.3.4"))
+    monkeypatch.setattr("urllib.request.urlopen", mock_urlopen)
 
     net_util.get_external_ip()
 
-    # Verify timeout=1 was passed on the HTTP call
-    mock_get.assert_called_once()
-    _, kwargs = mock_get.call_args
+    mock_urlopen.assert_called_once()
+    _, kwargs = mock_urlopen.call_args
     assert kwargs.get("timeout") == 1, (
         f"Expected timeout=1, got {kwargs.get('timeout')}"
     )
 
 
 def test_get_external_ip_https_fallback_uses_short_timeout(monkeypatch) -> None:
-    """Verify HTTPS fallback in get_external_ip also uses 1s timeout."""
-    # Reset cache to force new request
+    """Verify the HTTPS fallback in get_external_ip also uses a 1s timeout."""
+    # Reset cache to force a new request.
     monkeypatch.setattr(net_util, "_external_ip", None)
 
-    mock_get = MagicMock()
-
-    def side_effect(url: str, timeout: float = 5) -> MagicMock:
+    def side_effect(url: str, timeout: float | None = None) -> MagicMock:
         """Simulate HTTP failure, HTTPS success."""
         if url == net_util._AWS_CHECK_IP:
-            raise requests.exceptions.ConnectTimeout()
-        mock_response = MagicMock()
-        mock_response.text = "1.2.3.4"
-        return mock_response
+            raise urllib.error.URLError("timeout")
+        return _mock_response("1.2.3.4")
 
-    mock_get.side_effect = side_effect
-    monkeypatch.setattr("requests.get", mock_get)
+    mock_urlopen = MagicMock(side_effect=side_effect)
+    monkeypatch.setattr("urllib.request.urlopen", mock_urlopen)
 
     result = net_util.get_external_ip()
 
-    # Verify both calls were made with timeout=1
     assert result == "1.2.3.4"
-    assert mock_get.call_count == 2
-
-    # Check first call (HTTP)
-    first_call_kwargs = mock_get.call_args_list[0].kwargs
-    assert first_call_kwargs.get("timeout") == 1, (
-        f"HTTP call: Expected timeout=1, got {first_call_kwargs.get('timeout')}"
-    )
-
-    # Check second call (HTTPS fallback)
-    second_call_kwargs = mock_get.call_args_list[1].kwargs
-    assert second_call_kwargs.get("timeout") == 1, (
-        f"HTTPS fallback: Expected timeout=1, got {second_call_kwargs.get('timeout')}"
-    )
+    assert mock_urlopen.call_count == 2
+    # Both the HTTP call and the HTTPS fallback use timeout=1.
+    for mock_call in mock_urlopen.call_args_list:
+        assert mock_call.kwargs.get("timeout") == 1

--- a/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
@@ -1,0 +1,223 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from streamlit.runtime.caching.ttl_cache import TTLCache
+
+
+class _Clock:
+    """A controllable timer for deterministic TTL tests."""
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_basic_set_get_len_contains():
+    """Basic mapping behavior: set, get, len, and membership."""
+    cache = TTLCache(maxsize=10, ttl=100, timer=_Clock())
+    cache["a"] = 1
+    cache["b"] = 2
+
+    assert cache["a"] == 1
+    assert len(cache) == 2
+    assert "a" in cache
+    assert "missing" not in cache
+
+
+def test_lru_eviction_respects_reads():
+    """Reads mark an entry most-recently-used, so eviction skips read entries."""
+    cache = TTLCache(maxsize=3, ttl=100, timer=_Clock())
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # Read "a" to bump its recency; LRU order becomes b, c, a.
+    assert cache["a"] == 1
+
+    # Inserting a 4th entry evicts the least-recently-used, which is now "b".
+    cache["d"] = 4
+
+    assert "b" not in cache
+    assert set(cache) == {"a", "c", "d"}
+
+
+def test_setitem_existing_key_does_not_evict():
+    """Updating an existing key must not trigger maxsize eviction."""
+    cache = TTLCache(maxsize=2, ttl=100, timer=_Clock())
+    cache["a"] = 1
+    cache["b"] = 2
+
+    cache["a"] = 11
+
+    assert cache.currsize == 2
+    assert cache["a"] == 11
+    assert cache["b"] == 2
+
+
+def test_unbounded_maxsize_never_evicts():
+    """An infinite maxsize should never evict entries."""
+    cache = TTLCache(maxsize=math.inf, ttl=math.inf, timer=_Clock())
+    for i in range(100):
+        cache[i] = i
+    assert cache.currsize == 100
+
+
+def test_expired_entries_are_absent_but_not_removed_on_read():
+    """Expired entries read as absent, yet are only reaped by expire()."""
+    clock = _Clock(1000.0)
+    cache = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+    cache["b"] = 2
+
+    clock.now = 1011.0  # past the expiry time (1010)
+
+    assert "a" not in cache
+    with pytest.raises(KeyError):
+        _ = cache["a"]
+
+    # Reads did not remove the entries: expire() still returns them.
+    assert sorted(cache.expire()) == [("a", 1), ("b", 2)]
+    assert len(cache) == 0
+
+
+def test_expire_only_removes_expired_and_preserves_order():
+    """expire() removes just the expired entries, oldest first."""
+    clock = _Clock(1000.0)
+    cache = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+    clock.now = 1005.0
+    cache["b"] = 2  # "a" expires at 1010, "b" at 1015
+
+    clock.now = 1012.0  # "a" expired, "b" still valid
+
+    assert cache.expire() == [("a", 1)]
+    assert "b" in cache
+    assert list(cache) == ["b"]
+
+
+def test_write_expires_stale_entries_first():
+    """A write drops already-expired entries before inserting the new one."""
+    clock = _Clock(1000.0)
+    cache = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+
+    clock.now = 1011.0
+    cache["b"] = 2
+
+    assert "a" not in cache
+    assert list(cache) == ["b"]
+
+
+def test_iter_yields_only_non_expired_keys():
+    """Iteration skips expired keys."""
+    clock = _Clock(1000.0)
+    cache = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+    clock.now = 1005.0
+    cache["b"] = 2
+
+    clock.now = 1011.0  # "a" expired, "b" valid
+    assert list(cache) == ["b"]
+
+
+def test_values_iteration_is_safe():
+    """values() works even though reading each value reorders the LRU map."""
+    cache = TTLCache(maxsize=10, ttl=100, timer=_Clock())
+    for i in range(5):
+        cache[i] = i * 10
+    assert sorted(cache.values()) == [0, 10, 20, 30, 40]
+
+
+def test_popitem_returns_lru_and_raises_when_empty():
+    """popitem() removes the least-recently-used entry, then raises when empty."""
+    cache = TTLCache(maxsize=10, ttl=100, timer=_Clock())
+    cache["a"] = 1
+    cache["b"] = 2
+    assert cache["a"] == 1  # bump "a"; "b" is now least-recently-used
+
+    assert cache.popitem() == ("b", 2)
+    assert cache.popitem() == ("a", 1)
+    with pytest.raises(KeyError):
+        cache.popitem()
+
+
+def test_delitem_of_expired_removes_but_raises():
+    """Deleting an expired entry removes it but signals absence via KeyError."""
+    clock = _Clock(1000.0)
+    cache = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+
+    clock.now = 1011.0
+    with pytest.raises(KeyError):
+        del cache["a"]
+
+    # It was still removed, so there is nothing left to expire.
+    assert cache.expire() == []
+
+
+def test_delitem_missing_raises():
+    """Deleting a key that was never present raises KeyError."""
+    cache = TTLCache(maxsize=10, ttl=10, timer=_Clock())
+    with pytest.raises(KeyError):
+        del cache["missing"]
+
+
+def test_maxsize_below_one_rejects_writes():
+    """A maxsize below one cannot hold any entry, so writes raise ValueError."""
+    cache = TTLCache(maxsize=0, ttl=10, timer=_Clock())
+    with pytest.raises(ValueError, match="value too large"):
+        cache["a"] = 1
+
+
+def test_get_and_pop_defaults():
+    """get()/pop() honor defaults for missing keys and remove on pop."""
+    cache = TTLCache(maxsize=10, ttl=100, timer=_Clock())
+    cache["a"] = 1
+
+    assert cache.get("a") == 1
+    assert cache.get("missing") is None
+    assert cache.pop("a") == 1
+    assert "a" not in cache
+    assert cache.pop("missing", "default") == "default"
+
+
+def test_clear_empties_cache():
+    """clear() removes all entries."""
+    cache = TTLCache(maxsize=10, ttl=100, timer=_Clock())
+    cache["a"] = 1
+    cache["b"] = 2
+
+    cache.clear()
+
+    assert len(cache) == 0
+    assert "a" not in cache
+
+
+def test_config_properties():
+    """maxsize/ttl/currsize expose the cache configuration and size."""
+    cache = TTLCache(maxsize=5, ttl=30, timer=_Clock())
+    cache["a"] = 1
+    cache["b"] = 2
+
+    assert cache.maxsize == 5
+    assert cache.ttl == 30
+    assert cache.currsize == 2

--- a/lib/tests/streamlit/runtime/credentials_test.py
+++ b/lib/tests/streamlit/runtime/credentials_test.py
@@ -16,15 +16,17 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import textwrap
 import unittest
+import urllib.error
+import urllib.request
 from pathlib import Path
 from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
-import requests_mock
 from testfixtures import tempdir
 
 from streamlit import file_util
@@ -34,6 +36,59 @@ from streamlit.runtime.credentials import (
     _verify_email,
     email_prompt,
 )
+
+
+def _mock_response(body: bytes) -> MagicMock:
+    """Build a urlopen return value usable as a context manager."""
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+class _FakeMetricsUrlopen:
+    """A urllib.request.urlopen replacement for the metrics email flow.
+
+    Records each call and returns the metrics JSON for the GET, then either a
+    successful response or an HTTPError for the POST, based on the configured
+    status codes.
+    """
+
+    def __init__(
+        self,
+        *,
+        metrics_status: int = 200,
+        metrics_json: dict | None = None,
+        post_status: int = 200,
+    ) -> None:
+        self.metrics_status = metrics_status
+        self.metrics_json = metrics_json if metrics_json is not None else {}
+        self.post_status = post_status
+        self.calls: list[tuple[str, str, bytes | None]] = []
+
+    def __call__(self, url_or_request, timeout=None):
+        if isinstance(url_or_request, urllib.request.Request):
+            method = url_or_request.get_method()
+            url = url_or_request.full_url
+            data = url_or_request.data
+        else:
+            method = "GET"
+            url = url_or_request
+            data = None
+        self.calls.append((method, url, data))
+
+        if method == "GET":
+            if self.metrics_status != 200:
+                raise urllib.error.HTTPError(
+                    url, self.metrics_status, "Not Found", {}, None
+                )
+            return _mock_response(json.dumps(self.metrics_json).encode("utf-8"))
+
+        if self.post_status != 200:
+            raise urllib.error.HTTPError(url, self.post_status, "Forbidden", {}, None)
+        return _mock_response(b"")
+
 
 PROMPT = "click.prompt"
 MOCK_PATH = "/mock/home/folder/.streamlit/credentials.toml"
@@ -313,33 +368,29 @@ class CredentialsClassTest(unittest.TestCase):
     def test_email_send(self, temp_dir):
         """Test that saving a new Credential sends an email"""
 
-        with requests_mock.mock() as m:
-            m.get(
-                "https://data.streamlit.io/metrics.json",
-                status_code=200,
-                json={"url": "https://www.example.com"},
-            )
-            m.post("https://www.example.com", status_code=200)
+        fake = _FakeMetricsUrlopen(metrics_json={"url": "https://www.example.com"})
+        with patch("urllib.request.urlopen", fake):
             creds: Credentials = Credentials.get_current()  # type: ignore
             creds._conf_file = str(Path(temp_dir.path) / "config.toml")
             creds.activation = _verify_email("email@example.com")
             creds.save()
-            # Check that metrics url fetched
-            first_request = m.request_history[0]
-            assert first_request.method == "GET"
-            assert first_request.url == "https://data.streamlit.io/metrics.json"
-            # Check that email sent to the url fetched
-            last_request = m.request_history[-1]
-            assert last_request.method == "POST"
-            assert last_request.url == "https://www.example.com/"
-            assert '"userId": "email@example.com"' in last_request.text
+
+        # Check that the metrics url was fetched first.
+        assert fake.calls[0][0] == "GET"
+        assert fake.calls[0][1] == "https://data.streamlit.io/metrics.json"
+        # Check that the email was posted to the fetched url.
+        last_method, last_url, last_body = fake.calls[-1]
+        assert last_method == "POST"
+        assert last_url == "https://www.example.com"
+        assert last_body is not None
+        assert b'"userId": "email@example.com"' in last_body
 
     @tempdir()
     def test_email_failed_metrics_fetch(self, temp_dir):
         """Test that saving a new Credential does not send an email if metrics fetch fails"""
 
-        with requests_mock.mock() as m:
-            m.get("https://data.streamlit.io/metrics.json", status_code=404)
+        fake = _FakeMetricsUrlopen(metrics_status=404)
+        with patch("urllib.request.urlopen", fake):
             creds: Credentials = Credentials.get_current()
             creds._conf_file = str(Path(temp_dir.path) / "config.toml")
             creds.activation = _verify_email("email@example.com")
@@ -347,7 +398,8 @@ class CredentialsClassTest(unittest.TestCase):
                 "streamlit.runtime.credentials", level="ERROR"
             ) as mock_logger:
                 creds.save()
-                assert len(m.request_history) == 1
+                # Only the metrics fetch was attempted (no POST).
+                assert len(fake.calls) == 1
                 assert len(mock_logger.output) == 1
                 assert "Failed to fetch metrics URL" in mock_logger.output[0]
 
@@ -357,18 +409,13 @@ class CredentialsClassTest(unittest.TestCase):
         Test that saving a new Credential does not send an email if the email is invalid
         """
 
-        with requests_mock.mock() as m:
-            m.get(
-                "https://data.streamlit.io/metrics.json",
-                status_code=200,
-                json={"url": "https://www.example.com"},
-            )
-            m.post("https://www.example.com", status_code=200)
+        fake = _FakeMetricsUrlopen(metrics_json={"url": "https://www.example.com"})
+        with patch("urllib.request.urlopen", fake):
             creds: Credentials = Credentials.get_current()  # type: ignore
             creds._conf_file = str(Path(temp_dir.path) / "config.toml")
             creds.activation = _verify_email("some_email")
             creds.save()
-            assert len(m.request_history) == 0
+            assert len(fake.calls) == 0
 
     @tempdir()
     def test_email_send_exception_handling(self, temp_dir):
@@ -376,13 +423,10 @@ class CredentialsClassTest(unittest.TestCase):
         Test that saving a new Credential catches and logs failures from the segment
         endpoint
         """
-        with requests_mock.mock() as m:
-            m.get(
-                "https://data.streamlit.io/metrics.json",
-                status_code=200,
-                json={"url": "https://www.example.com"},
-            )
-            m.post("https://www.example.com", status_code=403)
+        fake = _FakeMetricsUrlopen(
+            metrics_json={"url": "https://www.example.com"}, post_status=403
+        )
+        with patch("urllib.request.urlopen", fake):
             creds: Credentials = Credentials.get_current()  # type: ignore
             creds._conf_file = str(Path(temp_dir.path) / "config.toml")
             creds.activation = _verify_email("email@example.com")

--- a/lib/tests/streamlit/runtime/memory_session_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_session_storage_test.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import MagicMock
 
-from cachetools import TTLCache
-
+from streamlit.runtime.caching.ttl_cache import TTLCache
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
 
 
@@ -26,17 +25,18 @@ class MemorySessionStorageTest(unittest.TestCase):
     """Test MemorySessionStorage.
 
     These tests are intentionally extremely simple to ensure that we don't just end up
-    testing cachetools.TTLCache. We try to just verify that we've wrapped TTLCache
-    correctly, and in particular we avoid testing cache expiry functionality.
+    testing TTLCache. We try to just verify that we've wrapped TTLCache correctly, and
+    in particular we avoid testing cache expiry functionality (that is covered directly
+    in ttl_cache_test.py).
     """
 
     def test_uses_ttl_cache(self):
         """Verify that the backing cache of a MemorySessionStorage is a TTLCache.
 
         We do this because we're intentionally avoiding writing tests around cache
-        expiry because the cachetools library should do this for us. In the case
-        that the backing cache for a MemorySessionStorage ever changes, we'll likely be
-        responsible for adding our own tests.
+        expiry here, since TTLCache handles it (and is covered by ttl_cache_test.py). In
+        the case that the backing cache for a MemorySessionStorage ever changes, we'll
+        likely be responsible for adding our own tests.
         """
         store = MemorySessionStorage()
         assert isinstance(store._cache, TTLCache)

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from blinker import Signal
 from parameterized import parameterized
 from typing_extensions import Self
 
@@ -43,6 +42,7 @@ from streamlit.runtime.secrets import (
     Secrets,
     _convert_to_dict,
 )
+from streamlit.signal_util import Signal
 from tests import testutil
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.exception_capturing_thread import call_on_threads

--- a/lib/tests/streamlit/signal_util_test.py
+++ b/lib/tests/streamlit/signal_util_test.py
@@ -1,0 +1,174 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import gc
+
+from streamlit.signal_util import ANY, Signal
+
+
+class _Receiver:
+    """A helper receiver object used to test bound-method (weak) connections."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, dict[str, object]]] = []
+
+    def on_signal(self, sender: object, **kwargs: object) -> str:
+        self.calls.append((sender, kwargs))
+        return "handled"
+
+
+def test_send_calls_receiver_with_sender_and_kwargs():
+    """send() passes the sender positionally and forwards keyword arguments."""
+    sig = Signal()
+    received: list[tuple[object, dict[str, object]]] = []
+
+    def receiver(sender: object, **kwargs: object) -> None:
+        received.append((sender, kwargs))
+
+    sig.connect(receiver, weak=False)
+    sig.send("the-sender", event="x")
+
+    assert received == [("the-sender", {"event": "x"})]
+
+
+def test_send_returns_receiver_result_pairs():
+    """send() returns a list of (receiver, return_value) tuples."""
+    sig = Signal()
+
+    def receiver(_sender: object, **_kwargs: object) -> int:
+        return 42
+
+    sig.connect(receiver, weak=False)
+    results = sig.send()
+
+    assert results == [(receiver, 42)]
+
+
+def test_send_with_no_receivers_returns_empty_list():
+    """Sending a signal with no receivers is a no-op that returns []."""
+    assert Signal().send("sender") == []
+
+
+def test_default_sender_is_none():
+    """send() with no argument passes None as the sender."""
+    sig = Signal()
+    seen: list[object] = []
+    sig.connect(lambda sender, **_kw: seen.append(sender), weak=False)
+
+    sig.send()
+
+    assert seen == [None]
+
+
+def test_weak_bound_method_is_auto_disconnected_on_gc():
+    """A weakly-connected bound method is dropped once its object is collected."""
+    sig = Signal()
+    receiver = _Receiver()
+    sig.connect(receiver.on_signal)  # weak=True by default
+
+    sig.send("s", value=1)
+    assert receiver.calls == [("s", {"value": 1})]
+    assert sig.has_receivers_for(ANY) is True
+
+    del receiver
+    gc.collect()
+
+    # The dead weak receiver is skipped and pruned.
+    assert sig.send("s") == []
+    assert sig.has_receivers_for(ANY) is False
+
+
+def test_weak_false_receiver_is_retained():
+    """A non-weak receiver survives even without an external strong reference."""
+    sig = Signal()
+
+    def make_and_connect() -> None:
+        def receiver(_sender: object, **_kwargs: object) -> None:
+            pass
+
+        sig.connect(receiver, weak=False)
+
+    make_and_connect()
+    gc.collect()
+
+    # The closure is not collected because weak=False keeps a strong reference.
+    assert sig.has_receivers_for(ANY) is True
+    assert len(sig.send("s")) == 1
+
+
+def test_disconnect_uses_stable_identity_for_bound_methods():
+    """disconnect() matches a bound method even though each access is a new object."""
+    sig = Signal()
+    receiver = _Receiver()
+
+    sig.connect(receiver.on_signal)
+    # A freshly-accessed bound method compares unequal by identity but must still
+    # resolve to the same receiver for disconnect purposes.
+    sig.disconnect(receiver.on_signal)
+
+    assert sig.send("s") == []
+    assert sig.has_receivers_for(ANY) is False
+
+
+def test_sender_specific_receiver_only_called_for_that_sender():
+    """A receiver bound to a specific sender ignores other senders."""
+    sig = Signal()
+    seen: list[object] = []
+    sig.connect(lambda sender, **_kw: seen.append(sender), sender="a", weak=False)
+
+    sig.send("b")  # different sender -> not delivered
+    assert seen == []
+
+    sig.send("a")  # matching sender -> delivered
+    assert seen == ["a"]
+
+
+def test_any_receiver_called_for_every_sender():
+    """A receiver connected to ANY is called regardless of the sender."""
+    sig = Signal()
+    seen: list[object] = []
+    sig.connect(lambda sender, **_kw: seen.append(sender), sender=ANY, weak=False)
+
+    sig.send("a")
+    sig.send("b")
+
+    assert seen == ["a", "b"]
+
+
+def test_has_receivers_for_specific_and_any():
+    """has_receivers_for reflects both sender-specific and ANY registrations."""
+    sig = Signal()
+    assert sig.has_receivers_for("a") is False
+
+    sig.connect(lambda *_a, **_k: None, sender="a", weak=False)
+    assert sig.has_receivers_for("a") is True
+    # No ANY receiver, so a different sender has none, and ANY itself has none.
+    assert sig.has_receivers_for("b") is False
+    assert sig.has_receivers_for(ANY) is False
+
+
+def test_string_sender_without_weakref_support():
+    """Non-weakref-able senders (e.g. str) still route correctly.
+
+    Mirrors event_based_path_watcher, which sends the changed path (a str) as sender.
+    """
+    sig = Signal()
+    seen: list[object] = []
+    sig.connect(lambda sender, **_kw: seen.append(sender), weak=False)
+
+    sig.send("/some/path")
+
+    assert seen == ["/some/path"]

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -22,13 +22,13 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import urllib.error
 from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-import requests_mock
 from click.testing import CliRunner
 from parameterized import parameterized
 from requests.adapters import HTTPAdapter, Retry
@@ -41,6 +41,15 @@ from streamlit.runtime.credentials import Credentials
 from streamlit.web import cli
 from streamlit.web.cli import _convert_config_option_to_click_option
 from tests import testutil
+
+
+def _mock_urlopen_response(body: bytes) -> MagicMock:
+    """Build a urlopen return value usable as a context manager."""
+    response = MagicMock()
+    response.read.return_value = body
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
 
 
 class CliTest(unittest.TestCase):
@@ -147,13 +156,15 @@ class CliTest(unittest.TestCase):
     def test_run_valid_url(self, temp_dir):
         """streamlit run succeeds if an existing url is passed."""
 
+        file_content = b"content"
         with (
             patch("streamlit.url_util.is_url", return_value=True),
             patch("streamlit.web.cli._main_run"),
-            requests_mock.mock() as m,
+            patch(
+                "urllib.request.urlopen",
+                return_value=_mock_urlopen_response(file_content),
+            ),
         ):
-            file_content = b"content"
-            m.get("http://url/app.py", content=file_content)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
                 mock_tmp.return_value.__enter__.return_value = temp_dir.path
                 result = self.runner.invoke(cli, ["run", "http://url/app.py"])
@@ -171,9 +182,11 @@ class CliTest(unittest.TestCase):
         with (
             patch("streamlit.url_util.is_url", return_value=True),
             patch("streamlit.web.cli._main_run"),
-            requests_mock.mock() as m,
+            patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.URLError("connection failed"),
+            ),
         ):
-            m.get("http://url/app.py", exc=requests.exceptions.RequestException)
             with patch("streamlit.temporary_directory.TemporaryDirectory") as mock_tmp:
                 mock_tmp.return_value.__enter__.return_value = temp_dir.path
                 result = self.runner.invoke(cli, ["run", "http://url/app.py"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ dev = [
   "types-requests",
   "types-setuptools",
   "types-toml",
-  "types-cachetools",
   "types-Authlib",
   # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version.
   # We need to pin 2.3.3.260113 since higher versions require a min Python 3.11 support.
@@ -110,8 +109,12 @@ test = [
   "seaborn>=0.11.2",
   "watchdog>=2.1.5",
   "streamlit-pdf>=1.0.0",
+  # pydeck is an optional dependency (st.pydeck_chart / hello mapping demo):
+  "pydeck>=0.8.0b4,<1",
   # Optional dependency for better performance:
   "uvloop>=0.15.2; sys_platform != 'win32'",
+  # httptools is an optional performance dependency for the uvicorn server:
+  "httptools>=0.6.3",
   # Optional dependency used for improved exception formatting:
   "rich>=10.14.0",
   # Used by vega-lite / altair e2e tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,9 @@ test = [
   "pytest-cov",
   "hypothesis>=6.17.4",
   "parameterized",
-  "requests-mock",
+  # requests is only used by tests/e2e (e.g. the CLI live-HTTP helper and some
+  # e2e tests); Streamlit itself uses urllib at runtime.
+  "requests>=2.27",
   "testfixtures",
   # tomli is the backport of tomllib for Python <3.11:
   "tomli>=2.0.0; python_version < '3.11'",

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -9,7 +9,6 @@ pillow==7.1.0
 protobuf==3.20
 pyarrow==7.0
 python-multipart==0.0.10
-requests==2.27
 starlette==0.40.0
 toml==0.10.1
 typing-extensions==4.10.0

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -1,10 +1,6 @@
 altair==4.0
 anyio==4.0.0
-blinker==1.5.0
-cachetools==5.5
 click==7.0
-gitpython==3.0.7
-httptools==0.6.3
 itsdangerous==2.1.2
 numpy==1.23
 packaging==20
@@ -12,11 +8,9 @@ pandas==1.4.0
 pillow==7.1.0
 protobuf==3.20
 pyarrow==7.0
-pydeck==0.8.0b4
 python-multipart==0.0.10
 requests==2.27
 starlette==0.40.0
-tenacity==8.1.0
 toml==0.10.1
 typing-extensions==4.10.0
 uvicorn==0.30.0


### PR DESCRIPTION
## Describe your changes

Reduces the required runtime dependencies from **24 → 17** to lower supply-chain risk. Each removed dependency is replaced by a small internal module / the stdlib, or moved to an optional extra; runtime behavior is preserved (covered by existing + new tests and a live functional check).

- **Replaced with internal implementations:** `tenacity` → `connections/retry_util.py`, `blinker` → `signal_util.py`, `cachetools` → `runtime/caching/ttl_cache.py`, `gitpython` → a subprocess-based `git_util.py`. The internal `Signal` preserves blinker's weak-reference receiver semantics; `TTLCache` preserves cachetools' LRU-on-read + TTL semantics (both locked by tests).
- **Replaced with the stdlib:** `requests` → `urllib.request` at the three outbound HTTP call sites (external-IP lookup, metrics email, remote app-script download). `requests` is now a test-only dependency (still used by CLI/e2e test helpers).
- **Moved to optional extras:** `pydeck` → new `mapping` extra, `httptools` → `performance` extra. Neither is needed as a hard runtime dependency — `st.map` builds the deck JSON itself, and uvicorn falls back to `h11`.

**Net install footprint:** `blinker`, `cachetools`, `tenacity`, `gitpython` (+ transitive `gitdb`/`smmap`), and `requests` (+ transitive `urllib3`/`certifi`/`charset-normalizer`) are no longer installed; `pydeck`/`httptools` come only via extras.

**User-facing note:** `pip install streamlit` no longer pulls in `pydeck`, `httptools`, or `requests`. `st.map` is unaffected; `st.pydeck_chart` now requires `streamlit[mapping]` (users already need `pydeck` installed to construct a `Deck`).

Background analysis that informed this PR: [ranked dependency-removal feasibility](https://issues.streamlit.app/agent_wiki_explorer?file=references/2026-07-06-required-dependency-removal-feasibility.md).

## Screenshot or video (only for visual changes)

N/A — no visual changes.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **New unit tests:** `connections/retry_util_test.py`, `signal_util_test.py` (weak-ref/GC/ANY-routing), `runtime/caching/ttl_cache_test.py` (LRU-on-read, TTL, eviction quirks).
- **Updated unit tests** to mock `urllib` instead of `requests`: `net_util_test.py`, `runtime/credentials_test.py`, `web/cli_test.py`; plus `git_util_test.py` (subprocess-boundary tests), `runtime/memory_session_storage_test.py`, `runtime/secrets_test.py`.
- **Parity checks:** `retry_util` is additionally validated by the existing SQL/Snowflake connection retry integration tests; the `urllib` call sites were verified with a live local-HTTP smoke test (text GET, redirect following, 404 handling, file download, POST, non-2xx → error).
- Full Python unit suite passes locally (10300 passed); CI `py-integration-tests` and wheel build are green.
- No E2E tests needed: changes are internal dependency swaps / packaging, with no user-facing UI or behavior change.