### PR TITLE
[fix] Remove flaky Missing Submit Button warning

### DIFF
--- a/frontend/lib/src/components/core/FormsContext.tsx
+++ b/frontend/lib/src/components/core/FormsContext.tsx
@@ -25,8 +25,7 @@ export interface FormsContextProps {
    * when forms are updated. This FormsData instance should be updated
    * from that callback.
    *
-   * Consumed by: Form, FormSubmitButton
-   * @see Form
+   * Consumed by: FormSubmitButton
    * @see FormSubmitButton
    */
   formsData: FormsData

--- a/frontend/lib/src/components/widgets/Form/Form.test.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.test.tsx
@@ -15,24 +15,12 @@
  */
 
 import { screen } from "@testing-library/react"
-import { enableMapSet, enablePatches } from "immer"
-
-import { Button as SubmitButtonProto } from "@streamlit/protobuf"
 
 import { ScriptRunState } from "~lib/ScriptRunState"
 import { renderWithContexts } from "~lib/test_util"
-import {
-  createFormsData,
-  FormsData,
-  WidgetStateManager,
-} from "~lib/WidgetStateManager"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import Form, { Props } from "./Form"
-import { FormSubmitButton } from "./FormSubmitButton"
-
-// Required by ImmerJS
-enablePatches()
-enableMapSet()
 
 describe("Form", () => {
   function getProps(props: Partial<Props> = {}): Props {
@@ -49,129 +37,53 @@ describe("Form", () => {
     }
   }
 
-  const defaultFormsData = (
-    formsDataOverrides: Partial<FormsData> = {}
-  ): FormsData => {
-    return {
-      ...createFormsData(),
-      ...formsDataOverrides,
-    }
-  }
-
   it("renders without crashing", () => {
-    renderWithContexts(<Form {...getProps()} />, {
-      formsContext: {
-        formsData: defaultFormsData(),
-      },
-    })
+    renderWithContexts(<Form {...getProps()} />)
     const formElement = screen.getByTestId("stForm")
-    expect(formElement).toBeInTheDocument()
+    expect(formElement).toBeVisible()
     expect(formElement).toHaveClass("stForm")
   })
 
-  it("does not show missing submit button error when submit button registers after form renders", () => {
-    const formId = "mockFormId"
-    let formsData = createFormsData()
-    const widgetMgr = new WidgetStateManager({
-      sendRerunBackMsg: vi.fn(),
-      formsDataChanged: newData => {
-        formsData = newData
-      },
-    })
-
-    const submitButtonElement = SubmitButtonProto.create({
-      id: "submit-button-id",
-      label: "Submit",
-      formId,
-    })
-
-    const { rerenderWithContexts } = renderWithContexts(
-      <Form {...getProps({ formId, widgetMgr })}>
-        <FormSubmitButton
-          disabled={false}
-          element={submitButtonElement}
-          widgetMgr={widgetMgr}
-        />
-      </Form>,
-      {
-        formsContext: {
-          formsData,
-        },
-        scriptRunContext: {
-          scriptRunId: "script run 123",
-          scriptRunState: ScriptRunState.RUNNING,
-        },
-      }
-    )
-
-    rerenderWithContexts(
-      <Form {...getProps({ formId, widgetMgr })}>
-        <FormSubmitButton
-          disabled={false}
-          element={submitButtonElement}
-          widgetMgr={widgetMgr}
-        />
-      </Form>,
-      {
-        formsContext: {
-          formsData,
-        },
-        scriptRunContext: {
-          scriptRunState: ScriptRunState.NOT_RUNNING,
-        },
-      }
-    )
-
-    expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
-  })
-
-  it("shows error if !hasSubmitButton && scriptRunState==NOT_RUNNING", () => {
-    const formId = "mockFormId"
-    const props = getProps({ formId })
-
-    // Start with script RUNNING, no submit button
-    const { rerenderWithContexts } = renderWithContexts(<Form {...props} />, {
-      formsContext: {
-        // default formsData has no submit buttons
-        formsData: defaultFormsData(),
-      },
-      scriptRunContext: {
-        scriptRunState: ScriptRunState.RUNNING,
-      },
-    })
-
-    // We have no Submit Button, but the app is still running
-    expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
-
-    // When the app stops running, we show an error if the submit button
-    // is still missing.
-    rerenderWithContexts(<Form {...props} />, {
+  it("does not render a missing submit button warning when the form has no submit button", () => {
+    // The frontend no longer surfaces a "Missing Submit Button" error. The
+    // requirement to include at least one submit button for a functional form
+    // is documented instead (see the st.form / st.form_submit_button
+    // docstrings). Even after the script finishes with no submit button
+    // registered, no warning should be shown.
+    renderWithContexts(<Form {...getProps()} />, {
       scriptRunContext: {
         scriptRunState: ScriptRunState.NOT_RUNNING,
       },
     })
-    expect(screen.getByText("Missing Submit Button")).toBeInTheDocument()
 
-    // If the app restarts, we continue to show the error...
-    rerenderWithContexts(<Form {...props} />, {
-      scriptRunContext: {
-        scriptRunState: ScriptRunState.RUNNING,
-      },
-    })
-    expect(screen.getByText("Missing Submit Button")).toBeInTheDocument()
-
-    // Until we get a submit button, and the error is removed immediately,
-    // regardless of ScriptRunState.
-    const formsDataWithButton = createFormsData()
-    formsDataWithButton.submitButtons.set(formId, [
-      { formId } as SubmitButtonProto,
-    ])
-    rerenderWithContexts(<Form {...props} />, {
-      formsContext: {
-        formsData: formsDataWithButton,
-      },
-    })
-    expect(screen.getByTestId("stForm")).toBeInTheDocument()
+    expect(screen.getByTestId("stForm")).toBeVisible()
     expect(screen.queryByText("Missing Submit Button")).not.toBeInTheDocument()
+  })
+
+  it("registers the form's submit behaviors with the widget manager", () => {
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg: vi.fn(),
+      formsDataChanged: vi.fn(),
+    })
+    const setFormSubmitBehaviorsSpy = vi.spyOn(
+      widgetMgr,
+      "setFormSubmitBehaviors"
+    )
+
+    renderWithContexts(
+      <Form
+        {...getProps({
+          widgetMgr,
+          clearOnSubmit: true,
+          enterToSubmit: false,
+        })}
+      />
+    )
+
+    expect(setFormSubmitBehaviorsSpy).toHaveBeenCalledWith(
+      "mockFormId",
+      true,
+      false
+    )
   })
 })

--- a/frontend/lib/src/components/widgets/Form/Form.tsx
+++ b/frontend/lib/src/components/widgets/Form/Form.tsx
@@ -14,24 +14,11 @@
  * limitations under the License.
  */
 
-import {
-  memo,
-  ReactElement,
-  ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from "react"
+import { memo, ReactElement, ReactNode, useEffect } from "react"
 
-import { FormsContext } from "~lib/components/core/FormsContext"
-import { ScriptRunContext } from "~lib/components/core/ScriptRunContext"
-import AlertElement from "~lib/components/elements/AlertElement/AlertElement"
-import { Kind } from "~lib/components/shared/AlertContainer/AlertContainer"
-import { useRequiredContext } from "~lib/hooks/useRequiredContext"
-import { ScriptRunState } from "~lib/ScriptRunState"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
-import { StyledErrorContainer, StyledForm } from "./styled-components"
+import { StyledForm } from "./styled-components"
 
 export interface Props {
   formId: string
@@ -46,14 +33,6 @@ export interface Props {
   overflow?: React.CSSProperties["overflow"]
 }
 
-const MISSING_SUBMIT_BUTTON_WARNING =
-  "**Missing Submit Button**" +
-  "\n\nThis form has no submit button, which means that user interactions will " +
-  "never be sent to your Streamlit app." +
-  "\n\nTo create a submit button, use the `st.form_submit_button()` function." +
-  "\n\nFor more information, refer to the " +
-  "[documentation for forms](https://docs.streamlit.io/develop/api-reference/execution-flow/st.form)."
-
 function Form(props: Props): ReactElement {
   const {
     formId,
@@ -65,46 +44,10 @@ function Form(props: Props): ReactElement {
     overflow,
   } = props
 
-  // Consume FormsContext to get submit button state
-  // This ensures only Form components re-render when form data changes,
-  // not all Block components in the tree.
-  const { formsData } = useRequiredContext(FormsContext)
-  const submitButtons = formsData.submitButtons.get(formId)
-  const hasSubmitButton =
-    submitButtons !== undefined && submitButtons.length > 0
-
-  // Consume ScriptRunContext to get script run state
-  const { scriptRunState } = useContext(ScriptRunContext)
-  const scriptNotRunning = scriptRunState === ScriptRunState.NOT_RUNNING
-
   // Tell WidgetStateManager if this form is `clearOnSubmit` and `enterToSubmit`
   useEffect(() => {
     widgetMgr.setFormSubmitBehaviors(formId, clearOnSubmit, enterToSubmit)
   }, [widgetMgr, formId, clearOnSubmit, enterToSubmit])
-
-  // Determine if we need to show the "missing submit button" warning.
-  // If we have a submit button, we don't show the warning, of course.
-  // If we *don't* have a submit button, then we only mutate the showWarning
-  // flag after render when the script is not running. This gives child
-  // FormSubmitButton components a chance to register themselves first.
-  const [showWarning, setShowWarning] = useState(false)
-
-  useEffect(() => {
-    if (hasSubmitButton) {
-      setShowWarning(false)
-    } else if (scriptNotRunning) {
-      setShowWarning(true)
-    }
-  }, [hasSubmitButton, scriptNotRunning])
-
-  let submitWarning: ReactElement | undefined
-  if (showWarning && !hasSubmitButton) {
-    submitWarning = (
-      <StyledErrorContainer>
-        <AlertElement body={MISSING_SUBMIT_BUTTON_WARNING} kind={Kind.ERROR} />
-      </StyledErrorContainer>
-    )
-  }
 
   return (
     <StyledForm
@@ -114,7 +57,6 @@ function Form(props: Props): ReactElement {
       overflow={overflow}
     >
       {children}
-      {submitWarning}
     </StyledForm>
   )
 }

--- a/frontend/lib/src/components/widgets/Form/styled-components.ts
+++ b/frontend/lib/src/components/widgets/Form/styled-components.ts
@@ -37,7 +37,3 @@ export const StyledForm = styled.div<StyledFormProps>(
     overflow: overflow,
   })
 )
-
-export const StyledErrorContainer = styled.div(({ theme }) => ({
-  marginTop: theme.spacing.lg,
-}))

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
@@ -70,8 +70,8 @@ Run this command with the Streamlit installation relevant to the code being edit
 | `st.expander` | Insert a multi-element container that can be expanded/collapsed. Use it for optional details that should not dominate the main page. |
 | `st.feedback` | Display a feedback widget. It supports compact user reactions such as thumbs, faces, or stars depending on configuration. |
 | `st.file_uploader` | Display a file uploader widget. It returns uploaded file objects and can support multiple files and type filtering. |
-| `st.form` | Create a form that batches elements together with a "Submit" button. Use it when several inputs should update the app together instead of on every widget change. |
-| `st.form_submit_button` | Display a form submit button. It must be used inside `st.form` and triggers the form's batched submission. |
+| `st.form` | Create a form that batches elements together with a "Submit" button. Use it when several inputs should update the app together instead of on every widget change. Every form must contain at least one `st.form_submit_button`, otherwise it's non-functional. |
+| `st.form_submit_button` | Display a form submit button. It must be used inside `st.form` and triggers the form's batched submission. A form needs at least one submit button to be functional. |
 | `st.fragment` | Decorator to turn a function into a fragment which can rerun independently of the full app. Use it to reduce rerun cost for isolated interactive sections or run independent, slow sections in parallel during full app reruns. |
 | `st.get_option` | Return the current value of a given Streamlit configuration option. Use it for runtime-aware behavior that depends on configured settings. |
 | `st.graphviz_chart` | Display a graph using the dagre-d3 library. Use it for directed graphs, diagrams, and node-edge visualizations. |

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -185,6 +185,8 @@ if submitted:
     save_user(name, email, role)
 ```
 
+**Every form must include at least one `st.form_submit_button`.** It's the only way to submit a form—without it, the form's widget values are never sent to your app and the form is non-functional. Note that `st.button` and `st.download_button` can't be placed inside a form.
+
 Use `border=False` for seamless inline forms that don't look like forms:
 
 ```python

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -96,7 +96,10 @@ class FormMixin:
 
         Forms have a few constraints:
 
-        - Every form must contain a ``st.form_submit_button``.
+        - Every form must contain at least one ``st.form_submit_button``.
+          Without a submit button, there is no way to submit the form, so the
+          values of the widgets inside it are never sent to your app and the
+          form is non-functional.
         - ``st.button`` and ``st.download_button`` cannot be added to a form.
         - Forms can appear anywhere in your app (sidebar, columns, etc),
           but they cannot be embedded inside other forms.
@@ -262,7 +265,9 @@ class FormMixin:
         When this button is clicked, all widget values inside the form will be
         sent from the user's browser to your Streamlit server in a batch.
 
-        Every form must have at least one ``st.form_submit_button``. An
+        Every form must have at least one ``st.form_submit_button``. It is the
+        only way to submit a form: without it, the widget values inside the
+        form are never sent to your app, so the form is non-functional. An
         ``st.form_submit_button`` cannot exist outside of a form.
 
         For more information about forms, check out our `docs

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1675,7 +1675,9 @@ class ButtonMixin:
         if runtime.exists():
             if is_in_form(self.dg) and not is_form_submitter:
                 raise StreamlitAPIException(
-                    f"`st.button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
+                    "`st.button()` can't be used in an `st.form()`. Use "
+                    "`st.form_submit_button()` instead to submit the form."
+                    f"{FORM_DOCS_INFO}"
                 )
             if not is_in_form(self.dg) and is_form_submitter:
                 raise StreamlitAPIException(

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -280,6 +280,8 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
                 st.button("foo")
 
         assert "`st.button()` can't be used in an `st.form()`" in str(ctx.value)
+        # The error should point users to the correct alternative.
+        assert "`st.form_submit_button()`" in str(ctx.value)
 
     def test_form_block_data(self):
         """Test that a form creates a block element with correct data."""


### PR DESCRIPTION
## Describe your changes

The "Missing Submit Button" error flashed spuriously during app load. The submit button component is lazy-loaded, so on slow connections the form rendered (and the script reported finished) before the button registered, briefly triggering the warning. Rather than patch the timing (a previous attempt in #15561 didn't fully fix it), the frontend error is removed entirely and the requirement is documented instead.

- Removed the frontend "Missing Submit Button" warning from `Form`.
- Documented that a form needs at least one `st.form_submit_button` (in the `st.form` / `st.form_submit_button` docstrings and the `developing-with-streamlit` skill references).
- The `st.button()`-in-a-form error now suggests using `st.form_submit_button()` instead.

## GitHub Issue Link (if applicable)

- Closes #14247

## Testing Plan

- `frontend/lib/src/components/widgets/Form/Form.test.tsx` — verifies no "Missing Submit Button" warning renders (even when the script is not running) and that the form's submit behaviors are registered with the widget manager.
- `lib/tests/streamlit/form_test.py` — asserts the `st.button()`-in-a-form error suggests `st.form_submit_button()`.

Made with [Cursor](https://cursor.com)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | understanding-streamlit-architecture | 1 |

</details>
<!-- agent-metrics-end -->