### PR TITLE
[fix] Abort in-flight pings on cancel to prevent zombie loops

### DIFF
--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -73,11 +73,25 @@ export function doInitPings(
   let totalTries = 0
   let uriNumber = 0
   let timeout: ReturnType<typeof setTimeout> | undefined
+  // Once cancelled, the loop must not schedule new attempts, fire new requests,
+  // or invoke any callbacks. This guards against a cancelled loop "resurrecting"
+  // itself: cancel() can be called while a request is in-flight, and without
+  // this flag the settling request would re-arm the retry timer, leaving an
+  // untracked loop running (and potentially two loops running concurrently in
+  // the bypass path).
+  let cancelled = false
+  // Used to abort in-flight health/host-config requests when the loop is
+  // cancelled (e.g. when the WebSocket reconnects), so we don't leave orphaned
+  // requests running against the server.
+  const abortController = new AbortController()
 
   // Hoist the connect() declaration.
   let connect = (): void => {}
 
   const retryImmediately = (): void => {
+    if (cancelled) {
+      return
+    }
     uriNumber++
     if (uriNumber >= uriPartsList.length) {
       uriNumber = 0
@@ -87,6 +101,9 @@ export function doInitPings(
   }
 
   const retry = (errorDetails: ErrorDetails): void => {
+    if (cancelled) {
+      return
+    }
     // Adjust retry time by +- 20% to spread out load
     const jitter = Math.random() * 0.4 - 0.2
     // Exponential backoff to reduce load from health pings when experiencing
@@ -153,6 +170,9 @@ If you are trying to access a Streamlit app running on another server, this coul
   }
 
   connect = () => {
+    if (cancelled) {
+      return
+    }
     const uriParts = uriPartsList[uriNumber]
     const healthzUri = buildHttpUri(uriParts, SERVER_PING_PATH)
 
@@ -181,14 +201,20 @@ If you are trying to access a Streamlit app running on another server, this coul
     // not to do so as it's semantically cleaner to not give the healthcheck
     // endpoint additional responsibilities.
     Promise.all([
-      fetchWithTimeout(healthzUri, PING_TIMEOUT_MS),
-      fetchWithTimeout(hostConfigUri, PING_TIMEOUT_MS),
+      fetchWithTimeout(healthzUri, PING_TIMEOUT_MS, abortController.signal),
+      fetchWithTimeout(hostConfigUri, PING_TIMEOUT_MS, abortController.signal),
     ])
       .then(([_, hostConfigResp]) => {
+        if (cancelled) {
+          return
+        }
         onHostConfigResp(hostConfigResp.data as IHostConfigProperties)
         resolve(uriNumber)
       })
       .catch((error: FetchError) => {
+        if (cancelled) {
+          return
+        }
         // If its our 6th try (retry count at which we show connection error dialog), send a client error
         // to inform the host of connection error
         const tooManyRetries = totalTries >= MAX_RETRIES_BEFORE_CLIENT_ERROR
@@ -291,10 +317,14 @@ If you are trying to access a Streamlit app running on another server, this coul
   connect()
 
   const cancel = (): void => {
+    cancelled = true
     if (notNullOrUndefined(timeout)) {
       // Use globalThis to clear timers safely without relying on window
       globalThis.clearTimeout(timeout)
     }
+    // Abort any in-flight health/host-config requests so they stop running
+    // against the server and can't re-arm the retry loop after cancellation.
+    abortController.abort()
     reject(new PingCancelledError())
   }
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1015,6 +1015,45 @@ If you are trying to access a Streamlit app running on another server, this coul
     expect(MOCK_PING_DATA.retryCallback).not.toHaveBeenCalled()
     expect(MOCK_PING_DATA.setAllowedOrigins).not.toHaveBeenCalled()
   })
+
+  it("does not apply config or resolve when an in-flight request settles successfully after cancel", async () => {
+    // Companion to the failure-path test above: exercises the success guard in
+    // the Promise.all .then, ensuring a cancelled loop can't apply host config
+    // or resolve when the in-flight requests settle successfully post-cancel.
+    const resolveInFlight: Array<(value: unknown) => void> = []
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveInFlight.push(resolve)
+        })
+    )
+    globalThis.fetch = fetchMock
+
+    const { promise, cancel } = doInitPings(
+      MOCK_PING_DATA.uri,
+      MOCK_PING_DATA.timeoutMs,
+      MOCK_PING_DATA.maxTimeoutMs,
+      MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
+      MOCK_PING_DATA.setAllowedOrigins
+    )
+
+    // Let connect() fire the health + host-config requests in parallel.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(resolveInFlight.length).toBe(2)
+
+    // Cancel while both requests are still in-flight.
+    cancel()
+    await expect(promise).rejects.toBeInstanceOf(PingCancelledError)
+
+    // Settle BOTH requests successfully. The .then guard must prevent
+    // onHostConfigResp from firing and the promise from resolving.
+    resolveInFlight.forEach(resolve => resolve(createSuccessResponse({})))
+    await vi.advanceTimersByTimeAsync(MOCK_PING_DATA.maxTimeoutMs + 100)
+
+    expect(MOCK_PING_DATA.setAllowedOrigins).not.toHaveBeenCalled()
+    expect(MOCK_PING_DATA.retryCallback).not.toHaveBeenCalled()
+  })
 })
 
 describe("WebsocketConnection", () => {

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -37,7 +37,7 @@ import {
   MAX_RETRIES_BEFORE_CLIENT_ERROR,
   PING_MINIMUM_RETRY_PERIOD_MS,
 } from "./constants"
-import { doInitPings } from "./DoInitPings"
+import { doInitPings, PingCancelledError } from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
 import { ErrorDetails, OnRetry } from "./types"
 import { Args, WebsocketConnection } from "./WebsocketConnection"
@@ -972,6 +972,48 @@ If you are trying to access a Streamlit app running on another server, this coul
         expect.any(String)
       )
     })
