### PR TITLE
Improve XSRF/CORS configuration warning

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2961,11 +2961,9 @@ def _check_conflicts() -> None:
         not get_option("server.enableCORS") or get_option("global.developmentMode")
     ):
         logger.warning(
-            """
-Warning: the config option 'server.enableCORS=false' is not compatible with
+            """Warning: the config option 'server.enableCORS=false' is not compatible with
 'server.enableXsrfProtection=true'.
-As a result, 'server.enableCORS' is being overridden to 'true'.
-
+Streamlit automatically sets 'server.enableCORS=true' to preserve XSRF protection.
 More information:
 In order to protect against CSRF attacks, we send a cookie with each request.
 To do so, we must specify allowable origins, which places a restriction on


### PR DESCRIPTION
## Describe your changes

Improved the XSRF/CORS configuration warning to make it clearer that Streamlit automatically enables `server.enableCORS` when XSRF protection is enabled. This helps users understand why their configuration is overridden instead of simply stating that it happens.

## Screenshot or video

N/A

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Ran:
  ```bash
  pytest lib/tests/streamlit/config_test.py -k server_csrf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log message copy only in config conflict checking; no runtime or security logic changes.
> 
> **Overview**
> Updates the **`logger.warning`** text in **`_check_conflicts()`** when **`server.enableXsrfProtection`** is on but **`server.enableCORS`** is off (or development mode triggers the same path).
> 
> The message now states that **Streamlit automatically sets `server.enableCORS=true` to preserve XSRF protection**, instead of only saying CORS is being overridden. Minor string formatting changes remove the leading blank line and the separate “As a result…” sentence. **No config validation or override behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ae583994916d3bbd5561a0aaed5d1941867fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->