### PR TITLE
[fix] Add initial jitter to reconnect and increase jitter and max reconnection times

### DIFF
--- a/frontend/connection/src/DoInitPings.tsx
+++ b/frontend/connection/src/DoInitPings.tsx
@@ -33,6 +33,7 @@ import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   HOST_CONFIG_PATH,
   MAX_RETRIES_BEFORE_CLIENT_ERROR,
+  PING_RETRY_JITTER,
   PING_TIMEOUT_MS,
   SERVER_PING_PATH,
 } from "./constants"
@@ -67,7 +68,10 @@ export function doInitPings(
     message: string,
     source: string
   ) => void,
-  onHostConfigResp: (resp: IHostConfigProperties) => void
+  onHostConfigResp: (resp: IHostConfigProperties) => void,
+  // Delay (ms) before the first ping attempt. Used on reconnect to spread a
+  // fleet of clients that dropped together; defaults to 0 (fire immediately).
+  initialDelayMs = 0
 ): AsyncPingRequest {
   const { promise, resolve, reject } = Promise.withResolvers<number>()
   let totalTries = 0
@@ -104,15 +108,23 @@ export function doInitPings(
     if (cancelled) {
       return
     }
-    // Adjust retry time by +- 20% to spread out load
-    const jitter = Math.random() * 0.4 - 0.2
-    // Exponential backoff to reduce load from health pings when experiencing
-    // persistent failure. Starts at minimumTimeoutMs.
-    const timeoutMs =
-      totalTries === 1
-        ? minimumTimeoutMs
-        : minimumTimeoutMs * 2 ** (totalTries - 1) * (1 + jitter)
-    const retryTimeout = Math.min(maximumTimeoutMs, timeoutMs)
+    // Exponential backoff to reduce load from health pings during persistent
+    // failure. We cap the backoff FIRST and apply jitter AFTER: applying jitter
+    // before the cap (the previous behavior) meant that once the exponential
+    // term exceeded the cap, the Math.min() clamp discarded the jitter and every
+    // client converged on exactly the maximum, re-synchronizing the fleet during
+    // a sustained outage precisely when spreading load matters most.
+    const cappedBackoffMs = Math.min(
+      maximumTimeoutMs,
+      minimumTimeoutMs * 2 ** (totalTries - 1)
+    )
+    // Spread retries across clients so a fleet that dropped together doesn't
+    // reconnect in lockstep. PING_RETRY_JITTER is a fraction (e.g. 0.5 ==
+    // +/-50%): pick a uniform offset fraction in [-PING_RETRY_JITTER,
+    // +PING_RETRY_JITTER) and scale the capped backoff by (1 + that), yielding a
+    // timeout in [base * (1 - PING_RETRY_JITTER), base * (1 + PING_RETRY_JITTER)).
+    const jitterFraction = (Math.random() * 2 - 1) * PING_RETRY_JITTER
+    const retryTimeout = cappedBackoffMs * (1 + jitterFraction)
 
     retryCallback(totalTries, errorDetails, retryTimeout)
 
@@ -314,7 +326,14 @@ If you are trying to access a Streamlit app running on another server, this coul
       })
   }
 
