### PR TITLE
[fix] Ignore skill symlinks in generated gitignore snippet

### DIFF
--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -59,7 +59,7 @@ def _generate_gitignore_snippet(
             rel_dir = target_dir.relative_to(project_root)
         except ValueError:
             rel_dir = target_dir
-        lines.extend(f"{rel_dir}/{skill_name}/" for skill_name in skills)
+        lines.extend(f"{rel_dir}/{skill_name}" for skill_name in skills)
     return "\n".join(lines)
 
 

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -123,8 +123,10 @@ class TestGenerateGitignoreSnippet:
             skill_names, target_dirs, project_root
         )
 
-        assert "# Streamlit agent skills" in result
-        assert ".agents/skills/developing-with-streamlit/" in result
+        assert result == (
+            "# Streamlit agent skills (environment-specific symlinks)\n"
+            ".agents/skills/developing-with-streamlit"
+        )
 
     def test_generates_snippet_for_multiple_targets(self, tmp_path: Path) -> None:
         """Generates entries for both .agents and .claude target directories."""
@@ -139,8 +141,9 @@ class TestGenerateGitignoreSnippet:
             skill_names, target_dirs, project_root
         )
 
-        assert ".agents/skills/developing-with-streamlit/" in result
-        assert ".claude/skills/developing-with-streamlit/" in result
+        assert ".agents/skills/developing-with-streamlit" in result
+        assert ".claude/skills/developing-with-streamlit" in result
+        assert "developing-with-streamlit/" not in result
 
     def test_generates_snippet_for_multiple_skills(self, tmp_path: Path) -> None:
         """Generates entries for all discovered skills."""
@@ -152,8 +155,10 @@ class TestGenerateGitignoreSnippet:
             skill_names, target_dirs, project_root
         )
 
-        assert ".agents/skills/developing-with-streamlit/" in result
-        assert ".agents/skills/debugging-apps/" in result
+        assert ".agents/skills/developing-with-streamlit" in result
+        assert ".agents/skills/debugging-apps" in result
+        assert "developing-with-streamlit/" not in result
+        assert "debugging-apps/" not in result
 
 
 class TestFindProjectRoot:
@@ -1973,7 +1978,8 @@ class TestGenerateGitignoreSnippetEdgeCases:
         )
 
         # Snippet should contain the absolute path of the unrelated dir
-        assert f"{unrelated_dir}/my-skill/" in result
+        assert f"{unrelated_dir}/my-skill" in result
+        assert "my-skill/" not in result
 
 
 class TestGetDisplayPath:

--- a/specs/2026-05-11-streamlit-skills-cli/product-spec.md
+++ b/specs/2026-05-11-streamlit-skills-cli/product-spec.md
@@ -196,8 +196,8 @@ breaking changes roll out to users.
   snippet:
   ```
   # Streamlit agent skills (environment-specific symlinks)
-  .agents/skills/developing-with-streamlit/
-  .claude/skills/developing-with-streamlit/
+  .agents/skills/developing-with-streamlit
+  .claude/skills/developing-with-streamlit
   ```
 
 ## Follow-Up Work


### PR DESCRIPTION
## Describe your changes

Drops the trailing slash from the `.gitignore` entries generated for installed skills.

- Trailing slashes in `.gitignore` patterns only match directories, so the installed skill **symlinks** were never being ignored. Without the slash, the generated entries match the symlinks as intended.

## GitHub Issue Link (if applicable)

## Testing Plan

- `lib/tests/streamlit/web/skills_test.py` — Updated `TestGenerateGitignoreSnippet` and edge-case tests to assert entries have no trailing slash.

Made with [Cursor](https://cursor.com)