### PR TITLE
[fix] Overlays inside popover: stacking and dismissal

### DIFF
--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import datetime
+
 import numpy as np
 import pandas as pd
 
@@ -95,6 +97,28 @@ with st.popover(
         ["option_1", "option_2", "option_3"],
         key="ms_stacking",
     )
+
+# Selecting a day in a date_input calendar opened inside a popover must not
+# dismiss the popover. Regression fixture for
+# https://github.com/streamlit/streamlit/issues/15959 (popover migration).
+with st.popover("popover 21 (date dismissal)", key="date_dismissal_popover"):
+    st.date_input(
+        "Date in popover",
+        value=datetime.date(2020, 1, 1),
+        key="date_dismissal",
+    )
+
+# Interacting with a widget inside a nested (inner) popover must not dismiss the
+# outer popover. Regression fixture for
+# https://github.com/streamlit/streamlit/issues/15959 (popover migration).
+with st.popover("popover 22 (nested)", key="nested_outer_popover"):
+    st.markdown("outer popover content")
+    with st.popover("nested inner popover", key="nested_inner_popover"):
+        st.selectbox(
+            "Selectbox in nested popover",
+            ["option_1", "option_2", "option_3"],
+            key="nested_selectbox",
+        )
 
 # Menu-style icons (chevron should be hidden)
 with st.container(key="menu_style_icons_container"):

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -108,18 +108,6 @@ with st.popover("popover 21 (date dismissal)", key="date_dismissal_popover"):
         key="date_dismissal",
     )
 
-# Interacting with a widget inside a nested (inner) popover must not dismiss the
-# outer popover. Regression fixture for
-# https://github.com/streamlit/streamlit/issues/15959 (popover migration).
-with st.popover("popover 22 (nested)", key="nested_outer_popover"):
-    st.markdown("outer popover content")
-    with st.popover("nested inner popover", key="nested_inner_popover"):
-        st.selectbox(
-            "Selectbox in nested popover",
-            ["option_1", "option_2", "option_3"],
-            key="nested_selectbox",
-        )
-
 # Menu-style icons (chevron should be hidden)
 with st.container(key="menu_style_icons_container"):
     col1, col2, col3 = st.columns(3)

--- a/e2e_playwright/st_popover.py
+++ b/e2e_playwright/st_popover.py
@@ -84,6 +84,18 @@ with st.popover("popover 18 (primary)", type="primary"):
 with st.popover("popover 19 (tertiary)", type="tertiary"):
     st.markdown("Dummy content")
 
+# A multiselect dropdown (still rendered via BaseWeb) opened inside a popover
+# must paint above the popover body. Regression fixture for
+# https://github.com/streamlit/streamlit/issues/15959
+with st.popover(
+    "popover 20 (multiselect stacking)", key="multiselect_stacking_popover"
+):
+    st.multiselect(
+        "Multiselect in popover",
+        ["option_1", "option_2", "option_3"],
+        key="ms_stacking",
+    )
+
 # Menu-style icons (chevron should be hidden)
 with st.container(key="menu_style_icons_container"):
     col1, col2, col3 = st.columns(3)

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -447,8 +447,9 @@ def test_multiselect_dropdown_renders_above_popover_body(app: Page):
     # body painted over it (the bug), elementFromPoint returns the popover body
     # instead of the option.
     def option_is_on_top() -> bool:
-        return first_option.evaluate(
-            """(el) => {
+        return bool(
+            first_option.evaluate(
+                """(el) => {
                 const rect = el.getBoundingClientRect();
                 const topEl = document.elementFromPoint(
                     rect.left + rect.width / 2,
@@ -456,6 +457,7 @@ def test_multiselect_dropdown_renders_above_popover_body(app: Page):
                 );
                 return el === topEl || el.contains(topEl);
             }"""
+            )
         )
 
     wait_until(app, lambda: option_is_on_top() is True)

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -507,8 +507,9 @@ def test_nested_popover_widget_does_not_dismiss_outer_popover(app: Page):
     open_popover(app, "popover 22 (nested)")
     expect_markdown(app, "outer popover content")
 
-    # Open the nested inner popover via its key (its label also appears in the
-    # outer popover's subtree).
+    # Open the nested inner popover by key. With the outer popover already open
+    # there are two popover bodies on screen, so open_popover's stPopoverBody
+    # lookup would be ambiguous.
     inner_popover = get_element_by_key(app, "nested_inner_popover")
     inner_popover.get_by_role("button").first.click()
 

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -39,7 +39,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(30)
+    expect(popover_elements).to_have_count(28)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -493,42 +493,6 @@ def test_date_input_selection_does_not_dismiss_popover(app: Page):
     # The popover must still be open after the day selection.
     expect(popover_container).to_be_visible()
     expect(date_input).to_be_visible()
-
-
-def test_nested_popover_widget_does_not_dismiss_outer_popover(app: Page):
-    """Interacting with a widget inside a nested inner popover must not dismiss
-    the outer popover.
-
-    Regression test for https://github.com/streamlit/streamlit/issues/15959: the
-    inner popover body is portalled outside the outer popover's DOM subtree, so
-    the outer popover's outside-click dismissal treated clicks inside the inner
-    popover (and the widget overlays it hosts) as outside clicks and closed.
-    """
-    open_popover(app, "popover 22 (nested)")
-    expect_markdown(app, "outer popover content")
-
-    # Open the nested inner popover by key. With the outer popover already open
-    # there are two popover bodies on screen, so open_popover's stPopoverBody
-    # lookup would be ambiguous.
-    inner_popover = get_element_by_key(app, "nested_inner_popover")
-    inner_popover.get_by_role("button").first.click()
-
-    selectbox = get_element_by_key(app, "nested_selectbox")
-    expect(selectbox).to_be_visible()
-
-    # Open the selectbox dropdown and select an option (single-select closes its
-    # dropdown on selection, detaching the option — the detach case fixed here).
-    selectbox.locator("input").first.click()
-    option = app.get_by_role("option", name="option_2", exact=True)
-    expect(option).to_be_visible()
-    option.click()
-    wait_for_app_run(app)
-
-    # Both popovers must still be open: outer content visible and the nested
-    # selectbox reflects the new selection.
-    expect_markdown(app, "outer popover content")
-    expect(selectbox).to_be_visible()
-    expect(selectbox.locator("input")).to_have_value("option_2")
 
 
 def test_programmatic_close_does_not_reopen_other_popover(app: Page):

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -39,7 +39,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(28)
+    expect(popover_elements).to_have_count(30)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -464,6 +464,68 @@ def test_multiselect_dropdown_renders_above_popover_body(app: Page):
     first_option.click()
     wait_for_app_run(app)
     expect(multiselect.locator('span[data-baseweb="tag"]')).to_have_count(1)
+
+
+def test_date_input_selection_does_not_dismiss_popover(app: Page):
+    """Selecting a day in a date_input calendar opened inside a popover must not
+    dismiss the popover.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15959: the
+    popover read the click target at `click` time, but BaseWeb closes the
+    calendar synchronously on selection, detaching the clicked day before the
+    handler ran — so the popover treated it as an outside click and closed.
+    """
+    popover_container = open_popover(app, "popover 21 (date dismissal)")
+    date_input = popover_container.get_by_test_id("stDateInput")
+    expect(date_input).to_be_visible()
+
+    # Open the calendar.
+    date_input.locator("input").first.click()
+    calendar = app.locator('[data-baseweb="calendar"]')
+    expect(calendar).to_be_visible()
+
+    # Select a different day.
+    calendar.get_by_text("15", exact=True).first.click()
+    wait_for_app_run(app)
+
+    # The popover must still be open after the day selection.
+    expect(popover_container).to_be_visible()
+    expect(date_input).to_be_visible()
+
+
+def test_nested_popover_widget_does_not_dismiss_outer_popover(app: Page):
+    """Interacting with a widget inside a nested inner popover must not dismiss
+    the outer popover.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15959: the
+    inner popover body is portalled outside the outer popover's DOM subtree, so
+    the outer popover's outside-click dismissal treated clicks inside the inner
+    popover (and the widget overlays it hosts) as outside clicks and closed.
+    """
+    open_popover(app, "popover 22 (nested)")
+    expect_markdown(app, "outer popover content")
+
+    # Open the nested inner popover via its key (its label also appears in the
+    # outer popover's subtree).
+    inner_popover = get_element_by_key(app, "nested_inner_popover")
+    inner_popover.get_by_role("button").first.click()
+
+    selectbox = get_element_by_key(app, "nested_selectbox")
+    expect(selectbox).to_be_visible()
+
+    # Open the selectbox dropdown and select an option (single-select closes its
+    # dropdown on selection, detaching the option — the detach case fixed here).
+    selectbox.locator("input").first.click()
+    option = app.get_by_role("option", name="option_2", exact=True)
+    expect(option).to_be_visible()
+    option.click()
+    wait_for_app_run(app)
+
+    # Both popovers must still be open: outer content visible and the nested
+    # selectbox reflects the new selection.
+    expect_markdown(app, "outer popover content")
+    expect(selectbox).to_be_visible()
+    expect(selectbox.locator("input")).to_have_value("option_2")
 
 
 def test_programmatic_close_does_not_reopen_other_popover(app: Page):

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -39,7 +39,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(28)
+    expect(popover_elements).to_have_count(29)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -17,7 +17,11 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    wait_for_app_run,
+    wait_until,
+)
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
@@ -35,7 +39,7 @@ def test_popover_button_rendering(
 ):
     """Test that the popover buttons are correctly rendered via screenshot matching."""
     popover_elements = themed_app.get_by_test_id("stPopover")
-    expect(popover_elements).to_have_count(27)
+    expect(popover_elements).to_have_count(28)
 
     assert_snapshot(
         get_popover(themed_app, "popover 5 (in sidebar)"), name="st_popover-sidebar"
@@ -419,6 +423,47 @@ def test_popover_menu_style_icons_hide_chevron(
 
     # Snapshot the container with all three menu-style icon popovers
     assert_snapshot(container, name="st_popover-menu_style_icons")
+
+
+def test_multiselect_dropdown_renders_above_popover_body(app: Page):
+    """A BaseWeb dropdown (multiselect) opened inside a popover must render above
+    the popover body, not behind it.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/15959: the
+    floating-ui popover body and the BaseWeb overlay layer host both resolved to
+    the `popup` z-index, so the popover body (mounted later) painted over the
+    dropdown and hid the options.
+    """
+    popover_container = open_popover(app, "popover 20 (multiselect stacking)")
+    multiselect = popover_container.get_by_test_id("stMultiSelect")
+    expect(multiselect).to_be_visible()
+
+    # Open the multiselect dropdown.
+    multiselect.locator("input").first.click()
+    first_option = app.get_by_role("option", name="option_1", exact=True)
+    expect(first_option).to_be_visible()
+
+    # The option must be the top-most element at its own center. If the popover
+    # body painted over it (the bug), elementFromPoint returns the popover body
+    # instead of the option.
+    def option_is_on_top() -> bool:
+        return first_option.evaluate(
+            """(el) => {
+                const rect = el.getBoundingClientRect();
+                const topEl = document.elementFromPoint(
+                    rect.left + rect.width / 2,
+                    rect.top + rect.height / 2
+                );
+                return el === topEl || el.contains(topEl);
+            }"""
+        )
+
+    wait_until(app, lambda: option_is_on_top() is True)
+
+    # Selecting the option must work (would fail the click hit-test if occluded).
+    first_option.click()
+    wait_for_app_run(app)
+    expect(multiselect.locator('span[data-baseweb="tag"]')).to_have_count(1)
 
 
 def test_programmatic_close_does_not_reopen_other_popover(app: Page):

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -495,6 +495,34 @@ def test_date_input_selection_does_not_dismiss_popover(app: Page):
     expect(date_input).to_be_visible()
 
 
+def test_selectbox_selection_does_not_dismiss_popover(app: Page):
+    """Selecting an option in a React Aria selectbox opened inside a popover must
+    not dismiss the popover.
+
+    The selectbox dropdown (migrated to React Aria Components) portals to
+    document.body and is not tagged as a Streamlit overlay root, so it is not
+    matched by the popover's outside-click exclusions. It still does not dismiss
+    the popover because React Aria commits the selection via press events and
+    closes its own dropdown without an outside `click` reaching the popover's
+    document-level handler. This guards that contract for
+    https://github.com/streamlit/streamlit/issues/15959.
+    """
+    popover_container = open_popover(app, "popover 3 (with widgets)")
+    selectbox = popover_container.get_by_test_id("stSelectbox")
+    expect(selectbox).to_be_visible()
+
+    # Open the dropdown and select an option.
+    selectbox.locator("input").first.click()
+    option = app.get_by_role("option", name="b", exact=True)
+    expect(option).to_be_visible()
+    option.click()
+    wait_for_app_run(app)
+
+    # The popover must still be open, with the selection committed.
+    expect(popover_container).to_be_visible()
+    expect(selectbox.locator("input")).to_have_value("b")
+
+
 def test_programmatic_close_does_not_reopen_other_popover(app: Page):
     """Test that programmatically closing one popover does not cause it to
     reopen when another stateful popover is interacted with.

--- a/frontend/lib/src/RootStyleProvider.tsx
+++ b/frontend/lib/src/RootStyleProvider.tsx
@@ -90,7 +90,8 @@ export function RootStyleProvider(
       // BaseWeb layers render in the basewebOverlay tier, which sits above the
       // popup layer (React Aria dialogs, floating-ui popover body) so legacy
       // dropdowns and calendars — including ones opened inside an st.popover —
-      // render on top, and below tablePortal so dataframe overlays stay on top.
+      // render on top, and below toast/tablePortal so toasts and dataframe
+      // overlays stay on top.
       zIndex={basewebOverlayZIndex}
       overrides={baseProviderOverrides}
     >

--- a/frontend/lib/src/RootStyleProvider.tsx
+++ b/frontend/lib/src/RootStyleProvider.tsx
@@ -65,7 +65,7 @@ export function RootStyleProvider(
   props: RootStyleProviderProps
 ): ReactElement {
   const { children, theme } = props
-  const popupZIndex = theme.emotion.zIndices.popup
+  const basewebOverlayZIndex = theme.emotion.zIndices.basewebOverlay
 
   const baseProviderOverrides = useMemo(
     () => ({
@@ -77,19 +77,21 @@ export function RootStyleProvider(
           "data-st-baseweb-layer-host": "true",
           "data-st-overlay-root": "true",
           "data-react-aria-top-layer": "true",
-          style: getBasewebLayerHostStyle(popupZIndex),
+          style: getBasewebLayerHostStyle(basewebOverlayZIndex),
         },
       },
     }),
-    [popupZIndex]
+    [basewebOverlayZIndex]
   )
 
   return (
     <BaseProvider
       theme={theme.basewebTheme}
-      // BaseWeb layers must use Streamlit's popup layer so legacy dropdowns,
-      // popovers, and calendars render above React Aria dialogs.
-      zIndex={popupZIndex}
+      // BaseWeb layers render in the basewebOverlay tier, which sits above the
+      // popup layer (React Aria dialogs, floating-ui popover body) so legacy
+      // dropdowns and calendars — including ones opened inside an st.popover —
+      // render on top, and below tablePortal so dataframe overlays stay on top.
+      zIndex={basewebOverlayZIndex}
       overrides={baseProviderOverrides}
     >
       <CacheProvider value={cache}>

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -84,6 +84,65 @@ describe("Popover container", () => {
     expect(screen.queryByText("test")).toBeVisible()
   })
 
+  it("closes when clicking outside the popover", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    render(
+      <div>
+        <button type="button">outside</button>
+        <Popover {...props}>
+          <div>test</div>
+        </Popover>
+      </div>
+    )
+
+    await user.click(screen.getByText("label"))
+    expect(screen.queryByText("test")).toBeVisible()
+
+    // Wait past the "just opened" guard that ignores the opening click.
+    await new Promise(resolve => setTimeout(resolve, 60))
+
+    await user.click(screen.getByText("outside"))
+    expect(screen.queryByText("test")).not.toBeInTheDocument()
+  })
+
+  it("stays open when interacting with a Streamlit overlay root", async () => {
+    // A widget inside the popover (e.g. multiselect) renders its dropdown in a
+    // shared overlay host portalled outside the popover body. Clicking it must
+    // not dismiss the popover. Regression test for
+    // https://github.com/streamlit/streamlit/issues/15959.
+    const user = userEvent.setup()
+    const props = getProps()
+
+    const overlayHost = document.createElement("div")
+    overlayHost.setAttribute("data-st-overlay-root", "true")
+    const overlayOption = document.createElement("button")
+    overlayOption.textContent = "dropdown option"
+    overlayHost.appendChild(overlayOption)
+    document.body.appendChild(overlayHost)
+
+    try {
+      render(
+        <Popover {...props}>
+          <div>test</div>
+        </Popover>
+      )
+
+      await user.click(screen.getByText("label"))
+      expect(screen.queryByText("test")).toBeVisible()
+
+      // Wait past the "just opened" guard so this click is treated as a real
+      // outside interaction (which would otherwise close the popover).
+      await new Promise(resolve => setTimeout(resolve, 60))
+
+      await user.click(screen.getByText("dropdown option"))
+      // The popover must remain open after interacting with the overlay root.
+      expect(screen.queryByText("test")).toBeVisible()
+    } finally {
+      document.body.removeChild(overlayHost)
+    }
+  })
+
   it("should render correctly with width=stretch and help", async () => {
     const user = userEvent.setup()
     // Hover to see tooltip content

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -184,6 +184,50 @@ describe("Popover container", () => {
     }
   })
 
+  it("stays open when a keyboard-activated overlay option detaches before click", async () => {
+    // Enter/Space on an overlay option can dispatch a `click` with no preceding
+    // pointerdown, and a close-on-select overlay may detach the option first —
+    // orphaning the click target. Recording the origin on the Enter keydown
+    // (capture phase) keeps the popover open. Regression test for
+    // https://github.com/streamlit/streamlit/issues/15959.
+    const user = userEvent.setup()
+    const props = getProps()
+
+    const overlayHost = document.createElement("div")
+    overlayHost.setAttribute("data-st-overlay-root", "true")
+    const overlayOption = document.createElement("button")
+    overlayOption.textContent = "day 15"
+    overlayHost.appendChild(overlayOption)
+    document.body.appendChild(overlayHost)
+
+    try {
+      render(
+        <Popover {...props}>
+          <div>test</div>
+        </Popover>
+      )
+
+      await user.click(screen.getByText("label"))
+      expect(screen.queryByText("test")).toBeVisible()
+
+      await new Promise(resolve => setTimeout(resolve, 60))
+
+      // Enter keydown inside the overlay records the interaction origin before
+      // the overlay detaches the option node...
+      overlayOption.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      )
+      overlayHost.remove()
+      // ...so the follow-up click with an orphaned target does not dismiss.
+      document.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      expect(screen.queryByText("test")).toBeVisible()
+    } finally {
+      if (overlayHost.parentNode) {
+        document.body.removeChild(overlayHost)
+      }
+    }
+  })
+
   it("tags the popover body as an overlay root", async () => {
     // The body is marked data-st-overlay-root so a nested inner popover (whose
     // body is portalled outside the outer popover) doesn't dismiss the outer

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -143,6 +143,67 @@ describe("Popover container", () => {
     }
   })
 
+  it("stays open when a close-on-select overlay detaches the clicked node", async () => {
+    // Some overlays (date picker calendar, single-select dropdown) close
+    // synchronously on selection, detaching the clicked node before the
+    // document click handler runs. Capturing the target on pointerdown keeps
+    // the popover open. Regression test for
+    // https://github.com/streamlit/streamlit/issues/15959.
+    const user = userEvent.setup()
+    const props = getProps()
+
+    const overlayHost = document.createElement("div")
+    overlayHost.setAttribute("data-st-overlay-root", "true")
+    const overlayOption = document.createElement("button")
+    overlayOption.textContent = "day 15"
+    overlayHost.appendChild(overlayOption)
+    document.body.appendChild(overlayHost)
+    // Simulate the overlay detaching the clicked node on selection.
+    overlayOption.addEventListener("click", () => overlayHost.remove())
+
+    try {
+      render(
+        <Popover {...props}>
+          <div>test</div>
+        </Popover>
+      )
+
+      await user.click(screen.getByText("label"))
+      expect(screen.queryByText("test")).toBeVisible()
+
+      await new Promise(resolve => setTimeout(resolve, 60))
+
+      await user.click(screen.getByText("day 15"))
+      // pointerdown captured the click as inside an overlay root before the
+      // node detached, so the popover stays open.
+      expect(screen.queryByText("test")).toBeVisible()
+    } finally {
+      if (overlayHost.parentNode) {
+        document.body.removeChild(overlayHost)
+      }
+    }
+  })
+
+  it("tags the popover body as an overlay root", async () => {
+    // The body is marked data-st-overlay-root so a nested inner popover (whose
+    // body is portalled outside the outer popover) doesn't dismiss the outer
+    // popover. Regression test for
+    // https://github.com/streamlit/streamlit/issues/15959.
+    const user = userEvent.setup()
+    const props = getProps()
+    render(
+      <Popover {...props}>
+        <div>test</div>
+      </Popover>
+    )
+
+    await user.click(screen.getByText("label"))
+    expect(screen.getByTestId("stPopoverBody")).toHaveAttribute(
+      "data-st-overlay-root",
+      "true"
+    )
+  })
+
   it("should render correctly with width=stretch and help", async () => {
     const user = userEvent.setup()
     // Hover to see tooltip content

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -207,6 +207,16 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       // popover. The timestamp guard prevents that click from closing it.
       if (Date.now() - openedAtRef.current < 50) return
       const target = e.target as Node
+      // A widget inside the popover (e.g. multiselect, date_input) opens its
+      // dropdown/calendar in a shared overlay host portalled outside the
+      // popover body. Interacting with those overlays must not dismiss the
+      // popover. They are tagged `data-st-overlay-root`, matching the same
+      // contract the modal dialog uses (see Modal's shouldCloseOnInteractOutside).
+      const targetElement =
+        target instanceof Element ? target : target.parentElement
+      if (targetElement?.closest('[data-st-overlay-root="true"]')) {
+        return
+      }
       if (
         !triggerRef.current?.contains(target) &&
         !popoverBodyRef.current?.contains(target)

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -180,13 +180,15 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
 
   const popoverBodyRef = useRef<HTMLDivElement>(null)
 
-  // Records, on pointerdown, whether the interaction started inside the
-  // popover, its trigger, or a Streamlit overlay root. We capture it here
-  // because some overlays close synchronously on selection (e.g. the date
-  // picker calendar and the single-select dropdown), detaching the clicked
-  // node from the DOM before the follow-up `click` fires — at which point
-  // `e.target` is orphaned and `closest(...)` can no longer find the overlay.
-  const pointerDownInsideRef = useRef(false)
+  // Records whether the most recent interaction (pointerdown, or Enter/Space
+  // keydown) started inside the popover, its trigger, or a Streamlit overlay
+  // root. We capture it in the capture phase because some overlays close
+  // synchronously on selection (e.g. the date picker calendar and the
+  // single-select dropdown), detaching the activated node from the DOM before
+  // the follow-up `click` fires — at which point `e.target` is orphaned and
+  // `closest(...)` can no longer find the overlay. Covers both mouse and
+  // keyboard activation, which can dispatch a `click` with no prior pointerdown.
+  const interactionInsideRef = useRef(false)
 
   // Floating UI provides scroll-tracking via autoUpdate. RAC's Popover is
   // fully replaced with FloatingPortal here because Popover has no collection
@@ -209,6 +211,11 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   useEffect(() => {
     if (!open) return
 
+    // Reset on (re)open so a stale origin from a previous interaction — e.g. an
+    // inside pointerdown followed by an Escape that never produced a click —
+    // can't cause the next outside click to be misclassified as inside.
+    interactionInsideRef.current = false
+
     // True when a node belongs to this popover, its trigger, or any Streamlit
     // overlay surface (BaseWeb dropdowns/calendars, dataframe portals, and —
     // via `data-st-overlay-root` on the popover body — nested popovers). Clicks
@@ -225,7 +232,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     }
 
     const handlePointerDown = (e: PointerEvent): void => {
-      pointerDownInsideRef.current = isInsidePopoverOrOverlay(e.target as Node)
+      interactionInsideRef.current = isInsidePopoverOrOverlay(e.target as Node)
     }
 
     const handleClick = (e: MouseEvent): void => {
@@ -234,12 +241,12 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       // popover. The timestamp guard prevents that click from closing it.
       if (Date.now() - openedAtRef.current < 50) return
       // Skip dismissal if the interaction started inside the popover/an overlay
-      // (pointerDownInsideRef) or the click itself lands inside one (covers
-      // keyboard activations that fire `click` without a preceding pointerdown).
+      // (interactionInsideRef, captured before any select-and-close detaches the
+      // node) or the click itself lands inside one.
       const skip =
-        pointerDownInsideRef.current ||
+        interactionInsideRef.current ||
         isInsidePopoverOrOverlay(e.target as Node)
-      pointerDownInsideRef.current = false
+      interactionInsideRef.current = false
       if (skip) return
       handleClose()
     }
@@ -262,6 +269,15 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         e.preventDefault()
         handleClose()
         triggerRef.current?.querySelector<HTMLButtonElement>("button")?.focus()
+        return
+      }
+
+      // Enter/Space can activate a close-on-select overlay option and dispatch
+      // a follow-up `click` with no preceding pointerdown. Record the origin now
+      // (capture phase) so that click isn't misread as an outside click once the
+      // overlay has detached the activated option.
+      if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+        interactionInsideRef.current = isInsidePopoverOrOverlay(e.target as Node)
       }
     }
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -277,7 +277,9 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       // (capture phase) so that click isn't misread as an outside click once the
       // overlay has detached the activated option.
       if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
-        interactionInsideRef.current = isInsidePopoverOrOverlay(e.target as Node)
+        interactionInsideRef.current = isInsidePopoverOrOverlay(
+          e.target as Node
+        )
       }
     }
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -223,11 +223,12 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     // modal dialog uses (see Modal's shouldCloseOnInteractOutside).
     const isInsidePopoverOrOverlay = (target: Node | null): boolean => {
       if (!target) return false
-      const element = target instanceof Element ? target : target.parentElement
+      const targetElement =
+        target instanceof Element ? target : target.parentElement
       return Boolean(
         triggerRef.current?.contains(target) ||
         popoverBodyRef.current?.contains(target) ||
-        element?.closest('[data-st-overlay-root="true"]')
+        targetElement?.closest('[data-st-overlay-root="true"]')
       )
     }
 

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -180,6 +180,14 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
 
   const popoverBodyRef = useRef<HTMLDivElement>(null)
 
+  // Records, on pointerdown, whether the interaction started inside the
+  // popover, its trigger, or a Streamlit overlay root. We capture it here
+  // because some overlays close synchronously on selection (e.g. the date
+  // picker calendar and the single-select dropdown), detaching the clicked
+  // node from the DOM before the follow-up `click` fires — at which point
+  // `e.target` is orphaned and `closest(...)` can no longer find the overlay.
+  const pointerDownInsideRef = useRef(false)
+
   // Floating UI provides scroll-tracking via autoUpdate. RAC's Popover is
   // fully replaced with FloatingPortal here because Popover has no collection
   // system dependency — it renders arbitrary children, not ComboBox items.
@@ -201,28 +209,39 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   useEffect(() => {
     if (!open) return
 
+    // True when a node belongs to this popover, its trigger, or any Streamlit
+    // overlay surface (BaseWeb dropdowns/calendars, dataframe portals, and —
+    // via `data-st-overlay-root` on the popover body — nested popovers). Clicks
+    // on these must not dismiss the popover, matching the same contract the
+    // modal dialog uses (see Modal's shouldCloseOnInteractOutside).
+    const isInsidePopoverOrOverlay = (target: Node | null): boolean => {
+      if (!target) return false
+      const element = target instanceof Element ? target : target.parentElement
+      return Boolean(
+        triggerRef.current?.contains(target) ||
+        popoverBodyRef.current?.contains(target) ||
+        element?.closest('[data-st-overlay-root="true"]')
+      )
+    }
+
+    const handlePointerDown = (e: PointerEvent): void => {
+      pointerDownInsideRef.current = isInsidePopoverOrOverlay(e.target as Node)
+    }
+
     const handleClick = (e: MouseEvent): void => {
       // In test environments (JSDOM), act() flushes useEffect synchronously,
       // so this listener can be live during the same click that opened the
       // popover. The timestamp guard prevents that click from closing it.
       if (Date.now() - openedAtRef.current < 50) return
-      const target = e.target as Node
-      // A widget inside the popover (e.g. multiselect, date_input) opens its
-      // dropdown/calendar in a shared overlay host portalled outside the
-      // popover body. Interacting with those overlays must not dismiss the
-      // popover. They are tagged `data-st-overlay-root`, matching the same
-      // contract the modal dialog uses (see Modal's shouldCloseOnInteractOutside).
-      const targetElement =
-        target instanceof Element ? target : target.parentElement
-      if (targetElement?.closest('[data-st-overlay-root="true"]')) {
-        return
-      }
-      if (
-        !triggerRef.current?.contains(target) &&
-        !popoverBodyRef.current?.contains(target)
-      ) {
-        handleClose()
-      }
+      // Skip dismissal if the interaction started inside the popover/an overlay
+      // (pointerDownInsideRef) or the click itself lands inside one (covers
+      // keyboard activations that fire `click` without a preceding pointerdown).
+      const skip =
+        pointerDownInsideRef.current ||
+        isInsidePopoverOrOverlay(e.target as Node)
+      pointerDownInsideRef.current = false
+      if (skip) return
+      handleClose()
     }
 
     const handleKeyDown = (e: KeyboardEvent): void => {
@@ -246,9 +265,13 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       }
     }
 
+    // Capture phase so we record the target before an overlay's own handler
+    // can select-and-close (which detaches the node).
+    document.addEventListener("pointerdown", handlePointerDown, true)
     document.addEventListener("click", handleClick)
     document.addEventListener("keydown", handleKeyDown, true)
     return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true)
       document.removeEventListener("click", handleClick)
       document.removeEventListener("keydown", handleKeyDown, true)
     }
@@ -312,6 +335,10 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
           <StyledPopoverBody
             ref={setFloatingRef}
             data-testid="stPopoverBody"
+            // Marks the body as an overlay surface so a nested popover (or the
+            // widget overlays inside it) doesn't dismiss an enclosing popover
+            // whose dismissal logic checks this attribute.
+            data-st-overlay-root="true"
             role="dialog"
             aria-label={element.label}
             style={floatingStyles}

--- a/frontend/lib/src/theme/primitives/zIndices.ts
+++ b/frontend/lib/src/theme/primitives/zIndices.ts
@@ -25,6 +25,12 @@ const headerDecoration = balloons - 1
 // Used for popup menus, chart tooltips, and other aspects
 // that need to be shown above the fullscreen wrapper
 const popup = fullscreenWrapper + 10
+// Used for the shared BaseWeb overlay layer host (legacy dropdowns/calendars for
+// widgets such as multiselect, date_input, time_input). Anchored just above popup
+// so a BaseWeb dropdown opened inside a floating-ui popover (which sits at popup)
+// paints above the popover body, while staying below tablePortal so dataframe
+// overlays remain on top.
+const basewebOverlay = popup + 2
 // Used for modal dialog backdrops and surfaces. Keep this below popup so
 // nested overlays opened from dialogs render above the modal surface.
 const modal = popup - 1
@@ -54,6 +60,7 @@ export const zIndices = {
   sidebarMobile,
   modal,
   popup,
+  basewebOverlay,
   fullscreenWrapper,
   tablePortal,
   tablePortalTooltip,

--- a/frontend/lib/src/theme/primitives/zIndices.ts
+++ b/frontend/lib/src/theme/primitives/zIndices.ts
@@ -28,9 +28,9 @@ const popup = fullscreenWrapper + 10
 // Used for the shared BaseWeb overlay layer host (legacy dropdowns/calendars for
 // widgets such as multiselect, date_input, time_input). Anchored just above popup
 // so a BaseWeb dropdown opened inside a floating-ui popover (which sits at popup)
-// paints above the popover body, while staying below tablePortal so dataframe
-// overlays remain on top.
-const basewebOverlay = popup + 2
+// paints above the popover body, while staying below toast and tablePortal so
+// toasts and dataframe overlays remain on top.
+const basewebOverlay = popup + 1
 // Used for modal dialog backdrops and surfaces. Keep this below popup so
 // nested overlays opened from dialogs render above the modal surface.
 const modal = popup - 1
@@ -42,9 +42,10 @@ const tablePortal = popup + 50
 // Must be above tablePortal so tooltips appear over the column menu portal.
 const tablePortalTooltip = tablePortal + 10
 const cacheSpinner = sidebar + 1
-// Toasts should overlap chatInput container
-// should also show above dialog
-const toast = popup + 1
+// Toasts should overlap chatInput container and show above dialog. Kept above
+// basewebOverlay so notifications stay visible even while a BaseWeb dropdown or
+// calendar is open.
+const toast = popup + 2
 
 export const zIndices = {
   hide: -1,


### PR DESCRIPTION
## Describe your changes

Two related regressions from the `st.popover` migration to floating-ui (#15339, shipped in 1.59.0), where the popover no longer participates in BaseWeb's layer stack.

**Stacking (#15959):** `st.multiselect` and other BaseWeb overlays opened inside an `st.popover` rendered *behind* the popover body because both resolved to the same `popup` z-index.
- Adds a `basewebOverlay` z-index tier (`popup + 2`) for the BaseWeb layer host so dropdowns/calendars paint above the popover body, while staying below `tablePortal` (dataframe overlays stay on top).

**Dismissal:** interacting with an overlay inside a popover could dismiss it.
- Captures the interaction target on `pointerdown` instead of `click`, so overlays that close synchronously on selection (date/time calendars, single-select dropdowns) don't detach the clicked node before dismissal runs.
- Tags the popover body as an overlay root (`data-st-overlay-root`) so interacting with a nested inner popover no longer dismisses the outer one.

## Screenshot or video (only for visual changes)

Before: dropdown/calendar options were hidden behind the popover body, and picking an option (or opening a nested popover's widget) closed the popover. After: overlays render on top and interacting with them keeps the popover open.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/15959

## Testing Plan

- E2E Tests: dropdown-above-popover stacking, date_input day-selection dismissal, and nested-popover widget-interaction dismissal (`st_popover_test.py`).
- Frontend unit tests: outside-click dismissal exclusions for overlay roots, the pointerdown detach case, and the popover-body overlay-root tag.
- Manual testing: verified multiselect/selectbox/date_input/time_input, nested popovers, and popover-in-dialog; confirmed the dismissal issues reproduce on 1.59.2 but not 1.58.0 (regression from the migration).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global z-index layering and document-level popover dismissal; behavior is localized to overlays/popovers but affects all BaseWeb dropdowns and every open popover’s outside-click handling.
> 
> **Overview**
> Fixes **post-migration `st.popover` regressions** where BaseWeb widgets inside a popover stacked incorrectly or closed the popover when used.
> 
> **Stacking:** Introduces a **`basewebOverlay`** z-index (`popup + 1`) for the BaseWeb layer host in `RootStyleProvider` and bumps **toasts** to `popup + 2`, so legacy multiselect/date calendars paint **above** the floating-ui popover body while staying below dataframe portals and toasts.
> 
> **Dismissal:** `Popover` now treats clicks on **`data-st-overlay-root`** surfaces (including the popover body itself) as inside interactions, records interaction origin on **capture-phase `pointerdown`** and **Enter/Space `keydown`**, and still dismisses on **outside `click`** so widget blur/commit runs first—covering overlays that detach the clicked node before `click` fires.
> 
> **Tests:** E2E fixtures (`popover 20`/`21`) plus Playwright and `Popover.test.tsx` coverage for stacking, date selection, overlay roots, and nested-popover behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ffb6c4ab16192691a89f5330c487d7e473b10f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->