### PR TITLE
[fix] Copy bundled skills from the local package on the global install

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7244,15 +7244,23 @@ describe("Skills install nudge", () => {
 
   it("appends the server failure reason to the install-failed label", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    // The server classifies the failure (e.g. the Windows symlink → GitHub
-    // download fallback) and the rejected error carries a machine-readable reason.
+    // The server classifies the failure (e.g. a copy failure on the Windows
+    // global-copy fallback) and the rejected error carries a machine-readable
+    // reason.
     vi.spyOn(
       BackendOperationClient.prototype,
       "requestInstallSkills"
     ).mockRejectedValue(
-      Object.assign(new Error("Failed to download skills from GitHub"), {
-        reason: "download_failed",
-      })
+      Object.assign(
+        new Error(
+          "Couldn't write .agents/skills/developing-with-streamlit. Check that " +
+            "you have write permission and that the path isn't too long, then " +
+            "try again."
+        ),
+        {
+          reason: "copy_failed",
+        }
+      )
     )
     renderApp(getProps())
     const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
@@ -7264,7 +7272,7 @@ describe("Skills install nudge", () => {
     // The reason is a label suffix (mirroring skillsNudgeSuppressedNonLocal:<locality>)
     // so the funnel can break install failures down by cause.
     expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallFailed:download_failed",
+      label: "skillsNudgeInstallFailed:copy_failed",
     })
     expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
       label: "skillsNudgeInstallFailed",

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1591,17 +1591,17 @@ export class App extends PureComponent<Props, State> {
         return result.detail ?? undefined
       })
       .catch((error: unknown) => {
-        // A dropped or timed-out connection during a long install (e.g. the
-        // GitHub global fallback) rejects the request even though the server
-        // install may have completed. Count it separately — not as a failure,
-        // which would over-count the funnel — and surface a reassuring,
+        // A dropped or timed-out connection during a long install (e.g. a large
+        // skill-directory copy on a slow disk) rejects the request even though
+        // the server install may have completed. Count it separately — not as a
+        // failure, which would over-count the funnel — and surface a reassuring,
         // retry-friendly message; re-install is idempotent.
         if (isSkillsNudgeDroppedConnection(error)) {
           this.trackSkillsNudge("skillsNudgeInstallDropped")
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)
         }
         // Append the server's machine-readable failure reason (e.g. "conflict",
-        // "download_failed", "symlinks_unsupported") as a label suffix — mirroring
+        // "copy_failed", "symlinks_unsupported") as a label suffix — mirroring
         // `skillsNudgeSuppressedNonLocal:<locality>` — so the install-failure rate
         // can be broken down by cause. The reason is a fixed server-side vocabulary
         // (never user input), safe to emit as a label.

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -34,11 +34,12 @@ const DEFERRED_FILE_REQUEST_TIMEOUT_MS = 180_000
 /**
  * Timeout for skills-install requests (3 minutes).
  *
- * The default 30s is too short here: a project-mode install is fast (it just
- * creates symlinks), but `streamlit skills` falls back to downloading the
- * skills archive from GitHub when symlinks aren't supported (e.g. Windows
- * without Developer Mode). That download can exceed 30s on a slow network,
- * which would surface a spurious "install failed" in the toast while the
+ * The default 30s is too short here. The install is always local: a
+ * project-mode install creates symlinks, and when symlinks aren't supported
+ * (e.g. Windows without Developer Mode) it copies the bundled skill from the
+ * local Streamlit package. Both are filesystem operations, but a large
+ * skill-directory copy onto a slow or network-mounted disk can still exceed
+ * 30s, which would surface a spurious "install failed" in the toast while the
  * server keeps installing. We use the same generous budget as deferred files.
  */
 const INSTALL_SKILLS_REQUEST_TIMEOUT_MS = 180_000

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -210,7 +210,7 @@ class InstallSkillsHandler(BackendOperationHandler):
         # predicate. Three conditions make a request anomalous and unsafe to honor:
         #   - headless mode (deployments / CI / SiS): the nudge is never shown
         #     there, so the request is a replayed/spoofed BackMsg; refuse the
-        #     filesystem writes (and the GitHub download in the global fallback).
+        #     filesystem writes.
         #   - no agent harness present: nothing would consume the skills.
         #   - the browser is not on a direct-loopback connection: the same
         #     conservative eligibility rule the nudge display uses, so a
@@ -243,8 +243,8 @@ class InstallSkillsHandler(BackendOperationHandler):
             )
 
         try:
-            # Run off the event loop: installing does filesystem I/O (and, in
-            # the global fallback, a network download). Resolve the install root
+            # Run off the event loop: installing does filesystem I/O (copying
+            # the bundled skill from the local package). Resolve the install root
             # from the app dir so it lands in the tree the nudge detection scans.
             result = await asyncio.to_thread(
                 skills.install_skills, global_mode=False, yes=True, app_dir=app_dir
@@ -255,7 +255,7 @@ class InstallSkillsHandler(BackendOperationHandler):
             format_message = getattr(ex, "format_message", None)
             detail = format_message() if callable(format_message) else str(ex)
             # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
-            # (e.g. "conflict", "download_failed", "symlinks_unsupported") that the
+            # (e.g. "conflict", "copy_failed", "symlinks_unsupported") that the
             # client forwards to telemetry so the nudge's install-failure rate can
             # be split by cause. Any other exception is classified "unknown".
             reason = getattr(ex, "reason", "unknown")

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -24,6 +24,8 @@ import asyncio
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Final, Protocol
 
+import click
+
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import (
     BackendOperationResponse,
@@ -251,18 +253,27 @@ class InstallSkillsHandler(BackendOperationHandler):
             )
         except Exception as ex:
             _LOGGER.warning("One-click skills install failed", exc_info=ex)
-            # click.ClickException carries a clean, user-facing message.
-            format_message = getattr(ex, "format_message", None)
-            detail = format_message() if callable(format_message) else str(ex)
-            # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
-            # (e.g. "conflict", "copy_failed", "symlinks_unsupported") that the
-            # client forwards to telemetry so the nudge's install-failure rate can
-            # be split by cause. Any other exception is classified "unknown".
-            reason = getattr(ex, "reason", "unknown")
+            # Only ``click.ClickException`` messages are safe to show verbatim in
+            # the browser toast — they are developer-authored, never a raw OS
+            # string. For any other exception (e.g. an unexpected OSError whose
+            # message embeds an absolute path) use a generic message so a server
+            # path can't leak into the nudge.
+            detail = (
+                ex.format_message()
+                if isinstance(ex, click.ClickException)
+                else "Failed to install skills."
+            )
+            # ``skills._InstallError`` carries a bounded, machine-readable
+            # ``reason`` (e.g. "conflict", "copy_failed", "symlinks_unsupported")
+            # that the client forwards to telemetry so the nudge's install-failure
+            # rate can be split by cause. Bind it from the known type so
+            # ``error_reason`` is a provably bounded enum; any other exception is
+            # classified "unknown".
+            reason = ex.reason if isinstance(ex, skills._InstallError) else "unknown"
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",
-                error_reason=reason if isinstance(reason, str) else "unknown",
+                error_reason=reason,
             )
 
         # Invalidate the cached "skills installed" detection so a later session

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -577,15 +577,23 @@ def _collapse_display_paths(entries: list[str]) -> str:
     ``<harness>/skills/<skill>`` tails.
 
     Install-error messages surface the offending paths so the user knows what to
-    act on, but the in-app nudge shows them verbatim — so we drop everything
-    above the last three path parts to never leak an absolute server path when
-    the server's cwd isn't the project root.
+    act on, but the in-app nudge shows them verbatim. A home-relative path
+    (``~/…``) is already short and leaks nothing — the ``~`` is a placeholder, not
+    a server path — so it is kept whole; dropping the ``~`` would make a home
+    target read as project-local and misdirect the "remove it" hint. Any other
+    path is collapsed to its last three parts so an absolute path (when the
+    server's cwd isn't the project root) can never leak.
     """
     paths = []
     for entry in entries:
         raw = entry.split(" (", 1)[0]
         parts = Path(raw).parts
-        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+        if parts and parts[0] == "~":
+            paths.append(Path(*parts).as_posix())
+        elif len(parts) >= 3:
+            paths.append(Path(*parts[-3:]).as_posix())
+        else:
+            paths.append(raw)
     return ", ".join(paths)
 
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -16,18 +16,14 @@
 
 from __future__ import annotations
 
-import io
 import os
 import shutil
 import sys
-import tarfile
 import tempfile
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Final
-from urllib import request
-from urllib.error import URLError
 
 import click
 
@@ -35,11 +31,6 @@ import streamlit
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
-
-# GitHub URL for downloading global skills (versioned tag)
-_GLOBAL_SKILLS_URL: Final[str] = (
-    "https://github.com/streamlit/agent-skills/archive/refs/tags/v1.tar.gz"
-)
 
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
@@ -50,7 +41,7 @@ class _InstallError(click.ClickException):
 
     Behaves like a normal ``click.ClickException`` — its ``format_message`` still
     supplies the user-facing text shown in the CLI and the in-app nudge — but also
-    carries a bounded ``reason`` (e.g. ``"conflict"``, ``"download_failed"``,
+    carries a bounded ``reason`` (e.g. ``"conflict"``, ``"copy_failed"``,
     ``"symlinks_unsupported"``) that the backend-operation handler forwards to the
     client so the nudge's install-failure telemetry can be split by cause. The
     reason is a fixed vocabulary set at each raise site, never user input, so it is
@@ -86,7 +77,13 @@ class _InstallResult:
 
     installed: list[str] = field(default_factory=list)
     up_to_date: list[str] = field(default_factory=list)
+    # ``skipped``: a pre-existing, non-Streamlit path blocks the install (a user
+    # file or foreign symlink) — the user must remove it. ``failed``: the write
+    # itself errored (permissions, disk, or the Windows 260-char path limit) even
+    # though nothing was in the way. They surface distinct errors and distinct
+    # telemetry reasons ("conflict" vs "copy_failed"), so keep them separate.
     skipped: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
 
 
 def _get_source_skills_dir() -> Path:
@@ -440,68 +437,14 @@ def _install_skill_copy(
         temp_path = target_path.with_name(f".{skill_name}.tmp")
         if temp_path.exists() and target_path.exists():
             shutil.rmtree(temp_path, ignore_errors=True)
-        result.skipped.append(f"{rel_target_path} (copy failed: {e})")
-
-
-def _download_global_skill(url: str, skill_name: str) -> Path:
-    """Download and extract global skill from GitHub.
-
-    Returns path to extracted skill directory in a temporary location.
-    Raises click.ClickException on network or extraction errors.
-    """
-    try:
-        with request.urlopen(url, timeout=30) as response:  # noqa: S310
-            data = response.read()
-    except URLError as e:
-        raise _InstallError(
-            f"Failed to download skills from GitHub: {e}\n"
-            "Check your network connection and try again.",
-            reason="download_failed",
-        ) from e
-
-    # Extract tarball to temp directory
-    temp_dir = Path(tempfile.mkdtemp(prefix="streamlit-skills-"))
-    try:
-        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
-            # Security: prevent path traversal and other attacks by filtering members.
-            # On Python 3.12+, use filter='data' which blocks absolute paths,
-            # parent directory references (..), and special files (devices, fifos, etc.).
-            # On earlier versions, manually filter to regular files and directories only.
-            if sys.version_info >= (3, 12):
-                tar.extractall(temp_dir, filter="data")
-            else:
-                # Manual safe extraction for Python 3.10/3.11
-                safe_members = [
-                    m
-                    for m in tar.getmembers()
-                    if (m.isfile() or m.isdir())
-                    and not os.path.isabs(m.name)
-                    and ".." not in m.name.split("/")
-                ]
-                tar.extractall(temp_dir, members=safe_members)  # noqa: S202
-    except tarfile.TarError as e:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        raise _InstallError(
-            f"Failed to extract skills archive: {e}", reason="extract_failed"
-        ) from e
-
-    # Find skill directory - search all top-level directories in case archive has
-    # multiple entries (typically GitHub archives have one: repo-name-tag/)
-    extracted_dirs = [d for d in temp_dir.iterdir() if d.is_dir()]
-    if not extracted_dirs:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        raise _InstallError("Downloaded archive is empty", reason="download_empty")
-
-    for archive_root in extracted_dirs:
-        skill_path = archive_root / skill_name
-        if skill_path.is_dir() and (skill_path / "SKILL.md").is_file():
-            return skill_path
-
-    shutil.rmtree(temp_dir, ignore_errors=True)
-    raise _InstallError(
-        f"Skill '{skill_name}' not found in downloaded archive",
-        reason="archive_missing_skill",
-    )
+        # A write failure (permissions, disk, Windows MAX_PATH), NOT a conflict:
+        # nothing pre-existed at the target. Bucket it separately so it surfaces
+        # the right message/reason, and log the underlying OS error (never shown
+        # to the user, so it can't leak an absolute path into the nudge).
+        _LOGGER.warning(
+            "Failed to copy skill %r into %s", skill_name, target_dir, exc_info=e
+        )
+        result.failed.append(f"{rel_target_path} (copy failed: {e})")
 
 
 def _print_result(result: _InstallResult) -> None:
@@ -524,6 +467,11 @@ def _print_result(result: _InstallResult) -> None:
         click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
         for path in result.skipped:
             click.echo(f"  {click.style('→', fg='yellow')} {path}")
+
+    if result.failed:
+        click.secho("\n✗ Failed to write:", fg="red", bold=True)
+        for path in result.failed:
+            click.echo(f"  {click.style('→', fg='red')} {path}")
 
 
 def _prompt_install_mode() -> str:
@@ -592,12 +540,14 @@ def _confirm_project_installation(
 def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     """Show global installation plan and confirm with user."""
     click.echo()
-    click.echo("Installing globally (downloads from GitHub)")
+    click.echo(
+        "Installing globally (copies the bundled skill from your Streamlit install)"
+    )
 
     click.secho("\nSource:", bold=True)
     click.echo(
         f"  {click.style('•', fg='magenta')} "
-        f"{click.style(_GLOBAL_SKILLS_URL, fg='cyan')}"
+        f"{click.style(str(_get_source_skills_dir() / _GLOBAL_SKILL_NAME), fg='cyan')}"
     )
 
     click.secho("\nSkill to install:", bold=True)
@@ -622,29 +572,55 @@ def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     return click.confirm("Proceed with installation?", default=True)
 
 
+def _collapse_display_paths(entries: list[str]) -> str:
+    """Collapse ``"<path> (<reason>)"`` entries to a comma-joined list of concise
+    ``<harness>/skills/<skill>`` tails.
+
+    Install-error messages surface the offending paths so the user knows what to
+    act on, but the in-app nudge shows them verbatim — so we drop everything
+    above the last three path parts to never leak an absolute server path when
+    the server's cwd isn't the project root.
+    """
+    paths = []
+    for entry in entries:
+        raw = entry.split(" (", 1)[0]
+        parts = Path(raw).parts
+        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+    return ", ".join(paths)
+
+
 def _conflict_error(skipped: list[str]) -> _InstallError:
     """Build a specific "couldn't install" error that names the conflicting
     paths, rather than a vague "remove conflicting files".
 
     ``skipped`` entries are formatted ``"<path> (<reason>)"``. We surface the
-    paths so the user knows exactly what to remove, collapsed to the concise
-    ``<harness>/skills/<skill>`` tail (like the install summary) so the message
-    never leaks an absolute path when the server's cwd isn't the project root.
-    This message is what the in-app nudge shows verbatim on failure, so it must
-    stand on its own (the CLI's detailed ``_print_result`` output never reaches
-    the browser).
+    paths so the user knows exactly what to remove. This message is what the
+    in-app nudge shows verbatim on failure, so it must stand on its own (the
+    CLI's detailed ``_print_result`` output never reaches the browser).
     """
-    paths = []
-    for entry in skipped:
-        raw = entry.split(" (", 1)[0]
-        parts = Path(raw).parts
-        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
-    joined = ", ".join(paths)
-    plural = len(paths) != 1
+    joined = _collapse_display_paths(skipped)
+    plural = len(skipped) != 1
     return _InstallError(
         f"{joined} already exist{'' if plural else 's'}. "
         f"Remove {'them' if plural else 'it'} and try again.",
         reason="conflict",
+    )
+
+
+def _copy_failed_error(failed: list[str]) -> _InstallError:
+    """Build a "couldn't write the skill" error for copy failures.
+
+    Distinct from :func:`_conflict_error`: these paths did not pre-exist — the
+    copy itself failed (permissions, disk, or the Windows 260-character path
+    limit). Like the conflict error the message stands on its own for the in-app
+    nudge and collapses to the concise path tail so it never leaks an absolute
+    server path; the underlying OS error is logged, not shown.
+    """
+    joined = _collapse_display_paths(failed)
+    return _InstallError(
+        f"Couldn't write {joined}. Check that you have write permission and "
+        "that the path isn't too long, then try again.",
+        reason="copy_failed",
     )
 
 
@@ -658,8 +634,12 @@ def _install_project_skills(
     # Discover bundled skills
     source_skills_dir = _get_source_skills_dir()
     if not source_skills_dir.is_dir():
+        # Keep the absolute path in the server log only - this message is shown
+        # verbatim in the in-app nudge, so it must not leak a server path.
+        _LOGGER.warning("Bundled skills directory not found at %s", source_skills_dir)
         raise _InstallError(
-            f"Bundled skills directory not found: {source_skills_dir}",
+            "Bundled skills were not found in your Streamlit installation. "
+            "Reinstall Streamlit and try again.",
             reason="source_missing",
         )
 
@@ -782,7 +762,16 @@ def _install_project_skills(
 
 
 def _install_global_skills(*, yes: bool = False) -> _InstallResult:
-    """Install skills globally by downloading from GitHub."""
+    """Install skills globally by copying from the bundled Streamlit package.
+
+    The skill files already ship inside the installed ``streamlit`` package
+    (:func:`_get_source_skills_dir`), so we copy them from local disk instead of
+    downloading from GitHub. This is what the Windows symlink→global fallback
+    reaches, and the old GitHub download made the in-app one-click install fail
+    for ~1 in 8 Windows users on locked-down networks (see issue #15933). Copying
+    the bundled skill also keeps the global install matched to the running
+    Streamlit version, exactly like the project-mode symlinks.
+    """
     target_dirs = _get_global_target_dirs()
 
     # Confirm installation
@@ -790,54 +779,61 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
         click.echo("Installation cancelled.")
         raise click.Abort()
 
-    # Download skill from GitHub
-    click.echo("Downloading skills from GitHub...")
-    skill_path = _download_global_skill(_GLOBAL_SKILLS_URL, _GLOBAL_SKILL_NAME)
+    # Copy the skill from the local package - no network dependency.
+    source_skills_dir = _get_source_skills_dir()
+    if not (source_skills_dir / _GLOBAL_SKILL_NAME / "SKILL.md").is_file():
+        # Keep the absolute path in the server log only - this message is shown
+        # verbatim in the in-app nudge, so it must not leak a server path.
+        _LOGGER.warning(
+            "Bundled skill %r not found under %s", _GLOBAL_SKILL_NAME, source_skills_dir
+        )
+        raise _InstallError(
+            f"The bundled '{_GLOBAL_SKILL_NAME}' skill was not found in your "
+            "Streamlit installation. Reinstall Streamlit and try again.",
+            reason="source_missing",
+        )
 
-    try:
-        # Install to each target directory
-        result = _InstallResult()
-        # For global install, only one skill is installed but we use a set for consistency
-        bundled_skill_names = {_GLOBAL_SKILL_NAME}
-        for target_dir in target_dirs:
-            _install_skill_copy(
-                _GLOBAL_SKILL_NAME,
-                skill_path.parent,
-                target_dir,
-                result,
-                bundled_skill_names,
-            )
+    # Install to each target directory
+    result = _InstallResult()
+    # For global install, only one skill is installed but we use a set for consistency
+    bundled_skill_names = {_GLOBAL_SKILL_NAME}
+    for target_dir in target_dirs:
+        _install_skill_copy(
+            _GLOBAL_SKILL_NAME,
+            source_skills_dir,
+            target_dir,
+            result,
+            bundled_skill_names,
+        )
 
-        # Report results
-        _print_result(result)
+    # Report results
+    _print_result(result)
 
-        if result.installed or result.up_to_date:
+    if result.installed or result.up_to_date:
+        click.echo()
+        click.secho(
+            "✨ Successfully installed globally",
+            fg="green",
+            bold=True,
+        )
+        if result.installed:
             click.echo()
+            click.secho("Note: ", fg="bright_black", bold=True, nl=False)
             click.secho(
-                "✨ Successfully installed globally",
-                fg="green",
-                bold=True,
+                "Global skills include a discover.py script that finds",
+                fg="bright_black",
             )
-            if result.installed:
-                click.echo()
-                click.secho("Note: ", fg="bright_black", bold=True, nl=False)
-                click.secho(
-                    "Global skills include a discover.py script that finds",
-                    fg="bright_black",
-                )
-                click.secho(
-                    "      project-specific bundled skills at runtime.",
-                    fg="bright_black",
-                )
-        elif result.skipped:
-            raise _conflict_error(result.skipped)
+            click.secho(
+                "      project-specific bundled skills at runtime.",
+                fg="bright_black",
+            )
+    # A write failure is more specific than a conflict, so report it first.
+    elif result.failed:
+        raise _copy_failed_error(result.failed)
+    elif result.skipped:
+        raise _conflict_error(result.skipped)
 
-        return result
-    finally:
-        # Clean up temp directory
-        temp_root = skill_path.parent.parent
-        if temp_root.name.startswith("streamlit-skills-"):
-            shutil.rmtree(temp_root, ignore_errors=True)
+    return result
 
 
 def install_skills(
@@ -910,10 +906,11 @@ def summarize_install(result: _InstallResult) -> str:
     """Return a short, user-facing summary of an install for the in-app nudge.
 
     Reports where skills were newly installed, or that they were already up to
-    date, and flags any skills skipped due to conflicts so a partial install is
-    not silently presented as a complete success. Used to give the one-click
-    "install skills" toast concrete feedback instead of a generic confirmation.
-    Returns an empty string when there is nothing meaningful to report.
+    date, and flags any skills skipped due to conflicts or that failed to write
+    so a partial install is not silently presented as a complete success. Used
+    to give the one-click "install skills" toast concrete feedback instead of a
+    generic confirmation. Returns an empty string when there is nothing
+    meaningful to report.
     """
     parts: list[str] = []
     if result.installed:
@@ -932,6 +929,15 @@ def summarize_install(result: _InstallResult) -> str:
         count = len(result.skipped)
         noun = "skill" if count == 1 else "skills"
         parts.append(f"{count} {noun} skipped due to conflicts.")
+    if result.failed:
+        # Surface write failures (permissions, disk, Windows MAX_PATH) too. A
+        # global install writes to every target dir (e.g. ~/.agents and
+        # ~/.claude); if one succeeds and another errors, the success branch
+        # above still runs, so without this the toast would read as a clean
+        # success while the harness the user actually runs got nothing.
+        count = len(result.failed)
+        noun = "skill" if count == 1 else "skills"
+        parts.append(f"{count} {noun} failed to install.")
     return " ".join(parts)
 
 

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -245,18 +245,30 @@ def test_install_skills_handler_reports_failure() -> None:
     assert not response.HasField("install_skills")
 
 
-def test_install_skills_handler_forwards_failure_reason() -> None:
+@pytest.mark.parametrize(
+    ("reason", "message"),
+    [
+        ("copy_failed", "Couldn't write .agents/skills/developing-with-streamlit."),
+        (
+            "source_missing",
+            "The bundled skill was not found in your Streamlit installation.",
+        ),
+        ("conflict", ".agents/skills/developing-with-streamlit already exists."),
+        ("symlinks_unsupported", "Symlinks not supported."),
+    ],
+)
+def test_install_skills_handler_forwards_failure_reason(
+    reason: str, message: str
+) -> None:
     """A ``skills._InstallError`` propagates its machine-readable ``reason`` into
     the response's ``error_reason`` so the client can split install-failure
-    telemetry by cause (e.g. the Windows symlink → GitHub-download fallback)."""
+    telemetry by cause (e.g. a copy failure vs a pre-existing conflict)."""
     with (
         patch("streamlit.config.get_option", return_value=False),
         patch.object(skills, "detect_installed_agents", return_value=["claude"]),
         patch(
             "streamlit.web.skills.install_skills",
-            side_effect=skills._InstallError(
-                "Failed to download skills from GitHub", reason="download_failed"
-            ),
+            side_effect=skills._InstallError(message, reason=reason),
         ),
     ):
         response = asyncio.run(
@@ -265,8 +277,8 @@ def test_install_skills_handler_forwards_failure_reason() -> None:
             )
         )
 
-    assert response.error_msg == "Failed to download skills from GitHub"
-    assert response.error_reason == "download_failed"
+    assert response.error_msg == message
+    assert response.error_reason == reason
     assert not response.HasField("install_skills")
 
 

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -16,13 +16,9 @@
 
 from __future__ import annotations
 
-import contextlib
-import io
 import os
-import tarfile
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
-from urllib.error import URLError
+from unittest.mock import patch
 
 import click
 import pytest
@@ -898,9 +894,7 @@ class TestInstallSkillsCli:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
         ):
             result = runner.invoke(cli.main, ["skills", "--global", "--yes"])
@@ -1055,9 +1049,7 @@ class TestInstallSkillsCli:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
         ):
             result = runner.invoke(cli.main, ["skills", "-g", "-y"])
@@ -1076,9 +1068,7 @@ class TestInstallSkillsCli:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
         ):
             runner.invoke(cli.main, ["skills", "-g", "-y"])
