### PR TITLE
[chore] Replace cachetools with internal TTLCache

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
   # See: https://github.com/streamlit/streamlit/issues/12064
   "altair>=4.0,<7,!=5.4.0,!=5.4.1",
   "blinker>=1.5.0,<2",
-  "cachetools>=5.5,<8",
   "click>=7.0,<9",
   "gitpython>=3.0.7,<4,!=3.1.19",
   "numpy>=1.23,<3",

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -673,9 +673,7 @@ class ResourceCache(Cache[R]):
 
     @property
     def ttl_seconds(self) -> float:
-        # Wrap in float() so this type-checks across types-cachetools versions:
-        # 6.x types .ttl as float, while 7.0.0+ types it as Any.
-        return float(self._mem_cache.ttl)
+        return self._mem_cache.ttl
 
     def read_result(self, key: str) -> CachedResult[R]:
         """Read a value and associated messages from the cache.

--- a/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
+++ b/lib/streamlit/runtime/caching/storage/in_memory_cache_storage_wrapper.py
@@ -17,8 +17,6 @@ import math
 import threading
 from typing import TYPE_CHECKING
 
-from cachetools import TTLCache
-
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.storage.cache_storage_protocol import (
@@ -26,6 +24,7 @@ from streamlit.runtime.caching.storage.cache_storage_protocol import (
     CacheStorageContext,
     CacheStorageKeyNotFoundError,
 )
+from streamlit.runtime.caching.ttl_cache import TTLCache
 from streamlit.runtime.stats import CACHE_MEMORY_FAMILY, CacheStat
 
 if TYPE_CHECKING:

--- a/lib/streamlit/runtime/caching/ttl_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cache.py
@@ -1,0 +1,208 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A minimal LRU cache with per-item time-to-live (TTL) support.
+
+This is a small, dependency-free replacement for ``cachetools.TTLCache`` that
+preserves the exact subset of behavior Streamlit relies on:
+
+- Entries are evicted least-recently-used first once ``maxsize`` is exceeded,
+  where recency is refreshed both on read and on write.
+- Every entry shares the same ``ttl``, so write order is also expiry order.
+  Expired entries are reported as absent on reads (``__getitem__`` /
+  ``in``) but are only actually removed by a write, by ``expire()``, or by a
+  length/size query. Some of Streamlit's cache-cleanup hooks depend on this.
+
+Like ``cachetools.TTLCache``, this cache is **not** thread-safe. Callers that
+share an instance across threads must provide their own locking.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import Callable, Iterator, MutableMapping
+from typing import Final, TypeVar, overload
+
+K = TypeVar("K")
+V = TypeVar("V")
+_T = TypeVar("_T")
+
+# Sentinel used to detect whether a default was passed to pop().
+_MISSING: Final = object()
+
+
+class TTLCache(MutableMapping[K, V]):
+    """LRU cache with a uniform per-item time-to-live."""
+
+    def __init__(
+        self,
+        maxsize: float,
+        ttl: float,
+        timer: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Create a new TTLCache.
+
+        Parameters
+        ----------
+        maxsize : float
+            The maximum number of entries the cache may hold. Use ``math.inf``
+            for an unbounded cache.
+        ttl : float
+            The time in seconds that an entry remains valid after it is written.
+        timer : Callable[[], float]
+            A zero-argument callable returning the current time. Defaults to
+            ``time.monotonic``.
+        """
+        self._maxsize = maxsize
+        self._ttl = ttl
+        self._timer = timer
+        # Maps key -> value in least-recently-used order (oldest first). The LRU
+        # position is refreshed on both reads and writes.
+        self._data: OrderedDict[K, V] = OrderedDict()
+        # Maps key -> expiry timestamp in write order (soonest-to-expire first).
+        # Because the TTL is uniform, write order is also expiry order, which
+        # lets expire() stop at the first still-valid entry.
+        self._expirations: OrderedDict[K, float] = OrderedDict()
+
+    @property
+    def maxsize(self) -> float:
+        """The maximum number of entries the cache may hold."""
+        return self._maxsize
+
+    @property
+    def ttl(self) -> float:
+        """The time-to-live value of the cache's entries, in seconds."""
+        return self._ttl
+
+    @property
+    def timer(self) -> Callable[[], float]:
+        """The timer function used by the cache."""
+        return self._timer
+
+    @property
+    def currsize(self) -> int:
+        """The current number of (non-expired) entries in the cache."""
+        return len(self)
+
+    def __contains__(self, key: object) -> bool:
+        # Membership never reorders entries and never reaps expired ones, which
+        # matches cachetools (and keeps `in` checks free of LRU side effects).
+        expires = self._expirations.get(key)  # type: ignore[arg-type]
+        return expires is not None and self._timer() < expires
+
+    def __getitem__(self, key: K) -> V:
+        try:
+            expires = self._expirations[key]
+        except KeyError:
+            raise KeyError(key) from None
+        # Bump recency on read, matching cachetools (which reorders even when the
+        # entry turns out to be expired but not yet reaped).
+        self._data.move_to_end(key)
+        if not (self._timer() < expires):
+            # Expired entries are treated as absent, but left in place to be
+            # reaped later by expire()/eviction.
+            raise KeyError(key)
+        return self._data[key]
+
+    def __setitem__(self, key: K, value: V) -> None:
+        if self._maxsize < 1:
+            raise ValueError("value too large")
+        now = self._timer()
+        # Reap expired entries first so freed capacity is reused before evicting.
+        self.expire(now)
+        if key not in self._data:
+            # Count-based sizing: each entry counts as one.
+            while len(self._data) + 1 > self._maxsize:
+                self.popitem()
+        self._data[key] = value
+        self._data.move_to_end(key)
+        self._expirations[key] = now + self._ttl
+        self._expirations.move_to_end(key)
+
+    def __delitem__(self, key: K) -> None:
+        try:
+            del self._data[key]
+        except KeyError:
+            raise KeyError(key) from None
+        expires = self._expirations.pop(key)
+        # Mirror cachetools: deleting an already-expired entry removes it but
+        # still signals a miss by raising KeyError.
+        if not (self._timer() < expires):
+            raise KeyError(key)
+
+    def __iter__(self) -> Iterator[K]:
+        now = self._timer()
+        # Iterate in expiry (write) order, yielding only still-valid keys.
+        # Snapshot the items so a caller reading values mid-iteration can't
+        # disturb the iteration.
+        for key, expires in list(self._expirations.items()):
+            if now < expires:
+                yield key
+
+    def __len__(self) -> int:
+        # Matches cachetools: querying the length reaps expired entries first.
+        self.expire()
+        return len(self._data)
+
+    @overload
+    def pop(self, key: K) -> V: ...
+    @overload
+    def pop(self, key: K, default: V) -> V: ...
+    @overload
+    def pop(self, key: K, default: _T) -> V | _T: ...
+    def pop(self, key: K, default: object = _MISSING) -> object:
+        # Read the timer once so the entry cannot flip from valid to expired
+        # between the membership check and the removal. This preserves the
+        # cachetools contract that pop() with a default never raises for an
+        # entry that was present-and-valid at the start of the call.
+        now = self._timer()
+        expires = self._expirations.get(key)
+        if expires is not None and now < expires:
+            del self._expirations[key]
+            return self._data.pop(key)
+        if default is _MISSING:
+            raise KeyError(key)
+        return default
+
+    def popitem(self) -> tuple[K, V]:
+        """Remove and return the least-recently-used non-expired ``(key, value)``."""
+        self.expire()
+        try:
+            key = next(iter(self._data))
+        except StopIteration:
+            raise KeyError(f"{type(self).__name__} is empty") from None
+        value = self._data.pop(key)
+        del self._expirations[key]
+        return key, value
+
+    def expire(self, time: float | None = None) -> list[tuple[K, V]]:
+        """Remove expired entries and return the removed ``(key, value)`` pairs."""
+        now = self._timer() if time is None else time
+        expired_keys: list[K] = []
+        for key, expires in self._expirations.items():
+            if now < expires:
+                # Uniform TTL means every later entry is also still valid.
+                break
+            expired_keys.append(key)
+        removed: list[tuple[K, V]] = []
+        for key in expired_keys:
+            value = self._data.pop(key)
+            del self._expirations[key]
+            removed.append((key, value))
+        return removed
+
+    def clear(self) -> None:
+        self._data.clear()
+        self._expirations.clear()

