### PR TITLE
[chore] Ignore color2k dependabot updates above patched version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,9 @@ updates:
       - dependency-name: "@types/node"
         # Our types should match the version of node we're using as defined in `.nvmrc`
         versions: [">=25.0.0"]
+      - dependency-name: "color2k"
+        # Our Yarn patch only applies to color2k 2.0.3.
+        versions: [">=2.0.4"]
 
     groups:
       deck-gl:


### PR DESCRIPTION
## Describe your changes

- Adds a Dependabot ignore rule for `color2k` versions `>=2.0.4`.
- Our Yarn patch (`color2k-npm-2.0.3-41f760285e.patch`) and resolution pin `color2k` to `2.0.3`, so a bump would break the patched install.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Configuration-only change (Dependabot); no unit/e2e tests applicable.

Made with [Cursor](https://cursor.com)