### PR TITLE
[fix] Derive @st.cache_data sampling seed from data to prevent hash collisions

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,6 +21,7 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
+import hashlib
 import inspect
 import io
 import os
@@ -57,6 +58,11 @@ _PANDAS_SAMPLE_SIZE: Final = 10_000
 _NP_SIZE_LARGE: Final = 500_000
 _NP_SAMPLE_SIZE: Final = 100_000
 
+# Number of leading elements/rows used to derive the data-dependent sampling
+# seed for large objects (see _numpy_sample_seed, _pandas_sample_seed, and
+# _polars_sample_seed).
+_SEED_PREFIX_SIZE: Final = 64
+
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
 
 # Arbitrary item to denote where we found a cycle in a hashed object.
@@ -64,6 +70,69 @@ HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
 _CYCLE_PLACEHOLDER: Final = (
     b"streamlit-57R34ML17-hesamagicalponyflyingthroughthesky-CYCLE"
 )
+
+
+def _bytes_to_seed(data: bytes) -> int:
+    """Reduce arbitrary bytes to a 32-bit deterministic sampling seed.
+
+    The result lies in ``[0, 2**32)``, which is a valid seed for numpy's
+    ``RandomState``, pandas' ``DataFrame.sample(random_state=...)``, and polars'
+    ``sample(seed=...)``.
+    """
+    return int.from_bytes(hashlib.md5(data, usedforsecurity=False).digest()[:4], "big")
+
+
+def _pandas_sample_seed(obj: pd.Series[Any] | pd.DataFrame) -> int:
+    """Derive a deterministic, data-dependent sampling seed from the first row.
+
+    A globally fixed seed lets a caller predict which rows the large-object
+    sampling path selects and craft two different inputs that collide by only
+    altering non-sampled rows. Seeding from the object's own leading row makes
+    the sampled indices content-dependent. Falls back to ``0`` (the legacy seed)
+    if the prefix cannot be hashed, preserving the pickle fallback path used by
+    the main hashing branch.
+    """
+    from pandas.util import hash_pandas_object
+
+    try:
+        prefix = hash_pandas_object(obj.iloc[:1]).to_numpy().tobytes()
+    except (TypeError, ValueError):
+        return 0
+    return _bytes_to_seed(prefix)
+
+
+def _numpy_sample_seed(np_obj: npt.NDArray[Any]) -> int:
+    """Derive a deterministic, data-dependent sampling seed from a prefix.
+
+    See :func:`_pandas_sample_seed` for the rationale. Falls back to ``0`` if the
+    prefix cannot be serialized to bytes.
+    """
+    import numpy as np
+
+    try:
+        prefix = np.ascontiguousarray(np_obj.flat[:_SEED_PREFIX_SIZE]).tobytes()
+    except (TypeError, ValueError, BufferError):
+        return 0
+    return _bytes_to_seed(prefix)
+
+
+def _polars_sample_seed(obj: Any) -> int:
+    """Derive a deterministic, data-dependent sampling seed via polars hashing.
+
+    Uses polars' native row hashing (rather than a numpy round-trip) so the seed
+    stays deterministic for non-numeric dtypes. See :func:`_pandas_sample_seed`
+    for the rationale. Falls back to ``0`` if the head cannot be hashed.
+    """
+    try:
+        head = obj.head(1)
+        # DataFrame exposes hash_rows(); Series exposes hash().
+        hashed = (
+            head.hash_rows(seed=0) if hasattr(head, "hash_rows") else head.hash(seed=0)
+        )
+        prefix = hashed.to_numpy().tobytes()
+    except (TypeError, ValueError, BufferError):
+        return 0
+    return _bytes_to_seed(prefix)
 
 
 class UserHashError(StreamlitAPIException):
@@ -427,7 +496,9 @@ class _CacheFuncHasher:
             self.update(h, series_obj.dtype.name)
 
             if len(series_obj) >= _PANDAS_ROWS_LARGE:
-                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                series_obj = series_obj.sample(
+                    n=_PANDAS_SAMPLE_SIZE, random_state=_pandas_sample_seed(series_obj)
+                )
 
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
@@ -449,7 +520,9 @@ class _CacheFuncHasher:
             self.update(h, df_obj.shape)
 
             if len(df_obj) >= _PANDAS_ROWS_LARGE:
-                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                df_obj = df_obj.sample(
+                    n=_PANDAS_SAMPLE_SIZE, random_state=_pandas_sample_seed(df_obj)
+                )
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -476,7 +549,7 @@ class _CacheFuncHasher:
             self.update(h, obj.shape)
 
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=_polars_sample_seed(obj))
 
             try:
                 self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
