### PR TITLE
Fix stale CODEOWNERS path for DefaultStreamlitEndpoints.ts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,4 +18,4 @@ scripts/audit_frontend_licenses.py @streamlit/open-source-release-team
 # compatibility implications for platforms that host Streamlit apps, so we need
 # to be extra-careful with these.
 lib/streamlit/web/server/server.py @streamlit/open-source-release-team
-frontend/lib/src/DefaultStreamlitEndpoints.ts @streamlit/open-source-release-team
+frontend/connection/src/DefaultStreamlitEndpoints.ts @streamlit/open-source-release-team


### PR DESCRIPTION
Hi, and thank you for Streamlit.

`.github/CODEOWNERS` (line 21) owns `frontend/lib/src/DefaultStreamlitEndpoints.ts`, but that path 404s — the file was moved to `frontend/connection/src/DefaultStreamlitEndpoints.ts` (verified via code search). So `@streamlit/open-source-release-team`'s ownership of it isn't actually applied anymore.

This PR re-points the rule to the file's current location (rather than dropping it, since the file still exists).

For transparency: I used AI assistance to spot and draft this; I verified the old path 404 and the new location myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line governance fix with no code or runtime impact; only corrects who is auto-requested for reviews on an existing file.
> 
> **Overview**
> Updates **`.github/CODEOWNERS`** so `@streamlit/open-source-release-team` again owns `DefaultStreamlitEndpoints.ts` at its current path **`frontend/connection/src/DefaultStreamlitEndpoints.ts`**, replacing the stale **`frontend/lib/src/...`** entry that no longer matches the file after it was moved into the connection package.
> 
> No application or CI behavior changes—only restores intended review routing for a backwards-compatibility–sensitive endpoint config file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37253dd010737dcae679e301b346c7bbf9f4fbfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->