### PR TITLE
[fix] Remove redundant keyboard tab stop from file uploader dropzone

### DIFF
--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -44,6 +44,14 @@ describe("FileDropzone widget", () => {
     expect(screen.getByTestId("stFileUploaderDropzone")).toBeInTheDocument()
   })
 
+  it("removes the dropzone section from the keyboard tab order", () => {
+    const props = getProps()
+    render(<FileDropzone {...props} />)
+
+    const dropzone = screen.getByTestId("stFileUploaderDropzone")
+    expect(dropzone).toHaveAttribute("tabindex", "-1")
+  })
+
   it("renders dropzone without extensions", () => {
     const props = getProps({
       acceptedTypes: [],

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.tsx
@@ -73,7 +73,7 @@ const FileDropzone = ({
 
       return (
         <StyledFileDropzoneSection
-          {...getRootProps()}
+          {...getRootProps({ tabIndex: -1 })}
           data-testid="stFileUploaderDropzone"
           isDisabled={disabled}
           isDragActive={isDragActive}


### PR DESCRIPTION

## Describe your changes

- Closes #15921

The file uploader dropzone `<section>` and its inner Upload `<button>` were both keyboard-focusable (`tabIndex=0`), creating two consecutive tab stops for the same file-upload action. This was caused by react-dropzone's `getRootProps()` assigning `tabIndex: 0` to the section by default.

Overrides the dropzone section's `tabIndex` to `-1` via `getRootProps({ tabIndex: -1 })`, removing it from the keyboard tab order while keeping the Upload button as the sole focus target. Drag-and-drop and click-to-upload remain unaffected.

**Alternatives considered:** Destructuring `tabIndex` out of `getRootProps()` — less clean than the library's supported override mechanism.

## GitHub Issue Link (if applicable)

- Closes #15921

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small accessibility tweak to focus order in the FileUploader widget with no auth, data, or API impact.
> 
> **Overview**
> Fixes **duplicate tab stops** in the file uploader: react-dropzone’s `getRootProps()` was putting `tabIndex: 0` on the outer dropzone `<section>` while the inner **Upload** button stayed focusable, so keyboard users hit two stops for one action.
> 
> The dropzone root now uses **`getRootProps({ tabIndex: -1 })`**, leaving the Upload button as the only tab target; drag-and-drop and click-to-upload behavior are unchanged.
> 
> A unit test asserts the dropzone has **`tabindex="-1"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6532a081e2421d9bdd28109e968936cc3623e989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->