@@ -1210,143 +1200,6 @@ class TestInstallProjectSkillsCancellation:
         ).exists()
 
 
-class TestDownloadGlobalSkill:
-    """Tests for _download_global_skill."""
-
-    def test_raises_on_network_error(self) -> None:
-        """Raises ClickException on network failure."""
-        with patch.object(skills.request, "urlopen", side_effect=URLError("Network")):
-            with pytest.raises(click.ClickException, match="Failed to download") as exc:
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "skill"
-                )
-        assert exc.value.reason == "download_failed"
-
-    def test_raises_on_empty_archive(self, tmp_path: Path) -> None:
-        """Raises ClickException when archive is empty."""
-        # Create an empty tar.gz
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz"):
-            pass  # Empty archive
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            with pytest.raises(click.ClickException, match="archive is empty") as exc:
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "skill"
-                )
-        assert exc.value.reason == "download_empty"
-
-    def test_raises_on_missing_skill(self, tmp_path: Path) -> None:
-        """Raises ClickException when skill not found in archive."""
-        # Create archive with a different skill
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-            # Add a root directory
-            root_info = tarfile.TarInfo(name="repo-v1/")
-            root_info.type = tarfile.DIRTYPE
-            root_info.mode = 0o755  # Ensure directory is traversable
-            tar.addfile(root_info)
-            # Add a different skill
-            other_skill = tarfile.TarInfo(name="repo-v1/other-skill/")
-            other_skill.type = tarfile.DIRTYPE
-            other_skill.mode = 0o755
-            tar.addfile(other_skill)
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            with pytest.raises(
-                click.ClickException, match="not found in downloaded"
-            ) as exc:
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "missing-skill"
-                )
-        assert exc.value.reason == "archive_missing_skill"
-
-    def test_extracts_skill_successfully(self, tmp_path: Path) -> None:
-        """Successfully extracts skill from valid archive."""
-        # Create archive with the expected skill
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-            # Add root directory
-            root_info = tarfile.TarInfo(name="repo-v1/")
-            root_info.type = tarfile.DIRTYPE
-            root_info.mode = 0o755  # Ensure directory is traversable
-            tar.addfile(root_info)
-            # Add skill directory
-            skill_dir = tarfile.TarInfo(name="repo-v1/test-skill/")
-            skill_dir.type = tarfile.DIRTYPE
-            skill_dir.mode = 0o755
-            tar.addfile(skill_dir)
-            # Add SKILL.md file
-            skill_md = tarfile.TarInfo(name="repo-v1/test-skill/SKILL.md")
-            content = b"# Test Skill\n"
-            skill_md.size = len(content)
-            tar.addfile(skill_md, io.BytesIO(content))
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            result = skills._download_global_skill(
-                "https://example.com/test.tar.gz", "test-skill"
-            )
-
-        assert result.name == "test-skill"
-        assert (result / "SKILL.md").is_file()
-
-    def test_blocks_path_traversal_members(self, tmp_path: Path) -> None:
-        """A malicious archive member is never written outside the extraction dir.
-
-        Guards the ``tarfile`` ``data`` filter (Python 3.12+) and the manual
-        absolute-/``..``-path filter (3.10/3.11) in ``_download_global_skill``.
-        An absolute-path member targeting an arbitrary location must not be
-        extracted: on 3.12+ the data filter rejects the archive (ClickException);
-        on 3.10/3.11 the member is silently dropped (and the requested skill is
-        then "not found"). Either way the target file must not exist afterward.
-        """
-        evil_target = tmp_path / "pwned.txt"
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-            root_info = tarfile.TarInfo(name="repo-v1/")
-            root_info.type = tarfile.DIRTYPE
-            root_info.mode = 0o755
-            tar.addfile(root_info)
-            # Malicious absolute-path member attempting an arbitrary file write.
-            evil = tarfile.TarInfo(name=str(evil_target))
-            content = b"pwned"
-            evil.size = len(content)
-            tar.addfile(evil, io.BytesIO(content))
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            # 3.12+ rejects the unsafe member outright; older versions drop it.
-            with contextlib.suppress(click.ClickException):
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "skill"
-                )
-
-        assert not evil_target.exists()
-
-
 class TestSkillCopyMatches:
     """Tests for _skill_copy_matches."""
 