--- a/lib/streamlit/runtime/caching/ttl_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cache.py
@@ -96,6 +96,15 @@ class TTLCache(MutableMapping[K, V]):
         """The current number of (non-expired) entries in the cache."""
         return len(self)
 
+    def __repr__(self) -> str:
+        # Report the raw number of stored entries rather than currsize/len(),
+        # which would reap expired entries (and, in TTLCleanupCache, fire
+        # release hooks) as a side effect. __repr__ must never mutate the cache.
+        return (
+            f"{type(self).__name__}(maxsize={self._maxsize!r}, "
+            f"ttl={self._ttl!r}, currsize={len(self._data)!r})"
+        )
+
     def __contains__(self, key: object) -> bool:
         # Membership never reorders entries and never reaps expired ones, which
         # matches cachetools (and keeps `in` checks free of LRU side effects).

--- a/lib/streamlit/runtime/caching/ttl_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cache.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import time
 from collections import OrderedDict
-from collections.abc import Callable, Iterator, MutableMapping
+from collections.abc import Callable, ItemsView, Iterator, MutableMapping, ValuesView
 from typing import Final, TypeVar, overload
 
 K = TypeVar("K")
@@ -160,6 +160,28 @@ class TTLCache(MutableMapping[K, V]):
             if now < expires:
                 yield key
 
