### PR TITLE
[fix] Clip dataframe canvas to rounded corners (#12080, #11998)

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/styled-components.ts
@@ -39,6 +39,10 @@ export const StyledResizableContainer =
         minWidth: "100%",
         minHeight: minHeight,
         borderRadius: theme.radii.default,
+        // Clip the grid canvas (header background, cell highlights, etc.)
+        // to the rounded corners; without this, border-radius on the parent
+        // does not affect the child's painted content.
+        overflow: "hidden",
       },
 
       "& .dvn-scroller": {


### PR DESCRIPTION
## Summary

Fixes #12080 and #11998. The outer `Resizable` applies `border` +
`border-radius` on the dataframe container, but neither it nor the
inner `.stDataFrameGlideDataEditor` sets `overflow: hidden`. Without
`overflow: hidden`, `border-radius` does not clip a child's painted
content — so the grid canvas (header background, cell selection
highlights) renders past the rounded corners.

Add `overflow: hidden` to `.stDataFrameGlideDataEditor` so its
existing `border-radius` actually clips the grid content.

- Fixes the visible gap between border and colored header background
  when `baseRadius` is large + `dataframeHeaderBackgroundColor` is set
  (#12080).
- Fixes the cell highlight/selection color being clipped at the
  rounded corners in `st.data_editor` (#11998).

## Test plan

- [ ] Repro #12080: with `baseRadius="large"` and
      `dataframeHeaderBackgroundColor="lightblue"`, verify no gap
      between the top corners of the border and the header background.
- [ ] Repro #11998: select a cell in the corner of a data_editor and
      verify the highlight reaches the rounded corner without a visible
      clip gap.
- [ ] Regression: search bar (`gdg-search-bar`), cell tooltips,
      resize handle, and horizontal/vertical scrollbars still render
      and function correctly.
- [ ] Regression: no rounding config (default theme) still looks
      correct.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS property on the dataframe editor wrapper; possible regression if popovers or scroll UI were clipped, but inner scroller keeps its own overflow.
> 
> **Overview**
> Adds **`overflow: hidden`** on **`.stDataFrameGlideDataEditor`** in `styled-components.ts` so the Glide grid canvas (header fill, selection highlights) is clipped to the element’s existing **`border-radius`**, instead of painting square past the rounded frame.
> 
> This addresses the corner gap when **`baseRadius`** is large with a colored header background, and clipped selection highlights at the corners in **`st.data_editor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148ce197183efce4c3fb59a490fce96804181025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->