@@ -499,7 +572,7 @@ class _CacheFuncHasher:
             self.update(h, obj.shape)
 
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=_polars_sample_seed(obj))
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
@@ -530,7 +603,7 @@ class _CacheFuncHasher:
             if np_obj.size >= _NP_SIZE_LARGE:
                 import numpy as np
 
-                state = np.random.RandomState(0)
+                state = np.random.RandomState(_numpy_sample_seed(np_obj))
                 np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -50,6 +50,9 @@ from streamlit.runtime.caching.hashing import (
     _CacheFuncHasher,
     _HashStack,
     _HashStacks,
+    _numpy_sample_seed,
+    _pandas_sample_seed,
+    _polars_sample_seed,
     update_hash,
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
@@ -1014,3 +1017,119 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
 
     # But the hashes should differ because we now include the palette
     assert get_hash(im1) != get_hash(im2)
+
+
+def test_numpy_sample_seed_is_data_dependent() -> None:
+    """The numpy sampling seed changes when the leading prefix changes.
+
+    Regression test for GitHub issue #14622: a globally fixed sampling seed lets
+    the sampled indices be predicted in advance, enabling crafted collisions.
+    """
+    arr_a = np.arange(100, dtype=np.float64)
+    arr_b = arr_a.copy()
+    arr_b[0] = -1.0
+
+    assert _numpy_sample_seed(arr_a) != _numpy_sample_seed(arr_b)
+
+
+def test_numpy_sample_seed_is_stable() -> None:
+    """Identical numpy arrays derive the same sampling seed."""
+    arr = np.arange(100, dtype=np.float64)
+
+    assert _numpy_sample_seed(arr) == _numpy_sample_seed(arr.copy())
+
+
+def test_numpy_sample_seed_falls_back_to_zero_on_error() -> None:
+    """An unserializable prefix degrades to the legacy seed of 0, never raising."""
+    arr = np.arange(100, dtype=np.float64)
+    with mock.patch("numpy.ascontiguousarray", side_effect=BufferError("forced")):
+        assert _numpy_sample_seed(arr) == 0
+
+
+def test_pandas_sample_seed_is_data_dependent() -> None:
+    """The pandas sampling seed changes when the first row changes.
+
+    Regression test for GitHub issue #14622.
+    """
+    df_a = pd.DataFrame({"val": np.arange(100, dtype=np.float64)})
+    df_b = df_a.copy()
+    df_b.iloc[0, 0] = -1.0
+
+    assert _pandas_sample_seed(df_a) != _pandas_sample_seed(df_b)
+
+
+def test_pandas_sample_seed_is_stable() -> None:
+    """Identical pandas objects derive the same sampling seed."""
+    df = pd.DataFrame({"val": np.arange(100, dtype=np.float64)})
+
+    assert _pandas_sample_seed(df) == _pandas_sample_seed(df.copy())
+
+
+def test_pandas_sample_seed_falls_back_to_zero_when_unhashable() -> None:
+    """An unhashable first row degrades to the legacy seed of 0, never raising."""
+    series = pd.Series([[1, 2], [3, 4]])
+
+    assert _pandas_sample_seed(series) == 0
+
+
+def test_numpy_large_array_diverges_when_seed_prefix_differs() -> None:
+    """Large numpy arrays differing in the seed prefix hash differently.
+
+    Regression test for GitHub issue #14622. The prefix is mutated directly so
+    the derived seed provably changes (rather than relying on the sample not
+    covering the prefix), guaranteeing different sampled indices and hashes.
+    """
+    n = _NP_SIZE_LARGE + 10_000
+    arr_a = np.arange(n, dtype=np.float64)
+    arr_b = arr_a.copy()
+    arr_b[0] = -1.0
+
+    assert get_hash(arr_a) != get_hash(arr_b)
+
+
+def test_pandas_large_dataframe_diverges_when_seed_prefix_differs() -> None:
+    """Large pandas DataFrames differing in the seed row hash differently.
+
+    Regression test for GitHub issue #14622 (see the numpy analog for the
+    prefix-mutation rationale).
+    """
+    n = _PANDAS_ROWS_LARGE + 5_000
+    df_a = pd.DataFrame({"val": np.arange(n, dtype=np.float64)})
+    df_b = df_a.copy()
+    df_b.iloc[0, 0] = -1.0
+
+    assert get_hash(df_a) != get_hash(df_b)
+
+
+@pytest.mark.require_integration
+def test_polars_sample_seed_is_data_dependent() -> None:
+    """The polars sampling seed changes when the head of the object changes."""
+    import polars as pl
+
+    series_a = pl.Series([1, 2, 3, 4])
+    series_b = pl.Series([9, 2, 3, 4])
+    assert _polars_sample_seed(series_a) != _polars_sample_seed(series_b)
+    assert _polars_sample_seed(series_a) == _polars_sample_seed(pl.Series([1, 2, 3, 4]))
+
+    df_a = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    df_b = pl.DataFrame({"a": [9, 2], "b": [3, 4]})
+    assert _polars_sample_seed(df_a) != _polars_sample_seed(df_b)
+
+
+@pytest.mark.require_integration
+def test_polars_large_dataframe_diverges_when_seed_prefix_differs() -> None:
+    """Large polars DataFrames differing in the seed row hash differently.
+
+    Regression test for GitHub issue #14622.
+    """
+    import polars as pl
+
+    n = _PANDAS_ROWS_LARGE + 5_000
+    vals_a = np.arange(n, dtype=np.float64)
+    vals_b = vals_a.copy()
+    vals_b[0] = -1.0
+
+    df_a = pl.DataFrame({"val": vals_a})
+    df_b = pl.DataFrame({"val": vals_b})
+
+    assert get_hash(df_a) != get_hash(df_b)


### PR DESCRIPTION
## Describe your changes

`@st.cache_data` / `@st.cache_resource` sample a subset of large
pandas/polars/numpy objects before hashing (for objects above the
`_PANDAS_ROWS_LARGE` / `_NP_SIZE_LARGE` thresholds). The sampling used a
**hardcoded seed** (`random_state=0`, `seed=0`, `RandomState(0)`), so the sampled
indices were a global constant known in advance. As reported in #14622, this lets
two structurally different large inputs that agree only at the sampled positions
produce the **same cache key**, silently returning stale or adversarially-poisoned
data with no error.

This PR derives the sampling seed from each input's own **leading prefix** so the
sampled indices become content-dependent instead of globally fixed:

- `_pandas_sample_seed` — hashes the first row via `hash_pandas_object`.
- `_numpy_sample_seed` — hashes the first `_SEED_PREFIX_SIZE` elements.
- `_polars_sample_seed` — uses polars-native row hashing (`hash_rows`/`hash`),
  avoiding a numpy round-trip so the seed stays deterministic for non-numeric
  dtypes.

Each helper falls back to `0` (the legacy seed) if the prefix can't be hashed, so
the existing pickle fallback path is preserved and no exception can escape seed
derivation. Identical inputs still hash identically.

**Notes**
- This changes cache keys for large sampled objects, causing a one-time cache
  miss on upgrade. This is expected and preferable to silently returning wrong
  cache hits.
- Bug 2 from the issue (PIL P-mode palette omission) was already fixed in #15397,
  so this change is scoped to the sampling-seed collision (Bug 1).
- This revives the approach from the previously-approved-but-stale-closed #14635,
  additionally addressing that PR's review feedback: consistent exception
  handling, polars-native hashing, and prefix-mutation-based (non-fragile)
  regression tests including the previously-missing Polars case.

## Screenshot or video (only for visual changes)

N/A — backend-only change.

## GitHub Issue Link (if applicable)

Closes #14622

## Testing Plan

- **Unit Tests (Python)** added to
  `lib/tests/streamlit/runtime/caching/hashing_test.py`:
  - Seed helpers are data-dependent, stable for identical input, and fall back
    to `0` when the prefix is unhashable (pandas, numpy, polars).
  - End-to-end regression: large numpy/pandas/polars objects that differ in the
    seed prefix now hash differently. The prefix is mutated **directly** so the
    derived seed provably changes (rather than relying on the sample not covering
    the prefix).
- Existing equality/inequality hashing tests continue to pass unchanged
  (identical data → identical seed → identical hash).
- E2E Tests: not applicable (internal cache-key computation, no UI surface).
- Verified locally: `ruff format`, `ruff check`, `mypy`, and
  `pytest lib/tests/streamlit/runtime/caching/hashing_test.py` (87 passed;
  polars cases validated under the integration path).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache-key generation for `@st.cache_data`; behavior change causes one-time cache misses, but the fix is narrow, fallback-preserving, and heavily regression-tested.
> 
> **Overview**
> Fixes **#14622** by replacing a **fixed sampling seed** (`0`) on large pandas, polars, and numpy inputs with a **content-derived seed**, so `@st.cache_data` / `@st.cache_resource` cannot collide when two big objects differ only outside the sampled rows.
> 
> New helpers hash a small **leading prefix** (first row for pandas/polars, first 64 elements for numpy), map it to a 32-bit seed via MD5, and use that for `sample` / `RandomState`. Unhashable prefixes still use seed `0`, matching the old pickle-fallback behavior.
> 
> **Cache keys for large sampled objects change on upgrade** (expected one-time misses). Tests cover seed stability, fallback, and end-to-end hash divergence for numpy, pandas, and polars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f77bfaff75bb01a9a5682c465fcab512b94f3d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->