### PR TITLE
[fix] Apply initial_sidebar_state on page navigation

### DIFF
--- a/e2e_playwright/st_sidebar_page_navigation.py
+++ b/e2e_playwright/st_sidebar_page_navigation.py
@@ -27,6 +27,10 @@ def collapsed_page() -> None:
     st.header("Collapsed page")
     st.sidebar.write("Collapsed page sidebar")
     st.button("Rerun collapsed page")
+    # Main-content navigation stays reachable while the sidebar (and its nav
+    # links) is collapsed, so tests can enter another page without expanding it.
+    if st.button("Switch to expanded page"):
+        st.switch_page(expanded)
 
 
 def unconfigured_page() -> None:
@@ -34,10 +38,8 @@ def unconfigured_page() -> None:
     st.sidebar.write("Unconfigured page sidebar")
 
 
-st.navigation(
-    [
-        st.Page(expanded_page, title="Expanded", default=True),
-        st.Page(collapsed_page, title="Collapsed"),
-        st.Page(unconfigured_page, title="Unconfigured"),
-    ]
-).run()
+expanded = st.Page(expanded_page, title="Expanded", default=True)
+collapsed = st.Page(collapsed_page, title="Collapsed")
+unconfigured = st.Page(unconfigured_page, title="Unconfigured")
+
+st.navigation([expanded, collapsed, unconfigured]).run()

--- a/e2e_playwright/st_sidebar_page_navigation.py
+++ b/e2e_playwright/st_sidebar_page_navigation.py
@@ -1,0 +1,43 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+
+def expanded_page() -> None:
+    st.set_page_config(initial_sidebar_state="expanded")
+    st.header("Expanded page")
+    st.sidebar.write("Expanded page sidebar")
+    st.button("Rerun expanded page")
+
+
+def collapsed_page() -> None:
+    st.set_page_config(initial_sidebar_state="collapsed")
+    st.header("Collapsed page")
+    st.sidebar.write("Collapsed page sidebar")
+    st.button("Rerun collapsed page")
+
+
+def unconfigured_page() -> None:
+    st.header("Unconfigured page")
+    st.sidebar.write("Unconfigured page sidebar")
+
+
+st.navigation(
+    [
+        st.Page(expanded_page, title="Expanded", default=True),
+        st.Page(collapsed_page, title="Collapsed"),
+        st.Page(unconfigured_page, title="Unconfigured"),
+    ]
+).run()

--- a/e2e_playwright/st_sidebar_page_navigation_test.py
+++ b/e2e_playwright/st_sidebar_page_navigation_test.py
@@ -69,10 +69,28 @@ def test_explicit_sidebar_state_applies_only_on_page_navigation(app: Page) -> No
     wait_for_app_run(app)
     expect(sidebar).to_have_attribute("aria-expanded", "false")
 
-    # Expand via a user action so navigation is available, then verify a page
-    # without explicit config uses the persisted expanded preference.
-    app.get_by_test_id("stExpandSidebarButton").click()
+    # Force-expand direction (issue #12065 is bidirectional): entering a page
+    # whose explicit state is "expanded" must expand a collapsed sidebar, even
+    # over a persisted collapsed preference. The sidebar is still collapsed here,
+    # so navigate via the main-content button rather than a (hidden) nav link.
+    app.evaluate("window.localStorage.setItem('stSidebarCollapsed-', 'true')")
+    app.get_by_role("button", name="Switch to expanded page").click()
+    wait_for_app_run(app)
+    expect(
+        app.get_by_test_id("stHeading").filter(has_text="Expanded page")
+    ).to_be_visible()
     expect(sidebar).to_have_attribute("aria-expanded", "true")
+
+    # The page-entry override must not overwrite the user's stored preference.
+    wait_until(
+        app,
+        lambda: (
+            app.evaluate("window.localStorage.getItem('stSidebarCollapsed-')") == "true"
+        ),
+    )
+
+    # A page without explicit config uses the persisted preference: the stored
+    # collapsed value now wins on entry to the unconfigured page.
     _sidebar_nav_link(app, "Unconfigured").click()
     wait_for_app_run(app)
-    expect(sidebar).to_have_attribute("aria-expanded", "true")
+    expect(sidebar).to_have_attribute("aria-expanded", "false")