-  connect()
+  if (initialDelayMs > 0 && typeof window !== "undefined") {
+    // Delay the first attempt (reconnect only). Reuses the `timeout` handle so
+    // cancel() tears it down if we reconnect/disconnect before it fires.
+    // eslint-disable-next-line no-restricted-properties -- Ping scheduler requires a raw timer outside React.
+    timeout = globalThis.setTimeout(connect, initialDelayMs)
+  } else {
+    connect()
+  }
 
   const cancel = (): void => {
     cancelled = true

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1113,6 +1113,45 @@ describe("WebsocketConnection", () => {
     expect(client.state).toBe(ConnectionState.PINGING_SERVER)
   })
 
+  it("pins to the connected URI so reconnects skip path discovery", () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "a.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "b.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+    ]
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Before connecting, all candidate URIs are probed (path discovery).
+    // @ts-expect-error - accessing private method for testing
+    expect(ws.getBaseUrisToProbe()).toEqual(baseUriPartsList)
+
+    // Simulate a successful WebSocket connection on the second URI.
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.state = ConnectionState.CONNECTING
+    // @ts-expect-error - accessing private method for testing
+    ws.stepFsm("CONNECTION_SUCCEEDED")
+
+    // Entering CONNECTED records the working URI...
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.connectedUriIndex).toBe(1)
+    // ...so reconnects probe only that URI.
+    // @ts-expect-error - accessing private method for testing
+    expect(ws.getBaseUrisToProbe()).toEqual([baseUriPartsList[1]])
+
+    ws.disconnect()
+  })
+
   it("increments message cache run count", () => {
     const incrementRunCountSpy = vi.spyOn(
       // @ts-expect-error

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -25,7 +25,6 @@ vi.mock("@streamlit/utils", async () => {
   }
 })
 
-import { zip } from "lodash-es"
 import { MockInstance } from "vitest"
 import { default as WS } from "vitest-websocket-mock"
 
@@ -36,6 +35,7 @@ import {
   CORS_ERROR_MESSAGE_DOCUMENTATION_LINK,
   MAX_RETRIES_BEFORE_CLIENT_ERROR,
   PING_MINIMUM_RETRY_PERIOD_MS,
+  PING_RETRY_JITTER,
 } from "./constants"
 import { doInitPings, PingCancelledError } from "./DoInitPings"
 import { mockEndpoints } from "./testUtils"
@@ -158,6 +158,16 @@ function createMockArgs(overrides?: Partial<Args>): Args {
     onHostConfigResp: vi.fn(),
     ...overrides,
   }
+}
+
+/**
+ * Assert that a retry timeout falls within the jittered band for a given capped
+ * base backoff. With +/- PING_RETRY_JITTER jitter, the timeout lies in the
+ * half-open interval [base * (1 - jitter), base * (1 + jitter)).
+ */
+function expectTimeoutForBase(timeout: number, baseMs: number): void {
+  expect(timeout).toBeGreaterThanOrEqual(baseMs * (1 - PING_RETRY_JITTER))
+  expect(timeout).toBeLessThan(baseMs * (1 + PING_RETRY_JITTER))
 }
 
 /** Create a robust fetch mock that handles any number of HTTP requests */
@@ -723,15 +733,13 @@ If you are trying to access a Streamlit app running on another server, this coul
     await promise
 
     expect(timeouts.length).toEqual(5)
-    expect(timeouts[0]).toEqual(10)
-    expect(timeouts[4]).toEqual(100)
-    // timeouts should be monotonically increasing until they hit the cap
-    expect(
-      zip(timeouts.slice(0, -1), timeouts.slice(1)).every(
-        // @ts-expect-error
-        timePair => timePair[0] < timePair[1] || timePair[0] === 100
-      )
-    ).toEqual(true)
+    // Backoff doubles each attempt (10, 20, 40, 80) then caps at 100. Jitter is
+    // applied AFTER the cap, so even the capped attempt varies within its band
+    // (this is what prevents a fleet from converging on exactly the cap).
+    const expectedBases = [10, 20, 40, 80, 100]
+    timeouts.forEach((timeout, i) => {
+      expectTimeoutForBase(timeout, expectedBases[i])
+    })
   })
 
   it("backs off independently for each target url", async () => {
@@ -781,10 +789,13 @@ If you are trying to access a Streamlit app running on another server, this coul
     await promise
 
     expect(timeouts.length).toEqual(5)
-    expect(timeouts[0]).toEqual(10)
-    expect(timeouts[1]).toEqual(10)
-    expect(timeouts[2]).toBeGreaterThan(timeouts[0])
-    expect(timeouts[3]).toBeGreaterThan(timeouts[1])
+    // totalTries (and therefore the backoff level) only advances after a full
+    // round-robin over both URIs, so consecutive URIs share the same base:
+    // (10, 10) then (20, 20) then 40, each jittered.
+    const expectedBases = [10, 10, 20, 20, 40]
+    timeouts.forEach((timeout, i) => {
+      expectTimeoutForBase(timeout, expectedBases[i])
+    })
   })
 
   it("resets timeout each ping call", async () => {
@@ -871,9 +882,13 @@ If you are trying to access a Streamlit app running on another server, this coul
     await vi.runAllTimersAsync()
     await promise2
 
-    expect(timeouts[0]).toEqual(10)
-    expect(timeouts[1]).toBeGreaterThan(timeouts[0])
-    expect(timeouts2[0]).toEqual(10)
+    // First ping call backs off from the base and doubles (10 -> 20), jittered.
+    expect(timeouts.length).toEqual(2)
+    expectTimeoutForBase(timeouts[0], 10)
+    expectTimeoutForBase(timeouts[1], 20)
+    // A fresh ping call resets the backoff, starting again from the base.
+    expect(timeouts2.length).toEqual(2)
+    expectTimeoutForBase(timeouts2[0], 10)
   })
 
   describe("calls sendClientError when we've reached connection error threshold", () => {
@@ -1053,6 +1068,55 @@ If you are trying to access a Streamlit app running on another server, this coul
 
     expect(MOCK_PING_DATA.setAllowedOrigins).not.toHaveBeenCalled()
     expect(MOCK_PING_DATA.retryCallback).not.toHaveBeenCalled()
+  })
+
+  it("delays the first ping attempt by initialDelayMs (reconnect jitter)", async () => {
+    const fetchMock = createFetchMock()
+    globalThis.fetch = fetchMock
+
+    const { promise } = doInitPings(
+      MOCK_PING_DATA.uri,
+      MOCK_PING_DATA.timeoutMs,
+      MOCK_PING_DATA.maxTimeoutMs,
+      MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
+      MOCK_PING_DATA.setAllowedOrigins,
+      1000
+    )
+
+    // The first attempt is delayed: nothing fires immediately.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    // Still nothing just before the delay elapses.
+    await vi.advanceTimersByTimeAsync(999)
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    // The first ping fires once the delay elapses.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fetchMock).toHaveBeenCalled()
+
+    await promise
+  })
+
+  it("fires the first ping immediately when no initialDelayMs is given", async () => {
+    const fetchMock = createFetchMock()
+    globalThis.fetch = fetchMock
+
+    const { promise } = doInitPings(
+      MOCK_PING_DATA.uri,
+      MOCK_PING_DATA.timeoutMs,
+      MOCK_PING_DATA.maxTimeoutMs,
+      MOCK_PING_DATA.retryCallback,
+      MOCK_PING_DATA.sendClientError,
+      MOCK_PING_DATA.setAllowedOrigins
+    )
+
+    // With no delay, the first ping fires without any timer advance.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetchMock).toHaveBeenCalled()
+
+    await promise
   })
 })
 

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1207,9 +1207,12 @@ describe("WebsocketConnection", () => {
         pathname: "/",
       } as URL,
     ]
