### PR TITLE
[fix] Surface missing httpx error for auth extra

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -110,8 +110,12 @@ snowflake = [
 ]
 # Optional dependency required for PDF rendering:
 pdf = ["streamlit-pdf>=1.0.0"]
-# Optional dependency required for auth:
-auth = ["Authlib>=1.3.2"]
+# Optional dependencies required for auth:
+auth = [
+  "Authlib>=1.3.2",
+  # Required by Authlib's Starlette integration.
+  "httpx>=0.24.1",
+]
 # Optional charting dependencies:
 charts = [
   "matplotlib>=3.0.0",

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -339,8 +339,10 @@ def _create_oauth_client(provider: str) -> tuple[Any, str]:
 
     try:
         from authlib.integrations import starlette_client
-    except ModuleNotFoundError:  # pragma: no cover - optional dependency
-        raise StreamlitMissingAuthlibError()
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        if exc.name == "authlib":
+            raise StreamlitMissingAuthlibError() from exc
+        raise
 
     auth_section = get_secrets_auth_section()
     if auth_section:

--- a/lib/streamlit/web/server/starlette/starlette_auth_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_auth_routes.py
@@ -340,7 +340,12 @@ def _create_oauth_client(provider: str) -> tuple[Any, str]:
     try:
         from authlib.integrations import starlette_client
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
-        if exc.name == "authlib":
+        # A missing module within the "authlib" namespace means Authlib itself is
+        # missing or too old to expose the Starlette integration. Any other missing
+        # module (e.g. a nested dependency like httpx) should surface its real error
+        # instead of being masked as a missing Authlib install.
+        module_name = exc.name or ""
+        if module_name == "authlib" or module_name.startswith("authlib."):
             raise StreamlitMissingAuthlibError() from exc
         raise
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -15,11 +15,13 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 from http.cookies import SimpleCookie
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
+import pytest
 from authlib.integrations import starlette_client
 from starlette.applications import Starlette
 from starlette.middleware.sessions import SessionMiddleware
@@ -28,6 +30,7 @@ from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from streamlit.errors import StreamlitMissingAuthlibError
 from streamlit.web.server.starlette import starlette_app_utils, starlette_auth_routes
 from streamlit.web.server.starlette.starlette_auth_routes import (
     _get_cookie_path,
@@ -42,9 +45,6 @@ from streamlit.web.server.starlette.starlette_server_config import (
     USER_COOKIE_NAME,
 )
 from tests.testutil import patch_config_options
-
-if TYPE_CHECKING:
-    import pytest
 
 TORNADO_SIGNED_USER_COOKIE = (
     "2|1:0|10:1780515959|15:_streamlit_user|68:"
@@ -114,6 +114,51 @@ def _patch_login_with_dummy_client(monkeypatch: pytest.MonkeyPatch) -> None:
         "_create_oauth_client",
         lambda provider: (_DummyClient(), "/redirect"),
     )
+
+
+def _mock_missing_starlette_client_import(missing_module: str) -> Any:
+    original_import = builtins.__import__
+
+    def mock_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "authlib.integrations" and "starlette_client" in fromlist:
+            raise ModuleNotFoundError(
+                f"No module named '{missing_module}'", name=missing_module
+            )
+        return original_import(name, globals, locals, fromlist, level)
+
+    return mock_import
+
+
+def test_create_oauth_client_reports_missing_authlib(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Report the auth extra install hint when Authlib itself is unavailable."""
+    monkeypatch.setattr(
+        builtins, "__import__", _mock_missing_starlette_client_import("authlib")
+    )
+
+    with pytest.raises(StreamlitMissingAuthlibError):
+        starlette_auth_routes._create_oauth_client("default")
+
+
+def test_create_oauth_client_preserves_nested_module_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preserve nested import failures from Authlib's Starlette integration."""
+    monkeypatch.setattr(
+        builtins, "__import__", _mock_missing_starlette_client_import("httpx")
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="httpx") as exc_info:
+        starlette_auth_routes._create_oauth_client("default")
+
+    assert exc_info.value.name == "httpx"
 
 
 def test_redirect_without_provider(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py
@@ -135,12 +135,21 @@ def _mock_missing_starlette_client_import(missing_module: str) -> Any:
     return mock_import
 
 
+@pytest.mark.parametrize(
+    "missing_module",
+    [
+        # Authlib itself is not installed.
+        "authlib",
+        # Authlib is installed but too old to expose the Starlette integration.
+        "authlib.integrations.starlette_client",
+    ],
+)
 def test_create_oauth_client_reports_missing_authlib(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, missing_module: str
 ) -> None:
-    """Report the auth extra install hint when Authlib itself is unavailable."""
+    """Report the auth extra install hint when Authlib is missing or too old."""
     monkeypatch.setattr(
-        builtins, "__import__", _mock_missing_starlette_client_import("authlib")
+        builtins, "__import__", _mock_missing_starlette_client_import(missing_module)
     )
 
     with pytest.raises(StreamlitMissingAuthlibError):


### PR DESCRIPTION
## Describe your changes

Authlib's Starlette integration depends on `httpx`, but a missing `httpx` was masked by `StreamlitMissingAuthlibError`, incorrectly telling users to install Authlib (which was already installed).

- `_create_oauth_client` now only raises `StreamlitMissingAuthlibError` when Authlib itself is missing (`exc.name == "authlib"`) and re-raises other `ModuleNotFoundError`s so the real missing dependency surfaces.
- Added `httpx>=0.24.1` to the `auth` optional dependency so `streamlit[auth]` installs a working set.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/15855

## Testing Plan

- `lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py` — Covers both the missing-Authlib case (friendly error) and the missing-nested-dependency case (original `ModuleNotFoundError` preserved).

Made with [Cursor](https://cursor.com)