+  })
+
+  it("stops the loop on cancel and does not resurrect when an in-flight request settles", async () => {
+    // Simulate a hanging request that we can settle manually AFTER cancel(),
+    // reproducing the scenario where cancellation lands mid-request.
+    let rejectInFlight: ((reason?: unknown) => void) | undefined
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectInFlight = reject
+        })
+    )
+    globalThis.fetch = fetchMock
+
+    const { promise, cancel } = doInitPings(
+      MOCK_PING_DATA.uri,
+      MOCK_PING_DATA.timeoutMs,
+      MOCK_PING_DATA.maxTimeoutMs,
+      MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
+      MOCK_PING_DATA.setAllowedOrigins
+    )
+
+    // Let connect() fire the first health + host-config requests.
+    await vi.advanceTimersByTimeAsync(0)
+    const callsWhileInFlight = fetchMock.mock.calls.length
+    expect(callsWhileInFlight).toBeGreaterThan(0)
+
+    // Cancel while the requests are still in-flight.
+    cancel()
+    await expect(promise).rejects.toBeInstanceOf(PingCancelledError)
+
+    // Settle the in-flight request as a failure. Previously this would re-arm
+    // the retry loop, resurrecting a cancelled (and now untracked) ping loop.
+    rejectInFlight?.(new TypeError("Network error"))
+    await vi.advanceTimersByTimeAsync(MOCK_PING_DATA.maxTimeoutMs + 100)
+
+    // No new requests fired, no retry scheduled, and no config applied after
+    // cancellation.
+    expect(fetchMock.mock.calls.length).toBe(callsWhileInFlight)
+    expect(MOCK_PING_DATA.retryCallback).not.toHaveBeenCalled()
+    expect(MOCK_PING_DATA.setAllowedOrigins).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -481,6 +481,49 @@ describe("fetchWithTimeout", () => {
     })
   })
 
