### PR TITLE
[fix] st.tabs panels stacking after widget rerun

### DIFF
--- a/e2e_playwright/st_tabs.py
+++ b/e2e_playwright/st_tabs.py
@@ -279,3 +279,36 @@ st.write(
     f"Tabs callback args result: "
     f"{st.session_state.get('tabs_cb_args_result', 'Not called')}"
 )
+
+# ============================================================================
+# Ordinary tabs with widget-triggered rerun
+# ============================================================================
+
+rerun_tab_names = ["Rerun All", "Rerun Indy", "Rerun Clarksville", "Rerun Fort Wayne"]
+rerun_tabs = st.tabs(rerun_tab_names)
+
+for rerun_tab, rerun_tab_name in zip(rerun_tabs, rerun_tab_names, strict=True):
+    with rerun_tab:
+        st.write(f"{rerun_tab_name} tab marker")
+        st.line_chart([1, 2, 3])
+        st.selectbox(
+            "Rerun tab select",
+            ["A", "B", "C"],
+            key=f"{rerun_tab_name}_select",
+        )
+
+# ============================================================================
+# Nested tabs with a rerun triggered from a doubly-nested widget
+# ============================================================================
+
+outer_tabs = st.tabs(["Outer A", "Outer B"])
+with outer_tabs[0]:
+    st.write("Outer A marker")
+    inner_tabs = st.tabs(["Inner 1", "Inner 2"])
+    with inner_tabs[0]:
+        st.write("Inner 1 marker")
+        st.button("Nested rerun button", key="nested_rerun_button")
+    with inner_tabs[1]:
+        st.write("Inner 2 marker")
+with outer_tabs[1]:
+    st.write("Outer B marker")

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -373,9 +373,10 @@ def _count_laid_out(locator: Locator | Page, test_id: str) -> int:
     """Count elements with the given test id that are actually laid out; hidden
     elements (``display: none``) have a null offsetParent.
     """