--- a/e2e_playwright/st_sidebar_page_navigation_test.py
+++ b/e2e_playwright/st_sidebar_page_navigation_test.py
@@ -14,7 +14,11 @@
 
 from playwright.sync_api import Locator, Page, expect
 
-from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
+from e2e_playwright.conftest import (
+    wait_for_app_loaded,
+    wait_for_app_run,
+    wait_until,
+)
 
 
 def _sidebar_nav_link(app: Page, name: str) -> Locator:
@@ -44,7 +48,13 @@ def test_explicit_sidebar_state_applies_only_on_page_navigation(app: Page) -> No
     expect(sidebar).to_have_attribute("aria-expanded", "false")
 
     # Page configuration must not overwrite the user-owned storage value.
-    assert app.evaluate("window.localStorage.getItem('stSidebarCollapsed-')") == "false"
+    wait_until(
+        app,
+        lambda: (
+            app.evaluate("window.localStorage.getItem('stSidebarCollapsed-')")
+            == "false"
+        ),
+    )
 
     # A browser reload is not an in-app page transition, so the stored user
     # preference continues to win over the page's initial config.

--- a/e2e_playwright/st_sidebar_page_navigation_test.py
+++ b/e2e_playwright/st_sidebar_page_navigation_test.py
@@ -1,0 +1,68 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.conftest import wait_for_app_loaded, wait_for_app_run
+
+
+def _sidebar_nav_link(app: Page, name: str) -> Locator:
+    return app.get_by_test_id("stSidebarNavLink").filter(has_text=name)
+
+
+def test_explicit_sidebar_state_applies_only_on_page_navigation(app: Page) -> None:
+    sidebar = app.get_by_test_id("stSidebar")
+    expect(sidebar).to_have_attribute("aria-expanded", "true")
+
+    # Establish the pre-existing user preference that should keep winning on
+    # initial loads and reloads.
+    app.evaluate("window.localStorage.setItem('stSidebarCollapsed-', 'false')")
+
+    _sidebar_nav_link(app, "Collapsed").click()
+    wait_for_app_run(app)
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
+    expect(
+        app.get_by_test_id("stHeading").filter(has_text="Collapsed page")
+    ).to_be_visible()
+
+    # The page-entry override survives a same-page rerun and a desktop resize.
+    app.get_by_role("button", name="Rerun collapsed page").click()
+    wait_for_app_run(app)
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
+    app.set_viewport_size({"width": 1100, "height": 800})
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
+
+    # Page configuration must not overwrite the user-owned storage value.
+    assert app.evaluate("window.localStorage.getItem('stSidebarCollapsed-')") == "false"
+
+    # A browser reload is not an in-app page transition, so the stored user
+    # preference continues to win over the page's initial config.
+    app.reload()
+    wait_for_app_loaded(app)
+    expect(sidebar).to_have_attribute("aria-expanded", "true")
+
+    # Re-entering the collapsed page applies its explicit state again.
+    _sidebar_nav_link(app, "Expanded").click()
+    wait_for_app_run(app)
+    _sidebar_nav_link(app, "Collapsed").click()
+    wait_for_app_run(app)
+    expect(sidebar).to_have_attribute("aria-expanded", "false")
+
+    # Expand via a user action so navigation is available, then verify a page
+    # without explicit config uses the persisted expanded preference.
+    app.get_by_test_id("stExpandSidebarButton").click()
+    expect(sidebar).to_have_attribute("aria-expanded", "true")
+    _sidebar_nav_link(app, "Unconfigured").click()
+    wait_for_app_run(app)
+    expect(sidebar).to_have_attribute("aria-expanded", "true")

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -87,6 +87,7 @@ import {
   IPageNotFound,
   IParentMessage,
   Navigation,
+  PageConfig,
   SessionEvent,
   SessionStatus,
   TextInput,
@@ -1826,7 +1827,31 @@ describe("App", () => {
 
     afterEach(() => {
       document.title = documentTitle
+      window.localStorage.clear()
     })
+
+    const TWO_PAGE_NAV_APP_PAGES = [
+      {
+        pageScriptHash: "page_script_hash",
+        pageName: "Page 1",
+        urlPathname: "page-1",
+        isDefault: true,
+      },
+      {
+        pageScriptHash: "page_2_hash",
+        pageName: "Page 2",
+        urlPathname: "page-2",
+      },
+    ]
+
+    const sendTwoPageNavigation = (pageScriptHash: string): void => {
+      sendForwardMessage("navigation", {
+        appPages: TWO_PAGE_NAV_APP_PAGES,
+        pageScriptHash,
+        position: Navigation.Position.SIDEBAR,
+        sections: [],
+      })
+    }
 
     it("sets document title when 'PageConfig.title' is set", () => {
       renderApp(getProps())
@@ -1835,6 +1860,69 @@ describe("App", () => {
       })
 
       expect(document.title).toBe("Jabberwocky")
+    })
+
+    it("applies explicit sidebar state when entering a different page", () => {
+      window.localStorage.setItem("stSidebarCollapsed-", "false")
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendTwoPageNavigation("page_script_hash")
+      sendForwardMessage(
+        "pageConfigChanged",
+        { initialSidebarState: PageConfig.SidebarState.COLLAPSED },
+        { activeScriptHash: "page_script_hash" }
+      )
+
+      // On initial load, the existing persisted preference remains
+      // authoritative even when the page config says collapsed.
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      )
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        pageScriptHash: "page_2_hash",
+        scriptRunId: "page_2_run_id",
+      })
+      sendTwoPageNavigation("page_2_hash")
+      sendForwardMessage(
+        "pageConfigChanged",
+        { initialSidebarState: PageConfig.SidebarState.COLLAPSED },
+        { activeScriptHash: "page_2_hash" }
+      )
+
+      // The destination config applies even though it has the same enum value
+      // as the source page, so navigation cannot rely on value inequality.
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      )
+      expect(window.localStorage.getItem("stSidebarCollapsed-")).toBe("false")
+    })
+
+    it("does not treat common-script page config as destination config", () => {
+      window.localStorage.setItem("stSidebarCollapsed-", "false")
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", NEW_SESSION_JSON)
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        pageScriptHash: "page_2_hash",
+        scriptRunId: "page_2_run_id",
+      })
+      sendTwoPageNavigation("page_2_hash")
+      sendForwardMessage(
+        "pageConfigChanged",
+        { initialSidebarState: PageConfig.SidebarState.COLLAPSED },
+        { activeScriptHash: "page_hash" }
+      )
+
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      )
     })
   })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -193,6 +193,9 @@ interface State {
   connectionErrorDismissed: boolean
   layout: PageConfig.Layout
   initialSidebarState: PageConfig.SidebarState
+  // Bumped when an explicit sidebar state is received while entering a
+  // different page. AppView uses this to distinguish page entry from reruns.
+  sidebarPageChangeSequence: number
   initialSidebarWidth?: number
   menuItems?: PageConfig.IMenuItems | null
   allowRunOnSave: boolean
@@ -309,6 +312,11 @@ export class App extends PureComponent<Props, State> {
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
 
+  // The page whose explicit sidebar config should be applied on entry. This is
+  // intentionally imperative: it only lives while messages for that page's
+  // first full run are arriving.
+  private pendingSidebarPageScriptHash: string | null = null
+
   // Active `run_every` auto-rerun timers, keyed by fragment id. These are
   // imperative resources (setInterval handles), so they live outside of React
   // state. Keying by fragment id lets us keep a single timer per fragment: we
@@ -353,6 +361,7 @@ export class App extends PureComponent<Props, State> {
       connectionErrorDismissed: false,
       layout: PageConfig.Layout.CENTERED,
       initialSidebarState: PageConfig.SidebarState.AUTO,
+      sidebarPageChangeSequence: 0,
       initialSidebarWidth: undefined,
       menuItems: undefined,
       allowRunOnSave: true,
@@ -1040,7 +1049,10 @@ export class App extends PureComponent<Props, State> {
             msgProto.hash
           ),
         pageConfigChanged: (pageConfig: PageConfig) =>
-          this.handlePageConfigChanged(pageConfig),
+          this.handlePageConfigChanged(
+            pageConfig,
+            msgProto.metadata as ForwardMsgMetadata
+          ),
         pageInfoChanged: (pageInfo: PageInfo) =>
           this.handlePageInfoChanged(pageInfo),
         pageNotFound: (pageNotFound: PageNotFound) =>
@@ -1093,7 +1105,10 @@ export class App extends PureComponent<Props, State> {
     })
   }
 
-  handlePageConfigChanged = (pageConfig: PageConfig): void => {
+  handlePageConfigChanged = (
+    pageConfig: PageConfig,
+    metadata?: ForwardMsgMetadata
+  ): void => {
     const {
       title,
       favicon,
@@ -1133,13 +1148,31 @@ export class App extends PureComponent<Props, State> {
       }))
     }
 
-    if (
-      initialSidebarState !== this.state.initialSidebarState &&
-      initialSidebarState !== PageConfig.SidebarState.SIDEBAR_UNSET
-    ) {
-      this.setState(() => ({
-        initialSidebarState,
-      }))
+    if (initialSidebarState !== PageConfig.SidebarState.SIDEBAR_UNSET) {
+      // Only treat this config as a page-entry override when it originates from
+      // the body of the page being entered (its activeScriptHash matches the
+      // pending page). Config emitted from the shared main script runs on every
+      // page and would report a different activeScriptHash, so it is
+      // intentionally excluded and falls back to the value-change handling below.
+      const appliesOnPageChange =
+        this.pendingSidebarPageScriptHash !== null &&
+        metadata?.activeScriptHash === this.pendingSidebarPageScriptHash
+
+      if (
+        initialSidebarState !== this.state.initialSidebarState ||
+        appliesOnPageChange
+      ) {
+        this.setState(prevState => ({
+          initialSidebarState,
+          sidebarPageChangeSequence: appliesOnPageChange
+            ? prevState.sidebarPageChangeSequence + 1
+            : prevState.sidebarPageChangeSequence,
+        }))
+      }
+
+      if (appliesOnPageChange) {
+        this.pendingSidebarPageScriptHash = null
+      }
     }
 
     // Extract pixelWidth from SidebarWidthConfig message
@@ -1479,6 +1512,16 @@ export class App extends PureComponent<Props, State> {
       this.sessionInfo.current.installationId + mainScriptPath
     )
 
+    if (
+      !fragmentIdsThisRun.length &&
+      appHash === newSessionHash &&
+      prevPageScriptHash !== "" &&
+      newPageScriptHash !== "" &&
+      prevPageScriptHash !== newPageScriptHash
+    ) {
+      this.pendingSidebarPageScriptHash = newPageScriptHash
+    }
+
     this.metricsMgr.setMetadata(this.state.deployedAppMetadata)
     this.metricsMgr.setAppHash(newSessionHash)
 
@@ -1775,6 +1818,14 @@ export class App extends PureComponent<Props, State> {
       scriptRunFinishedSequence: prevState.scriptRunFinishedSequence + 1,
       scriptRunFinishedFragmentIds: prevState.fragmentIdsThisRun,
     }))