+    def _live_snapshot(self) -> dict[K, V]:
+        # Capture the non-expired entries against a single timer reading. The
+        # default MutableMapping items()/values() views re-read the timer via
+        # __getitem__ for every key, so an entry that expires between __iter__
+        # yielding it and the follow-up __getitem__ would raise KeyError mid-
+        # iteration. cachetools avoids this by freezing its timer for the
+        # duration of iteration; reading everything against one timestamp gives
+        # the same consistent view. Entries are returned in expiry (write) order,
+        # matching __iter__.
+        now = self._timer()
+        return {
+            key: self._data[key]
+            for key, expires in list(self._expirations.items())
+            if now < expires
+        }
+
+    def items(self) -> ItemsView[K, V]:
+        return self._live_snapshot().items()
+
+    def values(self) -> ValuesView[V]:
+        return self._live_snapshot().values()
+
     def __len__(self) -> int:
         # Matches cachetools: querying the length reaps expired entries first.
         self.expire()
@@ -196,9 +218,9 @@ class TTLCache(MutableMapping[K, V]):
         del self._expirations[key]
         return key, value
 
-    def expire(self, time: float | None = None) -> list[tuple[K, V]]:
+    def expire(self, at_time: float | None = None) -> list[tuple[K, V]]:
         """Remove expired entries and return the removed ``(key, value)`` pairs."""
-        now = self._timer() if time is None else time
+        now = self._timer() if at_time is None else at_time
         expired_keys: list[K] = []
         for key, expires in self._expirations.items():
             if now < expires:

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -17,13 +17,12 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-from cachetools import TTLCache
-
 # override is in typing after Python 3.12 and can be imported from there after 3.11
 # support is retired.
 from typing_extensions import override
 
 from streamlit.runtime.caching.cache_utils import OnRelease
+from streamlit.runtime.caching.ttl_cache import TTLCache
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -77,8 +76,9 @@ class TTLCleanupCache(TTLCache[K, V]):
 
     @override
     def clear(self) -> None:
-        # cachetools 7.0.2 makes clear() O(1) and bypasses popitem(). We clear
-        # via popitem() to preserve the behavior seen in cachetools <= 7.0.1.
+        # The base TTLCache.clear() is O(1) and bypasses popitem(), so it would
+        # not invoke our release hooks. Clear via popitem() instead to ensure
+        # on_release is called for every entry.
         while True:
             try:
                 self.popitem()

--- a/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
+++ b/lib/streamlit/runtime/caching/ttl_cleanup_cache.py
@@ -67,8 +67,8 @@ class TTLCleanupCache(TTLCache[K, V]):
         return key, value
 
     @override
