### PR TITLE
[fix] Prevent file watcher crash on Windows drive paths

### DIFF
--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -63,6 +63,7 @@ from typing_extensions import Self
 from watchdog import events
 from watchdog.observers import Observer
 
+from streamlit import env_util
 from streamlit.errors import StreamlitMaxRetriesError
 from streamlit.logger import get_logger
 from streamlit.util import repr_
@@ -445,7 +446,10 @@ class _FolderEventHandler(events.FileSystemEventHandler):
 
             # Windows can report the same path with an extended-length prefix
             # (``\\?\``), which does not compare equal to the standard spelling.
-            if changed_path_info is None:
+            # On other platforms path comparison is exact, so the dict lookup
+            # above already covers every equivalent spelling and this fallback
+            # scan can be skipped.
+            if changed_path_info is None and env_util.IS_WINDOWS:
                 for path, info in self._watched_paths.items():
                     if util.paths_are_same(path, abs_changed_path):
                         changed_path_info = info
@@ -506,11 +510,6 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             # briefly and re-read the file. If the hash reverts to the original
             # value, this was likely a spurious event and we should ignore it.
             # See: https://github.com/streamlit/streamlit/issues/13954
-            # Import at function level to avoid circular imports and
-            # because this code path is rarely executed (only on Windows
-            # after a hash change is detected)
-            from streamlit import env_util
-
             if env_util.IS_WINDOWS:
                 import time
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -443,6 +443,14 @@ class _FolderEventHandler(events.FileSystemEventHandler):
             # First check if the exact path is being watched
             changed_path_info = self._watched_paths.get(abs_changed_path, None)
 
+            # Windows can report the same path with an extended-length prefix
+            # (``\\?\``), which does not compare equal to the standard spelling.
+            if changed_path_info is None:
+                for path, info in self._watched_paths.items():
+                    if util.paths_are_same(path, abs_changed_path):
+                        changed_path_info = info
+                        break
+
             # If the exact path isn't found, check if it's inside any watched
             # directories. This is necessary for the folder watching feature to
             # detect changes to files within watched directories, not just the
@@ -451,21 +459,9 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 for path, info in self._watched_paths.items():
                     if not os.path.isdir(path):
                         continue
-                    try:
-                        if os.path.commonpath([path, abs_changed_path]) == path:
-                            changed_path_info = info
-                            break
-                    except ValueError as ex:
-                        # On Windows, os.path.commonpath raises ValueError when paths
-                        # are on different drives. In that case, the changed path
-                        # cannot be inside the watched directory.
-                        _LOGGER.debug(
-                            "Ignoring changed path %s.\nWatched_paths: %s",
-                            abs_changed_path,
-                            self._watched_paths,
-                            exc_info=ex,
-                        )
-                        continue
+                    if util.path_is_in_directory(abs_changed_path, path):
+                        changed_path_info = info
+                        break
 
         # If we still haven't found a matching path, ignore this event
         if changed_path_info is None:

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -19,7 +19,7 @@ import sys
 import threading
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast
 
-from streamlit import config, file_util
+from streamlit import config, env_util, file_util
 from streamlit.logger import get_logger
 from streamlit.watcher import util
 from streamlit.watcher.folder_black_list import FolderBlackList
@@ -128,9 +128,16 @@ class LocalSourcesWatcher:
         _LOGGER.debug("Path changed: %s", filepath)
 
         norm_filepath = os.path.realpath(filepath)