+
+    if (
+      this.hasReceivedNewSession &&
+      (status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
+        status === ForwardMsg.ScriptFinishedStatus.FINISHED_WITH_COMPILE_ERROR)
+    ) {
+      this.pendingSidebarPageScriptHash = null
+    }
 
     if (
       status === ForwardMsg.ScriptFinishedStatus.FINISHED_SUCCESSFULLY ||
@@ -2592,6 +2643,7 @@ export class App extends PureComponent<Props, State> {
       appPages,
       navSections,
       navigationPosition,
+      sidebarPageChangeSequence,
       scriptChangedOnDisk,
     } = this.state
 
@@ -2686,6 +2738,7 @@ export class App extends PureComponent<Props, State> {
               widgetMgr={this.widgetMgr}
               uploadClient={this.uploadClient}
               navigationPosition={effectiveNavigationPosition}
+              sidebarPageChangeSequence={sidebarPageChangeSequence}
               wideMode={userSettings.wideMode}
               embedded={isEmbed()}
               showPadding={showPadding}

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -1599,6 +1599,48 @@ describe("AppView element", () => {
       )
     })
 
+    it("keeps a locked desktop sidebar open when entering a page", () => {
+      // A stored collapsed preference must not win, and neither should the
+      // page-entry override path collapse a locked sidebar.
+      window.localStorage.setItem("stSidebarCollapsed-", "true")
+
+      const initialProps = getProps({
+        elements: elementsWithSidebar,
+        sidebarPageChangeSequence: 0,
+      })
+      const { rerenderWithContexts } = renderWithContexts(
+        <AppView {...initialProps} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.LOCKED,
+          },
+          navigationContext: { currentPageScriptHash: "page-1" },
+        }
+      )
+
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      )
+
+      // Entering a new page bumps the sequence; the locked sidebar must stay
+      // open through the page-entry branch instead of being collapsed.
+      rerenderWithContexts(
+        <AppView {...initialProps} sidebarPageChangeSequence={1} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.LOCKED,
+          },
+          navigationContext: { currentPageScriptHash: "page-2" },
+        }
+      )
+
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      )
+    })
+
     it("uses persisted state on a later page without explicit sidebar config", () => {
       window.localStorage.setItem("stSidebarCollapsed-", "false")
 

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -106,6 +106,7 @@ function getProps(props: Partial<AppViewProps> = {}): AppViewProps {
     showPadding: false,
     disableScrolling: false,
     navigationPosition: Navigation.Position.SIDEBAR,
+    sidebarPageChangeSequence: 0,
     addScriptFinishedHandler: vi.fn(),
     removeScriptFinishedHandler: vi.fn(),
     componentRegistry: new ComponentRegistry(mockEndpointProp),
@@ -1544,6 +1545,146 @@ describe("AppView element", () => {
 
       const sidebarDOMElement = screen.getByTestId("stSidebar")
       expect(sidebarDOMElement).toHaveAttribute("aria-expanded", "true")
+    })
+
+    it("applies explicit sidebar config when entering a different page", () => {
+      window.localStorage.setItem("stSidebarCollapsed-", "false")
+
+      const initialProps = getProps({
+        elements: elementsWithSidebar,
+        sidebarPageChangeSequence: 0,
+      })
+      const { rerenderWithContexts } = renderWithContexts(
+        <AppView {...initialProps} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.EXPANDED,
+          },
+          navigationContext: { currentPageScriptHash: "page-1" },
+        }
+      )
+
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      )
+
+      rerenderWithContexts(
+        <AppView {...initialProps} sidebarPageChangeSequence={1} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+          },
+          navigationContext: { currentPageScriptHash: "page-2" },
+        }
+      )
+
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      )
+      // Page config is an in-memory entry override, not a user preference.
+      expect(window.localStorage.getItem("stSidebarCollapsed-")).toBe("false")
+
+      // A same-page rerender must not restore the older stored preference.
+      rerenderWithContexts(
+        <AppView {...initialProps} sidebarPageChangeSequence={1} />,
+        {
+          navigationContext: { currentPageScriptHash: "page-2" },
+        }
+      )
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      )
+    })
+
+    it("uses persisted state on a later page without explicit sidebar config", () => {
+      window.localStorage.setItem("stSidebarCollapsed-", "false")
+
+      const initialProps = getProps({
+        elements: elementsWithSidebar,
+        sidebarPageChangeSequence: 0,
+      })
+      const { rerenderWithContexts } = renderWithContexts(
+        <AppView {...initialProps} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.EXPANDED,
+          },
+          navigationContext: { currentPageScriptHash: "page-1" },
+        }
+      )
+
+      rerenderWithContexts(
+        <AppView {...initialProps} sidebarPageChangeSequence={1} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+          },
+          navigationContext: { currentPageScriptHash: "page-2" },
+        }
+      )
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      )
+
+      // No new sequence means page 3 did not explicitly configure its state.
+      rerenderWithContexts(
+        <AppView {...initialProps} sidebarPageChangeSequence={1} />,
+        {
+          navigationContext: { currentPageScriptHash: "page-3" },
+        }
+      )
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "true"
+      )
+    })
+
+    it("retains page-entry config received before sidebar content", () => {
+      window.localStorage.setItem("stSidebarCollapsed-", "false")
+
+      const initialProps = getProps({
+        sidebarPageChangeSequence: 0,
+        navigationPosition: Navigation.Position.HIDDEN,
+      })
+      const { rerenderWithContexts } = renderWithContexts(
+        <AppView {...initialProps} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.EXPANDED,
+            hideSidebarNav: true,
+          },
+          navigationContext: { currentPageScriptHash: "page-1" },
+        }
+      )
+
+      expect(screen.queryByTestId("stSidebar")).not.toBeInTheDocument()
+
+      rerenderWithContexts(
+        <AppView {...initialProps} sidebarPageChangeSequence={1} />,
+        {
+          sidebarConfigContext: {
+            initialSidebarState: PageConfig.SidebarState.COLLAPSED,
+          },
+          navigationContext: { currentPageScriptHash: "page-2" },
+        }
+      )
+
+      rerenderWithContexts(
+        <AppView
+          {...initialProps}
+          elements={elementsWithSidebar}
+          sidebarPageChangeSequence={1}
+        />
+      )
+
+      expect(screen.getByTestId("stSidebar")).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      )
     })
 
     it("handles invalid localStorage values gracefully", () => {

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -58,7 +58,7 @@ import {
   useWindowDimensionsContext,
   WidgetStateManager,
 } from "@streamlit/lib"
-import { Navigation } from "@streamlit/protobuf"
+import { Navigation, PageConfig } from "@streamlit/protobuf"
 
 import ScrollToBottomContainer from "./ScrollToBottomContainer"
 import {
@@ -116,6 +116,13 @@ export interface AppViewProps {
 
   navigationPosition: Navigation.Position
 
+  /**
+   * Bumped when an explicit sidebar state is received while entering a new
+   * page. This is intentionally separate from initialSidebarState because two
+   * adjacent pages can configure the same value.
+   */
+  sidebarPageChangeSequence: number
+
   topRightContent?: React.ReactNode
 
   wideMode: boolean
@@ -158,6 +165,7 @@ function AppView(props: AppViewProps): ReactElement {
     sendMessageToHost,
     endpoints,
     navigationPosition,
+    sidebarPageChangeSequence,
     topRightContent,
     wideMode,
     embedded,
@@ -209,7 +217,8 @@ function AppView(props: AppViewProps): ReactElement {
 
   const { activeTheme } = useContext(ThemeContext)
 
-  const { appPages, pageLinkBaseUrl } = useContext(NavigationContext)
+  const { appPages, pageLinkBaseUrl, currentPageScriptHash } =
+    useContext(NavigationContext)
 
   const { initialSidebarState, appLogo, hideSidebarNav, isSidebarLocked } =
     useContext(SidebarConfigContext)
@@ -308,11 +317,65 @@ function AppView(props: AppViewProps): ReactElement {
     )
   })
 
+  const previousPageScriptHashRef = useRef(currentPageScriptHash)
+  const consumedSidebarPageChangeSequenceRef = useRef(
+    sidebarPageChangeSequence
+  )
+  const pageEntrySidebarStateRef = useRef<PageConfig.SidebarState | null>(null)
+
+  // Reconcile the sidebar collapse state during render (the sanctioned
+  // "adjust state when a prop changes" pattern) instead of an effect. The refs
+  // below are consumed and updated in the same pass, so this relies on React
+  // committing the accompanying setSidebarIsCollapsed update synchronously. The
+  // page-entry override is only driven by non-transition ForwardMsg updates
+  // (which commit), so a discarded/interrupted render dropping the override is
+  // not a concern in practice.
   useExecuteWhenChanged(() => {
+    const collapseForSidebarState = (
+      sidebarState: PageConfig.SidebarState
+    ): void => {
+      setSidebarIsCollapsed(
+        shouldCollapse(
+          sidebarState,
+          parseInt(activeTheme.emotion.breakpoints.md, 10),
+          innerWidth
+        )
+      )
+    }
+
+    const previousPageScriptHash = previousPageScriptHashRef.current
+    const pageChanged =
+      previousPageScriptHash !== "" &&
+      currentPageScriptHash !== "" &&
+      previousPageScriptHash !== currentPageScriptHash
+    previousPageScriptHashRef.current = currentPageScriptHash
+
+    const hasExplicitPageEntryState =
+      consumedSidebarPageChangeSequenceRef.current !==
+      sidebarPageChangeSequence
+
+    if (hasExplicitPageEntryState && innerWidth > 0) {
+      consumedSidebarPageChangeSequenceRef.current = sidebarPageChangeSequence
+      pageEntrySidebarStateRef.current = initialSidebarState
+      collapseForSidebarState(initialSidebarState)
+      return
+    }
+
+    if (pageChanged) {
+      // A destination without an explicit sidebar state falls back to the
+      // user's persisted preference.
+      pageEntrySidebarStateRef.current = null
+    }
+
     if (innerWidth > 0 && showSidebar) {
       // Locked sidebar (desktop only) always stays open; skip saved preference.
       if (isEffectivelyLocked) {
         setSidebarIsCollapsed(false)
+        return
+      }
+
+      if (pageEntrySidebarStateRef.current !== null) {
+        collapseForSidebarState(pageEntrySidebarStateRef.current)
         return
       }
 
@@ -322,13 +385,7 @@ function AppView(props: AppViewProps): ReactElement {
         // User has adjusted the sidebar, respect it
         setSidebarIsCollapsed(savedSidebarState)
       } else {
-        setSidebarIsCollapsed(
-          shouldCollapse(
-            initialSidebarState,
-            parseInt(activeTheme.emotion.breakpoints.md, 10),
-            innerWidth
-          )
-        )
+        collapseForSidebarState(initialSidebarState)
       }
     }
   }, [
@@ -338,6 +395,8 @@ function AppView(props: AppViewProps): ReactElement {
     activeTheme.emotion.breakpoints.md,
     pageLinkBaseUrl,
     isEffectivelyLocked,
+    currentPageScriptHash,
+    sidebarPageChangeSequence,
   ])
 
   const setSidebarCollapsedWithOptionalPersistence = useCallback(
@@ -345,6 +404,9 @@ function AppView(props: AppViewProps): ReactElement {
       // Locked sidebar (desktop only) cannot be collapsed; skip localStorage writes.
       if (isEffectivelyLocked) {
         return
+      }
+      if (shouldPersist) {
+        pageEntrySidebarStateRef.current = null
       }
       setSidebarIsCollapsed(isCollapsed)
       if (shouldPersist) {

--- a/frontend/app/src/components/AppView/AppView.tsx
+++ b/frontend/app/src/components/AppView/AppView.tsx
@@ -357,7 +357,14 @@ function AppView(props: AppViewProps): ReactElement {
     if (hasExplicitPageEntryState && innerWidth > 0) {
       consumedSidebarPageChangeSequenceRef.current = sidebarPageChangeSequence
       pageEntrySidebarStateRef.current = initialSidebarState
-      collapseForSidebarState(initialSidebarState)
+      if (isEffectivelyLocked) {
+        // A locked desktop sidebar stays open and non-dismissible; page-entry
+        // config must not collapse it. Keep this consistent with the locked
+        // guard below and in setSidebarCollapsedWithOptionalPersistence.
+        setSidebarIsCollapsed(false)
+      } else {
+        collapseForSidebarState(initialSidebarState)
+      }
       return
     }
 


### PR DESCRIPTION
## Describe your changes

Multipage apps now honor a destination page's explicit `initial_sidebar_state` on page entry, fixing a regression where the sidebar stayed open when navigating to a page configured with `initial_sidebar_state="collapsed"` (and vice versa).

- On **page navigation**, the destination page's explicit `initial_sidebar_state` is applied — even when adjacent pages configure the same enum value (so we can't rely on value inequality). A `sidebarPageChangeSequence` counter drives this, gated on the incoming `PageConfig` message's `activeScriptHash` matching the page being entered (config from the shared main script is intentionally excluded).
- On **reruns, browser reloads, and pages without an explicit config**, the user's persisted sidebar preference continues to win, so page config never overwrites a user-owned choice.

## Screenshot or video (only for visual changes)

## GitHub Issue Link (if applicable)

- Closes #12065

## Testing Plan

- `frontend/app/src/App.test.tsx` — page-entry override is applied on navigation (incl. equal enum values across pages), and shared-main-script config is not treated as a page-entry override.
- `frontend/app/src/components/AppView/AppView.test.tsx` — sequence-driven apply, fallback to persisted preference on unconfigured pages, and page-entry config received before the sidebar content renders.
- `e2e_playwright/st_sidebar_page_navigation_test.py` — end-to-end navigation, same-page rerun + desktop resize persistence, localStorage not overwritten, reload honoring the stored preference, re-entry re-applying, and an unconfigured page using the persisted preference.

Made with [Cursor](https://cursor.com)