### PR TITLE
Fix widget ID cleanup when clearing st.empty placeholders

### DIFF
--- a/lib/streamlit/elements/empty.py
+++ b/lib/streamlit/elements/empty.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, cast
 
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner import get_script_run_ctx
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -96,6 +97,12 @@ class EmptyMixin:
 
         """
         empty_proto = EmptyProto()
+        ctx = get_script_run_ctx()
+        if ctx is not None and self.dg._cursor is not None:
+            ctx.shared.clear_widget_registrations_at_delta_path(
+                tuple(self.dg._cursor.delta_path)
+            )
+
         return self.dg._enqueue("empty", empty_proto)
 
     @property

--- a/lib/streamlit/elements/lib/utils.py
+++ b/lib/streamlit/elements/lib/utils.py
@@ -111,7 +111,11 @@ def to_key(key: Key | None) -> str | None:
 
 
 def _register_element_id(
-    ctx: ScriptRunContext, element_type: str, element_id: str
+    ctx: ScriptRunContext,
+    element_type: str,
+
+        element_id: str,
+    delta_path: tuple[int, ...] | None = None,
 ) -> None:
     """Register the element ID and key for the given element.
 
@@ -144,6 +148,8 @@ def _register_element_id(
 
     if not ctx.shared.widget_ids_this_run.check_and_add(element_id):
         raise StreamlitDuplicateElementId(element_type)
+
+    ctx.shared.track_element_id_delta_path(element_id, user_key, delta_path)
 
 
 def _compute_element_id(
@@ -243,6 +249,10 @@ def compute_and_register_element_id(
         kwargs_to_use = {} if ignore_command_kwargs else {**kwargs}
 
     if ctx:
+        delta_path = None
+        if dg is not None and dg._active_dg._cursor is not None:
+            delta_path = tuple(dg._active_dg._cursor.delta_path)
+
         # Add the active script hash to give elements on different
         # pages unique IDs. This is added even if
         # key_as_main_identity is specified.
@@ -258,7 +268,7 @@ def compute_and_register_element_id(
     element_id = _compute_element_id(element_type, user_key, **kwargs_to_use)
 
     if ctx:
-        _register_element_id(ctx, element_type, element_id)
+        _register_element_id(ctx, element_type, element_id, delta_path)
     return element_id
 
 

--- a/lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py
@@ -38,6 +38,10 @@ class SharedRunState:
         self.form_ids_this_run: ThreadSafeSet[str] = ThreadSafeSet()
         self.new_fragment_ids: ThreadSafeSet[str] = ThreadSafeSet()
 
+         self._element_ids_by_delta_path_lock = threading.Lock()
+        self._element_ids_by_delta_path: dict[tuple[int, ...], set[str]] = {}
+        self._user_keys_by_delta_path: dict[tuple[int, ...], set[str]] = {}
+
         self._telemetry_lock = threading.Lock()
         self._tracked_commands: list[Command] = []
         self._tracked_commands_counter: collections.Counter[str] = collections.Counter()
@@ -53,9 +57,56 @@ class SharedRunState:
         self.form_ids_this_run.clear()
         self.new_fragment_ids.clear()
 
+        with self._element_ids_by_delta_path_lock:
+            self._element_ids_by_delta_path.clear()
+            self._user_keys_by_delta_path.clear()
+
         with self._telemetry_lock:
             self._tracked_commands = []
             self._tracked_commands_counter = collections.Counter()
+
+    def track_element_id_delta_path(
+        self,
+        element_id: str,
+        user_key: str | None,
+        delta_path: tuple[int, ...] | None,
+    ) -> None:
+        """Associate an element ID with the delta path it occupies."""
+        if delta_path is None:
+            return
+
+        with self._element_ids_by_delta_path_lock:
+            self._element_ids_by_delta_path.setdefault(delta_path, set()).add(
+                element_id
+            )
+            if user_key is not None:
+                self._user_keys_by_delta_path.setdefault(delta_path, set()).add(
+                    user_key
+                )
+
+    def clear_widget_registrations_at_delta_path(
+        self, delta_path: tuple[int, ...]
+    ) -> None:
+        """Clear same-run widget registrations at the given delta path.
+
+        ``st.empty`` replaces the element tree at its own delta path. Any
+        widgets registered at that path or beneath it no longer exist in the
+        visible app and should not block new widgets created later in the same
+        script run.
+        """
+        element_ids: set[str] = set()
+        user_keys: set[str] = set()
+        with self._element_ids_by_delta_path_lock:
+            for path in list(self._element_ids_by_delta_path):
+                if path[: len(delta_path)] == delta_path:
+                    element_ids.update(self._element_ids_by_delta_path.pop(path))
+                    user_keys.update(self._user_keys_by_delta_path.pop(path, set()))
+
+        if not element_ids:
+            return
+
+        self.widget_ids_this_run.difference_update(element_ids)
+        self.widget_user_keys_this_run.difference_update(user_keys)
 
     @property
     def tracked_commands(self) -> tuple[Command, ...]:

--- a/lib/streamlit/runtime/scriptrunner_utils/thread_safe_set.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/thread_safe_set.py
@@ -52,6 +52,11 @@ class ThreadSafeSet(Generic[T]):
         with self._lock:
             self._data.clear()
 
+    def difference_update(self, values: set[T]) -> None:
+        """Remove all values that exist in the provided set."""
+        with self._lock:
+            self._data.difference_update(values)
+
     def snapshot(self) -> frozenset[T]:
         """Return an immutable copy for read-only consumers."""
         with self._lock:

--- a/lib/tests/streamlit/elements/empty_test.py
+++ b/lib/tests/streamlit/elements/empty_test.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import streamlit as st
+from streamlit import errors
 from streamlit.proto.Empty_pb2 import Empty as EmptyProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -26,3 +29,43 @@ class StEmptyAPITest(DeltaGeneratorTestCase):
 
         el = self.get_delta_from_queue().new_element
         assert el.empty == EmptyProto()
+
+    def test_empty_allows_reusing_widget_ids_in_same_run(self):
+        """Test that clearing a placeholder releases nested widget IDs."""
+        placeholder = st.empty()
+
+        with placeholder.container():
+            st.number_input("One", value=1)
+            st.number_input("Two", value=2)
+
+        placeholder.empty()
+
+        with placeholder.container():
+            st.number_input("One", value=1)
+            st.number_input("Two", value=2)
+            st.number_input("Three", value=3)
+
+    def test_empty_allows_reusing_widget_user_keys_in_same_run(self):
+        """Test that clearing a placeholder releases nested widget user keys."""
+        placeholder = st.empty()
+
+        with placeholder.container():
+            st.number_input("One", value=1, key="one")
+
+        placeholder.empty()
+
+        with placeholder.container():
+            st.number_input("One", value=1, key="one")
+
+    def test_empty_does_not_clear_sibling_widget_ids(self):
+        """Test that clearing a placeholder preserves sibling duplicate checks."""
+        st.number_input("One", value=1)
+        placeholder = st.empty()
+
+        with placeholder.container():
+            st.number_input("Two", value=2)
+
+        placeholder.empty()
+
+        with pytest.raises(errors.DuplicateWidgetID):
+            st.number_input("One", value=1)

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/shared_run_state_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/shared_run_state_test.py
@@ -46,6 +46,28 @@ def test_reset_clears_all_fields() -> None:
     assert shared.command_count_for("markdown") == 0
 
 
+def test_clear_widget_registrations_at_delta_path() -> None:
+    """``clear_widget_registrations_at_delta_path`` clears only matching paths."""
+    shared = SharedRunState()
+    for widget_id, user_key, delta_path in [
+        ("nested_auto", None, (0, 1, 0)),
+        ("nested_keyed", "nested", (0, 1, 1)),
+        ("sibling", "sibling", (0, 2, 0)),
+    ]:
+        shared.widget_ids_this_run.check_and_add(widget_id)
+        if user_key is not None:
+            shared.widget_user_keys_this_run.check_and_add(user_key)
+        shared.track_element_id_delta_path(widget_id, user_key, delta_path)
+
+    shared.clear_widget_registrations_at_delta_path((0, 1))
+
+    assert "nested_auto" not in shared.widget_ids_this_run
+    assert "nested_keyed" not in shared.widget_ids_this_run
+    assert "nested" not in shared.widget_user_keys_this_run
+    assert "sibling" in shared.widget_ids_this_run
+    assert "sibling" in shared.widget_user_keys_this_run
+
+
 def test_track_command_appends_and_counts() -> None:
     """``track_command()`` records commands in the list and counter."""
     shared = SharedRunState()


### PR DESCRIPTION
## Describe your changes

Fixes same-run `DuplicateWidgetID` errors when widgets are rendered inside an `st.empty` placeholder, the placeholder is cleared, and equivalent widgets are rendered again later in the same script run.

Previously, `placeholder.empty()` cleared the frontend element tree but did not clear the backend same-run widget ID/user-key registrations for widgets that had occupied the placeholder. This caused re-rendered widgets with the same generated IDs or explicit keys to be treated as duplicates.

This change tracks widget IDs and user keys by delta path during element registration. When an `st.empty` placeholder is cleared, Streamlit removes same-run duplicate registrations for widgets at that placeholder path and descendant paths only. Sibling widgets remain protected by the normal duplicate checks.

## GitHub Issue Link

Closes #5044

## Testing Plan

- Python unit tests:
  - `uv run pytest lib/tests/streamlit/elements/empty_test.py lib/tests/streamlit/runtime/scriptrunner_utils/thread_safe_set_test.py lib/tests/streamlit/runtime/scriptrunner_utils/shared_run_state_test.py`
- Lint/format:
  - `uv run ruff format --check lib/streamlit/elements/empty.py lib/streamlit/elements/lib/utils.py lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py lib/streamlit/runtime/scriptrunner_utils/thread_safe_set.py lib/tests/streamlit/elements/empty_test.py lib/tests/streamlit/runtime/scriptrunner_utils/shared_run_state_test.py`
  - `uv run ruff check lib/streamlit/elements/empty.py lib/streamlit/elements/lib/utils.py lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py lib/streamlit/runtime/scriptrunner_utils/thread_safe_set.py lib/tests/streamlit/elements/empty_test.py lib/tests/streamlit/runtime/scriptrunner_utils/shared_run_state_test.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes same-run widget ID/key bookkeeping in the scriptrunner, which is core rendering behavior, but the scope is limited to placeholder subtree cleanup with targeted tests.
> 
> **Overview**
> Fixes **same-run `DuplicateWidgetID` / duplicate key errors** when widgets are drawn inside an `st.empty` placeholder, the placeholder is cleared, and equivalent widgets are created again in one script run.
> 
> **Widget registration** now records each element ID and user key against the widget’s **delta path** during `compute_and_register_element_id`. **`placeholder.empty()`** calls `clear_widget_registrations_at_delta_path` for that placeholder’s path so IDs and keys under that subtree are removed from the same-run duplicate sets; **sibling** widgets elsewhere still fail duplicate checks as before. **`ThreadSafeSet.difference_update`** supports removing those registrations atomically.
> 
> Unit tests cover reusing auto IDs and explicit keys after clear, sibling duplicate protection, and path-scoped clearing in `SharedRunState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b9192f4baf7384d3cb65cc027195ce18063383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->