-        is_watched_file = norm_filepath in self._watched_modules or any(
-            util.paths_are_same(watched_path, norm_filepath)
-            for watched_path in self._watched_modules
+        # On Windows the same path can be reported with an extended-length
+        # prefix (``\\?\``), so fall back to a normalized comparison there. On
+        # other platforms the plain membership check already covers every
+        # equivalent spelling.
+        is_watched_file = norm_filepath in self._watched_modules or (
+            env_util.IS_WINDOWS
+            and any(
+                util.paths_are_same(watched_path, norm_filepath)
+                for watched_path in self._watched_modules
+            )
         )
         if not is_watched_file:
             # Check if this is a file in a watched directory

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast
 
 from streamlit import config, file_util
 from streamlit.logger import get_logger
+from streamlit.watcher import util
 from streamlit.watcher.folder_black_list import FolderBlackList
 from streamlit.watcher.path_watcher import (
     NoOpPathWatcher,
@@ -127,13 +128,15 @@ class LocalSourcesWatcher:
         _LOGGER.debug("Path changed: %s", filepath)
 
         norm_filepath = os.path.realpath(filepath)
-        if norm_filepath not in self._watched_modules:
+        is_watched_file = norm_filepath in self._watched_modules or any(
+            util.paths_are_same(watched_path, norm_filepath)
+            for watched_path in self._watched_modules
+        )
+        if not is_watched_file:
             # Check if this is a file in a watched directory
             for watched_path in self._watched_modules:
-                if (
-                    os.path.isdir(watched_path)
-                    and os.path.commonpath([watched_path, norm_filepath])
-                    == watched_path
+                if os.path.isdir(watched_path) and util.path_is_in_directory(
+                    norm_filepath, watched_path
                 ):
                     _LOGGER.debug("File changed in watched directory: %s", filepath)
                     for cb in self._on_path_changed:

--- a/lib/streamlit/watcher/util.py
+++ b/lib/streamlit/watcher/util.py
@@ -20,11 +20,13 @@ functions that use streamlit.config can go here to avoid a dependency cycle.
 
 from __future__ import annotations
 
+import ntpath
 import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
+from streamlit import env_util
 from streamlit.errors import StreamlitMaxRetriesError
 from streamlit.util import calc_hash
 
@@ -36,6 +38,59 @@ _MAX_RETRIES = 5
 
 # How long to wait between retries.
 _RETRY_WAIT_SECS = 0.1
+
+_WINDOWS_EXTENDED_PATH_PREFIX = "\\\\?\\"
+_WINDOWS_EXTENDED_UNC_PATH_PREFIX = "\\\\?\\UNC\\"
+
+
+def _normalize_path_for_comparison(path: str) -> str:
+    """Normalize an already-absolute path for comparisons."""
+    if not env_util.IS_WINDOWS:
+        return os.path.normcase(path)
+
+    # Windows APIs can represent the same path as either ``C:\\...`` or
+    # ``\\\\?\\C:\\...``. Python's ntpath treats those as different drives, so
+    # convert extended drive and UNC paths to their standard spelling before
+    # comparing them. Other device namespace paths (neither drive nor UNC) are
+    # left unchanged.
+    if path.casefold().startswith(_WINDOWS_EXTENDED_UNC_PATH_PREFIX.casefold()):
+        # ``\\\\?\\UNC\\server\\share`` -> ``\\\\server\\share``
+        path = "\\\\" + path[len(_WINDOWS_EXTENDED_UNC_PATH_PREFIX) :]
+    elif path.startswith(_WINDOWS_EXTENDED_PATH_PREFIX):
+        remainder = path[len(_WINDOWS_EXTENDED_PATH_PREFIX) :]
+        # ``\\\\?\\C:\\...`` -> ``C:\\...``, but only for drive-letter paths.
+        if (
+            len(remainder) >= 3
+            and remainder[0].isalpha()
+            and remainder[1] == ":"
+            and remainder[2] in "\\/"
+        ):
+            path = remainder
+
+    return ntpath.normcase(path)
+
+
+def paths_are_same(path1: str, path2: str) -> bool:
+    """Return whether two paths have the same canonical representation."""
+    return _normalize_path_for_comparison(path1) == _normalize_path_for_comparison(
+        path2
+    )
+
+
+def path_is_in_directory(path: str, directory: str) -> bool:
+    """Return whether a path is inside a directory without raising on drives."""
+    normalized_path = _normalize_path_for_comparison(path)
+    normalized_directory = _normalize_path_for_comparison(directory)
+    commonpath = ntpath.commonpath if env_util.IS_WINDOWS else os.path.commonpath
+
+    try:
+        return (
+            commonpath([normalized_directory, normalized_path]) == normalized_directory
+        )
+    except ValueError:
+        # commonpath raises for paths on different Windows drives, or when
+        # absolute and relative paths are mixed. Neither can be a child path.
+        return False
 
 
 def calc_hash_with_blocking_retries(
@@ -122,7 +177,13 @@ def _get_file_content(file_path: str) -> bytes:
 def _dirfiles(dir_path: str, glob_pattern: str) -> str:
     p = Path(dir_path)
     filenames = sorted(
-        [f.name for f in p.glob(glob_pattern) if not f.name.startswith(".")]
+        [
+            f.name
+            for f in p.glob(glob_pattern)
+            if not f.name.startswith(".")
+            and "__pycache__" not in f.relative_to(p).parts
+            and f.suffix not in {".pyc", ".pyo"}
+        ]
     )
     return "+".join(filenames)
 

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -140,7 +140,10 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         ev = events.FileSystemEvent(equivalent_path)
         ev.event_type = events.EVENT_TYPE_MODIFIED
-        folder_handler.on_modified(ev)
+        # The normalized-spelling fallback only runs on Windows, where the same
+        # path can be reported with an extended-length prefix.
+        with mock.patch.object(event_based_path_watcher.env_util, "IS_WINDOWS", True):
+            folder_handler.on_modified(ev)
 
         cb.assert_called_once_with(equivalent_path)
         self.mock_util.paths_are_same.assert_called_once_with(

--- a/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
+++ b/lib/tests/streamlit/watcher/event_based_path_watcher_test.py
@@ -24,6 +24,7 @@ from watchdog import events
 
 from streamlit.errors import StreamlitMaxRetriesError
 from streamlit.watcher import event_based_path_watcher
+from streamlit.watcher import util as watcher_util
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -48,6 +49,10 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         )
         self.MockObserverClass = self.observer_class_patcher.start()
         self.mock_util = self.util_patcher.start()
+        self.mock_util.paths_are_same.side_effect = watcher_util.paths_are_same
+        self.mock_util.path_is_in_directory.side_effect = (
+            watcher_util.path_is_in_directory
+        )
 
     def tearDown(self):
         # The test suite patches MultiPathWatcher. We need to close
@@ -114,6 +119,33 @@ class EventBasedPathWatcherTest(unittest.TestCase):
 
         cb.assert_called_once()
 
+        ro.close()
+
+    def test_equivalent_path_spelling_matches_watched_file(self):
+        """Test that canonically equivalent paths match the same watched file."""
+        cb = mock.Mock()
+        watched_path = "/this/is/my/file.py"
+        equivalent_path = "/equivalent/spelling/file.py"
+
+        self.mock_util.path_modification_time = lambda *args: 101.0
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "1"
+        ro = event_based_path_watcher.EventBasedPathWatcher(watched_path, cb)
+
+        fo = event_based_path_watcher._MultiPathWatcher.get_singleton()
+        folder_handler = fo._observer.schedule.call_args[0][0]
+        self.mock_util.paths_are_same.side_effect = None
+        self.mock_util.paths_are_same.return_value = True
+        self.mock_util.path_modification_time = lambda *args: 102.0
+        self.mock_util.calc_hash_with_blocking_retries = lambda _, **kwargs: "2"
+
+        ev = events.FileSystemEvent(equivalent_path)
+        ev.event_type = events.EVENT_TYPE_MODIFIED
+        folder_handler.on_modified(ev)
+
+        cb.assert_called_once_with(equivalent_path)
+        self.mock_util.paths_are_same.assert_called_once_with(
+            watched_path, equivalent_path
+        )
         ro.close()
 
     def test_works_with_directories(self):
@@ -510,9 +542,8 @@ class EventBasedPathWatcherTest(unittest.TestCase):
         folder_handler = fo._observer.schedule.call_args[0][0]
 
         # Simulate an event on a different "drive" by making commonpath raise
-        with mock.patch(
-            "streamlit.watcher.event_based_path_watcher.os.path.commonpath",
-            side_effect=ValueError,
+        with mock.patch.object(
+            watcher_util.os.path, "commonpath", side_effect=ValueError
         ):
             ev = events.FileSystemEvent("/other_drive/some_file.py")
             ev.event_type = events.EVENT_TYPE_MODIFIED
@@ -814,6 +845,8 @@ def ebpw_mocks() -> Generator[tuple[mock.MagicMock, mock.MagicMock], None, None]
         ) as mock_observer_class,
         mock.patch("streamlit.watcher.event_based_path_watcher.util") as mock_util,
     ):
+        mock_util.paths_are_same.side_effect = watcher_util.paths_are_same
+        mock_util.path_is_in_directory.side_effect = watcher_util.path_is_in_directory
         yield mock_observer_class, mock_util
 
         if event_based_path_watcher._MultiPathWatcher._singleton is not None:

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -544,6 +544,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_extended_windows_path_matches_watched_file(self, _fob):
+        """Test that an extended-length Windows path matches a watched file."""
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
         callback = MagicMock()
         lsw.register_file_change_callback(callback)
@@ -565,6 +566,7 @@ class LocalSourcesWatcherTest(unittest.TestCase):
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_extended_windows_path_matches_watched_directory(self, _fob):
+        """Test that an extended-length Windows path matches a watched directory."""
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
         callback = MagicMock()
         lsw.register_file_change_callback(callback)

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -543,6 +543,49 @@ class LocalSourcesWatcherTest(unittest.TestCase):
         assert saved_filepath == SCRIPT_PATH
 
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_extended_windows_path_matches_watched_file(self, _fob):
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        callback = MagicMock()
+        lsw.register_file_change_callback(callback)
+        watched_path = r"C:\project\module.py"
+        changed_path = r"\\?\C:\project\module.py"
+        lsw._watched_modules = {
+            watched_path: local_sources_watcher.WatchedModule(MagicMock(), None)
+        }
+
+        with (
+            patch.object(
+                local_sources_watcher.os.path, "realpath", side_effect=lambda p: p
+            ),
+            patch.object(local_sources_watcher.util.env_util, "IS_WINDOWS", True),
+        ):
+            lsw.on_path_changed(changed_path)
+
+        callback.assert_called_once_with(changed_path)
+
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
+    def test_extended_windows_path_matches_watched_directory(self, _fob):
+        lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))
+        callback = MagicMock()
+        lsw.register_file_change_callback(callback)
+        watched_path = r"C:\project"
+        changed_path = r"\\?\C:\project\__pycache__\module.pyc"
+        lsw._watched_modules = {
+            watched_path: local_sources_watcher.WatchedModule(MagicMock(), None)
+        }
+
+        with (
+            patch.object(
+                local_sources_watcher.os.path, "realpath", side_effect=lambda p: p
+            ),
+            patch.object(local_sources_watcher.os.path, "isdir", return_value=True),
+            patch.object(local_sources_watcher.util.env_util, "IS_WINDOWS", True),
+        ):
+            lsw.on_path_changed(changed_path)
+
+        callback.assert_called_once_with(changed_path)
+
+    @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     @patch("os.path.isdir")
     def test_folder_watch_list(self, mock_isdir, mock_path_watcher):
         watch_folders = ["/watch/path1", "/watch/path2"]

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -114,6 +114,7 @@ class DirHelperTests(unittest.TestCase):
         assert filename_prefixes == ["01", "02", "03"]
 
     def test_dirfiles_ignores_python_cache_artifacts(self):
+        """Test that _dirfiles excludes __pycache__, .pyc, and .pyo artifacts."""
         test_dir = Path(self._test_dir.name)
         cache_dir = test_dir / "__pycache__"
         cache_dir.mkdir()
@@ -140,6 +141,7 @@ class DirHelperTests(unittest.TestCase):
 
 class PathComparisonTests(unittest.TestCase):
     def test_windows_extended_paths_match_standard_paths(self):
+        """Test that extended-length/UNC Windows paths match their standard spelling."""
         with patch.object(util.env_util, "IS_WINDOWS", True):
             assert util.paths_are_same(
                 r"C:\project\module.py", r"\\?\c:\PROJECT\module.py"
@@ -153,6 +155,7 @@ class PathComparisonTests(unittest.TestCase):
             )
 
     def test_windows_paths_on_different_drives_do_not_match(self):
+        """Test that paths on different drives or distinct files are not matched."""
         with patch.object(util.env_util, "IS_WINDOWS", True):
             assert not util.path_is_in_directory(r"D:\project\module.py", r"C:\project")
             # Normalization must not collapse genuinely different files into a
@@ -162,6 +165,7 @@ class PathComparisonTests(unittest.TestCase):
             )
 
     def test_path_is_in_directory_handles_commonpath_value_error(self):
