### PR TITLE
build(frontend): type-check with TypeScript 7

### DIFF
--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -8,7 +8,7 @@ alwaysApply: false
 
 # TypeScript Development Guide
 
-- TypeScript: v6
+- TypeScript: v7 for type-checking (native `tsc`, run via the `typescript-v7` alias); v6 stays for `.d.ts` emit (vite-plugin-dts) and typed linting (typescript-eslint), which need the v6 compiler API
 - Linters: oxlint v1 + eslint v10
 - Formatter: oxfmt v0.x
 - Framework: React v18

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -6,7 +6,7 @@ applyTo: "**/*.ts, **/*.tsx"
 
 # TypeScript Development Guide
 
-- TypeScript: v6
+- TypeScript: v7 for type-checking (native `tsc`, run via the `typescript-v7` alias); v6 stays for `.d.ts` emit (vite-plugin-dts) and typed linting (typescript-eslint), which need the v6 compiler API
 - Linters: oxlint v1 + eslint v10
 - Formatter: oxfmt v0.x
 - Framework: React v18

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,6 +1,6 @@
 # TypeScript Development Guide
 
-- TypeScript: v6
+- TypeScript: v7 for type-checking (native `tsc`, run via the `typescript-v7` alias); v6 stays for `.d.ts` emit (vite-plugin-dts) and typed linting (typescript-eslint), which need the v6 compiler API
 - Linters: oxlint v1 + eslint v10
 - Formatter: oxfmt v0.x
 - Framework: React v18

--- a/frontend/eslint-plugin-streamlit-custom/package.json
+++ b/frontend/eslint-plugin-streamlit-custom/package.json
@@ -25,6 +25,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",
     "typescript": "^6.0.3",
+    "typescript-v7": "npm:typescript@7.0.2",
     "typesync": "^0.14.3",
     "vitest": "^4.1.9"
   },

--- a/frontend/eslint-plugin-streamlit-custom/package.json
+++ b/frontend/eslint-plugin-streamlit-custom/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --cache --max-warnings 0 src",
     "test": "vitest run",
     "testWatch": "vitest",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "node \"$PROJECT_CWD/node_modules/typescript-v7/bin/tsc\" --noEmit",
     "typesync:ci": "typesync --dry=fail",
     "typesync": "typesync"
   },

--- a/frontend/typescript-config/package.json
+++ b/frontend/typescript-config/package.json
@@ -9,10 +9,11 @@
   ],
   "type": "module",
   "scripts": {
-    "typecheck:all": "cd $INIT_CWD && tsc"
+    "typecheck:all": "cd $INIT_CWD && node \"$PROJECT_CWD/node_modules/typescript-v7/bin/tsc\""
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "typescript-v7": "npm:typescript@7.0.2"
   },
   "browserslist": [
     ">0.2%",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9558,6 +9558,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.1.9"
     eslint: "npm:^10.6.0"
     typescript: "npm:^6.0.3"
+    typescript-v7: "npm:typescript@7.0.2"
     typesync: "npm:^0.14.3"
     vitest: "npm:^4.1.9"
   peerDependencies:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3813,6 +3813,7 @@ __metadata:
   resolution: "@streamlit/typescript-config@workspace:typescript-config"
   dependencies:
     typescript: "npm:^6.0.3"
+    typescript-v7: "npm:typescript@7.0.2"
   languageName: unknown
   linkType: soft
 
@@ -5490,6 +5491,146 @@ __metadata:
     "@typescript-eslint/types": "npm:8.63.0"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/595b47b08efecc35d93a8ac072798f9dc2371a371f03a1a03ab134a8505fe422fc647014bd096eac75a3d487c5eecf24393048ca88ed06f759d00115c11dd8bc
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-aix-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-loong64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-mips64el@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-riscv64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-s390x@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-sunos-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -17870,6 +18011,77 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/0dff8ca99a78854bb0d1d070543fd01242fc816897480d406dd31004ff0d5d69b1215e50d465dc89f9a45f8530174f8bda9fc6302d29bb96165b6e9b3e099a21
+  languageName: node
+  linkType: hard
+
+"typescript-v7@npm:typescript@7.0.2":
+  version: 7.0.2
+  resolution: "typescript@npm:7.0.2"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
+  bin:
+    tsc: bin/tsc
+  checksum: 10c0/3dcee51ec8c332492325bcdbf7df48b66668751f127e622ae7d41b6c716eb19184424a45e14f7750f50f340232388b69e6287859155f06a5ce2df76f12cb31cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

Run the frontend type checker on the native TypeScript 7 compiler for a large speedup, while keeping TypeScript 6 for the tools that still need the v6 compiler API.

In CI, the `Run type checks` step (`make frontend-types`) drops from ~23-29s on `develop` (v6) to ~12s on this branch (v7) - roughly half the wall-clock time. Locally the underlying `tsc` invocation drops from tens of seconds to ~5s.

TypeScript 7 is the Go port and has no stable programmatic API until 7.1, so vite-plugin-dts (`.d.ts` emit for the published packages) and typescript-eslint typed linting cannot run on it yet. To get the type-checking speedup without breaking those tools, v7 is added under a `typescript-v7` npm alias (`npm:typescript@7.0.2`) and invoked only by the `typecheck` scripts; the bare `typescript` package stays on v6 so vite-plugin-dts and typescript-eslint resolve it unchanged.

The `typecheck` scripts now call `tsc` from the aliased package directly (`node "$PROJECT_CWD/node_modules/typescript-v7/bin/tsc"`). Agent-facing TypeScript guides (`.cursor/rules`, `.github/instructions`, `frontend/AGENTS.md`) are updated to document the v6/v7 split.

## Screenshot or video (only for visual changes)

N/A - build tooling change only.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Why no additional automated tests are needed:** This is a build-tooling change with no runtime or user-facing surface. Type checking is already exercised in CI via `make frontend-types` (the `Run type checks` step in the `js-unit-tests` job), which now runs on the v7 alias.
- **Measured impact:** On this branch the `Run type checks` CI step ran in ~12s vs ~23-29s across recent `develop` runs on v6.
- **Manual verification:**
  - `make frontend-types` passes on v7 and produces the same diagnostics as v6 (no new type errors).
  - vite-plugin-dts still emits `.d.ts` declarations for the published packages on v6.
  - typescript-eslint typed linting still passes on v6.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tooling only with no runtime impact; main caveat is possible v6 vs v7 diagnostic drift, which the PR validates against existing CI type checks.
> 
> **Overview**
> Frontend **type-checking** now runs on **TypeScript 7** via a `typescript-v7` npm alias (`npm:typescript@7.0.2`), invoked as `node "$PROJECT_CWD/node_modules/typescript-v7/bin/tsc"` from `typecheck` / `typecheck:all` in `@streamlit/typescript-config` and `eslint-plugin-streamlit-custom`. The default `typescript` package stays on **v6** so **vite-plugin-dts** and **typescript-eslint** keep using the v6 compiler API.
> 
> Agent docs (`frontend/AGENTS.md` and generated `.cursor` / `.github` TypeScript guides) document the v6/v7 split. `yarn.lock` picks up the aliased v7 package and its platform binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315a68b896229f6c45c70b202bdfd37596140810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->