### PR TITLE
[fix] Restore type-to-search in st.selectbox

### DIFF
--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -212,6 +212,37 @@ def test_shows_correct_options_via_fuzzy_search(
     assert_snapshot(selection_dropdown, name="st_selectbox-fuzzy_matching")
 
 
+def test_type_to_search_replaces_committed_value(app: Page):
+    """Regression test for https://github.com/streamlit/streamlit/issues/15985.
+
+    With a value already committed, focusing the selectbox and typing must start
+    a fresh search (replacing the committed label) instead of appending the typed
+    characters behind it (which matched nothing).
+    """
+    selectbox_input = get_selectbox_input(app, "selectbox 1 (default)")
+    expect(selectbox_input).to_have_value("male")
+
+    # Click to focus, then type character-by-character to exercise the
+    # append-vs-replace behavior (fill() would replace the value wholesale).
+    selectbox_input.click()
+    selectbox_input.press_sequentially("fem")
+
+    # The committed "male" must be replaced by the query, not become "malefem".
+    expect(selectbox_input).to_have_value("fem")
+
+    # The dropdown filters to the matching option and hides the previous one.
+    selection_dropdown = app.get_by_test_id("stSelectboxVirtualDropdown")
+    options = selection_dropdown.get_by_role("option")
+    expect(options).to_have_count(1)
+    expect(options.first).to_have_text("female")
+    expect(
+        selection_dropdown.get_by_role("option", name="male", exact=True)
+    ).to_have_count(0)
+
+    selectbox_input.press("Enter")
+    expect_markdown(app, "value 1: female")
+
+
 def test_empty_selectbox_behaves_correctly(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -356,7 +356,10 @@ describe("Selectbox widget", () => {
     // With a value already committed, focusing and typing must start a fresh
     // search (replace the label) instead of appending behind it.
     const user = userEvent.setup()
-    props = getProps({ options: ["Apple", "Banana", "Cherry"], value: "Banana" })
+    props = getProps({
+      options: ["Apple", "Banana", "Cherry"],
+      value: "Banana",
+    })
     render(<Selectbox {...props} />)
     const input = screen.getByRole("combobox")
     expect(input).toHaveValue("Banana")
@@ -366,9 +369,7 @@ describe("Selectbox widget", () => {
 
     // The committed "Banana" must be replaced, not appended to ("BananaCh").
     expect(input).toHaveValue("Ch")
-    expect(
-      screen.getByRole("option", { name: "Cherry" })
-    ).toBeVisible()
+    expect(screen.getByRole("option", { name: "Cherry" })).toBeVisible()
     expect(
       screen.queryByRole("option", { name: "Banana" })
     ).not.toBeInTheDocument()
@@ -379,7 +380,10 @@ describe("Selectbox widget", () => {
     // shows the committed label, so a refocus after the first keystroke does
     // not clobber characters already typed.
     const user = userEvent.setup()
-    props = getProps({ options: ["Apple", "Banana", "Cherry"], value: "Banana" })
+    props = getProps({
+      options: ["Apple", "Banana", "Cherry"],
+      value: "Banana",
+    })
     render(<Selectbox {...props} />)
     const input = screen.getByRole("combobox")
 

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -404,6 +404,31 @@ describe("Selectbox widget", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("filters when the typed query equals the committed label", async () => {
+    // Edge case of the type-to-search diff: committed "a", the user types "a"
+    // so the browser reports "aa" and the diff yields "a" (== committed). This
+    // is still a real edit and must activate filtering / open the dropdown,
+    // not be mistaken for RAC's unchanged-label revert.
+    const user = userEvent.setup()
+    props = getProps({ options: ["a", "ab", "b"], value: "a" })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+
+    await user.click(input)
+    // Simulate the browser appending "a" behind the committed "a".
+    act(() => {
+      // eslint-disable-next-line testing-library/prefer-user-event
+      fireEvent.change(input, { target: { value: "aa" } })
+    })
+
+    expect(input).toHaveValue("a")
+    // Filtering is active: "a"/"ab" match the query, "b" is filtered out.
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "ab" })).toBeVisible()
+    })
+    expect(screen.queryByRole("option", { name: "b" })).not.toBeInTheDocument()
+  })
+
   it("updates value if new value provided from parent", () => {
     const { rerender } = render(<Selectbox {...props} />)
     expect(screen.getByDisplayValue(props.options[0])).toBeVisible()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -429,6 +429,34 @@ describe("Selectbox widget", () => {
     expect(screen.queryByRole("option", { name: "b" })).not.toBeInTheDocument()
   })
 
+  it("starts a fresh search over a committed value when acceptNewOptions is true", async () => {
+    // The fresh-search strip also runs with acceptNewOptions, so typing over a
+    // committed value yields the typed text ("foo" + "bar" -> "bar", offering
+    // "Add: bar") instead of the 1.59.x append bug ("foobar"). Other
+    // acceptNewOptions tests use value: undefined, so none cover this path.
+    const user = userEvent.setup()
+    props = getProps({
+      options: ["foo", "other"],
+      value: "foo",
+      acceptNewOptions: true,
+    })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+    expect(input).toHaveValue("foo")
+
+    await user.click(input)
+    act(() => {
+      // Simulate the browser appending the keystrokes behind the committed label.
+      // eslint-disable-next-line testing-library/prefer-user-event
+      fireEvent.change(input, { target: { value: "foobar" } })
+    })
+
+    expect(input).toHaveValue("bar")
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Add: bar/i })).toBeVisible()
+    })
+  })
+
   it("updates value if new value provided from parent", () => {
     const { rerender } = render(<Selectbox {...props} />)
     expect(screen.getByDisplayValue(props.options[0])).toBeVisible()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -23,7 +23,7 @@ import { render } from "~lib/test_util"
 import * as MobileUtil from "~lib/util/isMobile"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
-import Selectbox, { Props } from "./Selectbox"
+import Selectbox, { getInsertedText, Props } from "./Selectbox"
 
 vi.mock("~lib/WidgetStateManager")
 
@@ -604,5 +604,35 @@ describe("Selectbox widget with optional props", () => {
 
     // "AA" is case-sensitively distinct from "aa", "Aa", "aA" → Add option shown
     expect(screen.getByRole("option", { name: /Add: AA/i })).toBeVisible()
+  })
+})
+
+describe("getInsertedText", () => {
+  it.each([
+    // An unchanged label is not an insertion of new characters. Returning ""
+    // here (rather than treating it as a replace) prevents the committed label
+    // from clearing itself when RAC re-reports it on close/revert.
+    ["Banana", "Banana", ""],
+    ["Banana", "Bananac", "c"],
+    ["Banana", "Bananach", "ch"],
+    // Insertions at the start or middle are detected regardless of caret.
+    ["male", "xmale", "x"],
+    ["male", "mafle", "f"],
+    // Repeated characters do not confuse the prefix/suffix diff.
+    ["aa", "aaa", "a"],
+    // Empty committed label: everything typed is the insertion.
+    ["", "abc", "abc"],
+  ])("returns %j -> %j = %j", (before, after, expected) => {
+    expect(getInsertedText(before, after)).toBe(expected)
+  })
+
+  it.each([
+    // Not pure insertions (characters removed/replaced) → null, so the caller
+    // keeps the reported text as-is.
+    ["male", "mole", null],
+    ["Banana", "Cherry", null],
+    ["male", "mal", null],
+  ])("returns null for non-insertions %j -> %j", (before, after, expected) => {
+    expect(getInsertedText(before, after)).toBe(expected)
   })
 })

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -351,6 +351,48 @@ describe("Selectbox widget", () => {
     expect(screen.queryAllByRole("option")).toHaveLength(3)
   })
 
+  it("replaces the committed label when typing after focus (type-to-search)", async () => {
+    // Regression test for https://github.com/streamlit/streamlit/issues/15985
+    // With a value already committed, focusing and typing must start a fresh
+    // search (replace the label) instead of appending behind it.
+    const user = userEvent.setup()
+    props = getProps({ options: ["Apple", "Banana", "Cherry"], value: "Banana" })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+    expect(input).toHaveValue("Banana")
+
+    await user.click(input)
+    await user.keyboard("Ch")
+
+    // The committed "Banana" must be replaced, not appended to ("BananaCh").
+    expect(input).toHaveValue("Ch")
+    expect(
+      screen.getByRole("option", { name: "Cherry" })
+    ).toBeVisible()
+    expect(
+      screen.queryByRole("option", { name: "Banana" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not re-select the query when RAC refocuses the input mid-typing", async () => {
+    // Guards the focus handler: it must only select while the input still
+    // shows the committed label, so a refocus after the first keystroke does
+    // not clobber characters already typed.
+    const user = userEvent.setup()
+    props = getProps({ options: ["Apple", "Banana", "Cherry"], value: "Banana" })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+
+    await user.click(input)
+    await user.keyboard("c")
+    // A second focus event (as RAC may fire when opening the dropdown) must
+    // not re-select the "c" the user just typed.
+    fireEvent.focus(input)
+    await user.keyboard("h")
+
+    expect(input).toHaveValue("ch")
+  })
+
   it("updates value if new value provided from parent", () => {
     const { rerender } = render(<Selectbox {...props} />)
     expect(screen.getByDisplayValue(props.options[0])).toBeVisible()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -377,9 +377,9 @@ describe("Selectbox widget", () => {
 
   it("replaces the committed label when the browser appends the keystroke", async () => {
     // Some browsers (e.g. Safari/WebKit) place the caret at the end of the
-    // committed label on click-focus, so the first keystroke arrives appended
-    // to the whole label. The change handler must still strip the label and
-    // keep only the typed character(s), regardless of caret behavior.
+    // committed label on click-focus, appending the first keystroke to the
+    // whole label. The change handler must still strip the label and keep only
+    // the typed character(s), regardless of caret behavior.
     const user = userEvent.setup()
     props = getProps({
       options: ["Apple", "Banana", "Cherry"],

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -375,10 +375,11 @@ describe("Selectbox widget", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("does not re-select the query when RAC refocuses the input mid-typing", async () => {
-    // Guards the focus handler: it must only select while the input still
-    // shows the committed label, so a refocus after the first keystroke does
-    // not clobber characters already typed.
+  it("replaces the committed label when the browser appends the keystroke", async () => {
+    // Some browsers (e.g. Safari/WebKit) place the caret at the end of the
+    // committed label on click-focus, so the first keystroke arrives appended
+    // to the whole label. The change handler must still strip the label and
+    // keep only the typed character(s), regardless of caret behavior.
     const user = userEvent.setup()
     props = getProps({
       options: ["Apple", "Banana", "Cherry"],
@@ -388,13 +389,19 @@ describe("Selectbox widget", () => {
     const input = screen.getByRole("combobox")
 
     await user.click(input)
-    await user.keyboard("c")
-    // A second focus event (as RAC may fire when opening the dropdown) must
-    // not re-select the "c" the user just typed.
-    fireEvent.focus(input)
-    await user.keyboard("h")
+    // Simulate the browser appending "c" behind the committed "Banana".
+    act(() => {
+      // eslint-disable-next-line testing-library/prefer-user-event
+      fireEvent.change(input, { target: { value: "Bananac" } })
+    })
 
-    expect(input).toHaveValue("ch")
+    expect(input).toHaveValue("c")
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Cherry" })).toBeVisible()
+    })
+    expect(
+      screen.queryByRole("option", { name: "Banana" })
+    ).not.toBeInTheDocument()
   })
 
   it("updates value if new value provided from parent", () => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -385,6 +385,24 @@ const Selectbox: FC<Props> = ({
     openDropdownRef.current?.()
   }, [selectDisabled])
 
+  // Select the committed label when the input gains focus so the first
+  // keystroke replaces it and starts a fresh search, instead of appending
+  // behind the caret (which is placed at the end of the text). The label
+  // stays visible until the user types. Skipped for the mobile read-only
+  // path where typing is disabled.
+  const handleInputFocus = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>): void => {
+      if (inputReadOnly) return
+      // Only select while the input still shows the committed label. RAC can
+      // refocus the input mid-typing (e.g. when the dropdown opens); guarding
+      // on the current text avoids re-selecting and clobbering the query.
+      if (e.currentTarget.value === (valueRef.current ?? "")) {
+        e.currentTarget.select()
+      }
+    },
+    [inputReadOnly]
+  )
+
   /**
    * Capture-phase keydown — fires before RAC's handler:
    * - Records wasOpenBeforeEnterRef so the bubble-phase handler can check
@@ -505,6 +523,7 @@ const Selectbox: FC<Props> = ({
               placeholder={resolvedPlaceholder}
               readOnly={inputReadOnly}
               onPointerDown={handleInputPointerDown}
+              onFocus={handleInputFocus}
               onKeyDownCapture={handleInputKeyDownCapture}
               onKeyDown={handleInputKeyDown}
               onPaste={isFilterNone ? e => e.preventDefault() : undefined}

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -415,10 +415,10 @@ const Selectbox: FC<Props> = ({
     // case treated as a non-edit.
     const isEdit = text !== committed
     setFilterActive(isEdit)
-    // Update the ref synchronously too: setFilterActive only refreshes it on the
-    // next render, so a second keystroke arriving before that render would
-    // otherwise see a stale `false`, re-run the fresh-search strip against the
-    // committed label, and truncate a growing query (e.g. "ab" back to "b").
+    // Update the ref synchronously, not just via setFilterActive, which
+    // refreshes it only on the next render. Otherwise a second keystroke before
+    // that render reads a stale `false` and re-strips the growing query (e.g.
+    // "ab" back to "b").
     filterActiveRef.current = isEdit
     if (isEdit) {
       openDropdownRef.current?.()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -408,9 +408,12 @@ const Selectbox: FC<Props> = ({
     }
 
     setInputValue(nextText)
-    // RAC calls onInputChange(committedLabel) when the dropdown closes to
-    // revert the input — don't treat that automatic revert as user filtering.
-    if (nextText !== committed) {
+    // Decide filtering from the raw reported text, not from nextText: when the
+    // fresh-search diff yields a query equal to the committed label (e.g.
+    // committed "a", typing "a"), filtering must still activate. RAC reports
+    // text === committed when it reverts the input on close — that is the only
+    // case treated as a non-edit.
+    if (text !== committed) {
       setFilterActive(true)
       openDropdownRef.current?.()
     } else {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -402,7 +402,7 @@ const Selectbox: FC<Props> = ({
       // An empty insertion means no new characters were typed (e.g. RAC
       // reporting the unchanged committed label on close/revert), which must
       // not clear the input.
-      if (inserted !== null && inserted !== "" && inserted !== text) {
+      if (inserted !== null && inserted !== "") {
         nextText = inserted
       }
     }

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -100,7 +100,10 @@ const CREATABLE_ID = "__creatable__"
  * caret. Works purely from the reported input text, so it is independent of
  * caret position and browser-specific focus/selection behavior.
  */
-const getInsertedText = (before: string, after: string): string | null => {
+export const getInsertedText = (
+  before: string,
+  after: string
+): string | null => {
   const maxPrefix = Math.min(before.length, after.length)
   let prefix = 0
   while (prefix < maxPrefix && before[prefix] === after[prefix]) {
@@ -396,7 +399,10 @@ const Selectbox: FC<Props> = ({
     let nextText = text
     if (!filterActiveRef.current && committed !== "") {
       const inserted = getInsertedText(committed, text)
-      if (inserted !== null && inserted !== text) {
+      // An empty insertion means no new characters were typed (e.g. RAC
+      // reporting the unchanged committed label on close/revert), which must
+      // not clear the input.
+      if (inserted !== null && inserted !== "" && inserted !== text) {
         nextText = inserted
       }
     }

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -92,6 +92,36 @@ type ComboOption = {
 const CREATABLE_ID = "__creatable__"
 
 /**
+ * If `after` is `before` with extra characters inserted (at any position),
+ * return just those inserted characters; otherwise return null.
+ *
+ * Used to detect the user typing over an untouched committed label so the
+ * first keystroke starts a fresh search instead of appending behind the
+ * caret. Works purely from the reported input text, so it is independent of
+ * caret position and browser-specific focus/selection behavior.
+ */
+const getInsertedText = (before: string, after: string): string | null => {
+  const maxPrefix = Math.min(before.length, after.length)
+  let prefix = 0
+  while (prefix < maxPrefix && before[prefix] === after[prefix]) {
+    prefix++
+  }
+  const maxSuffix = Math.min(before.length - prefix, after.length - prefix)
+  let suffix = 0
+  while (
+    suffix < maxSuffix &&
+    before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+  // A pure insertion removes none of `before`'s characters.
+  if (before.slice(prefix, before.length - suffix) !== "") {
+    return null
+  }
+  return after.slice(prefix, after.length - suffix)
+}
+
+/**
  * Null-render component mounted inside <ComboBox> to expose RAC's internal
  * open/close methods via refs. Required because ComboBox v1.x has no controlled
  * isOpen prop; we use menuTrigger="manual" and open explicitly on pointer/key
@@ -356,10 +386,25 @@ const Selectbox: FC<Props> = ({
   }, [])
 
   const handleInputChange = useCallback((text: string): void => {
-    setInputValue(text)
+    const committed = valueRef.current ?? ""
+
+    // Typing over an untouched committed label starts a fresh search: replace
+    // the label with just the newly typed characters instead of editing it in
+    // place. The ComboBox keeps the committed label in the input with the caret
+    // at the end, so without this the first keystroke would append behind it
+    // (e.g. "Banana" + "c" -> "Bananac") and match nothing.
+    let nextText = text
+    if (!filterActiveRef.current && committed !== "") {
+      const inserted = getInsertedText(committed, text)
+      if (inserted !== null && inserted !== text) {
+        nextText = inserted
+      }
+    }
+
+    setInputValue(nextText)
     // RAC calls onInputChange(committedLabel) when the dropdown closes to
     // revert the input — don't treat that automatic revert as user filtering.
-    if (text !== (valueRef.current ?? "")) {
+    if (nextText !== committed) {
       setFilterActive(true)
       openDropdownRef.current?.()
     } else {
@@ -384,24 +429,6 @@ const Selectbox: FC<Props> = ({
     if (selectDisabled) return
     openDropdownRef.current?.()
   }, [selectDisabled])
-
-  // Select the committed label when the input gains focus so the first
-  // keystroke replaces it and starts a fresh search, instead of appending
-  // behind the caret (which is placed at the end of the text). The label
-  // stays visible until the user types. Skipped for the mobile read-only
-  // path where typing is disabled.
-  const handleInputFocus = useCallback(
-    (e: React.FocusEvent<HTMLInputElement>): void => {
-      if (inputReadOnly) return
-      // Only select while the input still shows the committed label. RAC can
-      // refocus the input mid-typing (e.g. when the dropdown opens); guarding
-      // on the current text avoids re-selecting and clobbering the query.
-      if (e.currentTarget.value === (valueRef.current ?? "")) {
-        e.currentTarget.select()
-      }
-    },
-    [inputReadOnly]
-  )
 
   /**
    * Capture-phase keydown — fires before RAC's handler:
@@ -523,7 +550,6 @@ const Selectbox: FC<Props> = ({
               placeholder={resolvedPlaceholder}
               readOnly={inputReadOnly}
               onPointerDown={handleInputPointerDown}
-              onFocus={handleInputFocus}
               onKeyDownCapture={handleInputKeyDownCapture}
               onKeyDown={handleInputKeyDown}
               onPaste={isFilterNone ? e => e.preventDefault() : undefined}

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -97,8 +97,8 @@ const CREATABLE_ID = "__creatable__"
  *
  * Used to detect the user typing over an untouched committed label so the
  * first keystroke starts a fresh search instead of appending behind the
- * caret. Works purely from the reported input text, so it is independent of
- * caret position and browser-specific focus/selection behavior.
+ * committed label. Works from the reported input text alone, so it is
+ * independent of caret position and browser-specific focus/selection behavior.
  */
 export const getInsertedText = (
   before: string,

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -413,11 +413,15 @@ const Selectbox: FC<Props> = ({
     // committed "a", typing "a"), filtering must still activate. RAC reports
     // text === committed when it reverts the input on close — that is the only
     // case treated as a non-edit.
-    if (text !== committed) {
-      setFilterActive(true)
+    const isEdit = text !== committed
+    setFilterActive(isEdit)
+    // Update the ref synchronously too: setFilterActive only refreshes it on the
+    // next render, so a second keystroke arriving before that render would
+    // otherwise see a stale `false`, re-run the fresh-search strip against the
+    // committed label, and truncate a growing query (e.g. "ab" back to "b").
+    filterActiveRef.current = isEdit
+    if (isEdit) {
       openDropdownRef.current?.()
-    } else {
-      setFilterActive(false)
     }
   }, [])
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Closes #15985

## Describe your changes

Typing into an `st.selectbox` that already has a value no longer cleared the committed label to start a fresh search — the typed characters were appended behind the selection (select "Banana", type `ch` → input shows `Bananach`, dropdown shows "No results").

**Root cause:** The react-aria-components `ComboBox` rewrite (#15438), which first shipped in **1.59.0**, keeps the committed label as the controlled `inputValue` on focus with the caret placed at the end. The first keystroke is therefore treated as an *append*, and the fuzzy filter runs against the concatenated string, matching nothing. The old BaseWeb selectbox cleared the query when the user began typing. (Note: the reporter guessed #15870, but that dropdown-virtualization PR is only in dev builds and is not in stable 1.59.x, so it cannot be the cause.)

**Fix:** In the ComboBox input change handler, detect when the user is typing over an untouched committed label and start a fresh search — replacing the label with only the newly typed character(s). The newly typed characters are extracted with a prefix/suffix diff against the committed label, so it works regardless of caret position and browser-specific focus/selection behavior. This preserves arrow-key navigation, Enter-to-commit, `clearable`, `accept_new_options`, `filter_mode=None`, and the mobile read-only path (all covered by existing tests).

## Alternatives considered

- **`select()` the label on focus** (the "standard" select-all-on-focus). Simpler, but not cross-browser robust: WebKit/Safari places the caret on mouse-up after focus, which collapses the selection so the keystroke still appends (verified failing in the WebKit e2e run — input became `malefem`). The prefix/suffix diff is independent of selection behavior.
- **Clear `inputValue` on focus and rely on blur-restore.** Deterministic, but the committed value visually disappears on focus and it risks fighting RAC's own focus/blur input reconciliation.

## Testing

- Frontend unit tests (`Selectbox.test.tsx`): typing after focus replaces the committed label and filters to the match; and a browser-independent case that simulates a browser appending the keystroke behind the label (`Bananac`) still resolves to `c`. Both fail before the fix and pass after.
- E2E Playwright test (`st_selectbox_test.py::test_type_to_search_replaces_committed_value`). Verified locally passing in both Chromium and WebKit; the full `st_selectbox` suite (66 tests) passes in both browsers.

Repro: https://issues.streamlit.app/?issue=gh-15985
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1161e74b-8a17-426b-8541-a7a33d3a445e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1161e74b-8a17-426b-8541-a7a33d3a445e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