+        """Test that path_is_in_directory returns False when commonpath raises."""
         with patch.object(util.os.path, "commonpath", side_effect=ValueError):
             assert not util.path_is_in_directory("/other/file.py", "/watched")
 

--- a/lib/tests/streamlit/watcher/util_test.py
+++ b/lib/tests/streamlit/watcher/util_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -112,6 +113,20 @@ class DirHelperTests(unittest.TestCase):
         filename_prefixes = [f[:2] for f in dirfiles.split("+")]
         assert filename_prefixes == ["01", "02", "03"]
 
+    def test_dirfiles_ignores_python_cache_artifacts(self):
+        test_dir = Path(self._test_dir.name)
+        cache_dir = test_dir / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "module.cpython-313.pyc").write_bytes(b"compiled")
+        (test_dir / "legacy.pyc").write_bytes(b"compiled")
+        (test_dir / "optimized.pyo").write_bytes(b"compiled")
+
+        dirfiles = util._dirfiles(self._test_dir.name, "**/*")
+
+        assert "__pycache__" not in dirfiles
+        assert ".pyc" not in dirfiles
+        assert ".pyo" not in dirfiles
+
     @patch("streamlit.watcher.util._dirfiles", MagicMock(side_effect=["foo", "foo"]))
     def test_stable_dir(self):
         assert util._stable_dir_identifier("my_dir", "*") == "my_dir+foo"
