### PR TITLE
[fix] Suppress mobile keyboard for selectbox filter_mode=None

### DIFF
--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -533,25 +533,46 @@ def test_selectbox_contains_filter_mode_matches_substrings(app: Page):
 
 
 def test_selectbox_filter_mode_none_disables_typing_but_keeps_selection(app: Page):
-    """Test that filter_mode=None keeps the input readonly, blocks typing, and
-    keeps the dropdown selectable.
+    """Test that filter_mode=None blocks typing while keeping the dropdown and
+    keyboard navigation usable.
+
+    The input uses inputmode="none" (not readonly) so the mobile software
+    keyboard stays hidden while the input remains focusable: clicking opens the
+    dropdown and Arrow/Enter navigation keeps working right afterwards.
     """
     selectbox_input = get_selectbox_input(app, "selectbox 23 (filter_mode=None)")
-    expect(selectbox_input).to_have_attribute("readonly", "")
+    # inputmode="none" suppresses the mobile software keyboard. readonly is NOT
+    # used because it breaks focus-on-click and React Aria keyboard navigation.
+    expect(selectbox_input).to_have_attribute("inputmode", "none")
+    expect(selectbox_input).not_to_have_attribute("readonly", "")
+    # The text caret is hidden so the input looks non-editable (like a plain
+    # select) even though it stays focusable for keyboard navigation.
+    expect(selectbox_input).to_have_css("caret-color", "rgba(0, 0, 0, 0)")
 
+    # Clicking must focus the input: a readonly + preventDefault approach used to
+    # drop focus, which broke the click-then-keyboard flow. Asserting focus here
+    # guards that regression deterministically.
     selectbox_input.click()
+    expect(selectbox_input).to_be_focused()
+
+    # ArrowDown reliably opens the dropdown (backup for pointer-triggered open,
+    # matching select_selectbox_option) and highlights the first option.
+    selectbox_input.press("ArrowDown")
     selection_dropdown = app.get_by_test_id("stSelectboxVirtualDropdown")
     expect(selection_dropdown).to_be_visible()
     options = selection_dropdown.get_by_role("option")
     expect(options).to_have_count(3)
 
-    # Typing must NOT filter the list: the input is readonly and character
-    # input is blocked, so all options stay visible.
+    # Typing must NOT filter the list: character input is blocked, so all
+    # options stay visible.
     selectbox_input.press("n")
     selectbox_input.press("o")
     expect(options).to_have_count(3)
 
-    options.nth(1).click()
+    # Keyboard navigation still selects: a second ArrowDown reaches "No" and
+    # Enter commits it, proving Arrow/Enter work after focusing via click.
+    selectbox_input.press("ArrowDown")
+    selectbox_input.press("Enter")
     expect_markdown(app, "value 23: No")
 
 

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -533,21 +533,22 @@ def test_selectbox_contains_filter_mode_matches_substrings(app: Page):
 
 
 def test_selectbox_filter_mode_none_disables_typing_but_keeps_selection(app: Page):
-    """Test that filter_mode=None blocks typing while leaving the dropdown usable.
-
-    With filter_mode=None, the input is not marked readOnly (to allow the
-    ComboBox to open on click/focus), but character input is blocked via
-    onKeyDown so options always show the full unfiltered list.
+    """Test that filter_mode=None keeps the input readonly, blocks typing, and
+    keeps the dropdown selectable.
     """
     selectbox_input = get_selectbox_input(app, "selectbox 23 (filter_mode=None)")
+    expect(selectbox_input).to_have_attribute("readonly", "")
 
-    # The input should NOT block dropdown opening — click + ArrowDown opens reliably.
-    # (ArrowDown navigates but does NOT commit for non-readonly inputs.)
     selectbox_input.click()
-    selectbox_input.press("ArrowDown")
     selection_dropdown = app.get_by_test_id("stSelectboxVirtualDropdown")
     expect(selection_dropdown).to_be_visible()
     options = selection_dropdown.get_by_role("option")
