### PR TITLE
[superseded] Split skills-install telemetry by cause, and fix what it exposed → #16279 + #16280

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7332,6 +7332,62 @@ describe("Skills install nudge", () => {
     })
   })
 
+  it("tags a global-fallback install with :global_fallback on success", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // Symlinks-unsupported installs (e.g. Windows without Developer Mode) are
+    // rerouted server-side to a global copy; the flag lets us count that cohort.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockResolvedValue({
+      detail: "Installed to ~/.agents/skills",
+      usedGlobalFallback: true,
+    })
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded:global_fallback",
+    })
+    // The plain success label must not also fire (it would double-count).
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded",
+    })
+  })
+
+  it("tracks a safety-gate refusal as Refused, not Failed", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // Gate reasons (headless / no_agent / non_loopback) are installs refused
+    // before being attempted; they must not inflate the install-failure rate.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockRejectedValue(
+      Object.assign(
+        new Error("Skills install is not available in this environment."),
+        { reason: "non_loopback" }
+      )
+    )
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallRefused:non_loopback",
+    })
+    // A refusal is not a failure and must stay off the failure funnel.
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed:non_loopback",
+    })
+  })
+
   it("counts a dropped-connection install separately from a failure", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     vi.spyOn(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7332,16 +7332,17 @@ describe("Skills install nudge", () => {
     })
   })
 
-  it("tags a global-fallback install with :global_fallback on success", async () => {
+  it("tags a rerouted install with the server's fallback reason", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    // Symlinks-unsupported installs (e.g. Windows without Developer Mode) are
-    // rerouted server-side to a global copy; the flag lets us count that cohort.
+    // Installs the server reroutes from project mode to a global copy carry WHY.
+    // Symlinks being unavailable machine-wide (Windows without Developer Mode) is a
+    // different problem from a single link failing, so the label keeps them apart.
     vi.spyOn(
       BackendOperationClient.prototype,
       "requestInstallSkills"
     ).mockResolvedValue({
       detail: "Installed to ~/.agents/skills",
-      usedGlobalFallback: true,
+      fallbackReason: "symlinks_unsupported",
     })
     renderApp(getProps())
     const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
@@ -7351,11 +7352,34 @@ describe("Skills install nudge", () => {
     await flushInstall()
 
     expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallSucceeded:global_fallback",
+      label: "skillsNudgeInstallSucceeded:symlinks_unsupported",
     })
     // The plain success label must not also fire (it would double-count).
     expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
       label: "skillsNudgeInstallSucceeded",
+    })
+  })
+
+  it("emits the bare success label when no reroute happened", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // A normal project install carries no fallback reason, so no suffix — and an
+    // older backend that omits the field must degrade to this same label.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockResolvedValue({ detail: "Installed to .agents/skills" })
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded",
+    })
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded:",
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7302,6 +7302,35 @@ describe("Skills install nudge", () => {
     })
   })
 