@@ -121,6 +136,34 @@ class DirHelperTests(unittest.TestCase):
     )
     def test_stable_dir_files_change(self):
         assert util._stable_dir_identifier("my_dir", "*") == "my_dir+bar"
+
+
+class PathComparisonTests(unittest.TestCase):
+    def test_windows_extended_paths_match_standard_paths(self):
+        with patch.object(util.env_util, "IS_WINDOWS", True):
+            assert util.paths_are_same(
+                r"C:\project\module.py", r"\\?\c:\PROJECT\module.py"
+            )
+            assert util.paths_are_same(
+                r"\\server\share\module.py",
+                r"\\?\UNC\SERVER\share\module.py",
+            )
+            assert util.path_is_in_directory(
+                r"\\?\C:\project\__pycache__\module.pyc", r"C:\project"
+            )
+
+    def test_windows_paths_on_different_drives_do_not_match(self):
+        with patch.object(util.env_util, "IS_WINDOWS", True):
+            assert not util.path_is_in_directory(r"D:\project\module.py", r"C:\project")
+            # Normalization must not collapse genuinely different files into a
+            # match (guards against over-matching).
+            assert not util.paths_are_same(
+                r"C:\project\module.py", r"C:\project\other.py"
+            )
+
+    def test_path_is_in_directory_handles_commonpath_value_error(self):
+        with patch.object(util.os.path, "commonpath", side_effect=ValueError):
+            assert not util.path_is_in_directory("/other/file.py", "/watched")
 
 
 class RaceConditionTests(unittest.TestCase):


