### PR TITLE
[feature] Add `new_tab` parameter to `st.link_button` (#7464)

### DIFF
--- a/e2e_playwright/st_link_button.py
+++ b/e2e_playwright/st_link_button.py
@@ -122,3 +122,17 @@ rerun_link_clicked = st.link_button(
     on_click="rerun",
 )
 st.write("Link Button with rerun value:", rerun_link_clicked)
+
+st.link_button(
+    "Link Button same tab",
+    url="https://streamlit.io",
+    new_tab=False,
+    key="same_tab_link_button",
+)
+
+st.link_button(
+    "Link Button explicit new tab",
+    url="https://streamlit.io",
+    new_tab=True,
+    key="explicit_new_tab_link_button",
+)

--- a/e2e_playwright/st_link_button_test.py
+++ b/e2e_playwright/st_link_button_test.py
@@ -26,7 +26,7 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-LINK_BUTTON_ELEMENTS = 19
+LINK_BUTTON_ELEMENTS = 21
 
 
 def _click_link_and_wait_for_rerun(app: Page, link: Locator) -> None:
@@ -162,3 +162,30 @@ def test_link_button_shortcut_triggers(app: Page):
     popup = popup_info.value
     expect(popup).to_have_url(re.compile(r"https://streamlit\.io/?"))
     popup.close()
+
+
+def test_default_link_opens_in_new_tab(app: Page):
+    """Anti-regression: the default link button opens in a new tab."""
+    default_link = (
+        app.get_by_test_id("stLinkButton")
+        .filter(has_text="Default Link")
+        .get_by_role("link")
+    )
+    expect(default_link).to_have_attribute("target", "_blank")
+    expect(default_link).to_have_attribute("rel", "noreferrer")
+
+
+def test_new_tab_false_opens_in_same_tab(app: Page):
+    """Test that `new_tab=False` renders an anchor without `target=_blank`."""
+    same_tab_link = get_element_by_key(app, "same_tab_link_button").get_by_role("link")
+    expect(same_tab_link).not_to_have_attribute("target", re.compile(r".+"))
+    expect(same_tab_link).not_to_have_attribute("rel", re.compile(r".+"))
+
+
+def test_new_tab_true_explicit_opens_in_new_tab(app: Page):
+    """Test that an explicit `new_tab=True` still renders `target=_blank`."""
+    new_tab_link = get_element_by_key(app, "explicit_new_tab_link_button").get_by_role(
+        "link"
+    )
+    expect(new_tab_link).to_have_attribute("target", "_blank")
+    expect(new_tab_link).to_have_attribute("rel", "noreferrer")

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -184,6 +184,22 @@ describe("LinkButton widget", () => {
     expect(props.widgetMgr.setTriggerValue).not.toHaveBeenCalled()
   })
 
+  it("opens in a new tab by default (newTab=true)", () => {
+    render(<LinkButton {...getProps({ newTab: true })} />)
+
+    const linkButton = screen.getByRole("link")
+    expect(linkButton).toHaveAttribute("target", "_blank")
+    expect(linkButton).toHaveAttribute("rel", "noreferrer")
+  })
+
+  it("opens in the same tab when newTab=false", () => {
+    render(<LinkButton {...getProps({ newTab: false })} />)
+
+    const linkButton = screen.getByRole("link")
+    expect(linkButton).not.toHaveAttribute("target")
+    expect(linkButton).not.toHaveAttribute("rel")
+  })
+
   describe("wrapped BaseLinkButton", () => {
     const LINK_BUTTON_TYPES = ["primary", "secondary", "tertiary"]
 

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -95,8 +95,8 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           disabled={element.disabled}
           onClick={handleClick}
           href={element.url}
-          target="_blank"
-          rel="noreferrer"
+          target={element.newTab ? "_blank" : undefined}
+          rel={element.newTab ? "noreferrer" : undefined}
           aria-disabled={element.disabled}
         >
           <DynamicButtonLabel

--- a/frontend/lib/src/components/elements/LinkButton/styled-components.ts
+++ b/frontend/lib/src/components/elements/LinkButton/styled-components.ts
@@ -39,12 +39,15 @@ export interface BaseLinkButtonProps {
   children: ReactNode
   autoFocus?: boolean
   href: string
-  target: string
-  rel: string
+  target?: string
+  rel?: string
   onClick: (event: MouseEvent<HTMLAnchorElement>) => void
 }
 
-type RequiredBaseLinkButtonProps = Required<BaseLinkButtonProps>
+type RequiredBaseLinkButtonProps = Required<
+  Omit<BaseLinkButtonProps, "target" | "rel">
+> &
+  Pick<BaseLinkButtonProps, "target" | "rel">
 
 function getSizeStyle(size: BaseButtonSize, theme: EmotionTheme): CSSObject {
   switch (size) {

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -812,6 +812,7 @@ class ButtonMixin:
         use_container_width: bool | None = None,
         width: Width = "content",
         shortcut: str | None = None,
+        new_tab: bool = True,
     ) -> DeltaGenerator: ...
 
     @overload
@@ -832,6 +833,7 @@ class ButtonMixin:
         use_container_width: bool | None = None,
         width: Width = "content",
         shortcut: str | None = None,
+        new_tab: bool = True,
     ) -> bool: ...
 
     @overload
@@ -852,6 +854,7 @@ class ButtonMixin:
         use_container_width: bool | None = None,
         width: Width = "content",
         shortcut: str | None = None,
+        new_tab: bool = True,
     ) -> bool: ...
 
     @gather_metrics("link_button")
@@ -872,11 +875,13 @@ class ButtonMixin:
         use_container_width: bool | None = None,
         width: Width = "content",
         shortcut: str | None = None,
+        new_tab: bool = True,
     ) -> bool | DeltaGenerator:
         r"""Display a link button element.
 
-        When clicked, a new tab will be opened to the specified URL. This will
-        create a new session for the user if directed within the app.
+        When clicked, the specified URL is opened. By default, the URL opens in
+        a new tab; set ``new_tab=False`` to open it in the same tab instead.
+        Opening the link within the app will create a new session for the user.
 
         Parameters
         ----------
@@ -919,15 +924,17 @@ class ButtonMixin:
             whether or not the button behaves like an input widget. This can
             be one of the following values:
 
-            - ``"ignore"`` (default): Streamlit opens the link in a new tab
-              and doesn't rerun the app. The button won't behave like an
-              input widget.
-            - ``"rerun"``: Streamlit opens the link in a new tab and reruns
-              the app. In this case, ``st.link_button`` returns a Boolean value
-              like ``st.button``.
-            - A ``callable``: Streamlit opens the link in a new tab, reruns
-              the app, and executes the callable at the beginning of the rerun.
-              In this case, ``st.link_button`` returns a Boolean value.
+            - ``"ignore"`` (default): Streamlit opens the link and doesn't
+              rerun the app. The button won't behave like an input widget.
+            - ``"rerun"``: Streamlit opens the link and reruns the app. In
+              this case, ``st.link_button`` returns a Boolean value like
+              ``st.button``.
+            - A ``callable``: Streamlit opens the link, reruns the app, and
+              executes the callable at the beginning of the rerun. In this
+              case, ``st.link_button`` returns a Boolean value.
+
+            Whether the link opens in a new tab or the current tab is
+            controlled by the ``new_tab`` parameter.
 
         args : list or tuple
             An optional list or tuple of args to pass to the callback when
@@ -1037,6 +1044,11 @@ class ButtonMixin:
             .. |st.button| replace:: ``st.button``
             .. _st.button: https://docs.streamlit.io/develop/api-reference/widgets/st.button
 
+        new_tab : bool
+            Whether to open the link in a new browser tab. If this is ``True``
+            (default), the link opens in a new tab. If this is ``False``, the
+            link opens in the same tab, replacing the current app.
+
         Returns
         -------
         element or bool
@@ -1084,6 +1096,7 @@ class ButtonMixin:
             icon_position=normalized_icon_position,
             width=width,
             shortcut=shortcut,
+            new_tab=new_tab,
             ctx=ctx,
         )
 
@@ -1429,6 +1442,7 @@ class ButtonMixin:
         disabled: bool = False,
         width: Width = "content",
         shortcut: str | None = None,
+        new_tab: bool = True,
         ctx: ScriptRunContext | None = None,
     ) -> bool | DeltaGenerator:
         key = to_key(key)
@@ -1472,6 +1486,7 @@ class ButtonMixin:
                 width=width,
                 icon_position=icon_position,
                 shortcut=normalized_shortcut,
+                new_tab=new_tab,
             )
 
         link_button_proto.label = label
@@ -1479,6 +1494,7 @@ class ButtonMixin:
         link_button_proto.type = type
         link_button_proto.disabled = disabled
         link_button_proto.ignore_rerun = ignore_rerun
+        link_button_proto.new_tab = new_tab
 
         if help is not None:
             link_button_proto.help = dedent(help)

--- a/lib/tests/streamlit/elements/link_button_test.py
+++ b/lib/tests/streamlit/elements/link_button_test.py
@@ -184,3 +184,41 @@ class LinkButtonTest(DeltaGeneratorTestCase):
             'The value "invalid" is not a valid emoji. '
             "Shortcodes are not allowed, please use a single character instead."
         )
+
+    def test_new_tab_default(self):
+        """Test that new_tab defaults to True on the proto."""
+        st.link_button("the label", url="https://streamlit.io")
+
+        c = self.get_delta_from_queue().new_element.link_button
+        assert c.new_tab is True
+
+    @parameterized.expand([(True,), (False,)])
+    def test_new_tab_forwards_to_proto(self, new_tab: bool) -> None:
+        """Test that the new_tab parameter is forwarded to the proto."""
+        st.link_button("the label", url="https://streamlit.io", new_tab=new_tab)
+
+        c = self.get_delta_from_queue().new_element.link_button
+        assert c.new_tab is new_tab
+
+    def test_new_tab_changes_element_id(self) -> None:
+        """new_tab should be part of the auto-computed element identity."""
+        st.link_button(
+            "the label",
+            url="https://streamlit.io",
+            on_click="rerun",
+            new_tab=True,
+        )
+        first_id = self.get_delta_from_queue().new_element.link_button.id
+
+        # Reset the run so that we don't collide with the previous element id.
+        self.script_run_ctx.reset()
+
+        st.link_button(
+            "the label",
+            url="https://streamlit.io",
+            on_click="rerun",
+            new_tab=False,
+        )
+        second_id = self.get_delta_from_queue().new_element.link_button.id
+
+        assert first_id != second_id

--- a/lib/tests/streamlit/typing/button_types.py
+++ b/lib/tests/streamlit/typing/button_types.py
@@ -251,6 +251,14 @@ if TYPE_CHECKING:
         link_button("Link", "https://example.com", shortcut=None), DeltaGenerator
     )
 
+    # Link button with new_tab parameter
+    assert_type(
+        link_button("Link", "https://example.com", new_tab=True), DeltaGenerator
+    )
+    assert_type(
+        link_button("Link", "https://example.com", new_tab=False), DeltaGenerator
+    )
+
     # Link button with on_click parameter - supports "rerun", "ignore", or callable
     assert_type(
         link_button("Link", "https://example.com", on_click="ignore"), DeltaGenerator
@@ -291,6 +299,7 @@ if TYPE_CHECKING:
             disabled=False,
             width="stretch",
             shortcut="Ctrl+Shift+S",
+            new_tab=False,
         ),
         bool,
     )

--- a/proto/streamlit/proto/LinkButton.proto
+++ b/proto/streamlit/proto/LinkButton.proto
@@ -31,4 +31,8 @@ message LinkButton {
   string shortcut = 11;
   streamlit.ButtonLikeIconPosition icon_position = 12;
   bool ignore_rerun = 13;
+
+  // If false, the link opens in the same tab instead of a new tab. Defaults to
+  // true, which preserves the original behavior of opening in a new tab.
+  bool new_tab = 14;
 }


### PR DESCRIPTION
## Summary

Closes #7464.

Adds a keyword-only `new_tab: bool = True` parameter to `st.link_button`. When `False`, the button opens the link in the same tab instead of a new one. Default `True` preserves existing behavior.

```python
st.link_button("Open docs", "https://docs.streamlit.io", new_tab=False)
```

## Design decisions

- Boolean `new_tab: bool = True` (positive-sense, defaulting to current behavior). Considered a `target: str` param but the boolean form is simpler and matches other `st.*` toggles.
- Default `True` = no behavior change for existing apps.
- When `new_tab=False`, the frontend omits both `target="_blank"` and `rel="noopener noreferrer"`.
- Included in the widget identity hash (`compute_and_register_element_id`) so that toggling the parameter creates a distinct widget.

## Test plan

- [x] Python unit tests — proto forwarding for default/True/False
- [x] Typing tests — `assert_type` coverage
- [x] Frontend RTL — anchor `target`/`rel` attributes vary by prop
- [x] E2E — DOM assertions for both branches + anti-regression on default
- [x] `make python-lint`, `make python-types`, frontend lint + typecheck — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)