-    return locator.get_by_test_id(test_id).evaluate_all(
+    count = locator.get_by_test_id(test_id).evaluate_all(
         "(elements) => elements.filter(el => el.offsetParent !== null).length"
     )
+    return int(count)
 
 
 def _expect_single_visible_chart(app: Page, rerun_tabs: Locator) -> None:
@@ -385,10 +386,17 @@ def _expect_single_visible_chart(app: Page, rerun_tabs: Locator) -> None:
     wait_until(app, lambda: _count_laid_out(rerun_tabs, "stVegaLiteChart") == 1)
 
 
-def _change_active_tab_selectbox(app: Page, rerun_tabs: Locator, option: str) -> None:
-    """Change the selectbox in the active tab to trigger a widget rerun. Scoped to
-    the active tabpanel because every tab renders a selectbox with the same label.
+def _change_active_tab_selectbox(rerun_tabs: Locator, option: str) -> None:
+    """Change the selectbox in the active tab to trigger a widget rerun.
+
+    Every force-mounted tab renders a selectbox with the same label, so we scope to
+    the active tab panel. Opening the dropdown makes React Aria mark the background
+    content ``aria-hidden``, which drops any locator scoped through the panel
+    mid-interaction (inconsistently across browsers). To avoid re-resolving the
+    now-hidden input, we click it once to open the dropdown, then drive selection via
+    the page keyboard and the portaled (not-hidden) option list.
     """
+    page = rerun_tabs.page
     selectbox_input = (
         rerun_tabs.get_by_role("tabpanel")
         .get_by_test_id("stSelectbox")
@@ -396,11 +404,11 @@ def _change_active_tab_selectbox(app: Page, rerun_tabs: Locator, option: str) ->
         .locator("input")
     )
     selectbox_input.click()
-    selectbox_input.press("ArrowDown")
-    app.get_by_test_id("stSelectboxVirtualDropdown").get_by_role(
-        "option", name=option, exact=True
-    ).click()
-    wait_for_app_run(app)
+    page.keyboard.press("ArrowDown")
+    dropdown = page.get_by_test_id("stSelectboxVirtualDropdown")
+    expect(dropdown).to_be_visible()
+    dropdown.get_by_role("option", name=option, exact=True).click()
+    wait_for_app_run(page)
 
 
 def _count_visible_tab_panels(locator: Locator | Page) -> int:
@@ -440,7 +448,7 @@ def test_widget_rerun_keeps_inactive_tab_panels_hidden(app: Page):
     # Capture the number of visible panels across the whole page before the rerun.
     visible_panels_before = _count_visible_tab_panels(app)
 
-    _change_active_tab_selectbox(app, rerun_tabs, "B")
+    _change_active_tab_selectbox(rerun_tabs, "B")
 
     expect(rerun_tabs.get_by_role("tablist")).to_be_visible()
     expect(rerun_tabs.get_by_role("tab", name="Rerun All")).to_have_attribute(

--- a/e2e_playwright/st_tabs_test.py
+++ b/e2e_playwright/st_tabs_test.py
@@ -14,9 +14,9 @@
 
 import re
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
@@ -29,7 +29,7 @@ from e2e_playwright.shared.app_utils import (
 
 def test_tabs_render_correctly(themed_app: Page, assert_snapshot: ImageCompareFunction):
     st_tabs = themed_app.get_by_test_id("stTabs")
-    expect(st_tabs).to_have_count(14)
+    expect(st_tabs).to_have_count(17)
 
     assert_snapshot(st_tabs.nth(0), name="st_tabs-sidebar")
     assert_snapshot(st_tabs.nth(1), name="st_tabs-text_input")
@@ -367,3 +367,124 @@ def test_keyed_tabs_persist_active_tab_across_remount(app: Page):
     expect(keyed_tabs.get_by_role("tab", name="Details")).to_have_attribute(
         "aria-selected", "true"
     )
+
+
+def _count_laid_out(locator: Locator | Page, test_id: str) -> int:
+    """Count elements with the given test id that are actually laid out; hidden
+    elements (``display: none``) have a null offsetParent.
+    """
+    return locator.get_by_test_id(test_id).evaluate_all(
+        "(elements) => elements.filter(el => el.offsetParent !== null).length"
+    )
+
+
+def _expect_single_visible_chart(app: Page, rerun_tabs: Locator) -> None:
+    """Only the active tab's chart should be laid out. Wrapped in wait_until
+    because Vega charts render asynchronously.
+    """
+    wait_until(app, lambda: _count_laid_out(rerun_tabs, "stVegaLiteChart") == 1)
+
+
+def _change_active_tab_selectbox(app: Page, rerun_tabs: Locator, option: str) -> None:
+    """Change the selectbox in the active tab to trigger a widget rerun. Scoped to
+    the active tabpanel because every tab renders a selectbox with the same label.
+    """
+    selectbox_input = (
+        rerun_tabs.get_by_role("tabpanel")
+        .get_by_test_id("stSelectbox")
+        .filter(has_text="Rerun tab select")
+        .locator("input")
+    )
+    selectbox_input.click()
+    selectbox_input.press("ArrowDown")
+    app.get_by_test_id("stSelectboxVirtualDropdown").get_by_role(
+        "option", name=option, exact=True
+    ).click()
+    wait_for_app_run(app)
+
+
+def _count_visible_tab_panels(locator: Locator | Page) -> int:
+    """Count tab panels that are actually laid out. Used to assert the fix keeps
+    only active panels visible.
+    """
+    return _count_laid_out(locator, "stTabPanel")
+
+
+def test_widget_rerun_keeps_inactive_tab_panels_hidden(app: Page):
+    """Regression test for #15892 and #15893.
+
+    Ordinary tabs force-mount inactive panels. A widget rerun inside the active
+    tab must not make the other panels (in these tabs, the sidebar tabs, or
+    anywhere else on the page) become visible.
+    """
+    rerun_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="Rerun Fort Wayne"))
+        .first
+    )
+    sidebar = app.get_by_test_id("stSidebar")
+
+    expect(rerun_tabs.get_by_role("tab", name="Rerun All")).to_have_attribute(
+        "aria-selected", "true"
+    )
+    expect(rerun_tabs.get_by_text("Rerun All tab marker")).to_be_visible()
+    expect(rerun_tabs.get_by_text("Rerun Indy tab marker")).not_to_be_visible()
+    _expect_single_visible_chart(app, rerun_tabs)
+
+    # Sidebar tabs use the same force-mount mechanism; only the active panel shows.
+    expect(sidebar.get_by_text("I am in the sidebar", exact=True)).to_be_visible()
+    expect(
+        sidebar.get_by_text("I'm also in the sidebar", exact=True)
+    ).not_to_be_visible()
+
+    # Capture the number of visible panels across the whole page before the rerun.
+    visible_panels_before = _count_visible_tab_panels(app)
+
+    _change_active_tab_selectbox(app, rerun_tabs, "B")
+
+    expect(rerun_tabs.get_by_role("tablist")).to_be_visible()
+    expect(rerun_tabs.get_by_role("tab", name="Rerun All")).to_have_attribute(
+        "aria-selected", "true"
+    )
+    expect(rerun_tabs.get_by_text("Rerun All tab marker")).to_be_visible()
+    expect(rerun_tabs.get_by_text("Rerun Indy tab marker")).not_to_be_visible()
+    expect(rerun_tabs.get_by_text("Rerun Clarksville tab marker")).not_to_be_visible()
+    expect(rerun_tabs.get_by_text("Rerun Fort Wayne tab marker")).not_to_be_visible()
+    _expect_single_visible_chart(app, rerun_tabs)
+
+    # Sidebar tabs must stay collapsed after the rerun.
+    expect(sidebar.get_by_text("I am in the sidebar", exact=True)).to_be_visible()
+    expect(
+        sidebar.get_by_text("I'm also in the sidebar", exact=True)
+    ).not_to_be_visible()
+
+    # The rerun must not add visible panels anywhere (the reported bug stacked all
+    # panels down the page). wait_until guards against async re-layout.
+    wait_until(app, lambda: _count_visible_tab_panels(app) == visible_panels_before)
+
+
+def test_nested_tabs_stay_collapsed_after_rerun(app: Page):
+    """Regression guard for #15892/#15893 with nested tabs: a rerun triggered from
+    a doubly-nested widget must keep exactly the active outer + active inner panel
+    visible (2 panels), not stack every nested panel.
+    """
+    nested_tabs = (
+        app.get_by_test_id("stTabs")
+        .filter(has=app.get_by_role("tab", name="Outer A"))
+        .first
+    )
+
+    expect(nested_tabs.get_by_text("Outer A marker")).to_be_visible()
+    expect(nested_tabs.get_by_text("Inner 1 marker")).to_be_visible()
+    expect(nested_tabs.get_by_text("Inner 2 marker")).not_to_be_visible()
+    expect(nested_tabs.get_by_text("Outer B marker")).not_to_be_visible()
+    # Active outer panel + active inner panel = 2 visible panels in this group.
+    wait_until(app, lambda: _count_visible_tab_panels(nested_tabs) == 2)
+
+    click_button(app, "Nested rerun button")
+
+    expect(nested_tabs.get_by_text("Outer A marker")).to_be_visible()
+    expect(nested_tabs.get_by_text("Inner 1 marker")).to_be_visible()
+    expect(nested_tabs.get_by_text("Inner 2 marker")).not_to_be_visible()
+    expect(nested_tabs.get_by_text("Outer B marker")).not_to_be_visible()
+    wait_until(app, lambda: _count_visible_tab_panels(nested_tabs) == 2)

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -168,16 +168,22 @@ describe("st.tabs", () => {
   })
 
   it("renders all tab panels in the DOM but only shows the active one", () => {
-    const { container } = render(<Tabs {...getProps()} />)
+    render(<Tabs {...getProps()} />)
 
-    // The active tab panel is accessible with full ARIA attributes
+    // The active tab panel is accessible and interactive (not inert).
     const activePanel = screen.getByRole("tabpanel")
     expect(activePanel).not.toHaveAttribute("inert")
 
-    // RAC force-mounts inactive panels with `inert` to keep them in the DOM
-    // (preserves scroll state) while blocking interaction and AT access
-    const inertPanels = container.querySelectorAll("[inert]")
-    expect(inertPanels).toHaveLength(4)
+    // All panels stay mounted, but visibility is driven by our own active-tab
+    // state (display:none on inactive panels) rather than RAC's `inert`, which
+    // is unreliable across reruns (#15892, #15893).
+    const panels = screen.getAllByTestId("stTabPanel")
+    expect(panels).toHaveLength(5)
+    expect(panels[0]).toBeVisible()
+
+    panels.slice(1).forEach(panel => {
+      expect(panel).not.toBeVisible()
+    })
   })
 
   it("does not show scroll arrows when tabs don't overflow", () => {

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -411,7 +411,9 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
             }
             return (
               <StyledTabPanel
+                data-testid="stTabPanel"
                 id={String(index)}
+                $isActive={activeTabKey === index}
                 // TODO: Update to match React best practices
                 // eslint-disable-next-line @eslint-react/no-array-index-key
                 key={index}

--- a/frontend/lib/src/components/elements/Tabs/styled-components.ts
+++ b/frontend/lib/src/components/elements/Tabs/styled-components.ts
@@ -173,18 +173,24 @@ export const StyledTab = styled(RATab, {
   ...($isStale ? STALE_STYLES : {}),
 }))
 
-/** Tab panel content area. Inactive force-mounted panels receive `inert="true"` from
- * RAC (not `hidden`), which prevents interaction but does NOT hide them visually.
- * We explicitly hide [inert] panels so only the active panel is visible.
+/** Tab panel content area. All panels stay force-mounted (`shouldForceMount`) to
+ * preserve their state and scroll position across tab switches — matching the
+ * previous BaseWeb `renderAll` behavior: https://github.com/streamlit/streamlit/issues/5069
+ *
+ * Visibility is driven by Streamlit's own active-tab state (`$isActive`), not by
+ * React Aria's `inert` attribute. RAC drops `inert` from inactive panels when
+ * their content re-renders on a rerun, which previously left every panel visible
+ * and stacked down the page (#15892, #15893).
+ *
  * The active panel is focusable (RAC sets tabIndex=0 on role="tabpanel"), so we
  * suppress the default outline and show Streamlit's focus ring for keyboard users. */
-export const StyledTabPanel = styled(RATabPanel)(({ theme }) => ({
+export const StyledTabPanel = styled(RATabPanel, {
+  shouldForwardProp: prop => prop !== "$isActive",
+})<{ $isActive: boolean }>(({ theme, $isActive }) => ({
+  display: $isActive ? undefined : "none",
   paddingTop: theme.spacing.lg,
   outline: "none",
   "&[data-focus-visible]": {
     boxShadow: theme.shadows.focusRing,
-  },
-  "&[inert]": {
-    display: "none",
   },
 }))

--- a/frontend/lib/src/components/elements/Tabs/styled-components.ts
+++ b/frontend/lib/src/components/elements/Tabs/styled-components.ts
@@ -173,17 +173,17 @@ export const StyledTab = styled(RATab, {
   ...($isStale ? STALE_STYLES : {}),
 }))
 
-/** Tab panel content area. All panels stay force-mounted (`shouldForceMount`) to
- * preserve their state and scroll position across tab switches — matching the
- * previous BaseWeb `renderAll` behavior: https://github.com/streamlit/streamlit/issues/5069
+/** Tab panel content area.
  *
- * Visibility is driven by Streamlit's own active-tab state (`$isActive`), not by
- * React Aria's `inert` attribute. RAC drops `inert` from inactive panels when
- * their content re-renders on a rerun, which previously left every panel visible
- * and stacked down the page (#15892, #15893).
+ * All panels stay mounted (`shouldForceMount`) so their state and scroll
+ * position survive tab switches (see #5069).
  *
- * The active panel is focusable (RAC sets tabIndex=0 on role="tabpanel"), so we
- * suppress the default outline and show Streamlit's focus ring for keyboard users. */
+ * We control visibility via `$isActive` (`display: none` when inactive) rather
+ * than RAC's `inert`, because RAC drops `inert` from inactive panels on rerun
+ * (#15892, #15893).
+ *
+ * The active panel is focusable (RAC sets tabIndex=0), so we replace the
+ * default outline with Streamlit's focus ring. */
 export const StyledTabPanel = styled(RATabPanel, {
   shouldForwardProp: prop => prop !== "$isActive",
 })<{ $isActive: boolean }>(({ theme, $isActive }) => ({


### PR DESCRIPTION
## Describe your changes

Drive `st.tabs` panel visibility from Streamlit's own active-tab state instead of React Aria's `inert` attribute, fixing a 1.59.0 regression where a widget-triggered rerun inside a tab made every tab's content visible and stacked down the page (the tab bar disappeared until a full page reload).

- `StyledTabPanel` now hides inactive force-mounted panels via `display: none` keyed on an `$isActive` prop (the same state that drives RAC's `selectedKey`), and the old `&[inert] { display: none }` rule is removed. RAC drops `inert` from inactive panels when their content re-renders on a rerun, which was the root cause; owning visibility ourselves mirrors how the pre-migration BaseWeb implementation hid panels from its controlled `activeKey`.

## GitHub Issue Link (if applicable)

- Closes #15892
- Closes #15893

## Testing Plan

- `frontend/lib/src/components/elements/Tabs/Tabs.test.tsx` — asserts all panels stay mounted but only the active one is visible.
- `e2e_playwright/st_tabs_test.py` — `test_widget_rerun_keeps_inactive_tab_panels_hidden` (ordinary tabs + sidebar tabs + a page-wide "visible panel count doesn't grow" invariant) and `test_nested_tabs_stay_collapsed_after_rerun`. Both reproduce the reported bug and fail when the fix is reverted.

Made with [Cursor](https://cursor.com)