@@ -1432,7 +1285,7 @@ class TestInstallSkillCopyEdgeCases:
                 {"developing-with-streamlit"},
             )
 
-        assert any("copy failed" in s for s in result.skipped)
+        assert any("copy failed" in s for s in result.failed)
 
     def test_preserves_existing_directory_on_copy_failure(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1461,7 +1314,7 @@ class TestInstallSkillCopyEdgeCases:
         # Original should be preserved with old content
         assert target.is_dir()
         assert (target / "SKILL.md").read_text() == "# Old version\n"
-        assert any("copy failed" in s for s in result.skipped)
+        assert any("copy failed" in s for s in result.failed)
 
 
 class TestInstallSkillSymlinkEdgeCases:
@@ -1574,9 +1427,7 @@ class TestGlobalInstallationConflicts:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
         ):
             result = runner.invoke(cli.main, ["skills", "--global", "--yes"])
@@ -1603,9 +1454,7 @@ class TestInteractiveModeSelection:
             patch.object(skills, "_prompt_install_mode", return_value="global"),
             patch.object(skills, "_confirm_global_installation", return_value=True),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
         ):
             mock_sys.stdin.isatty.return_value = True
@@ -1819,6 +1668,68 @@ class TestSummarizeInstall:
             "Skills are already up to date. 2 skills skipped due to conflicts."
         )
 