-    def expire(self, time: float | None = None) -> list[tuple[K, V]]:
-        items = super().expire(time)
+    def expire(self, at_time: float | None = None) -> list[tuple[K, V]]:
+        items = super().expire(at_time)
         for _, value in items:
             self._on_release(value)
 

--- a/lib/streamlit/runtime/memory_session_storage.py
+++ b/lib/streamlit/runtime/memory_session_storage.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cachetools import TTLCache
-
+from streamlit.runtime.caching.ttl_cache import TTLCache
 from streamlit.runtime.session_manager import SessionInfo, SessionStorage
 
 if TYPE_CHECKING:
@@ -28,7 +27,7 @@ class MemorySessionStorage(SessionStorage):
     """A SessionStorage that stores sessions in memory.
 
     At most maxsize sessions are stored with a TTL of ttl seconds. This class is really
-    just a thin wrapper around cachetools.TTLCache that complies with the SessionStorage
+    just a thin wrapper around a TTLCache that complies with the SessionStorage
     protocol.
     """
 

--- a/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
@@ -1,0 +1,374 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the internal ``TTLCache`` implementation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from streamlit.runtime.caching.ttl_cache import TTLCache
+
+
+class _FakeClock:
+    """A controllable timer that returns whatever time we set."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_basic_mapping_operations() -> None:
+    """The cache supports the core get/set/contains/delete/len operations."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+
+    cache["a"] = 1
+    cache["b"] = 2
+
+    assert cache["a"] == 1
+    assert "a" in cache
+    assert "missing" not in cache
+    assert len(cache) == 2
+
+    del cache["a"]
+    assert "a" not in cache
+    assert len(cache) == 1
+
+
+def test_getitem_missing_raises_key_error() -> None:
+    """Reading an absent key raises ``KeyError``."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+
+    with pytest.raises(KeyError):
+        _ = cache["missing"]
+
+
+def test_get_and_pop_defaults() -> None:
+    """``get`` and ``pop`` return defaults for absent keys, and ``pop`` removes."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+    cache["a"] = 1
+
+    assert cache.get("a") == 1
+    assert cache.get("missing") is None
+    assert cache.get("missing", -1) == -1
+
+    assert cache.pop("a") == 1
+    assert "a" not in cache
+    assert cache.pop("missing", -1) == -1
+    with pytest.raises(KeyError):
+        cache.pop("missing")
+
+
+def test_lru_eviction_when_exceeding_maxsize() -> None:
+    """Once ``maxsize`` is exceeded, the least-recently-used entry is evicted."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=3, ttl=100, timer=_FakeClock())
+
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # A read refreshes recency, so "a" is no longer the least recently used.
+    assert cache["a"] == 1
+
+    # Adding a 4th entry evicts "b" (now the least recently used), not "a".
+    cache["d"] = 4
+
+    assert "b" not in cache
+    assert set(cache) == {"a", "c", "d"}
+
+
+def test_overwrite_existing_key_does_not_evict() -> None:
+    """Overwriting an existing key updates the value and recency without eviction."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=2, ttl=100, timer=_FakeClock())
+
+    cache["a"] = 1
+    cache["b"] = 2
+
+    # Overwriting "a" must not evict "b", and bumps "a" to most-recently-used.
+    cache["a"] = 10
+    assert cache["a"] == 10
+    assert "b" in cache
+
+    # Adding "c" now evicts "b" (the least recently used), keeping "a".
+    cache["c"] = 3
+    assert "b" not in cache
+    assert cache["a"] == 10
+    assert cache["c"] == 3
+
+
+def test_unbounded_maxsize_never_evicts() -> None:
+    """A cache with ``math.inf`` maxsize never evicts on size."""
+    cache: TTLCache[int, int] = TTLCache(maxsize=math.inf, ttl=100, timer=_FakeClock())
+
+    for i in range(1000):
+        cache[i] = i
+
+    assert len(cache) == 1000
+
+
+def test_maxsize_below_one_raises_on_write() -> None:
+    """Writing to a cache that cannot hold a single entry raises ``ValueError``."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=0, ttl=100, timer=_FakeClock())
+
+    with pytest.raises(ValueError, match="value too large"):
+        cache["a"] = 1
+
+
+def test_expired_entries_are_absent_on_read_but_not_reaped() -> None:
+    """Expired entries look absent on reads yet remain until reaped by a write/query."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1  # expires at t=10
+
+    clock.now = 5
+    assert "a" in cache
+    assert cache["a"] == 1
+
+    # At the TTL boundary the entry is considered expired.
+    clock.now = 10
+    assert "a" not in cache
+    with pytest.raises(KeyError):
+        _ = cache["a"]
+
+    # It is still physically present (not yet reaped) until a length/size query.
+    assert "a" in cache._data
+    assert len(cache) == 0
+    assert "a" not in cache._data
+
+
+def test_expire_reaps_in_write_order_and_returns_pairs() -> None:
+    """``expire`` removes entries whose TTL has passed and returns the pairs."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1  # expires at 10
+    clock.now = 1
+    cache["b"] = 2  # expires at 11
+    clock.now = 2
+    cache["c"] = 3  # expires at 12
+
+    clock.now = 11
+    removed = cache.expire()
+
+    # "a" and "b" have expired; "c" is still valid.
+    assert removed == [("a", 1), ("b", 2)]
+    assert set(cache) == {"c"}
+
+
+def test_expire_with_explicit_time() -> None:
+    """``expire`` honors an explicitly passed time instead of the timer."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1  # expires at 10
+
+    # Timer still reads 0, but we force expiry using an explicit time.
+    assert cache.expire(time=10) == [("a", 1)]
+    assert len(cache) == 0
+
+
+def test_iteration_uses_write_order_not_lru_order() -> None:
+    """Iteration yields still-valid keys in write order, unaffected by reads."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # Reading "a" changes LRU order but must not change iteration (write) order.
+    assert cache["a"] == 1
+
+    assert list(cache) == ["a", "b", "c"]
+    assert list(cache.keys()) == ["a", "b", "c"]
+    assert list(cache.values()) == [1, 2, 3]
+
+
+def test_iteration_skips_expired_entries() -> None:
+    """Iteration skips entries whose TTL has passed without reaping them."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1  # expires at 10
+    clock.now = 5
+    cache["b"] = 2  # expires at 15
+
+    clock.now = 12
+    # "a" is expired, "b" is not.
+    assert list(cache) == ["b"]
+
+
+def test_popitem_removes_least_recently_used() -> None:
+    """``popitem`` removes the least-recently-used non-expired entry."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # Reading "a" makes "b" the least recently used.
+    assert cache["a"] == 1
+
+    assert cache.popitem() == ("b", 2)
+    assert cache.popitem() == ("c", 3)
+    assert cache.popitem() == ("a", 1)
+
+
+def test_popitem_on_empty_cache_raises() -> None:
+    """``popitem`` raises ``KeyError`` when there is nothing to remove."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+
+    with pytest.raises(KeyError):
+        cache.popitem()
+
+
+def test_len_reaps_expired_entries() -> None:
+    """Querying the length reaps expired entries first."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1
+    cache["b"] = 2
+    assert len(cache) == 2
+
+    clock.now = 10
+    assert len(cache) == 0
+
+
+def test_delete_expired_entry_removes_it_but_raises() -> None:
+    """Deleting an already-expired entry removes it yet still signals a miss."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+
+    clock.now = 10
+    with pytest.raises(KeyError):
+        del cache["a"]
+
+    # Even though it raised, the entry was physically removed.
+    assert "a" not in cache._data
+
+
+def test_delete_missing_key_raises() -> None:
+    """Deleting an absent key raises ``KeyError``."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+
+    with pytest.raises(KeyError):
+        del cache["missing"]
+
+
+def test_clear_empties_cache() -> None:
+    """``clear`` removes all entries."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
+    cache["a"] = 1
+    cache["b"] = 2
+
+    cache.clear()
+
+    assert len(cache) == 0
+    assert list(cache) == []
+
+
+def test_properties_expose_configuration() -> None:
+    """The cache exposes its ``maxsize``, ``ttl`` and ``timer`` configuration."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=5, ttl=42, timer=clock)
+
+    assert cache.maxsize == 5
+    assert cache.ttl == 42
+    assert cache.timer is clock
+
+
+def test_currsize_reflects_non_expired_entries() -> None:
+    """``currsize`` counts only entries that have not expired."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1
+    cache["b"] = 2
+    assert cache.currsize == 2
+
+    clock.now = 10
+    assert cache.currsize == 0
+
+
+def test_contains_does_not_affect_eviction_order() -> None:
+    """A membership check must not refresh LRU recency (unlike a read)."""
+    cache: TTLCache[str, int] = TTLCache(maxsize=3, ttl=100, timer=_FakeClock())
+
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # Probing "a" with `in` must NOT bump its recency.
+    assert "a" in cache
+
+    # Since "a" was not refreshed, it remains the least recently used and is
+    # evicted when "d" is added.
+    cache["d"] = 4
+    assert "a" not in cache
+    assert set(cache) == {"b", "c", "d"}
+
+
+def test_expired_entry_frees_capacity_before_evicting_valid_entry() -> None:
+    """A write reaps expired entries first, so it won't evict a valid LRU entry."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=2, ttl=10, timer=clock)
+
+    cache["a"] = 1  # expires at 10
+    clock.now = 5
+    cache["b"] = 2  # expires at 15 (cache now full)
+
+    # "a" has expired; adding "c" should reap "a" rather than evict the still
+    # valid, least-recently-used "b".
+    clock.now = 11
+    cache["c"] = 3
+
+    assert set(cache) == {"b", "c"}
+
+
+def test_popitem_reaps_expired_before_returning_lru() -> None:
+    """``popitem`` first reaps expired entries, then returns the LRU survivor."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1  # expires at 10
+    clock.now = 1
+    cache["b"] = 2  # expires at 11
+    clock.now = 5
+    cache["c"] = 3  # expires at 15
+
+    clock.now = 11
+    # "a" and "b" are expired and silently reaped; "c" is the only survivor.
+    assert cache.popitem() == ("c", 3)
+    assert len(cache) == 0
+
+
+def test_get_and_pop_return_default_for_expired_keys() -> None:
+    """Expired-but-unreaped entries behave like absent keys for ``get``/``pop``."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+    cache["a"] = 1
+
+    clock.now = 10
+    assert cache.get("a") is None
+    assert cache.get("a", -1) == -1
+    # pop() with a default must not raise at the exact expiry boundary.
+    assert cache.pop("a", -1) == -1
+    # pop() without a default raises for an expired entry.
+    with pytest.raises(KeyError):
+        cache.pop("a")

--- a/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
@@ -283,6 +283,21 @@ def test_clear_empties_cache() -> None:
     assert list(cache) == []
 
 
+def test_repr_reports_configuration_without_mutating() -> None:
+    """``repr`` summarizes configuration and must not reap expired entries."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=5, ttl=10, timer=clock)
+    cache["a"] = 1
+
+    assert repr(cache) == "TTLCache(maxsize=5, ttl=10, currsize=1)"
+
+    # Once "a" has expired but not yet been reaped, inspecting it via repr must
+    # not reap it (repr must be side-effect free).
+    clock.now = 10
+    _ = repr(cache)
+    assert "a" in cache._data
+
+
 def test_properties_expose_configuration() -> None:
     """The cache exposes its ``maxsize``, ``ttl`` and ``timer`` configuration."""
     clock = _FakeClock()

