### PR TITLE
[fix] Sanitize dangerous st.link_button and st.image URLs

### DIFF
--- a/e2e_playwright/st_image.py
+++ b/e2e_playwright/st_image.py
@@ -269,3 +269,12 @@ st.image(
     caption="Image with link.",
     link="https://streamlit.io",
 )
+
+# Image with a dangerous javascript: link. The frontend must neutralize this to
+# "#" to prevent XSS when the link is clicked.
+st.image(
+    img,
+    width=100,
+    caption="Image with dangerous link.",
+    link="javascript:alert('xss')",
+)

--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -30,7 +30,7 @@ from e2e_playwright.shared.app_utils import (
     goto_app,
 )
 
-IMAGE_ELEMENTS_USING_MEDIA_ENDPOINT = 42
+IMAGE_ELEMENTS_USING_MEDIA_ENDPOINT = 43
 
 
 def check_image_source_error_count(messages: list[str], expected_count: int):
@@ -371,3 +371,16 @@ def test_image_link_parameter(app: Page):
     # Test image WITHOUT link does not have a link wrapper
     unlinked_image = get_image(app, "Black Square as JPEG.")
     expect(unlinked_image.get_by_test_id("stImageLink")).to_have_count(0)
+
+
+def test_image_sanitizes_dangerous_link(app: Page):
+    """Test that a dangerous javascript: link URL is neutralized to '#'.
+
+    This relies on real-browser URL normalization that jsdom cannot fully
+    replicate, so it complements the frontend unit tests.
+    """
+    dangerous_image = get_image(app, "Image with dangerous link.")
+    link = dangerous_image.get_by_test_id("stImageLink")
+
+    expect(link).to_have_attribute("href", "#")
+    expect(link).to_have_attribute("target", "_self")

--- a/e2e_playwright/st_link_button.py
+++ b/e2e_playwright/st_link_button.py
@@ -122,3 +122,11 @@ rerun_link_clicked = st.link_button(
     on_click="rerun",
 )
 st.write("Link Button with rerun value:", rerun_link_clicked)
+
+# Link button with a dangerous javascript: URL. The frontend must neutralize
+# this to "#" to prevent XSS when the button is clicked.
+st.link_button(
+    "Dangerous Link",
+    "javascript:alert('xss')",
+    key="dangerous_link_button",
+)

--- a/e2e_playwright/st_link_button_test.py
+++ b/e2e_playwright/st_link_button_test.py
@@ -26,7 +26,7 @@ from e2e_playwright.shared.app_utils import (
     get_expander,
 )
 
-LINK_BUTTON_ELEMENTS = 19
+LINK_BUTTON_ELEMENTS = 20
 
 
 def _click_link_and_wait_for_rerun(app: Page, link: Locator) -> None:
@@ -119,6 +119,19 @@ def test_link_button_click_calls_callback(app: Page):
     expect_prefixed_markdown(
         app, "Link Button callback times clicked:", "1", exact_match=True
     )
+
+
+def test_link_button_sanitizes_dangerous_url(app: Page):
+    """Test that a dangerous javascript: URL is neutralized to '#'.
+
+    This relies on real-browser URL normalization that jsdom cannot fully
+    replicate, so it complements the frontend unit tests.
+    """
+    dangerous_link = get_element_by_key(app, "dangerous_link_button").get_by_role(
+        "link"
+    )
+    expect(dangerous_link).to_have_attribute("href", "#")
+    expect(dangerous_link).to_have_attribute("target", "_self")
 
 
 def test_link_button_click_returns_true_for_rerun(app: Page):

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -135,6 +135,24 @@ describe("ImageList Element", () => {
       const caption = screen.getByTestId("stImageCaption")
       expect(caption).toHaveTextContent("Test caption")
     })