-    // Pending fetch so the initial ping from the constructor never resolves.
+    // Pending fetch so the constructor's ping can't resolve; cancel it so it
+    // can't retry-loop during teardown.
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
     const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+    // @ts-expect-error - cancelling the constructor's auto-started ping loop
+    ws.pingRequest?.cancel()
 
     // Simulate a prior successful connection pinned to index 1.
     // @ts-expect-error - accessing private property for testing
@@ -1224,7 +1227,9 @@ describe("WebsocketConnection", () => {
     ws.state = ConnectionState.PINGING_SERVER
     // @ts-expect-error - accessing private method for testing
     const pingPromise = ws.pingServer()
-    await vi.advanceTimersByTimeAsync(0)
+    // Advance well past any scheduled initial reconnect delay before the first
+    // ping fires (reconnect pings may be delayed up to a few seconds).
+    await vi.advanceTimersByTimeAsync(4000)
     await pingPromise
 
     // @ts-expect-error - accessing private property for testing
@@ -1248,9 +1253,12 @@ describe("WebsocketConnection", () => {
         pathname: "/",
       } as URL,
     ]
-    // Pending fetch so the initial ping from the constructor never resolves.
+    // Pending fetch so the constructor's ping can't resolve; cancel it so it
+    // can't retry-loop during teardown.
     globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
     const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+    // @ts-expect-error - cancelling the constructor's auto-started ping loop
+    ws.pingRequest?.cancel()
 
     // Simulate an already-connected, pinned-to-index-1 state.
     // @ts-expect-error - accessing private property for testing
@@ -1258,12 +1266,12 @@ describe("WebsocketConnection", () => {
     // @ts-expect-error - accessing private property for testing
     ws.uriIndex = 1
 
-    // The background ping resolves (index 0 for the pinned single-URI list) but
-    // the guard must keep the pinned index rather than clobbering it.
+    // The background ping resolves (index 0) but the guard must keep the pinned
+    // index rather than clobbering it.
     globalThis.fetch = createFetchMock()
     // @ts-expect-error - accessing private method for testing
     const bgPromise = ws.pingServerInBackground()
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(4000)
     await bgPromise
 
     // @ts-expect-error - accessing private property for testing

--- a/frontend/connection/src/WebsocketConnection.test.tsx
+++ b/frontend/connection/src/WebsocketConnection.test.tsx
@@ -1152,6 +1152,126 @@ describe("WebsocketConnection", () => {
     ws.disconnect()
   })
 
+  it("pins the connected index to the socket's URI even if uriIndex changed (bypass)", () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "a.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "b.example.com",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+    ]
+    // Pending fetch so the initial ping can't resolve and interfere.
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Simulate bypass mode: the socket was created from index 0, but a
+    // background ping has since overwritten uriIndex to a different candidate.
+    // @ts-expect-error - accessing private property for testing
+    ws.socketUriIndex = 0
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.state = ConnectionState.CONNECTING
+    // @ts-expect-error - accessing private method for testing
+    ws.stepFsm("CONNECTION_SUCCEEDED")
+
+    // The pin must follow the URI the socket actually used (0), not the
+    // clobbered uriIndex, and uriIndex is realigned to match.
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.connectedUriIndex).toBe(0)
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.uriIndex).toBe(0)
+
+    ws.disconnect()
+  })
+
+  it("remaps the resolved ping index back to the pinned URI on reconnect", async () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "other.example.com",
+        port: "9999",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "localhost",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+    ]
+    // Pending fetch so the initial ping from the constructor never resolves.
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Simulate a prior successful connection pinned to index 1.
+    // @ts-expect-error - accessing private property for testing
+    ws.connectedUriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+
+    // A reconnect ping probes only the pinned single-URI list, so doInitPings
+    // resolves index 0, which must be remapped back to the real index (1).
+    globalThis.fetch = createFetchMock()
+    // @ts-expect-error - accessing private property for testing
+    ws.state = ConnectionState.PINGING_SERVER
+    // @ts-expect-error - accessing private method for testing
+    const pingPromise = ws.pingServer()
+    await vi.advanceTimersByTimeAsync(0)
+    await pingPromise
+
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.uriIndex).toBe(1)
+
+    ws.disconnect()
+  })
+
+  it("does not overwrite the pinned URI index when a background ping resolves", async () => {
+    const baseUriPartsList = [
+      {
+        protocol: "http:",
+        hostname: "localhost",
+        port: "1234",
+        pathname: "/",
+      } as URL,
+      {
+        protocol: "http:",
+        hostname: "other.example.com",
+        port: "9999",
+        pathname: "/",
+      } as URL,
+    ]
+    // Pending fetch so the initial ping from the constructor never resolves.
+    globalThis.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    const ws = new WebsocketConnection(createMockArgs({ baseUriPartsList }))
+
+    // Simulate an already-connected, pinned-to-index-1 state.
+    // @ts-expect-error - accessing private property for testing
+    ws.connectedUriIndex = 1
+    // @ts-expect-error - accessing private property for testing
+    ws.uriIndex = 1
+
+    // The background ping resolves (index 0 for the pinned single-URI list) but
+    // the guard must keep the pinned index rather than clobbering it.
+    globalThis.fetch = createFetchMock()
+    // @ts-expect-error - accessing private method for testing
+    const bgPromise = ws.pingServerInBackground()
+    await vi.advanceTimersByTimeAsync(0)
+    await bgPromise
+
+    // @ts-expect-error - accessing private property for testing
+    expect(ws.uriIndex).toBe(1)
+
+    ws.disconnect()
+  })
+
   it("increments message cache run count", () => {
     const incrementRunCountSpy = vi.spyOn(
       // @ts-expect-error

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -27,6 +27,7 @@ import { ConnectionState } from "./ConnectionState"
 import {
   PING_MAXIMUM_RETRY_PERIOD_MS,
   PING_MINIMUM_RETRY_PERIOD_MS,
+  PING_RECONNECT_INITIAL_DELAY_MAX_MS,
   WEBSOCKET_STREAM_PATH,
   WEBSOCKET_TIMEOUT_MS,
 } from "./constants"
@@ -437,13 +438,22 @@ export class WebsocketConnection {
   }
 
   private async pingServer(): Promise<void> {
+    // On reconnect (we've connected before), delay the first ping by a random
+    // amount so a fleet of clients that dropped together doesn't hit the server
+    // in lockstep. The initial page-load connection is not delayed.
+    const initialDelayMs =
+      this.connectedUriIndex !== undefined
+        ? Math.random() * PING_RECONNECT_INITIAL_DELAY_MAX_MS
+        : 0
+
     const currentRequest = doInitPings(
       this.getBaseUrisToProbe(),
       PING_MINIMUM_RETRY_PERIOD_MS,
       PING_MAXIMUM_RETRY_PERIOD_MS,
       this.args.onRetry,
       this.args.sendClientError,
-      this.args.onHostConfigResp
+      this.args.onHostConfigResp,
+      initialDelayMs
     )
     this.pingRequest = currentRequest
 

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -185,6 +185,12 @@ export class WebsocketConnection {
   private uriIndex = 0
 
   /**
+   * Index into baseUriPartsList that the WebSocket last successfully connected
+   * on. Once set, we skip path discovery on reconnect and only probe this URI.
+   */
+  private connectedUriIndex?: number
+
+  /**
    * To guarantee packet transmission order, this is the index of the last
    * dispatched incoming message.
    */
@@ -271,6 +277,11 @@ export class WebsocketConnection {
       case ConnectionState.PINGING_SERVER:
         // eslint-disable-next-line @typescript-eslint/no-floating-promises -- TODO: Fix this
         this.pingServer()
+        break
+
+      case ConnectionState.CONNECTED:
+        // Remember the URI that worked so reconnects skip path discovery.
+        this.connectedUriIndex = this.uriIndex
         break
 
       default:
@@ -398,9 +409,23 @@ export class WebsocketConnection {
     )
   }
 
+  /**
+   * Returns the base URIs to probe when (re)connecting. Before the first
+   * successful connection we probe all candidates (path discovery for multipage
+   * apps). Once connected, we pin to the URI that worked so reconnects don't
+   * re-run discovery — which would double requests and risk selecting the wrong
+   * path.
+   */
+  private getBaseUrisToProbe(): URL[] {
+    if (this.connectedUriIndex !== undefined) {
+      return [this.args.baseUriPartsList[this.connectedUriIndex]]
+    }
+    return this.args.baseUriPartsList
+  }
+
   private async pingServer(): Promise<void> {
     const currentRequest = doInitPings(
-      this.args.baseUriPartsList,
+      this.getBaseUrisToProbe(),
       PING_MINIMUM_RETRY_PERIOD_MS,
       PING_MAXIMUM_RETRY_PERIOD_MS,
       this.args.onRetry,
@@ -410,7 +435,10 @@ export class WebsocketConnection {
     this.pingRequest = currentRequest
 
     try {
-      this.uriIndex = await currentRequest.promise
+      const resolvedIndex = await currentRequest.promise
+      // When probing a pinned single-URI list, doInitPings resolves index 0;
+      // map it back to the real index into baseUriPartsList.
+      this.uriIndex = this.connectedUriIndex ?? resolvedIndex
       // Only clear if we're still the active request
       if (this.pingRequest === currentRequest) {
         this.pingRequest = undefined
@@ -466,7 +494,11 @@ export class WebsocketConnection {
 
     try {
       const uriIndex = await currentRequest.promise
-      this.uriIndex = uriIndex
+      // Don't overwrite the index once the WebSocket has already connected on a
+      // URI; the connected path takes precedence over background discovery.
+      if (this.connectedUriIndex === undefined) {
+        this.uriIndex = uriIndex
+      }
       LOG.info("Background pings completed successfully")
     } catch (e) {
       if (e instanceof PingCancelledError) {

--- a/frontend/connection/src/WebsocketConnection.tsx
+++ b/frontend/connection/src/WebsocketConnection.tsx
@@ -191,6 +191,14 @@ export class WebsocketConnection {
   private connectedUriIndex?: number
 
   /**
+   * Index into baseUriPartsList used to build the currently-open WebSocket.
+   * Captured when the socket is created so that, once connected, we pin to the
+   * URI the socket actually used rather than this.uriIndex, which a background
+   * ping (bypass mode) may have overwritten before the socket's open event.
+   */
+  private socketUriIndex?: number
+
+  /**
    * To guarantee packet transmission order, this is the index of the last
    * dispatched incoming message.
    */
@@ -280,8 +288,13 @@ export class WebsocketConnection {
         break
 
       case ConnectionState.CONNECTED:
-        // Remember the URI that worked so reconnects skip path discovery.
-        this.connectedUriIndex = this.uriIndex
+        // Pin to the URI the live socket actually used (captured at socket
+        // creation), not this.uriIndex: in bypass mode a background ping can
+        // overwrite this.uriIndex before the socket's open event fires, which
+        // would otherwise pin a URI the socket never used. Also realign
+        // this.uriIndex so getBaseUriParts() and reconnects stay consistent.
+        this.connectedUriIndex = this.socketUriIndex ?? this.uriIndex
+        this.uriIndex = this.connectedUriIndex
         break
 
       default:
@@ -547,8 +560,11 @@ export class WebsocketConnection {
   }
 
   private async connectToWebSocket(): Promise<void> {
+    // Capture the index this socket is built from so that, once connected, we
+    // pin to it even if a background ping overwrites this.uriIndex in between.
+    this.socketUriIndex = this.uriIndex
     const uri = buildWsUri(
-      this.args.baseUriPartsList[this.uriIndex],
+      this.args.baseUriPartsList[this.socketUriIndex],
       WEBSOCKET_STREAM_PATH
     )
 

--- a/frontend/connection/src/constants.ts
+++ b/frontend/connection/src/constants.ts
@@ -38,9 +38,29 @@ export const HOST_CONFIG_PATH = "_stcore/host-config"
 
 /**
  * Min and max wait time between pings in millis.
+ *
+ * The maximum caps the exponential backoff during a sustained outage. It is
+ * deliberately larger than the minimum by several doublings so that clients
+ * that can't reach the server quickly back off to an infrequent, low-load
+ * poll rather than hammering the server every couple of seconds indefinitely.
  */
 export const PING_MINIMUM_RETRY_PERIOD_MS = 100
-export const PING_MAXIMUM_RETRY_PERIOD_MS = 2000
+export const PING_MAXIMUM_RETRY_PERIOD_MS = 8000
+
+/**
+ * Fractional +/- jitter applied to the (capped) retry backoff to de-synchronize
+ * reconnect attempts across clients and avoid a "thundering herd" where many
+ * clients retry in lockstep (e.g. 0.5 == +/-50%).
+ */
+export const PING_RETRY_JITTER = 0.5
+
+/**
+ * On reconnect (after having previously connected), the first health ping is
+ * delayed by a uniform random amount in [0, this) to de-synchronize a fleet of
+ * clients that dropped together. This is NOT applied on the initial page-load
+ * connection, so first paint stays fast.
+ */
+export const PING_RECONNECT_INITIAL_DELAY_MAX_MS = 3000
 
 /**
  * Max number of times we retry pinging the server before we show an error.


### PR DESCRIPTION
## Describe your changes
Raise the max retry period from 2s to 8s so clients that can't reach the server during a sustained outage back off to an infrequent poll instead of hammering it every couple seconds. Cap the exponential backoff FIRST and apply jitter AFTER (+/-50% via PING_RETRY_JITTER): previously jitter was applied before the cap, so once the exponential term exceeded the cap every client converged on exactly the max, re-synchronizing the fleet precisely when spreading load matters most.

Also add a jittered initial delay before the first ping on reconnect (doInitPings initialDelayMs, driven by PING_RECONNECT_INITIAL_DELAY_MAX_MS) so a fleet that dropped together doesn't reconnect in lockstep. The initial page-load connection is not delayed, keeping first paint fast.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection/reconnect timing for all deployments; behavior changes are intentional but could slightly slow recovery perception on reconnect (up to 3s before first ping) while reducing server load during outages.
> 
> **Overview**
> Reduces **thundering herd** load when many Streamlit clients lose the server at once by changing how health-ping retries and reconnects are scheduled.
> 
> **Retry backoff:** `PING_MAXIMUM_RETRY_PERIOD_MS` rises from **2s to 8s** so sustained outages poll less aggressively. Exponential backoff is **capped first**, then **±50% jitter** (`PING_RETRY_JITTER`) is applied—fixing the old order where jitter was lost at the cap and every client retried on exactly the same interval.
> 
> **Reconnect:** `doInitPings` accepts optional **`initialDelayMs`** (wired from `WebsocketConnection` only when `connectedUriIndex` is set). The first ping after a prior connection waits a random **0–3s** (`PING_RECONNECT_INITIAL_DELAY_MAX_MS`); initial page load still pings immediately.
> 
> Tests now assert jitter bands instead of fixed timeouts and cover the initial-delay behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7871d49f4765cd64d25696c6d15e17928d26dab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->