--- a/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cache_test.py
@@ -33,6 +33,24 @@ class _FakeClock:
         return self.now
 
 
+class _SteppingClock:
+    """A timer that advances by ``step`` seconds on every call.
+
+    Used to reproduce the "an entry expires between two timer reads" race that a
+    naive ``values()``/``items()`` (which re-reads the timer once per
+    ``__getitem__``) would hit.
+    """
+
+    def __init__(self, start: float = 0.0, step: float = 0.0) -> None:
+        self.now = start
+        self.step = step
+
+    def __call__(self) -> float:
+        current = self.now
+        self.now += self.step
+        return current
+
+
 def test_basic_mapping_operations() -> None:
     """The cache supports the core get/set/contains/delete/len operations."""
     cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=_FakeClock())
@@ -111,6 +129,27 @@ def test_overwrite_existing_key_does_not_evict() -> None:
     assert cache["c"] == 3
 
 
+def test_overwrite_refreshes_expiry_ordering() -> None:
+    """Overwriting a key re-sorts ``_expirations`` so ``expire`` reaps correctly."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=clock)
+
+    cache["a"] = 1  # expires at 100
+    clock.now = 10
+    cache["b"] = 2  # expires at 110
+    clock.now = 20
+    cache["a"] = 11  # overwrite: expiry refreshed to 120 and moved after "b"
+
+    # At t=115, "b" (expires 110) is expired but the refreshed "a" (expires 120)
+    # is still valid. expire() relies on _expirations being sorted by expiry and
+    # stops at the first still-valid entry; if the overwrite had not moved "a" to
+    # the end, expire() would stop early at "a" and never reap the expired "b".
+    clock.now = 115
+    assert cache.expire() == [("b", 2)]
+    assert cache["a"] == 11
+    assert "b" not in cache
+
+
 def test_unbounded_maxsize_never_evicts() -> None:
     """A cache with ``math.inf`` maxsize never evicts on size."""
     cache: TTLCache[int, int] = TTLCache(maxsize=math.inf, ttl=100, timer=_FakeClock())
@@ -178,7 +217,7 @@ def test_expire_with_explicit_time() -> None:
     cache["a"] = 1  # expires at 10
 
     # Timer still reads 0, but we force expiry using an explicit time.
-    assert cache.expire(time=10) == [("a", 1)]
+    assert cache.expire(at_time=10) == [("a", 1)]
     assert len(cache) == 0
 
 
@@ -210,6 +249,51 @@ def test_iteration_skips_expired_entries() -> None:
     clock.now = 12
     # "a" is expired, "b" is not.
     assert list(cache) == ["b"]
+
+
+def test_values_uses_consistent_time_snapshot() -> None:
+    """``values()`` reads every entry against one timestamp, never mid-expiring."""
+    clock = _SteppingClock(start=0.0)
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=clock)
+
+    cache["a"] = 1
+    cache["b"] = 2
+
+    # Position the clock just before expiry and make each timer read advance by
+    # 1s. A naive values() reads the timer once per __getitem__, so the second
+    # entry would be seen as expired and raise KeyError mid-iteration.
+    clock.now = 99.0
+    clock.step = 1.0
+    assert list(cache.values()) == [1, 2]
+
+
+def test_items_uses_consistent_time_snapshot() -> None:
+    """``items()`` reads every entry against one timestamp, never mid-expiring."""
+    clock = _SteppingClock(start=0.0)
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=100, timer=clock)
+
+    cache["a"] = 1
+    cache["b"] = 2
+
+    clock.now = 99.0
+    clock.step = 1.0
+    assert list(cache.items()) == [("a", 1), ("b", 2)]
+
+
+def test_values_and_items_skip_expired_entries() -> None:
+    """``values()``/``items()`` omit expired entries without reaping them."""
+    clock = _FakeClock()
+    cache: TTLCache[str, int] = TTLCache(maxsize=10, ttl=10, timer=clock)
+
+    cache["a"] = 1  # expires at 10
+    clock.now = 5
+    cache["b"] = 2  # expires at 15
+
+    clock.now = 12
+    # "a" is expired, "b" is not, and the expired entry is not physically reaped.
+    assert list(cache.values()) == [2]
+    assert list(cache.items()) == [("b", 2)]
+    assert "a" in cache._data
 
 
 def test_popitem_removes_least_recently_used() -> None:

--- a/lib/tests/streamlit/runtime/caching/ttl_cleanup_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/ttl_cleanup_cache_test.py
@@ -113,6 +113,27 @@ class TestTTLCleanupCache:
 
         assert released_items == [i + 10 for i in range(5)]
 
+    def test_repr_does_not_fire_release_hooks(self):
+        """Inspecting the cache via repr() must not trigger on_release.
+
+        currsize/len() reap expired entries (firing release hooks), so __repr__
+        must avoid them and stay side-effect free.
+        """
+        released_items = []
+
+        def on_release(item: int) -> None:
+            released_items.append(item)
+
+        # ttl=0 means the entry is expired the moment it is written.
+        test_cache = TTLCleanupCache(
+            maxsize=500, ttl=0, timer=fake_timer, on_release=on_release
+        )
+        test_cache[0] = 10
+
+        assert repr(test_cache) == "TTLCleanupCache(maxsize=500, ttl=0, currsize=1)"
+        # The expired-but-unreaped entry must not have been released by repr().
+        assert released_items == []
+
     def test_safe_del_calls_release(self):
         """Tests that safe_del() will call release() on elements."""
         released_items = []

--- a/lib/tests/streamlit/runtime/memory_session_storage_test.py
+++ b/lib/tests/streamlit/runtime/memory_session_storage_test.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import MagicMock
 
-from cachetools import TTLCache
-
+from streamlit.runtime.caching.ttl_cache import TTLCache
 from streamlit.runtime.memory_session_storage import MemorySessionStorage
 
 
@@ -26,7 +25,7 @@ class MemorySessionStorageTest(unittest.TestCase):
     """Test MemorySessionStorage.
 
     These tests are intentionally extremely simple to ensure that we don't just end up