+
+    it.each([
+      "javascript:alert(1)",
+      "JAVASCRIPT:alert(1)",
+      "java\nscript:alert(1)",
+      "vbscript:msgbox(1)",
+    ])("blocks dangerous link URLs: %s", linkUrl => {
+      const props = getProps({
+        imgs: [{ caption: "a", url: "/media/mockImage1.jpeg" }],
+        link: linkUrl,
+      })
+      render(<ImageList {...props} />)
+
+      const link = screen.getByTestId("stImageLink")
+      expect(link).toHaveAttribute("href", "#")
+      expect(link).toHaveAttribute("target", "_self")
+      expect(link).toHaveAttribute("rel", "noreferrer")
+    })
   })
 
   describe("New width configuration system", () => {

--- a/frontend/lib/src/components/elements/ImageList/ImageList.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.tsx
@@ -32,6 +32,7 @@ import Toolbar from "~lib/components/shared/Toolbar/Toolbar"
 import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
 import { useRequiredContext } from "~lib/hooks/useRequiredContext"
 import { StreamlitEndpoints } from "~lib/StreamlitEndpoints"
+import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil"
 
 import {
   StyledCaption,
@@ -97,6 +98,8 @@ const Image = ({
   link?: string
 }): ReactElement => {
   const crossOrigin = useCrossOriginAttribute(image.url)
+  const isLinkBlocked = link ? isDangerousLinkUri(link) : false
+  const href = isLinkBlocked ? BLOCKED_LINK_URI : link
 
   const imageElement = (
     <img
@@ -113,12 +116,15 @@ const Image = ({
       data-testid="stImageContainer"
       shouldStretch={shouldStretch}
     >
-      {link ? (
+      {href ? (
         <StyledImageLink
-          href={link}
-          target="_blank"
+          href={href}
+          target={isLinkBlocked ? "_self" : "_blank"}
           rel="noreferrer"
-          aria-label={image.caption || link}
+          onClick={isLinkBlocked ? event => event.preventDefault() : undefined}
+          // For blocked links, fall back to the image's alt text instead of the
+          // neutralized "#" href, which is meaningless to screen readers.
+          aria-label={image.caption || (isLinkBlocked ? undefined : link)}
           data-testid="stImageLink"
         >
           {imageElement}

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx
@@ -88,6 +88,49 @@ describe("LinkButton widget", () => {
     expect(linkButton).toBeInTheDocument()
   })
 
+  it("uses the provided URL for safe links", () => {
+    const props = getProps({ url: "https://streamlit.io/gallery" })
+    render(<LinkButton {...props} />)
+
+    const linkButton = screen.getByRole("link")
+    expect(linkButton).toHaveAttribute("href", "https://streamlit.io/gallery")
+    expect(linkButton).toHaveAttribute("target", "_blank")
+    expect(linkButton).toHaveAttribute("rel", "noreferrer")
+  })
+
+  it.each([
+    "javascript:alert(1)",
+    "JAVASCRIPT:alert(1)",
+    "java\nscript:alert(1)",
+    "vbscript:msgbox(1)",
+  ])("blocks dangerous URL: %s", url => {
+    const props = getProps({ url })
+    render(<LinkButton {...props} />)
+
+    const linkButton = screen.getByRole("link")
+    expect(linkButton).toHaveAttribute("href", "#")
+    expect(linkButton).toHaveAttribute("target", "_self")
+    expect(linkButton).toHaveAttribute("rel", "noreferrer")
+  })
+
+  it("does not trigger blocked links from shortcuts", () => {
+    const props = getProps({
+      shortcut: "Ctrl+Enter",
+      url: "javascript:alert(1)",
+    })
+    const useRegisterShortcutMock = vi.mocked(useRegisterShortcut)
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click")
+
+    render(<LinkButton {...props} />)
+
+    const { onActivate } = useRegisterShortcutMock.mock.calls[0][0]
+    onActivate()
+
+    expect(clickSpy).not.toHaveBeenCalled()
+
+    clickSpy.mockRestore()
+  })
+
   it("renders with help properly", async () => {
     const user = userEvent.setup()
     render(<LinkButton {...getProps({ help: "mockHelpText" })} />)
@@ -176,6 +219,20 @@ describe("LinkButton widget", () => {
       id: "link-id",
       ignoreRerun: false,
       disabled: true,
+    })
+    render(<LinkButton {...props} />)
+
+    await user.click(screen.getByRole("link"))
+
+    expect(props.widgetMgr.setTriggerValue).not.toHaveBeenCalled()
+  })
+
+  it("does not trigger rerun when clicking a blocked URL", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      id: "link-id",
+      ignoreRerun: false,
+      url: "javascript:alert(1)",
     })
     render(<LinkButton {...props} />)
 

--- a/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
+++ b/frontend/lib/src/components/elements/LinkButton/LinkButton.tsx
@@ -27,6 +27,7 @@ import { BaseButtonTooltip } from "~lib/components/shared/BaseButton/BaseButtonT
 import { DynamicButtonLabel } from "~lib/components/shared/BaseButton/DynamicButtonLabel"
 import { mapProtoIconPosition } from "~lib/components/shared/BaseButton/iconPosition"
 import { useRegisterShortcut } from "~lib/hooks/useRegisterShortcut"
+import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import BaseLinkButton from "./BaseLinkButton"
@@ -40,6 +41,8 @@ export interface Props {
 function LinkButton(props: Readonly<Props>): ReactElement {
   const { element, widgetMgr, fragmentId } = props
   const shortcut = element.shortcut || undefined
+  const isLinkBlocked = isDangerousLinkUri(element.url)
+  const href = isLinkBlocked ? BLOCKED_LINK_URI : element.url
 
   let kind = BaseButtonKind.SECONDARY
   if (element.type === "primary") {
@@ -51,17 +54,18 @@ function LinkButton(props: Readonly<Props>): ReactElement {
   const anchorRef = useRef<HTMLAnchorElement | null>(null)
 
   const handleShortcut = useCallback((): void => {
-    if (element.disabled) {
+    if (element.disabled || isLinkBlocked) {
       return
     }
 
     anchorRef.current?.click()
-  }, [element.disabled])
+  }, [element.disabled, isLinkBlocked])
 
   const handleClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>): void => {
-      if (element.disabled) {
-        // Prevent the link from being followed if the button is disabled.
+      if (element.disabled || isLinkBlocked) {
+        // Prevent the link from being followed if the button is disabled or
+        // if its URI uses a dangerous scheme.
         event.preventDefault()
         return
       }
@@ -70,7 +74,7 @@ function LinkButton(props: Readonly<Props>): ReactElement {
         void widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
       }
     },
-    [element, fragmentId, widgetMgr]
+    [element, fragmentId, isLinkBlocked, widgetMgr]
   )
 
   useRegisterShortcut({
@@ -94,8 +98,8 @@ function LinkButton(props: Readonly<Props>): ReactElement {
           size={BaseButtonSize.SMALL}
           disabled={element.disabled}
           onClick={handleClick}
-          href={element.url}
-          target="_blank"
+          href={href}
+          target={isLinkBlocked ? "_self" : "_blank"}
           rel="noreferrer"
           aria-disabled={element.disabled}
         >


### PR DESCRIPTION
## Describe your changes

Extends the client-side XSS mitigation from #15819 (Graphviz) to `st.link_button` and clickable `st.image` links.

- Dangerous URI schemes (`javascript:`, `vbscript:`, including forms obfuscated with C0 control characters like `java\nscript:`) are neutralized to `#` with `target="_self"`, and click / keyboard-shortcut activation no longer follows the blocked link.
- Reuses the shared `isDangerousLinkUri` / `BLOCKED_LINK_URI` helper (`frontend/lib/src/util/UriUtil.ts`) rather than duplicating the scheme blocklist.
- Blocked, caption-less linked images fall back to the image `alt` text for their accessible name instead of announcing `#`.

## GitHub Issue Link (if applicable)

SNOW-3715965

## Testing Plan

- `frontend/lib/src/components/elements/LinkButton/LinkButton.test.tsx` — safe URLs keep their `href`/`target="_blank"`; dangerous URLs render `#`/`target="_self"`; neither click nor shortcut triggers a rerun for blocked URLs
- `frontend/lib/src/components/elements/ImageList/ImageList.test.tsx` — dangerous image link URLs render `#`/`target="_self"`
- `e2e_playwright/st_link_button_test.py`, `e2e_playwright/st_image_test.py` — real-browser normalization neutralizes a `javascript:` URL to `#`

Made with [Cursor](https://cursor.com)