### PR TITLE
[chore] Fix flaky spinner-before-tabs test on firefox

### DIFF
--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -108,7 +108,12 @@ if st.button("Enable spinner before tabs scenario"):
 
 if st.session_state.get("show_spinner_before_tabs"):
     with st.spinner("Starting up..."):
-        time.sleep(1)
+        # st.spinner only emits its transient node if the block runs longer than
+        # its internal DELAY_SECS (0.5s). The transient node is exactly what this
+        # #14018 regression exercises (tabs replacing a spinner's TransientNode),
+        # so this sleep must stay above 0.5s. Keep a small margin; don't shorten
+        # below ~0.5s or the regression coverage is silently lost.
+        time.sleep(0.75)
 
     tab_one, tab_two = st.tabs(["tab_one", "tab_two"])
     with tab_one:

--- a/e2e_playwright/st_spinner.py
+++ b/e2e_playwright/st_spinner.py
@@ -108,12 +108,14 @@ if st.button("Enable spinner before tabs scenario"):
 
 if st.session_state.get("show_spinner_before_tabs"):
     with st.spinner("Starting up..."):
-        # st.spinner only emits its transient node if the block runs longer than
-        # its internal DELAY_SECS (0.5s). The transient node is exactly what this
-        # #14018 regression exercises (tabs replacing a spinner's TransientNode),
-        # so this sleep must stay above 0.5s. Keep a small margin; don't shorten
-        # below ~0.5s or the regression coverage is silently lost.
-        time.sleep(0.75)
+        # st.spinner only emits its transient node after an internal 0.5s delay
+        # (DELAY_SECS), enqueued from a threading.Timer. That transient node is
+        # exactly what this #14018 regression exercises (tabs replacing a
+        # spinner's TransientNode). Sleep comfortably longer than 0.5s so the
+        # timer reliably fires before the context exits (which cancels it), even
+        # when a loaded CI runner delays the callback. If the transient is never
+        # emitted, this test would silently pass without covering the regression.
+        time.sleep(1)
 
     tab_one, tab_two = st.tabs(["tab_one", "tab_two"])
     with tab_one:

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -245,10 +245,12 @@ def test_spinner_before_tabs_preserves_active_tab_and_increments_number_input(
     """
     get_button(app, "Enable spinner before tabs scenario").click()
 
-    # A spinner ("Starting up...") shows briefly before the tabs, but it is too
-    # short-lived to assert on reliably: it can disappear before Playwright polls,
-    # causing flakiness (especially on Firefox). We wait for the run to finish and
-    # assert on the resulting tabs instead.
+    # A spinner ("Starting up...") shows before the tabs, but only for a short
+    # window: st.spinner delays rendering by ~0.5s, so it appears for roughly the
+    # back half of the app's 1s sleep and is then immediately replaced by the
+    # tabs. That window can close before Playwright polls it, causing flakiness
+    # (especially on Firefox). Wait for the run to finish and assert on the
+    # resulting tabs instead.
     wait_for_app_run(app)
 
     tab_one = app.get_by_role("tab", name="tab_one")

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -245,13 +245,21 @@ def test_spinner_before_tabs_preserves_active_tab_and_increments_number_input(
     """
     get_button(app, "Enable spinner before tabs scenario").click()
 
-    # Spinner appears while the scenario is initializing.
-    expect(app.get_by_test_id("stSpinner")).to_be_visible()
+    # The scenario briefly shows a spinner ("Starting up...") that only lives for
+    # the ~1s ``time.sleep`` in the app. We intentionally do not assert on the
+    # spinner being visible here: it is transient scaffolding for this regression
+    # test, and on slower browsers (e.g. Firefox) it can be gone before Playwright
+    # polls, causing flakiness. What matters for #14018 is the state *after* the
+    # rerun, so we wait for the app run to finish and assert on the tabs instead.
     wait_for_app_run(app)
 
     tab_one = app.get_by_role("tab", name="tab_one")
     tab_two = app.get_by_role("tab", name="tab_two")
     number_input = app.get_by_role("spinbutton", name="number in tab")
+
+    # Tabs (rendered after the spinner context) should be present after the rerun.
+    expect(tab_one).to_be_visible()
+    expect(tab_two).to_be_visible()
 
     tab_two.click()
     expect(tab_two).to_have_attribute("aria-selected", "true")

--- a/e2e_playwright/st_spinner_test.py
+++ b/e2e_playwright/st_spinner_test.py
@@ -245,12 +245,10 @@ def test_spinner_before_tabs_preserves_active_tab_and_increments_number_input(
     """
     get_button(app, "Enable spinner before tabs scenario").click()
 
-    # The scenario briefly shows a spinner ("Starting up...") that only lives for
-    # the ~1s ``time.sleep`` in the app. We intentionally do not assert on the
-    # spinner being visible here: it is transient scaffolding for this regression
-    # test, and on slower browsers (e.g. Firefox) it can be gone before Playwright
-    # polls, causing flakiness. What matters for #14018 is the state *after* the
-    # rerun, so we wait for the app run to finish and assert on the tabs instead.
+    # A spinner ("Starting up...") shows briefly before the tabs, but it is too
+    # short-lived to assert on reliably: it can disappear before Playwright polls,
+    # causing flakiness (especially on Firefox). We wait for the run to finish and
+    # assert on the resulting tabs instead.
     wait_for_app_run(app)
 
     tab_one = app.get_by_role("tab", name="tab_one")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Fixes an intermittent failure of `test_spinner_before_tabs_preserves_active_tab_and_increments_number_input[firefox]` in the `playwright-e2e-tests` job.

**CI failure:** `expect(app.get_by_test_id("stSpinner")).to_be_visible()` timed out (`element(s) not found`), with an aria snapshot showing the tabs already rendered and selected.

**Root cause:** `st.spinner` intentionally delays rendering by `DELAY_SECS = 0.5s` (a `threading.Timer`) to avoid flicker. With the app's 1s `time.sleep`, the spinner is therefore only on screen for roughly the back half of the sleep (~0.5s) before it is cleared and replaced by the tabs. On a loaded CI machine (websocket latency + headless Firefox) that short window can close before Playwright's first visibility poll, so `stSpinner` is never found. The spinner assertion is incidental scaffolding — the real regression check for #14018 is that tab selection and the number-input interaction survive reruns rendered after a spinner context.

**Fix:** drop the racy transient-spinner assertion; instead rely on `wait_for_app_run` plus a deterministic tab-visibility check before the existing (unchanged) regression assertions.

The app's `time.sleep(1)` is intentionally left as-is: `st.spinner` only emits its `TransientNode` if the block runs longer than `DELAY_SECS = 0.5s`, and that transient node is exactly what #14018 exercises (a tabs `BlockNode` replacing the spinner's `TransientNode` and inheriting its anchor's children). Keeping a comfortable 0.5s margin ensures the transient is reliably emitted even when a loaded CI runner delays the timer callback — otherwise the test could silently pass without covering the regression. (Verified empirically via `AppTest` that the transient is emitted at ≥0.75s but not at 0.3s/0.1s.)

## GitHub Issue Link (if applicable)

Regression coverage for #14018 (fix was #14023).

## Testing Plan

- E2E Tests: verified 10/10 passes on Firefox, plus sanity passes on Chromium and WebKit. Confirmed the root cause by temporarily shrinking the spinner window, which reproduced the exact CI failure (`stSpinner` not found), then reverted that experiment.
- No product/behavior changes; no additional unit tests needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5eccc7b-2f2b-459d-bc3d-5109b30f83a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5eccc7b-2f2b-459d-bc3d-5109b30f83a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