-    testing cachetools.TTLCache. We try to just verify that we've wrapped TTLCache
+    testing TTLCache. We try to just verify that we've wrapped TTLCache
     correctly, and in particular we avoid testing cache expiry functionality.
     """
 
@@ -34,7 +33,7 @@ class MemorySessionStorageTest(unittest.TestCase):
         """Verify that the backing cache of a MemorySessionStorage is a TTLCache.
 
         We do this because we're intentionally avoiding writing tests around cache
-        expiry because the cachetools library should do this for us. In the case
+        expiry because TTLCache should do this for us. In the case
         that the backing cache for a MemorySessionStorage ever changes, we'll likely be
         responsible for adding our own tests.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ dev = [
   "types-requests",
   "types-setuptools",
   "types-toml",
-  "types-cachetools",
   "types-Authlib",
   # pandas-stubs have caused a couple of CI breaks, so we pin to a specific version.
   # We need to pin 2.3.3.260113 since higher versions require a min Python 3.11 support.

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -1,7 +1,6 @@
 altair==4.0
 anyio==4.0.0
 blinker==1.5.0
-cachetools==5.5
 click==7.0
 gitpython==3.0.7
 httptools==0.6.3


### PR DESCRIPTION
## Describe your changes

Removes the required `cachetools` runtime dependency by replacing `cachetools.TTLCache` with a small internal `TTLCache` (`lib/streamlit/runtime/caching/ttl_cache.py`) that preserves the exact semantics Streamlit relies on.

- Internal `TTLCache` mirrors cachetools' LRU-on-read/write eviction and uniform-TTL behavior — expired entries are reported absent on reads (`__getitem__`/`in`) but only reaped on write / `expire()` / `len`; `TTLCleanupCache` now extends it, so `st.cache_resource` release hooks are unchanged.
- `pop()` reads the timer once so `pop(key, default)` never raises at the exact TTL-expiry instant (parity with cachetools' frozen-timer behavior).
- Drops `cachetools` and `types-cachetools` from packaging and `scripts/assets/min-constraints-gen.txt`; `pip install streamlit` no longer pulls in `cachetools`.

Preparation PR for background cache refresh: https://github.com/streamlit/streamlit/pull/14690

Reasoning:

- Background cache refresh will add additional complexity around our caching, which would require custom logic around what cachetools provides. This is easier to do if we own the implementation.
- We are only using a tiny part of cachetools, having it as a required dependency adds more issues (e.g. updates breaking streamlit like with pyarrow) and risks (e.g. supply chain attack) compared to having an internally written ~200 LOC implementation. I think this is a bit of a trend enabled by agents to replace small required dependencies with internal implementations, since it's so cheap to implement and maintain them. And this is a good opportunity to do this with cachetools.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Explanation of why no additional E2E tests are needed: internal dependency swap with no user-facing UI or behavior change.
- Unit Tests (Python): new `lib/tests/streamlit/runtime/caching/ttl_cache_test.py` covers LRU eviction, TTL expiry/reaping, non-reordering `in`, `popitem`/`pop`/`get` on expired entries, and the `__delitem__` delete-then-raise quirk. Existing `ttl_cleanup_cache_test.py`, `memory_session_storage_test.py`, and `in_memory_cache_storage_wrapper_test.py` continue to pass against the internal cache.

Made with [Cursor](https://cursor.com)