### PR TITLE
[fix] Fix st.metric area chart fill baseline

### DIFF
--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -598,6 +598,10 @@ describe("Metric element", () => {
       { chartData: [0, 0, 0], expectedBaseline: 0 },
       { chartData: [42], expectedBaseline: 42 },
       { chartData: [], expectedBaseline: 0 },
+      // Series that only touch zero do not cross it: they still anchor to
+      // the data minimum rather than diverging around the zero line.
+      { chartData: [-2, -1, 0], expectedBaseline: -2 },
+      { chartData: [0, 5, 10], expectedBaseline: 0 },
     ])(
       "sets area chart baseline to $expectedBaseline for $chartData",
       ({ chartData, expectedBaseline }) => {

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -583,9 +583,54 @@ describe("Metric element", () => {
                 strokeCap: "round",
               }),
             }),
+            encoding: expect.objectContaining({
+              y2: { datum: 1 },
+            }),
           }),
         ]),
       })
+    })
+
+    it.each([
+      { chartData: [100, 110, 105], expectedBaseline: 100 },
+      { chartData: [-30, -20, -25], expectedBaseline: -30 },
+      { chartData: [-10, 0, 10], expectedBaseline: 0 },
+      { chartData: [0, 0, 0], expectedBaseline: 0 },
+      { chartData: [42], expectedBaseline: 42 },
+    ])(
+      "sets area chart baseline to $expectedBaseline for $chartData",
+      ({ chartData, expectedBaseline }) => {
+        const spec = getMetricChartSpec(
+          chartData,
+          MetricProto.ChartType.AREA,
+          200,
+          mockTheme.emotion,
+          MetricProto.MetricColor.GRAY
+        ) as TopLevelSpec & {
+          layer: Array<{ encoding?: { y2?: { datum: number } } }>
+        }
+
+        expect(spec.layer[0].encoding?.y2).toEqual({
+          datum: expectedBaseline,
+        })
+      }
+    )
+
+    it.each([
+      { chartType: MetricProto.ChartType.LINE, name: "line" },
+      { chartType: MetricProto.ChartType.BAR, name: "bar" },
+    ])("does not set a y2 baseline for $name charts", ({ chartType }) => {
+      const spec = getMetricChartSpec(
+        [-10, 0, 10],
+        chartType,
+        200,
+        mockTheme.emotion,
+        MetricProto.MetricColor.GRAY
+      ) as TopLevelSpec & {
+        layer: Array<{ encoding?: { y2?: { datum: number } } }>
+      }
+
+      expect(spec.layer[0].encoding?.y2).toBeUndefined()
     })
 
     it("handles single value by duplicating it", () => {

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -597,6 +597,7 @@ describe("Metric element", () => {
       { chartData: [-10, 0, 10], expectedBaseline: 0 },
       { chartData: [0, 0, 0], expectedBaseline: 0 },
       { chartData: [42], expectedBaseline: 42 },
+      { chartData: [], expectedBaseline: 0 },
     ])(
       "sets area chart baseline to $expectedBaseline for $chartData",
       ({ chartData, expectedBaseline }) => {

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -51,6 +51,32 @@ import {
 const LARGE_DATASET_POINT_THRESHOLD = 1000
 
 /**
+ * Returns the baseline value (`y2`) to anchor an area chart's shaded region.
+ *
+ * The baseline is `0` when the data crosses zero (so the fill diverges around
+ * the zero line), otherwise the data minimum (so the fill is anchored to the
+ * bottom of the visible range). The returned value is always within
+ * `[dataMin, dataMax]`, which keeps it from expanding the `zero: false` y-scale.
+ *
+ * Uses a single pass instead of `Math.min(...chartData)` to avoid a potential
+ * argument-spread `RangeError` on very large datasets.
+ */
+function getAreaChartBaseline(chartData: number[]): number {
+  let dataMin = chartData[0]
+  let dataMax = chartData[0]
+  for (const value of chartData) {
+    if (value < dataMin) {
+      dataMin = value
+    }
+    if (value > dataMax) {
+      dataMax = value
+    }
+  }
+
+  return dataMin <= 0 && dataMax >= 0 ? 0 : dataMin
+}
+
+/**
  * Safely format a numeric string, returning the original value if formatting fails.
  */
 function safeFormatNumber(value: string, format: string): string {
@@ -88,6 +114,7 @@ export function getMetricChartSpec(
   // charts need at least two points:
   const data =
     chartData.length === 1 ? [chartData[0], chartData[0]] : chartData
+  const isAreaChart = chartType === MetricProto.ChartType.AREA
 
   const spec: TopLevelSpec = {
     $schema: "https://vega.github.io/schema/vega-lite/v5.json",
@@ -144,6 +171,11 @@ export function getMetricChartSpec(
               nice: false,
             },
           },
+          ...(isAreaChart && {
+            y2: {
+              datum: getAreaChartBaseline(data),
+            },
+          }),
         },
       },
       {

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -62,6 +62,12 @@ const LARGE_DATASET_POINT_THRESHOLD = 1000
  * argument-spread `RangeError` on very large datasets.
  */
 function getAreaChartBaseline(chartData: number[]): number {
+  if (chartData.length === 0) {
+    // Defensive fallback: an empty dataset has no meaningful baseline, so
+    // return `0` to keep the `y2` datum a valid finite number.
+    return 0
+  }
+
   let dataMin = chartData[0]
   let dataMax = chartData[0]
   for (const value of chartData) {

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -53,10 +53,13 @@ const LARGE_DATASET_POINT_THRESHOLD = 1000
 /**
  * Returns the baseline value (`y2`) to anchor an area chart's shaded region.
  *
- * The baseline is `0` when the data crosses zero (so the fill diverges around
- * the zero line), otherwise the data minimum (so the fill is anchored to the
- * bottom of the visible range). The returned value is always within
- * `[dataMin, dataMax]`, which keeps it from expanding the `zero: false` y-scale.
+ * The baseline is `0` only when the data strictly crosses zero (i.e. it has
+ * both a value below and a value above zero, so the fill diverges around the
+ * zero line), otherwise the data minimum (so the fill is anchored to the
+ * bottom of the visible range). A series that merely touches zero (e.g.
+ * `[-2, -1, 0]`) does not cross it and still anchors to the data minimum. The
+ * returned value is always within `[dataMin, dataMax]`, which keeps it from
+ * expanding the `zero: false` y-scale.
  *
  * Uses a single pass instead of `Math.min(...chartData)` to avoid a potential
  * argument-spread `RangeError` on very large datasets.
@@ -79,7 +82,7 @@ function getAreaChartBaseline(chartData: number[]): number {
     }
   }
 
-  return dataMin <= 0 && dataMax >= 0 ? 0 : dataMin
+  return dataMin < 0 && dataMax > 0 ? 0 : dataMin
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

Anchors the `st.metric` area chart's shaded region to a sensible baseline via an explicit `y2` encoding instead of relying on Vega-Lite's default zero baseline.

- Baseline is `0` when the data crosses zero (fill diverges around the zero line), otherwise the data minimum, so the fill is always anchored to the bottom of the visible range. This fixes all-negative sparklines, where the default zero baseline (combined with the `zero: false` y-scale) filled on the wrong side of the line.
- Scoped to area charts only — line and bar variants are untouched.

## Screenshot or video (only for visual changes)

_Omitted._

## GitHub Issue Link (if applicable)

_N/A_

## Testing Plan

- `frontend/lib/src/components/elements/Metric/Metric.test.tsx` — Unit tests for the baseline across positive-only, negative-only, zero-crossing, all-zero, and single-value data, plus a regression guard that line/bar specs omit `y2`.
- Existing `e2e_playwright/st_metric_test.py` area chart snapshot provides visual regression coverage.

Made with [Cursor](https://cursor.com)