### PR TITLE
[feature] Preserve st.dataframe row selections on sort

### DIFF
--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -433,10 +433,17 @@ def test_multi_row_select_and_sort(app: Page):
         exact_match=True,
     )
 
+    # Capture the run counter before sorting to verify that sorting is
+    # frontend-only and does not trigger an extra rerun (the reported selection
+    # value is unchanged, so no on_select / rerun should fire).
+    runs_element = app.get_by_test_id("stMarkdownContainer").filter(has_text="Runs:")
+    runs_before_sort = runs_element.inner_text()
+
     # Sort the first column ascending. Both selections should be preserved and
     # keep pointing at the same underlying data rows. Sorting is frontend-only:
-    # the reported original row indices stay [0, 2] (no reordering) and no extra
-    # rerun is triggered, since the underlying selected data rows are unchanged.
+    # the reported original row indices stay [0, 2] (stable ascending order,
+    # independent of the display order) and no extra rerun is triggered, since
+    # the underlying selected data rows are unchanged.
     sort_column(canvas, 1, has_row_marker_col=True)
     wait_for_app_run(app)
     expect_prefixed_markdown(
@@ -445,6 +452,8 @@ def test_multi_row_select_and_sort(app: Page):
         "{'selection': {'rows': [0, 2], 'columns': [], 'cells': []}}",
         exact_match=True,
     )
+    # The sort must NOT trigger an additional rerun (frontend-only operation).
+    expect(runs_element).to_have_text(runs_before_sort)
 
 
 # Issue #11345: Test for behavior consistency with sorting via column menu

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -434,14 +434,15 @@ def test_multi_row_select_and_sort(app: Page):
     )
 
     # Sort the first column ascending. Both selections should be preserved and
-    # keep pointing at the same underlying data rows. The reported rows are
-    # ordered by their new display position after sorting, hence [2, 0].
+    # keep pointing at the same underlying data rows. Sorting is frontend-only:
+    # the reported original row indices stay [0, 2] (no reordering) and no extra
+    # rerun is triggered, since the underlying selected data rows are unchanged.
     sort_column(canvas, 1, has_row_marker_col=True)
     wait_for_app_run(app)
     expect_prefixed_markdown(
         app,
         "Dataframe multi-row selection:",
-        "{'selection': {'rows': [2, 0], 'columns': [], 'cells': []}}",
+        "{'selection': {'rows': [0, 2], 'columns': [], 'cells': []}}",
         exact_match=True,
     )
 

--- a/e2e_playwright/st_dataframe_selections_test.py
+++ b/e2e_playwright/st_dataframe_selections_test.py
@@ -133,6 +133,7 @@ def test_single_row_select(app: Page):
 
 
 def test_single_row_select_with_sorted_column(app: Page):
+    """Test that sorting preserves the row selection in single-row mode (#8851)."""
     canvas = _get_single_row_select_df(app)
     expect_canvas_to_be_visible(canvas)
 
@@ -144,25 +145,28 @@ def test_single_row_select_with_sorted_column(app: Page):
     selection_text = app.get_by_test_id("stMarkdownContainer").filter(has_text=expected)
     expect(selection_text).to_have_count(1)
 
-    # Sort the first column
-    # this is expected to clear the previous row selection:
+    # Sort the first column ascending. The row selection should be preserved
+    # and keep pointing at the same underlying data row (original index 0),
+    # even though its display position changed.
     sort_column(canvas, 1, has_row_marker_col=True)
     wait_for_app_run(app)
+    expect_prefixed_markdown(
+        app,
+        "Dataframe single-row selection:",
+        "{'selection': {'rows': [0], 'columns': [], 'cells': []}}",
+        exact_match=True,
+    )
 
-    # The dataframe selection should be cleared
-    expected = "Dataframe single-row selection: {'selection': {'rows': [], 'columns': [], 'cells': []}}"
-    selection_text = app.get_by_test_id("stMarkdownContainer").filter(has_text=expected)
-    expect(selection_text).to_have_count(1)
-
-    # select first row again:
+    # Selecting the first *display* row now selects a different original row,
+    # since the column is sorted (original row 4 sorts to the top for this data).
     select_row(canvas, 1)
     wait_for_app_run(app)