+  it("appends the server failure reason to the install-failed label", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // The server classifies the failure (e.g. the Windows symlink → GitHub
+    // download fallback) and the rejected error carries a machine-readable reason.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockRejectedValue(
+      Object.assign(new Error("Failed to download skills from GitHub"), {
+        reason: "download_failed",
+      })
+    )
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    // The reason is a label suffix (mirroring skillsNudgeSuppressedNonLocal:<locality>)
+    // so the funnel can break install failures down by cause.
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed:download_failed",
+    })
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed",
+    })
+  })
+
   it("counts a dropped-connection install separately from a failure", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     vi.spyOn(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7361,15 +7361,15 @@ describe("Skills install nudge", () => {
 
   it("tracks a safety-gate refusal as Refused, not Failed", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    // Gate reasons (headless / no_agent / non_loopback) are installs refused
-    // before being attempted; they must not inflate the install-failure rate.
+    // The server prefixes gate reasons with `refused:` — the install was declined
+    // before it was attempted, so it must not inflate the install-failure rate.
     vi.spyOn(
       BackendOperationClient.prototype,
       "requestInstallSkills"
     ).mockRejectedValue(
       Object.assign(
         new Error("Skills install is not available in this environment."),
-        { reason: "non_loopback" }
+        { reason: "refused:non_loopback" }
       )
     )
     renderApp(getProps())
@@ -7379,12 +7379,13 @@ describe("Skills install nudge", () => {
     await user.click(screen.getByRole("button", { name: "Install" }))
     await flushInstall()
 
+    // The prefix is stripped, so the gate name stays readable in the label.
     expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
       label: "skillsNudgeInstallRefused:non_loopback",
     })
     // A refusal is not a failure and must stay off the failure funnel.
     expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallFailed:non_loopback",
+      label: "skillsNudgeInstallFailed:refused:non_loopback",
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7304,14 +7304,15 @@ describe("Skills install nudge", () => {
 
   it("appends the server failure reason to the install-failed label", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    // The server classifies the failure (e.g. the Windows symlink → GitHub
-    // download fallback) and the rejected error carries a machine-readable reason.
+    // The server classifies the failure (e.g. a filesystem write failure on a
+    // locked-down target dir) and the rejected error carries a machine-readable
+    // reason from the fixed vocabulary.
     vi.spyOn(
       BackendOperationClient.prototype,
       "requestInstallSkills"
     ).mockRejectedValue(
-      Object.assign(new Error("Failed to download skills from GitHub"), {
-        reason: "download_failed",
+      Object.assign(new Error("Could not write ~/.claude/skills/..."), {
+        reason: "write_failed",
       })
     )
     renderApp(getProps())
@@ -7324,7 +7325,7 @@ describe("Skills install nudge", () => {
     // The reason is a label suffix (mirroring skillsNudgeSuppressedNonLocal:<locality>)
     // so the funnel can break install failures down by cause.
     expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallFailed:download_failed",
+      label: "skillsNudgeInstallFailed:write_failed",
     })
     expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
       label: "skillsNudgeInstallFailed",

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -32,6 +32,7 @@ import {
   setSkillsNudgeDismissed,
   setSkillsNudgeSnoozed,
   SKILLS_NUDGE_DROPPED_MESSAGE,
+  SKILLS_NUDGE_REFUSAL_REASONS,
 } from "@streamlit/app/src/components/SkillsNudgeToast/skillsNudge"
 import SkillsNudgeToast from "@streamlit/app/src/components/SkillsNudgeToast/SkillsNudgeToast"
 import StatusWidget from "@streamlit/app/src/components/StatusWidget/StatusWidget"
@@ -1604,7 +1605,16 @@ export class App extends PureComponent<Props, State> {
         // — no need to also write the permanent "don't show again" flag here,
         // which would conflate "installed" with a permanent opt-out. The card
         // shows its own success confirmation and auto-dismisses.
-        this.trackSkillsNudge("skillsNudgeInstallSucceeded")
+        //
+        // Tag installs that took the symlink -> global-copy fallback (symlinks
+        // unsupported, e.g. Windows without Developer Mode) so that cohort is
+        // countable — a fallback install is otherwise indistinguishable from a
+        // project install in the success telemetry.
+        this.trackSkillsNudge(
+          result.usedGlobalFallback
+            ? "skillsNudgeInstallSucceeded:global_fallback"
+            : "skillsNudgeInstallSucceeded"
+        )
         return result.detail ?? undefined
       })
       .catch((error: unknown) => {
@@ -1617,17 +1627,19 @@ export class App extends PureComponent<Props, State> {
           this.trackSkillsNudge("skillsNudgeInstallDropped")
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)
         }
-        // Append the server's machine-readable failure reason (e.g. "conflict",
-        // "source_missing", "symlinks_unsupported") as a label suffix — mirroring
-        // `skillsNudgeSuppressedNonLocal:<locality>` — so the install-failure rate
-        // can be broken down by cause. The reason is a fixed server-side vocabulary
-        // (never user input), safe to emit as a label.
+        // Append the server's machine-readable reason as a label suffix —
+        // mirroring `skillsNudgeSuppressedNonLocal:<locality>` — so outcomes split
+        // by cause (e.g. "conflict", "write_failed", "source_missing"). Safety-gate
+        // refusals (headless / no_agent / non_loopback) are installs we refused to
+        // attempt, not failures, so they go under a distinct
+        // `skillsNudgeInstallRefused:<reason>` and never inflate the failure rate.
+        // Reasons are a fixed server-side vocabulary (never user input).
         const reason = (error as { reason?: string } | null)?.reason
-        this.trackSkillsNudge(
-          reason
-            ? `skillsNudgeInstallFailed:${reason}`
+        const eventName =
+          reason && SKILLS_NUDGE_REFUSAL_REASONS.has(reason)
+            ? "skillsNudgeInstallRefused"
             : "skillsNudgeInstallFailed"
-        )
+        this.trackSkillsNudge(reason ? `${eventName}:${reason}` : eventName)
         // Re-throw so the toast renders its error state.
         throw error
       })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1606,11 +1606,11 @@ export class App extends PureComponent<Props, State> {
         // which would conflate "installed" with a permanent opt-out. The card
         // shows its own success confirmation and auto-dismisses.
         //
-        // Tag installs the server rerouted from project mode to a global copy,
-        // with which of the two causes — symlinks unavailable machine-wide vs. an
-        // individual link that would not lay. Those point at different fixes, and
-        // a fallback install is otherwise indistinguishable from a project install
-        // in the success telemetry.
+        // Tag installs the server rerouted from project mode to a global copy with
+        // the reason it gave (a bounded set — see fallback_reason in the proto). The
+        // distinctions matter because they point at different fixes, and a fallback
+        // install is otherwise indistinguishable from a project install in the
+        // success telemetry.
         const fallbackReason = result.fallbackReason
         this.trackSkillsNudge(
           fallbackReason

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1617,7 +1617,17 @@ export class App extends PureComponent<Props, State> {
           this.trackSkillsNudge("skillsNudgeInstallDropped")
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)
         }
-        this.trackSkillsNudge("skillsNudgeInstallFailed")
+        // Append the server's machine-readable failure reason (e.g. "conflict",
+        // "download_failed", "symlinks_unsupported") as a label suffix — mirroring
+        // `skillsNudgeSuppressedNonLocal:<locality>` — so the install-failure rate
+        // can be broken down by cause. The reason is a fixed server-side vocabulary
+        // (never user input), safe to emit as a label.
+        const reason = (error as { reason?: string } | null)?.reason
+        this.trackSkillsNudge(
+          reason
+            ? `skillsNudgeInstallFailed:${reason}`
+            : "skillsNudgeInstallFailed"
+        )
         // Re-throw so the toast renders its error state.
         throw error
       })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -29,10 +29,10 @@ import {
   isSkillsNudgeDismissed,
   isSkillsNudgeDroppedConnection,
   isSkillsNudgeSnoozed,
+  REFUSED_REASON_PREFIX,
   setSkillsNudgeDismissed,
   setSkillsNudgeSnoozed,
   SKILLS_NUDGE_DROPPED_MESSAGE,
-  SKILLS_NUDGE_REFUSAL_REASONS,
 } from "@streamlit/app/src/components/SkillsNudgeToast/skillsNudge"
 import SkillsNudgeToast from "@streamlit/app/src/components/SkillsNudgeToast/SkillsNudgeToast"
 import StatusWidget from "@streamlit/app/src/components/StatusWidget/StatusWidget"
@@ -1629,17 +1629,21 @@ export class App extends PureComponent<Props, State> {
         }
         // Append the server's machine-readable reason as a label suffix —
         // mirroring `skillsNudgeSuppressedNonLocal:<locality>` — so outcomes split
-        // by cause (e.g. "conflict", "write_failed", "source_missing"). Safety-gate
-        // refusals (headless / no_agent / non_loopback) are installs we refused to
-        // attempt, not failures, so they go under a distinct
-        // `skillsNudgeInstallRefused:<reason>` and never inflate the failure rate.
-        // Reasons are a fixed server-side vocabulary (never user input).
+        // by cause (e.g. "conflict", "write_failed", "source_missing"). A reason the
+        // server marked with REFUSED_REASON_PREFIX is an install a safety gate
+        // declined to attempt, not one that ran and failed, so it goes under a
+        // distinct `skillsNudgeInstallRefused:<reason>` and never inflates the
+        // failure rate. Reasons are a fixed server-side vocabulary (never user input).
         const reason = (error as { reason?: string } | null)?.reason
-        const eventName =
-          reason && SKILLS_NUDGE_REFUSAL_REASONS.has(reason)
-            ? "skillsNudgeInstallRefused"
-            : "skillsNudgeInstallFailed"
-        this.trackSkillsNudge(reason ? `${eventName}:${reason}` : eventName)
+        const isRefusal = reason?.startsWith(REFUSED_REASON_PREFIX) ?? false
+        const eventName = isRefusal
+          ? "skillsNudgeInstallRefused"
+          : "skillsNudgeInstallFailed"
+        // Strip the marker so the label reads `...Refused:non_loopback`.
+        const suffix = isRefusal
+          ? reason?.slice(REFUSED_REASON_PREFIX.length)
+          : reason
+        this.trackSkillsNudge(suffix ? `${eventName}:${suffix}` : eventName)
         // Re-throw so the toast renders its error state.
         throw error
       })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1608,11 +1608,11 @@ export class App extends PureComponent<Props, State> {
         return result.detail ?? undefined
       })
       .catch((error: unknown) => {
-        // A dropped or timed-out connection during a long install (e.g. the
-        // GitHub global fallback) rejects the request even though the server
-        // install may have completed. Count it separately — not as a failure,
-        // which would over-count the funnel — and surface a reassuring,
-        // retry-friendly message; re-install is idempotent.
+        // A dropped or timed-out connection during a long install rejects the
+        // request even though the server install may have completed. Count it
+        // separately — not as a failure, which would over-count the funnel —
+        // and surface a reassuring, retry-friendly message; re-install is
+        // idempotent.
         if (isSkillsNudgeDroppedConnection(error)) {
           this.trackSkillsNudge("skillsNudgeInstallDropped")
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1606,13 +1606,15 @@ export class App extends PureComponent<Props, State> {
         // which would conflate "installed" with a permanent opt-out. The card
         // shows its own success confirmation and auto-dismisses.
         //
-        // Tag installs that took the symlink -> global-copy fallback (symlinks
-        // unsupported, e.g. Windows without Developer Mode) so that cohort is
-        // countable — a fallback install is otherwise indistinguishable from a
-        // project install in the success telemetry.
+        // Tag installs the server rerouted from project mode to a global copy,
+        // with which of the two causes — symlinks unavailable machine-wide vs. an
+        // individual link that would not lay. Those point at different fixes, and
+        // a fallback install is otherwise indistinguishable from a project install
+        // in the success telemetry.
+        const fallbackReason = result.fallbackReason
         this.trackSkillsNudge(
-          result.usedGlobalFallback
-            ? "skillsNudgeInstallSucceeded:global_fallback"
+          fallbackReason
+            ? `skillsNudgeInstallSucceeded:${fallbackReason}`
             : "skillsNudgeInstallSucceeded"
         )
         return result.detail ?? undefined

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1618,7 +1618,7 @@ export class App extends PureComponent<Props, State> {
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)
         }
         // Append the server's machine-readable failure reason (e.g. "conflict",
-        // "download_failed", "symlinks_unsupported") as a label suffix — mirroring
+        // "source_missing", "symlinks_unsupported") as a label suffix — mirroring
         // `skillsNudgeSuppressedNonLocal:<locality>` — so the install-failure rate
         // can be broken down by cause. The reason is a fixed server-side vocabulary
         // (never user input), safe to emit as a label.

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -124,15 +124,12 @@ export function isSkillsNudgeDroppedConnection(error: unknown): boolean {
 }
 
 /**
- * Server-side safety-gate reasons: the install was *refused before it was
- * attempted* (headless server, no agent harness present, or a non-loopback
- * connection), not an install that ran and failed. These must be tracked
- * distinctly (`skillsNudgeInstallRefused:<reason>`) so they don't inflate the
- * genuine install-failure rate. Kept in sync with the gate reasons emitted by
- * ``InstallSkillsHandler`` in ``backend_operation_handler.py``.
+ * Prefix the server puts on an `error_reason` when a safety gate *refused* the
+ * install before attempting it (headless server, no agent harness, non-loopback
+ * connection) rather than an install that ran and failed. Refusals are tracked
+ * under their own event (`skillsNudgeInstallRefused:<reason>`) so they don't
+ * inflate the genuine install-failure rate. The server owns which reasons are
+ * refusals — we only strip the prefix — so a gate added there needs no change
+ * here. Mirrors `_REFUSED_REASON_PREFIX` in `backend_operation_handler.py`.
  */
-export const SKILLS_NUDGE_REFUSAL_REASONS: ReadonlySet<string> = new Set([
-  "headless",
-  "no_agent",
-  "non_loopback",
-])
+export const REFUSED_REASON_PREFIX = "refused:"

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -122,3 +122,17 @@ export function isSkillsNudgeDroppedConnection(error: unknown): boolean {
     message === REQUEST_TIMED_OUT_MESSAGE
   )
 }
+
+/**
+ * Server-side safety-gate reasons: the install was *refused before it was
+ * attempted* (headless server, no agent harness present, or a non-loopback
+ * connection), not an install that ran and failed. These must be tracked
+ * distinctly (`skillsNudgeInstallRefused:<reason>`) so they don't inflate the
+ * genuine install-failure rate. Kept in sync with the gate reasons emitted by
+ * ``InstallSkillsHandler`` in ``backend_operation_handler.py``.
+ */
+export const SKILLS_NUDGE_REFUSAL_REASONS: ReadonlySet<string> = new Set([
+  "headless",
+  "no_agent",
+  "non_loopback",
+])

--- a/frontend/lib/src/BackendOperationClient.test.ts
+++ b/frontend/lib/src/BackendOperationClient.test.ts
@@ -252,6 +252,48 @@ describe("BackendOperationClient", () => {
     await expect(promise).rejects.toThrow("No skills found")
   })
 
+  it("attaches the server's error_reason to the rejected install error", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        errorMsg: "developing-with-streamlit already exists.",
+        errorReason: "conflict",
+      })
+    )
+
+    // The rejection carries both the human message and the machine-readable
+    // reason (so App can route it to install-failure telemetry by cause).
+    await expect(promise).rejects.toMatchObject({
+      message: "developing-with-streamlit already exists.",
+      reason: "conflict",
+    })
+  })
+
+  it("leaves reason undefined when the server omits error_reason", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        errorMsg: "Failed to install skills.",
+      })
+    )
+
+    await expect(promise).rejects.toSatisfy(
+      (error: unknown) => (error as { reason?: string }).reason === undefined
+    )
+  })
+
   it("sends dismiss skills nudge requests and resolves on the ack", async () => {
     const sendRequest = vi.fn()
     const client = createClient(sendRequest)

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -214,12 +214,14 @@ export class BackendOperationClient {
    * @returns A promise that resolves with an optional outcome detail, or
    * rejects with the server-provided error message on failure.
    */
-  public requestInstallSkills(): Promise<{ detail?: string | null }> {
-    return this.request<{ detail?: string | null }>(
-      "installSkills",
-      {},
-      INSTALL_SKILLS_REQUEST_TIMEOUT_MS
-    )
+  public requestInstallSkills(): Promise<{
+    detail?: string | null
+    usedGlobalFallback?: boolean
+  }> {
+    return this.request<{
+      detail?: string | null
+      usedGlobalFallback?: boolean
+    }>("installSkills", {}, INSTALL_SKILLS_REQUEST_TIMEOUT_MS)
   }
 
   /**

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -212,17 +212,17 @@ export class BackendOperationClient {
    * Request a one-click install of the bundled Streamlit agent skills.
    *
    * @returns A promise that resolves with an optional outcome detail and a
-   * `usedGlobalFallback` flag (true when a project install was rerouted to a
-   * global copy), or rejects with a {@link BackendOperationError} whose `reason`
-   * classifies the failure for telemetry.
+   * `fallbackReason` naming why a project install was rerouted to a global copy
+   * (empty when it wasn't), or rejects with a {@link BackendOperationError} whose
+   * `reason` classifies the failure for telemetry.
    */
   public requestInstallSkills(): Promise<{
     detail?: string | null
-    usedGlobalFallback?: boolean
+    fallbackReason?: string | null
   }> {
     return this.request<{
       detail?: string | null
-      usedGlobalFallback?: boolean
+      fallbackReason?: string | null
     }>("installSkills", {}, INSTALL_SKILLS_REQUEST_TIMEOUT_MS)
   }
 

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -58,6 +58,22 @@ export const CONNECTION_CLOSED_MESSAGE = "Connection closed"
 /** Rejection message used when a request exceeds its timeout. */
 export const REQUEST_TIMED_OUT_MESSAGE = "Request timed out"
 
+/**
+ * Error a backend operation rejects with when the server returns a failure.
+ * Carries the server's machine-readable `reason` (e.g. the skills-install
+ * failure cause) alongside the human-readable message, so callers can route it
+ * to telemetry without parsing the message text.
+ */
+export class BackendOperationError extends Error {
+  public readonly reason?: string
+
+  constructor(message: string, reason?: string) {
+    super(message)
+    this.name = "BackendOperationError"
+    this.reason = reason || undefined
+  }
+}
+
 /** Information about a pending request. */
 interface PendingRequest<T> {
   resolver: PromiseWithResolvers<T>
@@ -230,7 +246,12 @@ export class BackendOperationClient {
     this.cleanupRequest(requestId)
 
     if (response.errorMsg) {
-      pending.resolver.reject(new Error(response.errorMsg))
+      pending.resolver.reject(
+        new BackendOperationError(
+          response.errorMsg,
+          response.errorReason ?? undefined
+        )
+      )
     } else {
       try {
         const payload = this.extractResponsePayload(response)

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -62,9 +62,11 @@ export const REQUEST_TIMED_OUT_MESSAGE = "Request timed out"
  * Error a backend operation rejects with when the server returns a failure.
  * Carries the server's machine-readable `reason` (e.g. the skills-install
  * failure cause) alongside the human-readable message, so callers can route it
- * to telemetry without parsing the message text.
+ * to telemetry without parsing the message text. Not exported: it is thrown
+ * from within this module and consumers read the `reason` property structurally
+ * (`(error as { reason?: string }).reason`) rather than via `instanceof`.
  */
-export class BackendOperationError extends Error {
+class BackendOperationError extends Error {
   public readonly reason?: string
 
   constructor(message: string, reason?: string) {

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -39,12 +39,12 @@ const DATAFRAME_CHUNK_REQUEST_TIMEOUT_MS = 120_000
 /**
  * Timeout for skills-install requests (3 minutes).
  *
- * The default 30s is too short here: a project-mode install is fast (it just
- * creates symlinks), but `streamlit skills` falls back to downloading the
- * skills archive from GitHub when symlinks aren't supported (e.g. Windows
- * without Developer Mode). That download can exceed 30s on a slow network,
- * which would surface a spurious "install failed" in the toast while the
- * server keeps installing. We use the same generous budget as deferred files.
+ * The default 30s is too short here: an install does real filesystem I/O -
+ * copying the bundled meta-skill/content skills into project or home dirs -
+ * which can be slow on locked-down machines (antivirus scans, networked or
+ * OneDrive-backed home directories). A too-short timeout would surface a
+ * spurious "install failed" in the toast while the server keeps installing.
+ * We use the same generous budget as deferred files.
  */
 const INSTALL_SKILLS_REQUEST_TIMEOUT_MS = 180_000
 

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -211,8 +211,10 @@ export class BackendOperationClient {
   /**
    * Request a one-click install of the bundled Streamlit agent skills.
    *
-   * @returns A promise that resolves with an optional outcome detail, or
-   * rejects with the server-provided error message on failure.
+   * @returns A promise that resolves with an optional outcome detail and a
+   * `usedGlobalFallback` flag (true when a project install was rerouted to a
+   * global copy), or rejects with a {@link BackendOperationError} whose `reason`
+   * classifies the failure for telemetry.
    */
   public requestInstallSkills(): Promise<{
     detail?: string | null

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -224,14 +224,20 @@ class InstallSkillsHandler(BackendOperationHandler):
         # after a dropped connection whose first attempt already completed
         # server-side — surfacing a success as an unrecoverable error and
         # logging it as a failed install. Idempotent retry is the correct path.
-        if (
-            config.get_option("server.headless")
-            or not skills.detect_installed_agents()
-            or connection_locality(session_id) != "loopback"
-        ):
+        gate_reason = (
+            "headless"
+            if config.get_option("server.headless")
+            else "no_agent"
+            if not skills.detect_installed_agents()
+            else "non_loopback"
+            if connection_locality(session_id) != "loopback"
+            else None
+        )
+        if gate_reason is not None:
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg="Skills install is not available in this environment.",
+                error_reason=gate_reason,
             )
 
         try:
@@ -253,9 +259,15 @@ class InstallSkillsHandler(BackendOperationHandler):
                 if isinstance(ex, click.ClickException)
                 else "Failed to install skills."
             )
+            # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
+            # (e.g. "conflict", "source_missing", "symlinks_unsupported") that the
+            # client forwards to telemetry so the nudge's install-failure rate can
+            # be split by cause. Any other exception is classified "unknown".
+            reason = getattr(ex, "reason", "unknown")
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",
+                error_reason=reason if isinstance(reason, str) else "unknown",
             )
 
         # Invalidate the cached "skills installed" detection so a later session

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -42,6 +42,13 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = get_logger(__name__)
 
+# Prefix marking an ``error_reason`` as a refusal: the operation was declined by a
+# safety gate before it ran, rather than attempted and failed. The client strips the
+# prefix and counts refusals under their own telemetry event, so they never inflate
+# the genuine failure rate. Mirrored by REFUSED_REASON_PREFIX in the frontend's
+# components/SkillsNudgeToast/skillsNudge.ts.
+_REFUSED_REASON_PREFIX: Final[str] = "refused:"
+
 
 def connection_locality(session_id: str) -> str:
     """Classify the WebSocket peer of ``session_id`` for the skills nudge.
@@ -241,7 +248,12 @@ class InstallSkillsHandler(BackendOperationHandler):
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg="Skills install is not available in this environment.",
-                error_reason=gate_reason,
+                # The ``refused:`` prefix tells the client this install was declined
+                # before it ran, so it counts separately from installs that ran and
+                # failed. Namespacing it server-side keeps that distinction in one
+                # place: a gate added here is classified correctly without the
+                # frontend having to mirror the list of gate names.
+                error_reason=f"{_REFUSED_REASON_PREFIX}{gate_reason}",
             )
 
         try:
@@ -264,14 +276,15 @@ class InstallSkillsHandler(BackendOperationHandler):
                 else "Failed to install skills."
             )
             # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
-            # (e.g. "conflict", "write_failed", "source_missing") that the client
-            # forwards to telemetry as a label suffix. Read it ONLY from that known
-            # type - never getattr-duck-type, or an unrelated exception that happens
-            # to expose a str ``.reason`` (e.g. UnicodeDecodeError.reason) would emit
-            # an unbounded label and break the fixed vocabulary. A bare ``OSError``
-            # that escaped the installer (e.g. a permission error before the copy's
-            # own try/except) is a filesystem write failure; anything else "unknown".
-            if isinstance(ex, skills._InstallError) and isinstance(ex.reason, str):
+            # that the client forwards to telemetry as a label suffix. Read it ONLY
+            # from that known type - never getattr-duck-type, or an unrelated
+            # exception that happens to expose a str ``.reason`` (e.g.
+            # UnicodeDecodeError.reason) would emit an unbounded label and break the
+            # fixed vocabulary. A bare ``OSError`` that escaped the installer (e.g. a
+            # permission error before the copy's own try/except) is a filesystem write
+            # failure; anything else "unknown".
+            reason: str
+            if isinstance(ex, skills._InstallError):
                 reason = ex.reason
             elif isinstance(ex, OSError):
                 reason = "write_failed"

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -290,7 +290,8 @@ class InstallSkillsHandler(BackendOperationHandler):
         return BackendOperationResponse(
             request_id=request.request_id,
             install_skills=InstallSkillsResponsePayload(
-                detail=skills.summarize_install(result)
+                detail=skills.summarize_install(result),
+                used_global_fallback=result.used_global_fallback,
             ),
         )
 

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -224,15 +224,19 @@ class InstallSkillsHandler(BackendOperationHandler):
         # after a dropped connection whose first attempt already completed
         # server-side — surfacing a success as an unrecoverable error and
         # logging it as a failed install. Idempotent retry is the correct path.
-        gate_reason = (
-            "headless"
-            if config.get_option("server.headless")
-            else "no_agent"
-            if not skills.detect_installed_agents()
-            else "non_loopback"
-            if connection_locality(session_id) != "loopback"
-            else None
-        )
+        #
+        # Check the conditions in order; the first that trips names the telemetry
+        # reason. This short-circuits, so e.g. detect_installed_agents() (which
+        # touches the filesystem) isn't called in headless mode.
+        if config.get_option("server.headless"):
+            gate_reason = "headless"
+        elif not skills.detect_installed_agents():
+            gate_reason = "no_agent"
+        elif connection_locality(session_id) != "loopback":
+            gate_reason = "non_loopback"
+        else:
+            gate_reason = None
+
         if gate_reason is not None:
             return BackendOperationResponse(
                 request_id=request.request_id,

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -264,14 +264,19 @@ class InstallSkillsHandler(BackendOperationHandler):
                 else "Failed to install skills."
             )
             # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
-            # (e.g. "conflict", "source_missing", "symlinks_unsupported") that the
-            # client forwards to telemetry so the nudge's install-failure rate can
-            # be split by cause. Any other exception is classified "unknown".
-            reason = getattr(ex, "reason", "unknown")
+            # (e.g. "conflict", "write_failed", "source_missing") that the client
+            # forwards to telemetry so the nudge's install-failure rate can be
+            # split by cause. A bare ``OSError`` that escaped the installer
+            # (e.g. a permission error creating the target dir, before the copy's
+            # own try/except) is a filesystem write failure - classify it as such
+            # rather than burying it in "unknown". Anything else is "unknown".
+            reason = getattr(ex, "reason", None)
+            if not isinstance(reason, str):
+                reason = "write_failed" if isinstance(ex, OSError) else "unknown"
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",
-                error_reason=reason if isinstance(reason, str) else "unknown",
+                error_reason=reason,
             )
 
         # Invalidate the cached "skills installed" detection so a later session

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -281,13 +281,15 @@ class InstallSkillsHandler(BackendOperationHandler):
             # exception that happens to expose a str ``.reason`` (e.g.
             # UnicodeDecodeError.reason) would emit an unbounded label and break the
             # fixed vocabulary. A bare ``OSError`` that escaped the installer (e.g. a
-            # permission error before the copy's own try/except) is a filesystem write
-            # failure; anything else "unknown".
+            # permission error before the copy's own try/except) gets the same errno
+            # classification the installer would have applied, so it lands in a
+            # specific write_* bucket rather than being flattened; anything else
+            # "unknown".
             reason: str
             if isinstance(ex, skills._InstallError):
                 reason = ex.reason
             elif isinstance(ex, OSError):
-                reason = "write_failed"
+                reason = skills._classify_write_error(ex)
             else:
                 reason = "unknown"
             return BackendOperationResponse(
@@ -304,7 +306,7 @@ class InstallSkillsHandler(BackendOperationHandler):
             request_id=request.request_id,
             install_skills=InstallSkillsResponsePayload(
                 detail=skills.summarize_install(result),
-                used_global_fallback=result.used_global_fallback,
+                fallback_reason=result.fallback_reason or "",
             ),
         )
 

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -265,14 +265,18 @@ class InstallSkillsHandler(BackendOperationHandler):
             )
             # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
             # (e.g. "conflict", "write_failed", "source_missing") that the client
-            # forwards to telemetry so the nudge's install-failure rate can be
-            # split by cause. A bare ``OSError`` that escaped the installer
-            # (e.g. a permission error creating the target dir, before the copy's
-            # own try/except) is a filesystem write failure - classify it as such
-            # rather than burying it in "unknown". Anything else is "unknown".
-            reason = getattr(ex, "reason", None)
-            if not isinstance(reason, str):
-                reason = "write_failed" if isinstance(ex, OSError) else "unknown"
+            # forwards to telemetry as a label suffix. Read it ONLY from that known
+            # type - never getattr-duck-type, or an unrelated exception that happens
+            # to expose a str ``.reason`` (e.g. UnicodeDecodeError.reason) would emit
+            # an unbounded label and break the fixed vocabulary. A bare ``OSError``
+            # that escaped the installer (e.g. a permission error before the copy's
+            # own try/except) is a filesystem write failure; anything else "unknown".
+            if isinstance(ex, skills._InstallError) and isinstance(ex.reason, str):
+                reason = ex.reason
+            elif isinstance(ex, OSError):
+                reason = "write_failed"
+            else:
+                reason = "unknown"
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
 import shutil
 import sys
@@ -39,12 +40,27 @@ _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
 # Prefix for the scratch directories a replacement install stages into. Only
 # ``mkdtemp`` produces these names, which is what makes the cleanup sweep in
 # _sweep_staging_dirs safe to run against a directory holding user files.
-_STAGING_PREFIX: Final[str] = ".streamlit-skills-staging-"
+#
+# Kept deliberately short, as are the child names below: staging adds a path
+# segment, and Windows still caps paths at 260 characters without long-path
+# support - which is itself one of the failure causes this telemetry is meant to
+# identify. Lengthening the path while hunting a path-length bug would be its own
+# footgun.
+_STAGING_PREFIX: Final[str] = ".st-skills-"
+# Children of the staging dir: the incoming copy and the displaced old install.
+# Single letters for the same path-budget reason; neither name is ever user-visible.
+_STAGING_NEW: Final[str] = "n"
+_STAGING_OLD: Final[str] = "o"
 
 # The full vocabulary of install-failure causes. A closed set so the reason stays
 # safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
 # typo or an ad-hoc reason at the raise site instead of silently minting a new
 # label the analysis queries won't know about.
+#
+# The ``write_*`` values subdivide what would otherwise be a single opaque
+# "a write failed". That distinction is the point: a lock clears on retry, a path
+# that is too long can be shortened, and neither is fixed by the permissions advice
+# a generic write failure would earn. See :func:`_classify_write_error`.
 _InstallFailureReason = Literal[
     "conflict",  # A pre-existing file or foreign symlink we won't overwrite.
     "incomplete",  # Project symlinks failed and the global fallback was cancelled.
@@ -52,8 +68,66 @@ _InstallFailureReason = Literal[
     "non_interactive",  # No TTY to prompt on and --yes wasn't passed.
     "source_missing",  # The bundled skills are absent from the installation.
     "symlinks_unsupported",  # Project install needs symlinks; this OS won't make them.
-    "write_failed",  # An OSError while writing: permissions, disk space, locks.
+    "write_denied",  # Permissions, or a read-only filesystem.
+    "write_locked",  # Another process holds the path (antivirus, sync clients).
+    "write_name_too_long",  # The path exceeded the OS limit (Windows MAX_PATH).
+    "write_no_space",  # Out of disk, or over a quota.
+    "write_failed",  # A write failed for a reason none of the above cover.
 ]
+
+# Why a project install was rerouted to a global copy. Split because the two mean
+# different things: ``symlinks_unsupported`` is a categorical property of the machine
+# (Windows without Developer Mode) that a user can fix, while ``symlink_failed`` means
+# the pre-check passed and an individual link still would not lay - closer to a bug or
+# a directory-specific permission problem, and worth chasing separately.
+_FallbackReason = Literal["symlinks_unsupported", "symlink_failed"]
+
+# OSError.errno -> reason. Built by name so a platform missing one of these (they
+# are not all defined everywhere) simply omits it rather than failing at import.
+_ERRNO_GROUPS: Final[tuple[tuple[tuple[str, ...], _InstallFailureReason], ...]] = (
+    (("EACCES", "EPERM", "EROFS"), "write_denied"),
+    (("ENOSPC", "EDQUOT", "EFBIG"), "write_no_space"),
+    (("EBUSY", "EAGAIN", "ETXTBSY"), "write_locked"),
+    (("ENAMETOOLONG",), "write_name_too_long"),
+)
+_WRITE_REASON_BY_ERRNO: Final[dict[int, _InstallFailureReason]] = {
+    code: reason
+    for names, reason in _ERRNO_GROUPS
+    for name in names
+    if (code := getattr(errno, name, None)) is not None
+}
+
+# Windows native codes, consulted BEFORE errno because CPython's mapping is lossy in
+# exactly the way that would mislead us: a sharing violation (antivirus or OneDrive
+# holding the file) arrives as EACCES, which reads as a permissions problem and sends
+# us after folder ACLs when the actual fix is to retry.
+_WRITE_REASON_BY_WINERROR: Final[dict[int, _InstallFailureReason]] = {
+    5: "write_denied",  # ERROR_ACCESS_DENIED
+    19: "write_denied",  # ERROR_WRITE_PROTECT
+    32: "write_locked",  # ERROR_SHARING_VIOLATION
+    33: "write_locked",  # ERROR_LOCK_VIOLATION
+    39: "write_no_space",  # ERROR_HANDLE_DISK_FULL
+    112: "write_no_space",  # ERROR_DISK_FULL
+    206: "write_name_too_long",  # ERROR_FILENAME_EXCED_RANGE
+}
+
+
+def _classify_write_error(error: OSError) -> _InstallFailureReason:
+    """Map a filesystem ``OSError`` to a bounded, actionable failure reason.
+
+    Only the error *class* is used - never the message, which can embed an absolute
+    server path - so the result stays safe to emit as a telemetry label.
+
+    Returns the generic ``"write_failed"`` when the code is unrecognised, so an
+    unclassified failure is visible as such in the data rather than being guessed
+    into the wrong bucket.
+    """
+    winerror = getattr(error, "winerror", None)
+    if isinstance(winerror, int) and winerror in _WRITE_REASON_BY_WINERROR:
+        return _WRITE_REASON_BY_WINERROR[winerror]
+    if error.errno is not None and error.errno in _WRITE_REASON_BY_ERRNO:
+        return _WRITE_REASON_BY_ERRNO[error.errno]
+    return "write_failed"
 
 
 class _InstallError(click.ClickException):
@@ -106,11 +180,14 @@ class _InstallResult:
     # nudge's install-failure telemetry reason. Only the copy path fills this;
     # symlink failures reroute to a global install instead of being recorded here.
     errored: list[str] = field(default_factory=list)
-    # True when a project install was rerouted to a global copy - either because
-    # the up-front symlink pre-check failed, or because laying an individual
-    # symlink failed. Surfaced to telemetry so that cohort is countable - see
+    # Classified cause for each ``errored`` entry, in the same order. Kept apart from
+    # the display strings above because those carry raw OSError text (fine for the
+    # CLI, never for the browser) while these are the bounded telemetry reasons.
+    write_reasons: list[_InstallFailureReason] = field(default_factory=list)
+    # Set when a project install was rerouted to a global copy, to which of the two
+    # causes. Surfaced to telemetry so that cohort is countable and separable - see
     # InstallSkillsResponsePayload.
-    used_global_fallback: bool = False
+    fallback_reason: _FallbackReason | None = None
 
 
 def _get_source_skills_dir() -> Path:
@@ -437,7 +514,7 @@ def _install_skill_symlink(
         # ``rel_source`` is relative to target_dir, so while the link sits one level
         # down in staging it dangles. Nothing reads it there, and the rename below
         # moves the link verbatim, after which it resolves.
-        link_path = staging / skill_name
+        link_path = staging / _STAGING_NEW
 
     try:
         link_path.symlink_to(rel_source, target_is_directory=True)
@@ -567,8 +644,8 @@ def _install_skill_copy(
         # a fresh mkdtemp rather than a fixed sibling name.
         if old_target_to_remove is not None:
             staging = _open_staging_dir(target_dir)
-            new_path = staging / skill_name
-            backup_path = staging / f"{skill_name}.old"
+            new_path = staging / _STAGING_NEW
+            backup_path = staging / _STAGING_OLD
             shutil.copytree(source_path, new_path)
             # Move the old target aside rather than deleting it: if the swap then
             # fails we can put it back, instead of stranding the new copy in
@@ -603,6 +680,7 @@ def _install_skill_copy(
         # A write failure, not a conflict - record it in ``errored`` so it is
         # classified as such (reason="write_failed"), not "conflict".
         result.errored.append(f"{rel_target_path} (copy failed: {e})")
+        result.write_reasons.append(_classify_write_error(e))
     finally:
         # Discard staging unless the target ended up empty, which happens only when
         # the swap AND the restore both failed - there it holds the user's only
@@ -776,19 +854,27 @@ def _conflict_error(skipped: list[str]) -> _InstallError:
     )
 
 
-def _write_error(errored: list[str]) -> _InstallError:
+def _write_error(result: _InstallResult) -> _InstallError:
     """Build a "couldn't write" error for filesystem failures during copy.
 
     Distinct from :func:`_conflict_error`: ``errored`` entries are ``OSError``
-    failures (permissions, disk space, locked files), not pre-existing files.
-    Keeping them apart stops the nudge's failure telemetry from misreporting a
-    write failure as a ``conflict``.
+    failures, not pre-existing files. Keeping them apart stops the nudge's failure
+    telemetry from misreporting a write failure as a ``conflict``.
+
+    The reason is the specific cause when every failed target agreed on one, and the
+    generic ``write_failed`` when they disagreed - claiming "permission denied" for a
+    set of failures that were half permissions and half disk-full would point whoever
+    reads the telemetry at the wrong fix.
     """
-    joined = ", ".join(_concise_install_paths(errored))
+    joined = ", ".join(_concise_install_paths(result.errored))
+    distinct = set(result.write_reasons)
+    reason: _InstallFailureReason = (
+        next(iter(distinct)) if len(distinct) == 1 else "write_failed"
+    )
     return _InstallError(
         f"Could not write {joined}. Check folder permissions and free disk "
         "space, then try again.",
-        reason="write_failed",
+        reason=reason,
     )
 
 
@@ -840,7 +926,7 @@ def _install_project_skills(
             )
             click.echo()
             global_result = _install_global_skills(yes=yes)
-            global_result.used_global_fallback = True
+            global_result.fallback_reason = "symlinks_unsupported"
             return global_result
 
         raise _InstallError(
@@ -883,7 +969,9 @@ def _install_project_skills(
         click.echo()
         try:
             global_result = _install_global_skills(yes=yes)
-            global_result.used_global_fallback = True
+            # The pre-check said symlinks work here, yet laying one still failed -
+            # distinct from the categorical case above, and worth chasing separately.
+            global_result.fallback_reason = "symlink_failed"
             return global_result
         except click.ClickException:
             # Global install failed - partial project symlinks remain as fallback
@@ -997,7 +1085,7 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
     # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
     # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
     if result.errored:
-        raise _write_error(result.errored)
+        raise _write_error(result)
 
     if result.installed or result.up_to_date:
         click.echo()

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -51,6 +52,11 @@ _STAGING_PREFIX: Final[str] = ".st-skills-"
 # Single letters for the same path-budget reason; neither name is ever user-visible.
 _STAGING_NEW: Final[str] = "n"
 _STAGING_OLD: Final[str] = "o"
+# How long a staging dir must sit untouched before the sweep will reclaim it. A live
+# install writes into staging within seconds, so anything older was orphaned by a crash
+# or a kill - and anything younger may belong to a concurrent install whose staging dir
+# holds the only copy of the installation it has already moved aside.
+_STAGING_ORPHAN_AGE_S: Final[float] = 3600.0
 
 # The full vocabulary of install-failure causes. A closed set so the reason stays
 # safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
@@ -619,13 +625,26 @@ def _open_staging_dir(target_dir: Path) -> Path:
 def _sweep_staging_dirs(target_dir: Path) -> None:
     """Reclaim staging directories orphaned by an interrupted install.
 
-    Matches only :data:`_STAGING_PREFIX`, which ``mkdtemp`` alone produces, so this
-    can never remove a user's own files. Best-effort: a failure to tidy up must not
-    fail an install.
+    Two guards, both load-bearing:
+
+    - Only :data:`_STAGING_PREFIX` names are candidates, and only ``mkdtemp``
+      produces those, so a user's own files are never at risk.
+    - Only directories untouched for :data:`_STAGING_ORPHAN_AGE_S` are removed.
+      Sweeping on name alone would delete a *concurrent* install's staging
+      directory - which may already hold the old installation it moved aside, so
+      the sweep would take out both that and its replacement and leave the
+      canonical path empty. Orphan cleanup turning into data loss is worse than
+      the orphans it set out to prevent. A live install writes into staging within
+      seconds, so age separates the two cleanly without needing a lock.
+
+    Best-effort throughout: failing to tidy up must never fail an install.
     """
+    cutoff = time.time() - _STAGING_ORPHAN_AGE_S
     with contextlib.suppress(OSError):
         for stale in target_dir.glob(f"{_STAGING_PREFIX}*"):
-            shutil.rmtree(stale, ignore_errors=True)
+            with contextlib.suppress(OSError):
+                if stale.stat().st_mtime < cutoff:
+                    shutil.rmtree(stale, ignore_errors=True)
 
 
 def _install_skill_copy(

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -66,7 +66,8 @@ _InstallFailureReason = Literal[
     "incomplete",  # Project symlinks failed and the global fallback was cancelled.
     "no_skills",  # The bundled skills dir exists but contains nothing installable.
     "non_interactive",  # No TTY to prompt on and --yes wasn't passed.
-    "source_missing",  # The bundled skills are absent from the installation.
+    "source_missing",  # The bundled skills dir is absent from the installation.
+    "source_incomplete",  # The dir is present but a required file is missing.
     "symlinks_unsupported",  # Project install needs symlinks; this OS won't make them.
     "write_denied",  # Permissions, or a read-only filesystem.
     "write_locked",  # Another process holds the path (antivirus, sync clients).
@@ -75,12 +76,18 @@ _InstallFailureReason = Literal[
     "write_failed",  # A write failed for a reason none of the above cover.
 ]
 
-# Why a project install was rerouted to a global copy. Split because the two mean
-# different things: ``symlinks_unsupported`` is a categorical property of the machine
-# (Windows without Developer Mode) that a user can fix, while ``symlink_failed`` means
-# the pre-check passed and an individual link still would not lay - closer to a bug or
-# a directory-specific permission problem, and worth chasing separately.
-_FallbackReason = Literal["symlinks_unsupported", "symlink_failed"]
+# Why a project install was rerouted to a global copy. Split as finely as the OS lets
+# us, because most Windows users take this path and then SUCCEED - so this, not the
+# failure vocabulary, is where their diagnostic signal lives. The distinctions map to
+# different responses: Developer Mode off is a documentable user action, a denial on
+# the project directory is an environment problem, a filesystem with no symlink support
+# at all is neither, and a link failing after the pre-check passed is closer to a bug.
+_FallbackReason = Literal[
+    "symlinks_no_privilege",  # Windows Developer Mode off (ERROR_PRIVILEGE_NOT_HELD).
+    "symlinks_denied",  # Permissions on the project dir refused the probe.
+    "symlinks_unsupported",  # The filesystem/OS has no directory symlinks.
+    "symlink_failed",  # Pre-check passed, then an individual link would not lay.
+]
 
 # OSError.errno -> reason. Built by name so a platform missing one of these (they
 # are not all defined everywhere) simply omits it rather than failing at import.
@@ -406,17 +413,41 @@ def _skill_copy_matches(source_path: Path, target_path: Path) -> bool:
     return True
 
 
-def _symlinks_supported(project_root: Path, source_path: Path) -> bool:
-    """Return whether project install can create directory symlinks."""
+def _symlink_blocker(project_root: Path, source_path: Path) -> _FallbackReason | None:
+    """Return why project install can't use symlinks here, or ``None`` if it can.
+
+    Probes by actually creating one in a temp dir, then classifies the failure rather
+    than collapsing it to "unsupported". This is the highest-value split in the whole
+    vocabulary: most Windows users land here and then *succeed* via the global
+    fallback, so this is what their success label carries, and the causes want
+    completely different responses. ``symlinks_no_privilege`` (Developer Mode off) is
+    a documentable user action, while a denial on the project directory or a
+    filesystem that has no symlinks at all are not.
+    """
     try:
         with tempfile.TemporaryDirectory(
             prefix=".streamlit-skills-", dir=project_root
         ) as temp_dir:
             link_path = Path(temp_dir) / "skill-link"
             link_path.symlink_to(source_path, target_is_directory=True)
-            return link_path.is_symlink()
-    except (OSError, NotImplementedError):
-        return False
+            if link_path.is_symlink():
+                return None
+            # Created without error yet isn't a symlink: treat as unsupported rather
+            # than claiming success we can't verify.
+            return "symlinks_unsupported"
+    except NotImplementedError:
+        return "symlinks_unsupported"
+    except OSError as e:
+        # ERROR_PRIVILEGE_NOT_HELD: the account lacks SeCreateSymbolicLinkPrivilege,
+        # which in practice means Windows Developer Mode is off. Distinguishing this
+        # is the point of the exercise - it is the one cause a user can simply fix.
+        if getattr(e, "winerror", None) == 1314:
+            return "symlinks_no_privilege"
+        if e.errno in _WRITE_REASON_BY_ERRNO and (
+            _WRITE_REASON_BY_ERRNO[e.errno] == "write_denied"
+        ):
+            return "symlinks_denied"
+        return "symlinks_unsupported"
 
 
 def _get_display_path(
@@ -909,7 +940,8 @@ def _install_project_skills(
     project_root = _find_project_root(Path(app_dir) if app_dir else None)
     target_dirs = _get_project_target_dirs(project_root)
 
-    if not _symlinks_supported(project_root, source_skills_dir / skills[0]):
+    symlink_blocker = _symlink_blocker(project_root, source_skills_dir / skills[0])
+    if symlink_blocker is not None:
         if fallback_to_global:
             click.secho(
                 "\n⚠ Symlinks not supported on this system.",
@@ -926,7 +958,7 @@ def _install_project_skills(
             )
             click.echo()
             global_result = _install_global_skills(yes=yes)
-            global_result.fallback_reason = "symlinks_unsupported"
+            global_result.fallback_reason = symlink_blocker
             return global_result
 
         raise _InstallError(
@@ -1062,7 +1094,10 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
         raise _InstallError(
             f"The bundled '{_GLOBAL_SKILL_NAME}' meta-skill was not found in your "
             "Streamlit installation. Reinstall Streamlit and try again.",
-            reason="source_missing",
+            # Distinct from source_missing: the directory is there but a required
+            # file is not, which points at a too-narrow package-data glob rather
+            # than skills being absent from the wheel entirely.
+            reason="source_incomplete",
         )
 
     # Install to each target directory

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -36,6 +36,11 @@ _LOGGER: Final = get_logger(__name__)
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
 
+# Prefix for the scratch directories a replacement install stages into. Only
+# ``mkdtemp`` produces these names, which is what makes the cleanup sweep in
+# _sweep_staging_dirs safe to run against a directory holding user files.
+_STAGING_PREFIX: Final[str] = ".streamlit-skills-staging-"
+
 # The full vocabulary of install-failure causes. A closed set so the reason stays
 # safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
 # typo or an ad-hoc reason at the raise site instead of silently minting a new
@@ -420,22 +425,30 @@ def _install_skill_symlink(
     # old one has to go first, and "remove then re-create" loses a working install
     # whenever the re-create fails. Since a failing re-create means this system
     # can't make symlinks at all, an attempt to restore would fail for the same
-    # reason. So prove we can make the link - under a temp name - BEFORE removing
-    # anything. If that fails, the existing install is still untouched.
+    # reason. So prove we can make the link - inside a private staging dir - BEFORE
+    # removing anything. If that fails, the existing install is still untouched.
+    staging: Path | None = None
     link_path = target_path
     if replace_owned_link:
-        link_path = target_path.with_name(f".{skill_name}.newlink")
-        with contextlib.suppress(OSError):
-            _remove_skill_target(link_path)
+        try:
+            staging = _open_staging_dir(target_dir)
+        except OSError:
+            return False
+        # ``rel_source`` is relative to target_dir, so while the link sits one level
+        # down in staging it dangles. Nothing reads it there, and the rename below
+        # moves the link verbatim, after which it resolves.
+        link_path = staging / skill_name
 
     try:
         link_path.symlink_to(rel_source, target_is_directory=True)
     except (OSError, NotImplementedError):
         # Symlink not supported (e.g., Windows without Developer Mode, or some
         # environments where symlinks are not implemented). Nothing was removed.
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
         return False
 
-    if replace_owned_link:
+    if staging is not None:
         try:
             target_path.unlink()
             # Renaming into a name we just freed, in the same directory.
@@ -444,37 +457,67 @@ def _install_skill_symlink(
             if target_path.exists() or target_path.is_symlink():
                 # The unlink failed, so the old install is intact and the staged
                 # link is redundant. Drop it and let the caller fall back.
-                with contextlib.suppress(OSError):
-                    _remove_skill_target(link_path)
+                shutil.rmtree(staging, ignore_errors=True)
                 return False
             # The old link is gone but the staged one wouldn't move, leaving the
             # canonical path empty. Creating a link here demonstrably works - we
             # just made one - so lay it directly rather than stranding the install
-            # under a dot-name that nothing reads.
+            # inside a staging dir that nothing reads.
             try:
                 target_path.symlink_to(rel_source, target_is_directory=True)
             except OSError:
-                # Keep the staged link: it is now the only one, so deleting it
-                # would leave nothing at all.
+                # Leave staging in place: it holds the only link, and the sweep on
+                # the next install is what reclaims it.
                 return False
-            with contextlib.suppress(OSError):
-                _remove_skill_target(link_path)
+        shutil.rmtree(staging, ignore_errors=True)
 
     result.installed.append(str(rel_target_path))
     return True
 
 
-def _remove_skill_target(path: Path) -> None:
-    """Delete an installed skill target, whichever form it took.
+def _open_staging_dir(target_dir: Path) -> Path:
+    """Create a private scratch directory inside ``target_dir`` for a replacement.
 
-    A target can be a real directory (global copy) or a symlink (project
-    install), and ``shutil.rmtree`` refuses symlinks. Absent paths are a no-op so
-    callers can use this to clear a possibly-stale leftover.
+    Replacing an installed skill can't be done in one step: ``symlink_to`` won't
+    overwrite, and no OS offers an atomic replace for a non-empty directory
+    (``rename`` onto one gives ``ENOTEMPTY``, or ``PermissionError`` on Windows).
+    So a replacement has to build the new copy somewhere else first and then swap
+    it in, which raises the question of *where* "somewhere else" is.
+
+    Three options, and why this is the one:
+
+    - **A fixed sibling name** (``.<skill>.tmp``) is predictable, so clearing it
+      before use can recursively delete a directory the installer never created,
+      and two concurrent installs silently clobber each other's scratch space.
+    - **A unique name with no cleanup** can't collide, but every interrupted
+      install leaves a permanent orphan directory in a folder users browse and
+      gitignore.
+    - **A unique name plus a prefix-scoped sweep** — this. ``mkdtemp`` guarantees
+      the directory is ours and fresh, so nothing is ever deleted that we didn't
+      create; :func:`_sweep_staging_dirs` reclaims orphans on the next install by
+      matching only our own prefix, so they don't accumulate either.
+
+    The one accepted consequence: a staging directory deliberately left behind by
+    an unrecoverable swap (see :func:`_install_skill_copy`) is reclaimed by the
+    next install's sweep. That is bounded — anything in it is a copy of a bundled
+    skill, reproducible from the wheel — and by the time the sweep runs, the
+    install that follows it repopulates the canonical path anyway.
     """
-    if path.is_symlink():
-        path.unlink()
-    elif path.is_dir():
-        shutil.rmtree(path)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    _sweep_staging_dirs(target_dir)
+    return Path(tempfile.mkdtemp(dir=target_dir, prefix=_STAGING_PREFIX))
+
+
+def _sweep_staging_dirs(target_dir: Path) -> None:
+    """Reclaim staging directories orphaned by an interrupted install.
+
+    Matches only :data:`_STAGING_PREFIX`, which ``mkdtemp`` alone produces, so this
+    can never remove a user's own files. Best-effort: a failure to tidy up must not
+    fail an install.
+    """
+    with contextlib.suppress(OSError):
+        for stale in target_dir.glob(f"{_STAGING_PREFIX}*"):
+            shutil.rmtree(stale, ignore_errors=True)
 
 
 def _install_skill_copy(
@@ -493,6 +536,7 @@ def _install_skill_copy(
     # the target dir, removing an old streamlit-owned target, or the copy itself
     # - is recorded as a write failure (reason="write_failed") instead of
     # escaping as an uncaught OSError the caller can only classify as "unknown".
+    staging: Path | None = None
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -516,23 +560,22 @@ def _install_skill_copy(
                 result.skipped.append(f"{rel_target_path} (existing file)")
                 return
 
-        # Replacing an existing install copies to a temp dir and swaps, so a
-        # failed copy leaves the working installation in place. Removing the old
-        # target up front would delete a usable skill and then fail, leaving the
-        # user with nothing.
+        # A replacement builds the new copy in a private staging dir and swaps it
+        # in, so a failed copy leaves the working installation in place. Removing
+        # the old target up front would delete a usable skill and then fail,
+        # leaving the user with nothing. See _open_staging_dir for why staging is
+        # a fresh mkdtemp rather than a fixed sibling name.
         if old_target_to_remove is not None:
-            temp_path = target_path.with_name(f".{skill_name}.tmp")
-            backup_path = target_path.with_name(f".{skill_name}.old")
-            if temp_path.exists():
-                shutil.rmtree(temp_path)
-            shutil.copytree(source_path, temp_path)
+            staging = _open_staging_dir(target_dir)
+            new_path = staging / skill_name
+            backup_path = staging / f"{skill_name}.old"
+            shutil.copytree(source_path, new_path)
             # Move the old target aside rather than deleting it: if the swap then
-            # fails we can put it back, instead of stranding the new copy under a
-            # hidden name with nothing at the path the agent looks in.
-            _remove_skill_target(backup_path)
+            # fails we can put it back, instead of stranding the new copy in
+            # staging with nothing at the path the agent looks in.
             old_target_to_remove.rename(backup_path)
             try:
-                temp_path.rename(target_path)
+                new_path.rename(target_path)
             except OSError:
                 # Put the old install back, then let the handler below record the
                 # write failure. There is no atomic replace for a non-empty
@@ -550,30 +593,25 @@ def _install_skill_copy(
                         "recover.",
                         target_path,
                         backup_path,
-                        temp_path,
+                        new_path,
                     )
                 raise
-            # The swap has landed, so the install succeeded - dropping the backup
-            # is bookkeeping. Suppress its errors: letting one reach the handler
-            # below would report write_failed for a skill that is correctly in
-            # place, a false failure in both the nudge and the telemetry this
-            # reason feeds. A leftover backup is cleared by the next install.
-            with contextlib.suppress(OSError):
-                _remove_skill_target(backup_path)
         else:
             shutil.copytree(source_path, target_path)
         result.installed.append(str(rel_target_path))
     except OSError as e:
-        # Drop the temp copy only if something is still at the target. If the
-        # target is empty, the swap died mid-flight and the restore also failed -
-        # so temp (new content) and the .old backup (previous install) are all the
-        # user has left. Keep them rather than leaving the path with nothing.
-        temp_path = target_path.with_name(f".{skill_name}.tmp")
-        if temp_path.exists() and (target_path.exists() or target_path.is_symlink()):
-            shutil.rmtree(temp_path, ignore_errors=True)
         # A write failure, not a conflict - record it in ``errored`` so it is
         # classified as such (reason="write_failed"), not "conflict".
         result.errored.append(f"{rel_target_path} (copy failed: {e})")
+    finally:
+        # Discard staging unless the target ended up empty, which happens only when
+        # the swap AND the restore both failed - there it holds the user's only
+        # copies, so it is left for the next install's sweep to reclaim. Dropping it
+        # is bookkeeping either way and must never turn a landed install into a
+        # reported failure, hence the belt-and-braces suppression.
+        if staging is not None and (target_path.exists() or target_path.is_symlink()):
+            with contextlib.suppress(OSError):
+                shutil.rmtree(staging, ignore_errors=True)
 
 
 def _print_result(result: _InstallResult) -> None:

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -511,14 +511,21 @@ def _install_skill_copy(
                 with contextlib.suppress(OSError):
                     backup_path.rename(target_path)
                 raise
-            _remove_skill_target(backup_path)
+            # The swap has landed, so the install succeeded - dropping the backup
+            # is bookkeeping. Suppress its errors: letting one reach the handler
+            # below would report write_failed for a skill that is correctly in
+            # place, a false failure in both the nudge and the telemetry this
+            # reason feeds. A leftover backup is cleared by the next install.
+            with contextlib.suppress(OSError):
+                _remove_skill_target(backup_path)
         else:
             shutil.copytree(source_path, target_path)
         result.installed.append(str(rel_target_path))
     except OSError as e:
-        # Clean up temp path only if the old target is still in place. If it's
-        # gone, the swap got past the removal and temp is our only copy - keep it
-        # so the user isn't left with nothing.
+        # Drop the temp copy only if something is still at the target. If the
+        # target is empty, the swap died mid-flight and both the restore failed -
+        # so temp (new content) and the .old backup (previous install) are all the
+        # user has left. Keep them rather than leaving the path with nothing.
         temp_path = target_path.with_name(f".{skill_name}.tmp")
         if temp_path.exists() and (target_path.exists() or target_path.is_symlink()):
             shutil.rmtree(temp_path, ignore_errors=True)

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -408,31 +408,35 @@ def _install_skill_copy(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.home(), use_tilde=True)
 
-    # Ensure parent directory exists
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    old_target_to_remove: Path | None = None
-
-    if target_path.exists() or target_path.is_symlink():
-        # Target exists - check if we can replace it
-        if target_path.is_symlink():
-            if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                target_path.unlink()
-            else:
-                result.skipped.append(f"{rel_target_path} (existing symlink)")
-                return
-        elif target_path.is_dir():
-            if _skill_copy_matches(source_path, target_path):
-                result.up_to_date.append(str(rel_target_path))
-                return
-            # Defer removal until after successful copy to ensure atomicity
-            old_target_to_remove = target_path
-        else:
-            result.skipped.append(f"{rel_target_path} (existing file)")
-            return
-
-    # Copy skill directory - use temp location first to ensure atomicity
+    # All filesystem work runs under one try so a failure at ANY step - creating
+    # the target dir, removing an old streamlit-owned symlink, or the copy itself
+    # - is recorded as a write failure (reason="write_failed") instead of
+    # escaping as an uncaught OSError the caller can only classify as "unknown".
     try:
+        # Ensure parent directory exists
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        old_target_to_remove: Path | None = None
+
+        if target_path.exists() or target_path.is_symlink():
+            # Target exists - check if we can replace it
+            if target_path.is_symlink():
+                if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
+                    target_path.unlink()
+                else:
+                    result.skipped.append(f"{rel_target_path} (existing symlink)")
+                    return
+            elif target_path.is_dir():
+                if _skill_copy_matches(source_path, target_path):
+                    result.up_to_date.append(str(rel_target_path))
+                    return
+                # Defer removal until after successful copy to ensure atomicity
+                old_target_to_remove = target_path
+            else:
+                result.skipped.append(f"{rel_target_path} (existing file)")
+                return
+
+        # Copy skill directory - use temp location first to ensure atomicity
         if old_target_to_remove is not None:
             # Copy to temp location, then swap
             temp_path = target_path.with_name(f".{skill_name}.tmp")

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -77,7 +77,13 @@ class _InstallResult:
 
     installed: list[str] = field(default_factory=list)
     up_to_date: list[str] = field(default_factory=list)
+    # Pre-existing files/symlinks we won't overwrite - a genuine "conflict".
     skipped: list[str] = field(default_factory=list)
+    # Filesystem failures during copy (OSError: permissions, disk space, locked
+    # files). Tracked separately from ``skipped`` so a write failure is never
+    # misreported as a "conflict" - both in the CLI summary and, crucially, in
+    # the nudge's install-failure telemetry reason.
+    errored: list[str] = field(default_factory=list)
 
 
 def _get_source_skills_dir() -> Path:
@@ -446,7 +452,9 @@ def _install_skill_copy(
         temp_path = target_path.with_name(f".{skill_name}.tmp")
         if temp_path.exists() and target_path.exists():
             shutil.rmtree(temp_path, ignore_errors=True)
-        result.skipped.append(f"{rel_target_path} (copy failed: {e})")
+        # A write failure, not a conflict - record it in ``errored`` so it is
+        # classified as such (reason="write_failed"), not "conflict".
+        result.errored.append(f"{rel_target_path} (copy failed: {e})")
 
 
 def _print_result(result: _InstallResult) -> None:
@@ -469,6 +477,11 @@ def _print_result(result: _InstallResult) -> None:
         click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
         for path in result.skipped:
             click.echo(f"  {click.style('→', fg='yellow')} {path}")
+
+    if result.errored:
+        click.secho("\n✗ Failed to write:", fg="red", bold=True)
+        for path in result.errored:
+            click.echo(f"  {click.style('→', fg='red')} {path}")
 
 
 def _prompt_install_mode() -> str:
@@ -590,6 +603,30 @@ def _conflict_error(skipped: list[str]) -> _InstallError:
         f"{joined} already exist{'' if plural else 's'}. "
         f"Remove {'them' if plural else 'it'} and try again.",
         reason="conflict",
+    )
+
+
+def _write_error(errored: list[str]) -> _InstallError:
+    """Build a "couldn't write" error for filesystem failures during copy.
+
+    Distinct from :func:`_conflict_error`: ``errored`` entries are ``OSError``
+    failures (permissions, disk space, locked files), not pre-existing files.
+    Keeping them apart stops the nudge's failure telemetry from misreporting a
+    write failure as a ``conflict``. Like the conflict message this is shown
+    verbatim in the nudge, so it collapses paths to the
+    ``<harness>/skills/<skill>`` tail and never echoes the raw ``OSError`` text
+    (which can embed an absolute server path).
+    """
+    paths = []
+    for entry in errored:
+        raw = entry.split(" (", 1)[0]
+        parts = Path(raw).parts
+        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+    joined = ", ".join(paths)
+    return _InstallError(
+        f"Could not write {joined}. Check folder permissions and free disk "
+        "space, then try again.",
+        reason="write_failed",
     )
 
 
@@ -724,6 +761,8 @@ def _install_project_skills(
         )
         for line in gitignore_snippet.splitlines():
             click.secho(f"  {line}", fg="bright_black")
+    elif result.errored:
+        raise _write_error(result.errored)
     elif result.skipped:
         raise _conflict_error(result.skipped)
 
@@ -808,6 +847,8 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
                 "      project-specific bundled skills at runtime.",
                 fg="bright_black",
             )
+    elif result.errored:
+        raise _write_error(result.errored)
     elif result.skipped:
         raise _conflict_error(result.skipped)
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -62,6 +62,11 @@ _STAGING_ORPHAN_AGE_S: Final[float] = 3600.0
 # unable to match it, or it would eventually delete the data it was retained to save.
 # Nothing reclaims these - that is the point - and the failure is logged with the path.
 _RECOVERY_PREFIX: Final[str] = ".st-recover-"
+# Sentinel written into every staging dir. The sweep requires it before deleting, so a
+# hidden user directory that merely shares the prefix is never touched: mkdtemp
+# guarantees uniqueness for the *creating* side, but the sweep matches on name and age,
+# which is a convention rather than proof of ownership.
+_STAGING_MARKER: Final[str] = ".streamlit-owned"
 
 # The full vocabulary of install-failure causes. A closed set so the reason stays
 # safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
@@ -202,9 +207,9 @@ class _InstallResult:
     # the display strings above because those carry raw OSError text (fine for the
     # CLI, never for the browser) while these are the bounded telemetry reasons.
     write_reasons: list[_InstallFailureReason] = field(default_factory=list)
-    # Set when a project install was rerouted to a global copy, to which of the two
-    # causes. Surfaced to telemetry so that cohort is countable and separable - see
-    # InstallSkillsResponsePayload.
+    # Set when a project install was rerouted to a global copy, naming why (see
+    # :data:`_FallbackReason`). Surfaced to telemetry so that cohort is countable and
+    # separable - see InstallSkillsResponsePayload.
     fallback_reason: _FallbackReason | None = None
 
 
@@ -568,25 +573,30 @@ def _install_skill_symlink(
         return False
 
     if staging is not None:
+        # Move the old link aside rather than unlinking it, mirroring the copy path:
+        # if the swap then fails, the canonical path can be restored from staging
+        # instead of being left empty.
+        displaced = staging / _STAGING_OLD
         try:
-            target_path.unlink()
-            # Renaming into a name we just freed, in the same directory.
+            target_path.rename(displaced)
             link_path.rename(target_path)
         except OSError:
             if target_path.exists() or target_path.is_symlink():
-                # The unlink failed, so the old install is intact and the staged
+                # The move-aside failed, so the old install is intact and the staged
                 # link is redundant. Drop it and let the caller fall back.
                 shutil.rmtree(staging, ignore_errors=True)
                 return False
-            # The old link is gone but the staged one wouldn't move, leaving the
-            # canonical path empty. Creating a link here demonstrably works - we
-            # just made one - so lay it directly rather than stranding the install
-            # inside a staging dir that nothing reads.
+            # The old link is out of the way but the staged one wouldn't move, leaving
+            # the canonical path empty. Creating a link here demonstrably works - we
+            # just made one - so lay it directly.
             try:
                 target_path.symlink_to(rel_source, target_is_directory=True)
             except OSError:
-                # Leave staging in place: it holds the only link, and the sweep on
-                # the next install is what reclaims it.
+                # Last resort: put the displaced link back, so the canonical path is
+                # populated even though this install failed.
+                with contextlib.suppress(OSError):
+                    displaced.rename(target_path)
+                shutil.rmtree(staging, ignore_errors=True)
                 return False
         shutil.rmtree(staging, ignore_errors=True)
 
@@ -624,7 +634,9 @@ def _open_staging_dir(target_dir: Path) -> Path:
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     _sweep_staging_dirs(target_dir)
-    return Path(tempfile.mkdtemp(dir=target_dir, prefix=_STAGING_PREFIX))
+    staging = Path(tempfile.mkdtemp(dir=target_dir, prefix=_STAGING_PREFIX))
+    (staging / _STAGING_MARKER).touch()
+    return staging
 
 
 def _sweep_staging_dirs(target_dir: Path) -> None:
@@ -632,8 +644,10 @@ def _sweep_staging_dirs(target_dir: Path) -> None:
 
     Two guards, both load-bearing:
 
-    - Only :data:`_STAGING_PREFIX` names are candidates, and only ``mkdtemp``
-      produces those, so a user's own files are never at risk.
+    - A candidate must both match :data:`_STAGING_PREFIX` and contain the
+      :data:`_STAGING_MARKER` sentinel. The prefix alone is a convention; the marker
+      is proof we created it, so a hidden user directory that happens to share the
+      prefix is never removed.
     - Only directories untouched for :data:`_STAGING_ORPHAN_AGE_S` are removed.
       Sweeping on name alone would delete a *concurrent* install's staging
       directory - which may already hold the old installation it moved aside, so
@@ -648,7 +662,9 @@ def _sweep_staging_dirs(target_dir: Path) -> None:
     with contextlib.suppress(OSError):
         for stale in target_dir.glob(f"{_STAGING_PREFIX}*"):
             with contextlib.suppress(OSError):
-                if stale.stat().st_mtime < cutoff:
+                if (
+                    stale / _STAGING_MARKER
+                ).is_file() and stale.stat().st_mtime < cutoff:
                     shutil.rmtree(stale, ignore_errors=True)
 
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import sys
@@ -364,6 +365,11 @@ def _install_skill_symlink(
     # an existing target) runs under one guard: any OSError here means we can't
     # lay the symlink, so return False and let the caller fall back to a global
     # copy - never let it escape and get misbooked as a hard write_failed.
+    #
+    # ``symlink_to`` won't overwrite, so replacing an owned link means unlinking
+    # first. Remember where it pointed so a failed re-link can put it back: the
+    # caller's fallback installs GLOBALLY, which wouldn't restore a project link.
+    replaced_link_target: str | None = None
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -382,6 +388,8 @@ def _install_skill_symlink(
 
                 # Check if it's a Streamlit-owned symlink we can replace
                 if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
+                    with contextlib.suppress(OSError):
+                        replaced_link_target = os.readlink(target_path)
                     target_path.unlink()
                 else:
                     result.skipped.append(f"{rel_target_path} (existing symlink)")
@@ -418,7 +426,26 @@ def _install_skill_symlink(
     except (OSError, NotImplementedError):
         # Symlink not supported (e.g., Windows without Developer Mode, or some
         # environments where symlinks are not implemented)
+        if replaced_link_target is not None:
+            # Put back the working link we removed. Without this, a reinstall that
+            # can't re-link destroys a usable project install and the caller's
+            # global fallback lands somewhere else entirely.
+            with contextlib.suppress(OSError):
+                target_path.symlink_to(replaced_link_target, target_is_directory=True)
         return False
+
+
+def _remove_skill_target(path: Path) -> None:
+    """Delete an installed skill target, whichever form it took.
+
+    A target can be a real directory (global copy) or a symlink (project
+    install), and ``shutil.rmtree`` refuses symlinks. Absent paths are a no-op so
+    callers can use this to clear a possibly-stale leftover.
+    """
+    if path.is_symlink():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
 
 
 def _install_skill_copy(
@@ -466,16 +493,25 @@ def _install_skill_copy(
         # user with nothing.
         if old_target_to_remove is not None:
             temp_path = target_path.with_name(f".{skill_name}.tmp")
+            backup_path = target_path.with_name(f".{skill_name}.old")
             if temp_path.exists():
                 shutil.rmtree(temp_path)
             shutil.copytree(source_path, temp_path)
-            # Now safe to remove old and rename new. rmtree refuses symlinks, so
-            # an owned symlink target has to be unlinked instead.
-            if old_target_to_remove.is_symlink():
-                old_target_to_remove.unlink()
-            else:
-                shutil.rmtree(old_target_to_remove)
-            temp_path.rename(target_path)
+            # Move the old target aside rather than deleting it: if the swap then
+            # fails we can put it back, instead of stranding the new copy under a
+            # hidden name with nothing at the path the agent looks in.
+            _remove_skill_target(backup_path)
+            old_target_to_remove.rename(backup_path)
+            try:
+                temp_path.rename(target_path)
+            except OSError:
+                # Restore, then let the handler below record the write failure. If
+                # the restore itself fails, leave the backup on disk - both copies
+                # survive, which beats losing the only one.
+                with contextlib.suppress(OSError):
+                    backup_path.rename(target_path)
+                raise
+            _remove_skill_target(backup_path)
         else:
             shutil.copytree(source_path, target_path)
         result.installed.append(str(rel_target_path))
@@ -614,6 +650,23 @@ def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     return click.confirm("Proceed with installation?", default=True)
 
 
+def _concise_install_paths(entries: list[str]) -> list[str]:
+    """Collapse ``_InstallResult`` entries to short paths safe to show a user.
+
+    Entries look like ``"<path> (why)"``. Both failure messages built from them
+    are shown verbatim in the in-app nudge, so this keeps only the
+    ``<harness>/skills/<skill>`` tail and drops the parenthetical: neither an
+    absolute server path nor a raw ``OSError`` string may reach the browser.
+    Shared by the two error builders so that invariant lives in one place.
+    """
+    paths = []
+    for entry in entries:
+        raw = entry.split(" (", 1)[0]
+        parts = Path(raw).parts
+        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+    return paths
+
+
 def _conflict_error(skipped: list[str]) -> _InstallError:
     """Build a specific "couldn't install" error that names the conflicting
     paths, rather than a vague "remove conflicting files".
@@ -626,11 +679,7 @@ def _conflict_error(skipped: list[str]) -> _InstallError:
     stand on its own (the CLI's detailed ``_print_result`` output never reaches
     the browser).
     """
-    paths = []
-    for entry in skipped:
-        raw = entry.split(" (", 1)[0]
-        parts = Path(raw).parts
-        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+    paths = _concise_install_paths(skipped)
     joined = ", ".join(paths)
     plural = len(paths) != 1
     return _InstallError(
@@ -646,17 +695,9 @@ def _write_error(errored: list[str]) -> _InstallError:
     Distinct from :func:`_conflict_error`: ``errored`` entries are ``OSError``
     failures (permissions, disk space, locked files), not pre-existing files.
     Keeping them apart stops the nudge's failure telemetry from misreporting a
-    write failure as a ``conflict``. Like the conflict message this is shown
-    verbatim in the nudge, so it collapses paths to the
-    ``<harness>/skills/<skill>`` tail and never echoes the raw ``OSError`` text
-    (which can embed an absolute server path).
+    write failure as a ``conflict``.
     """
-    paths = []
-    for entry in errored:
-        raw = entry.split(" (", 1)[0]
-        parts = Path(raw).parts
-        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
-    joined = ", ".join(paths)
+    joined = ", ".join(_concise_install_paths(errored))
     return _InstallError(
         f"Could not write {joined}. Check folder permissions and free disk "
         "space, then try again.",

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -596,6 +596,14 @@ def _install_skill_symlink(
                 # populated even though this install failed.
                 with contextlib.suppress(OSError):
                     displaced.rename(target_path)
+                if not (target_path.exists() or target_path.is_symlink()):
+                    # The restore didn't land either, so staging holds the only copy
+                    # of the old link. Deleting it here would destroy the very thing
+                    # the move-aside preserved. Keep it, and drop the ownership marker
+                    # so the sweep can't take it later either.
+                    with contextlib.suppress(OSError):
+                        (staging / _STAGING_MARKER).unlink()
+                    return False
                 shutil.rmtree(staging, ignore_errors=True)
                 return False
         shutil.rmtree(staging, ignore_errors=True)

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -342,31 +342,38 @@ def _install_skill_symlink(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.cwd())
 
-    # Ensure parent directory exists
-    target_dir.mkdir(parents=True, exist_ok=True)
+    # Pre-symlink filesystem work (creating the parent dir, inspecting or removing
+    # an existing target) runs under one guard: any OSError here means we can't
+    # lay the symlink, so return False and let the caller fall back to a global
+    # copy - never let it escape and get misbooked as a hard write_failed.
+    try:
+        # Ensure parent directory exists
+        target_dir.mkdir(parents=True, exist_ok=True)
 
-    if target_path.exists() or target_path.is_symlink():
-        # Target exists - check if it's a matching symlink
-        if target_path.is_symlink():
-            try:
-                resolved = target_path.resolve()
-                if resolved == source_path.resolve():
-                    result.up_to_date.append(str(rel_target_path))
+        if target_path.exists() or target_path.is_symlink():
+            # Target exists - check if it's a matching symlink
+            if target_path.is_symlink():
+                try:
+                    resolved = target_path.resolve()
+                    if resolved == source_path.resolve():
+                        result.up_to_date.append(str(rel_target_path))
+                        return True
+                except (OSError, ValueError):
+                    # Broken symlink or resolution error - check ownership below
+                    pass
+
+                # Check if it's a Streamlit-owned symlink we can replace
+                if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
+                    target_path.unlink()
+                else:
+                    result.skipped.append(f"{rel_target_path} (existing symlink)")
                     return True
-            except (OSError, ValueError):
-                # Broken symlink or resolution error - check ownership pattern below
-                pass
-
-            # Check if it's a Streamlit-owned symlink we can replace
-            if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                target_path.unlink()
             else:
-                result.skipped.append(f"{rel_target_path} (existing symlink)")
+                # Regular file or directory - skip
+                result.skipped.append(f"{rel_target_path} (existing file or directory)")
                 return True
-        else:
-            # Regular file or directory - skip
-            result.skipped.append(f"{rel_target_path} (existing file or directory)")
-            return True
+    except (OSError, NotImplementedError):
+        return False
 
     # Compute the relative symlink target from the REAL (symlink-resolved) paths
     # of both ends. os.path.relpath counts ``..`` levels against the logical
@@ -462,30 +469,39 @@ def _install_skill_copy(
 
 
 def _print_result(result: _InstallResult) -> None:
-    """Print the installation result summary."""
-    if result.installed:
-        click.secho("\n✓ Installed:", fg="green", bold=True)
-        for path in result.installed:
-            click.echo(
-                f"  {click.style('→', fg='green')} {click.style(path, fg='cyan')}"
-            )
+    """Print the installation result summary.
 
-    if result.up_to_date:
-        click.secho("\n● Up to date:", fg="blue", bold=True)
-        for path in result.up_to_date:
-            click.echo(
-                f"  {click.style('→', fg='blue')} {click.style(path, fg='cyan')}"
-            )
+    Purely cosmetic. It runs after the install has committed (and, for the
+    in-app nudge, inside an ``asyncio.to_thread`` worker whose stdout is the
+    server's), so a broken/closed stream must never raise here and flip a real
+    outcome into a mislabeled failure - all output is swallowed on I/O error.
+    """
+    try:
+        if result.installed:
+            click.secho("\n✓ Installed:", fg="green", bold=True)
+            for path in result.installed:
+                click.echo(
+                    f"  {click.style('→', fg='green')} {click.style(path, fg='cyan')}"
+                )
 
-    if result.skipped:
-        click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
-        for path in result.skipped:
-            click.echo(f"  {click.style('→', fg='yellow')} {path}")
+        if result.up_to_date:
+            click.secho("\n● Up to date:", fg="blue", bold=True)
+            for path in result.up_to_date:
+                click.echo(
+                    f"  {click.style('→', fg='blue')} {click.style(path, fg='cyan')}"
+                )
 
-    if result.errored:
-        click.secho("\n✗ Failed to write:", fg="red", bold=True)
-        for path in result.errored:
-            click.echo(f"  {click.style('→', fg='red')} {path}")
+        if result.skipped:
+            click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
+            for path in result.skipped:
+                click.echo(f"  {click.style('→', fg='yellow')} {path}")
+
+        if result.errored:
+            click.secho("\n✗ Failed to write:", fg="red", bold=True)
+            for path in result.errored:
+                click.echo(f"  {click.style('→', fg='red')} {path}")
+    except (OSError, ValueError):
+        pass
 
 
 def _prompt_install_mode() -> str:
@@ -743,30 +759,41 @@ def _install_project_skills(
     # Report results
     _print_result(result)
 
-    if result.installed or result.up_to_date:
-        click.echo()
-        click.secho("✨ Successfully installed to ", fg="green", bold=True, nl=False)
-        click.secho(str(project_root), fg="bright_blue")
-        if result.installed:
-            click.echo()
-            click.secho("Note: ", fg="bright_black", bold=True, nl=False)
-            click.secho(
-                "Installed skills are symlinks to your local Streamlit environment.",
-                fg="bright_black",
-            )
-            click.secho(
-                "      They generally should not be committed to git.",
-                fg="bright_black",
-            )
-        click.echo()
-        click.secho("Recommended .gitignore snippet:", fg="bright_black", bold=True)
-        gitignore_snippet = _generate_gitignore_snippet(
-            skills, target_dirs, project_root
-        )
-        for line in gitignore_snippet.splitlines():
-            click.secho(f"  {line}", fg="bright_black")
-    elif result.errored:
+    # A write failure on ANY target is a hard failure, even if another target
+    # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
+    # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
+    if result.errored:
         raise _write_error(result.errored)
+
+    if result.installed or result.up_to_date:
+        # Decorative output only - a broken/closed server stdout must never turn
+        # a committed install into a reported (mis)failure.
+        try:
+            click.echo()
+            click.secho(
+                "✨ Successfully installed to ", fg="green", bold=True, nl=False
+            )
+            click.secho(str(project_root), fg="bright_blue")
+            if result.installed:
+                click.echo()
+                click.secho("Note: ", fg="bright_black", bold=True, nl=False)
+                click.secho(
+                    "Installed skills are symlinks to your local Streamlit environment.",
+                    fg="bright_black",
+                )
+                click.secho(
+                    "      They generally should not be committed to git.",
+                    fg="bright_black",
+                )
+            click.echo()
+            click.secho("Recommended .gitignore snippet:", fg="bright_black", bold=True)
+            gitignore_snippet = _generate_gitignore_snippet(
+                skills, target_dirs, project_root
+            )
+            for line in gitignore_snippet.splitlines():
+                click.secho(f"  {line}", fg="bright_black")
+        except (OSError, ValueError):
+            pass
     elif result.skipped:
         raise _conflict_error(result.skipped)
 
@@ -833,26 +860,35 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
     # Report results
     _print_result(result)
 
-    if result.installed or result.up_to_date:
-        click.echo()
-        click.secho(
-            "✨ Successfully installed globally",
-            fg="green",
-            bold=True,
-        )
-        if result.installed:
-            click.echo()
-            click.secho("Note: ", fg="bright_black", bold=True, nl=False)
-            click.secho(
-                "Global skills include a discover.py script that finds",
-                fg="bright_black",
-            )
-            click.secho(
-                "      project-specific bundled skills at runtime.",
-                fg="bright_black",
-            )
-    elif result.errored:
+    # A write failure on ANY target is a hard failure, even if another target
+    # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
+    # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
+    if result.errored:
         raise _write_error(result.errored)
+
+    if result.installed or result.up_to_date:
+        # Decorative output only - a broken/closed server stdout must never turn
+        # a committed install into a reported (mis)failure.
+        try:
+            click.echo()
+            click.secho(
+                "✨ Successfully installed globally",
+                fg="green",
+                bold=True,
+            )
+            if result.installed:
+                click.echo()
+                click.secho("Note: ", fg="bright_black", bold=True, nl=False)
+                click.secho(
+                    "Global skills include a discover.py script that finds",
+                    fg="bright_black",
+                )
+                click.secho(
+                    "      project-specific bundled skills at runtime.",
+                    fg="bright_black",
+                )
+        except (OSError, ValueError):
+            pass
     elif result.skipped:
         raise _conflict_error(result.skipped)
 
@@ -951,6 +987,13 @@ def summarize_install(result: _InstallResult) -> str:
         count = len(result.skipped)
         noun = "skill" if count == 1 else "skills"
         parts.append(f"{count} {noun} skipped due to conflicts.")
+    if result.errored:
+        # Defensive: the install path raises on any errored target before the
+        # success summary is built, so this normally can't be reached - but if a
+        # write failure ever slips through, never present it as a clean success.
+        count = len(result.errored)
+        noun = "skill" if count == 1 else "skills"
+        parts.append(f"{count} {noun} failed to write.")
     return " ".join(parts)
 
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -521,11 +521,24 @@ def _install_skill_copy(
             try:
                 temp_path.rename(target_path)
             except OSError:
-                # Restore, then let the handler below record the write failure. If
-                # the restore itself fails, leave the backup on disk - both copies
-                # survive, which beats losing the only one.
-                with contextlib.suppress(OSError):
+                # Put the old install back, then let the handler below record the
+                # write failure. There is no atomic replace for a non-empty
+                # directory on either POSIX or Windows, so this move-aside dance is
+                # the best available and a restore that ALSO fails can't be
+                # recovered in code. Log where both copies ended up - the
+                # user-facing message deliberately carries no server paths, so this
+                # is the only way the state is diagnosable.
+                try:
                     backup_path.rename(target_path)
+                except OSError:
+                    _LOGGER.warning(
+                        "Skills install left %s empty: the previous install is at "
+                        "%s and the new copy at %s. Move either one back to "
+                        "recover.",
+                        target_path,
+                        backup_path,
+                        temp_path,
+                    )
                 raise
             # The swap has landed, so the install succeeded - dropping the backup
             # is bookkeeping. Suppress its errors: letting one reach the handler

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -565,7 +565,7 @@ def _install_skill_copy(
         result.installed.append(str(rel_target_path))
     except OSError as e:
         # Drop the temp copy only if something is still at the target. If the
-        # target is empty, the swap died mid-flight and both the restore failed -
+        # target is empty, the swap died mid-flight and the restore also failed -
         # so temp (new content) and the .old backup (previous install) are all the
         # user has left. Keep them rather than leaving the path with nothing.
         temp_path = target_path.with_name(f".{skill_name}.tmp")

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -54,12 +54,14 @@ _InstallFailureReason = Literal[
 class _InstallError(click.ClickException):
     """A skills-install failure carrying a stable machine-readable ``reason`` code.
 
-    Behaves like a normal ``click.ClickException`` — its ``format_message`` still
-    supplies the user-facing text shown in the CLI and the in-app nudge — but also
-    carries a bounded ``reason`` (see :data:`_InstallFailureReason`) that the
-    backend-operation handler forwards to the client so the nudge's install-failure
-    telemetry can be split by cause. The reason is a fixed vocabulary set at each
-    raise site, never user input, so it is safe to emit as a telemetry label suffix.
+    The ``reason`` (see :data:`_InstallFailureReason`) is what the backend-operation
+    handler forwards to the client so the nudge's install-failure telemetry can be
+    split by cause. It is a fixed vocabulary set at each raise site, never user
+    input, so it is safe to emit as a telemetry label suffix.
+
+    Otherwise this behaves like a normal ``click.ClickException`` — its
+    ``format_message`` still supplies the user-facing text shown in the CLI and the
+    in-app nudge — so raising it changes nothing a user sees.
     """
 
     def __init__(self, message: str, *, reason: _InstallFailureReason) -> None:
@@ -99,9 +101,10 @@ class _InstallResult:
     # nudge's install-failure telemetry reason. Only the copy path fills this;
     # symlink failures reroute to a global install instead of being recorded here.
     errored: list[str] = field(default_factory=list)
-    # True when project (symlink) install fell back to a global copy because
-    # symlinks aren't supported (e.g. Windows without Developer Mode). Surfaced
-    # to telemetry so that cohort is countable - see InstallSkillsResponsePayload.
+    # True when a project install was rerouted to a global copy - either because
+    # the up-front symlink pre-check failed, or because laying an individual
+    # symlink failed. Surfaced to telemetry so that cohort is countable - see
+    # InstallSkillsResponsePayload.
     used_global_fallback: bool = False
 
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -469,39 +469,30 @@ def _install_skill_copy(
 
 
 def _print_result(result: _InstallResult) -> None:
-    """Print the installation result summary.
+    """Print the installation result summary."""
+    if result.installed:
+        click.secho("\n✓ Installed:", fg="green", bold=True)
+        for path in result.installed:
+            click.echo(
+                f"  {click.style('→', fg='green')} {click.style(path, fg='cyan')}"
+            )
 
-    Purely cosmetic. It runs after the install has committed (and, for the
-    in-app nudge, inside an ``asyncio.to_thread`` worker whose stdout is the
-    server's), so a broken/closed stream must never raise here and flip a real
-    outcome into a mislabeled failure - all output is swallowed on I/O error.
-    """
-    try:
-        if result.installed:
-            click.secho("\n✓ Installed:", fg="green", bold=True)
-            for path in result.installed:
-                click.echo(
-                    f"  {click.style('→', fg='green')} {click.style(path, fg='cyan')}"
-                )
+    if result.up_to_date:
+        click.secho("\n● Up to date:", fg="blue", bold=True)
+        for path in result.up_to_date:
+            click.echo(
+                f"  {click.style('→', fg='blue')} {click.style(path, fg='cyan')}"
+            )
 
-        if result.up_to_date:
-            click.secho("\n● Up to date:", fg="blue", bold=True)
-            for path in result.up_to_date:
-                click.echo(
-                    f"  {click.style('→', fg='blue')} {click.style(path, fg='cyan')}"
-                )
+    if result.skipped:
+        click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
+        for path in result.skipped:
+            click.echo(f"  {click.style('→', fg='yellow')} {path}")
 
-        if result.skipped:
-            click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
-            for path in result.skipped:
-                click.echo(f"  {click.style('→', fg='yellow')} {path}")
-
-        if result.errored:
-            click.secho("\n✗ Failed to write:", fg="red", bold=True)
-            for path in result.errored:
-                click.echo(f"  {click.style('→', fg='red')} {path}")
-    except (OSError, ValueError):
-        pass
+    if result.errored:
+        click.secho("\n✗ Failed to write:", fg="red", bold=True)
+        for path in result.errored:
+            click.echo(f"  {click.style('→', fg='red')} {path}")
 
 
 def _prompt_install_mode() -> str:
@@ -766,34 +757,27 @@ def _install_project_skills(
         raise _write_error(result.errored)
 
     if result.installed or result.up_to_date:
-        # Decorative output only - a broken/closed server stdout must never turn
-        # a committed install into a reported (mis)failure.
-        try:
+        click.echo()
+        click.secho("✨ Successfully installed to ", fg="green", bold=True, nl=False)
+        click.secho(str(project_root), fg="bright_blue")
+        if result.installed:
             click.echo()
+            click.secho("Note: ", fg="bright_black", bold=True, nl=False)
             click.secho(
-                "✨ Successfully installed to ", fg="green", bold=True, nl=False
+                "Installed skills are symlinks to your local Streamlit environment.",
+                fg="bright_black",
             )
-            click.secho(str(project_root), fg="bright_blue")
-            if result.installed:
-                click.echo()
-                click.secho("Note: ", fg="bright_black", bold=True, nl=False)
-                click.secho(
-                    "Installed skills are symlinks to your local Streamlit environment.",
-                    fg="bright_black",
-                )
-                click.secho(
-                    "      They generally should not be committed to git.",
-                    fg="bright_black",
-                )
-            click.echo()
-            click.secho("Recommended .gitignore snippet:", fg="bright_black", bold=True)
-            gitignore_snippet = _generate_gitignore_snippet(
-                skills, target_dirs, project_root
+            click.secho(
+                "      They generally should not be committed to git.",
+                fg="bright_black",
             )
-            for line in gitignore_snippet.splitlines():
-                click.secho(f"  {line}", fg="bright_black")
-        except (OSError, ValueError):
-            pass
+        click.echo()
+        click.secho("Recommended .gitignore snippet:", fg="bright_black", bold=True)
+        gitignore_snippet = _generate_gitignore_snippet(
+            skills, target_dirs, project_root
+        )
+        for line in gitignore_snippet.splitlines():
+            click.secho(f"  {line}", fg="bright_black")
     elif result.skipped:
         raise _conflict_error(result.skipped)
 
@@ -867,28 +851,23 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
         raise _write_error(result.errored)
 
     if result.installed or result.up_to_date:
-        # Decorative output only - a broken/closed server stdout must never turn
-        # a committed install into a reported (mis)failure.
-        try:
+        click.echo()
+        click.secho(
+            "✨ Successfully installed globally",
+            fg="green",
+            bold=True,
+        )
+        if result.installed:
             click.echo()
+            click.secho("Note: ", fg="bright_black", bold=True, nl=False)
             click.secho(
-                "✨ Successfully installed globally",
-                fg="green",
-                bold=True,
+                "Global skills include a discover.py script that finds",
+                fg="bright_black",
             )
-            if result.installed:
-                click.echo()
-                click.secho("Note: ", fg="bright_black", bold=True, nl=False)
-                click.secho(
-                    "Global skills include a discover.py script that finds",
-                    fg="bright_black",
-                )
-                click.secho(
-                    "      project-specific bundled skills at runtime.",
-                    fg="bright_black",
-                )
-        except (OSError, ValueError):
-            pass
+            click.secho(
+                "      project-specific bundled skills at runtime.",
+                fg="bright_black",
+            )
     elif result.skipped:
         raise _conflict_error(result.skipped)
 
@@ -987,13 +966,6 @@ def summarize_install(result: _InstallResult) -> str:
         count = len(result.skipped)
         noun = "skill" if count == 1 else "skills"
         parts.append(f"{count} {noun} skipped due to conflicts.")
-    if result.errored:
-        # Defensive: the install path raises on any errored target before the
-        # success summary is built, so this normally can't be reached - but if a
-        # write failure ever slips through, never present it as a clean success.
-        count = len(result.errored)
-        noun = "skill" if count == 1 else "skills"
-        parts.append(f"{count} {noun} failed to write.")
     return " ".join(parts)
 
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -23,7 +23,7 @@ import tempfile
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
 import click
 
@@ -35,20 +35,33 @@ _LOGGER: Final = get_logger(__name__)
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
 
+# The full vocabulary of install-failure causes. A closed set so the reason stays
+# safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
+# typo or an ad-hoc reason at the raise site instead of silently minting a new
+# label the analysis queries won't know about.
+_InstallFailureReason = Literal[
+    "conflict",  # A pre-existing file or foreign symlink we won't overwrite.
+    "incomplete",  # Project symlinks failed and the global fallback was cancelled.
+    "no_skills",  # The bundled skills dir exists but contains nothing installable.
+    "non_interactive",  # No TTY to prompt on and --yes wasn't passed.
+    "source_missing",  # The bundled skills are absent from the installation.
+    "symlinks_unsupported",  # Project install needs symlinks; this OS won't make them.
+    "write_failed",  # An OSError while writing: permissions, disk space, locks.
+]
+
 
 class _InstallError(click.ClickException):
     """A skills-install failure carrying a stable machine-readable ``reason`` code.
 
     Behaves like a normal ``click.ClickException`` — its ``format_message`` still
     supplies the user-facing text shown in the CLI and the in-app nudge — but also
-    carries a bounded ``reason`` (e.g. ``"conflict"``, ``"write_failed"``,
-    ``"source_missing"``) that the backend-operation handler forwards to the
-    client so the nudge's install-failure telemetry can be split by cause. The
-    reason is a fixed vocabulary set at each raise site, never user input, so it is
-    safe to emit as a telemetry label suffix.
+    carries a bounded ``reason`` (see :data:`_InstallFailureReason`) that the
+    backend-operation handler forwards to the client so the nudge's install-failure
+    telemetry can be split by cause. The reason is a fixed vocabulary set at each
+    raise site, never user input, so it is safe to emit as a telemetry label suffix.
     """
 
-    def __init__(self, message: str, *, reason: str) -> None:
+    def __init__(self, message: str, *, reason: _InstallFailureReason) -> None:
         super().__init__(message)
         self.reason = reason
 
@@ -79,10 +92,11 @@ class _InstallResult:
     up_to_date: list[str] = field(default_factory=list)
     # Pre-existing files/symlinks we won't overwrite - a genuine "conflict".
     skipped: list[str] = field(default_factory=list)
-    # Filesystem failures during copy (OSError: permissions, disk space, locked
-    # files). Tracked separately from ``skipped`` so a write failure is never
-    # misreported as a "conflict" - both in the CLI summary and, crucially, in
-    # the nudge's install-failure telemetry reason.
+    # Filesystem failures during the global copy (OSError: permissions, disk space,
+    # locked files). Tracked separately from ``skipped`` so a write failure is never
+    # misreported as a "conflict" - both in the CLI summary and, crucially, in the
+    # nudge's install-failure telemetry reason. Only the copy path fills this;
+    # symlink failures reroute to a global install instead of being recorded here.
     errored: list[str] = field(default_factory=list)
     # True when project (symlink) install fell back to a global copy because
     # symlinks aren't supported (e.g. Windows without Developer Mode). Surfaced
@@ -420,7 +434,7 @@ def _install_skill_copy(
     rel_target_path = _get_display_path(target_path, Path.home(), use_tilde=True)
 
     # All filesystem work runs under one try so a failure at ANY step - creating
-    # the target dir, removing an old streamlit-owned symlink, or the copy itself
+    # the target dir, removing an old streamlit-owned target, or the copy itself
     # - is recorded as a write failure (reason="write_failed") instead of
     # escaping as an uncaught OSError the caller can only classify as "unknown".
     try:
@@ -432,40 +446,45 @@ def _install_skill_copy(
         if target_path.exists() or target_path.is_symlink():
             # Target exists - check if we can replace it
             if target_path.is_symlink():
-                if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                    target_path.unlink()
-                else:
+                if not _is_streamlit_owned_symlink(target_path, bundled_skill_names):
                     result.skipped.append(f"{rel_target_path} (existing symlink)")
                     return
+                # Defer removal until after the copy succeeds, same as a directory.
+                old_target_to_remove = target_path
             elif target_path.is_dir():
                 if _skill_copy_matches(source_path, target_path):
                     result.up_to_date.append(str(rel_target_path))
                     return
-                # Defer removal until after successful copy to ensure atomicity
                 old_target_to_remove = target_path
             else:
                 result.skipped.append(f"{rel_target_path} (existing file)")
                 return
 
-        # Copy skill directory - use temp location first to ensure atomicity
+        # Replacing an existing install copies to a temp dir and swaps, so a
+        # failed copy leaves the working installation in place. Removing the old
+        # target up front would delete a usable skill and then fail, leaving the
+        # user with nothing.
         if old_target_to_remove is not None:
-            # Copy to temp location, then swap
             temp_path = target_path.with_name(f".{skill_name}.tmp")
             if temp_path.exists():
                 shutil.rmtree(temp_path)
             shutil.copytree(source_path, temp_path)
-            # Now safe to remove old and rename new
-            shutil.rmtree(old_target_to_remove)
+            # Now safe to remove old and rename new. rmtree refuses symlinks, so
+            # an owned symlink target has to be unlinked instead.
+            if old_target_to_remove.is_symlink():
+                old_target_to_remove.unlink()
+            else:
+                shutil.rmtree(old_target_to_remove)
             temp_path.rename(target_path)
         else:
             shutil.copytree(source_path, target_path)
         result.installed.append(str(rel_target_path))
     except OSError as e:
-        # Clean up temp path only if target still exists (meaning old wasn't removed).
-        # If target is gone, the old directory was deleted and temp is our only copy -
-        # keep it so the user isn't left with nothing.
+        # Clean up temp path only if the old target is still in place. If it's
+        # gone, the swap got past the removal and temp is our only copy - keep it
+        # so the user isn't left with nothing.
         temp_path = target_path.with_name(f".{skill_name}.tmp")
-        if temp_path.exists() and target_path.exists():
+        if temp_path.exists() and (target_path.exists() or target_path.is_symlink()):
             shutil.rmtree(temp_path, ignore_errors=True)
         # A write failure, not a conflict - record it in ``errored`` so it is
         # classified as such (reason="write_failed"), not "conflict".
@@ -757,12 +776,6 @@ def _install_project_skills(
 
     # Report results
     _print_result(result)
-
-    # A write failure on ANY target is a hard failure, even if another target
-    # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
-    # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
-    if result.errored:
-        raise _write_error(result.errored)
 
     if result.installed or result.up_to_date:
         click.echo()

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -36,6 +36,23 @@ _LOGGER: Final = get_logger(__name__)
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
 
 
+class _InstallError(click.ClickException):
+    """A skills-install failure carrying a stable machine-readable ``reason`` code.
+
+    Behaves like a normal ``click.ClickException`` — its ``format_message`` still
+    supplies the user-facing text shown in the CLI and the in-app nudge — but also
+    carries a bounded ``reason`` (e.g. ``"conflict"``, ``"source_missing"``,
+    ``"symlinks_unsupported"``) that the backend-operation handler forwards to the
+    client so the nudge's install-failure telemetry can be split by cause. The
+    reason is a fixed vocabulary set at each raise site, never user input, so it is
+    safe to emit as a telemetry label suffix.
+    """
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
 def _generate_gitignore_snippet(
     skills: list[str], target_dirs: list[Path], project_root: Path
 ) -> str:
@@ -550,7 +567,7 @@ def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     return click.confirm("Proceed with installation?", default=True)
 
 
-def _conflict_error(skipped: list[str]) -> click.ClickException:
+def _conflict_error(skipped: list[str]) -> _InstallError:
     """Build a specific "couldn't install" error that names the conflicting
     paths, rather than a vague "remove conflicting files".
 
@@ -569,9 +586,10 @@ def _conflict_error(skipped: list[str]) -> click.ClickException:
         paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
     joined = ", ".join(paths)
     plural = len(paths) != 1
-    return click.ClickException(
+    return _InstallError(
         f"{joined} already exist{'' if plural else 's'}. "
-        f"Remove {'them' if plural else 'it'} and try again."
+        f"Remove {'them' if plural else 'it'} and try again.",
+        reason="conflict",
     )
 
 
@@ -588,14 +606,17 @@ def _install_project_skills(
         # Keep the absolute path in the server log only - this message is shown
         # verbatim in the in-app nudge, so it must not leak a server path.
         _LOGGER.warning("Bundled skills directory not found at %s", source_skills_dir)
-        raise click.ClickException(
+        raise _InstallError(
             "Bundled skills were not found in your Streamlit installation. "
-            "Reinstall Streamlit and try again."
+            "Reinstall Streamlit and try again.",
+            reason="source_missing",
         )
 
     skills = _discover_skills(source_skills_dir)
     if not skills:
-        raise click.ClickException("No installable skills found in Streamlit package.")
+        raise _InstallError(
+            "No installable skills found in Streamlit package.", reason="no_skills"
+        )
 
     # Determine targets. The in-app installer passes ``app_dir`` so the project
     # root resolves from the running app's directory (matching the nudge's skill
@@ -621,8 +642,9 @@ def _install_project_skills(
             click.echo()
             return _install_global_skills(yes=yes)
 
-        raise click.ClickException(
-            "Symlinks not supported. Use --global for global installation."
+        raise _InstallError(
+            "Symlinks not supported. Use --global for global installation.",
+            reason="symlinks_unsupported",
         )
 
     # Confirm installation
@@ -665,14 +687,16 @@ def _install_project_skills(
             raise
         except click.exceptions.Abort:
             # User cancelled global install - report that nothing was fully installed
-            raise click.ClickException(
+            raise _InstallError(
                 "Installation incomplete. Project symlinks failed and global install "
-                "was cancelled."
+                "was cancelled.",
+                reason="incomplete",
             )
 
     if symlink_failed:
-        raise click.ClickException(
-            "Symlinks not supported. Use --global for global installation."
+        raise _InstallError(
+            "Symlinks not supported. Use --global for global installation.",
+            reason="symlinks_unsupported",
         )
 
     # Report results
@@ -744,9 +768,10 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
             _GLOBAL_SKILL_NAME,
             meta_skill_dir,
         )
-        raise click.ClickException(
+        raise _InstallError(
             f"The bundled '{_GLOBAL_SKILL_NAME}' meta-skill was not found in your "
-            "Streamlit installation. Reinstall Streamlit and try again."
+            "Streamlit installation. Reinstall Streamlit and try again.",
+            reason="source_missing",
         )
 
     # Install to each target directory
@@ -815,8 +840,9 @@ def install_skills(
     """
     # Check if running interactively
     if not yes and not sys.stdin.isatty():
-        raise click.ClickException(
-            "Non-interactive terminal detected. Use --yes to skip prompts."
+        raise _InstallError(
+            "Non-interactive terminal detected. Use --yes to skip prompts.",
+            reason="non_interactive",
         )
 
     # Interactive mode selection (when not using flags)

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -57,6 +57,11 @@ _STAGING_OLD: Final[str] = "o"
 # or a kill - and anything younger may belong to a concurrent install whose staging dir
 # holds the only copy of the installation it has already moved aside.
 _STAGING_ORPHAN_AGE_S: Final[float] = 3600.0
+# Where a staging dir is moved when it holds the user's only copies (both the swap and
+# the restore failed). Deliberately NOT under _STAGING_PREFIX: the orphan sweep must be
+# unable to match it, or it would eventually delete the data it was retained to save.
+# Nothing reclaims these - that is the point - and the failure is logged with the path.
+_RECOVERY_PREFIX: Final[str] = ".st-recover-"
 
 # The full vocabulary of install-failure causes. A closed set so the reason stays
 # safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
@@ -664,6 +669,7 @@ def _install_skill_copy(
     # - is recorded as a write failure (reason="write_failed") instead of
     # escaping as an uncaught OSError the caller can only classify as "unknown".
     staging: Path | None = None
+    unrecoverable = False
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -714,14 +720,7 @@ def _install_skill_copy(
                 try:
                     backup_path.rename(target_path)
                 except OSError:
-                    _LOGGER.warning(
-                        "Skills install left %s empty: the previous install is at "
-                        "%s and the new copy at %s. Move either one back to "
-                        "recover.",
-                        target_path,
-                        backup_path,
-                        new_path,
-                    )
+                    unrecoverable = True
                 raise
         else:
             shutil.copytree(source_path, target_path)
@@ -732,14 +731,38 @@ def _install_skill_copy(
         result.errored.append(f"{rel_target_path} (copy failed: {e})")
         result.write_reasons.append(_classify_write_error(e))
     finally:
-        # Discard staging unless the target ended up empty, which happens only when
-        # the swap AND the restore both failed - there it holds the user's only
-        # copies, so it is left for the next install's sweep to reclaim. Dropping it
-        # is bookkeeping either way and must never turn a landed install into a
-        # reported failure, hence the belt-and-braces suppression.
-        if staging is not None and (target_path.exists() or target_path.is_symlink()):
-            with contextlib.suppress(OSError):
-                shutil.rmtree(staging, ignore_errors=True)
+        # Dropping staging is bookkeeping and must never turn a landed install into a
+        # reported failure, hence the suppression throughout.
+        if staging is not None:
+            if unrecoverable:
+                # Both the swap and the restore failed, so staging holds the only
+                # copies of the old install and its replacement. Move it OUT of the
+                # swept namespace: leaving it under _STAGING_PREFIX would let a later
+                # install's orphan sweep delete the very thing we kept it for. The
+                # contents are usually reproducible from the wheel, but not if the
+                # user had edited their installed skill - so this is not ours to
+                # garbage-collect on a timer.
+                # Best-effort: relocating is itself a rename, and rename may be the
+                # very operation failing here. If it doesn't work the copies stay
+                # under the staging prefix, where only the age gate protects them -
+                # hence the log below naming their location either way.
+                keep = staging.with_name(
+                    _RECOVERY_PREFIX + staging.name[len(_STAGING_PREFIX) :]
+                )
+                with contextlib.suppress(OSError):
+                    staging.rename(keep)
+                    staging = keep
+                _LOGGER.warning(
+                    "Skills install left %s empty. The previous install is at %s and "
+                    "the new copy at %s - move either one back to recover. Nothing "
+                    "will clean this up automatically.",
+                    target_path,
+                    staging / _STAGING_OLD,
+                    staging / _STAGING_NEW,
+                )
+            else:
+                with contextlib.suppress(OSError):
+                    shutil.rmtree(staging, ignore_errors=True)
 
 
 def _print_result(result: _InstallResult) -> None:

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -438,14 +438,24 @@ def _install_skill_symlink(
             # Renaming into a name we just freed, in the same directory.
             link_path.rename(target_path)
         except OSError:
-            # If something is still at the target the unlink failed and the old
-            # install is intact, so drop the staged link. If the target is empty
-            # the rename failed and the staged link is the only copy left - keep
-            # it rather than deleting the last one. Either way, fall back.
             if target_path.exists() or target_path.is_symlink():
+                # The unlink failed, so the old install is intact and the staged
+                # link is redundant. Drop it and let the caller fall back.
                 with contextlib.suppress(OSError):
                     _remove_skill_target(link_path)
-            return False
+                return False
+            # The old link is gone but the staged one wouldn't move, leaving the
+            # canonical path empty. Creating a link here demonstrably works - we
+            # just made one - so lay it directly rather than stranding the install
+            # under a dot-name that nothing reads.
+            try:
+                target_path.symlink_to(rel_source, target_is_directory=True)
+            except OSError:
+                # Keep the staged link: it is now the only one, so deleting it
+                # would leave nothing at all.
+                return False
+            with contextlib.suppress(OSError):
+                _remove_skill_target(link_path)
 
     result.installed.append(str(rel_target_path))
     return True

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -41,8 +41,8 @@ class _InstallError(click.ClickException):
 
     Behaves like a normal ``click.ClickException`` — its ``format_message`` still
     supplies the user-facing text shown in the CLI and the in-app nudge — but also
-    carries a bounded ``reason`` (e.g. ``"conflict"``, ``"source_missing"``,
-    ``"symlinks_unsupported"``) that the backend-operation handler forwards to the
+    carries a bounded ``reason`` (e.g. ``"conflict"``, ``"write_failed"``,
+    ``"source_missing"``) that the backend-operation handler forwards to the
     client so the nudge's install-failure telemetry can be split by cause. The
     reason is a fixed vocabulary set at each raise site, never user input, so it is
     safe to emit as a telemetry label suffix.
@@ -84,6 +84,10 @@ class _InstallResult:
     # misreported as a "conflict" - both in the CLI summary and, crucially, in
     # the nudge's install-failure telemetry reason.
     errored: list[str] = field(default_factory=list)
+    # True when project (symlink) install fell back to a global copy because
+    # symlinks aren't supported (e.g. Windows without Developer Mode). Surfaced
+    # to telemetry so that cohort is countable - see InstallSkillsResponsePayload.
+    used_global_fallback: bool = False
 
 
 def _get_source_skills_dir() -> Path:
@@ -688,7 +692,9 @@ def _install_project_skills(
                 "Developer Mode to use project installs."
             )
             click.echo()
-            return _install_global_skills(yes=yes)
+            global_result = _install_global_skills(yes=yes)
+            global_result.used_global_fallback = True
+            return global_result
 
         raise _InstallError(
             "Symlinks not supported. Use --global for global installation.",
@@ -729,7 +735,9 @@ def _install_project_skills(
         click.echo("Falling back to global installation mode...")
         click.echo()
         try:
-            return _install_global_skills(yes=yes)
+            global_result = _install_global_skills(yes=yes)
+            global_result.used_global_fallback = True
+            return global_result
         except click.ClickException:
             # Global install failed - partial project symlinks remain as fallback
             raise

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -768,6 +768,15 @@ def _install_skill_copy(
                 with contextlib.suppress(OSError):
                     staging.rename(keep)
                     staging = keep
+                if staging.name.startswith(_STAGING_PREFIX):
+                    # The relocation didn't take - rename may be the very operation
+                    # failing here. Drop the ownership marker instead: the sweep
+                    # requires it, so removing it makes this directory permanently
+                    # invisible to cleanup. Unlinking one small file is far likelier
+                    # to succeed than renaming a directory, so between the two the
+                    # retained copies are protected whichever operation is broken.
+                    with contextlib.suppress(OSError):
+                        (staging / _STAGING_MARKER).unlink()
                 _LOGGER.warning(
                     "Skills install left %s empty. The previous install is at %s and "
                     "the new copy at %s - move either one back to recover. Nothing "

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -361,15 +361,11 @@ def _install_skill_symlink(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.cwd())
 
-    # Pre-symlink filesystem work (creating the parent dir, inspecting or removing
-    # an existing target) runs under one guard: any OSError here means we can't
-    # lay the symlink, so return False and let the caller fall back to a global
-    # copy - never let it escape and get misbooked as a hard write_failed.
-    #
-    # ``symlink_to`` won't overwrite, so replacing an owned link means unlinking
-    # first. Remember where it pointed so a failed re-link can put it back: the
-    # caller's fallback installs GLOBALLY, which wouldn't restore a project link.
-    replaced_link_target: str | None = None
+    # Pre-symlink filesystem work (creating the parent dir, inspecting an existing
+    # target) runs under one guard: any OSError here means we can't lay the
+    # symlink, so return False and let the caller fall back to a global copy -
+    # never let it escape and get misbooked as a hard write_failed.
+    replace_owned_link = False
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -386,11 +382,10 @@ def _install_skill_symlink(
                     # Broken symlink or resolution error - check ownership below
                     pass
 
-                # Check if it's a Streamlit-owned symlink we can replace
+                # Check if it's a Streamlit-owned symlink we can replace. Don't
+                # remove it yet - see the staged replacement below.
                 if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                    with contextlib.suppress(OSError):
-                        replaced_link_target = os.readlink(target_path)
-                    target_path.unlink()
+                    replace_owned_link = True
                 else:
                     result.skipped.append(f"{rel_target_path} (existing symlink)")
                     return True
@@ -418,21 +413,42 @@ def _install_skill_symlink(
         # absolute (resolved) source path, which still resolves correctly.
         rel_source = os.path.realpath(source_path)
 
-    # Create symlink
+    # Replacing an existing link is staged: ``symlink_to`` won't overwrite, so the
+    # old one has to go first, and "remove then re-create" loses a working install
+    # whenever the re-create fails. Since a failing re-create means this system
+    # can't make symlinks at all, an attempt to restore would fail for the same
+    # reason. So prove we can make the link - under a temp name - BEFORE removing
+    # anything. If that fails, the existing install is still untouched.
+    link_path = target_path
+    if replace_owned_link:
+        link_path = target_path.with_name(f".{skill_name}.newlink")
+        with contextlib.suppress(OSError):
+            _remove_skill_target(link_path)
+
     try:
-        target_path.symlink_to(rel_source, target_is_directory=True)
-        result.installed.append(str(rel_target_path))
-        return True
+        link_path.symlink_to(rel_source, target_is_directory=True)
     except (OSError, NotImplementedError):
         # Symlink not supported (e.g., Windows without Developer Mode, or some
-        # environments where symlinks are not implemented)
-        if replaced_link_target is not None:
-            # Put back the working link we removed. Without this, a reinstall that
-            # can't re-link destroys a usable project install and the caller's
-            # global fallback lands somewhere else entirely.
-            with contextlib.suppress(OSError):
-                target_path.symlink_to(replaced_link_target, target_is_directory=True)
+        # environments where symlinks are not implemented). Nothing was removed.
         return False
+
+    if replace_owned_link:
+        try:
+            target_path.unlink()
+            # Renaming into a name we just freed, in the same directory.
+            link_path.rename(target_path)
+        except OSError:
+            # If something is still at the target the unlink failed and the old
+            # install is intact, so drop the staged link. If the target is empty
+            # the rename failed and the staged link is the only copy left - keep
+            # it rather than deleting the last one. Either way, fall back.
+            if target_path.exists() or target_path.is_symlink():
+                with contextlib.suppress(OSError):
+                    _remove_skill_target(link_path)
+            return False
+
+    result.installed.append(str(rel_target_path))
+    return True
 
 
 def _remove_skill_target(path: Path) -> None:

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -229,7 +229,7 @@ def test_install_skills_handler_installs_in_project_mode() -> None:
 def test_install_skills_handler_forwards_global_fallback_flag() -> None:
     """A fallback install (symlinks unsupported -> global copy) forwards
     used_global_fallback so the frontend can emit the countable
-    skillsNudgeInstallSucceeded:global_fallback label (decision A).
+    skillsNudgeInstallSucceeded:global_fallback label.
     """
     install_result = skills._InstallResult(
         installed=["~/.agents/skills/foo"], used_global_fallback=True
@@ -334,14 +334,14 @@ def test_install_skills_handler_does_not_leak_os_error_path() -> None:
 def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
     """A non-_InstallError exception exposing a str ``.reason`` must NOT be emitted.
 
-    Regression (adversarial-sweep): the handler used to ``getattr(ex, 'reason')``,
-    so any exception with a free-form str ``.reason`` (e.g. UnicodeDecodeError)
-    would leak an unbounded, attacker-influenced telemetry label and break the
-    fixed vocabulary. The reason is now trusted ONLY from skills._InstallError;
-    a non-OSError foreign exception is classified ``unknown``.
+    The handler used to read the reason with ``getattr(ex, 'reason')``, so any
+    exception carrying a free-form str ``.reason`` (``UnicodeDecodeError`` and
+    several stdlib errors do) would emit an unbounded telemetry label and break the
+    fixed vocabulary. The reason is now trusted ONLY from skills._InstallError; a
+    non-OSError foreign exception is classified ``unknown``.
     """
     foreign = ValueError("boom")
-    foreign.reason = "attacker-controlled-label"  # type: ignore[attr-defined]
+    foreign.reason = "some-unbounded-string"  # type: ignore[attr-defined]
     with (
         patch("streamlit.config.get_option", return_value=False),
         patch.object(skills, "detect_installed_agents", return_value=["claude"]),
@@ -354,7 +354,6 @@ def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
         )
 
     assert response.error_reason == "unknown"
-    assert "attacker-controlled-label" not in response.error_reason
 
 
 def test_install_skills_handler_refuses_without_agent_harness() -> None:
@@ -375,7 +374,7 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
-    assert response.error_reason == "no_agent"
+    assert response.error_reason == "refused:no_agent"
     assert not response.HasField("install_skills")
 
 
@@ -400,7 +399,7 @@ def test_install_skills_handler_refuses_non_loopback_connection() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
-    assert response.error_reason == "non_loopback"
+    assert response.error_reason == "refused:non_loopback"
     assert not response.HasField("install_skills")
 
 
@@ -462,7 +461,7 @@ def test_install_skills_handler_refuses_in_headless_mode() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
-    assert response.error_reason == "headless"
+    assert response.error_reason == "refused:headless"
     assert not response.HasField("install_skills")
 
 

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -248,14 +248,15 @@ def test_install_skills_handler_reports_failure() -> None:
 def test_install_skills_handler_forwards_failure_reason() -> None:
     """A ``skills._InstallError`` propagates its machine-readable ``reason`` into
     the response's ``error_reason`` so the client can split install-failure
-    telemetry by cause (e.g. the Windows symlink → GitHub-download fallback)."""
+    telemetry by cause (e.g. conflict vs. write_failed vs. source_missing)."""
     with (
         patch("streamlit.config.get_option", return_value=False),
         patch.object(skills, "detect_installed_agents", return_value=["claude"]),
         patch(
             "streamlit.web.skills.install_skills",
             side_effect=skills._InstallError(
-                "Failed to download skills from GitHub", reason="download_failed"
+                "developing-with-streamlit already exists. Remove it and try again.",
+                reason="conflict",
             ),
         ),
     ):
@@ -265,18 +266,24 @@ def test_install_skills_handler_forwards_failure_reason() -> None:
             )
         )
 
-    assert response.error_msg == "Failed to download skills from GitHub"
-    assert response.error_reason == "download_failed"
+    assert response.error_msg == (
+        "developing-with-streamlit already exists. Remove it and try again."
+    )
+    assert response.error_reason == "conflict"
     assert not response.HasField("install_skills")
 
 
 def test_install_skills_handler_does_not_leak_os_error_path() -> None:
-    """A non-``ClickException`` (e.g. ``OSError``) yields a generic message.
+    """A non-``ClickException`` ``OSError`` yields a generic message but a
+    ``write_failed`` reason.
 
     ``click.ClickException`` messages are developer-authored and safe to show in
-    the browser toast, but a raw ``OSError`` can embed an absolute server path.
-    The handler must forward only the former verbatim and replace anything else
-    with a generic string, so a server path can never leak into the nudge.
+    the browser toast, but a raw ``OSError`` can embed an absolute server path -
+    so the message is replaced with a generic string. The reason, however, is
+    still meaningful: a bare ``OSError`` escaping the installer (e.g. a
+    permission error creating the target dir, before the copy's own try/except)
+    is a filesystem write failure, so it's classified ``write_failed`` rather
+    than buried in ``unknown``.
     """
     with (
         patch("streamlit.config.get_option", return_value=False),
@@ -294,6 +301,7 @@ def test_install_skills_handler_does_not_leak_os_error_path() -> None:
 
     assert response.error_msg == "Failed to install skills."
     assert "/absolute/server/path" not in response.error_msg
+    assert response.error_reason == "write_failed"
     assert not response.HasField("install_skills")
 
 

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -305,6 +305,32 @@ def test_install_skills_handler_does_not_leak_os_error_path() -> None:
     assert not response.HasField("install_skills")
 
 
+def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
+    """A non-_InstallError exception exposing a str ``.reason`` must NOT be emitted.
+
+    Regression (adversarial-sweep): the handler used to ``getattr(ex, 'reason')``,
+    so any exception with a free-form str ``.reason`` (e.g. UnicodeDecodeError)
+    would leak an unbounded, attacker-influenced telemetry label and break the
+    fixed vocabulary. The reason is now trusted ONLY from skills._InstallError;
+    a non-OSError foreign exception is classified ``unknown``.
+    """
+    foreign = ValueError("boom")
+    foreign.reason = "attacker-controlled-label"  # type: ignore[attr-defined]
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", side_effect=foreign),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_reason == "unknown"
+    assert "attacker-controlled-label" not in response.error_reason
+
+
 def test_install_skills_handler_refuses_without_agent_harness() -> None:
     """The install ACTION is gated on safety, not the nudge's display predicate:
     with no agent harness present (and not headless) the request is anomalous,

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -223,16 +223,16 @@ def test_install_skills_handler_installs_in_project_mode() -> None:
     )
     assert response.error_msg == ""
     # A normal project (symlink) install did not take the global fallback.
-    assert response.install_skills.used_global_fallback is False
+    assert response.install_skills.fallback_reason == ""
 
 
 def test_install_skills_handler_forwards_global_fallback_flag() -> None:
-    """A fallback install (symlinks unsupported -> global copy) forwards
-    used_global_fallback so the frontend can emit the countable
-    skillsNudgeInstallSucceeded:global_fallback label.
+    """A fallback install forwards WHICH fallback route it took, so the frontend can
+    emit skillsNudgeInstallSucceeded:<fallback_reason> and the two causes stay
+    separable in the funnel.
     """
     install_result = skills._InstallResult(
-        installed=["~/.agents/skills/foo"], used_global_fallback=True
+        installed=["~/.agents/skills/foo"], fallback_reason="symlink_failed"
     )
     with (
         patch("streamlit.config.get_option", return_value=False),
@@ -247,7 +247,7 @@ def test_install_skills_handler_forwards_global_fallback_flag() -> None:
         )
 
     assert response.HasField("install_skills")
-    assert response.install_skills.used_global_fallback is True
+    assert response.install_skills.fallback_reason == "symlink_failed"
 
 
 def test_install_skills_handler_reports_failure() -> None:

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -241,6 +241,32 @@ def test_install_skills_handler_reports_failure() -> None:
         )
 
     assert response.error_msg == "No skills found"
+    assert response.error_reason == "unknown"
+    assert not response.HasField("install_skills")
+
+
+def test_install_skills_handler_forwards_failure_reason() -> None:
+    """A ``skills._InstallError`` propagates its machine-readable ``reason`` into
+    the response's ``error_reason`` so the client can split install-failure
+    telemetry by cause (e.g. the Windows symlink → GitHub-download fallback)."""
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch(
+            "streamlit.web.skills.install_skills",
+            side_effect=skills._InstallError(
+                "Failed to download skills from GitHub", reason="download_failed"
+            ),
+        ),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_msg == "Failed to download skills from GitHub"
+    assert response.error_reason == "download_failed"
     assert not response.HasField("install_skills")
 
 
@@ -289,6 +315,7 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
+    assert response.error_reason == "no_agent"
     assert not response.HasField("install_skills")
 
 
@@ -313,6 +340,7 @@ def test_install_skills_handler_refuses_non_loopback_connection() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
+    assert response.error_reason == "non_loopback"
     assert not response.HasField("install_skills")
 
 
@@ -353,6 +381,7 @@ def test_install_skills_handler_allows_idempotent_retry_when_already_installed()
         global_mode=False, yes=True, app_dir="/app/dir"
     )
     assert response.error_msg == ""
+    assert response.error_reason == ""
     assert response.HasField("install_skills")
     assert response.install_skills.detail == "Skills are already up to date."
 
@@ -373,6 +402,7 @@ def test_install_skills_handler_refuses_in_headless_mode() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
+    assert response.error_reason == "headless"
     assert not response.HasField("install_skills")
 
 

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -222,6 +222,32 @@ def test_install_skills_handler_installs_in_project_mode() -> None:
         response.install_skills.detail == "Installed to .agents/skills, .claude/skills."
     )
     assert response.error_msg == ""
+    # A normal project (symlink) install did not take the global fallback.
+    assert response.install_skills.used_global_fallback is False
+
+
+def test_install_skills_handler_forwards_global_fallback_flag() -> None:
+    """A fallback install (symlinks unsupported -> global copy) forwards
+    used_global_fallback so the frontend can emit the countable
+    skillsNudgeInstallSucceeded:global_fallback label (decision A).
+    """
+    install_result = skills._InstallResult(
+        installed=["~/.agents/skills/foo"], used_global_fallback=True
+    )
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", return_value=install_result),
+        patch.object(skills, "clear_installed_skills_cache"),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.HasField("install_skills")
+    assert response.install_skills.used_global_fallback is True
 
 
 def test_install_skills_handler_reports_failure() -> None:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1298,6 +1298,46 @@ class TestInstallSkillCopyEdgeCases:
         assert target.is_dir()
         assert (target / "SKILL.md").is_file()
 
+    def test_preserves_existing_symlink_on_copy_failure(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed replacement leaves an existing owned symlink usable.
+
+        Replacing a Streamlit-owned symlink used to unlink it before copying, so a
+        copy that failed (permissions, full disk, antivirus lock) deleted a working
+        skill and left nothing in its place. The replacement now copies to a temp
+        dir and swaps, so the old install survives a failure.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        # A working install: an owned symlink pointing at a real skill directory.
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text(
+            "# Working install\n", encoding="utf-8"
+        )
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(skills.shutil, "copytree", side_effect=OSError("Disk full")),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert any("copy failed" in entry for entry in result.errored)
+        assert not result.installed
+
     def test_reports_copy_failure(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
@@ -1318,8 +1358,8 @@ class TestInstallSkillCopyEdgeCases:
             )
 
         assert any("copy failed" in s for s in result.errored)
-        # Regression (Greptile P1): a write failure must land in ``errored``,
-        # never ``skipped`` - otherwise the caller labels it reason="conflict".
+        # A write failure must land in ``errored``, never ``skipped`` - otherwise
+        # the caller labels it reason="conflict".
         assert not result.skipped
 
     def test_preserves_existing_directory_on_copy_failure(
@@ -1445,10 +1485,10 @@ class TestInstallSkillSymlinkEdgeCases:
     ) -> None:
         """A filesystem error in the symlink PRE-work returns False (-> fallback).
 
-        Regression (adversarial-sweep #2): mkdir / existence-check / unlink ran
-        outside the guard, so an OSError there escaped and was booked as a hard
-        write_failed AND bypassed the symlink->global fallback. It must instead
-        return False so the caller falls back to a global copy.
+        The mkdir / existence-check / unlink steps used to run outside the guard, so
+        an OSError there escaped as a hard write_failed and bypassed the
+        symlink->global fallback. Whatever stops us laying the symlink, the caller
+        should get the chance to fall back to a global copy.
         """
         target_dir = tmp_path / "project" / ".agents" / "skills"
         result = skills._InstallResult()
@@ -1540,10 +1580,10 @@ class TestGlobalInstallationConflicts:
     ) -> None:
         """A filesystem copy failure raises reason='write_failed', not 'conflict'.
 
-        Regression for the Greptile P1: an ``OSError`` during the global copy
-        (permissions, disk space, locked dir) used to land in ``skipped`` and be
-        labeled ``conflict``, so the nudge's failure telemetry misclassified
-        write failures - the dominant residual Windows cause - as conflicts.
+        An ``OSError`` during the global copy (permissions, disk space, locked dir)
+        used to land in ``skipped`` and be labeled ``conflict``, so the nudge's
+        failure telemetry misclassified write failures - the dominant residual
+        Windows cause - as conflicts.
         """
         home = tmp_path / "home"
         home.mkdir(parents=True)
@@ -1569,12 +1609,12 @@ class TestGlobalInstallationConflicts:
     ) -> None:
         """One target succeeds, another OSErrors -> hard write_failed, not success.
 
-        Regression (critical, adversarial-sweep #1): _get_global_target_dirs
-        returns TWO targets when ~/.claude exists. If ~/.agents copies OK
-        (result.installed non-empty) but ~/.claude raises OSError (result.errored),
-        the success branch used to win over the errored branch, so the install
-        returned success and emitted NO skillsNudgeInstallFailed:write_failed on
-        the exact Windows cohort under study. Any errored target must fail loud.
+        ``_get_global_target_dirs`` returns TWO targets when ``~/.claude`` exists. If
+        ``~/.agents`` copies OK (result.installed non-empty) but ``~/.claude`` raises
+        OSError (result.errored), the success branch used to win over the errored
+        branch - so a half-installed system reported success and emitted no
+        write_failed telemetry for exactly the locked-down cohort under study. Any
+        errored target must fail loud.
         """
         home = tmp_path / "home"
         # ~/.claude present -> _get_global_target_dirs yields both targets.
@@ -2202,9 +2242,10 @@ class TestInstallProjectSkillsFallbackSignal:
     ) -> None:
         """A successful symlink->global fallback flags used_global_fallback.
 
-        (decision A) so the Windows-no-Dev-Mode cohort - symlinks unsupported,
-        silently rerouted to a global copy - is countable in telemetry as
-        skillsNudgeInstallSucceeded:global_fallback rather than invisible.
+        A project install that can't lay symlinks is silently rerouted to a global
+        copy, which looks identical to a project install in the success telemetry.
+        The flag makes that cohort (Windows without Developer Mode, mainly) countable
+        as skillsNudgeInstallSucceeded:global_fallback rather than invisible.
         """
         project_dir = tmp_path / "project"
         project_dir.mkdir()

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2686,6 +2686,101 @@ class TestInstallProjectSkillsFallbackSignal:
         assert result.fallback_reason is None
 
 
+class TestRaiseSiteReasons:
+    """Every raise site reports the reason the telemetry vocabulary expects.
+
+    mypy rejects an *invalid* reason but not a wrong *choice* among valid ones — so
+    tagging the meta-skill check ``source_missing`` instead of ``source_incomplete``
+    would type-check, ship, and quietly point a dashboard at the wrong packaging bug.
+    The existing tests for these paths assert on user-facing messages, which a
+    mis-tagged reason passes. These assert the reason itself.
+    """
+
+    def test_absent_skills_directory_is_source_missing(self, tmp_path: Path) -> None:
+        """Nothing installed in the wheel at all -> missing package data."""
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=tmp_path / "nope"
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_project_skills(yes=True)
+
+        assert exc.value.reason == "source_missing"
+
+    def test_incomplete_meta_skill_is_source_incomplete(self, tmp_path: Path) -> None:
+        """Directory present but a required file missing -> too-narrow glob.
+
+        Distinct from source_missing on purpose: "the wheel has no skills" and "the
+        wheel has the folder but not scripts/discover.py" are different packaging
+        bugs with different fixes.
+        """
+        meta_dir = tmp_path / "meta"
+        skill_dir = meta_dir / "developing-with-streamlit"
+        skill_dir.mkdir(parents=True)
+        # SKILL.md present, scripts/discover.py absent - the router without its target.
+        (skill_dir / "SKILL.md").write_text("# Meta\n", encoding="utf-8")
+
+        with (
+            patch.object(skills, "_get_meta_skill_dir", return_value=meta_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "source_incomplete"
+
+    def test_empty_skills_directory_is_no_skills(self, tmp_path: Path) -> None:
+        """The directory exists but discovery found nothing installable."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with (
+            patch.object(skills, "_get_source_skills_dir", return_value=empty),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_project_skills(yes=True)
+
+        assert exc.value.reason == "no_skills"
+
+    def test_no_tty_without_yes_is_non_interactive(
+        self, mock_source_skills_dir: Path
+    ) -> None:
+        """CLI-only: nothing to prompt on and --yes was not passed."""
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch("sys.stdin.isatty", return_value=False),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills.install_skills()
+
+        assert exc.value.reason == "non_interactive"
+
+    def test_cancelled_global_fallback_is_incomplete(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """Project symlinks failed and the user declined the global fallback."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(skills, "_symlink_blocker", return_value=None),
+            patch.object(skills, "_install_skill_symlink", return_value=False),
+            patch.object(
+                skills, "_install_global_skills", side_effect=click.exceptions.Abort()
+            ),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_project_skills(yes=True)
+
+        assert exc.value.reason == "incomplete"
+
+
 class TestSymlinkBlocker:
     """_symlink_blocker names WHY symlinks are unavailable, not just that they are."""
 

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1444,7 +1444,7 @@ class TestInstallSkillCopyEdgeCases:
         # Reported as a failure, and the backup name is not left behind.
         assert result.errored
         assert not result.installed
-        assert not (target_dir / ".developing-with-streamlit.old").exists()
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
 
     def test_keeps_both_copies_when_swap_and_restore_both_fail(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1489,21 +1489,25 @@ class TestInstallSkillCopyEdgeCases:
         # Reported as a failure, never a success.
         assert result.errored
         assert not result.installed
-        # Both copies survive under their hidden names - nothing is destroyed.
-        old_copy = target_dir / ".developing-with-streamlit.old"
-        new_copy = target_dir / ".developing-with-streamlit.tmp"
-        assert (old_copy / "SKILL.md").read_text() == "# Old version\n"
-        assert (new_copy / "SKILL.md").read_text() == "# Test Skill\n"
+        # Both copies survive inside the retained staging dir - nothing is destroyed.
+        staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+        assert len(staged) == 1
+        assert (
+            staged[0] / "developing-with-streamlit.old" / "SKILL.md"
+        ).read_text() == "# Old version\n"
+        assert (
+            staged[0] / "developing-with-streamlit" / "SKILL.md"
+        ).read_text() == "# Test Skill\n"
 
     def test_reports_success_when_only_backup_cleanup_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
         """A failed backup cleanup after a landed swap is still a success.
 
-        Dropping the moved-aside ``.old`` backup is bookkeeping that happens after
-        the new skill is already at the target. If its error reached the write
-        handler, a correct install would be reported as ``write_failed`` — a false
-        failure in the nudge and a false reason in the telemetry.
+        Discarding the staging dir is bookkeeping that happens after the new skill
+        is already at the target. If its error reached the write handler, a correct
+        install would be reported as ``write_failed`` — a false failure in the nudge
+        and a false reason in the telemetry.
         """
         target_dir = tmp_path / "target" / "skills"
         target_dir.mkdir(parents=True)
@@ -1514,7 +1518,7 @@ class TestInstallSkillCopyEdgeCases:
         result = skills._InstallResult()
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            # The only rmtree in this path is the post-swap backup cleanup.
+            # Every rmtree here is cleanup; none of it may affect the outcome.
             patch.object(
                 skills.shutil, "rmtree", side_effect=OSError("Directory not empty")
             ),
@@ -1738,7 +1742,7 @@ class TestInstallSkillSymlinkEdgeCases:
         assert target.is_symlink()
         assert (target / "SKILL.md").read_text() == "# Test Skill\n"
         # ...and the staging name is cleaned up rather than left as clutter.
-        assert not (target_dir / ".developing-with-streamlit.newlink").exists()
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
 
     def test_keeps_old_link_when_unlink_fails_after_staging(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1830,10 +1834,11 @@ class TestInstallSkillSymlinkEdgeCases:
 
         assert not success
         assert not result.installed
-        # The staged link is the only remaining copy, so it must survive.
-        staged = target_dir / ".developing-with-streamlit.newlink"
-        assert staged.is_symlink()
-        assert (staged / "SKILL.md").read_text() == "# Test Skill\n"
+        # The staged link is the only remaining copy, so its staging dir must survive.
+        staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+        assert len(staged) == 1
+        link = staged[0] / "developing-with-streamlit"
+        assert link.is_symlink()
 
 
 class TestPromptInstallModeRetry:
@@ -2617,25 +2622,23 @@ class TestInstallProjectSkillsFallbackSignal:
         assert result.used_global_fallback is False
 
 
-class TestInstallSkillCopyTempCleanup:
-    """Tests for temp file cleanup paths in _install_skill_copy."""
+class TestInstallSkillCopyStaging:
+    """Staging behavior for _install_skill_copy replacements."""
 
-    def test_removes_leftover_temp_before_copying(
+    def test_sweeps_leftover_staging_dir(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """Removes leftover temp directory from a previous failed copy."""
+        """A staging dir orphaned by an interrupted install is reclaimed."""
         target_dir = tmp_path / "target" / "skills"
         target_dir.mkdir(parents=True)
-        # Existing target directory with different content forces use of the
-        # temp-swap path.
+        # Existing target with different content forces the staged-swap path.
         target = target_dir / "developing-with-streamlit"
         target.mkdir()
         (target / "stale-file.txt").write_text("old", encoding="utf-8")
 
-        # Leftover temp directory from a previous failed run.
-        leftover_temp = target_dir / ".developing-with-streamlit.tmp"
-        leftover_temp.mkdir()
-        (leftover_temp / "leftover.txt").write_text("leftover", encoding="utf-8")
+        orphan = target_dir / f"{skills._STAGING_PREFIX}abc123"
+        orphan.mkdir()
+        (orphan / "leftover.txt").write_text("leftover", encoding="utf-8")
 
         result = skills._InstallResult()
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -2648,11 +2651,53 @@ class TestInstallSkillCopyTempCleanup:
             )
 
         assert len(result.installed) == 1
-        # New target must replace the old one and contain only the source content.
         assert (target / "SKILL.md").is_file()
         assert not (target / "stale-file.txt").exists()
-        # Temp directory must be cleaned up after the swap.
-        assert not leftover_temp.exists()
+        # The orphan is gone, and this run's own staging dir left nothing behind.
+        assert not orphan.exists()
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_never_deletes_a_directory_it_did_not_create(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """Unrelated hidden directories in the target survive an install.
+
+        Staging used to use predictable sibling names (``.<skill>.tmp`` /
+        ``.<skill>.old``) and cleared them before use, so a directory the installer
+        never created could be recursively deleted. Staging is now a fresh
+        ``mkdtemp``, and the sweep matches only its own prefix, so nothing outside
+        that prefix is ever touched.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        # The exact names the old implementation would have wiped, plus a plain one.
+        bystanders = [
+            target_dir / ".developing-with-streamlit.tmp",
+            target_dir / ".developing-with-streamlit.old",
+            target_dir / ".developing-with-streamlit.newlink",
+            target_dir / ".my-notes",
+        ]
+        for d in bystanders:
+            d.mkdir()
+            (d / "precious.txt").write_text("do not delete", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        for d in bystanders:
+            assert (d / "precious.txt").read_text() == "do not delete"
 
 
 class TestGetMetaSkillDir:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1493,13 +1493,20 @@ class TestInstallSkillCopyEdgeCases:
         # Reported as a failure, never a success.
         assert result.errored
         assert not result.installed
-        # Both copies survive inside the retained staging dir - nothing is destroyed.
-        staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
-        assert len(staged) == 1
-        assert (staged[0] / skills._STAGING_OLD / "SKILL.md").read_text() == (
+        # Both copies survive somewhere - nothing is destroyed. They stay under the
+        # staging prefix here rather than moving to the recovery one, because the
+        # relocation is itself a rename and rename is the operation failing in this
+        # scenario. The age gate is then the only thing protecting them, which is why
+        # the warning log names the paths. See
+        # test_never_sweeps_a_retained_recovery_directory for the normal case.
+        kept = list(target_dir.glob(f"{skills._STAGING_PREFIX}*")) + list(
+            target_dir.glob(f"{skills._RECOVERY_PREFIX}*")
+        )
+        assert len(kept) == 1
+        assert (kept[0] / skills._STAGING_OLD / "SKILL.md").read_text() == (
             "# Old version\n"
         )
-        assert (staged[0] / skills._STAGING_NEW / "SKILL.md").read_text() == (
+        assert (kept[0] / skills._STAGING_NEW / "SKILL.md").read_text() == (
             "# Test Skill\n"
         )
 
@@ -2928,6 +2935,53 @@ class TestInstallSkillCopyStaging:
         # The orphan is gone, and this run's own staging dir left nothing behind.
         assert not orphan.exists()
         assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_never_sweeps_a_retained_recovery_directory(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """Copies kept for manual recovery are never garbage-collected on a timer.
+
+        When the swap and the restore both fail, staging holds the only copies of the
+        old install and its replacement. Leaving them under the staging prefix would
+        let a later install's orphan sweep delete exactly what was retained to save —
+        and the age gate is no defence, since a recovery directory becomes old by
+        definition while it waits for the user. Moving it out of the swept namespace
+        is what makes it safe.
+
+        The contents are usually reproducible from the wheel, but not if the user had
+        edited their installed skill, so this is not ours to reclaim.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+
+        # A recovery dir left by an earlier unrecoverable swap, long past the age gate.
+        recovery = target_dir / f"{skills._RECOVERY_PREFIX}old99"
+        (recovery / skills._STAGING_OLD).mkdir(parents=True)
+        (recovery / skills._STAGING_OLD / "SKILL.md").write_text(
+            "# Their edited skill\n", encoding="utf-8"
+        )
+        ancient = time.time() - skills._STAGING_ORPHAN_AGE_S * 24
+        os.utime(recovery, (ancient, ancient))
+
+        # A later replacement install, which is what runs the sweep.
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        assert (recovery / skills._STAGING_OLD / "SKILL.md").read_text() == (
+            "# Their edited skill\n"
+        )
 
     def test_leaves_a_concurrent_installs_staging_dir_alone(
         self, tmp_path: Path, mock_source_skills_dir: Path

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1737,6 +1737,15 @@ class TestConflictError:
         assert ".agents/skills/developing-with-streamlit already exists." in message
         assert "Remove it and try again." in message
 
+    def test_conflict_error_carries_conflict_reason(self) -> None:
+        """The conflict error is an ``_InstallError`` tagged ``reason="conflict"`` so
+        the handler forwards it to install-failure telemetry."""
+        err = skills._conflict_error(
+            [".agents/skills/developing-with-streamlit (existing file or directory)"]
+        )
+        assert isinstance(err, skills._InstallError)
+        assert err.reason == "conflict"
+
 
 class TestInstallSkillsReturnsResult:
     """install_skills returns the structured result for callers (e.g. the nudge)."""

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import subprocess
 import sys
@@ -1492,12 +1493,12 @@ class TestInstallSkillCopyEdgeCases:
         # Both copies survive inside the retained staging dir - nothing is destroyed.
         staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
         assert len(staged) == 1
-        assert (
-            staged[0] / "developing-with-streamlit.old" / "SKILL.md"
-        ).read_text() == "# Old version\n"
-        assert (
-            staged[0] / "developing-with-streamlit" / "SKILL.md"
-        ).read_text() == "# Test Skill\n"
+        assert (staged[0] / skills._STAGING_OLD / "SKILL.md").read_text() == (
+            "# Old version\n"
+        )
+        assert (staged[0] / skills._STAGING_NEW / "SKILL.md").read_text() == (
+            "# Test Skill\n"
+        )
 
     def test_reports_success_when_only_backup_cleanup_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1837,8 +1838,7 @@ class TestInstallSkillSymlinkEdgeCases:
         # The staged link is the only remaining copy, so its staging dir must survive.
         staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
         assert len(staged) == 1
-        link = staged[0] / "developing-with-streamlit"
-        assert link.is_symlink()
+        assert (staged[0] / skills._STAGING_NEW).is_symlink()
 
 
 class TestPromptInstallModeRetry:
@@ -1932,6 +1932,65 @@ class TestGlobalInstallationConflicts:
         assert exc.value.reason == "write_failed"
         # Must NOT be misclassified as a conflict.
         assert "already exist" not in exc.value.format_message()
+
+    def test_reports_the_specific_write_cause_not_a_generic_failure(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """A permission error surfaces as write_denied, end to end.
+
+        The point of the whole exercise: "a write failed" does not say what to do,
+        while "permission denied" and "path too long" imply different fixes. The
+        errno has to survive from the copy site out to the raised reason.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=OSError(errno.EACCES, "Permission denied"),
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_denied"
+
+    def test_generalises_when_targets_fail_for_different_reasons(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """Disagreeing targets report the generic write_failed, not a guess.
+
+        Claiming "permission denied" when one target was denied and the other was out
+        of disk would send whoever reads the telemetry after half the problem.
+        """
+        home = tmp_path / "home"
+        # ~/.claude present -> _get_global_target_dirs yields two targets.
+        (home / ".claude").mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=[
+                    OSError(errno.EACCES, "Permission denied"),
+                    OSError(errno.ENOSPC, "No space left"),
+                ],
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_failed"
 
     def test_partial_write_failure_reports_write_failed_not_success(
         self, tmp_path: Path, mock_meta_skill_dir: Path
@@ -2556,25 +2615,27 @@ class TestInstallProjectSkillsFallbackErrors:
 
 
 class TestInstallProjectSkillsFallbackSignal:
-    """used_global_fallback marks installs that took the symlink->global path."""
+    """fallback_reason names WHY an install took the symlink->global path."""
 
     @pytest.mark.parametrize(
-        "symlinks_supported",
-        [False, True],
-        ids=["fallback_via_precheck", "fallback_via_symlink_failure"],
+        ("symlinks_supported", "expected_reason"),
+        [(False, "symlinks_unsupported"), (True, "symlink_failed")],
+        ids=["precheck_says_unsupported", "individual_link_failed"],
     )
-    def test_fallback_sets_used_global_fallback(
+    def test_fallback_records_its_cause(
         self,
         tmp_path: Path,
         mock_source_skills_dir: Path,
         symlinks_supported: bool,
+        expected_reason: str,
     ) -> None:
-        """A successful symlink->global fallback flags used_global_fallback.
+        """The two fallback routes are recorded distinctly, not as one flag.
 
         A project install that can't lay symlinks is silently rerouted to a global
-        copy, which looks identical to a project install in the success telemetry.
-        The flag makes that cohort (Windows without Developer Mode, mainly) countable
-        as skillsNudgeInstallSucceeded:global_fallback rather than invisible.
+        copy, so it looks identical to a project install in the success telemetry.
+        Naming the cause separates the machine-wide case a user can fix (Developer
+        Mode off) from a link that would not lay despite the pre-check passing —
+        different problems, different fixes.
         """
         project_dir = tmp_path / "project"
         project_dir.mkdir()
@@ -2585,8 +2646,8 @@ class TestInstallProjectSkillsFallbackSignal:
             patch.object(
                 skills, "_symlinks_supported", return_value=symlinks_supported
             ),
-            # Force the per-skill symlink to fail (only reached when symlinks are
-            # "supported" but a link can't be laid); harmless on the pre-check path.
+            # Force the per-skill symlink to fail (only reached when the pre-check
+            # said symlinks work); harmless on the pre-check path.
             patch.object(skills, "_install_skill_symlink", return_value=False),
             patch.object(
                 skills,
@@ -2600,12 +2661,12 @@ class TestInstallProjectSkillsFallbackSignal:
         ):
             result = skills._install_project_skills(yes=True)
 
-        assert result.used_global_fallback is True
+        assert result.fallback_reason == expected_reason
 
-    def test_project_symlink_install_has_no_fallback_flag(
+    def test_project_symlink_install_has_no_fallback_reason(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """A normal project (symlink) install does NOT set used_global_fallback."""
+        """A normal project (symlink) install records no fallback reason."""
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         with (
@@ -2619,7 +2680,54 @@ class TestInstallProjectSkillsFallbackSignal:
         ):
             result = skills._install_project_skills(yes=True)
 
-        assert result.used_global_fallback is False
+        assert result.fallback_reason is None
+
+
+class TestClassifyWriteError:
+    """_classify_write_error maps OSError codes to actionable reasons."""
+
+    @pytest.mark.parametrize(
+        ("errno_name", "expected"),
+        [
+            ("EACCES", "write_denied"),
+            ("EPERM", "write_denied"),
+            ("EROFS", "write_denied"),
+            ("ENOSPC", "write_no_space"),
+            ("EBUSY", "write_locked"),
+            ("ENAMETOOLONG", "write_name_too_long"),
+        ],
+    )
+    def test_maps_posix_errnos(self, errno_name: str, expected: str) -> None:
+        """Each POSIX code that implies a distinct fix gets its own reason."""
+        code = getattr(errno, errno_name)
+        assert skills._classify_write_error(OSError(code, "boom")) == expected
+
+    def test_unrecognised_errno_stays_generic(self) -> None:
+        """An unmapped code reports write_failed rather than being mis-bucketed.
+
+        Guessing would be worse than admitting ignorance: a wrong specific reason
+        sends whoever reads the telemetry after the wrong fix.
+        """
+        assert skills._classify_write_error(OSError(errno.EIO, "io")) == "write_failed"
+        assert skills._classify_write_error(OSError()) == "write_failed"
+
+    def test_winerror_takes_precedence_over_errno(self) -> None:
+        """A Windows sharing violation is a lock, not a permissions problem.
+
+        CPython maps ERROR_SHARING_VIOLATION (32) to EACCES, so trusting errno on
+        Windows would report write_denied and point at folder ACLs — when the real
+        cause is antivirus or a sync client holding the file, and the real fix is to
+        retry. winerror is therefore consulted first.
+        """
+        locked = OSError(errno.EACCES, "in use")
+        locked.winerror = 32  # type: ignore[attr-defined]
+        assert skills._classify_write_error(locked) == "write_locked"
+
+    def test_unrecognised_winerror_falls_back_to_errno(self) -> None:
+        """An unmapped Windows code still uses whatever errno CPython supplied."""
+        denied = OSError(errno.EACCES, "denied")
+        denied.winerror = 1_000_000  # type: ignore[attr-defined]
+        assert skills._classify_write_error(denied) == "write_denied"
 
 
 class TestInstallSkillCopyStaging:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1392,6 +1392,42 @@ class TestInstallSkillCopyEdgeCases:
         assert any("copy failed" in s for s in result.errored)
         assert not result.skipped
 
+    def test_restores_old_install_when_final_swap_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed swap restores the old install instead of stranding the copy.
+
+        The copy succeeds, so the old target is moved aside — but if renaming the
+        new copy into place then fails (a held handle, antivirus), deleting the old
+        one outright would leave the fresh copy under a hidden dot-name with
+        nothing at the path agents actually read.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(
+                skills.Path, "rename", side_effect=OSError("Access is denied")
+            ),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert target.is_dir()
+        assert (target / "SKILL.md").read_text() == "# Old version\n"
+        assert result.errored
+        assert not result.installed
+
     def test_reports_mkdir_failure_as_error(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
@@ -1509,6 +1545,59 @@ class TestInstallSkillSymlinkEdgeCases:
 
         assert not success
         assert not result.errored
+        assert not result.installed
+
+    def test_restores_replaced_symlink_when_relink_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed re-link puts back the project symlink it removed.
+
+        ``symlink_to`` cannot overwrite, so replacing an owned link means unlinking
+        first. If the new link then fails to appear, the caller falls back to a
+        *global* install, which lands elsewhere and would leave the project skill
+        deleted.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text(
+            "# Working install\n", encoding="utf-8"
+        )
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+        real_symlink_to = skills.Path.symlink_to
+        attempts = {"n": 0}
+
+        def _fail_first_symlink(
+            self: Path, target: object, target_is_directory: bool = False
+        ) -> None:
+            """Fail the install link only; let the restore link through."""
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise OSError("A required privilege is not held by the client")
+            real_symlink_to(self, target, target_is_directory=target_is_directory)  # type: ignore[arg-type]
+
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "symlink_to", _fail_first_symlink),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # False so the caller still falls back to a global copy...
+        assert not success
+        # ...but the working project install must survive, still pointing where it did.
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
         assert not result.installed
 
 

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1736,6 +1736,19 @@ class TestInstallSkillSymlinkEdgeCases:
         assert (target / "SKILL.md").read_text() == "# Working install\n"
         assert not result.installed
 
+    def _fail_from_nth_rename(self, n: int) -> object:
+        """Rename mock that fails the nth call and every one after it."""
+        real = skills.Path.rename
+        calls = {"n": 0}
+
+        def _rename(self: Path, target: object) -> object:
+            calls["n"] += 1
+            if calls["n"] >= n:
+                raise OSError("Access is denied")
+            return real(self, target)  # type: ignore[arg-type]
+
+        return _rename
+
     def _fail_nth_rename(self, n: int) -> object:
         """Rename mock that fails only the nth call, letting the others through."""
         real = skills.Path.rename
@@ -1809,6 +1822,58 @@ class TestInstallSkillSymlinkEdgeCases:
         assert target.is_symlink()
         assert (target / "SKILL.md").read_text() == "# Test Skill\n"
         assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_keeps_displaced_link_when_even_the_restore_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """When the restore fails too, the displaced link is not deleted with staging.
+
+        Move-aside succeeded, so staging holds the only copy of the old link. The swap,
+        the direct re-lay and the restore all fail — and the cleanup that follows must
+        not take staging with it, or the move-aside would have destroyed exactly what it
+        was there to preserve. The ownership marker is dropped so no later sweep can
+        take it either.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir, target = self._existing_project_link(tmp_path)
+
+        real_symlink_to = skills.Path.symlink_to
+        calls = {"n": 0}
+
+        def _only_staged_link_works(
+            self: Path, link_target: object, target_is_directory: bool = False
+        ) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                real_symlink_to(
+                    self, link_target, target_is_directory=target_is_directory
+                )  # type: ignore[arg-type]
+                return
+            raise OSError("A required privilege is not held by the client")
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            # Move-aside is rename #1 and must work; every later rename fails, so both
+            # the swap and the restore are blocked.
+            patch.object(skills.Path, "rename", self._fail_from_nth_rename(2)),
+            patch.object(skills.Path, "symlink_to", _only_staged_link_works),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.installed
+        # The old link survives inside staging, and staging is now un-sweepable.
+        staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+        assert len(staged) == 1
+        assert (staged[0] / skills._STAGING_OLD).is_symlink()
+        assert not (staged[0] / skills._STAGING_MARKER).exists()
 
     def test_restores_displaced_link_when_recovery_also_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1028,7 +1028,9 @@ class TestInstallSkillsCli:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(skills, "_symlinks_supported", return_value=False),
+            patch.object(
+                skills, "_symlink_blocker", return_value="symlinks_unsupported"
+            ),
             patch.object(skills, "_install_global_skills") as install_global_skills,
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
@@ -2537,10 +2539,10 @@ class TestInstallProjectSkillsNoFallback:
     """Tests for _install_project_skills with fallback_to_global=False."""
 
     @pytest.mark.parametrize(
-        ("symlinks_supported", "install_skill_symlink_return"),
+        ("precheck_blocker", "install_skill_symlink_return"),
         [
-            (False, True),
-            (True, False),
+            ("symlinks_unsupported", True),
+            (None, False),
         ],
         ids=["symlinks_unsupported_globally", "individual_symlink_failed"],
     )
@@ -2548,7 +2550,7 @@ class TestInstallProjectSkillsNoFallback:
         self,
         tmp_path: Path,
         mock_source_skills_dir: Path,
-        symlinks_supported: bool,
+        precheck_blocker: str | None,
         install_skill_symlink_return: bool,
     ) -> None:
         """Raises ClickException when symlinks are unavailable and fallback disabled."""
@@ -2559,9 +2561,7 @@ class TestInstallProjectSkillsNoFallback:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(
-                skills, "_symlinks_supported", return_value=symlinks_supported
-            ),
+            patch.object(skills, "_symlink_blocker", return_value=precheck_blocker),
             patch.object(
                 skills,
                 "_install_skill_symlink",
@@ -2600,7 +2600,7 @@ class TestInstallProjectSkillsFallbackErrors:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(skills, "_symlinks_supported", return_value=True),
+            patch.object(skills, "_symlink_blocker", return_value=None),
             patch.object(skills, "_install_skill_symlink", return_value=False),
             patch.object(
                 skills,
@@ -2618,24 +2618,29 @@ class TestInstallProjectSkillsFallbackSignal:
     """fallback_reason names WHY an install took the symlink->global path."""
 
     @pytest.mark.parametrize(
-        ("symlinks_supported", "expected_reason"),
-        [(False, "symlinks_unsupported"), (True, "symlink_failed")],
-        ids=["precheck_says_unsupported", "individual_link_failed"],
+        ("precheck_blocker", "expected_reason"),
+        [
+            ("symlinks_no_privilege", "symlinks_no_privilege"),
+            ("symlinks_denied", "symlinks_denied"),
+            ("symlinks_unsupported", "symlinks_unsupported"),
+            (None, "symlink_failed"),
+        ],
+        ids=["dev_mode_off", "project_dir_denied", "no_symlink_support", "link_failed"],
     )
     def test_fallback_records_its_cause(
         self,
         tmp_path: Path,
         mock_source_skills_dir: Path,
-        symlinks_supported: bool,
+        precheck_blocker: str | None,
         expected_reason: str,
     ) -> None:
-        """The two fallback routes are recorded distinctly, not as one flag.
+        """Each fallback route is recorded distinctly, not collapsed into one flag.
 
         A project install that can't lay symlinks is silently rerouted to a global
         copy, so it looks identical to a project install in the success telemetry.
-        Naming the cause separates the machine-wide case a user can fix (Developer
-        Mode off) from a link that would not lay despite the pre-check passing —
-        different problems, different fixes.
+        Most Windows users land here and then succeed, which makes this the label
+        carrying their diagnostic signal — and Developer Mode being off is a
+        documentable user action, while the others are not.
         """
         project_dir = tmp_path / "project"
         project_dir.mkdir()
@@ -2643,9 +2648,7 @@ class TestInstallProjectSkillsFallbackSignal:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(
-                skills, "_symlinks_supported", return_value=symlinks_supported
-            ),
+            patch.object(skills, "_symlink_blocker", return_value=precheck_blocker),
             # Force the per-skill symlink to fail (only reached when the pre-check
             # said symlinks work); harmless on the pre-check path.
             patch.object(skills, "_install_skill_symlink", return_value=False),
@@ -2673,7 +2676,7 @@ class TestInstallProjectSkillsFallbackSignal:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(skills, "_symlinks_supported", return_value=True),
+            patch.object(skills, "_symlink_blocker", return_value=None),
             patch.object(skills, "_install_skill_symlink", return_value=True),
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
@@ -2681,6 +2684,68 @@ class TestInstallProjectSkillsFallbackSignal:
             result = skills._install_project_skills(yes=True)
 
         assert result.fallback_reason is None
+
+
+class TestSymlinkBlocker:
+    """_symlink_blocker names WHY symlinks are unavailable, not just that they are."""
+
+    def test_returns_none_when_symlinks_work(self, tmp_path: Path) -> None:
+        """A successful probe reports no blocker."""
+        _skip_if_symlinks_not_supported(tmp_path)
+        source = tmp_path / "source"
+        source.mkdir()
+        assert skills._symlink_blocker(tmp_path, source) is None
+
+    def test_identifies_windows_developer_mode_off(self, tmp_path: Path) -> None:
+        """ERROR_PRIVILEGE_NOT_HELD is reported as symlinks_no_privilege.
+
+        This is the single most useful value in the vocabulary: it means the account
+        lacks SeCreateSymbolicLinkPrivilege, i.e. Developer Mode is off — the one
+        cause of a global-fallback install that a user can simply fix. Collapsing it
+        into "unsupported" would hide a documentable action behind a dead end.
+        """
+        source = tmp_path / "source"
+        source.mkdir()
+        denied = OSError(errno.EPERM, "A required privilege is not held")
+        denied.winerror = 1314  # type: ignore[attr-defined]
+
+        with patch.object(skills.Path, "symlink_to", side_effect=denied):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_no_privilege"
+
+    def test_distinguishes_a_denied_project_directory(self, tmp_path: Path) -> None:
+        """A plain permission denial is an environment problem, not a missing feature."""
+        source = tmp_path / "source"
+        source.mkdir()
+        with patch.object(
+            skills.Path, "symlink_to", side_effect=OSError(errno.EACCES, "denied")
+        ):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_denied"
+
+    def test_reports_unsupported_for_a_filesystem_without_symlinks(
+        self, tmp_path: Path
+    ) -> None:
+        """NotImplementedError means the platform has no directory symlinks at all."""
+        source = tmp_path / "source"
+        source.mkdir()
+        with patch.object(skills.Path, "symlink_to", side_effect=NotImplementedError):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_unsupported"
+
+    def test_reports_unsupported_when_the_link_silently_is_not_one(
+        self, tmp_path: Path
+    ) -> None:
+        """A probe that "succeeds" without producing a symlink is not support.
+
+        Some filesystems accept the call and create something else. Claiming support
+        we could not verify would route the install down the symlink path and fail
+        later, with a worse reason attached.
+        """
+        source = tmp_path / "source"
+        source.mkdir()
+        with (
+            patch.object(skills.Path, "symlink_to"),
+            patch.object(skills.Path, "is_symlink", return_value=False),
+        ):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_unsupported"
 
 
 class TestClassifyWriteError:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1581,6 +1581,22 @@ class TestInstallSkillCopyEdgeCases:
 
 
 class TestInstallSkillSymlinkEdgeCases:
+    @staticmethod
+    def _existing_project_link(tmp_path: Path) -> tuple[Path, Path]:
+        """Create a working Streamlit-owned project symlink.
+
+        Returns ``(target_dir, target)`` — the directory the install writes into and
+        the link itself.
+        """
+        existing = tmp_path / "existing-skill"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text("# Working install\n", encoding="utf-8")
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing, target_is_directory=True)
+        return target_dir, target
+
     """Additional edge case tests for _install_skill_symlink."""
 
     def test_replaces_existing_symlink_with_skill_name(
@@ -1715,72 +1731,34 @@ class TestInstallSkillSymlinkEdgeCases:
         assert (target / "SKILL.md").read_text() == "# Working install\n"
         assert not result.installed
 
-    def test_lays_link_directly_when_swap_rename_fails(
+    def _fail_nth_rename(self, n: int) -> object:
+        """Rename mock that fails only the nth call, letting the others through."""
+        real = skills.Path.rename
+        calls = {"n": 0}
+
+        def _rename(self: Path, target: object) -> object:
+            calls["n"] += 1
+            if calls["n"] == n:
+                raise OSError("Access is denied")
+            return real(self, target)  # type: ignore[arg-type]
+
+        return _rename
+
+    def test_keeps_old_link_when_move_aside_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """A failed swap recovers by creating the link at the canonical path.
+        """If the old link can't be moved aside, it is left exactly as it was.
 
-        The staged link exists and the old one is removed, but the rename into place
-        fails. Creating a symlink here is already proven to work — the staged one
-        just succeeded — so it is laid directly rather than stranding the install
-        under a dot-name that nothing reads.
+        This is the branch staging exists for: the replacement is fully prepared, and
+        the first thing that touches the existing install fails, so nothing is lost.
         """
         _skip_if_symlinks_not_supported(tmp_path)
-        existing_skill = tmp_path / "existing-skill"
-        existing_skill.mkdir()
-        (existing_skill / "SKILL.md").write_text("# Old link\n", encoding="utf-8")
-        target_dir = tmp_path / "project" / ".agents" / "skills"
-        target_dir.mkdir(parents=True)
-        target = target_dir / "developing-with-streamlit"
-        target.symlink_to(existing_skill, target_is_directory=True)
+        target_dir, target = self._existing_project_link(tmp_path)
 
         result = skills._InstallResult()
         with (
             patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
-            patch.object(skills.Path, "rename", side_effect=OSError("Access denied")),
-        ):
-            success = skills._install_skill_symlink(
-                "developing-with-streamlit",
-                mock_source_skills_dir,
-                target_dir,
-                result,
-                {"developing-with-streamlit"},
-            )
-
-        assert success
-        assert result.installed
-        # The link is where agents look, pointing at the new source...
-        assert target.is_symlink()
-        assert (target / "SKILL.md").read_text() == "# Test Skill\n"
-        # ...and the staging name is cleaned up rather than left as clutter.
-        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
-
-    def test_keeps_old_link_when_unlink_fails_after_staging(
-        self, tmp_path: Path, mock_source_skills_dir: Path
-    ) -> None:
-        """A failed unlink leaves the old link in place, staged copy or not.
-
-        The staged link exists but the old one can't be removed, so the swap never
-        starts. This is the branch where staging pays off: the existing install was
-        never touched, so it is still exactly what it was.
-        """
-        _skip_if_symlinks_not_supported(tmp_path)
-        existing_skill = tmp_path / "existing-skill"
-        existing_skill.mkdir()
-        (existing_skill / "SKILL.md").write_text(
-            "# Working install\n", encoding="utf-8"
-        )
-        target_dir = tmp_path / "project" / ".agents" / "skills"
-        target_dir.mkdir(parents=True)
-        target = target_dir / "developing-with-streamlit"
-        target.symlink_to(existing_skill, target_is_directory=True)
-
-        result = skills._InstallResult()
-        with (
-            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
-            patch.object(
-                skills.Path, "unlink", side_effect=OSError("Permission denied")
-            ),
+            patch.object(skills.Path, "rename", self._fail_nth_rename(1)),
         ):
             success = skills._install_skill_symlink(
                 "developing-with-streamlit",
@@ -1792,36 +1770,59 @@ class TestInstallSkillSymlinkEdgeCases:
 
         assert not success
         assert not result.installed
-        # The old install is untouched, still resolving to its original content.
         assert target.is_symlink()
         assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
 
-    def test_keeps_staged_link_when_recovery_also_fails(
+    def test_lays_link_directly_when_swap_rename_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """When even the direct re-lay fails, the staged link is not deleted.
+        """A failed swap recovers by creating the link at the canonical path.
 
-        Rename fails and so does creating the link at the canonical path, so the
-        staged link is the only one left — deleting it would leave nothing at all.
-        The caller still falls back to a global install.
+        The old link is already moved aside and the staged one will not rename into
+        place — but creating a symlink here is proven to work, since the staged one
+        just succeeded, so it is laid directly rather than stranding the install.
         """
         _skip_if_symlinks_not_supported(tmp_path)
-        existing_skill = tmp_path / "existing-skill"
-        existing_skill.mkdir()
-        (existing_skill / "SKILL.md").write_text("# Old link\n", encoding="utf-8")
-        target_dir = tmp_path / "project" / ".agents" / "skills"
-        target_dir.mkdir(parents=True)
-        target = target_dir / "developing-with-streamlit"
-        target.symlink_to(existing_skill, target_is_directory=True)
+        target_dir, target = self._existing_project_link(tmp_path)
 
         result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "rename", self._fail_nth_rename(2)),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert success
+        assert result.installed
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Test Skill\n"
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_restores_displaced_link_when_recovery_also_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """When nothing else works, the original link goes back at the canonical path.
+
+        The swap failed and the direct re-lay failed too. Moving the old link aside
+        rather than unlinking it means there is still something to put back, so the
+        path an agent reads ends up populated even though the install failed.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir, target = self._existing_project_link(tmp_path)
+
         real_symlink_to = skills.Path.symlink_to
         calls = {"n": 0}
 
         def _only_staged_link_works(
             self: Path, link_target: object, target_is_directory: bool = False
         ) -> None:
-            """Let the staged link through; fail the direct re-lay after it."""
             calls["n"] += 1
             if calls["n"] == 1:
                 real_symlink_to(
@@ -1830,9 +1831,10 @@ class TestInstallSkillSymlinkEdgeCases:
                 return
             raise OSError("A required privilege is not held by the client")
 
+        result = skills._InstallResult()
         with (
             patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
-            patch.object(skills.Path, "rename", side_effect=OSError("Access denied")),
+            patch.object(skills.Path, "rename", self._fail_nth_rename(2)),
             patch.object(skills.Path, "symlink_to", _only_staged_link_works),
         ):
             success = skills._install_skill_symlink(
@@ -1845,10 +1847,10 @@ class TestInstallSkillSymlinkEdgeCases:
 
         assert not success
         assert not result.installed
-        # The staged link is the only remaining copy, so its staging dir must survive.
-        staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
-        assert len(staged) == 1
-        assert (staged[0] / skills._STAGING_NEW).is_symlink()
+        # The original link is back where agents look for it.
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
 
 
 class TestPromptInstallModeRetry:
@@ -2915,6 +2917,8 @@ class TestInstallSkillCopyStaging:
         orphan = target_dir / f"{skills._STAGING_PREFIX}abc123"
         orphan.mkdir()
         (orphan / "leftover.txt").write_text("leftover", encoding="utf-8")
+        # The sweep requires our ownership marker, so a real orphan carries one.
+        (orphan / skills._STAGING_MARKER).touch()
         # Backdate it well past the orphan threshold.
         old = time.time() - skills._STAGING_ORPHAN_AGE_S - 60
         os.utime(orphan, (old, old))
@@ -2935,6 +2939,44 @@ class TestInstallSkillCopyStaging:
         # The orphan is gone, and this run's own staging dir left nothing behind.
         assert not orphan.exists()
         assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_requires_an_ownership_marker_before_sweeping(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A prefix-shaped directory we did not create is never swept.
+
+        ``mkdtemp`` guarantees uniqueness for the side that *creates* the directory, but
+        the sweep matches on name and age — a convention, not proof of ownership. A user
+        directory that happens to share the prefix and is older than the threshold would
+        otherwise be deleted, so the sweep requires a sentinel we wrote ourselves.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+
+        # Prefix-shaped, well past the age gate, but NOT ours - no marker inside.
+        impostor = target_dir / f"{skills._STAGING_PREFIX}notours"
+        impostor.mkdir()
+        (impostor / "precious.txt").write_text("do not delete", encoding="utf-8")
+        ancient = time.time() - skills._STAGING_ORPHAN_AGE_S * 24
+        os.utime(impostor, (ancient, ancient))
+
+        # A replacement install, which is what runs the sweep.
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        assert (impostor / "precious.txt").read_text() == "do not delete"
 
     def test_never_sweeps_a_retained_recovery_directory(
         self, tmp_path: Path, mock_source_skills_dir: Path

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1409,11 +1409,23 @@ class TestInstallSkillCopyEdgeCases:
         (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
 
         result = skills._InstallResult()
+        real_rename = skills.Path.rename
+        calls = {"n": 0}
+
+        def _fail_only_the_swap(self: Path, target_name: object) -> object:
+            """Let the move-aside through and fail the swap; the restore then works.
+
+            Blanket-patching ``rename`` would fail the move-aside instead, so the
+            restore branch would never run and a broken restore would still pass.
+            """
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("Access is denied")
+            return real_rename(self, target_name)  # type: ignore[arg-type]
+
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch.object(
-                skills.Path, "rename", side_effect=OSError("Access is denied")
-            ),
+            patch.object(skills.Path, "rename", _fail_only_the_swap),
         ):
             skills._install_skill_copy(
                 "developing-with-streamlit",
@@ -1423,10 +1435,16 @@ class TestInstallSkillCopyEdgeCases:
                 {"developing-with-streamlit"},
             )
 
+        # rename #1 moved the old install aside, #2 (the swap) failed, #3 restored it.
+        assert calls["n"] == 3
+        # The old install is back at the canonical path with its original content.
         assert target.is_dir()
+        assert not target.is_symlink()
         assert (target / "SKILL.md").read_text() == "# Old version\n"
+        # Reported as a failure, and the backup name is not left behind.
         assert result.errored
         assert not result.installed
+        assert not (target_dir / ".developing-with-streamlit.old").exists()
 
     def test_keeps_both_copies_when_swap_and_restore_both_fail(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1721,6 +1739,47 @@ class TestInstallSkillSymlinkEdgeCases:
         assert (target / "SKILL.md").read_text() == "# Test Skill\n"
         # ...and the staging name is cleaned up rather than left as clutter.
         assert not (target_dir / ".developing-with-streamlit.newlink").exists()
+
+    def test_keeps_old_link_when_unlink_fails_after_staging(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed unlink leaves the old link in place, staged copy or not.
+
+        The staged link exists but the old one can't be removed, so the swap never
+        starts. This is the branch where staging pays off: the existing install was
+        never touched, so it is still exactly what it was.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text(
+            "# Working install\n", encoding="utf-8"
+        )
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(
+                skills.Path, "unlink", side_effect=OSError("Permission denied")
+            ),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.installed
+        # The old install is untouched, still resolving to its original content.
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
 
     def test_keeps_staged_link_when_recovery_also_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1352,6 +1352,35 @@ class TestInstallSkillCopyEdgeCases:
         assert any("copy failed" in s for s in result.errored)
         assert not result.skipped
 
+    def test_reports_mkdir_failure_as_error(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A permission error creating the target dir is an error, not a skip.
+
+        Regression: the mkdir/existence checks ran outside the copy try/except,
+        so a permission-denied mkdir escaped as an uncaught OSError (which the
+        handler could only classify as 'unknown'). It must land in ``errored``
+        so it maps to reason='write_failed'.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        result = skills._InstallResult()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(skills.Path, "mkdir", side_effect=OSError("Permission denied")),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert result.errored
+        assert not result.skipped
+        assert not result.installed
+
 
 class TestInstallSkillSymlinkEdgeCases:
     """Additional edge case tests for _install_skill_symlink."""

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1367,7 +1367,9 @@ class TestInstallSkillCopyEdgeCases:
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
-            patch.object(skills.Path, "mkdir", side_effect=OSError("Permission denied")),
+            patch.object(
+                skills.Path, "mkdir", side_effect=OSError("Permission denied")
+            ),
         ):
             skills._install_skill_copy(
                 "developing-with-streamlit",

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1317,7 +1317,10 @@ class TestInstallSkillCopyEdgeCases:
                 {"developing-with-streamlit"},
             )
 
-        assert any("copy failed" in s for s in result.skipped)
+        assert any("copy failed" in s for s in result.errored)
+        # Regression (Greptile P1): a write failure must land in ``errored``,
+        # never ``skipped`` - otherwise the caller labels it reason="conflict".
+        assert not result.skipped
 
     def test_preserves_existing_directory_on_copy_failure(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1346,7 +1349,8 @@ class TestInstallSkillCopyEdgeCases:
         # Original should be preserved with old content
         assert target.is_dir()
         assert (target / "SKILL.md").read_text() == "# Old version\n"
-        assert any("copy failed" in s for s in result.skipped)
+        assert any("copy failed" in s for s in result.errored)
+        assert not result.skipped
 
 
 class TestInstallSkillSymlinkEdgeCases:
@@ -1468,6 +1472,35 @@ class TestGlobalInstallationConflicts:
         # The error names the specific conflicting path, not a vague "conflicts".
         assert ".agents/skills/developing-with-streamlit" in result.output
         assert "already exist" in result.output
+
+    def test_copy_failure_reports_write_failed_not_conflict(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """A filesystem copy failure raises reason='write_failed', not 'conflict'.
+
+        Regression for the Greptile P1: an ``OSError`` during the global copy
+        (permissions, disk space, locked dir) used to land in ``skipped`` and be
+        labeled ``conflict``, so the nudge's failure telemetry misclassified
+        write failures - the dominant residual Windows cause - as conflicts.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch.object(
+                skills.shutil, "copytree", side_effect=OSError("Permission denied")
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_failed"
+        # Must NOT be misclassified as a conflict.
+        assert "already exist" not in exc.value.format_message()
 
 
 class TestInteractiveModeSelection:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1503,6 +1503,11 @@ class TestInstallSkillCopyEdgeCases:
             target_dir.glob(f"{skills._RECOVERY_PREFIX}*")
         )
         assert len(kept) == 1
+        # Relocation is itself a rename, and rename is what is failing here — so the
+        # copies stay under the staging prefix. The ownership marker is dropped instead,
+        # which makes them permanently invisible to the sweep: two independent
+        # protections, so whichever filesystem operation is broken, one still holds.
+        assert not (kept[0] / skills._STAGING_MARKER).exists()
         assert (kept[0] / skills._STAGING_OLD / "SKILL.md").read_text() == (
             "# Old version\n"
         )

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -20,6 +20,7 @@ import errno
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -2893,10 +2894,10 @@ class TestClassifyWriteError:
 class TestInstallSkillCopyStaging:
     """Staging behavior for _install_skill_copy replacements."""
 
-    def test_sweeps_leftover_staging_dir(
+    def test_sweeps_staging_dir_orphaned_by_an_interrupted_install(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """A staging dir orphaned by an interrupted install is reclaimed."""
+        """An old staging dir left by a crashed run is reclaimed."""
         target_dir = tmp_path / "target" / "skills"
         target_dir.mkdir(parents=True)
         # Existing target with different content forces the staged-swap path.
@@ -2907,6 +2908,9 @@ class TestInstallSkillCopyStaging:
         orphan = target_dir / f"{skills._STAGING_PREFIX}abc123"
         orphan.mkdir()
         (orphan / "leftover.txt").write_text("leftover", encoding="utf-8")
+        # Backdate it well past the orphan threshold.
+        old = time.time() - skills._STAGING_ORPHAN_AGE_S - 60
+        os.utime(orphan, (old, old))
 
         result = skills._InstallResult()
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -2924,6 +2928,47 @@ class TestInstallSkillCopyStaging:
         # The orphan is gone, and this run's own staging dir left nothing behind.
         assert not orphan.exists()
         assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_leaves_a_concurrent_installs_staging_dir_alone(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A freshly-created staging dir belongs to a live install — do not touch it.
+
+        Sweeping on name alone would delete a concurrent invocation's staging dir. That
+        dir may already hold the old installation it moved aside, so the sweep would
+        destroy both that and its replacement and leave the canonical path empty —
+        orphan cleanup turned into data loss. Age separates live from abandoned without
+        needing a lock.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        # Stand in for another process mid-swap: its staging dir already holds the
+        # only copy of the installation it displaced.
+        live = target_dir / f"{skills._STAGING_PREFIX}live99"
+        (live / skills._STAGING_OLD).mkdir(parents=True)
+        (live / skills._STAGING_OLD / "SKILL.md").write_text(
+            "# Their only copy\n", encoding="utf-8"
+        )
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        # The other invocation's displaced installation must survive untouched.
+        assert (live / skills._STAGING_OLD / "SKILL.md").read_text() == (
+            "# Their only copy\n"
+        )
 
     def test_never_deletes_a_directory_it_did_not_create(
         self, tmp_path: Path, mock_source_skills_dir: Path

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1835,7 +1835,7 @@ class TestInstallSkillSymlinkEdgeCases:
         take it either.
         """
         _skip_if_symlinks_not_supported(tmp_path)
-        target_dir, target = self._existing_project_link(tmp_path)
+        target_dir, _target = self._existing_project_link(tmp_path)
 
         real_symlink_to = skills.Path.symlink_to
         calls = {"n": 0}

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1585,15 +1585,18 @@ class TestInstallSkillSymlinkEdgeCases:
         assert not result.errored
         assert not result.installed
 
-    def test_restores_replaced_symlink_when_relink_fails(
+    def test_keeps_replaced_symlink_when_link_creation_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """A failed re-link puts back the project symlink it removed.
+        """An unmakeable symlink leaves the existing project install alone.
 
-        ``symlink_to`` cannot overwrite, so replacing an owned link means unlinking
-        first. If the new link then fails to appear, the caller falls back to a
-        *global* install, which lands elsewhere and would leave the project skill
-        deleted.
+        ``symlink_to`` cannot overwrite, so replacing an owned link means removing
+        it first — and "remove then re-create" loses a working install whenever the
+        re-create fails. A restore attempt is no defence: the re-create only fails
+        because this system won't make symlinks, so the restore fails identically.
+        Hence the new link is staged under a temp name first, and nothing is removed
+        until that has worked. Here every ``symlink_to`` fails, so the original must
+        be exactly as it was.
         """
         _skip_if_symlinks_not_supported(tmp_path)
         existing_skill = tmp_path / "existing-skill"
@@ -1607,21 +1610,13 @@ class TestInstallSkillSymlinkEdgeCases:
         target.symlink_to(existing_skill, target_is_directory=True)
 
         result = skills._InstallResult()
-        real_symlink_to = skills.Path.symlink_to
-        attempts = {"n": 0}
 
-        def _fail_first_symlink(
-            self: Path, target: object, target_is_directory: bool = False
-        ) -> None:
-            """Fail the install link only; let the restore link through."""
-            attempts["n"] += 1
-            if attempts["n"] == 1:
-                raise OSError("A required privilege is not held by the client")
-            real_symlink_to(self, target, target_is_directory=target_is_directory)  # type: ignore[arg-type]
+        def _always_fail(*args: object, **kwargs: object) -> None:
+            raise OSError("A required privilege is not held by the client")
 
         with (
             patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
-            patch.object(skills.Path, "symlink_to", _fail_first_symlink),
+            patch.object(skills.Path, "symlink_to", _always_fail),
         ):
             success = skills._install_skill_symlink(
                 "developing-with-streamlit",
@@ -1637,6 +1632,44 @@ class TestInstallSkillSymlinkEdgeCases:
         assert target.is_symlink()
         assert (target / "SKILL.md").read_text() == "# Working install\n"
         assert not result.installed
+
+    def test_keeps_staged_link_when_swap_rename_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed swap keeps the staged link rather than losing both copies.
+
+        The staged link is created and the old one removed, but if moving the new
+        link into place then fails, deleting it would leave the path with nothing at
+        all. It is kept so the content still exists on disk.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text("# Old link\n", encoding="utf-8")
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "rename", side_effect=OSError("Access denied")),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.installed
+        # The staged link is the only remaining copy, so it must not be deleted.
+        staged = target_dir / ".developing-with-streamlit.newlink"
+        assert staged.is_symlink()
+        assert (staged / "SKILL.md").read_text() == "# Test Skill\n"
 
 
 class TestPromptInstallModeRetry:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1428,6 +1428,44 @@ class TestInstallSkillCopyEdgeCases:
         assert result.errored
         assert not result.installed
 
+    def test_reports_success_when_only_backup_cleanup_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed backup cleanup after a landed swap is still a success.
+
+        Dropping the moved-aside ``.old`` backup is bookkeeping that happens after
+        the new skill is already at the target. If its error reached the write
+        handler, a correct install would be reported as ``write_failed`` — a false
+        failure in the nudge and a false reason in the telemetry.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            # The only rmtree in this path is the post-swap backup cleanup.
+            patch.object(
+                skills.shutil, "rmtree", side_effect=OSError("Directory not empty")
+            ),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # The new skill landed, so this is a success...
+        assert result.installed
+        assert (target / "SKILL.md").read_text() == "# Test Skill\n"
+        # ...and must not be booked as a write failure.
+        assert not result.errored
+
     def test_reports_mkdir_failure_as_error(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1440,6 +1440,37 @@ class TestInstallSkillSymlinkEdgeCases:
 
         assert not success
 
+    def test_returns_false_when_prework_fails_for_fallback(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A filesystem error in the symlink PRE-work returns False (-> fallback).
+
+        Regression (adversarial-sweep #2): mkdir / existence-check / unlink ran
+        outside the guard, so an OSError there escaped and was booked as a hard
+        write_failed AND bypassed the symlink->global fallback. It must instead
+        return False so the caller falls back to a global copy.
+        """
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        result = skills._InstallResult()
+
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(
+                skills.Path, "mkdir", side_effect=OSError("Permission denied")
+            ),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.errored
+        assert not result.installed
+
 
 class TestPromptInstallModeRetry:
     """Tests for _prompt_install_mode retry behavior."""
@@ -1532,6 +1563,39 @@ class TestGlobalInstallationConflicts:
         assert exc.value.reason == "write_failed"
         # Must NOT be misclassified as a conflict.
         assert "already exist" not in exc.value.format_message()
+
+    def test_partial_write_failure_reports_write_failed_not_success(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """One target succeeds, another OSErrors -> hard write_failed, not success.
+
+        Regression (critical, adversarial-sweep #1): _get_global_target_dirs
+        returns TWO targets when ~/.claude exists. If ~/.agents copies OK
+        (result.installed non-empty) but ~/.claude raises OSError (result.errored),
+        the success branch used to win over the errored branch, so the install
+        returned success and emitted NO skillsNudgeInstallFailed:write_failed on
+        the exact Windows cohort under study. Any errored target must fail loud.
+        """
+        home = tmp_path / "home"
+        # ~/.claude present -> _get_global_target_dirs yields both targets.
+        (home / ".claude").mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            # First target (~/.agents) copies fine; second (~/.claude) fails.
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=[None, OSError("Permission denied")],
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_failed"
 
 
 class TestInteractiveModeSelection:
@@ -1748,6 +1812,18 @@ class TestSummarizeInstall:
         assert skills.summarize_install(result) == (
             "Installed to .agents/skills. 1 skill skipped due to conflicts."
         )
+
+    def test_reports_errored_alongside_installed(self) -> None:
+        """Defensive: if a write failure ever reaches the summary, it is surfaced
+        rather than a mixed result being presented as a clean success.
+        """
+        result = skills._InstallResult(
+            installed=[".agents/skills/foo"],
+            errored=[".claude/skills/foo (copy failed: Permission denied)"],
+        )
+        summary = skills.summarize_install(result)
+        assert "Installed to .agents/skills." in summary
+        assert "1 skill failed to write." in summary
 
     def test_reports_skipped_alongside_up_to_date(self) -> None:
         """Skipped skills are surfaced even when nothing new was installed, so an

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1682,14 +1682,15 @@ class TestInstallSkillSymlinkEdgeCases:
         assert (target / "SKILL.md").read_text() == "# Working install\n"
         assert not result.installed
 
-    def test_keeps_staged_link_when_swap_rename_fails(
+    def test_lays_link_directly_when_swap_rename_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """A failed swap keeps the staged link rather than losing both copies.
+        """A failed swap recovers by creating the link at the canonical path.
 
-        The staged link is created and the old one removed, but if moving the new
-        link into place then fails, deleting it would leave the path with nothing at
-        all. It is kept so the content still exists on disk.
+        The staged link exists and the old one is removed, but the rename into place
+        fails. Creating a symlink here is already proven to work — the staged one
+        just succeeded — so it is laid directly rather than stranding the install
+        under a dot-name that nothing reads.
         """
         _skip_if_symlinks_not_supported(tmp_path)
         existing_skill = tmp_path / "existing-skill"
@@ -1713,9 +1714,64 @@ class TestInstallSkillSymlinkEdgeCases:
                 {"developing-with-streamlit"},
             )
 
+        assert success
+        assert result.installed
+        # The link is where agents look, pointing at the new source...
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Test Skill\n"
+        # ...and the staging name is cleaned up rather than left as clutter.
+        assert not (target_dir / ".developing-with-streamlit.newlink").exists()
+
+    def test_keeps_staged_link_when_recovery_also_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """When even the direct re-lay fails, the staged link is not deleted.
+
+        Rename fails and so does creating the link at the canonical path, so the
+        staged link is the only one left — deleting it would leave nothing at all.
+        The caller still falls back to a global install.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text("# Old link\n", encoding="utf-8")
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+        real_symlink_to = skills.Path.symlink_to
+        calls = {"n": 0}
+
+        def _only_staged_link_works(
+            self: Path, link_target: object, target_is_directory: bool = False
+        ) -> None:
+            """Let the staged link through; fail the direct re-lay after it."""
+            calls["n"] += 1
+            if calls["n"] == 1:
+                real_symlink_to(
+                    self, link_target, target_is_directory=target_is_directory
+                )  # type: ignore[arg-type]
+                return
+            raise OSError("A required privilege is not held by the client")
+
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "rename", side_effect=OSError("Access denied")),
+            patch.object(skills.Path, "symlink_to", _only_staged_link_works),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
         assert not success
         assert not result.installed
-        # The staged link is the only remaining copy, so it must not be deleted.
+        # The staged link is the only remaining copy, so it must survive.
         staged = target_dir / ".developing-with-streamlit.newlink"
         assert staged.is_symlink()
         assert (staged / "SKILL.md").read_text() == "# Test Skill\n"

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1428,6 +1428,55 @@ class TestInstallSkillCopyEdgeCases:
         assert result.errored
         assert not result.installed
 
+    def test_keeps_both_copies_when_swap_and_restore_both_fail(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """If the swap and the restore both fail, neither copy is discarded.
+
+        Moving the old install aside succeeds, then both renaming the new copy in
+        and putting the old one back fail. No atomic replace exists for a non-empty
+        directory on POSIX or Windows, so this state cannot be avoided in code — but
+        it must at least be non-destructive, leaving both copies recoverable on disk
+        and reporting the install as failed rather than succeeded.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
+
+        result = skills._InstallResult()
+        real_rename = skills.Path.rename
+        calls = {"n": 0}
+
+        def _only_first_rename_works(self: Path, target_name: object) -> object:
+            """Let the move-aside through; fail the swap and the restore after it."""
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return real_rename(self, target_name)  # type: ignore[arg-type]
+            raise OSError("Access is denied")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(skills.Path, "rename", _only_first_rename_works),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # Reported as a failure, never a success.
+        assert result.errored
+        assert not result.installed
+        # Both copies survive under their hidden names - nothing is destroyed.
+        old_copy = target_dir / ".developing-with-streamlit.old"
+        new_copy = target_dir / ".developing-with-streamlit.tmp"
+        assert (old_copy / "SKILL.md").read_text() == "# Old version\n"
+        assert (new_copy / "SKILL.md").read_text() == "# Test Skill\n"
+
     def test_reports_success_when_only_backup_cleanup_fails(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1813,18 +1813,6 @@ class TestSummarizeInstall:
             "Installed to .agents/skills. 1 skill skipped due to conflicts."
         )
 
-    def test_reports_errored_alongside_installed(self) -> None:
-        """Defensive: if a write failure ever reaches the summary, it is surfaced
-        rather than a mixed result being presented as a clean success.
-        """
-        result = skills._InstallResult(
-            installed=[".agents/skills/foo"],
-            errored=[".claude/skills/foo (copy failed: Permission denied)"],
-        )
-        summary = skills.summarize_install(result)
-        assert "Installed to .agents/skills." in summary
-        assert "1 skill failed to write." in summary
-
     def test_reports_skipped_alongside_up_to_date(self) -> None:
         """Skipped skills are surfaced even when nothing new was installed, so an
         up-to-date result with conflicts isn't mistaken for fully installed.

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2186,6 +2186,72 @@ class TestInstallProjectSkillsFallbackErrors:
                 skills._install_project_skills(yes=True)
 
 
+class TestInstallProjectSkillsFallbackSignal:
+    """used_global_fallback marks installs that took the symlink->global path."""
+
+    @pytest.mark.parametrize(
+        "symlinks_supported",
+        [False, True],
+        ids=["fallback_via_precheck", "fallback_via_symlink_failure"],
+    )
+    def test_fallback_sets_used_global_fallback(
+        self,
+        tmp_path: Path,
+        mock_source_skills_dir: Path,
+        symlinks_supported: bool,
+    ) -> None:
+        """A successful symlink->global fallback flags used_global_fallback.
+
+        (decision A) so the Windows-no-Dev-Mode cohort - symlinks unsupported,
+        silently rerouted to a global copy - is countable in telemetry as
+        skillsNudgeInstallSucceeded:global_fallback rather than invisible.
+        """
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(
+                skills, "_symlinks_supported", return_value=symlinks_supported
+            ),
+            # Force the per-skill symlink to fail (only reached when symlinks are
+            # "supported" but a link can't be laid); harmless on the pre-check path.
+            patch.object(skills, "_install_skill_symlink", return_value=False),
+            patch.object(
+                skills,
+                "_install_global_skills",
+                return_value=skills._InstallResult(
+                    installed=["~/.agents/skills/developing-with-streamlit"]
+                ),
+            ),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        ):
+            result = skills._install_project_skills(yes=True)
+
+        assert result.used_global_fallback is True
+
+    def test_project_symlink_install_has_no_fallback_flag(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A normal project (symlink) install does NOT set used_global_fallback."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(skills, "_symlinks_supported", return_value=True),
+            patch.object(skills, "_install_skill_symlink", return_value=True),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        ):
+            result = skills._install_project_skills(yes=True)
+
+        assert result.used_global_fallback is False
+
+
 class TestInstallSkillCopyTempCleanup:
     """Tests for temp file cleanup paths in _install_skill_copy."""
 

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -148,16 +148,18 @@ message DeferredFileResponsePayload {
 }
 
 // Response payload for one-click skills install. A successful, empty detail
-// indicates a clean install; failures are reported via the response's
-// error_msg field instead.
+// indicates a clean install; failures are not reported here at all, but via the
+// parent response's error_msg (human-readable) and error_reason (machine-readable).
 message InstallSkillsResponsePayload {
   // Optional human-readable detail about the install outcome.
   string detail = 1;
 
-  // True when the install took the symlink -> global-copy fallback (symlinks
-  // unsupported, e.g. Windows without Developer Mode). Lets the nudge telemetry
-  // count that cohort (skillsNudgeInstallSucceeded:global_fallback) since a
-  // fallback install is otherwise indistinguishable from a project install.
+  // True when a project install was rerouted to a global copy because symlinks
+  // could not be laid (e.g. Windows without Developer Mode) - set whether that
+  // was found by the up-front pre-check or by an individual symlink failing.
+  // Lets the nudge telemetry count that cohort
+  // (skillsNudgeInstallSucceeded:global_fallback), since a fallback install is
+  // otherwise indistinguishable from a project install.
   bool used_global_fallback = 2;
 }
 

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -155,13 +155,13 @@ message InstallSkillsResponsePayload {
   string detail = 1;
 
   // Why a project install was rerouted to a global copy, empty when it wasn't:
-  //   "symlinks_unsupported" - the up-front pre-check found symlinks unavailable
-  //                            (e.g. Windows without Developer Mode)
-  //   "symlink_failed"       - the pre-check passed but an individual link would
-  //                            not lay, which is closer to a bug or a
-  //                            directory-specific permission problem
-  // Split rather than a single flag because those two point at different fixes.
-  // Lets the nudge telemetry count each cohort
+  //   "symlinks_no_privilege" - Windows Developer Mode off (ERROR_PRIVILEGE_NOT_HELD)
+  //   "symlinks_denied"       - permissions on the project dir refused the probe
+  //   "symlinks_unsupported"  - the filesystem/OS has no directory symlinks
+  //   "symlink_failed"        - pre-check passed, then an individual link would not lay
+  // Split this finely because most Windows users take this path and then SUCCEED, so
+  // this is where their diagnostic signal lives - and only the first of these is
+  // something a user can simply fix. Lets the nudge telemetry count each cohort
   // (skillsNudgeInstallSucceeded:<fallback_reason>), since a fallback install is
   // otherwise indistinguishable from a project install.
   string fallback_reason = 3;

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -122,10 +122,10 @@ message BackendOperationResponse {
 
   // Machine-readable, bounded failure classification (empty on success).
   // Parallels the human-readable error_msg. For the one-click skills install
-  // this is the cause of the failure (e.g. "conflict", "download_failed",
+  // this is the cause of the failure (e.g. "conflict", "source_missing",
   // "symlinks_unsupported"), forwarded to telemetry so the nudge's
   // install-failure rate can be broken down by cause.
-  string error_reason = 6;
+  string error_reason = 7;
 
   oneof payload {
     // Response for deferred file requests

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -122,9 +122,9 @@ message BackendOperationResponse {
 
   // Machine-readable, bounded failure classification (empty on success).
   // Parallels the human-readable error_msg. For the one-click skills install
-  // this is the cause of the failure (e.g. "conflict", "source_missing",
-  // "symlinks_unsupported"), forwarded to telemetry so the nudge's
-  // install-failure rate can be broken down by cause.
+  // this is the cause of the failure (e.g. "conflict", "write_failed",
+  // "source_missing"), forwarded to telemetry so the nudge's install-failure
+  // rate can be broken down by cause.
   string error_reason = 7;
 
   oneof payload {
@@ -153,6 +153,12 @@ message DeferredFileResponsePayload {
 message InstallSkillsResponsePayload {
   // Optional human-readable detail about the install outcome.
   string detail = 1;
+
+  // True when the install took the symlink -> global-copy fallback (symlinks
+  // unsupported, e.g. Windows without Developer Mode). Lets the nudge telemetry
+  // count that cohort (skillsNudgeInstallSucceeded:global_fallback) since a
+  // fallback install is otherwise indistinguishable from a project install.
+  bool used_global_fallback = 2;
 }
 
 // Acknowledgement payload for dismissing the skills nudge. Carries no data;

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -120,6 +120,13 @@ message BackendOperationResponse {
   // Error message if request failed (empty on success)
   string error_msg = 2;
 
+  // Machine-readable, bounded failure classification (empty on success).
+  // Parallels the human-readable error_msg. For the one-click skills install
+  // this is the cause of the failure (e.g. "conflict", "download_failed",
+  // "symlinks_unsupported"), forwarded to telemetry so the nudge's
+  // install-failure rate can be broken down by cause.
+  string error_reason = 6;
+
   oneof payload {
     // Response for deferred file requests
     DeferredFileResponsePayload deferred_file = 3;

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -154,13 +154,22 @@ message InstallSkillsResponsePayload {
   // Optional human-readable detail about the install outcome.
   string detail = 1;
 
-  // True when a project install was rerouted to a global copy because symlinks
-  // could not be laid (e.g. Windows without Developer Mode) - set whether that
-  // was found by the up-front pre-check or by an individual symlink failing.
-  // Lets the nudge telemetry count that cohort
-  // (skillsNudgeInstallSucceeded:global_fallback), since a fallback install is
+  // Why a project install was rerouted to a global copy, empty when it wasn't:
+  //   "symlinks_unsupported" - the up-front pre-check found symlinks unavailable
+  //                            (e.g. Windows without Developer Mode)
+  //   "symlink_failed"       - the pre-check passed but an individual link would
+  //                            not lay, which is closer to a bug or a
+  //                            directory-specific permission problem
+  // Split rather than a single flag because those two point at different fixes.
+  // Lets the nudge telemetry count each cohort
+  // (skillsNudgeInstallSucceeded:<fallback_reason>), since a fallback install is
   // otherwise indistinguishable from a project install.
-  bool used_global_fallback = 2;
+  string fallback_reason = 3;
+
+  // 2 was a bool used_global_fallback, superseded by the fallback_reason string
+  // above. Never released, but a PR preview wheel carried it, so the number is
+  // retired rather than retyped.
+  reserved 2;
 }
 
 // Acknowledgement payload for dismissing the skills nudge. Carries no data;


### PR DESCRIPTION
## Summary

The one-click "install skills" nudge emits a single `skillsNudgeInstallFailed` label when an install goes wrong. No cause is attached, and the server's `error_msg` (a human string) never reaches telemetry.

That blind spot is expensive. The install funnel over the nine days since 1.60.0 (2026-07-22 → 07-30), counted per **developer** (`COALESCE(MACHINE_ID_V4, MACHINE_ID_V3)`) rather than per event:

| Funnel step | Developers |
| --- | --- |
| Saw the nudge | 147,095 |
| Clicked Install | 27,412 |
| Got a resolved outcome (success or failure) | 27,313 |

That last row is the denominator for everything below — **not** the nudge audience, which is 5× larger. "Blocked" means at least one failure and no success in the window:

| Platform | Developers | Blocked | Rate |
| --- | --- | --- | --- |
| Windows | 22,254 | 1,626 | **7.3%** |
| macOS | 4,202 | 60 | 1.4% |
| Linux/ChromeOS | 857 | 21 | 2.5% |
| **All** | **27,313** | **1,707** | **6.2%** |

#16026 (shipped in 1.60.0) removed the GitHub-download fallback that was the leading suspect for the Windows skew, and it helped materially — Windows went **11.8% → 7.3%**, overall **9.7% → 6.2%**. But Windows is still **~5× the macOS rate**, so a real residual cause remains and the label can't name it. Path conflict? Permissions? OneDrive-backed home directory? Symlinks refused? All indistinguishable today.

This PR threads a bounded, machine-readable **reason** end-to-end so those outcomes split by cause. Making the numbers trustworthy also meant fixing several places where the installer's *reported* outcome didn't match what happened on disk — a write failure labelled a conflict, a half-installed system reported as success, and three paths where a failed replacement deleted a working skill. Those are here too, because telemetry built on a wrong success signal measures nothing.

> **On grain:** the rates above are per developer. Failures are retried — 5,693 failure events came from 1,922 distinct developers (3.0 each; one machine retried 95 times) — so the per-*attempt* rate runs roughly 3× higher. Don't mix the two.

> **On these counts:** they are a snapshot. Late-arriving telemetry means a re-run moves the absolute numbers (an earlier run of the same query over the same window returned 25,654 developers, ~6% lower) while the *rates* held to a tenth of a point. Trust the percentages; re-derive the counts. And if these look small next to a dashboard, check three things: this window is nine days, it is 1.60.0-only, and the denominator is resolved outcomes rather than everyone who saw the nudge.

> Related: #15933 — this is the instrumentation to diagnose the residual Windows failures, not a fix for the install itself.

## Telemetry

The nudge now emits one of:

| Label | When |
| --- | --- |
| `skillsNudgeInstallSucceeded` | Normal project (symlink) install |
| `skillsNudgeInstallSucceeded:<fallback_reason>` | Rerouted from project mode to a global copy, naming why |
| `skillsNudgeInstallFailed:<reason>` | The install ran and failed |
| `skillsNudgeInstallRefused:<gate>` | The user clicked Install and a safety gate declined it |
| `skillsNudgeInstallDropped` | Connection dropped mid-install (unchanged) |

`Refused` means the toast **was** shown and clicked, and the server declined before touching the filesystem — not that the nudge was hidden. A nudge never shown is the separate, pre-existing `skillsNudgeSuppressedNonLocal:<locality>`. **Gates** are `headless`, `no_agent`, `non_loopback`.

**Reasons** are a closed server-side vocabulary, never user input. Nothing is derived from an error *message* — only from error classes — so no path or OS string can reach a label.

| Reason | Means | Points at |
| --- | --- | --- |
| `write_denied` | `EACCES`/`EPERM`/`EROFS`, `ERROR_ACCESS_DENIED` | Permissions, or a read-only location |
| `write_locked` | `ERROR_SHARING_VIOLATION`, `EBUSY` | Antivirus or a sync client holding the file — **a retry would fix this** |
| `write_name_too_long` | `ENAMETOOLONG`, `ERROR_FILENAME_EXCED_RANGE` | Windows `MAX_PATH` — **shortening paths would fix this** |
| `write_no_space` | `ENOSPC`, `ERROR_DISK_FULL` | Disk or quota; nothing to fix but the message |
| `write_failed` | Anything unrecognised | Genuinely unknown — deliberately not guessed |
| `conflict` | A pre-existing file or foreign symlink | Messaging, or an opt-in overwrite |
| `source_missing` | The bundled skills directory is absent | Missing package data in the wheel |
| `source_incomplete` | Directory present, a required file missing | A too-narrow package-data glob |
| `no_skills` | Nothing installable discovered | Packaging |
| `incomplete` / `non_interactive` | CLI-only prompt outcomes | n/a |
| `unknown` | A non-`OSError` escaped the installer | Read the server log |

`winerror` is consulted before `errno` because CPython's mapping is lossy in exactly the misleading direction: `ERROR_SHARING_VIOLATION` arrives as `EACCES`, so trusting `errno` on Windows would report a permissions problem and send us after folder ACLs when the fix is to retry.

**Fallback reasons** — these matter more than the failure list, because most Windows users cannot lay symlinks, get rerouted to a global copy, and *succeed*. Their diagnostic signal therefore lives on the **success** label, not a failure one:

| `fallback_reason` | Means |
| --- | --- |
| `symlinks_no_privilege` | `ERROR_PRIVILEGE_NOT_HELD` — Developer Mode off. The one cause a user can simply fix |
| `symlinks_denied` | Permissions on the project directory refused the probe |
| `symlinks_unsupported` | The filesystem has no directory symlinks at all |
| `symlink_failed` | Pre-check passed, then an individual link would not lay — closer to a bug |

Reachability differs by entry point, which matters when reading the data:

- **From the nudge** (`yes=True`, project mode, global fallback on): the `write_*` family, `conflict`, `source_missing`, `source_incomplete`, `no_skills`, `unknown`. Note the `write_*` reasons only arise in the global-copy path, so they can appear *only* after symlinks have already failed — which is exactly the Windows cohort under study.
- **CLI only**: `incomplete` (declining the fallback confirm) and `non_interactive` (no TTY and no `--yes`).
- **Currently unreachable**: `symlinks_unsupported` *as a failure* — both raise sites sit behind `fallback_to_global=False`, which no caller passes. It is still emitted as a *fallback* reason on success.

The label-suffix shape mirrors the nudge's existing `skillsNudgeSuppressedNonLocal:<locality>`, so downstream analysis splits with `split_part(label, ':', 2)` and the whole thing rides the existing `menuClick` / `gatherUsageStats` plumbing.

### ⚠️ Heads-up for dashboards

Three discontinuities land with this PR:

1. **Safety-gate refusals move off the failure metric** onto `skillsNudgeInstallRefused:<gate>`. They should be near-zero (see point 1 below), but the historical series will step down.
2. **Failure labels gain a `:<reason>` suffix**, so exact-match queries on `skillsNudgeInstallFailed` need to become prefix matches.
3. **So does the success label.** A rerouted install emits `skillsNudgeInstallSucceeded:<fallback_reason>` — one of four values — so exact-match queries on `skillsNudgeInstallSucceeded` will silently undercount successes. The same prefix fix is needed on both sides of the funnel, not just the failure side.

## What changed

**Proto** — `error_reason` on `BackendOperationResponse` (field 7; a machine-readable sibling to the human `error_msg`, empty on success) and `fallback_reason` on `InstallSkillsResponsePayload` (field 3). Both are new fields no released client sets or reads, and mixed versions degrade gracefully: an older backend omits them and the frontend falls back to the bare labels. Field 2 of `InstallSkillsResponsePayload` is `reserved` — it briefly held a `bool used_global_fallback` that a PR preview wheel carried, so the number is retired rather than retyped.

**`skills.py`** — `_InstallError(click.ClickException)` carries a stable `reason`, typed as a `Literal` so mypy rejects a typo'd or ad-hoc reason at the raise site rather than silently minting a label no query knows about. It still behaves like a plain `ClickException`, so user-facing messages and CLI exit behavior are unchanged.

**`InstallSkillsHandler`** — forwards the reason, read *only* from `_InstallError` (a `getattr(ex, "reason")` would duck-type stdlib exceptions that expose a free-form `.reason` and blow the bounded vocabulary). A bare `OSError` that escapes the installer is classified `write_failed`; anything else is `unknown`. Gate refusals are emitted namespaced as `refused:<gate>`, so the frontend strips a prefix instead of mirroring the list of gate names — a gate added here is classified correctly with no frontend change.

**Frontend** — `BackendOperationClient` rejects with a `BackendOperationError` carrying the reason; `App.tsx` routes it to the right event and appends it as a label suffix.

## Installer fixes

**A failed replacement no longer deletes a working skill.** Replacing a Streamlit-owned symlink unlinked it and then copied straight to the target — the copy-to-temp-then-swap path only covered *directory* targets. A `copytree` `OSError` (permissions, full disk, antivirus lock) therefore removed a usable skill and left nothing in its place. The symlink case now takes the same deferred-removal path, so a failed copy leaves the existing install untouched. Reproduced before and after with a regression test.

**Write failures are no longer reported as conflicts, or as success.** An `OSError` during a copy used to land in the `skipped` bucket, which the caller labels `conflict` — so genuine permission and disk failures (the likeliest residual Windows cause) were indistinguishable from a pre-existing file. They now land in a separate `errored` bucket and raise `write_failed`.

> **Behavior change:** a partial global install — say `~/.agents/skills` writes fine but `~/.claude/skills` is denied — previously reported success. It now fails, which changes the exit code of `streamlit skills install --global` for anyone in that state. That's deliberate: a half-install reported as success is exactly the blind spot this PR exists to close.

**Symlink pre-work failures fall back instead of erroring.** `mkdir` / existence-check / unlink errors in `_install_skill_symlink` used to escape as an uncaught `OSError`; they now return `False`, so the caller falls back to a global copy like any other symlink failure.

## Testing

**Python** — 913 passed across `skills_test.py` and `backend_operation_handler_test.py`:

- The reason reaches `error_reason`; a plain `ClickException` falls back to `unknown`; an exception carrying a *foreign* `.reason` is not trusted; a bare `OSError` becomes `write_failed`; success leaves `error_reason` empty.
- Each gate reports its own `refused:<gate>`.
- A copy `OSError` reports `write_failed`, not `conflict`, and never lands in `skipped`.
- A partial write failure (one target OK, one `OSError`) fails rather than reporting success.
- An owned symlink survives a failed replacement, with its original content intact.
- `fallback_reason` records the specific cause on each of the four reroute paths and stays empty for a normal project install.

**Frontend** — App.test.tsx (21 nudge tests) covers the failure suffix, the `:global_fallback` success tag, and a refusal landing on `Refused` rather than `Failed`, each with a negative assertion that the wrong label does *not* fire. `BackendOperationClient.test.ts` covers the reason arriving on the rejection and staying `undefined` when the server omits it.

`make protobuf` regenerated the Python and TS bindings.

## Follow-up

`error_reason` is generic on `BackendOperationResponse`, so the other backend operations (deferred file, dismiss) can adopt reason codes later; only the install path sets it today.

---

<sub>Rebased onto `develop` post-1.60.0. #16026 removed the GitHub-download global-install path, so the `download_failed` / `extract_failed` / `download_empty` / `archive_missing_skill` reasons no longer exist and were dropped; a missing or incomplete bundled skill is now `source_missing`. `error_reason` was renumbered 6 → 7 to avoid colliding with `dataframe_chunk`.</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem install paths and changes CLI exit behavior for partial global installs; telemetry label shapes break exact-match dashboards but are backward-compatible on the wire.
> 
> **Overview**
> **Skills nudge telemetry** now suffixes `menuClick` labels with server-owned reason codes instead of a single success/failure bucket: failures become `skillsNudgeInstallFailed:<reason>`, rerouted global installs `skillsNudgeInstallSucceeded:<fallback_reason>`, and safety-gate blocks `skillsNudgeInstallRefused:<gate>` (not counted as failures).
> 
> **Wire format:** `BackendOperationResponse` gains `error_reason`; install success payloads gain `fallback_reason`. The frontend `BackendOperationClient` rejects with a structured error carrying `reason`, which `App.tsx` maps to those labels.
> 
> **Installer (`streamlit skills`):** Failures use `_InstallError` with a fixed `Literal` vocabulary; write errors are classified (`write_denied`, `write_locked`, etc.) without parsing messages. Copy/symlink replacements use staged `mkdtemp` swaps so a failed update does not remove a working skill; copy `OSError`s go to `errored` / `write_failed` instead of `skipped` / `conflict`; partial multi-target global installs fail instead of reporting success; symlink pre-check failures return fallback instead of bubbling `OSError`. Gate refusals emit `refused:<gate>` on the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1576d9fea739a20ef3758bd2c80fdad9f9fe39e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





