### PR TITLE
[chore] Retry swallowed fullscreen click in st_image e2e on webkit

### DIFF
--- a/e2e_playwright/st_image_test.py
+++ b/e2e_playwright/st_image_test.py
@@ -222,21 +222,33 @@ def set_fullscreen(image_wrapper: Locator, open: bool):
     fullscreen_button = image_wrapper.get_by_role(
         "button", name="Fullscreen" if open else "Close fullscreen"
     )
-    # The toolbar (and its fullscreen button) only becomes interactive on hover
-    # and fades in via an opacity transition. In webkit a click dispatched while
-    # the toolbar is still fading in can be swallowed, leaving fullscreen
-    # un-toggled. Hover first and wait for the toolbar to be fully opaque before
-    # clicking (mirrors the pattern in shared/toolbar_utils.py).
-    image_wrapper.hover()
-    expect(toolbar).to_have_css("opacity", "1")
-    expect(fullscreen_button).to_be_visible()
-    fullscreen_button.click()
-    # Wait for the toolbar button to flip to its opposite label, which confirms
-    # the fullscreen state has finished toggling before we take a snapshot.
+    # After toggling, the toolbar button flips to its opposite label. We use
+    # this as the signal that the fullscreen state has finished changing.
     toggled_button = image_wrapper.get_by_role(
         "button", name="Close fullscreen" if open else "Fullscreen"
     )
-    expect(toggled_button).to_be_visible()
+    # The toolbar (and its fullscreen button) only becomes interactive on hover
+    # and fades/slides in via a CSS transition; when the hover is lost it snaps
+    # straight back to opacity 0 (transition: none). On webkit a click dispatched
+    # while the toolbar is still animating in can be silently swallowed, leaving
+    # fullscreen un-toggled (observed intermittently in CI under parallel load).
+    # Hover to reveal the toolbar, wait for it to be fully opaque, click, and
+    # confirm the label flipped. If the click did not register, retry the
+    # hover+click rather than failing on a lost webkit event.
+    max_attempts = 4
+    for attempt in range(max_attempts):
+        image_wrapper.hover()
+        expect(toolbar).to_have_css("opacity", "1")
+        expect(fullscreen_button).to_be_visible()
+        fullscreen_button.click()
+        try:
+            expect(toggled_button).to_be_visible(
+                timeout=2000 if attempt < max_attempts - 1 else 5000
+            )
+            return
+        except AssertionError:
+            if attempt == max_attempts - 1:
+                raise
 
 
 # SVGs without width or height are not rendered correctly in Firefox


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Fixes an intermittent `playwright-e2e-tests` failure on webkit in `e2e_playwright/st_image_test.py::test_width_stretch_fullscreen[webkit]` (also protects `test_svg_viewbox_only[webkit]`, which shares the `set_fullscreen` helper).

**CI failure:** Inside `set_fullscreen`, `expect(toggled_button).to_be_visible()` timed out (5s) waiting for the `"Close fullscreen"` button. The failure aria snapshot showed a fully-loaded page with many `"Fullscreen"` buttons but **no** `"Close fullscreen"` button anywhere — i.e. the fullscreen click never toggled.

**Root cause:** The element toolbar only becomes interactive on hover and fades/slides in via a CSS transition (`opacity` + `top`), and reverts with `transition: none` — so it snaps straight back to `opacity: 0` the instant hover is lost. On webkit, a click dispatched while the toolbar is still animating in (or as the pointer traverses the gap created when the toolbar slides up above the image) can be silently swallowed, leaving fullscreen un-toggled. The previous fix (#15808) hardened the *wait* strategy but assumed the click always registered.

**Fix:** In `set_fullscreen`, confirm the toggle actually happened (the toolbar button flips its label) and retry the hover+click if it did not, instead of failing on a single lost webkit event. This is central to the shared helper, so both fullscreen tests benefit. Test intent is unchanged and `@pytest.mark.skip_browser("firefox")` on `test_svg_viewbox_only` is preserved.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- E2E Tests: Consistent with #15808, the flake does **not** reproduce locally in isolation (25/25 passes on webkit) nor under heavy CPU contention (15/15 passes) — it is CI-parallel-load specific. After the fix: `test_width_stretch_fullscreen` passes **10/10** on webkit, `test_svg_viewbox_only` passes 5/5 on webkit (exercises both open and close toggles), and `test_width_stretch_fullscreen` passes 3/3 on chromium.
- No unit tests needed — change is limited to an e2e test helper's click/retry strategy.
- Manual testing: not required.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-018a1e4b-893c-44bc-8d7d-ff513a93df9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-018a1e4b-893c-44bc-8d7d-ff513a93df9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