+  it("aborts the in-flight request when the external signal fires", async () => {
+    const externalController = new AbortController()
+    globalThis.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"))
+        })
+      })
+    })
+
+    const resultPromise = fetchWithTimeout(
+      mockUrl,
+      5000,
+      externalController.signal
+    )
+    externalController.abort()
+
+    await expect(resultPromise).rejects.toMatchObject({
+      name: "FetchError",
+    })
+  })
+
+  it("aborts immediately when the external signal is already aborted", async () => {
+    const externalController = new AbortController()
+    externalController.abort()
+
+    globalThis.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal?.aborted) {
+          reject(new DOMException("Aborted", "AbortError"))
+          return
+        }
+        options?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"))
+        })
+      })
+    })
+
+    await expect(
+      fetchWithTimeout(mockUrl, 5000, externalController.signal)
+    ).rejects.toMatchObject({ name: "FetchError" })
+  })
+
   it("throws FetchError with isNetworkError on TypeError", async () => {
     globalThis.fetch = vi
       .fn()

--- a/frontend/connection/src/utils.test.ts
+++ b/frontend/connection/src/utils.test.ts
@@ -498,8 +498,11 @@ describe("fetchWithTimeout", () => {
     )
     externalController.abort()
 
+    // A caller-initiated abort must be reported as an abort, not a timeout.
     await expect(resultPromise).rejects.toMatchObject({
       name: "FetchError",
+      isAborted: true,
+      isTimeout: false,
     })
   })
 
@@ -521,7 +524,11 @@ describe("fetchWithTimeout", () => {
 
     await expect(
       fetchWithTimeout(mockUrl, 5000, externalController.signal)
-    ).rejects.toMatchObject({ name: "FetchError" })
+    ).rejects.toMatchObject({
+      name: "FetchError",
+      isAborted: true,
+      isTimeout: false,
+    })
   })
 
   it("throws FetchError with isNetworkError on TypeError", async () => {

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -159,12 +159,20 @@ export class FetchError extends Error {
 
   isNetworkError: boolean
 
+  /**
+   * True when the request was aborted via a caller-supplied external signal
+   * (e.g. a cancelled ping loop) rather than the internal timeout. Lets callers
+   * distinguish an intentional cancellation from a genuine timeout.
+   */
+  isAborted: boolean
+
   constructor(
     message: string,
     url: string,
     options: {
       isTimeout?: boolean
       isNetworkError?: boolean
+      isAborted?: boolean
       response?: { status: number; statusText: string; data: unknown }
     } = {}
   ) {
@@ -173,6 +181,7 @@ export class FetchError extends Error {
     this.url = url
     this.isTimeout = options.isTimeout ?? false
     this.isNetworkError = options.isNetworkError ?? false
+    this.isAborted = options.isAborted ?? false
     this.response = options.response
   }
 }
@@ -254,8 +263,14 @@ export async function fetchWithTimeout(
       throw error
     }
 
-    // Handle AbortController timeout
+    // Handle AbortController abort. This fires for both the internal timeout and
+    // a caller-supplied external signal, which produce the same AbortError. We
+    // check the external signal first so a caller-initiated cancellation is
+    // reported as an abort rather than being misclassified as a timeout.
     if (error instanceof DOMException && error.name === "AbortError") {
+      if (externalSignal?.aborted) {
+        throw new FetchError("Request aborted", url, { isAborted: true })
+      }
       throw new FetchError("Connection timed out", url, { isTimeout: true })
     }
 

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -180,18 +180,37 @@ export class FetchError extends Error {
 /**
  * Fetch with timeout support using AbortController.
  * Normalizes different error types (timeout, network, HTTP errors) into FetchError.
+ *
+ * An optional `externalSignal` allows callers to abort the in-flight request
+ * (e.g. when a ping loop is cancelled on reconnect) in addition to the internal
+ * timeout, so we don't leave orphaned requests running against the server.
  */
 export async function fetchWithTimeout(
   url: string,
-  timeoutMs: number
+  timeoutMs: number,
+  externalSignal?: AbortSignal
 ): Promise<{ data: unknown; url: string }> {
   const controller = new AbortController()
   // eslint-disable-next-line no-restricted-globals -- Network timeout utility runs outside React and cannot use hooks.
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
+  const onExternalAbort = (): void => controller.abort()
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort()
+    } else {
+      externalSignal.addEventListener("abort", onExternalAbort)
+    }
+  }
+
+  const cleanup = (): void => {
+    clearTimeout(timeoutId)
+    externalSignal?.removeEventListener("abort", onExternalAbort)
+  }
+
   try {
     const response = await fetch(url, { signal: controller.signal })
-    clearTimeout(timeoutId)
+    cleanup()
 
     if (!response.ok) {
       // Server responded with error status
@@ -228,7 +247,7 @@ export async function fetchWithTimeout(
       return { data: text, url }
     }
   } catch (error) {
-    clearTimeout(timeoutId)
+    cleanup()
 
     // Re-throw FetchError as-is
     if (error instanceof FetchError) {


### PR DESCRIPTION
## Describe your changes
doInitPings' cancel() previously left in-flight health/host-config requests running: when such a request settled it would re-arm the retry timer, resurrecting a cancelled (and now untracked) ping loop. In bypass mode this could leave two ping loops running concurrently resulting in x2 the necessary requests.

Add a `cancelled` guard plus an AbortController so cancel() aborts outstanding requests and every scheduling/callback path bails out once cancelled. fetchWithTimeout now accepts an optional external AbortSignal so callers can tear down requests in addition to the internal timeout.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebSocket connection bootstrap and retry timing; behavior change is intentional cancellation on reconnect/disconnect, with solid unit coverage for the race.
> 
> **Overview**
> Fixes a bug where **`doInitPings` `cancel()`** did not stop work that was already in flight: when health/host-config fetches finished after cancel, they could schedule retries, apply host config, or resolve—leaving an **untracked “zombie” ping loop** (notably **duplicate loops** in host-config bypass mode).
> 
> **`doInitPings`** now sets a **`cancelled`** flag and uses an **`AbortController`**: `cancel()` aborts outstanding fetches and every path that schedules retries or runs callbacks checks **`cancelled`** first (including **`Promise.all` success/failure handlers**).
> 
> **`fetchWithTimeout`** accepts an optional external **`AbortSignal`**, wires it to the internal abort controller, and **`FetchError`** gains **`isAborted`** so caller aborts are not reported as timeouts.
> 
> Unit tests cover post-cancel settlement (success and failure) and external-signal abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95335791d1af4745e3fbd59da2c7ec34fb4a8e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->