### PR TITLE
[fix] Virtualize selectbox dropdown option list

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -254,6 +254,16 @@ v24 = st.selectbox(
 )
 st.write("value 24:", v24.name)
 
+# Large option list to exercise the dropdown's virtualization: only a small
+# window of the options should be rendered in the DOM at any time.
+v25 = st.selectbox(
+    "selectbox 25 (large virtualized list)",
+    [f"Option {i}" for i in range(1000)],
+    index=None,
+    key="selectbox_25",
+)
+st.write("value 25:", v25)
+
 # --- Bound widgets (query-params) ---
 
 v_bound = st.selectbox(

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from e2e_playwright.conftest import ImageCompareFunction
 
 
-NUM_SELECTBOXES = 27
+NUM_SELECTBOXES = 28
 
 
 def get_selectbox_input(
@@ -547,6 +547,38 @@ def test_selectbox_filter_mode_none_disables_typing_but_keeps_selection(app: Pag
 
     options.nth(1).click()
     expect_markdown(app, "value 23: No")
+
+
+def test_selectbox_virtualizes_large_option_list(app: Page):
+    """Test that a selectbox with many options only renders a small window of
+    option rows (virtualization) while keeping far-down options selectable.
+    """
+    selectbox_input = get_selectbox_input(app, "selectbox 25 (large virtualized list)")
+    selectbox_input.click()
+    # ArrowDown ensures the dropdown opens reliably (backup for pointer-triggered open).
+    selectbox_input.press("ArrowDown")
+
+    selection_dropdown = app.get_by_test_id("stSelectboxVirtualDropdown")
+    expect(selection_dropdown).to_be_visible()
+
+    options = selection_dropdown.get_by_role("option")
+    # The top of the list is rendered when the dropdown opens.
+    expect(options.first).to_be_visible()
+    expect(
+        selection_dropdown.get_by_role("option", name="Option 0", exact=True)
+    ).to_be_visible()
+
+    # Virtualization: only a small window of the 1000 options is in the DOM, so a
+    # far-down option is NOT rendered even though it exists in the collection.
+    assert options.count() < 100
+    expect(
+        selection_dropdown.get_by_role("option", name="Option 999", exact=True)
+    ).to_have_count(0)
+
+    # A far-down option can still be selected by typing to filter for it.
+    selectbox_input.fill("Option 987")
+    selectbox_input.press("Enter")
+    expect_markdown(app, "value 25: Option 987")
 
 
 # --- Query param binding tests ---

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -18,7 +18,12 @@ from typing import TYPE_CHECKING
 
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import rerun_app, wait_for_app_loaded, wait_for_app_run
+from e2e_playwright.conftest import (
+    rerun_app,
+    wait_for_app_loaded,
+    wait_for_app_run,
+    wait_until,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
@@ -570,7 +575,9 @@ def test_selectbox_virtualizes_large_option_list(app: Page):
 
     # Virtualization: only a small window of the 1000 options is in the DOM, so a
     # far-down option is NOT rendered even though it exists in the collection.
-    assert options.count() < 100
+    # Use wait_until (auto-retrying) rather than a bare assert on a snapshot
+    # count to avoid flakiness while the virtualizer settles its window.
+    wait_until(app, lambda: options.count() < 100)
     expect(
         selection_dropdown.get_by_role("option", name="Option 999", exact=True)
     ).to_have_count(0)

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -147,10 +147,14 @@ describe("Selectbox widget", () => {
 
     await openDropdown(user)
 
-    // Only a small window of the 16k options is rendered when virtualized.
+    // Only a small window of the 16k options is rendered when virtualized:
+    // an upper bound guards against rendering the full list, and asserting a
+    // mid-window option is present guards against under-rendering (e.g. a
+    // single row) that an upper bound alone would not catch.
     const renderedOptions = await screen.findAllByRole("option")
     expect(renderedOptions.length).toBeLessThan(100)
     expect(screen.getByRole("option", { name: "Option 0" })).toBeVisible()
+    expect(screen.getByRole("option", { name: "Option 5" })).toBeVisible()
     expect(
       screen.queryByRole("option", { name: "Option 15999" })
     ).not.toBeInTheDocument()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -46,6 +46,12 @@ async function openDropdown(
   await user.click(screen.getByRole("button", { name: "Open" }))
 }
 
+/** Force a non-zero viewport so the virtualizer renders a window of rows. */
+function mockVirtualizerViewport(): void {
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(320)
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(300)
+}
+
 describe("Selectbox widget", () => {
   let props: Props
 
@@ -124,6 +130,30 @@ describe("Selectbox widget", () => {
     options.forEach((option, index) => {
       expect(option).toHaveTextContent(props.options[index])
     })
+  })
+
+  it("virtualizes large option lists", async () => {
+    mockVirtualizerViewport()
+    const user = userEvent.setup()
+    const largeOptions = Array.from(
+      { length: 16_000 },
+      (_, index) => `Option ${index}`
+    )
+    props = getProps({
+      options: largeOptions,
+      value: undefined,
+    })
+    render(<Selectbox {...props} />)
+
+    await openDropdown(user)
+
+    // Only a small window of the 16k options is rendered when virtualized.
+    const renderedOptions = await screen.findAllByRole("option")
+    expect(renderedOptions.length).toBeLessThan(100)
+    expect(screen.getByRole("option", { name: "Option 0" })).toBeVisible()
+    expect(
+      screen.queryByRole("option", { name: "Option 15999" })
+    ).not.toBeInTheDocument()
   })
 
   it("could be disabled", () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -17,6 +17,7 @@
 import {
   FC,
   memo,
+  type ReactElement,
   useCallback,
   useContext,
   useEffect,
@@ -32,6 +33,8 @@ import {
   ComboBoxStateContext,
   I18nProvider,
   type Key,
+  ListLayout,
+  Virtualizer,
 } from "react-aria-components"
 
 import { streamlit } from "@streamlit/protobuf"
@@ -113,6 +116,26 @@ const DropdownController = memo<{
   return null
 })
 DropdownController.displayName = "DropdownController"
+
+/**
+ * Render a single option row for the virtualized ListBox collection.
+ *
+ * The item is received untyped because emotion's `styled(ListBox)` erases
+ * React Aria's generic item type, so we assert it back to `ComboOption`.
+ * Defined at module scope for a stable identity across renders.
+ */
+const renderOption = (item: unknown): ReactElement => {
+  const option = item as ComboOption
+  return (
+    <StyledListBoxItem
+      id={option.id}
+      textValue={option.label}
+      $isCreatable={option.isCreatable}
+    >
+      <StyledItemHighlight data-item-hl="">{option.label}</StyledItemHighlight>
+    </StyledListBoxItem>
+  )
+}
 
 const Selectbox: FC<Props> = ({
   disabled,
@@ -233,6 +256,13 @@ const Selectbox: FC<Props> = ({
     () =>
       creatableItem ? [...filteredOptions, creatableItem] : filteredOptions,
     [filteredOptions, creatableItem]
+  )
+
+  const virtualizerLayoutOptions = useMemo(
+    () => ({
+      rowSize: convertRemToPx(theme.sizes.dropdownItemHeight),
+    }),
+    [theme.sizes.dropdownItemHeight]
   )
 
   // Controlled selectedKey so RAC always knows the committed item and doesn't
@@ -510,23 +540,18 @@ const Selectbox: FC<Props> = ({
             offset={0}
             style={floatingStyles}
           >
-            <StyledListBox
-              aria-label={label ?? "Selectbox options"}
-              renderEmptyState={() => <span>No results</span>}
+            <Virtualizer
+              layout={ListLayout}
+              layoutOptions={virtualizerLayoutOptions}
             >
-              {displayOptions.map(opt => (
-                <StyledListBoxItem
-                  key={opt.id}
-                  id={opt.id}
-                  textValue={opt.label}
-                  $isCreatable={opt.isCreatable}
-                >
-                  <StyledItemHighlight data-item-hl="">
-                    {opt.label}
-                  </StyledItemHighlight>
-                </StyledListBoxItem>
-              ))}
-            </StyledListBox>
+              <StyledListBox
+                aria-label={label ?? "Selectbox options"}
+                items={displayOptions}
+                renderEmptyState={() => <span>No results</span>}
+              >
+                {renderOption}
+              </StyledListBox>
+            </Virtualizer>
           </StyledPopover>
         </ComboBox>
       </I18nProvider>


### PR DESCRIPTION
## Describe your changes

- Wrap the selectbox dropdown's option list in react-aria's `Virtualizer` (with `ListLayout`) so only the visible window of option rows is mounted in the DOM. Previously every option was rendered, so large lists (thousands of items) made opening and scrolling the dropdown slow.
- Switch `StyledListBox` to the render-prop `items` collection API (via a module-level `renderOption`), which the virtualizer requires. The fixed `rowSize` matches the existing `dropdownItemHeight`, so the dropdown looks and behaves identically for small lists.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/15863

## Testing Plan

- **Frontend unit test** — `frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx`: asserts only a small window of a 16k-option list is rendered while a far-down option stays out of the DOM.
- **E2E test** — `e2e_playwright/st_selectbox_test.py::test_selectbox_virtualizes_large_option_list` (app: `e2e_playwright/st_selectbox.py`, "selectbox 25"): verifies the 1000-option dropdown only renders a windowed subset in the DOM and that a far-down option is still selectable via typing.
- Note: the two open-dropdown snapshots (`st_selectbox-selection_dropdown`, `st_selectbox-fuzzy_matching`) may need regeneration in CI due to the changed dropdown DOM structure; manual visual QA confirmed the rendering is unchanged.

Made with [Cursor](https://cursor.com)