-
-    # The first row got selected, but the real numerical row index
-    # should be different since the first column is sorted
-    expected = "Dataframe single-row selection: {'selection': {'rows': [4], 'columns': [], 'cells': []}}"
-    selection_text = app.get_by_test_id("stMarkdownContainer").filter(has_text=expected)
-    expect(selection_text).to_have_count(1)
+    expect_prefixed_markdown(
+        app,
+        "Dataframe single-row selection:",
+        "{'selection': {'rows': [4], 'columns': [], 'cells': []}}",
+        exact_match=True,
+    )
 
 
 def test_single_row_required_selection(
@@ -412,31 +416,32 @@ def test_multi_row_and_multi_column_select(app: Page):
     _expect_multi_row_multi_column_selection(app)
 
 
-def test_single_row_select_and_sort(app: Page):
-    canvas = _get_single_row_select_df(app)
+def test_multi_row_select_and_sort(app: Page):
+    """Test that sorting preserves multiple row selections in multi-row mode (#8851)."""
+    canvas = _get_multi_row_select_df(app)
     expect_canvas_to_be_visible(canvas)
+    canvas.scroll_into_view_if_needed()
 
-    # Select a single row
+    # Select two rows (original indices 0 and 2)
     select_row(canvas, 1)
+    select_row(canvas, 3)
     wait_for_app_run(app)
-
-    # The row selection should be returned
     expect_prefixed_markdown(
         app,
-        "Dataframe single-row selection:",
-        "{'selection': {'rows': [0], 'columns': [], 'cells': []}}",
+        "Dataframe multi-row selection:",
+        "{'selection': {'rows': [0, 2], 'columns': [], 'cells': []}}",
         exact_match=True,
     )
 
-    # Sort the dataframe via the column header
+    # Sort the first column ascending. Both selections should be preserved and
+    # keep pointing at the same underlying data rows. The reported rows are
+    # ordered by their new display position after sorting, hence [2, 0].
     sort_column(canvas, 1, has_row_marker_col=True)
     wait_for_app_run(app)
-
-    # The row selection should be cleared
     expect_prefixed_markdown(
         app,
-        "Dataframe single-row selection:",
-        "{'selection': {'rows': [], 'columns': [], 'cells': []}}",
+        "Dataframe multi-row selection:",
+        "{'selection': {'rows': [2, 0], 'columns': [], 'cells': []}}",
         exact_match=True,
     )
 
@@ -467,11 +472,11 @@ def test_single_row_and_single_column_select_and_sort(app: Page):
     app.get_by_test_id("stDataFrameColumnMenu").get_by_text("Sort ascending").click()
     wait_for_app_run(app)
 
-    # The row selection should be cleared, but the column selection should remain
+    # Both the row and column selections should be preserved after sorting (#8851).
     expect_prefixed_markdown(
         app,
         "Dataframe single-row-single-column selection:",
-        "{'selection': {'rows': [], 'columns': ['col_1'], 'cells': []}}",
+        "{'selection': {'rows': [0], 'columns': ['col_1'], 'cells': []}}",
         exact_match=True,
     )
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -492,11 +492,15 @@ function DataFrame({
       const shouldPreserveRowSelection =
         isRowSelectionActivated && isRowSelected
       if (shouldPreserveRowSelection) {
-        // Capture the original data indices and current column selection before
-        // sorting so they can be remapped to the new display positions after.
-        const originalRowIndices = gridSelection.rows
-          .toArray()
-          .map(getOriginalIndex)
+        // Capture the selected original row indices before sorting so they can
+        // be remapped to their new display positions afterwards. If a remap
+        // from a previous sort is still pending (e.g. back-to-back sorts before
+        // the deferred remap runs), its captured indices are authoritative:
+        // gridSelection still holds the stale pre-remap display rows, which
+        // would map to the wrong original rows under the new sort order.
+        const originalRowIndices =
+          pendingRowSelectionRemapRef.current?.originalRowIndices ??
+          gridSelection.rows.toArray().map(getOriginalIndex)
         pendingRowSelectionRemapRef.current = {
           originalRowIndices,
           columns: gridSelection.columns,

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -331,10 +331,10 @@ function DataFrame({
   )
 
   // Use a debounce to prevent rapid updates to the widget state.
-  const { debouncedCallback: syncSelectionState } = useDebouncedCallback(
-    innerSyncSelectionState,
-    DEBOUNCE_TIME_MS
-  )
+  const {
+    debouncedCallback: syncSelectionState,
+    cancel: cancelSelectionSync,
+  } = useDebouncedCallback(innerSyncSelectionState, DEBOUNCE_TIME_MS)
 
   const {
     gridSelection,
@@ -433,31 +433,35 @@ function DataFrame({
     // Build a Set for O(1) lookup instead of O(n²) nested loops
     const targetOriginalIndices = new Set(originalRowIndices)
     let newRows = CompactSelection.empty()
+    // Track matches with a local counter to avoid repeatedly walking
+    // CompactSelection's internal ranges via `.length` on every match.
+    let foundCount = 0
 
     for (let displayIdx = 0; displayIdx < originalNumRows; displayIdx++) {
       const origIdx = currentGetOriginalIndex(displayIdx)
       if (targetOriginalIndices.has(origIdx)) {
         newRows = newRows.add(displayIdx)
+        foundCount += 1
         // Early exit when all targets found
-        if (newRows.length === targetOriginalIndices.size) {
+        if (foundCount === targetOriginalIndices.size) {
           break
         }
       }
     }
 
-    if (newRows.length > 0) {
+    if (foundCount > 0) {
       const newSelection: GridSelection = {
         columns,
         rows: newRows,
         current,
       }
-      // Only update the display selection without syncing to the widget
-      // manager/backend. Sorting is a frontend-only operation and the backend
-      // already holds the correct original row indices. Re-syncing would only
-      // reorder the reported rows (e.g. [0, 2] -> [2, 0] in multi-row mode) and
-      // trigger an unnecessary rerun / on_select callback even though the
-      // underlying selected data rows are unchanged.
-      processSelectionChange(newSelection, { shouldSync: false })
+      // Re-sync the preserved selection so the backend keeps the correct
+      // original row indices, and so any debounced sync queued before the sort
+      // is replaced by this correctly-mapped one. Because reported rows use a
+      // stable ascending order (see createSyncSelectionState), the serialized
+      // value is unchanged when the underlying selection is unchanged, so this
+      // is deduplicated and triggers no extra rerun / on_select callback.
+      processSelectionChange(newSelection)
     }
   }, [originalNumRows, processSelectionChange])
 
@@ -469,6 +473,64 @@ function DataFrame({
     performRowSelectionRemap,
     0,
     { autoStart: false }
+  )
+
+  /**
+   * Handle a column sort while preserving the current row selection.
+   *
+   * Sorting is a frontend-only operation, so selected rows should keep pointing
+   * at the same underlying data rows even as their display positions change.
+   * The selected original row indices are captured before sorting and remapped
+   * to their new display positions afterwards (single-row, multi-row, and
+   * single-row-required modes). Cell selections are cleared because their
+   * display coordinates become stale after sorting.
+   *
+   * @param performSort - Callback that applies the actual column sort.
+   */
+  const handleSortWithSelectionPreservation = useCallback(
+    (performSort: () => void) => {
+      const shouldPreserveRowSelection =
+        isRowSelectionActivated && isRowSelected
+      if (shouldPreserveRowSelection) {
+        // Capture the original data indices and current column selection before
+        // sorting so they can be remapped to the new display positions after.
+        const originalRowIndices = gridSelection.rows
+          .toArray()
+          .map(getOriginalIndex)
+        pendingRowSelectionRemapRef.current = {
+          originalRowIndices,
+          columns: gridSelection.columns,
+          // Cell selections use display coordinates that become stale after
+          // sorting, so we don't preserve them.
+          current: undefined,
+        }
+        // Cancel any pending debounced selection sync queued by the initial row
+        // selection. Otherwise it could fire after the sort and serialize the
+        // pre-sort display rows through the post-sort index mapping, sending
+        // wrong row ids to the backend. The scheduled remap re-syncs the
+        // correct value.
+        cancelSelectionSync()
+      }
+      // Clear cell selections but keep row and column selections. Row selections
+      // are remapped to the same data rows after sorting.
+      clearSelection(true, true)
+
+      performSort()
+
+      // Schedule remap after sorting (ref was just set above).
+      if (shouldPreserveRowSelection) {
+        scheduleRowSelectionRemap()
+      }
+    },
+    [
+      isRowSelectionActivated,
+      isRowSelected,
+      gridSelection,
+      getOriginalIndex,
+      cancelSelectionSync,
+      clearSelection,
+      scheduleRowSelectionRemap,
+    ]
   )
 
   /**
@@ -1040,33 +1102,9 @@ function DataFrame({
               setShowSearch(false)
             }
 
-            const shouldPreserveRowSelection =
-              isRowSelectionActivated && isRowSelected
-            if (shouldPreserveRowSelection) {
-              // Preserve the row selection by remapping it to the same data rows
-              // after sort (single-row, multi-row, and single-row-required modes).
-              // Capture the original data indices and current column selection
-              // before sorting.
-              const originalRowIndices = gridSelection.rows
-                .toArray()
-                .map(getOriginalIndex)
-              pendingRowSelectionRemapRef.current = {
-                originalRowIndices,
-                columns: gridSelection.columns,
-                // Don't capture current cell selection - it uses display coordinates
-                // that become stale after sorting
-                current: undefined,
-              }
-            }
-            // Clear cell selections but keep row and column selections. Row
-            // selections are remapped to the same data rows after sorting.
-            clearSelection(true, true)
-
-            sortColumn(columnIdx, "auto")
-            // Schedule remap after sorting (ref was just set above)
-            if (shouldPreserveRowSelection) {
-              scheduleRowSelectionRemap()
-            }
+            handleSortWithSelectionPreservation(() =>
+              sortColumn(columnIdx, "auto")
+            )
           }}
           gridSelection={gridSelection}
           // We don't have to react to "onSelectionCleared" since
@@ -1251,34 +1289,9 @@ function DataFrame({
                       setShowSearch(false)
                     }
 
-                    const shouldPreserveRowSelection =
-                      isRowSelectionActivated && isRowSelected
-                    if (shouldPreserveRowSelection) {
-                      // Preserve the row selection by remapping it to the same
-                      // data rows after sort (single-row, multi-row, and
-                      // single-row-required modes). Capture the original data
-                      // indices and current column selection before sorting.
-                      const originalRowIndices = gridSelection.rows
-                        .toArray()
-                        .map(getOriginalIndex)
-                      pendingRowSelectionRemapRef.current = {
-                        originalRowIndices,
-                        columns: gridSelection.columns,
-                        // Don't capture current cell selection - it uses display coordinates
-                        // that become stale after sorting
-                        current: undefined,
-                      }
-                    }
-                    // Clear cell selections but keep row and column selections.
-                    // Row selections are remapped to the same data rows after
-                    // sorting.
-                    clearSelection(true, true)
-
-                    sortColumn(showMenu.columnIdx, direction, true)
-                    // Schedule remap after sorting (ref was just set above)
-                    if (shouldPreserveRowSelection) {
-                      scheduleRowSelectionRemap()
-                    }
+                    handleSortWithSelectionPreservation(() =>
+                      sortColumn(showMenu.columnIdx, direction, true)
+                    )
                   }
                 : undefined
             }

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -171,7 +171,8 @@ function DataFrame({
   const resizableRef = useRef<Resizable>(null)
   const dataEditorRef = useRef<DataEditorRef>(null)
   // Stores original data row indices that need remapping after a sort operation.
-  // Used to preserve row selection in single-row-required mode when columns are sorted.
+  // Used to preserve row selections (single-row, multi-row, and
+  // single-row-required modes) when columns are sorted on the frontend.
   const pendingRowSelectionRemapRef = useRef<{
     originalRowIndices: number[]
     columns: CompactSelection
@@ -414,7 +415,8 @@ function DataFrame({
   )
 
   /**
-   * Remap row selection after sort in single-row-required mode.
+   * Remap row selections after sort so that they keep pointing at the same
+   * underlying data rows (single-row, multi-row, and single-row-required modes).
    * Scheduled via useTimeout to run after React applies the sort state.
    */
   const performRowSelectionRemap = useCallback(() => {
@@ -430,23 +432,23 @@ function DataFrame({
 
     // Build a Set for O(1) lookup instead of O(n²) nested loops
     const targetOriginalIndices = new Set(originalRowIndices)
-    const newDisplayIndices: number[] = []
+    let newRows = CompactSelection.empty()
 
     for (let displayIdx = 0; displayIdx < originalNumRows; displayIdx++) {
       const origIdx = currentGetOriginalIndex(displayIdx)
       if (targetOriginalIndices.has(origIdx)) {
-        newDisplayIndices.push(displayIdx)
+        newRows = newRows.add(displayIdx)
         // Early exit when all targets found
-        if (newDisplayIndices.length === targetOriginalIndices.size) {
+        if (newRows.length === targetOriginalIndices.size) {
           break
         }
       }
     }
 
-    if (newDisplayIndices.length > 0) {
+    if (newRows.length > 0) {
       const newSelection: GridSelection = {
         columns,
-        rows: CompactSelection.fromSingleSelection(newDisplayIndices[0]),
+        rows: newRows,
         current,
       }
       processSelectionChange(newSelection)
@@ -1032,10 +1034,13 @@ function DataFrame({
               setShowSearch(false)
             }
 
-            if (isRequiredRowSelectionActivated && isRowSelected) {
-              // In single-row-required mode, preserve the row selection by remapping
-              // it to the same data row after sort. Capture the original data indices
-              // and current column selection before sorting.
+            const shouldPreserveRowSelection =
+              isRowSelectionActivated && isRowSelected
+            if (shouldPreserveRowSelection) {
+              // Preserve the row selection by remapping it to the same data rows
+              // after sort (single-row, multi-row, and single-row-required modes).
+              // Capture the original data indices and current column selection
+              // before sorting.
               const originalRowIndices = gridSelection.rows
                 .toArray()
                 .map(getOriginalIndex)
@@ -1046,21 +1051,14 @@ function DataFrame({
                 // that become stale after sorting
                 current: undefined,
               }
-              // Clear cell selections but keep row and column selections
-              clearSelection(true, true)
-            } else if (isRowSelectionActivated && isRowSelected) {
-              // For other row selection modes, clear the selection before sorting.
-              // Keeping row selections when sorting columns is not supported at the moment.
-              clearSelection()
-            } else {
-              // Cell selections are kept on the old position,
-              // which can be confusing. So we clear all cell selections before sorting.
-              clearSelection(true, true)
             }
+            // Clear cell selections but keep row and column selections. Row
+            // selections are remapped to the same data rows after sorting.
+            clearSelection(true, true)
 
             sortColumn(columnIdx, "auto")
             // Schedule remap after sorting (ref was just set above)
-            if (isRequiredRowSelectionActivated && isRowSelected) {
+            if (shouldPreserveRowSelection) {
               scheduleRowSelectionRemap()
             }
           }}
@@ -1247,10 +1245,13 @@ function DataFrame({
                       setShowSearch(false)
                     }
 
-                    if (isRequiredRowSelectionActivated && isRowSelected) {
-                      // In single-row-required mode, preserve the row selection by remapping
-                      // it to the same data row after sort. Capture the original data indices
-                      // and current column selection before sorting.
+                    const shouldPreserveRowSelection =
+                      isRowSelectionActivated && isRowSelected
+                    if (shouldPreserveRowSelection) {
+                      // Preserve the row selection by remapping it to the same
+                      // data rows after sort (single-row, multi-row, and
+                      // single-row-required modes). Capture the original data
+                      // indices and current column selection before sorting.
                       const originalRowIndices = gridSelection.rows
                         .toArray()
                         .map(getOriginalIndex)
@@ -1261,23 +1262,15 @@ function DataFrame({
                         // that become stale after sorting
                         current: undefined,
                       }
-                      // Clear cell selections but keep row and column selections
-                      clearSelection(true, true)
-                    } else if (isRowSelectionActivated && isRowSelected) {
-                      // For other row selection modes, clear the selection before sorting.
-                      // Keeping row selections when sorting columns is not supported at the moment.
-                      // So we need to clear the selected rows before we do the sorting (Issue #11345).
-                      // Maintain column selections as these are not impacted.
-                      clearSelection(false, true)
-                    } else {
-                      // Cell selection are kept on the old position,
-                      // which can be confusing. So we clear all cell selections before sorting.
-                      clearSelection(true, true)
                     }
+                    // Clear cell selections but keep row and column selections.
+                    // Row selections are remapped to the same data rows after
+                    // sorting.
+                    clearSelection(true, true)
 
                     sortColumn(showMenu.columnIdx, direction, true)
                     // Schedule remap after sorting (ref was just set above)
-                    if (isRequiredRowSelectionActivated && isRowSelected) {
+                    if (shouldPreserveRowSelection) {
                       scheduleRowSelectionRemap()
                     }
                   }

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -451,7 +451,13 @@ function DataFrame({
         rows: newRows,
         current,
       }
-      processSelectionChange(newSelection)
+      // Only update the display selection without syncing to the widget
+      // manager/backend. Sorting is a frontend-only operation and the backend
+      // already holds the correct original row indices. Re-syncing would only
+      // reorder the reported rows (e.g. [0, 2] -> [2, 0] in multi-row mode) and
+      // trigger an unnecessary rerun / on_select callback even though the
+      // underlying selected data rows are unchanged.
+      processSelectionChange(newSelection, { shouldSync: false })
     }
   }, [originalNumRows, processSelectionChange])
 

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -456,12 +456,16 @@ function DataFrame({
         current,
       }
       // Re-sync the preserved selection so the backend keeps the correct
-      // original row indices, and so any debounced sync queued before the sort
-      // is replaced by this correctly-mapped one. Because reported rows use a
-      // stable ascending order (see createSyncSelectionState), the serialized
-      // value is unchanged when the underlying selection is unchanged, so this
-      // is deduplicated and triggers no extra rerun / on_select callback.
-      processSelectionChange(newSelection)
+      // original row indices. We force the sync (`forceSync: true`) because the
+      // sort handler cancels any pending debounced sync: if the initial
+      // selection hadn't been synced yet and the preserved row keeps the same
+      // display index after sorting, the default change-detection would skip the
+      // sync and the backend would never receive the selection. Because reported
+      // rows use a stable ascending order (see createSyncSelectionState), the
+      // serialized value is unchanged when the underlying selection is
+      // unchanged, so the forced sync is still deduplicated at the widget-state
+      // level and triggers no extra rerun / on_select callback.
+      processSelectionChange(newSelection, { forceSync: true })
     }
   }, [originalNumRows, processSelectionChange])
 

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.test.ts
@@ -267,6 +267,63 @@ describe("useSelectionHandler hook", () => {
 
     expect(syncSelectionStateMock).toBeCalledTimes(2)
   })
+  it("forceSync syncs an unchanged row selection", () => {
+    // Regression test: when a column is sorted within the selection debounce
+    // window, the sort handler cancels the pending sync and re-syncs the
+    // remapped selection via `forceSync`. If the preserved row keeps the same
+    // display index after sorting, the display-selection is unchanged, so the
+    // default change-detection would skip the sync and the backend would never
+    // receive the selection. `forceSync` must sync it anyway.
+    const { result } = renderHook(() =>
+      useSelectionHandler(
+        DataframeProto.create({
+          selectionMode: [DataframeProto.SelectionMode.MULTI_ROW],
+        }),
+        false,
+        false,
+        [],
+        syncSelectionStateMock
+      )
+    )
+
+    const rowSelection = {
+      columns: CompactSelection.empty(),
+      rows: CompactSelection.fromSingleSelection(0),
+      current: undefined,
+    }
+
+    // Initial selection triggers a sync.
+    act(() => {
+      result.current.processSelectionChange(rowSelection)
+    })
+    expect(result.current.isRowSelected).toEqual(true)
+    expect(syncSelectionStateMock).toBeCalledTimes(1)
+
+    // Processing the same (unchanged) selection is deduplicated: no extra sync.
+    act(() => {
+      result.current.processSelectionChange({
+        columns: CompactSelection.empty(),
+        rows: CompactSelection.fromSingleSelection(0),
+        current: undefined,
+      })
+    })
+    expect(syncSelectionStateMock).toBeCalledTimes(1)
+
+    // Forcing a sync of the same (unchanged) selection syncs it anyway.
+    act(() => {
+      result.current.processSelectionChange(
+        {
+          columns: CompactSelection.empty(),
+          rows: CompactSelection.fromSingleSelection(0),
+          current: undefined,
+        },
+        { forceSync: true }
+      )
+    })
+    expect(result.current.isRowSelected).toEqual(true)
+    expect(syncSelectionStateMock).toBeCalledTimes(2)
+  })
+
   it("correctly processes and clears row+column selection", () => {
     const { result } = renderHook(() =>
       useSelectionHandler(

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useSelectionHandler.ts
@@ -53,6 +53,7 @@ type SelectionHandlerReturn = {
     newSelection: GridSelection,
     options?: {
       shouldSync?: boolean
+      forceSync?: boolean
     }
   ) => void
 }
@@ -142,9 +143,17 @@ function useSelectionHandler(
       newSelection: GridSelection,
       options: {
         shouldSync?: boolean
+        forceSync?: boolean
       } = {}
     ) => {
-      const { shouldSync = true } = options
+      // forceSync bypasses the display-selection change detection below and
+      // always syncs (as long as shouldSync is true). This is required for the
+      // post-sort remap: a pending debounced sync may have been cancelled, so
+      // the widget state can be stale even when the display selection is
+      // unchanged. The lower-level sync (createSyncSelectionState) still
+      // deduplicates against the serialized widget value, so this does not
+      // cause spurious reruns when the underlying selection is unchanged.
+      const { shouldSync = true, forceSync = false } = options
       const rowSelectionChanged = !isEqual(
         newSelection.rows.toArray(),
         gridSelection.rows.toArray()
@@ -163,7 +172,8 @@ function useSelectionHandler(
       // A flag to determine if the selection should be synced with the widget state
       const syncSelection =
         shouldSync &&
-        ((isRowSelectionActivated && rowSelectionChanged) ||
+        (forceSync ||
+          (isRowSelectionActivated && rowSelectionChanged) ||
           (isColumnSelectionActivated && columnSelectionChanged) ||
           (isCellSelectionActivated && cellSelectionChanged))
 
@@ -207,10 +217,12 @@ function useSelectionHandler(
       setGridSelection(updatedSelection)
 
       // Sync if there are actual changes to sync. When row clearing is prevented,
-      // we still need to sync if column or cell selection changed.
+      // we still need to sync if column or cell selection changed (or when the
+      // caller forces a sync).
       const actualSyncNeeded =
         syncSelection &&
-        (!rowSelectionPrevented ||
+        (forceSync ||
+          !rowSelectionPrevented ||
           columnSelectionChanged ||
           cellSelectionChanged)
       if (actualSyncNeeded) {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.test.ts
@@ -488,6 +488,60 @@ describe("useWidgetState hook", () => {
         expect.anything()
       )
     })
+
+    it("serializes row selection in stable ascending order regardless of display order", () => {
+      const mockWidgetMgr = createMockWidgetMgr()
+      const columns = [createMockColumn("col1", 0)]
+
+      const { result } = renderHook(() =>
+        useWidgetState({
+          element: DataframeProto.create({
+            id: "test-id",
+            formId: "",
+            editingMode: DataframeProto.EditingMode.READ_ONLY,
+          }),
+          widgetMgr: mockWidgetMgr as unknown as Parameters<
+            typeof useWidgetState
+          >[0]["widgetMgr"],
+          fragmentId: "test-fragment",
+          originalNumRows: 10,
+          originalColumns: columns,
+        })
+      )
+
+      // Simulate a sorted grid where the display order is not the original
+      // order: display 0 -> original 5, display 1 -> original 2.
+      const originalByDisplay = [5, 2]
+      const getOriginalIndex = (displayIdx: number): number =>
+        originalByDisplay[displayIdx] ?? displayIdx
+      const syncSelectionState = result.current.createSyncSelectionState(
+        columns,
+        getOriginalIndex
+      )
+
+      // Display rows 0 and 1 are selected (CompactSelection stores them in
+      // ascending display order), which map to original indices [5, 2].
+      const selection = {
+        rows: CompactSelection.empty().add(0).add(1),
+        columns: CompactSelection.empty(),
+        current: undefined,
+      }
+
+      act(() => {
+        syncSelectionState(selection, false)
+      })
+
+      // The serialized rows must be in stable ascending order ([2, 5]) rather
+      // than display order ([5, 2]), so the value is independent of the sort
+      // order and does not trigger a spurious rerun when only the display order
+      // changes.
+      expect(mockWidgetMgr.setStringValue).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('"rows":[2,5]'),
+        expect.anything(),
+        expect.anything()
+      )
+    })
   })
 
   describe("loadInitialSelectionState", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.ts
@@ -389,6 +389,12 @@ function useWidgetState({
         selectionState.selection.rows = newSelection.rows
           .toArray()
           .map(row => getOriginalIndex(row))
+          // Report row indices in a stable ascending order so the serialized
+          // selection is independent of the current sort/display order. This
+          // keeps the widget value unchanged when only the display order
+          // changes (e.g. after sorting), avoiding spurious reruns / on_select
+          // callbacks.
+          .sort((a, b) => a - b)
         selectionState.selection.columns = newSelection.columns
           .toArray()
           .map(columnIdx => getColumnName(columns[columnIdx]))

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -108,10 +108,10 @@ class DataframeSelectionState(TypedDict, total=False):
     except ``"multi-cell"``. If ``"single-cell"`` isn't included in the
     selection modes of the dataframe, programmatic cell selections are ignored.
 
-    .. warning::
-        If a user sorts a dataframe, row selections will be reset. If your
-        users need to sort and filter the dataframe to make selections, direct
-        them to use the search function in the dataframe toolbar instead.
+    .. note::
+        Row selections are preserved when a user sorts the dataframe in their
+        browser. The selected rows continue to reference the same underlying
+        data rows by their original integer position.
 
     Attributes
     ----------


### PR DESCRIPTION
## Describe your changes

Sorting a column in `st.dataframe` on the frontend now **preserves** row selections for the `single-row` and `multi-row` selection modes, instead of clearing them. Selections keep pointing at the same underlying data rows even as their display positions change.

- Generalizes the existing `single-row-required` remap mechanism (`performRowSelectionRemap`) to restore *all* selected rows, and applies it to both sort entry points (column header click and column menu).
- Column selections continue to be preserved; cell selections are still cleared on sort (their display coordinates become stale). No extra backend rerun is triggered since the reported original row indices are unchanged.

## GitHub Issue Link (if applicable)

- Closes #8851

## Testing Plan

- [x] E2E Tests (`e2e_playwright/st_dataframe_selections_test.py`)
  - `test_single_row_select_with_sorted_column` — single-row selection preserved after sort
  - `test_multi_row_select_and_sort` — multiple row selections preserved after sort
  - `test_single_row_and_single_column_select_and_sort` — row + column selection preserved when sorting via the column menu
  - `test_single_row_required_select_and_sort` — existing single-row-required behavior unchanged

Made with [Cursor](https://cursor.com)