### PR TITLE
Improve generating-changelog skill to fetch PR bodies and tighten entry length

### DIFF
--- a/.claude/skills/generating-changelog/SKILL.md
+++ b/.claude/skills/generating-changelog/SKILL.md
@@ -100,6 +100,8 @@ Do NOT proceed to Step 6 until the user confirms.
 
 For each user-facing PR in `work-tmp/pr-categorized.json`, read its `body` field before writing the changelog entry. Use the PR description as the primary source of truth for what actually changed — the title alone can be imprecise. Focus on the opening summary paragraph(s) of the body; ignore checklists, reviewer notes, and screenshot sections.
 
+**Entry length:** Keep every entry to **one sentence, two at most**. Capture the high-level idea only — what changed and why it matters to the user. Do not enumerate sub-features, implementation details, parameter lists, or edge-case behaviors. Those details live in the API docs.
+
 Generate the file in the `work-tmp/` directory: `work-tmp/changelog-website-<new-tag>.md`
 
 ### Entry writing style by category

--- a/.claude/skills/generating-changelog/SKILL.md
+++ b/.claude/skills/generating-changelog/SKILL.md
@@ -38,7 +38,7 @@ Run the fetch script to extract PR numbers from `git log` and batch-fetch metada
 uv run python scripts/changelog_fetch_prs.py <prev-tag> <new-tag>
 ```
 
-This produces `work-tmp/pr-data.json` — a JSON array of `{number, title, labels, author, related_issues, related_issues_truncated}` objects sorted by PR number.
+This produces `work-tmp/pr-data.json` — a JSON array of `{number, title, body, labels, author, related_issues, related_issues_truncated}` objects sorted by PR number. The `body` field contains the first 2500 characters of the PR description.
 
 `related_issues` is sourced from the same batched GraphQL query (no per-PR N+1 requests) and includes linked issue numbers plus 👍 counts:
 
@@ -96,7 +96,9 @@ Note: Internal-only feature PRs (e.g., e2e infra, CI workflows, agent skills) ar
 
 Do NOT proceed to Step 6 until the user confirms.
 
-## Step 6: Rewrite descriptions and generate output
+## Step 6: Read PR descriptions and generate output
+
+For each user-facing PR in `work-tmp/pr-categorized.json`, read its `body` field before writing the changelog entry. Use the PR description as the primary source of truth for what actually changed — the title alone can be imprecise. Focus on the opening summary paragraph(s) of the body; ignore checklists, reviewer notes, and screenshot sections.
 
 Generate the file in the `work-tmp/` directory: `work-tmp/changelog-website-<new-tag>.md`
 

--- a/scripts/changelog_fetch_prs.py
+++ b/scripts/changelog_fetch_prs.py
@@ -20,8 +20,9 @@ Usage:
 
 Extracts PR numbers from `git log`, batches them into GraphQL queries
 (50 per batch), and writes a JSON array of
-{number, title, labels, author, related_issues, related_issues_truncated}
-objects sorted by PR number.
+{number, title, body, labels, author, related_issues, related_issues_truncated}
+objects sorted by PR number. The `body` field is truncated to
+_BODY_MAX_CHARS characters to keep the output file manageable.
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ import sys
 from typing import Any
 
 _BATCH_SIZE = 50
+_BODY_MAX_CHARS = 2500
 
 
 def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -69,7 +71,7 @@ def _build_graphql_query(pr_numbers: list[int]) -> str:
     for pr in pr_numbers:
         fields.append(
             f"pr{pr}: pullRequest(number:{pr}) {{ "
-            f"number title labels(first:100) {{ nodes {{ name }} }} "
+            f"number title body labels(first:100) {{ nodes {{ name }} }} "
             f"author {{ login }} "
             f"closingIssuesReferences(first:10) {{ "
             f"nodes {{ number reactions(content:THUMBS_UP) {{ totalCount }} }} "
@@ -104,10 +106,12 @@ def _parse_graphql_response(stdout: str) -> list[dict[str, Any]]:
                 }
             )
 
+        raw_body = pr_data.get("body") or ""
         prs.append(
             {
                 "number": pr_data["number"],
                 "title": pr_data["title"],
+                "body": raw_body[:_BODY_MAX_CHARS],
                 "labels": [
                     n["name"] for n in pr_data.get("labels", {}).get("nodes", [])
                 ],


### PR DESCRIPTION
## Summary

- Extends `scripts/changelog_fetch_prs.py` to fetch the PR `body` field via the same batched GraphQL query (truncated to 2500 chars to avoid giant files), so the agent has the actual PR description to work from rather than just the title.
- Updates the `generating-changelog` skill to instruct the agent to read the `body` for each user-facing PR before writing its entry, treating it as the primary source of truth.
- Adds explicit entry-length guidance: one sentence, two at most — high-level idea only, no sub-feature lists or implementation details.

## Test plan

- [ ] Run `uv run python scripts/changelog_fetch_prs.py <prev> <new>` and verify `work-tmp/pr-data.json` now contains a `body` field on each PR object.

Made with [Cursor](https://cursor.com)