### PR DESCRIPTION
## Describe your changes

Fixes a Windows-only crash where the file-watcher observer thread died with `ValueError: Paths don't have the same drive` (from `os.path.commonpath`), after which hot-reload silently stopped detecting code changes.

- Route all watched-path comparisons through new `util.paths_are_same()` / `util.path_is_in_directory()` helpers that guard `commonpath` against the `ValueError` (paths on different drives can never be a child path).
- Normalize Windows extended-length paths (`\\?\C:\...` and `\\?\UNC\...`) to their standard spelling before comparing, so events reported with the extended prefix still match the watched file/directory.
- Exclude `__pycache__`, `.pyc`, and `.pyo` artifacts from the stable directory identifier to avoid spurious reloads from bytecode regeneration.

Non-Windows behavior is unchanged (`normcase` is identity and `commonpath` results are the same).

## GitHub Issue Link (if applicable)

- Closes #12731

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/watcher/util_test.py` — extended-length/UNC path equivalence, different-drive and different-file negatives, `commonpath` `ValueError` handling, and `__pycache__`/`.pyc`/`.pyo` exclusion.
  - `lib/tests/streamlit/watcher/local_sources_watcher_test.py` — extended Windows path matches a watched file and a watched directory.
  - `lib/tests/streamlit/watcher/event_based_path_watcher_test.py` — equivalent path spellings match the same watched file; different-drive event is ignored without crashing.
- The crash is Windows-specific; the OS-dependent logic is exercised on any platform by patching `env_util.IS_WINDOWS`.

Made with [Cursor](https://cursor.com)