### PR TITLE
[fix] Dedupe run_every auto-rerun timers per fragment

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3911,6 +3911,41 @@ describe("App", () => {
         },
       })
     })
+
+    it("does not accumulate duplicate timers when a fragment re-registers its auto-rerun", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBefore = connectionManager.sendMessage.mock.calls.length
+      act(() => {
+        // Register the same fragment twice, as happens when an ancestor
+        // re-renders a run_every fragment.
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "myFragmentId",
+        })
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "myFragmentId",
+        })
+        vi.advanceTimersByTime(1000)
+      })
+
+      // Only one interval should be active despite two registrations; without
+      // deduping, two timers would each fire and send two messages per tick.
+      expect(
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        connectionManager.sendMessage.mock.calls.length - callsBefore
+      ).toBe(1)
+    })
   })
 
   describe("App.requestFileURLs", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3946,6 +3946,35 @@ describe("App", () => {
         connectionManager.sendMessage.mock.calls.length - callsBefore
       ).toBe(1)
     })
+
+    it("ignores an auto-rerun message without a fragment id", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBefore = connectionManager.sendMessage.mock.calls.length
+      act(() => {
+        // Auto-reruns are always fragment-scoped; a message with no fragment id
+        // must not register a timer (and two of them must not collide under an
+        // empty-string key).
+        sendForwardMessage("autoRerun", { interval: 1.0 })
+        sendForwardMessage("autoRerun", { interval: 1.0 })
+        vi.advanceTimersByTime(2000)
+      })
+
+      // No timer was registered, so no auto-rerun messages are sent.
+      expect(
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        connectionManager.sendMessage.mock.calls.length - callsBefore
+      ).toBe(0)
+    })
   })
 
   describe("App.requestFileURLs", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -3975,6 +3975,78 @@ describe("App", () => {
         connectionManager.sendMessage.mock.calls.length - callsBefore
       ).toBe(0)
     })
