### PR TITLE
[chore] Scope uv dependabot manifests and versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -124,6 +124,13 @@ updates:
     # Allow a limited number of update PRs at a time
     # to keep the number of parallel dependency updates manageable.
     open-pull-requests-limit: 3
+    # The published package manifest is owned by the /lib uv job below. The
+    # root uv job should only update the dev/test environment.
+    exclude-paths:
+      - "lib/pyproject.toml"
+    # Avoid raising lower-bound constraints when the latest release is already
+    # allowed. `widen` is not currently accepted by GitHub's uv config.
+    versioning-strategy: increase-if-necessary
 
     # Use cooldown to avoid updating dependencies too frequently
     # and minimize risk of supply chain attacks.
@@ -143,6 +150,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 3
+    # Let Dependabot classify the published Streamlit package as a library,
+    # which uses widening behavior internally for supported ranges.
+    versioning-strategy: auto
 
     cooldown:
       default-days: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -129,7 +129,7 @@ updates:
     exclude-paths:
       - "lib/pyproject.toml"
     # Avoid raising lower-bound constraints when the latest release is already
-    # allowed. `widen` is not currently accepted by GitHub's uv config.
+    # allowed; keeps the dev/test environment on broad ranges.
     versioning-strategy: increase-if-necessary
 
     # Use cooldown to avoid updating dependencies too frequently
@@ -150,8 +150,12 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 3
-    # Let Dependabot classify the published Streamlit package as a library,
-    # which uses widening behavior internally for supported ranges.
+    # Let Dependabot classify the published Streamlit package as a library, which
+    # widens supported version ranges internally. Explicit
+    # `versioning-strategy: widen` is not currently accepted for the uv ecosystem
+    # by GitHub's dependabot.yml schema (only lockfile-only, auto, increase, and
+    # increase-if-necessary are), so `auto` is used to opt into widening.
+    # Tracking issue: https://github.com/dependabot/dependabot-core/issues/15290
     versioning-strategy: auto
 
     cooldown:


### PR DESCRIPTION
## Describe your changes

Refines the two `uv` Dependabot jobs so each owns a distinct manifest and uses an appropriate versioning strategy:

- Root `uv` job (`directory: "/"`) now excludes `lib/pyproject.toml` via `exclude-paths` so it only manages the dev/test environment, and uses `versioning-strategy: increase-if-necessary` to avoid raising lower-bound constraints when the latest release is already allowed.
- `/lib` `uv` job (published `streamlit` package) uses `versioning-strategy: auto`, letting Dependabot classify it as a library and widen supported ranges. `widen` is not currently accepted directly for the uv ecosystem in GitHub's config, so `auto` is used to get library-widening behavior.

## GitHub Issue Link (if applicable)

## Testing Plan

- Configuration-only change to `.github/dependabot.yml`; validated by the `check-yaml` and `oxfmt-yaml` pre-commit hooks. No unit or E2E tests are applicable.

Made with [Cursor](https://cursor.com)