+    def test_reports_failed_alongside_installed(self) -> None:
+        """A partial global install (one target written, another failed to write,
+        e.g. Windows MAX_PATH or a permission error) is not presented as a clean
+        success: the failed target is surfaced too.
+        """
+        result = skills._InstallResult(
+            installed=[".agents/skills/developing-with-streamlit"],
+            failed=[
+                (
+                    ".claude/skills/developing-with-streamlit "
+                    "(copy failed: [Errno 13] Permission denied)"
+                )
+            ],
+        )
+        assert skills.summarize_install(result) == (
+            "Installed to .agents/skills. 1 skill failed to install."
+        )
+
+
+class TestGlobalInstallFailureReasons:
+    """The bundled-copy global install (and the Windows symlink->global fallback
+    that reaches it) tags failures with a machine-readable ``reason`` the handler
+    forwards to install telemetry, so the post-fix residual stays measurable."""
+
+    def test_copy_failure_reports_copy_failed_reason(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """An OSError while writing the copy (permissions, disk, or the Windows
+        260-char path limit) raises ``reason="copy_failed"`` - not the
+        pre-existing-path ``"conflict"`` it used to be mislabeled as."""
+        home = tmp_path / "home"
+        home.mkdir()
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(
+                skills.shutil, "copytree", side_effect=OSError("Filename too long")
+            ),
+        ):
+            with pytest.raises(skills._InstallError) as exc:
+                skills._install_global_skills(yes=True)
+        assert exc.value.reason == "copy_failed"
+
+    def test_missing_bundled_skill_reports_source_missing_reason(
+        self, tmp_path: Path
+    ) -> None:
+        """When the package ships no bundled skill the install fails fast with
+        ``reason="source_missing"`` - there is no network fetch to fall back on."""
+        home = tmp_path / "home"
+        home.mkdir()
+        empty_source = tmp_path / "empty" / ".agents" / "skills"
+        empty_source.mkdir(parents=True)
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(skills, "_get_source_skills_dir", return_value=empty_source),
+        ):
+            with pytest.raises(skills._InstallError) as exc:
+                skills._install_global_skills(yes=True)
+        assert exc.value.reason == "source_missing"
+
 
 class TestConflictError:
     """_conflict_error names the specific conflicting paths (the message the
@@ -1864,6 +1775,30 @@ class TestConflictError:
         )
         assert isinstance(err, skills._InstallError)
         assert err.reason == "conflict"
+
+
+class TestCopyFailedError:
+    """_copy_failed_error reports a failed *write* (not a pre-existing conflict)
+    and, like _conflict_error, collapses paths so the in-app nudge never shows an
+    absolute server path."""
+
+    def test_carries_copy_failed_reason_and_collapses_paths(self) -> None:
+        """Tagged ``reason="copy_failed"``; the absolute target path collapses to
+        the concise <harness>/skills/<skill> tail and the raw OS error (which may
+        contain an absolute path) is dropped entirely."""
+        err = skills._copy_failed_error(
+            [
+                (
+                    "/abs/home/.agents/skills/developing-with-streamlit "
+                    "(copy failed: [Errno 13] Permission denied: '/abs/home/x')"
+                )
+            ]
+        )
+        assert isinstance(err, skills._InstallError)
+        assert err.reason == "copy_failed"
+        message = err.format_message()
+        assert "/abs/home" not in message
+        assert ".agents/skills/developing-with-streamlit" in message
 
 
 class TestInstallSkillsReturnsResult:
@@ -2143,7 +2078,7 @@ class TestInstallProjectSkillsFallbackErrors:
         ("global_install_side_effect", "match"),
         [
             (click.exceptions.Abort(), "Installation incomplete"),
-            (click.ClickException("download failure"), "download failure"),
+            (click.ClickException("global install failed"), "global install failed"),
         ],
         ids=["user_aborted_global_install", "global_install_click_exception"],
     )
@@ -2212,32 +2147,3 @@ class TestInstallSkillCopyTempCleanup:
         assert not (target / "stale-file.txt").exists()
         # Temp directory must be cleaned up after the swap.
         assert not leftover_temp.exists()
-
-
-class TestInstallGlobalSkillsCleanup:
-    """Tests for temp directory cleanup at the end of _install_global_skills."""
-
-    def test_cleans_up_streamlit_skills_prefixed_temp_dir(
-        self, tmp_path: Path, mock_source_skills_dir: Path
-    ) -> None:
-        """Removes temp directories that follow the streamlit-skills- naming convention."""
-        home = tmp_path / "home"
-        home.mkdir(parents=True)
-
-        # Simulate the layout created by _download_global_skill:
-        # /tmp/streamlit-skills-XXXX/archive_root/<skill_name>/SKILL.md
-        temp_root = tmp_path / "streamlit-skills-test"
-        archive_root = temp_root / "archive-root"
-        skill_dir = archive_root / "developing-with-streamlit"
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Test Skill\n", encoding="utf-8")
-
-        with (
-            patch("pathlib.Path.home", return_value=home),
-            patch.object(skills, "_download_global_skill", return_value=skill_dir),
-        ):
-            skills._install_global_skills(yes=True)
-
-        # The temp root was cleaned up because its name starts with
-        # "streamlit-skills-".
-        assert not temp_root.exists()

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -1800,6 +1800,16 @@ class TestCopyFailedError:
         assert "/abs/home" not in message
         assert ".agents/skills/developing-with-streamlit" in message
 
+    def test_home_relative_path_keeps_tilde(self) -> None:
+        """A home-relative (``~/...``) target is shown whole, not stripped to a
+        project-local-looking tail — otherwise the 'remove it' hint points at the
+        wrong place. The ``~`` is a placeholder and leaks no server path."""
+        err = skills._copy_failed_error(
+            ["~/.agents/skills/developing-with-streamlit (copy failed: Disk full)"]
+        )
+        message = err.format_message()
+        assert "~/.agents/skills/developing-with-streamlit" in message
+
 
 class TestInstallSkillsReturnsResult:
     """install_skills returns the structured result for callers (e.g. the nudge)."""

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -120,7 +120,7 @@ message BackendOperationResponse {
 
   // Machine-readable, bounded failure classification (empty on success).
   // Parallels the human-readable error_msg. For the one-click skills install
-  // this is the cause of the failure (e.g. "conflict", "download_failed",
+  // this is the cause of the failure (e.g. "conflict", "copy_failed",
   // "symlinks_unsupported"), forwarded to telemetry so the nudge's
   // install-failure rate can be broken down by cause.
   string error_reason = 6;


### PR DESCRIPTION
> Related: #15933 (fixes 1 & 2). **Stacked on #15934** (reason-code telemetry) — review/merge that first; this PR's base is `skills-install-failure-reason-2`, so the diff shows only the fix.

## Summary

The in-app one-click "install skills" nudge fails **~12% on Windows** vs ~1% macOS/Linux (#15933). On Windows without Developer Mode symlinks fail, so the installer falls back to a **global install that downloaded the skills archive from GitHub** — and ~1 in 8 of those fail, most plausibly blocked GitHub egress on locked-down corporate networks.

## What changed

**#1 — copy from the local package instead of downloading (the fix).**
The bundled skill already ships on disk in the installed `streamlit` package (`_get_source_skills_dir()`). `_install_global_skills` now copies it from there instead of fetching a tarball from GitHub. The network dependency is gone entirely: `_download_global_skill`, the GitHub URL constant, and the `urllib`/`tarfile`/`io` imports are deleted. Bonus: the Windows-fallback install now gets the **same skill version as the running Streamlit** (matching project-mode symlinks) instead of a drifting GitHub tag.

**#2 — distinguish write failures from conflicts.**
Copy-time `OSError`s (permissions, disk, Windows `MAX_PATH`) were bucketed with pre-existing-path conflicts and both reported as `reason="conflict"`. They're now split: `_InstallResult.failed` → a new `copy_failed` reason + an accurate "check permissions / path length" message; genuine conflicts keep `conflict`. This keeps the post-fix residual measurable via #15934's telemetry.

**Hardening (from an adversarial self-review):**
- `summarize_install()` now surfaces the `failed` bucket, so a **partial** global install (one target dir written, another failing on MAX_PATH/permissions) is no longer reported to the nudge as a clean success.
- `source_missing` errors no longer interpolate the absolute package path into the browser-facing toast (logged server-side instead).

## Testing
- `skills.py` + `backend_operation_handler.py`: mypy + ruff clean.
- 128 skills unit tests + 33 handler tests pass (new: `copy_failed`/`source_missing` reasons end-to-end, partial-failure summary, path-leak collapse).
- Real `streamlit skills --global --yes` into a temp HOME copies the skill with **zero network**.

## Not in this PR (follow-up)
Fix #4 (align the nudge show-gate with the installer conflict check so deterministically-refused users stop being re-nudged) stacks on top of this branch.

## Self-review hardening (follow-up commit)

A fan-out self-review (security / user-impact / data / correctness / stack-coherence) surfaced only low/nit findings; the confirmed ones are fixed here:
- **Bounded telemetry enum + no path leak** — the backend-operation handler now forwards only `click.ClickException` messages verbatim to the toast (developer-authored; any other exception gets a generic message so an unexpected `OSError` cannot leak an absolute server path into the browser), and binds `error_reason` via `isinstance(_InstallError)` so it is a provably bounded enum.
- **`~` preserved** in `_collapse_display_paths`, so a home-relative copy target is not shown as project-local (which misdirected the “remove it” hint).
- **Doc sweep** — dropped the now-dead `download_failed` example / GitHub-download rationale from the `error_reason` proto comment, the install-timeout JSDoc, the `App.tsx` comments, and the App test fixture (the download path is removed in this PR).

Not changed (intentional): copy-mode replacing a real dir named `developing-with-streamlit` is pre-existing behavior identical to `develop`; “fixing” it in the show-gate would suppress the beneficial repair case.
