### PR TITLE
[fix] Cap server dependency major versions

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -55,6 +55,10 @@ alwaysApply: false
 - `pyproject.toml`: Package configuration of the Streamlit library.
 - `tests`: Python unit tests (pytest).
 
+## Dependencies
+
+- Required dependencies for the Streamlit library in `pyproject.toml` must include a lower bound and an upper bound pinned to the next unreleased major version, for example `package>=1.2.3,<2`. This minimizes potential breaks from new major versions. Exemptions are allowed, but must include a clear comment explaining why the dependency should not be capped.
+
 ## Typing
 
 - Add typing annotations to every new function, method or class member.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -53,6 +53,10 @@ applyTo: "**/*.py"
 - `pyproject.toml`: Package configuration of the Streamlit library.
 - `tests`: Python unit tests (pytest).
 
+## Dependencies
+
+- Required dependencies for the Streamlit library in `pyproject.toml` must include a lower bound and an upper bound pinned to the next unreleased major version, for example `package>=1.2.3,<2`. This minimizes potential breaks from new major versions. Exemptions are allowed, but must include a clear comment explaining why the dependency should not be capped.
+
 ## Typing
 
 - Add typing annotations to every new function, method or class member.

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -47,6 +47,10 @@
 - `pyproject.toml`: Package configuration of the Streamlit library.
 - `tests`: Python unit tests (pytest).
 
+## Dependencies
+
+- Required dependencies for the Streamlit library in `pyproject.toml` must include a lower bound and an upper bound pinned to the next unreleased major version, for example `package>=1.2.3,<2`. This minimizes potential breaks from new major versions. Exemptions are allowed, but must include a clear comment explaining why the dependency should not be capped.
+
 ## Typing
 
 - Add typing annotations to every new function, method or class member.

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -72,10 +72,9 @@ dependencies = [
   "pydeck>=0.8.0b4,<1",
   # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
   "protobuf>=3.20,<8",
-  # pyarrow is not semantically versioned, gets new major versions frequently, and
-  # doesn't tend to break the API on major version upgrades, so we don't put an
-  # upper bound on it.
-  "pyarrow>=7.0",
+  # pyarrow 25.0.0 has a crash issue in Streamlit's script-thread import pattern.
+  # See https://github.com/apache/arrow/issues/50471.
+  "pyarrow>=7.0,<25.0.0",
   "requests>=2.27,<3",
   "tenacity>=8.1.0,<10",
   # Starting from Python 3.11, Python has built in support for reading TOML files.

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -84,19 +84,19 @@ dependencies = [
   # Starlette requires typing-extensions >= 4.10.
   "typing-extensions>=4.10.0,<5",
   # ASGI web-framework:
-  "starlette>=0.40.0",
+  "starlette>=0.40.0,<2",
   # ASGI server:
-  "uvicorn>=0.30.0",
+  "uvicorn>=0.30.0,<1",
   # Faster http parsing for Starlette server:
-  "httptools>=0.6.3",
+  "httptools>=0.6.3,<1",
   # Required by starlette:
-  "anyio>=4.0.0",
+  "anyio>=4.0.0,<5",
   # Required for file-upload support:
-  "python-multipart>=0.0.10",
+  "python-multipart>=0.0.10,<1",
   # Required for websocket support:
-  "websockets>=12.0.0",
+  "websockets>=12.0.0,<17",
   # Required for cookie signing:
-  "itsdangerous>=2.1.2",
+  "itsdangerous>=2.1.2,<3",
   # Don't require watchdog on MacOS, since it'll fail without xcode tools.
   # Without watchdog, we fallback to a polling file watcher to check for app changes.
   "watchdog>=2.1.5,<7; platform_system != 'Darwin'",


### PR DESCRIPTION
## Describe your changes

Adds upper version bounds to previously-uncapped runtime dependencies in `lib/pyproject.toml`, to minimize breakage from future major releases:

- Server-related deps capped at the next unreleased major version: `starlette<2`, `uvicorn<1`, `httptools<1`, `anyio<5`, `python-multipart<1`, `websockets<17`, `itsdangerous<3`. All caps sit above the currently-resolved latest versions, so no existing install is affected.
- `pyarrow` capped at `<25.0.0` as a documented exemption: pyarrow 25.0.0 crashes in Streamlit's script-thread import pattern (see [apache/arrow#50471](https://github.com/apache/arrow/issues/50471)). To be relaxed once the upstream issue is resolved.
- Documents the dependency-capping policy in the Python agent guides (`lib/AGENTS.md`, and the generated `.cursor/rules/python.mdc` / `.github/instructions/python.instructions.md`).

## GitHub Issue Link (if applicable)

## Testing Plan

- No tests needed: dependency metadata + internal docs change. The server-dep caps are above the currently-installed versions, so resolution is unaffected; the pyarrow cap intentionally excludes the broken 25.0.0 release.