### PR TITLE
[fix] Honor expose_tokens with st.App programmatic secrets

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -414,6 +414,16 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                 if origin_header and starlette_app_utils.validate_xsrf_token(
                     xsrf_token, xsrf_cookie
                 ):
+                    # Read expose_tokens lazily on connect (rather than once at
+                    # handler creation) so programmatic secrets from
+                    # ``st.App(secrets=...)``, which are merged during the ASGI
+                    # lifespan after routes are built, are honored. Resolve it
+                    # outside the defensive cookie-parsing block below so an
+                    # invalid ``expose_tokens`` config surfaces as a clear error
+                    # instead of being silently swallowed as a cookie-parsing
+                    # failure.
+                    expose_tokens = get_expose_tokens_config()
+
                     try:
                         raw_auth_cookie = _get_signed_cookie_with_chunks(
                             websocket.cookies, USER_COOKIE_NAME
@@ -430,12 +440,6 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                             )
                             if raw_token_cookie:
                                 all_tokens = json.loads(raw_token_cookie)
-
-                                # Read expose_tokens lazily on connect (rather than
-                                # once at handler creation) so programmatic secrets
-                                # from ``st.App(secrets=...)``, which are merged during
-                                # the ASGI lifespan after routes are built, are honored.
-                                expose_tokens = get_expose_tokens_config()
 
                                 filtered_tokens: dict[str, str] = {}
                                 for token_type in expose_tokens:

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -384,8 +384,6 @@ def create_websocket_handler(runtime: Runtime) -> Any:
     """
     from starlette.websockets import WebSocketDisconnect
 
-    expose_tokens = get_expose_tokens_config()
-
     async def _websocket_endpoint(websocket: WebSocket) -> None:
         # Validate origin before accepting the connection to prevent
         # cross-site WebSocket hijacking.
@@ -432,6 +430,12 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                             )
                             if raw_token_cookie:
                                 all_tokens = json.loads(raw_token_cookie)
+
+                                # Read expose_tokens lazily on connect (rather than
+                                # once at handler creation) so programmatic secrets
+                                # from ``st.App(secrets=...)``, which are merged during
+                                # the ASGI lifespan after routes are built, are honored.
+                                expose_tokens = get_expose_tokens_config()
 
                                 filtered_tokens: dict[str, str] = {}
                                 for token_type in expose_tokens:

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from streamlit.errors import StreamlitAuthError
 from streamlit.runtime import runtime_util
 from streamlit.web.server.starlette import starlette_app_utils
 from streamlit.web.server.starlette.starlette_websocket import (
@@ -508,21 +509,9 @@ class TestWebsocketHandlerUserInfoPrecedence:
 class TestWebsocketHandlerTokenExposure:
     """Tests for exposing auth tokens to ``st.user`` via the websocket handler."""
 
-    @patch_config_options(
-        {
-            "server.enableXsrfProtection": True,
-            "server.cookieSecret": "test-secret",
-            "server.enableCORS": False,
-        }
-    )
-    def test_expose_tokens_read_lazily_on_connect(self) -> None:
-        """Token filtering honors ``expose_tokens`` resolved after handler creation.
-
-        ``st.App(secrets=...)`` merges programmatic secrets during the ASGI
-        lifespan, which runs *after* the websocket route (and its handler) is
-        built. Reading ``expose_tokens`` lazily on connect ensures those late
-        secrets are honored rather than the empty config captured at build time.
-        """
+    @staticmethod
+    def _make_authenticated_websocket() -> MagicMock:
+        """Build a mock websocket carrying valid signed user and token cookies."""
         from starlette.websockets import WebSocketDisconnect
 
         cookie_payload = json.dumps(
@@ -558,10 +547,33 @@ class TestWebsocketHandlerTokenExposure:
         mock_websocket.accept = AsyncMock()
         mock_websocket.close = AsyncMock()
         mock_websocket.receive_bytes = AsyncMock(side_effect=WebSocketDisconnect())
+        return mock_websocket
 
+    @staticmethod
+    def _make_runtime() -> MagicMock:
+        """Build a mock runtime that records ``connect_session`` calls."""
         mock_runtime = MagicMock()
         mock_runtime.connect_session = MagicMock(return_value="test-session-id")
         mock_runtime.disconnect_session = MagicMock()
+        return mock_runtime
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.cookieSecret": "test-secret",
+            "server.enableCORS": False,
+        }
+    )
+    def test_expose_tokens_read_lazily_on_connect(self) -> None:
+        """Token filtering honors ``expose_tokens`` resolved after handler creation.
+
+        ``st.App(secrets=...)`` merges programmatic secrets during the ASGI
+        lifespan, which runs *after* the websocket route (and its handler) is
+        built. Reading ``expose_tokens`` lazily on connect ensures those late
+        secrets are honored rather than the empty config captured at build time.
+        """
+        mock_websocket = self._make_authenticated_websocket()
+        mock_runtime = self._make_runtime()
 
         # Build the handler while expose_tokens is still empty, mirroring the
         # state before programmatic secrets are merged during the lifespan.
@@ -600,6 +612,96 @@ class TestWebsocketHandlerTokenExposure:
         # Only the exposed "access" token should be present; the "id" token was
         # in the cookie but is not in expose_tokens, so it must be excluded.
         assert user_info["tokens"] == {"access": "access-123"}
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.cookieSecret": "test-secret",
+            "server.enableCORS": False,
+        }
+    )
+    def test_no_tokens_exposed_when_expose_tokens_empty(self) -> None:
+        """No tokens leak into ``st.user`` when ``expose_tokens`` is unset/empty.
+
+        The token cookie carries both ``access`` and ``id`` tokens, but an empty
+        ``expose_tokens`` allowlist must yield an empty ``tokens`` dict so that
+        nothing is exposed by default.
+        """
+        mock_websocket = self._make_authenticated_websocket()
+        mock_runtime = self._make_runtime()
+
+        handler = create_websocket_handler(mock_runtime)
+
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.get_expose_tokens_config",
+                return_value=[],
+            ),
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.StarletteSessionClient"
+            ) as mock_client_class,
+            patch(
+                "streamlit.web.server.starlette.starlette_app_utils.validate_xsrf_token",
+                return_value=True,
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client.aclose = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            asyncio.run(handler(mock_websocket))
+
+        call_kwargs = mock_runtime.connect_session.call_args
+        user_info = call_kwargs.kwargs.get("user_info") or call_kwargs[1].get(
+            "user_info"
+        )
+
+        assert user_info["tokens"] == {}
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.cookieSecret": "test-secret",
+            "server.enableCORS": False,
+        }
+    )
+    def test_invalid_expose_tokens_config_surfaces(self) -> None:
+        """An invalid ``expose_tokens`` config surfaces instead of being swallowed.
+
+        ``get_expose_tokens_config`` raises ``StreamlitAuthError`` for unsupported
+        values (e.g. ``["refresh"]``). Resolving it outside the defensive
+        cookie-parsing block ensures the misconfiguration propagates rather than
+        being silently logged as a cookie-parsing failure that leaves the tokens
+        empty and the connection alive.
+        """
+        mock_websocket = self._make_authenticated_websocket()
+        mock_runtime = self._make_runtime()
+
+        handler = create_websocket_handler(mock_runtime)
+
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.get_expose_tokens_config",
+                side_effect=StreamlitAuthError("Invalid expose_tokens configuration."),
+            ),
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.StarletteSessionClient"
+            ) as mock_client_class,
+            patch(
+                "streamlit.web.server.starlette.starlette_app_utils.validate_xsrf_token",
+                return_value=True,
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client.aclose = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(StreamlitAuthError):
+                asyncio.run(handler(mock_websocket))
+
+        # The misconfiguration must abort the connection rather than silently
+        # proceeding with an empty token set.
+        mock_runtime.connect_session.assert_not_called()
 
 
 class TestWebsocketHandlerMessageSize:

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -505,6 +505,103 @@ class TestWebsocketHandlerUserInfoPrecedence:
         assert user_info["is_logged_in"] is True
 
 
+class TestWebsocketHandlerTokenExposure:
+    """Tests for exposing auth tokens to ``st.user`` via the websocket handler."""
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.cookieSecret": "test-secret",
+            "server.enableCORS": False,
+        }
+    )
+    def test_expose_tokens_read_lazily_on_connect(self) -> None:
+        """Token filtering honors ``expose_tokens`` resolved after handler creation.
+
+        ``st.App(secrets=...)`` merges programmatic secrets during the ASGI
+        lifespan, which runs *after* the websocket route (and its handler) is
+        built. Reading ``expose_tokens`` lazily on connect ensures those late
+        secrets are honored rather than the empty config captured at build time.
+        """
+        from starlette.websockets import WebSocketDisconnect
+
+        cookie_payload = json.dumps(
+            {
+                "origin": "http://localhost",
+                "is_logged_in": True,
+                "email": "user@example.com",
+            }
+        )
+        signed_user_cookie = starlette_app_utils.create_signed_value(
+            "test-secret", "_streamlit_user", cookie_payload
+        )
+        signed_tokens_cookie = starlette_app_utils.create_signed_value(
+            "test-secret",
+            "_streamlit_user_tokens",
+            json.dumps({"access_token": "access-123", "id_token": "id-456"}),
+        )
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+
+        mock_websocket = MagicMock()
+        mock_websocket.headers = MagicMock()
+        mock_websocket.headers.get.side_effect = lambda key: {
+            "Origin": "http://localhost",
+            "Host": "localhost:8501",
+            "sec-websocket-protocol": f"streamlit, {xsrf_token}",
+        }.get(key)
+        mock_websocket.headers.getlist.return_value = []
+        mock_websocket.cookies = {
+            "_streamlit_user": signed_user_cookie.decode("utf-8"),
+            "_streamlit_user_tokens": signed_tokens_cookie.decode("utf-8"),
+            "_streamlit_xsrf": xsrf_token,
+        }
+        mock_websocket.accept = AsyncMock()
+        mock_websocket.close = AsyncMock()
+        mock_websocket.receive_bytes = AsyncMock(side_effect=WebSocketDisconnect())
+
+        mock_runtime = MagicMock()
+        mock_runtime.connect_session = MagicMock(return_value="test-session-id")
+        mock_runtime.disconnect_session = MagicMock()
+
+        # Build the handler while expose_tokens is still empty, mirroring the
+        # state before programmatic secrets are merged during the lifespan.
+        with patch(
+            "streamlit.web.server.starlette.starlette_websocket.get_expose_tokens_config",
+            return_value=[],
+        ):
+            handler = create_websocket_handler(mock_runtime)
+
+        # Now simulate the merged secrets exposing only the access token and
+        # connect. The handler must pick up the freshly resolved config.
+        with (
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.get_expose_tokens_config",
+                return_value=["access"],
+            ),
+            patch(
+                "streamlit.web.server.starlette.starlette_websocket.StarletteSessionClient"
+            ) as mock_client_class,
+            patch(
+                "streamlit.web.server.starlette.starlette_app_utils.validate_xsrf_token",
+                return_value=True,
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client.aclose = AsyncMock()
+            mock_client_class.return_value = mock_client
+
+            asyncio.run(handler(mock_websocket))
+
+        call_kwargs = mock_runtime.connect_session.call_args
+        user_info = call_kwargs.kwargs.get("user_info") or call_kwargs[1].get(
+            "user_info"
+        )
+
+        # Only the exposed "access" token should be present; the "id" token was
+        # in the cookie but is not in expose_tokens, so it must be excluded.
+        assert user_info["tokens"] == {"access": "access-123"}
+
+
 class TestWebsocketHandlerMessageSize:
     """Tests for inbound WebSocket message size enforcement."""
 


### PR DESCRIPTION
## Describe your changes

Fixes `st.user.tokens` being empty when auth is configured via `st.App(secrets=...)` instead of a `secrets.toml` file.

- The WebSocket handler read `expose_tokens` once at route-build time. With `st.App(secrets=...)`, programmatic secrets are merged later during the ASGI lifespan (after routes are built), so the handler captured an empty config and the connect-time token filter never populated `st.user.tokens`.
- Now `expose_tokens` is resolved lazily on each WebSocket connect, when secrets are guaranteed to be available. No behavior change for the file-based `secrets.toml` path.

## GitHub Issue Link (if applicable)

- Closes #15856

## Testing Plan

- Unit Tests (Python): `lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py` — added `TestWebsocketHandlerTokenExposure` which builds the handler while `expose_tokens` is empty, then simulates secrets merged afterward and asserts the exposed token flows through to `user_info["tokens"]` (and non-exposed tokens are excluded).

Made with [Cursor](https://cursor.com)