### PR TITLE
[fix] Pin websocket base URI after successful connection

### DIFF
--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1268,6 +1268,45 @@ describe("WebsocketConnection", () => {
     expect(client.state).toBe(ConnectionState.PINGING_SERVER)
   })
 
+  it("pins to the connected URI so reconnects skip path discovery", () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "a.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "b.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+    ]
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Before connecting, all candidate URIs are probed (path discovery).
+    // @ts-expect-error - accessing private method for testing
+    expect(ws.getBaseUrisToProbe()).toEqual(baseUriPartsList)
+
+    // Simulate a successful WebSocket connection on the second URI.
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.state = ConnectionState.CONNECTING
+    // @ts-expect-error - accessing private method for testing
+    ws.stepFsm("CONNECTION_SUCCEEDED")
+
+    // Entering CONNECTED records the working URI...
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.connectedUriIndex).toBe(1)
+    // ...so reconnects probe only that URI.
+    // @ts-expect-error - accessing private method for testing
+    expect(ws.getBaseUrisToProbe()).toEqual([baseUriPartsList[1]])
+
+    ws.disconnect()
+  })
+
   it("increments message cache run count", () => {
     const incrementRunCountSpy = vi.spyOn(
       // @ts-expect-error

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1307,6 +1307,126 @@ describe("WebsocketConnection", () => {
     ws.disconnect()
   })
 
+  it("pins the connected index to the socket's URI even if uriIndex changed (bypass)", () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "a.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "b.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+    ]
+    // Pending fetch so the initial ping can't resolve and interfere.
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Simulate bypass mode: the socket was created from index 0, but a
+    // background ping has since overwritten uriIndex to a different candidate.
+    // @ts-expect-error - accessing private property for testing
+    ws.socketUriIndex = 0
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.state = ConnectionState.CONNECTING
+    // @ts-expect-error - accessing private method for testing
+    ws.stepFsm("CONNECTION_SUCCEEDED")
+
+    // The pin must follow the URI the socket actually used (0), not the
+    // clobbered uriIndex, and uriIndex is realigned to match.
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.connectedUriIndex).toBe(0)
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.uriIndex).toBe(0)
+
+    ws.disconnect()
+  })
+
+  it("remaps the resolved ping index back to the pinned URI on reconnect", async () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "other.example.com",
+        port: "9999",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "localhost",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+    ]
+    // Pending fetch so the initial ping from the constructor never resolves.
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Simulate a prior successful connection pinned to index 1.
+    // @ts-expect-error - accessing private property for testing
+    ws.connectedUriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+
+    // A reconnect ping probes only the pinned single-URI list, so doInitPings
+    // resolves index 0, which must be remapped back to the real index (1).
+    globalThis.fetch = createFetchMock()
+    // @ts-expect-error - accessing private property for testing
+    ws.state = ConnectionState.PINGING_SERVER
+    // @ts-expect-error - accessing private method for testing
+    const pingPromise = ws.pingServer()
+    await vi.advanceTimersByTimeAsync(0)
+    await pingPromise
+
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.uriIndex).toBe(1)
+
+    ws.disconnect()
+  })
+
+  it("does not overwrite the pinned URI index when a background ping resolves", async () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "localhost",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "other.example.com",
+        port: "9999",
+        pathname: "/",
+      } as URL,
+    ]
+    // Pending fetch so the initial ping from the constructor never resolves.
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Simulate an already-connected, pinned-to-index-1 state.
+    // @ts-expect-error - accessing private property for testing
+    ws.connectedUriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+
+    // The background ping resolves (index 0 for the pinned single-URI list) but
+    // the guard must keep the pinned index rather than clobbering it.
+    globalThis.fetch = createFetchMock()
+    // @ts-expect-error - accessing private method for testing
+    const bgPromise = ws.pingServerInBackground()
+    await vi.advanceTimersByTimeAsync(0)
+    await bgPromise
+
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.uriIndex).toBe(1)
+
+    ws.disconnect()
+  })
+
   it("increments message cache run count", () => {
     const incrementRunCountSpy = vi.spyOn(
       // @ts-expect-error

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1362,9 +1362,12 @@ describe("WebsocketConnection", () => {
         pathname: "/",
       } as URL,
     ]
-    // Pending fetch so the initial ping from the constructor never resolves.
+    // Pending fetch so the constructor's ping can't resolve; cancel it so it
+    // can't retry-loop during teardown.
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
     const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+    // @ts-expect-error - cancelling the constructor's auto-started ping loop
+    ws.pingRequest?.cancel()
 
     // Simulate a prior successful connection pinned to index 1.
     // @ts-expect-error - accessing private property for testing
@@ -1379,7 +1382,9 @@ describe("WebsocketConnection", () => {
     ws.state = ConnectionState.PINGING_SERVER
     // @ts-expect-error - accessing private method for testing
     const pingPromise = ws.pingServer()
-    await vi.advanceTimersByTimeAsync(0)
+    // Advance well past any scheduled initial reconnect delay before the first
+    // ping fires (reconnect pings may be delayed up to a few seconds).
+    await vi.advanceTimersByTimeAsync(4000)
     await pingPromise
 
     // @ts-expect-error - accessing private property for testing
@@ -1403,9 +1408,12 @@ describe("WebsocketConnection", () => {
         pathname: "/",
       } as URL,
     ]
-    // Pending fetch so the initial ping from the constructor never resolves.
+    // Pending fetch so the constructor's ping can't resolve; cancel it so it
+    // can't retry-loop during teardown.
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
     const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+    // @ts-expect-error - cancelling the constructor's auto-started ping loop
+    ws.pingRequest?.cancel()
 
     // Simulate an already-connected, pinned-to-index-1 state.
     // @ts-expect-error - accessing private property for testing
@@ -1413,12 +1421,12 @@ describe("WebsocketConnection", () => {
     // @ts-expect-error - accessing private property for testing
     ws.uriIndex = 1
 
-    // The background ping resolves (index 0 for the pinned single-URI list) but
-    // the guard must keep the pinned index rather than clobbering it.
+    // The background ping resolves (index 0) but the guard must keep the pinned
+    // index rather than clobbering it.
     globalThis.fetch = createFetchMock()
     // @ts-expect-error - accessing private method for testing
     const bgPromise = ws.pingServerInBackground()
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(4000)
     await bgPromise
 
     // @ts-expect-error - accessing private property for testing

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -194,6 +194,14 @@ export class WebsocketConnection {
   private connectedUriIndex?: number
 
   /**
+   * Index into baseUriPartsList used to build the currently-open WebSocket.
+   * Captured when the socket is created so that, once connected, we pin to the
+   * URI the socket actually used rather than this.uriIndex, which a background
+   * ping (bypass mode) may have overwritten before the socket's open event.
+   */
+  private socketUriIndex?: number
+
+  /**
    * To guarantee packet transmission order, this is the index of the last
    * dispatched incoming message.
    */
@@ -299,8 +307,13 @@ export class WebsocketConnection {
         break
 
       case ConnectionState.CONNECTED:
-        // Remember the URI that worked so reconnects skip path discovery.
-        this.connectedUriIndex = this.uriIndex
+        // Pin to the URI the live socket actually used (captured at socket
+        // creation), not this.uriIndex: in bypass mode a background ping can
+        // overwrite this.uriIndex before the socket's open event fires, which
+        // would otherwise pin a URI the socket never used. Also realign
+        // this.uriIndex so getBaseUriParts() and reconnects stay consistent.
+        this.connectedUriIndex = this.socketUriIndex ?? this.uriIndex
+        this.uriIndex = this.connectedUriIndex
         break
 
       default:
@@ -649,8 +662,11 @@ export class WebsocketConnection {
   }
 
   private async connectToWebSocket(): Promise<void> {
+    // Capture the index this socket is built from so that, once connected, we
+    // pin to it even if a background ping overwrites this.uriIndex in between.
+    this.socketUriIndex = this.uriIndex
     const uri = buildWsUri(
-      this.args.baseUriPartsList[this.uriIndex],
+      this.args.baseUriPartsList[this.socketUriIndex],
       WEBSOCKET_STREAM_PATH
     )
 

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -188,6 +188,12 @@ export class WebsocketConnection {
   private uriIndex = 0
 
   /**
+   * Index into baseUriPartsList that the WebSocket last successfully connected
+   * on. Once set, we skip path discovery on reconnect and only probe this URI.
+   */
+  private connectedUriIndex?: number
+
+  /**
    * To guarantee packet transmission order, this is the index of the last
    * dispatched incoming message.
    */
@@ -290,6 +296,11 @@ export class WebsocketConnection {
       case ConnectionState.CONNECTED:
         this.reconnectAttempt = 0
         this.clearReconnectDelayTimeout()
+        break
+
+      case ConnectionState.CONNECTED:
+        // Remember the URI that worked so reconnects skip path discovery.
+        this.connectedUriIndex = this.uriIndex
         break
 
       default:
@@ -500,9 +511,23 @@ export class WebsocketConnection {
     }
   }
 
+  /**
+   * Returns the base URIs to probe when (re)connecting. Before the first
+   * successful connection we probe all candidates (path discovery for multipage
+   * apps). Once connected, we pin to the URI that worked so reconnects don't
+   * re-run discovery — which would double requests and risk selecting the wrong
+   * path.
+   */
+  private getBaseUrisToProbe(): URL[] {
+    if (this.connectedUriIndex !== undefined) {
+      return [this.args.baseUriPartsList[this.connectedUriIndex]]
+    }
+    return this.args.baseUriPartsList
+  }
+
   private async pingServer(): Promise<void> {
     const currentRequest = doInitPings(
-      this.args.baseUriPartsList,
+      this.getBaseUrisToProbe(),
       PING_MINIMUM_RETRY_PERIOD_MS,
       PING_MAXIMUM_RETRY_PERIOD_MS,
       this.args.onRetry,
@@ -512,7 +537,10 @@ export class WebsocketConnection {
     this.pingRequest = currentRequest
 
     try {
-      this.uriIndex = await currentRequest.promise
+      const resolvedIndex = await currentRequest.promise
+      // When probing a pinned single-URI list, doInitPings resolves index 0;
+      // map it back to the real index into baseUriPartsList.
+      this.uriIndex = this.connectedUriIndex ?? resolvedIndex
       // Only clear if we're still the active request
       if (this.pingRequest === currentRequest) {
         this.pingRequest = undefined
@@ -568,7 +596,11 @@ export class WebsocketConnection {
 
     try {
       const uriIndex = await currentRequest.promise
-      this.uriIndex = uriIndex
+      // Don't overwrite the index once the WebSocket has already connected on a
+      // URI; the connected path takes precedence over background discovery.
+      if (this.connectedUriIndex === undefined) {
+        this.uriIndex = uriIndex
+      }
       LOG.info("Background pings completed successfully")
     } catch (e) {
       if (e instanceof PingCancelledError) {

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -304,9 +304,6 @@ export class WebsocketConnection {
       case ConnectionState.CONNECTED:
         this.reconnectAttempt = 0
         this.clearReconnectDelayTimeout()
-        break
-
-      case ConnectionState.CONNECTED:
         // Pin to the URI the live socket actually used (captured at socket
         // creation), not this.uriIndex: in bypass mode a background ping can
         // overwrite this.uriIndex before the socket's open event fires, which


### PR DESCRIPTION
## Describe your changes
After the WebSocket connects on a base URI, reconnects re-ran the full path-discovery probe over every candidate URI. That doubles health/ host-config requests on reconnect and risks selecting a different path than the one that worked.

Record the URI index on entering CONNECTED and probe only that URI on reconnect (mapping the resolved index back to the real index). Background pings also stop clobbering the index once connected.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reconnect and multipage URI selection in the frontend connection FSM; behavior is well covered by new unit tests but wrong pinning could still misroute reconnects in multi-candidate deployments.
> 
> **Overview**
> **Reconnects no longer re-run full multipage path discovery** after the client has connected once. `WebsocketConnection` records `connectedUriIndex` on entering `CONNECTED`, routes health/host-config probes through `getBaseUrisToProbe()` (all candidates first, then only the pinned URI), and remaps `doInitPings`’ resolved index `0` back to the real list index on reconnect.
> 
> **Bypass races are handled** by capturing `socketUriIndex` when the WebSocket is created and pinning from that value instead of `uriIndex`, which background pings could overwrite before `open`. Background pings also stop updating `uriIndex` once a URI is pinned.
> 
> Unit tests cover pinning, bypass alignment, reconnect index remapping, and background-ping guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b6bfba229889fa1b9e59bb5a533d4160fb80b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->