+
+    it("does not reset the countdown when a fragment re-registers with the same interval", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBefore = connectionManager.sendMessage.mock.calls.length
+      act(() => {
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "myFragmentId",
+        })
+        vi.advanceTimersByTime(600)
+        // An ancestor re-render re-sends the same auto-rerun before the interval
+        // elapses. This must not restart the timer.
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "myFragmentId",
+        })
+        vi.advanceTimersByTime(500)
+      })
+
+      // The original countdown was preserved, so it fired ~1000ms after the
+      // first registration. If re-registration had reset it, only 500ms would
+      // have elapsed since the reset and nothing would have fired.
+      expect(
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        connectionManager.sendMessage.mock.calls.length - callsBefore
+      ).toBe(1)
+    })
+
+    it("restarts a fragment's timer when its interval changes", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBefore = connectionManager.sendMessage.mock.calls.length
+      act(() => {
+        // Start with a long interval, then re-register with a short one.
+        sendForwardMessage("autoRerun", {
+          interval: 10.0,
+          fragmentId: "myFragmentId",
+        })
+        vi.advanceTimersByTime(500)
+        sendForwardMessage("autoRerun", {
+          interval: 0.1,
+          fragmentId: "myFragmentId",
+        })
+        vi.advanceTimersByTime(250)
+      })
+
+      // The 10s timer was replaced by a 0.1s timer, which then fired. Had the
+      // interval change been ignored, the 10s timer would not have fired yet.
+      expect(
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        connectionManager.sendMessage.mock.calls.length - callsBefore
+      ).toBeGreaterThanOrEqual(1)
+    })
   })
 
   describe("App.requestFileURLs", () => {

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1240,6 +1240,15 @@ export class App extends PureComponent<Props, State> {
   handleAutoRerun = (autoRerun: AutoRerun): void => {
     const { fragmentId } = autoRerun
 
+    // Auto-reruns are always scoped to a fragment, so we expect a non-empty
+    // fragment id. Guard against an empty id (which protobuf produces when the
+    // field is unset): using it as a map key would collide, so a second empty-id
+    // registration would silently cancel the first. Skip it instead.
+    if (!fragmentId) {
+      LOG.warn("Ignoring auto-rerun message without a fragment id.")
+      return
+    }
+
     // A `run_every` fragment re-registers its auto-rerun every time an ancestor
     // re-renders it (a fragment-only rerun doesn't reset timers). Clear any
     // existing timer for this fragment first so repeated renders replace rather

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -309,13 +309,16 @@ export class App extends PureComponent<Props, State> {
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
 
-  // Active `run_every` auto-rerun interval timers, keyed by fragment id. These
-  // are imperative resources (setInterval handles), so they live outside of
-  // React state. Keying by fragment id lets us replace a fragment's timer when
-  // it re-registers, instead of stacking duplicate intervals.
+  // Active `run_every` auto-rerun timers, keyed by fragment id. These are
+  // imperative resources (setInterval handles), so they live outside of React
+  // state. Keying by fragment id lets us keep a single timer per fragment: we
+  // reuse the running timer when a fragment re-registers with the same interval
+  // (so frequent ancestor reruns don't reset its countdown), and only restart
+  // it when the interval changes. The stored `interval` (in seconds) is what we
+  // compare against on re-registration.
   private readonly autoRerunIntervals: Map<
     string,
-    ReturnType<typeof setInterval>
+    { timer: ReturnType<typeof setInterval>; interval: number }
   > = new Map()
 
   // Whether the skills-install nudge has been shown this page load.
@@ -1249,17 +1252,26 @@ export class App extends PureComponent<Props, State> {
       return
     }
 
+    const { interval } = autoRerun
+
     // A `run_every` fragment re-registers its auto-rerun every time an ancestor
-    // re-renders it (a fragment-only rerun doesn't reset timers). Clear any
-    // existing timer for this fragment first so repeated renders replace rather
-    // than stack intervals, which would otherwise multiply its rerun rate.
+    // re-renders it (a fragment-only rerun doesn't reset timers). If a timer for
+    // this fragment is already running with the same interval, leave it alone:
+    // restarting it would reset the countdown, so ancestor reruns firing more
+    // often than `run_every` could delay or starve the fragment's auto-rerun.
+    // We only (re)start the timer when there isn't one yet or the interval
+    // changed, which also avoids stacking duplicate intervals.
+    if (this.autoRerunIntervals.get(fragmentId)?.interval === interval) {
+      return
+    }
+
     this.clearAutoRerunInterval(fragmentId)
 
-    const intervalId = setInterval(() => {
+    const timer = setInterval(() => {
       this.widgetMgr.sendUpdateWidgetsMessage(fragmentId, true)
-    }, autoRerun.interval * 1000)
+    }, interval * 1000)
 
-    this.autoRerunIntervals.set(fragmentId, intervalId)
+    this.autoRerunIntervals.set(fragmentId, { timer, interval })
   }
 
   /**
@@ -1986,8 +1998,8 @@ export class App extends PureComponent<Props, State> {
    * lead to issues, e.g. when a new full app-rerun session is started or the active page changed.
    */
   cleanupAutoReruns = (): void => {
-    this.autoRerunIntervals.forEach(intervalId => {
-      clearInterval(intervalId)
+    this.autoRerunIntervals.forEach(({ timer }) => {
+      clearInterval(timer)
     })
     this.autoRerunIntervals.clear()
   }
@@ -1996,9 +2008,9 @@ export class App extends PureComponent<Props, State> {
    * Clear the auto-rerun interval for a single fragment, if one exists.
    */
   private clearAutoRerunInterval(fragmentId: string): void {
-    const intervalId = this.autoRerunIntervals.get(fragmentId)
-    if (intervalId !== undefined) {
-      clearInterval(intervalId)
+    const existing = this.autoRerunIntervals.get(fragmentId)
+    if (existing !== undefined) {
+      clearInterval(existing.timer)
       this.autoRerunIntervals.delete(fragmentId)
     }
   }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -235,7 +235,6 @@ interface State {
   deployedAppMetadata: DeployedAppMetadata
   libConfig: LibConfig
   appConfig: AppConfig
-  autoReruns: NodeJS.Timeout[]
   inputsDisabled: boolean
   scriptChangedOnDisk: boolean
   // Whether the framework "install skills" nudge is currently shown. Set once
@@ -309,6 +308,15 @@ export class App extends PureComponent<Props, State> {
   // we have received a NewSession message after the latest rerun request.
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
+
+  // Active `run_every` auto-rerun interval timers, keyed by fragment id. These
+  // are imperative resources (setInterval handles), so they live outside of
+  // React state. Keying by fragment id lets us replace a fragment's timer when
+  // it re-registers, instead of stacking duplicate intervals.
+  private readonly autoRerunIntervals: Map<
+    string,
+    ReturnType<typeof setInterval>
+  > = new Map()
 
   // Whether the skills-install nudge has been shown this page load.
   // `handleInitialization` re-runs on websocket reconnect, so this guards
@@ -385,7 +393,6 @@ export class App extends PureComponent<Props, State> {
       deployedAppMetadata: {},
       libConfig: {},
       appConfig: {},
-      autoReruns: [],
       inputsDisabled: false,
       navigationPosition: Navigation.Position.SIDEBAR,
       scriptChangedOnDisk: false,
@@ -922,7 +929,7 @@ export class App extends PureComponent<Props, State> {
         // Script is using fragments (fragments in last run or
         // fragment auto-reruns configured):
         this.state.fragmentIdsThisRun.length > 0 ||
-        this.state.autoReruns.length > 0
+        this.autoRerunIntervals.size > 0
       ) {
         LOG.info("Requesting a script run.")
         this.widgetMgr.sendUpdateWidgetsMessage(undefined)
@@ -1231,15 +1238,19 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleAutoRerun = (autoRerun: AutoRerun): void => {
+    const { fragmentId } = autoRerun
+
+    // A `run_every` fragment re-registers its auto-rerun every time an ancestor
+    // re-renders it (a fragment-only rerun doesn't reset timers). Clear any
+    // existing timer for this fragment first so repeated renders replace rather
+    // than stack intervals, which would otherwise multiply its rerun rate.
+    this.clearAutoRerunInterval(fragmentId)
+
     const intervalId = setInterval(() => {
-      this.widgetMgr.sendUpdateWidgetsMessage(autoRerun.fragmentId, true)
+      this.widgetMgr.sendUpdateWidgetsMessage(fragmentId, true)
     }, autoRerun.interval * 1000)
 
-    this.setState((prevState: State) => {
-      return {
-        autoReruns: [...prevState.autoReruns, intervalId],
-      }
-    })
+    this.autoRerunIntervals.set(fragmentId, intervalId)
   }
 
   /**
@@ -1966,10 +1977,21 @@ export class App extends PureComponent<Props, State> {
    * lead to issues, e.g. when a new full app-rerun session is started or the active page changed.
    */
   cleanupAutoReruns = (): void => {
-    this.state.autoReruns.forEach((value: NodeJS.Timeout) => {
-      clearInterval(value)
+    this.autoRerunIntervals.forEach(intervalId => {
+      clearInterval(intervalId)
     })
-    this.setState({ autoReruns: [] })
+    this.autoRerunIntervals.clear()
+  }
+
+  /**
+   * Clear the auto-rerun interval for a single fragment, if one exists.
+   */
+  private clearAutoRerunInterval(fragmentId: string): void {
+    const intervalId = this.autoRerunIntervals.get(fragmentId)
+    if (intervalId !== undefined) {
+      clearInterval(intervalId)
+      this.autoRerunIntervals.delete(fragmentId)
+    }
   }
 
   /**


### PR DESCRIPTION
## Describe your changes
`run_every` fragment auto-rerun timers were appended to a flat array that was only cleared on a full rerun or page change. Because the server re-sends an `AutoRerun` every time a `run_every` fragment's decorator runs, re-rendering such a fragment from an ancestor's fragment-only rerun stacked duplicate `setInterval`s, steadily multiplying the fragment's rerun rate.
Auto-rerun timers are now keyed by fragment id in a `Map` (kept outside React state, since they're imperative timer handles rather than render data) and a fragment's existing timer is cleared before a new one is registered. Full reruns and page changes still reset every timer.
## Screenshot or video (only for visual changes)
N/A
## GitHub Issue Link (if applicable)
Related to https://github.com/streamlit/streamlit/issues/15084
## Testing Plan
- Unit Tests (JS and/or Python): frontend test asserting a `run_every` fragment that re-registers its auto-rerun keeps only one active interval.
- E2E Tests: not needed — no new user-facing surface; existing fragment `run_every` coverage still applies.
- Manual testing: none required.
---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rerun scheduling in `App` (timers and reconnect/rerun gating), but behavior is narrowly scoped to fragment auto-reruns with regression tests.
> 
> **Overview**
> Fixes **`run_every`** fragments stacking multiple **`setInterval`** timers when the server re-sends **`AutoRerun`** on ancestor re-renders, which could multiply fragment rerun rate over time.
> 
> **`App`** now tracks auto-rerun timers in a **fragment-id-keyed `Map`** (outside React state) instead of appending every registration to **`state.autoReruns`**. Re-registration with the **same interval** is ignored so the countdown is not reset; a **changed interval** clears and restarts that fragment’s timer. Messages **without a `fragmentId`** are dropped so empty keys cannot collide. Full cleanup on new session / page change still clears all timers.
> 
> Adds **unit tests** for duplicate registration, missing fragment id, countdown preservation, and interval updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b74639f785245bc7a67b50b2800433b79763fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->