+    expect(options).to_have_count(3)
+
+    # Typing must NOT filter the list: the input is readonly and character
+    # input is blocked, so all options stay visible.
+    selectbox_input.press("n")
+    selectbox_input.press("o")
     expect(options).to_have_count(3)
 
     options.nth(1).click()

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -549,9 +549,9 @@ def test_selectbox_filter_mode_none_disables_typing_but_keeps_selection(app: Pag
     # select) even though it stays focusable for keyboard navigation.
     expect(selectbox_input).to_have_css("caret-color", "rgba(0, 0, 0, 0)")
 
-    # Clicking must focus the input: a readonly + preventDefault approach used to
-    # drop focus, which broke the click-then-keyboard flow. Asserting focus here
-    # guards that regression deterministically.
+    # Clicking must focus the input. An earlier readonly + preventDefault approach
+    # dropped focus and broke the click-then-keyboard flow; this assertion guards
+    # that regression.
     selectbox_input.click()
     expect(selectbox_input).to_be_focused()
 

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -568,6 +568,11 @@ def test_selectbox_filter_mode_none_disables_typing_but_keeps_selection(app: Pag
     selectbox_input.press("n")
     selectbox_input.press("o")
     expect(options).to_have_count(3)
+    # The count above stays 3 even without blocking, since filter_mode=None
+    # disables filtering regardless. The real regression guard is that the
+    # blocked keystrokes entered no visible text (mirrors the unit test's
+    # toHaveValue("")).
+    expect(selectbox_input).to_have_value("")
 
     # Keyboard navigation still selects: a second ArrowDown reaches "No" and
     # Enter commits it, proving Arrow/Enter work after focusing via click.

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.styled.ts
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.styled.ts
@@ -73,31 +73,40 @@ export const StyledGroup = styled(Group)(({ theme }) => ({
 /**
  * The text input inside the ComboBox. Grows to fill available space and
  * shows `$placeholderColor` when disabled (faded vs. normal faded text).
+ *
+ * `$typingDisabled` (FILTER_MODE_NONE) hides the text caret and shows a pointer
+ * cursor so the input looks non-editable — like a plain select — even though it
+ * stays focusable for keyboard navigation.
  */
 export const StyledInput = styled(Input, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
-})<{ $placeholderColor?: string }>(({ theme, $placeholderColor }) => ({
-  flexGrow: 1,
-  flexShrink: 1,
-  minWidth: theme.spacing.threeXS,
-  padding: theme.spacing.sm,
-  border: "none",
-  outline: "none",
-  background: "transparent",
-  fontSize: theme.fontSizes.sm,
-  lineHeight: theme.lineHeights.inputWidget,
-  fontWeight: theme.fontWeights.normal,
-  color: theme.colors.bodyText,
-  caretColor: theme.colors.bodyText,
-  boxSizing: "border-box",
-  "&::placeholder": {
-    color: $placeholderColor ?? theme.colors.fadedText60,
-  },
-  "&[data-disabled]": {
-    cursor: "not-allowed",
-    color: theme.colors.fadedText40,
-  },
-}))
+})<{ $placeholderColor?: string; $typingDisabled?: boolean }>(
+  ({ theme, $placeholderColor, $typingDisabled }) => ({
+    flexGrow: 1,
+    flexShrink: 1,
+    minWidth: theme.spacing.threeXS,
+    padding: theme.spacing.sm,
+    border: "none",
+    outline: "none",
+    background: "transparent",
+    fontSize: theme.fontSizes.sm,
+    lineHeight: theme.lineHeights.inputWidget,
+    fontWeight: theme.fontWeights.normal,
+    color: theme.colors.bodyText,
+    caretColor: $typingDisabled ? "transparent" : theme.colors.bodyText,
+    cursor: $typingDisabled ? "pointer" : undefined,
+    // Non-selectable text reinforces the non-editable, plain-select feel.
+    userSelect: $typingDisabled ? "none" : undefined,
+    boxSizing: "border-box",
+    "&::placeholder": {
+      color: $placeholderColor ?? theme.colors.fadedText60,
+    },
+    "&[data-disabled]": {
+      cursor: "not-allowed",
+      color: theme.colors.fadedText40,
+    },
+  })
+)
 
 /** Chevron button that opens/closes the dropdown list. */
 export const StyledOpenButton = styled(Button)(({ theme }) => ({

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -363,6 +363,38 @@ describe("Selectbox widget", () => {
     expect(currProps.onChange).toHaveBeenCalledWith("no")
   })
 
+  it("blocks paste and IME composition input when filterMode is none", async () => {
+    const user = userEvent.setup()
+    const currProps = getProps({
+      options: ["yes", "no", "maybe"],
+      filterMode: streamlit.SelectWidgetFilterMode.FILTER_MODE_NONE,
+      value: undefined,
+    })
+    render(<Selectbox {...currProps} />)
+    const selectboxInput = screen.getByRole("combobox")
+
+    await user.click(selectboxInput)
+    await waitFor(() => {
+      expect(screen.queryAllByRole("option")).toHaveLength(3)
+    })
+
+    // Pasting must not enter text or filter the list: onPaste calls
+    // preventDefault, so the input value never changes and the full list stays.
+    await user.paste("maybe")
+    expect(selectboxInput).toHaveValue("")
+    expect(screen.queryAllByRole("option")).toHaveLength(3)
+
+    // IME composition is likewise blocked: onCompositionStart cancels the
+    // event (dispatchEvent returns false), so composed text can never begin
+    // entering the input and the option list stays unfiltered.
+    const compositionAllowed = fireEvent.compositionStart(selectboxInput, {
+      data: "n",
+    })
+    expect(compositionAllowed).toBe(false)
+    expect(selectboxInput).toHaveValue("")
+    expect(screen.queryAllByRole("option")).toHaveLength(3)
+  })
+
   it("updates value if new value provided from parent", () => {
     const { rerender } = render(<Selectbox {...props} />)
     expect(screen.getByDisplayValue(props.options[0])).toBeVisible()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -350,10 +350,11 @@ describe("Selectbox widget", () => {
       expect(screen.queryAllByRole("option")).toHaveLength(3)
     })
 
-    // Typing is blocked, so the list stays unfiltered. Using keyboard() (not
-    // type()) avoids an implicit re-click, proving the earlier click is what
-    // focused the input.
+    // Typing is blocked, so no visible text is entered and the list stays
+    // unfiltered. Using keyboard() (not type()) avoids an implicit re-click,
+    // proving the earlier click is what focused the input.
     await user.keyboard("no")
+    expect(selectboxInput).toHaveValue("")
     expect(screen.queryAllByRole("option")).toHaveLength(3)
 
     // Arrow/Enter navigation works straight after the click with no manual

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -340,7 +340,7 @@ describe("Selectbox widget", () => {
 
     // filter_mode=None uses inputMode="none" (not readOnly) to suppress the
     // mobile software keyboard. readOnly would break both focus-on-click and
-    // RAC's keyboard navigation, so the input must stay editable-but-focusable.
+    // React Aria's keyboard navigation, so the input must stay editable-but-focusable.
     expect(selectboxInput).toHaveAttribute("inputmode", "none")
     expect(selectboxInput).not.toHaveAttribute("readonly")
 

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -328,7 +328,7 @@ describe("Selectbox widget", () => {
     })
   })
 
-  it("keeps all options visible and the input readonly when filterMode is none", async () => {
+  it("keeps all options visible and blocks typing when filterMode is none", async () => {
     const user = userEvent.setup()
     const currProps = getProps({
       options: ["yes", "no", "maybe"],
@@ -338,23 +338,27 @@ describe("Selectbox widget", () => {
     render(<Selectbox {...currProps} />)
     const selectboxInput = screen.getByRole("combobox")
 
-    // Native readonly prevents mobile browsers from opening the software
-    // keyboard while the manual pointer handler keeps the dropdown usable.
-    expect(selectboxInput).toHaveAttribute("readonly")
+    // filter_mode=None uses inputMode="none" (not readOnly) to suppress the
+    // mobile software keyboard. readOnly would break both focus-on-click and
+    // RAC's keyboard navigation, so the input must stay editable-but-focusable.
+    expect(selectboxInput).toHaveAttribute("inputmode", "none")
+    expect(selectboxInput).not.toHaveAttribute("readonly")
 
+    // Clicking focuses the input and opens the dropdown with the full list.
     await user.click(selectboxInput)
     await waitFor(() => {
       expect(screen.queryAllByRole("option")).toHaveLength(3)
     })
 
-    await user.type(selectboxInput, "no")
+    // Typing is blocked, so the list stays unfiltered. Using keyboard() (not
+    // type()) avoids an implicit re-click, proving the earlier click is what
+    // focused the input.
+    await user.keyboard("no")
     expect(screen.queryAllByRole("option")).toHaveLength(3)
 
-    // Navigating to a non-first option proves React Aria's keyboard navigation
-    // still works with the native readonly attribute — a match on "no" (the
-    // second option) rules out the auto-select-first fallback masking a
-    // regression.
-    act(() => selectboxInput.focus())
+    // Arrow/Enter navigation works straight after the click with no manual
+    // focus() — this catches the click-then-keyboard focus regression. Landing
+    // on "no" (the second option) rules out an auto-select-first fallback.
     await user.keyboard("{ArrowDown}{ArrowDown}{Enter}")
     expect(currProps.onChange).toHaveBeenCalledWith("no")
   })

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { act, fireEvent, screen, waitFor } from "@testing-library/react"
+import {
+  act,
+  createEvent,
+  fireEvent,
+  screen,
+  waitFor,
+} from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { streamlit } from "@streamlit/protobuf"
@@ -385,13 +391,17 @@ describe("Selectbox widget", () => {
     expect(selectboxInput).toHaveValue("")
     expect(screen.queryAllByRole("option")).toHaveLength(3)
 
-    // IME composition is likewise blocked: onCompositionStart cancels the
-    // event (dispatchEvent returns false), so composed text can never begin
-    // entering the input and the option list stays unfiltered.
-    const compositionAllowed = fireEvent.compositionStart(selectboxInput, {
+    // IME composition: onCompositionStart calls preventDefault as a best-effort
+    // block. Real browsers may ignore preventDefault on compositionstart, so we
+    // only assert that our handler requests cancellation (not that jsdom reports
+    // the event as canceled, which would be a jsdom-only artifact). The value and
+    // option list must stay unchanged regardless.
+    const compositionEvent = createEvent.compositionStart(selectboxInput, {
       data: "n",
     })
-    expect(compositionAllowed).toBe(false)
+    const preventDefaultSpy = vi.spyOn(compositionEvent, "preventDefault")
+    fireEvent(selectboxInput, compositionEvent)
+    expect(preventDefaultSpy).toHaveBeenCalled()
     expect(selectboxInput).toHaveValue("")
     expect(screen.queryAllByRole("option")).toHaveLength(3)
   })

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -338,17 +338,25 @@ describe("Selectbox widget", () => {
     render(<Selectbox {...currProps} />)
     const selectboxInput = screen.getByRole("combobox")
 
-    // With filter_mode=None the input is NOT marked readOnly — readOnly prevents
-    // React Aria from opening the dropdown on click/focus (menuTrigger="focus").
-    // Instead, character input is blocked via onKeyDown so options always show
-    // the full unfiltered list.
-    expect(selectboxInput).not.toHaveAttribute("readonly")
+    // Native readonly prevents mobile browsers from opening the software
+    // keyboard while the manual pointer handler keeps the dropdown usable.
+    expect(selectboxInput).toHaveAttribute("readonly")
 
-    await openDropdown(user)
-    expect(screen.queryAllByRole("option")).toHaveLength(3)
+    await user.click(selectboxInput)
+    await waitFor(() => {
+      expect(screen.queryAllByRole("option")).toHaveLength(3)
+    })
 
     await user.type(selectboxInput, "no")
     expect(screen.queryAllByRole("option")).toHaveLength(3)
+
+    // Navigating to a non-first option proves React Aria's keyboard navigation
+    // still works with the native readonly attribute — a match on "no" (the
+    // second option) rules out the auto-select-first fallback masking a
+    // regression.
+    act(() => selectboxInput.focus())
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}")
+    expect(currProps.onChange).toHaveBeenCalledWith("no")
   })
 
   it("updates value if new value provided from parent", () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -561,6 +561,25 @@ describe("Selectbox widget", () => {
       await user.type(input, "should not type")
       expect(screen.queryByText(/Add:/i)).not.toBeInTheDocument()
     })
+
+    it("uses inputMode=none instead of readonly for filterMode none", () => {
+      // On mobile, a small non-creatable selectbox normally gets `readonly` to
+      // suppress the software keyboard (see the test above). filter_mode=None
+      // must opt out of that via the `!isFilterNone` term and instead rely on
+      // inputMode="none", so the input stays focusable for React Aria keyboard
+      // navigation while the mobile keyboard is still suppressed. Desktop tests
+      // run with isMobile() false, so this is the only place the mobile-gated
+      // `!isFilterNone` term is exercised.
+      props = getProps({
+        acceptNewOptions: false,
+        options: ["yes", "no", "maybe"],
+        filterMode: streamlit.SelectWidgetFilterMode.FILTER_MODE_NONE,
+      })
+      render(<Selectbox {...props} />)
+      const input = screen.getByRole("combobox")
+      expect(input).toHaveAttribute("inputmode", "none")
+      expect(input).not.toHaveAttribute("readonly")
+    })
   })
 
   it("does not allow new options when acceptNewOptions is false", async () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -45,6 +45,7 @@ import { WidgetLabelHelpIcon } from "~lib/components/widgets/BaseWidget/WidgetLa
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
 import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
+import useTimeout from "~lib/hooks/useTimeout"
 import { convertRemToPx } from "~lib/theme/utils"
 import {
   filterSelectOptions,
@@ -187,6 +188,11 @@ const Selectbox: FC<Props> = ({
   // prevents auto-open on Tab-focus (which caused spurious reopens after reruns).
   const openDropdownRef = useRef<(() => void) | null>(null)
   const closeDropdownRef = useRef<(() => void) | null>(null)
+  const { restart: scheduleReadonlyInputOpen } = useTimeout(
+    () => openDropdownRef.current?.(),
+    0,
+    { autoStart: false }
+  )
 
   // Always-current mirrors of state values, for use inside stale RAC closures
   // that capture their dependencies at registration time.
@@ -282,11 +288,11 @@ const Selectbox: FC<Props> = ({
 
   const isFilterNone =
     filterMode === streamlit.SelectWidgetFilterMode.FILTER_MODE_NONE
-  // Don't use `readOnly` for FILTER_MODE_NONE: it disables RAC's internal
-  // keyboard navigation (Arrow keys, Enter). Block character input via
-  // onKeyDown/onPaste instead.
+  // FILTER_MODE_NONE must use the native readonly attribute so mobile browsers
+  // do not open the software keyboard. The manual pointer and keyboard handlers
+  // below keep the dropdown and option navigation available.
   const inputReadOnly =
-    isMobile() && options.length <= 10 && !acceptNewOptions && !isFilterNone
+    isFilterNone || (isMobile() && options.length <= 10 && !acceptNewOptions)
 
   /**
    * Commit a selection: update local state and notify the parent.
@@ -380,17 +386,29 @@ const Selectbox: FC<Props> = ({
 
   // Open on pointer-click. With menuTrigger="manual", opening on pointerDown
   // (before focus) avoids a timing gap where focus arrives first with no open action.
-  const handleInputPointerDown = useCallback((): void => {
-    if (selectDisabled) return
-    openDropdownRef.current?.()
-  }, [selectDisabled])
+  // Preventing pointer focus on readonly inputs also avoids Chromium immediately
+  // closing the dropdown after it opens. Keyboard focus remains available via Tab.
+  const handleInputPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLInputElement>): void => {
+      if (selectDisabled) return
+      if (inputReadOnly) {
+        e.preventDefault()
+        // React Aria may close a readonly ComboBox during the rest of the
+        // pointer event. Reopen after that event lifecycle has completed.
+        scheduleReadonlyInputOpen()
+        return
+      }
+      openDropdownRef.current?.()
+    },
+    [inputReadOnly, scheduleReadonlyInputOpen, selectDisabled]
+  )
 
   /**
    * Capture-phase keydown — fires before RAC's handler:
    * - Records wasOpenBeforeEnterRef so the bubble-phase handler can check
    *   whether the dropdown was open before RAC may have closed it.
    * - Opens the dropdown on ArrowUp/Down when closed.
-   * - Blocks character input for FILTER_MODE_NONE (can't use readOnly — see above).
+   * - Defensively blocks character input for FILTER_MODE_NONE.
    * - Clears the value on Escape when clearable.
    */
   const handleInputKeyDownCapture = useCallback(

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -139,7 +139,10 @@ const renderOption = (item: unknown): ReactElement => {
 
 /**
  * Swallow paste and IME composition events so FILTER_MODE_NONE inputs stay
- * non-editable, mirroring the character blocking in onKeyDownCapture.
+ * non-editable, mirroring the character blocking in onKeyDownCapture. Paste
+ * cancellation is honored by browsers; compositionstart cancellation is
+ * best-effort (some browsers ignore preventDefault on it), so IME text may
+ * still slip in — but it is never committed as a selection.
  */
 const preventInputEvent = (e: React.SyntheticEvent): void => {
   e.preventDefault()
@@ -514,12 +517,9 @@ const Selectbox: FC<Props> = ({
             <StyledInput
               placeholder={resolvedPlaceholder}
               readOnly={inputReadOnly}
-              // FILTER_MODE_NONE disables typing. inputMode="none" keeps the
-              // mobile software keyboard from opening while leaving the input
-              // focusable, so click/Tab still open the dropdown and Arrow/Enter
-              // navigation keeps working (unlike readOnly, which breaks both).
-              // $typingDisabled hides the caret and shows a pointer cursor so
-              // the input still looks non-editable, like a plain select.
+              // inputMode="none" suppresses the mobile software keyboard while
+              // keeping the input focusable (unlike readOnly — see above).
+              // $typingDisabled hides the caret and shows a pointer cursor.
               inputMode={isFilterNone ? "none" : undefined}
               $typingDisabled={isFilterNone}
               onPointerDown={handleInputPointerDown}

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -45,7 +45,6 @@ import { WidgetLabelHelpIcon } from "~lib/components/widgets/BaseWidget/WidgetLa
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
 import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
-import useTimeout from "~lib/hooks/useTimeout"
 import { convertRemToPx } from "~lib/theme/utils"
 import {
   filterSelectOptions,
@@ -138,6 +137,14 @@ const renderOption = (item: unknown): ReactElement => {
   )
 }
 
+/**
+ * Swallow paste and IME composition events so FILTER_MODE_NONE inputs stay
+ * non-editable, mirroring the character blocking in onKeyDownCapture.
+ */
+const preventInputEvent = (e: React.SyntheticEvent): void => {
+  e.preventDefault()
+}
+
 const Selectbox: FC<Props> = ({
   disabled,
   value: propValue,
@@ -188,11 +195,6 @@ const Selectbox: FC<Props> = ({
   // prevents auto-open on Tab-focus (which caused spurious reopens after reruns).
   const openDropdownRef = useRef<(() => void) | null>(null)
   const closeDropdownRef = useRef<(() => void) | null>(null)
-  const { restart: scheduleReadonlyInputOpen } = useTimeout(
-    () => openDropdownRef.current?.(),
-    0,
-    { autoStart: false }
-  )
 
   // Always-current mirrors of state values, for use inside stale RAC closures
   // that capture their dependencies at registration time.
@@ -288,11 +290,13 @@ const Selectbox: FC<Props> = ({
 
   const isFilterNone =
     filterMode === streamlit.SelectWidgetFilterMode.FILTER_MODE_NONE
-  // FILTER_MODE_NONE must use the native readonly attribute so mobile browsers
-  // do not open the software keyboard. The manual pointer and keyboard handlers
-  // below keep the dropdown and option navigation available.
+  // Don't use `readOnly` for FILTER_MODE_NONE: it disables RAC's internal
+  // keyboard navigation (Arrow keys, Enter) and makes Chromium close the
+  // ComboBox during the pointer-event lifecycle. Instead, suppress the mobile
+  // software keyboard with inputMode="none" (see the input below) and block
+  // character input via onKeyDown/onPaste.
   const inputReadOnly =
-    isFilterNone || (isMobile() && options.length <= 10 && !acceptNewOptions)
+    isMobile() && options.length <= 10 && !acceptNewOptions && !isFilterNone
 
   /**
    * Commit a selection: update local state and notify the parent.
@@ -386,29 +390,17 @@ const Selectbox: FC<Props> = ({
 
   // Open on pointer-click. With menuTrigger="manual", opening on pointerDown
   // (before focus) avoids a timing gap where focus arrives first with no open action.
-  // Preventing pointer focus on readonly inputs also avoids Chromium immediately
-  // closing the dropdown after it opens. Keyboard focus remains available via Tab.
-  const handleInputPointerDown = useCallback(
-    (e: React.PointerEvent<HTMLInputElement>): void => {
-      if (selectDisabled) return
-      if (inputReadOnly) {
-        e.preventDefault()
-        // React Aria may close a readonly ComboBox during the rest of the
-        // pointer event. Reopen after that event lifecycle has completed.
-        scheduleReadonlyInputOpen()
-        return
-      }
-      openDropdownRef.current?.()
-    },
-    [inputReadOnly, scheduleReadonlyInputOpen, selectDisabled]
-  )
+  const handleInputPointerDown = useCallback((): void => {
+    if (selectDisabled) return
+    openDropdownRef.current?.()
+  }, [selectDisabled])
 
   /**
    * Capture-phase keydown — fires before RAC's handler:
    * - Records wasOpenBeforeEnterRef so the bubble-phase handler can check
    *   whether the dropdown was open before RAC may have closed it.
    * - Opens the dropdown on ArrowUp/Down when closed.
-   * - Defensively blocks character input for FILTER_MODE_NONE.
+   * - Blocks character input for FILTER_MODE_NONE (can't use readOnly — see above).
    * - Clears the value on Escape when clearable.
    */
   const handleInputKeyDownCapture = useCallback(
@@ -522,13 +514,19 @@ const Selectbox: FC<Props> = ({
             <StyledInput
               placeholder={resolvedPlaceholder}
               readOnly={inputReadOnly}
+              // FILTER_MODE_NONE disables typing. inputMode="none" keeps the
+              // mobile software keyboard from opening while leaving the input
+              // focusable, so click/Tab still open the dropdown and Arrow/Enter
+              // navigation keeps working (unlike readOnly, which breaks both).
+              // $typingDisabled hides the caret and shows a pointer cursor so
+              // the input still looks non-editable, like a plain select.
+              inputMode={isFilterNone ? "none" : undefined}
+              $typingDisabled={isFilterNone}
               onPointerDown={handleInputPointerDown}
               onKeyDownCapture={handleInputKeyDownCapture}
               onKeyDown={handleInputKeyDown}
-              onPaste={isFilterNone ? e => e.preventDefault() : undefined}
-              onCompositionStart={
-                isFilterNone ? e => e.preventDefault() : undefined
-              }
+              onPaste={isFilterNone ? preventInputEvent : undefined}
+              onCompositionStart={isFilterNone ? preventInputEvent : undefined}
               $placeholderColor={
                 selectDisabled ? theme.colors.fadedText40 : undefined
               }

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -290,7 +290,7 @@ const Selectbox: FC<Props> = ({
 
   const isFilterNone =
     filterMode === streamlit.SelectWidgetFilterMode.FILTER_MODE_NONE
-  // Don't use `readOnly` for FILTER_MODE_NONE: it disables RAC's internal
+  // Don't use `readOnly` for FILTER_MODE_NONE: it disables React Aria's internal
   // keyboard navigation (Arrow keys, Enter) and makes Chromium close the
   // ComboBox during the pointer-event lifecycle. Instead, suppress the mobile
   // software keyboard with inputMode="none" (see the input below) and block

--- a/specs/2026-03-25-selectbox-filter-mode/product-spec.md
+++ b/specs/2026-03-25-selectbox-filter-mode/product-spec.md
@@ -135,9 +135,9 @@ selected = st.selectbox(
 **Empty input:** All modes show all options when the input is empty.
 
 **`filter_mode=None`:**
-- Input field is read-only (user cannot type)
+- Typing is disabled (keyboard, paste, and IME input are ignored)
 - On mobile, keyboard does not appear
-- Arrow keys still work for navigation
+- Input stays focusable, so arrow keys still work for navigation
 - Dropdown opens on click/focus
 
 ### Interaction with `accept_new_options`


### PR DESCRIPTION
## Describe your changes

`st.selectbox(..., filter_mode=None)` disables typing/filtering, but the software keyboard still opened on mobile because the input relied only on `onKeyDown`/`onPaste` handlers to block characters — it never told the browser to keep the keyboard closed.

- Add `inputMode="none"` to the `filter_mode=None` input so mobile browsers don't open the software keyboard, while keeping the input **focusable** — so click/Tab open the dropdown and Arrow/Enter navigation keep working.
- Hide the text caret, show a pointer cursor, and disable text selection (via a `$typingDisabled` style) so the input still *looks* non-editable, like a plain select.
- Keep character input blocked via `onKeyDown`/`onPaste`/`onCompositionStart` (defense-in-depth).

> Note: an earlier iteration of this PR used the native `readonly` attribute, but `readonly` disabled React Aria's keyboard navigation and caused Chromium to close the ComboBox during the pointer-event lifecycle — which needed a `preventDefault()` + deferred-open workaround that dropped focus-on-click. `inputMode="none"` avoids all of that while still suppressing the mobile keyboard.

## Testing Plan

- `frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx` — Asserts the input is `inputmode="none"` (not `readonly`), options stay unfiltered while typing, and click-then-Arrow/Enter navigation reaches a non-first option (guards the focus-on-click regression).
- `e2e_playwright/st_selectbox_test.py` — Verifies `inputmode="none"`, absence of `readonly`, the hidden caret, focus-on-click, that typing does not filter, and that click-then-keyboard selection commits.

Made with [Cursor](https://cursor.com)