### PR TITLE
[chore] fix flaky popover programmatic-close regression test

### DIFF
--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -431,6 +431,15 @@ def test_programmatic_close_does_not_reopen_other_popover(app: Page):
     open_popover(app, "Multi pop A")
     expect(app.get_by_text("Close A")).to_be_visible()
 
+    # Wait for the open rerun to finish before clicking "Close A". open_popover
+    # only waits for the (optimistically rendered) body to appear, not for the
+    # backend rerun that commits open=True. If we click "Close A" while that
+    # rerun is still in flight, the close rerun interrupts it before popover A's
+    # open=True delta is sent. The close rerun then renders open=False, which
+    # matches the cached initial False, so no delta is sent and the frontend's
+    # optimistic open state is never corrected — leaving the body stuck open.
+    wait_for_app_run(app)
+
     # Programmatically close it via the button inside
     click_button(app, "Close A")
 
@@ -442,6 +451,12 @@ def test_programmatic_close_does_not_reopen_other_popover(app: Page):
 
     # Popover B should be open
     expect(app.get_by_text("Close B")).to_be_visible()
+
+    # Wait for popover B's open rerun to finish so that, if the #14943 bug were
+    # present, popover A would have had the chance to reopen by now. Without this
+    # wait the assertion below could pass simply because B's rerun hasn't
+    # completed yet, weakening the regression guard.
+    wait_for_app_run(app)
 
     # Popover A must NOT have reopened (the bug from #14943).
     # If it did, "Close A" would be visible in a second popover body.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Fixes an intermittent failure of `st_popover_test.py::test_programmatic_close_does_not_reopen_other_popover` reported by the `playwright-e2e-tests` job. The flake surfaced at the `expect(app.get_by_text("Close A")).not_to_be_visible()` assertion with `Actual value: visible` (popover A's body stayed open).

**Root cause (timing race, not a product regression on the normal path):** `open_popover()` only waits for the *optimistically* rendered popover body to appear — it does **not** wait for the backend rerun that commits `open=True`. The test then clicked the inner "Close A" button while that open rerun was still in flight. The close rerun interrupts the open rerun before popover A's `open=True` delta is flushed; the close rerun then renders `open=False`, which matches the cached initial `False`, so **no delta is emitted for popover A**. As a result the frontend's optimistic `open=True` (set on the trigger click) is never corrected, and the body stays stuck open.

The fix waits for the open rerun to settle before interacting, closing the race:
- `wait_for_app_run()` after opening popover A, before clicking "Close A".
- `wait_for_app_run()` after opening popover B, so the #14943 guard (A must not reopen when B opens) can't pass just because B's rerun hasn't completed yet.

No product code changes; the #14943 regression coverage is preserved.

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

Regression test for https://github.com/streamlit/streamlit/issues/14943

## Testing Plan

- E2E Tests: Deterministically reproduced the exact CI symptom locally by adding a temporary backend `time.sleep` before the two stateful popovers (so the "Close A" click reliably interrupts the "open A" rerun): the unfixed flow failed 5/5 with `Actual value: visible`, while the `wait_for_app_run` variant passed 5/5. After applying the fix, ran the real test repeatedly on chromium (target 10/10), plus a sanity pass on firefox and webkit. The temporary reproduction files were removed.
- No unit tests needed (test-only stability fix).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1036b5d-4763-4430-a3ef-2fec05db950a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1036b5d-4763-4430-a3ef-2fec05db950a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

