### PR TITLE
Fix IndexError in simplify_number for values >= 1 quadrillion

### DIFF
--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -222,12 +222,15 @@ def simplify_number(num: int) -> str:
     """Simplifies number into Human readable format, returns str."""
     num_converted = float(f"{num:.2g}")
     magnitude = 0
-    while abs(num_converted) >= 1000:
+    suffixes = ["", "k", "m", "b", "t"]
+    # Stop at the largest available suffix so numbers beyond a trillion stay in
+    # trillions (e.g. "1000t") rather than raising an IndexError.
+    while abs(num_converted) >= 1000 and magnitude < len(suffixes) - 1:
         magnitude += 1
         num_converted /= 1000.0
     return "{}{}".format(
         f"{num_converted:f}".rstrip("0").rstrip("."),
-        ["", "k", "m", "b", "t"][magnitude],
+        suffixes[magnitude],
     )
 
 

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -146,6 +146,12 @@ class StringUtilTest(unittest.TestCase):
 
         assert string_util.simplify_number(1000000000000) == "1t"
 
+        # Numbers beyond a trillion stay in trillions instead of raising an
+        # IndexError past the largest suffix.
+        assert string_util.simplify_number(1000000000000000) == "1000t"
+
+        assert string_util.simplify_number(2500000000000000000) == "2500000t"
+
     @parameterized.expand(
         [
             ("", "`", 0),


### PR DESCRIPTION
## Describe your changes

`string_util.simplify_number` raises `IndexError` for numbers >= 1 quadrillion (`10**15`):

```python
>>> from streamlit.string_util import simplify_number
>>> simplify_number(10**15)
IndexError: list index out of range
```

It divides the value by 1000 until it drops below 1000, incrementing `magnitude` each time, but never bounds `magnitude` to the available suffixes `["", "k", "m", "b", "t"]`. Once the value reaches the quadrillion range, `magnitude` becomes 5 and indexes past the end of the list.

This change stops dividing once the largest suffix is reached, so such numbers stay expressed in trillions (e.g. `10**15` -> `"1000t"`) instead of crashing. All existing outputs are unchanged.

```python
simplify_number(1_000)                  # "1k"     (unchanged)
simplify_number(1_000_000_000_000)      # "1t"     (unchanged)
simplify_number(1_000_000_000_000_000)  # "1000t"  (was IndexError)
```

## Screenshot or video (only for visual changes)

N/A

## GitHub Issue Link (if applicable)

None - found while reading `string_util.py`.

## Testing Plan

- Unit Tests (Python): extended `StringUtilTest.test_simplify_number` in `lib/tests/streamlit/string_util_test.py` with two large-value cases (`10**15 -> "1000t"` and `2.5*10**18 -> "2500000t"`). These fail on `develop` with `IndexError` and pass with this change; the existing assertions (up to `1t`) are unchanged.
- No E2E or manual testing needed (pure formatting helper).

An AI assistant helped spot and implement this fix; I reviewed the change and verified the behavior of the edited function locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a display-formatting helper with bounded behavior; no security, auth, or data-path impact.
> 
> **Overview**
> **`simplify_number`** no longer crashes on integers at or above one quadrillion (`10**15`). The scaling loop now stops once the largest suffix (`t`) is reached, so extra-large values are shown in trillions (e.g. `10**15` → `"1000t"`) instead of indexing past `["", "k", "m", "b", "t"]`.
> 
> Suffixes are held in a named list used by the loop and return path; behavior for all previously supported magnitudes is unchanged. **Unit tests** cover two values above `1t` that used to raise `IndexError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096798082759088e3234ffac21a7134c1a55e38f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->