### PR TITLE
[docs] Update embedded skill guidance for st.iframe/st.html

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -96,6 +96,8 @@ Run this with the Streamlit installation relevant to the app being edited. Use `
 
 Apply these defaults unless the user's app or request clearly needs a different approach. For examples, read `references/best-practices.md`.
 - Do not use `use_container_width`; use `width="stretch"` or `width="content"` instead.
+- Prefer native Streamlit elements over recreating UI with custom HTML. Use custom HTML only when no native element provides the required UI or behavior.
+- Do not use the deprecated `st.components.v1.html` or `st.components.v1.iframe` commands. Use `st.iframe` for iframe-based rendering of URLs or HTML, and use `st.html` for HTML/CSS that should render directly in the app; `st.html` ignores JavaScript by default unless `unsafe_allow_javascript=True`.
 - Do not apply CSS to style the app unless the user actively requests it. Use native Streamlit features and `.streamlit/config.toml` to customize the appearance; see the [theming reference](references/theme.md).
 - Prefer Material Symbols icons (`:material/icon_name:`) over emojis for navigation, buttons, and labels. Use emojis sparingly, only when they add a special touch.
 - Prefer sentence casing over title casing, including titles and widget labels.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -96,7 +96,7 @@ Run this with the Streamlit installation relevant to the app being edited. Use `
 
 Apply these defaults unless the user's app or request clearly needs a different approach. For examples, read `references/best-practices.md`.
 - Do not use `use_container_width`; use `width="stretch"` or `width="content"` instead.
-- Prefer native Streamlit elements over recreating UI with custom HTML. Use custom HTML only when no native element provides the required UI or behavior.
+- Prefer native Streamlit elements over recreating UI with custom HTML. This includes UI created with `st.html`, `st.markdown(..., unsafe_allow_html=True)`, or `st.components.v1.html`. Use custom HTML only when no native element provides the required UI or behavior.
 - Do not use the deprecated `st.components.v1.html` or `st.components.v1.iframe` commands. Use `st.iframe` for iframe-based rendering of URLs or HTML, and use `st.html` for HTML/CSS that should render directly in the app; `st.html` ignores JavaScript by default unless `unsafe_allow_javascript=True`.
 - Do not apply CSS to style the app unless the user actively requests it. Use native Streamlit features and `.streamlit/config.toml` to customize the appearance; see the [theming reference](references/theme.md).
 - Prefer Material Symbols icons (`:material/icon_name:`) over emojis for navigation, buttons, and labels. Use emojis sparingly, only when they add a special touch.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
@@ -51,6 +51,15 @@ query = st.text_input(
 )
 ```
 
+## HTML and iframes
+
+Prefer native Streamlit elements over recreating UI with custom HTML. Use custom HTML only when no native element provides the required UI or behavior.
+
+Do not use the deprecated `st.components.v1.html` or `st.components.v1.iframe` commands.
+
+- Use `st.iframe` for URLs or HTML that should render inside an iframe. It is the iframe-based replacement for either legacy command.
+- Use `st.html` for static HTML or CSS that should render directly in the app instead of inside an iframe. JavaScript is ignored by default; only enable it with `unsafe_allow_javascript=True` when necessary, and never enable it for untrusted content.
+
 ## Layout
 
 Use `width` instead of deprecated `use_container_width`.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
@@ -53,7 +53,7 @@ query = st.text_input(
 
 ## HTML and iframes
 
-Prefer native Streamlit elements over recreating UI with custom HTML. Use custom HTML only when no native element provides the required UI or behavior.
+Prefer native Streamlit elements over recreating UI with custom HTML. This includes UI created with `st.html`, `st.markdown(..., unsafe_allow_html=True)`, or `st.components.v1.html`. Use custom HTML only when no native element provides the required UI or behavior.
 
 Do not use the deprecated `st.components.v1.html` or `st.components.v1.iframe` commands.
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/custom-components-v2.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/custom-components-v2.md
@@ -9,7 +9,7 @@ Custom Components **v1 is legacy and superseded by v2**. The `st.components.v1` 
 
 **Banned Python APIs (v1 — do not use for new components):**
 - `components.declare_component()` — v1 registration; use `st.components.v2.component()` instead
-- `components.v1.html()` — deprecated; use `st.iframe()` instead
+- `components.v1.html()` — deprecated; use `st.iframe()` for the same iframe-based behavior, or `st.html()` to insert static HTML/CSS directly into the app
 - `components.v1.iframe()` — deprecated; use `st.iframe()` instead
 
 **Banned JavaScript patterns (v1):**


### PR DESCRIPTION
## Describe your changes

Updates the bundled `developing-with-streamlit` agent skill to reflect the current HTML embedding APIs.

- Adds an "HTML and iframes" section (and a default in `SKILL.md`) instructing agents to prefer native Streamlit elements over custom HTML, and to avoid the deprecated `st.components.v1.html` / `st.components.v1.iframe`.
- Clarifies the split: use `st.iframe` for iframe-based rendering of URLs/HTML, and `st.html` for HTML/CSS rendered directly in the app (JavaScript ignored unless `unsafe_allow_javascript=True`).
- Points `components.v1.html()` users in the custom-components-v2 reference to both `st.iframe()` and `st.html()`.

## GitHub Issue Link (if applicable)

## Testing Plan

- Documentation-only changes to bundled agent skill files; no behavior or API changes, so no additional tests are needed.

Made with [Cursor](https://cursor.com)