### PR TITLE
[fix] stop auto rerun on fragment evict

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -86,6 +86,7 @@ import {
   IPageInfo,
   IPageNotFound,
   IParentMessage,
+  IStopAutoRerun,
   Navigation,
   SessionEvent,
   SessionStatus,
@@ -440,6 +441,7 @@ type ForwardMsgType =
   | IPageInfo
   | IParentMessage
   | IPageNotFound
+  | IStopAutoRerun
   | Omit<SessionEvent, "toJSON">
   | Omit<SessionStatus, "toJSON">
 
@@ -4046,6 +4048,64 @@ describe("App", () => {
         // @ts-expect-error - sendMessage is a vi.fn mock in tests
         connectionManager.sendMessage.mock.calls.length - callsBefore
       ).toBeGreaterThanOrEqual(1)
+    })
+
+    it("cancels only the targeted fragment's timer on a stopAutoRerun message", () => {
+      vi.mocked(isEmbed).mockReturnValue(false)
+      renderApp(getProps())
+
+      const connectionManager = getMockConnectionManager()
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      type SentRerun = { fragmentId?: string; isAutoRerun?: boolean }
+      const autoRerunFragmentIdsSince = (
+        fromIndex: number
+      ): (string | undefined)[] => {
+        // @ts-expect-error - sendMessage is a vi.fn mock in tests
+        const calls = connectionManager.sendMessage.mock.calls as Array<
+          [{ rerunScript?: SentRerun }]
+        >
+        return calls
+          .slice(fromIndex)
+          .map(call => call[0].rerunScript)
+          .filter((rerunScript): rerunScript is SentRerun =>
+            Boolean(rerunScript?.isAutoRerun)
+          )
+          .map(rerunScript => rerunScript.fragmentId)
+      }
+
+      act(() => {
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "fragmentA",
+        })
+        sendForwardMessage("autoRerun", {
+          interval: 1.0,
+          fragmentId: "fragmentB",
+        })
+        vi.advanceTimersByTime(1000)
+      })
+      expect(new Set(autoRerunFragmentIdsSince(0))).toEqual(
+        new Set(["fragmentA", "fragmentB"])
+      )
+
+      // The server evicts fragmentA and tells the client to cancel its timer.
+      // @ts-expect-error - sendMessage is a vi.fn mock in tests
+      const callsBeforeStop = connectionManager.sendMessage.mock.calls.length
+      act(() => {
+        sendForwardMessage("stopAutoRerun", { fragmentIds: ["fragmentA"] })
+        vi.advanceTimersByTime(2000)
+      })
+
+      const idsAfterStop = autoRerunFragmentIdsSince(callsBeforeStop)
+      // fragmentB keeps ticking; fragmentA's timer was cancelled.
+      expect(idsAfterStop.length).toBeGreaterThan(0)
+      expect(idsAfterStop).not.toContain("fragmentA")
+      expect(idsAfterStop.every(id => id === "fragmentB")).toBe(true)
     })
   })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -148,6 +148,7 @@ import {
   ParentMessage,
   SessionEvent,
   SessionStatus,
+  StopAutoRerun,
   WidgetStates,
 } from "@streamlit/protobuf"
 import {
@@ -1052,6 +1053,8 @@ export class App extends PureComponent<Props, State> {
         pageProfile: (pageProfile: PageProfile) =>
           this.handlePageProfileMsg(pageProfile),
         autoRerun: (autoRerun: AutoRerun) => this.handleAutoRerun(autoRerun),
+        stopAutoRerun: (stopAutoRerun: StopAutoRerun) =>
+          this.handleStopAutoRerun(stopAutoRerun),
         fileUrlsResponse: (fileURLsResponse: FileURLsResponse) =>
           this.uploadClient.onFileURLsResponse(fileURLsResponse),
         parentMessage: (parentMessage: ParentMessage) =>
@@ -1272,6 +1275,17 @@ export class App extends PureComponent<Props, State> {
     }, interval * 1000)
 
     this.autoRerunIntervals.set(fragmentId, { timer, interval })
+  }
+
+  /**
+   * Handler for ForwardMsg.stopAutoRerun messages. The server sends this when
+   * it evicts fragments (e.g. a nested ``run_every`` fragment whose ancestor
+   * stopped rendering it), so we cancel their pending auto-rerun timers.
+   */
+  handleStopAutoRerun = (stopAutoRerun: StopAutoRerun): void => {
+    stopAutoRerun.fragmentIds.forEach(fragmentId => {
+      this.clearAutoRerunInterval(fragmentId)
+    })
   }
 
   /**

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -130,12 +130,13 @@ class FragmentStorage(Protocol):
         self,
         root_fragment_id: str,
         newly_registered_ids: frozenset[str],
-    ) -> None:
+    ) -> list[str]:
         """Remove stored fragments that are strict descendants of ``root_fragment_id``
         but were not re-registered during the latest run of that root.
 
         Used after a fragment-only rerun so orphaned nested fragments (e.g. from a
-        removed ``run_every`` child) do not keep stale closures in storage.
+        removed ``run_every`` child) do not keep stale closures in storage. Returns
+        the list of removed fragment IDs.
         """
         raise NotImplementedError
 
@@ -293,8 +294,12 @@ class MemoryFragmentStorage(FragmentStorage):
         self,
         root_fragment_id: str,
         newly_registered_ids: frozenset[str],
-    ) -> None:
-        """Drop descendant fragments under ``root_fragment_id`` not seen this run."""
+    ) -> list[str]:
+        """Drop descendant fragments under ``root_fragment_id`` not seen this run.
+
+        Returns the list of fragment IDs that were removed so the caller can, for
+        example, tell the frontend to cancel their auto-rerun timers.
+        """
 
         with self._lock:
             to_remove = [
@@ -306,6 +311,7 @@ class MemoryFragmentStorage(FragmentStorage):
             ]
             for fragment_id in to_remove:
                 self._remove(fragment_id)
+            return to_remove
 
     def registration_sequence(self) -> int:
         with self._lock:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -769,10 +769,22 @@ class ScriptRunner:
                                         registration_sequence_before
                                     )
                                 )
-                                self._fragment_storage.clear_stale_descendants(
-                                    fragment_id,
-                                    registered_ids,
+                                removed_fragment_ids = (
+                                    self._fragment_storage.clear_stale_descendants(
+                                        fragment_id,
+                                        registered_ids,
+                                    )
                                 )
+                                # Tell the frontend to cancel auto-rerun timers for
+                                # fragments that were evicted (e.g. a nested
+                                # ``run_every`` child that is no longer rendered), so
+                                # they don't keep sending stale rerun requests.
+                                if removed_fragment_ids:
+                                    stop_msg = ForwardMsg()
+                                    stop_msg.stop_auto_rerun.fragment_ids.extend(
+                                        removed_fragment_ids
+                                    )
+                                    ctx.enqueue(stop_msg)
 
                     else:
                         # Drop wrappers from the previous run before the main

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -271,6 +271,25 @@ class MemoryFragmentStorageTest(unittest.TestCase):
         assert not self._storage.contains("inner")
         assert not self._storage.contains("leaf")
 
+    def test_clear_stale_descendants_returns_removed_ids(self):
+        """Removed descendant ids are returned so callers can react (e.g. cancel
+        auto-rerun timers)."""
+        self._set_fragment_chain("outer", "inner", "leaf")
+
+        removed = self._storage.clear_stale_descendants("outer", frozenset({"outer"}))
+
+        assert set(removed) == {"inner", "leaf"}
+
+    def test_clear_stale_descendants_returns_empty_when_nothing_removed(self):
+        """When no descendant is evicted, an empty list is returned."""
+        self._set_fragment_chain("outer", "inner")
+
+        removed = self._storage.clear_stale_descendants(
+            "outer", frozenset({"outer", "inner"})
+        )
+
+        assert removed == []
+
     def test_clear_stale_descendants_keeps_reregistered_child(self):
         """Descendants re-registered during this run are preserved."""
         self._set_fragment_chain("outer", "inner")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -417,6 +417,48 @@ class ScriptRunnerTest(unittest.TestCase):
         assert not scriptrunner._fragment_storage.contains("inner")
         assert scriptrunner._fragment_storage.contains("outer")
 
+    def test_evicted_fragment_enqueues_stop_auto_rerun(self) -> None:
+        """Evicting a stale descendant enqueues a StopAutoRerun so the frontend
+        can cancel that fragment's auto-rerun timer."""
+        outer = MagicMock()
+        inner = MagicMock()
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner._fragment_storage.register("outer", outer, parent_fragment_id=None)
+        scriptrunner._fragment_storage.register(
+            "inner", inner, parent_fragment_id="outer"
+        )
+
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["outer"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        stop_messages = [
+            msg
+            for msg in scriptrunner.forward_msgs()
+            if msg.HasField("stop_auto_rerun")
+        ]
+        assert len(stop_messages) == 1
+        assert list(stop_messages[0].stop_auto_rerun.fragment_ids) == ["inner"]
+
+    def test_fragment_rerun_without_eviction_enqueues_no_stop_auto_rerun(self) -> None:
+        """A fragment rerun that evicts nothing must not enqueue a StopAutoRerun."""
+        fragment = MagicMock()
+
+        scriptrunner = TestScriptRunner("good_script.py")
+        scriptrunner._fragment_storage.register("my_fragment", fragment)
+
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["my_fragment"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        stop_messages = [
+            msg
+            for msg in scriptrunner.forward_msgs()
+            if msg.HasField("stop_auto_rerun")
+        ]
+        assert stop_messages == []
+
     def test_fragment_queue_preserves_fifo_for_unrelated_fragments(self):
         """Unrelated queued fragments keep FIFO ordering across fragment trees."""
         execution_order = []

--- a/proto/streamlit/proto/AutoRerun.proto
+++ b/proto/streamlit/proto/AutoRerun.proto
@@ -23,3 +23,10 @@ message AutoRerun {
   // The fragment ID to rerun
   string fragment_id = 2;
 }
+
+// Sent when the server evicts fragments (e.g. an ancestor stopped rendering
+// them), so the client can cancel their pending auto-rerun timers.
+message StopAutoRerun {
+  // The fragment IDs whose auto-rerun timers should be cancelled.
+  repeated string fragment_ids = 1;
+}

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -75,6 +75,7 @@ message ForwardMsg {
     PageNotFound page_not_found = 15;
     FileURLsResponse file_urls_response = 19;
     AutoRerun auto_rerun = 21;
+    StopAutoRerun stop_auto_rerun = 28;
 
     // App logo message
     Logo logo = 22;

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -108,7 +108,7 @@ message ForwardMsg {
   string debug_last_backmsg_id = 17;
 
   reserved 7, 8, 16, 25;
-  // Next: 28
+  // Next: 29
 }
 
 // Generic backend operation response for server-side operations without script rerun.


### PR DESCRIPTION
## Describe your changes
Stops orphaned `run_every` auto-rerun timers by having the server tell the client
when a fragment is evicted.

- New `StopAutoRerun { repeated string fragment_ids }` proto message (added to
  `ForwardMsg` as field 28).
- `MemoryFragmentStorage.clear_stale_descendants` now returns the evicted ids;
  `ScriptRunner` enqueues a `StopAutoRerun` for them after a fragment run.
- Frontend `handleStopAutoRerun` cancels those fragments' interval timers.
Full reruns / page changes still reset all timers; the existing stale-BackMsg
drop in `AppSession.handle_backmsg` remains the backstop for in-flight ticks.
## GitHub Issue Link (if applicable)
Related to https://github.com/streamlit/streamlit/issues/15084
## Testing Plan
- Python: `clear_stale_descendants` returns evicted ids; `ScriptRunner` enqueues
  `StopAutoRerun` on eviction and not otherwise.
- Frontend: `App` cancels only the targeted fragment's timer on `stopAutoRerun`,
  leaving siblings running.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fragment lifecycle and client–server messaging for auto-reruns; behavior is scoped to eviction paths with tests, but incorrect targeting could stop the wrong timers or leave stale reruns.
> 
> **Overview**
> Fixes orphaned `run_every` timers on the client when nested fragments are removed from the tree but the browser still has `setInterval` handles for them.
> 
> Adds a **`StopAutoRerun`** protobuf (on `ForwardMsg` field 28) listing fragment IDs whose timers should stop. After a fragment-only run, **`clear_stale_descendants`** now returns evicted IDs instead of only mutating storage; **`ScriptRunner`** enqueues **`StopAutoRerun`** when that list is non-empty. The app wires **`handleStopAutoRerun`** to **`clearAutoRerunInterval`** per ID so sibling fragments keep ticking.
> 
> Tests cover storage return values, conditional enqueue from the script runner, and frontend selective cancellation vs. other fragments’ auto-reruns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d86d512e550f71036d13bae4a59ec721cfed2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->