### PR TITLE
[fix] Disable vega-embed actions with actions: false

### DIFF
--- a/e2e_playwright/shared/vega_utils.py
+++ b/e2e_playwright/shared/vega_utils.py
@@ -19,14 +19,35 @@ if TYPE_CHECKING:
     from playwright.sync_api._generated import Locator
 
 
+def get_vega_graphics_document(chart: Locator) -> Locator:
+    """Return the Vega "graphics-document" element(s) for a chart.
+
+    Vega-embed sets ``role="graphics-document"`` on the chart container
+    (``stVegaLiteChart``) itself once the chart has rendered. This resolves that
+    element whether ``chart`` is the container itself or an ancestor of it, and
+    matches every chart when ``chart`` resolves to multiple containers.
+
+    Parameters
+    ----------
+    chart : Locator
+        A locator resolving to one or more chart containers, or an ancestor of
+        them (e.g. the element returned by ``get_element_by_key``).
+
+    Returns
+    -------
+    Locator
+        The matching ``graphics-document`` element(s).
+    """
+    return chart.locator("xpath=descendant-or-self::*[@role='graphics-document']")
+
+
 def assert_vega_chart_height(
     vega_chart: Locator,
     expected_height: int,
     description: str | None = None,
     tolerance: int = 0,
 ):
-    vega_graphics_doc = vega_chart.locator("[role='graphics-document']")
-    bbox = vega_graphics_doc.bounding_box()
+    bbox = get_vega_graphics_document(vega_chart).bounding_box()
 
     chart_info = f" ({description})" if description else ""
     assert bbox is not None, f"Vega chart{chart_info} has no bounding box"
@@ -46,8 +67,7 @@ def assert_vega_chart_width(
     description: str | None = None,
     tolerance: int = 0,
 ):
-    vega_graphics_doc = vega_chart.locator("[role='graphics-document']")
-    bbox = vega_graphics_doc.bounding_box()
+    bbox = get_vega_graphics_document(vega_chart).bounding_box()
 
     chart_info = f" ({description})" if description else ""
     assert bbox is not None, f"Vega chart{chart_info} has no bounding box"

--- a/e2e_playwright/st_altair_chart_basic_select_test.py
+++ b/e2e_playwright/st_altair_chart_basic_select_test.py
@@ -32,6 +32,7 @@ from e2e_playwright.shared.app_utils import (
     expect_prefixed_markdown,
     get_element_by_key,
 )
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 
 @dataclass
@@ -72,99 +73,51 @@ def _click(app: Page, chart: Locator, click_position: _MousePosition) -> None:
 
 
 def _get_selection_point_scatter_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(0)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(0))
 
 
 def _get_selection_interval_scatter_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(1)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(1))
 
 
 def _get_selection_interval_scatter_chart_tooltip(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(2)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(2))
 
 
 def _get_selection_point_bar_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(3)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(3))
 
 
 def _get_selection_interval_bar_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(4)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(4))
 
 
 def _get_selection_point_area_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(5)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(5))
 
 
 def _get_selection_interval_area_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(6)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(6))
 
 
 def _get_selection_point_histogram(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(7)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(7))
 
 
 def _get_selection_interval_histogram(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(8)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(8))
 
 
 def _get_in_form_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(9)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(9))
 
 
 def _get_callback_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(10)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(10))
 
 
 def _get_in_fragment_chart(app: Page) -> Locator:
-    return (
-        app.get_by_test_id("stVegaLiteChart")
-        .locator("[role='graphics-document']")
-        .nth(11)
-    )
+    return get_vega_graphics_document(app.get_by_test_id("stVegaLiteChart").nth(11))
 
 
 def test_point_bar_chart_displays_selection_text(app: Page):
@@ -474,8 +427,8 @@ def test_custom_css_class_via_key(app: Page):
 
 
 def _get_persistent_selection_chart(app: Page) -> Locator:
-    return get_element_by_key(app, "persistent_selection_chart").locator(
-        "[role='graphics-document']"
+    return get_vega_graphics_document(
+        get_element_by_key(app, "persistent_selection_chart")
     )
 
 

--- a/e2e_playwright/st_altair_chart_multiview_select_test.py
+++ b/e2e_playwright/st_altair_chart_multiview_select_test.py
@@ -31,6 +31,7 @@ from e2e_playwright.shared.app_utils import (
     expect_prefixed_markdown,
     get_element_by_key,
 )
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 
 @dataclass
@@ -71,25 +72,19 @@ def _click(app: Page, chart: Locator, click_position: _MousePosition) -> None:
 
 
 def _get_layer_chart(app: Page) -> Locator:
-    return get_element_by_key(app, "layer_chart").locator("[role='graphics-document']")
+    return get_vega_graphics_document(get_element_by_key(app, "layer_chart"))
 
 
 def _get_hconcat_chart(app: Page) -> Locator:
-    return get_element_by_key(app, "hconcat_chart").locator(
-        "[role='graphics-document']"
-    )
+    return get_vega_graphics_document(get_element_by_key(app, "hconcat_chart"))
 
 
 def _get_vconcat_chart(app: Page) -> Locator:
-    return get_element_by_key(app, "vconcat_chart").locator(
-        "[role='graphics-document']"
-    )
+    return get_vega_graphics_document(get_element_by_key(app, "vconcat_chart"))
 
 
 def _get_hconcat_multi_chart(app: Page) -> Locator:
-    return get_element_by_key(app, "hconcat_multi_chart").locator(
-        "[role='graphics-document']"
-    )
+    return get_vega_graphics_document(get_element_by_key(app, "hconcat_multi_chart"))
 
 
 def test_layer_chart_point_selection(app: Page):

--- a/e2e_playwright/st_altair_chart_test.py
+++ b/e2e_playwright/st_altair_chart_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class
 from e2e_playwright.shared.react18_utils import wait_for_react_stability
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 BASELINE_CHARTS = 9
 REGRESSION_CHART_INDEX = 9
@@ -31,15 +32,11 @@ def test_altair_chart_displays_correctly(
     charts = themed_app.get_by_test_id("stVegaLiteChart")
     expect(charts).to_have_count(NUM_CHARTS)
 
-    # Compound charts (e.g. layered charts within concatenations) may render
-    # multiple graphics documents by design. Verify each baseline chart still
-    # renders exactly one visible graphics document before snapshotting.
+    # Each chart container carries the Vega "graphics-document" ARIA role once
+    # it has rendered. Verify every baseline chart is a visible graphics
+    # document before snapshotting.
     for idx in range(BASELINE_CHARTS):
-        chart = charts.nth(idx)
-        chart_displays = chart.locator("[role='graphics-document']")
-        expect(chart_displays).to_have_count(1)
-        vega_display = chart_displays.first
-        expect(vega_display).to_be_visible()
+        expect(get_vega_graphics_document(charts.nth(idx))).to_be_visible()
 
     assert_snapshot(charts.nth(0), name="st_altair_chart-pie_chart_large_legend_items")
     assert_snapshot(charts.nth(1), name="st_altair_chart-scatter_chart_default_theme")
@@ -69,7 +66,7 @@ def test_layered_vconcat_fit_x_regression_renders(app: Page):
 
     regression_chart = charts.nth(REGRESSION_CHART_INDEX)
     expect(regression_chart).to_be_visible()
-    expect(regression_chart.locator("[role='graphics-document']")).to_have_count(1)
+    expect(get_vega_graphics_document(regression_chart)).to_have_count(1)
 
     # Issue #13974 regression signal: hidden SVG with width=0.
     rendered_chart = regression_chart.locator("canvas, svg").first
@@ -83,10 +80,11 @@ def test_vconcat_layered_facet_regression_renders(app: Page):
 
     regression_chart = charts.nth(ISSUE_14050_CHART_INDEX)
     expect(regression_chart).to_be_visible()
+    expect(get_vega_graphics_document(regression_chart)).to_have_count(1)
 
     # This issue rendered an empty chart with repeated "Infinite extent" console errors.
-    # Assert at least one rendered graphics document exists.
-    expect(regression_chart.locator("[role='graphics-document']").first).to_be_visible()
+    # Assert the chart graphic is actually rendered.
+    expect(regression_chart.locator("canvas, svg").first).to_be_visible()
 
 
 def test_check_top_level_class(app: Page):
@@ -108,9 +106,7 @@ def test_chart_tooltip_styling(app: Page, assert_snapshot: ImageCompareFunction)
     wait_for_react_stability(app)
     pie_chart.scroll_into_view_if_needed()
     wait_for_react_stability(app)
-    pie_chart.locator("[role='graphics-document']").hover(
-        position={"x": 60, "y": 60}, force=True
-    )
+    get_vega_graphics_document(pie_chart).hover(position={"x": 60, "y": 60}, force=True)
     tooltip = app.locator("#vg-tooltip-element")
     expect(tooltip).to_be_visible()
 
@@ -136,6 +132,12 @@ def test_download_chart_as_png(app: Page):
     )
     expect(download_button).to_be_visible()
 
+    # The built-in vega-embed actions menu must not be rendered at all: no
+    # menu button (summary) and no actions container (.vega-actions), which
+    # is where the action links would otherwise live.
+    expect(chart.locator("summary")).to_have_count(0)
+    expect(chart.locator(".vega-actions")).to_have_count(0)
+
     with app.expect_download() as download_info:
         download_button.click()
 
@@ -156,11 +158,6 @@ def test_show_chart_data_button(app: Page, assert_snapshot: ImageCompareFunction
     expect(toolbar_buttons).to_have_count(4)
     expect(toolbar_buttons.get_by_label("Download as PNG")).to_be_visible()
     expect(toolbar_buttons.get_by_label("Copy Vega-Lite spec")).to_be_visible()
-
-    # The built-in vega-embed actions menu must no longer be usable: no menu
-    # button (summary) and no action links (View Source / Vega Editor / export).
-    expect(chart.locator("summary")).to_have_count(0)
-    expect(chart.locator(".vega-actions a")).to_have_count(0)
 
     expect(toolbar_buttons.get_by_label("Show Data")).to_be_visible()
     toolbar_buttons.get_by_label("Show Data").click()

--- a/e2e_playwright/st_altair_chart_title_test.py
+++ b/e2e_playwright/st_altair_chart_title_test.py
@@ -15,16 +15,15 @@
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 
 def test_altair_chart_title_displays_correctly(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
-    expect(
-        app.get_by_test_id("stVegaLiteChart").locator("[role='graphics-document']")
-    ).to_have_count(2)
     charts = app.get_by_test_id("stVegaLiteChart")
     expect(charts).to_have_count(2)
+    expect(get_vega_graphics_document(charts)).to_have_count(2)
     snapshot_names = [
         "st_altair_chart_title-long_title_rendering_use_container_width_true",
         "st_altair_chart_title-long_title_rendering_use_container_width_false",

--- a/e2e_playwright/st_area_chart_test.py
+++ b/e2e_playwright/st_area_chart_test.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 TOTAL_AREA_CHARTS = 15
 
@@ -25,8 +26,9 @@ def test_area_chart_rendering(app: Page, assert_snapshot: ImageCompareFunction):
     area_chart_elements = app.get_by_test_id("stVegaLiteChart")
     expect(area_chart_elements).to_have_count(TOTAL_AREA_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(area_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(area_chart_elements)).to_have_count(
         TOTAL_AREA_CHARTS
     )
 
@@ -65,8 +67,9 @@ def test_themed_area_chart_rendering(
     area_chart_elements = themed_app.get_by_test_id("stVegaLiteChart")
     expect(area_chart_elements).to_have_count(TOTAL_AREA_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(area_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(area_chart_elements)).to_have_count(
         TOTAL_AREA_CHARTS
     )
 

--- a/e2e_playwright/st_bar_chart_test.py
+++ b/e2e_playwright/st_bar_chart_test.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 TOTAL_BAR_CHARTS = 28
 
@@ -25,8 +26,9 @@ def test_bar_chart_rendering(app: Page, assert_snapshot: ImageCompareFunction):
     bar_chart_elements = app.get_by_test_id("stVegaLiteChart")
     expect(bar_chart_elements).to_have_count(TOTAL_BAR_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(bar_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(bar_chart_elements)).to_have_count(
         TOTAL_BAR_CHARTS
     )
 
@@ -89,8 +91,9 @@ def test_themed_bar_chart_rendering(
     bar_chart_elements = themed_app.get_by_test_id("stVegaLiteChart")
     expect(bar_chart_elements).to_have_count(TOTAL_BAR_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(bar_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(bar_chart_elements)).to_have_count(
         TOTAL_BAR_CHARTS
     )
 

--- a/e2e_playwright/st_chart_builtin_colors_test.py
+++ b/e2e_playwright/st_chart_builtin_colors_test.py
@@ -25,6 +25,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import expect_no_skeletons
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 
 @pytest.fixture(scope="module")
@@ -78,8 +79,9 @@ def test_builtin_colors_with_custom_theme(
     chart_elements = app.get_by_test_id("stVegaLiteChart")
     expect(chart_elements).to_have_count(4)
 
-    # Ensure all charts have rendered their Vega graphics
-    expect(chart_elements.locator("[role='graphics-document']")).to_have_count(4)
+    # Ensure all charts have rendered their Vega graphics (the graphics-document
+    # role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(chart_elements)).to_have_count(4)
 
     # Take a single snapshot of all charts
     assert_snapshot(app, name="st_chart_builtin_colors-custom_theme")

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -34,6 +34,7 @@ from e2e_playwright.shared.app_utils import (
 from e2e_playwright.shared.dataframe_utils import (
     open_column_menu,
 )
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 modal_test_id = "stDialog"
 
@@ -495,9 +496,7 @@ def test_dialog_with_chart(app: Page):
     expect(main_dialog).to_be_visible()
 
     # Check for the chart & tooltip
-    chart = main_dialog.get_by_test_id("stVegaLiteChart").locator(
-        "[role='graphics-document']"
-    )
+    chart = get_vega_graphics_document(main_dialog.get_by_test_id("stVegaLiteChart"))
     expect(chart).to_be_visible()
     # Wait for the app to fully render (helps webkit where bounding_box can be None initially)
     wait_for_app_run(app)
@@ -520,9 +519,7 @@ def test_dialog_with_layered_chart_shows_tooltips(app: Page):
     expect(main_dialog).to_have_count(1)
     expect(main_dialog).to_be_visible()
 
-    chart = main_dialog.get_by_test_id("stVegaLiteChart").locator(
-        "[role='graphics-document']"
-    )
+    chart = get_vega_graphics_document(main_dialog.get_by_test_id("stVegaLiteChart"))
     expect(chart).to_be_visible()
     wait_for_app_run(app)
     chart.scroll_into_view_if_needed()

--- a/e2e_playwright/st_line_chart_test.py
+++ b/e2e_playwright/st_line_chart_test.py
@@ -20,6 +20,7 @@ from e2e_playwright.conftest import (
 )
 from e2e_playwright.shared.app_utils import get_element_by_key
 from e2e_playwright.shared.theme_utils import apply_theme_via_window
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 TOTAL_LINE_CHARTS = 15
 
@@ -29,8 +30,9 @@ def test_line_chart_rendering(app: Page, assert_snapshot: ImageCompareFunction):
     line_chart_elements = app.get_by_test_id("stVegaLiteChart")
     expect(line_chart_elements).to_have_count(TOTAL_LINE_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(line_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(line_chart_elements)).to_have_count(
         TOTAL_LINE_CHARTS
     )
 
@@ -64,16 +66,14 @@ def test_line_chart_width_height(app: Page, assert_snapshot: ImageCompareFunctio
     """Test that st.line_chart renders correctly with different width and height."""
     content_width_chart = app.get_by_test_id("stVegaLiteChart").nth(12)
 
-    expect(content_width_chart.locator("[role='graphics-document']")).to_have_count(1)
+    expect(get_vega_graphics_document(content_width_chart)).to_have_count(1)
     assert_snapshot(
         content_width_chart,
         name="st_line_chart-width_content",
     )
 
     stretch_height_chart_container = get_element_by_key(app, "test_height_stretch")
-    expect(
-        stretch_height_chart_container.locator("[role='graphics-document']")
-    ).to_have_count(1)
+    expect(get_vega_graphics_document(stretch_height_chart_container)).to_have_count(1)
     assert_snapshot(
         stretch_height_chart_container,
         name="st_line_chart-height_stretch",
@@ -88,9 +88,7 @@ def test_fixed_width_in_horizontal_container(
         app, "test_fixed_width_in_horizontal_container"
     )
 
-    expect(
-        fixed_width_chart_container.locator("[role='graphics-document']")
-    ).to_have_count(1)
+    expect(get_vega_graphics_document(fixed_width_chart_container)).to_have_count(1)
     assert_snapshot(
         fixed_width_chart_container,
         name="st_line_chart-fixed_width_in_horizontal_container",
@@ -106,7 +104,7 @@ def test_content_width_chart_show_data(
 
     content_width_chart = all_charts.nth(12)
     expect(content_width_chart).to_be_visible()
-    expect(content_width_chart.locator("[role='graphics-document']")).to_be_visible()
+    expect(get_vega_graphics_document(content_width_chart)).to_be_visible()
 
     # Get toolbar from parent container (standard DOM structure for Vega-Lite charts)
     toolbar = content_width_chart.locator("..").get_by_test_id("stElementToolbar")
@@ -131,8 +129,9 @@ def test_themed_line_chart_rendering(
     line_chart_elements = themed_app.get_by_test_id("stVegaLiteChart")
     expect(line_chart_elements).to_have_count(TOTAL_LINE_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(line_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(line_chart_elements)).to_have_count(
         TOTAL_LINE_CHARTS
     )
 
@@ -149,7 +148,7 @@ def test_multi_line_hover(app: Page, assert_snapshot: ImageCompareFunction):
     expect(multi_line_chart).to_be_visible()
 
     multi_line_chart.scroll_into_view_if_needed()
-    multi_line_chart.locator("[role='graphics-document']").hover(
+    get_vega_graphics_document(multi_line_chart).hover(
         position={"x": 100, "y": 100}, force=True
     )
 
@@ -165,7 +164,7 @@ def test_single_line_hover(app: Page, assert_snapshot: ImageCompareFunction):
     expect(single_line_chart).to_be_visible()
 
     single_line_chart.scroll_into_view_if_needed()
-    single_line_chart.locator("[role='graphics-document']").hover(
+    get_vega_graphics_document(single_line_chart).hover(
         position={"x": 100, "y": 100}, force=True
     )
 
@@ -183,7 +182,7 @@ def test_column_order_with_colors(app: Page, assert_snapshot: ImageCompareFuncti
     expect(column_order_chart).to_be_visible()
 
     # The chart should have 3 lines in the specified order
-    vega_display = column_order_chart.locator("[role='graphics-document']")
+    vega_display = get_vega_graphics_document(column_order_chart)
     expect(vega_display).to_be_visible()
 
     # Hover to show tooltip and verify the order

--- a/e2e_playwright/st_scatter_chart_test.py
+++ b/e2e_playwright/st_scatter_chart_test.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import check_top_level_class
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 TOTAL_SCATTER_CHARTS = 13
 
@@ -25,8 +26,9 @@ def test_scatter_chart_rendering(app: Page, assert_snapshot: ImageCompareFunctio
     scatter_chart_elements = app.get_by_test_id("stVegaLiteChart")
     expect(scatter_chart_elements).to_have_count(TOTAL_SCATTER_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(scatter_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(scatter_chart_elements)).to_have_count(
         TOTAL_SCATTER_CHARTS
     )
 
@@ -76,8 +78,9 @@ def test_themed_scatter_chart_rendering(
     scatter_chart_elements = themed_app.get_by_test_id("stVegaLiteChart")
     expect(scatter_chart_elements).to_have_count(TOTAL_SCATTER_CHARTS)
 
-    # Also make sure that all Vega display objects are rendered:
-    expect(scatter_chart_elements.locator("[role='graphics-document']")).to_have_count(
+    # Also make sure that all Vega display objects are rendered (the
+    # graphics-document role is set on each chart container once rendered):
+    expect(get_vega_graphics_document(scatter_chart_elements)).to_have_count(
         TOTAL_SCATTER_CHARTS
     )
 

--- a/e2e_playwright/st_sidebar_test.py
+++ b/e2e_playwright/st_sidebar_test.py
@@ -20,6 +20,7 @@ from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_until
 from e2e_playwright.shared.app_utils import check_top_level_class
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 
 def create_sidebar_collapsed_checker(sidebar: Locator) -> Callable[[], bool]:
@@ -113,7 +114,7 @@ def test_sidebar_chart_and_toolbar(app: Page):
 
     chart.scroll_into_view_if_needed()
 
-    graphics_doc = chart.locator("[role='graphics-document']")
+    graphics_doc = get_vega_graphics_document(chart)
     expect(graphics_doc).to_be_visible()
 
     bbox = graphics_doc.bounding_box()

--- a/e2e_playwright/st_vega_lite_chart_test.py
+++ b/e2e_playwright/st_vega_lite_chart_test.py
@@ -17,6 +17,7 @@ from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import check_top_level_class, get_button
+from e2e_playwright.shared.vega_utils import get_vega_graphics_document
 
 VEGA_LITE_CHART_COUNT = 12
 
@@ -27,8 +28,7 @@ def test_vega_lite_chart(app: Page):
     expect(vega_lite_charts).to_have_count(VEGA_LITE_CHART_COUNT)
 
     for idx in range(VEGA_LITE_CHART_COUNT):
-        chart = vega_lite_charts.nth(idx)
-        vega_display = chart.locator("[role='graphics-document']").nth(0)
+        vega_display = get_vega_graphics_document(vega_lite_charts.nth(idx))
         expect(vega_display).to_be_visible()
         expect(vega_display.locator("svg")).to_have_class("marks")
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/styled-components.ts
@@ -108,18 +108,16 @@ export const StyledVegaLiteChartContainer =
         display: "inline-block",
         boxSizing: "border-box",
 
-        ".chart-wrapper": {
-          "&.fit-x": {
-            width: "100%",
-          },
-          "&.fit-y": {
-            height: "100%",
-          },
-          // Reset pointer events on background/foreground SVG paths to display tooltips on all layers in dialogs.
-          "svg.marks g.role-scope": {
-            "path.background, path.foreground": {
-              pointerEvents: "auto",
-            },
+        "&.fit-x": {
+          width: "100%",
+        },
+        "&.fit-y": {
+          height: "100%",
+        },
+        // Reset pointer events on background/foreground SVG paths to display tooltips on all layers in dialogs.
+        "svg.marks g.role-scope": {
+          "path.background, path.foreground": {
+            pointerEvents: "auto",
           },
         },
       },

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
@@ -173,12 +173,7 @@ describe("useVegaEmbed hook", () => {
         expr: expressionInterpreter,
         tooltip: { disableDefaultStyle: true },
         defaultStyle: false,
-        actions: {
-          export: false,
-          source: false,
-          compiled: false,
-          editor: false,
-        },
+        actions: false,
       }
     )
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
@@ -139,6 +139,11 @@ export function useVegaEmbed(
           // usermeta.embedOptions (see useVegaElementPreprocessor), this prevents
           // a chart spec from using these actions to open same-origin pages with
           // serialized spec contents. We expose our own toolbar actions instead.
+          // Note: `actions: false` also changes vega-embed's DOM output: it no
+          // longer wraps the chart in a `.chart-wrapper`/`.vega-actions`
+          // structure and instead applies `role="graphics-document"` and the
+          // `fit-x`/`fit-y` sizing classes directly to this container element
+          // (which our styles and e2e locators rely on).
           actions: false,
         }
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
@@ -139,17 +139,7 @@ export function useVegaEmbed(
           // usermeta.embedOptions (see useVegaElementPreprocessor), this prevents
           // a chart spec from using these actions to open same-origin pages with
           // serialized spec contents. We expose our own toolbar actions instead.
-          // We pass an object of disabled actions rather than `actions: false` so
-          // vega-embed still renders the chart inside a `.chart-wrapper` element,
-          // preserving the DOM structure, sizing, and ARIA that our styles and
-          // e2e tests rely on. Because `defaultStyle` is false and
-          // `forceActionsMenu` is unset, no actions menu button is rendered.
-          actions: {
-            export: false,
-            source: false,
-            compiled: false,
-            editor: false,
-          },
+          actions: false,
         }
 
         const { vgSpec, view, finalize } = await embed(


### PR DESCRIPTION
## Describe your changes

Follow-up simplification to #15806 (native vega-lite chart toolbar).

- Replace the object of individually-disabled vega-embed actions with `actions: false`. Vega-embed no longer emits the `.chart-wrapper` / `.vega-actions` DOM nodes and instead sets the `graphics-document` role (and `fit-x`/`fit-y` sizing) on the chart container itself. Rendering, sizing, and the chart's ARIA (`graphics-document` + `aria-label`) are unchanged for users; the built-in actions menu stays disabled.
- Flatten the now-unnecessary `.chart-wrapper` nesting in `styled-components.ts` onto the `.vega-embed` container.
- Add a shared `get_vega_graphics_document()` e2e helper in `shared/vega_utils.py` and route the chart tests through it, so assertions resolve the role whether it sits on the chart element itself or a descendant (robust to future DOM changes).

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Frontend unit tests: `frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts` — asserts `actions: false` is passed to vega-embed.
- E2E tests: updated the vega/altair chart suite (`st_altair_chart`, `st_vega_lite_chart`, `st_line/area/bar/scatter_chart`, `st_chart_builtin_colors`, `st_altair_chart_basic_select`, `st_altair_chart_multiview_select`, `st_altair_chart_title`, `st_dialog`, `st_sidebar`) plus `shared/vega_utils.py` to resolve the `graphics-document` role via the new helper. Validated locally on chromium (122 passed, 0 failures; remaining errors are missing local snapshots only).

Made with [Cursor](https://cursor.com)