### PR TITLE
[chore] Add readability review evaluator skills

### DIFF
--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -6,6 +6,8 @@ readonly: true
 disallowedTools: Write, Edit
 skills:
   - assessing-external-test-risk
+  - reviewing-readability
+  - reviewing-pr-description
 memory: user
 ---
 
@@ -84,8 +86,9 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
-6. Perform a thorough code review based on the checklist above.
-7. Write your review following the output format below.
+6. Evaluate readability: run the `reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
+7. Perform a thorough code review based on the checklist above.
+8. Write your review following the output format below.
 
 ## Output Format
 
@@ -119,6 +122,10 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 ## Accessibility
 
 [Assessment of accessibility considerations for frontend changes.]
+
+## Readability
+
+[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
 
 ## Recommendations
 

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -125,7 +125,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Readability
 
-[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
+[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite. Prefix minor items with `[nit]`.]
 
 ## Recommendations
 

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -125,7 +125,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Readability
 
-[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite. Prefix minor items with `[nit]`.]
+[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
 
 ## Recommendations
 

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -86,7 +86,7 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
-6. Evaluate readability: run the `reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
+6. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
 7. Perform a thorough code review based on the checklist above.
 8. Write your review following the output format below.
 
@@ -125,7 +125,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Readability
 
-[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
+[Findings from the `/reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `/reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
 
 ## Recommendations
 

--- a/.claude/agents/simplifying-local-changes.md
+++ b/.claude/agents/simplifying-local-changes.md
@@ -2,6 +2,8 @@
 name: simplifying-local-changes
 description: Simplify and refine code for clarity, consistency, and maintainability while preserving all functionality. Focuses on changes in the current branch.
 model: inherit
+skills:
+  - reviewing-readability
 memory: user
 ---
 
@@ -47,27 +49,22 @@ git diff "origin/$BASE_BRANCH"
 1. Determine the base branch and identify changed files (see above)
 2. Analyze changed code for improvement opportunities
 3. Apply simplifications while preserving behavior
-4. Verify functionality remains unchanged
-5. Run `make check` or the `/checking-changes` skill to validate changes
+4. Evaluate comments, docstrings, and naming with the `reviewing-readability` skill and apply its proposed rewrites (subject to the scope constraint below)
+5. Verify functionality remains unchanged
+6. Run `make check` or the `/checking-changes` skill to validate changes
 
 ## Simplification Guidelines
 
 ### General
 
 - Eliminate redundant code and dead branches
-- Improve naming for clarity (variables, functions, parameters)
 - Consolidate duplicate logic only when it improves readability
 - Avoid nested ternary operators; prefer `if/else` or `switch/case`
 - Do not add features, refactor unrelated code, or make improvements beyond what was asked
 
-### Comments
+### Comments, docstrings, and naming
 
-- Remove comments where the code is self-explanatory
-- Add brief comments for complex or non-obvious logic
-- Add brief docstrings to functions summarizing their purpose; omit if self-explanatory
-- Remove comments that refer to previous behavior; comments should describe current state
-- Every comment should add genuine value and be accurate
-- **Do not remove or modify comments in unchanged code**: Only touch comments that are part of lines you are actively changing; leave existing comments in surrounding unchanged code alone
+Follow the `reviewing-readability` skill to evaluate comments, docstrings, and names (variables, functions, parameters) in the changed code, and apply its proposed rewrites. Scope constraint: **only touch comments and names on lines you are actively changing — never modify or remove comments in surrounding unchanged code.**
 
 ### Python
 

--- a/.claude/agents/simplifying-local-changes.md
+++ b/.claude/agents/simplifying-local-changes.md
@@ -49,7 +49,7 @@ git diff "origin/$BASE_BRANCH"
 1. Determine the base branch and identify changed files (see above)
 2. Analyze changed code for improvement opportunities
 3. Apply simplifications while preserving behavior
-4. Evaluate comments, docstrings, and naming with the `reviewing-readability` skill and apply its proposed rewrites (subject to the scope constraint below)
+4. Evaluate comments, docstrings, and naming with the `/reviewing-readability` skill and apply its proposed rewrites (subject to the scope constraint below)
 5. Verify functionality remains unchanged
 6. Run `make check` or the `/checking-changes` skill to validate changes
 
@@ -58,13 +58,14 @@ git diff "origin/$BASE_BRANCH"
 ### General
 
 - Eliminate redundant code and dead branches
+- Improve naming for clarity (variables, functions, parameters)
 - Consolidate duplicate logic only when it improves readability
 - Avoid nested ternary operators; prefer `if/else` or `switch/case`
 - Do not add features, refactor unrelated code, or make improvements beyond what was asked
 
 ### Comments, docstrings, and naming
 
-Follow the `reviewing-readability` skill to evaluate comments, docstrings, and names (variables, functions, parameters) in the changed code, and apply its proposed rewrites. Scope constraint: **only touch comments and names on lines you are actively changing — never modify or remove comments in surrounding unchanged code.**
+Follow the `/reviewing-readability` skill to evaluate comments, docstrings, and names (variables, functions, parameters) in the changed code, and apply its proposed rewrites. Scope constraint: **only touch comments and names on lines you are actively changing — never modify or remove comments in surrounding unchanged code.**
 
 ### Python
 

--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -108,6 +108,8 @@ Read `.github/pull_request_template.md` for the required sections, then fill the
 
 Check the matching boxes in the PR template. If no test files changed, explain why. Leave "manual testing" unchecked (user fills in).
 
+**Review title and description:** Before writing the PR for user review, run the `reviewing-pr-description` skill on the drafted title and description and apply its proposed rewrites.
+
 ### 3.4 Write PR for user review
 
 Write complete PR details to `work-tmp/pr_description.md`:
@@ -150,5 +152,3 @@ rm work-tmp/pr_description.md work-tmp/pr_body.md
 ## Reference
 
 For full details on writing principles, labeling, branch naming, and testing plans, see the [Pull requests wiki](../../../wiki/pull-requests.md).
-
-To review whether a PR's title and description read clearly and concisely, use the `reviewing-pr-description` skill and apply its proposed rewrites.

--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -150,3 +150,5 @@ rm work-tmp/pr_description.md work-tmp/pr_body.md
 ## Reference
 
 For full details on writing principles, labeling, branch naming, and testing plans, see the [Pull requests wiki](../../../wiki/pull-requests.md).
+
+To review whether a PR's title and description read clearly and concisely, use the `reviewing-pr-description` skill and apply its proposed rewrites.

--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -59,6 +59,8 @@ Examples: `Add height parameter to plotly charts`, `Fix memory leak in dataframe
 
 ## Step 3: Compose and create PR
 
+When drafting the title and description below, follow the title/description guidance in the `/reviewing-pr-description` skill so they are clear and concise from the start.
+
 ### 3.1 Determine labels
 
 All PRs require these labels:
@@ -107,8 +109,6 @@ Read `.github/pull_request_template.md` for the required sections, then fill the
 | `e2e_playwright/**/*_test.py` | E2E tests |
 
 Check the matching boxes in the PR template. If no test files changed, explain why. Leave "manual testing" unchecked (user fills in).
-
-**Review title and description:** Before writing the PR for user review, run the `reviewing-pr-description` skill on the drafted title and description and apply its proposed rewrites.
 
 ### 3.4 Write PR for user review
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -13,7 +13,7 @@ Prepares the current branch for merge by running quality checks, simplifying cod
 
 Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding.
 
-> **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 6, 7, and 8.
+> **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 4, 7, 8, and 9.
 
 ### 1. Build and install
 
@@ -31,7 +31,11 @@ Run the `/updating-internal-docs` skill in a background subagent to auto-fix int
 
 Run the `simplifying-local-changes` subagent to clean up and simplify the code changes. Wait for completion before proceeding.
 
-### 4. Run autofix
+### 4. Review readability
+
+Read and follow the `reviewing-readability` skill to evaluate comments, docstrings, and naming in the changed code, then apply its proposed rewrites. (This covers the code only; the PR title and description are reviewed in step 10.)
+
+### 5. Run autofix
 
 Run autofix in a subagent to fix formatting and linting issues. Wait for completion before proceeding.
 
@@ -39,26 +43,26 @@ Run autofix in a subagent to fix formatting and linting issues. Wait for complet
 make autofix
 ```
 
-### 5. Run checks (first pass)
+### 6. Run checks (first pass)
 
 Run the /checking-changes skill in a subagent (uses `make check`) to validate the changes. Wait for completion, then fix any issues found before proceeding. Don't run other checks besides `make check` in this step.
 
-### 6. Review changes
+### 7. Review changes
 
 Run the `reviewing-local-changes` subagent to review the changes. Wait for completion and read the review output.
 
-### 7. Address review feedback
+### 8. Address review feedback
 
-Review the recommendations from step 6. For each recommendation:
+Review the recommendations from step 7. For each recommendation:
 
 - If valid and improves code quality: implement the change
 - If not applicable or would over-engineer: skip with brief reasoning
 
-### 8. Run checks (second pass)
+### 9. Run checks (second pass)
 
 Run the /checking-changes skill in a subagent with `E2E_CHECK=true make check` to also run changed e2e tests. Wait for completion, then fix any issues found before proceeding. Snapshot mismatches can be ignored (they require manual updates).
 
-### 9. Create or update PR
+### 10. Create or update PR
 
 > **Note:** If currently on `develop`, create a new branch first following the naming conventions in `wiki/pull-requests.md`.
 
@@ -105,11 +109,13 @@ EOF
 
 **If PR exists**, check if description needs updating based on current changes.
 
-### 10. Upload intermediate files
+**Review the PR title and description:** Once the PR exists (or its title/description are drafted), read and follow the `reviewing-pr-description` skill to evaluate the title and description, then apply its proposed rewrites.
+
+### 11. Upload intermediate files
 
 If relevant intermediate files exist (specs, plans, implementation notes in `work-tmp/` or untracked in `specs/`), run the `/sharing-pr-agent-artifacts` skill to push them to the wiki and comment on the PR with links.
 
-### 11. AI review and fix loop
+### 12. AI review and fix loop
 
 Iterate through AI review and fixes until the review passes (max 5 iterations):
 
@@ -153,7 +159,7 @@ The verdict section contains a bold keyword indicating the result:
 
 **Important:** After each `fixing-pr` run, re-check if changes were made. If changes were pushed, the AI review will be stale and needs re-triggering. Continue iterating until the review verdict is "approved" or max iterations reached.
 
-### 12. Post agent metrics
+### 13. Post agent metrics
 
 Post the agent metrics to the PR body:
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -13,7 +13,7 @@ Prepares the current branch for merge by running quality checks, simplifying cod
 
 Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding.
 
-> **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 4, 7, 8, and 9.
+> **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 7, 8, and 9. Still run step 4 (readability), since it is cheap and often the main concern for these changes.
 
 ### 1. Build and install
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -13,7 +13,7 @@ Prepares the current branch for merge by running quality checks, simplifying cod
 
 Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding.
 
-> **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 7, 8, and 9. Still run step 4 (readability), since it is cheap and often the main concern for these changes.
+> **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 6, 7, and 8.
 
 ### 1. Build and install
 
@@ -31,11 +31,7 @@ Run the `/updating-internal-docs` skill in a background subagent to auto-fix int
 
 Run the `simplifying-local-changes` subagent to clean up and simplify the code changes. Wait for completion before proceeding.
 
-### 4. Review readability
-
-Read and follow the `reviewing-readability` skill to evaluate comments, docstrings, and naming in the changed code, then apply its proposed rewrites. (This covers the code only; the PR title and description are reviewed in step 10.)
-
-### 5. Run autofix
+### 4. Run autofix
 
 Run autofix in a subagent to fix formatting and linting issues. Wait for completion before proceeding.
 
@@ -43,26 +39,26 @@ Run autofix in a subagent to fix formatting and linting issues. Wait for complet
 make autofix
 ```
 
-### 6. Run checks (first pass)
+### 5. Run checks (first pass)
 
 Run the /checking-changes skill in a subagent (uses `make check`) to validate the changes. Wait for completion, then fix any issues found before proceeding. Don't run other checks besides `make check` in this step.
 
-### 7. Review changes
+### 6. Review changes
 
 Run the `reviewing-local-changes` subagent to review the changes. Wait for completion and read the review output.
 
-### 8. Address review feedback
+### 7. Address review feedback
 
-Review the recommendations from step 7. For each recommendation:
+Review the recommendations from step 6. For each recommendation:
 
 - If valid and improves code quality: implement the change
 - If not applicable or would over-engineer: skip with brief reasoning
 
-### 9. Run checks (second pass)
+### 8. Run checks (second pass)
 
 Run the /checking-changes skill in a subagent with `E2E_CHECK=true make check` to also run changed e2e tests. Wait for completion, then fix any issues found before proceeding. Snapshot mismatches can be ignored (they require manual updates).
 
-### 10. Create or update PR
+### 9. Create or update PR
 
 > **Note:** If currently on `develop`, create a new branch first following the naming conventions in `wiki/pull-requests.md`.
 
@@ -72,7 +68,7 @@ Check if a PR exists for the current branch:
 gh pr view --json number,title,url
 ```
 
-**If no PR exists**, create one following the guidelines in `wiki/pull-requests.md` (please read!). Add appropriate labels and fill in the body based on `.github/pull_request_template.md` (skip the video/screenshot section).
+**If no PR exists**, create one following the guidelines in `wiki/pull-requests.md` (please read!) and the title/description guidance in the `/reviewing-pr-description` skill. Add appropriate labels and fill in the body based on `.github/pull_request_template.md` (skip the video/screenshot section).
 
 **Link related issues:** Add `- Closes #12345` to the PR description for any known GitHub issues this PR resolves.
 
@@ -109,13 +105,11 @@ EOF
 
 **If PR exists**, check if description needs updating based on current changes.
 
-**Review the PR title and description:** Once the PR exists (or its title/description are drafted), read and follow the `reviewing-pr-description` skill to evaluate the title and description, then apply its proposed rewrites.
-
-### 11. Upload intermediate files
+### 10. Upload intermediate files
 
 If relevant intermediate files exist (specs, plans, implementation notes in `work-tmp/` or untracked in `specs/`), run the `/sharing-pr-agent-artifacts` skill to push them to the wiki and comment on the PR with links.
 
-### 12. AI review and fix loop
+### 11. AI review and fix loop
 
 Iterate through AI review and fixes until the review passes (max 5 iterations):
 
@@ -159,7 +153,7 @@ The verdict section contains a bold keyword indicating the result:
 
 **Important:** After each `fixing-pr` run, re-check if changes were made. If changes were pushed, the AI review will be stale and needs re-triggering. Continue iterating until the review verdict is "approved" or max iterations reached.
 
-### 13. Post agent metrics
+### 12. Post agent metrics
 
 Post the agent metrics to the PR body:
 

--- a/.claude/skills/reviewing-pr-description/SKILL.md
+++ b/.claude/skills/reviewing-pr-description/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: reviewing-pr-description
+description: Evaluates a PR's title and description for readability — do they clearly and concisely convey what changed and why to a reviewer? Produces findings with concrete proposed rewrites; the caller decides whether to apply them or present them as feedback. Use when finalizing a PR or reviewing PR metadata. For code comments, docstrings, and naming, use reviewing-readability instead.
+---
+
+# Reviewing PR Description
+
+Review a PR's **title and description** for readability: do they clearly and concisely tell a reviewer what changed and why? Focus on the prose — checking the *format* (title pattern, required template sections) is a secondary, lighter concern.
+
+This skill only evaluates: it produces findings with concrete proposed rewrites and does **not** apply them. The caller decides whether to apply the rewrites or present them as feedback.
+
+## Audience
+
+The reader is a **reviewer or teammate skimming the PR to understand what changed and why**. They may not know the implementation context, and later readers will find this text via the commit log or changelog. The title and description should stand on their own.
+
+## Principles
+
+1. **Lead with the change and its purpose** — the first sentence should state what changed and why, not setup, process, or a description of the problem area.
+2. **Explain intent, not mechanics** — say what the change enables or why it was made; don't narrate the diff step by step.
+3. **Cut what the diff already shows** — omit routine, obvious changes (added tests, updated types, fixed lint). Call out only what's non-obvious or decision-worthy.
+4. **Concise wins** — fewer, denser bullets beat many thin ones. If a bullet restates the title or another bullet, drop it.
+5. **Explain non-obvious decisions** — deprecations, unit choices, fallback behavior, and trade-offs deserve a sentence on *why*.
+6. **Avoid jargon without context** — spell out internal terms or acronyms a newcomer wouldn't know.
+7. **Active voice; name the actor** — "Deprecates `use_container_width`" or "The server now rejects oversized uploads" reads more directly than passive or vague phrasing.
+8. **The title stands alone** — it should convey the change on its own in a commit list or changelog, without the body.
+9. **No meta-commentary** — cut "This PR...", "We have...", "I added..."; state what changed directly.
+
+## Evaluation Process
+
+1. **Gather** the PR title and description (`gh pr view <n> --json title,body`).
+2. **For each, ask**:
+   - Does the title convey the change on its own, or does it need the body to make sense?
+   - Does the description lead with the main change and its purpose, or bury it under context/mechanics?
+   - Does it explain *why* for non-obvious decisions, or only list *what*?
+   - Is there jargon or an acronym a newcomer wouldn't understand?
+   - Could it be shorter — are there obvious or duplicated points to cut?
+   - Is it in passive or vague voice where naming the actor would read more directly?
+   - Is there meta-commentary that adds no information?
+3. **Also confirm the format** briefly (secondary): title matches `[type] Description` within ~63 chars, and the required template sections from `.github/pull_request_template.md` are present. For the full standards, see `creating-pull-requests` and `wiki/pull-requests.md`.
+4. **Report** the findings per the Output Format below.
+
+## Common Patterns to Flag
+
+- A title that only makes sense alongside the body (e.g. "[fix] Fix the bug")
+- A description that opens with context or process instead of the change itself
+- Bullets that restate the diff (added tests, updated types) instead of explaining intent
+- Non-obvious decisions (deprecations, fallbacks, unit choices) stated without the *why*
+- Internal jargon or acronyms with no expansion
+- Passive or actor-less phrasing where naming the actor reads more directly
+- Meta-commentary ("This PR...", "I added...") that could be cut
+- More bullets than the change warrants, or bullets that duplicate each other
+
+## Output Format
+
+For the title and for the description, give the issue and a concrete proposed rewrite.

--- a/.claude/skills/reviewing-readability/SKILL.md
+++ b/.claude/skills/reviewing-readability/SKILL.md
@@ -46,11 +46,10 @@ Readability fixes are cheap — a comment reword or a rename takes seconds, so d
 
 - **Flag everything that makes the code clearer or more concise.** The only thing you skip is a change where it's genuinely ambiguous whether it improves readability (a lateral rewrite that's just a matter of taste). If a change is a clear improvement, include it no matter how small.
 - **Don't categorize by priority or severity.** Leave alone only what's already clear and concise.
-- **Mark minor items with a `[nit]` prefix** to soften the feedback and signal it's low-stakes and optional — but still include it. `[nit]` is how you communicate "this is minor," *not* a reason to drop the item. Reserve un-prefixed feedback for things that are actually misleading or confusing (e.g. a comment that describes deleted behavior).
 
 ## Output Format
 
-Produce findings, grouped by file. For each item, give the location (file and line or symbol), the issue, and a concrete proposed rewrite (or, for missing documentation, the comment/docstring to add). Prefix minor/optional items with `[nit]`.
+Produce findings, grouped by file. For each item, give the location (file and line or symbol), the issue, and a concrete proposed rewrite (or, for missing documentation, the comment/docstring to add).
 
 ## Common Patterns to Flag
 

--- a/.claude/skills/reviewing-readability/SKILL.md
+++ b/.claude/skills/reviewing-readability/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: reviewing-readability
+description: Evaluates comments, docstrings, and naming in code for readability by a developer new to the codebase — is the documentation clear and concise, and is non-obvious logic documented? Produces findings with concrete proposed rewrites (or additions where documentation is missing); the caller decides whether to apply them or present them as feedback. Use when reviewing a PR, branch, or set of changes for comment quality, naming clarity, or documentation readability. For a PR's title and description, use reviewing-pr-description instead.
+---
+
+# Reviewing Readability
+
+Review all comments, docstrings, and names (functions, classes, variables, tests) in the target code for clarity and conciseness, and flag non-obvious logic or unclear function purpose that lacks documentation.
+
+This skill only evaluates: it produces findings with concrete proposed rewrites and does **not** apply them. The caller decides whether to apply the rewrites or present them as feedback.
+
+## Audience
+
+The reader is a **developer unfamiliar with the implementation context** who is trying to understand the logic in the location they are currently reading. They have general Python/TypeScript expertise but don't know the history of why things were built this way.
+
+## Principles
+
+1. **Explain intent, not mechanics** — don't restate what the code does; explain *why* or *what would go wrong without it*.
+2. **Lead with the main idea** — the first sentence should state the rule or intent; put mechanics, edge cases, and exceptions after. A comment can be concise and accurate yet still bury the point by opening with the mechanics.
+3. **Concise wins** — shorter comments are easier to understand. If a 4-line comment can be 2 lines, make it 2.
+4. **Use a list for multiple cases** — when a comment enumerates several conditions, outcomes, or steps, a bulleted list (`-`) is usually easier to scan than the same content packed into prose. Lead with a one-line summary, then list the cases.
+5. **Avoid jargon without context** — if a term is project-specific (e.g. "delta path", "fragment path", "DG"), either define it briefly or use a more descriptive phrase.
+6. **Names should stand alone** — a test name or function name should communicate what it does without needing to read the docstring.
+7. **Comment non-obvious logic, not the obvious** — skip comments that restate the code (`# increment counter`), but flag genuinely complex or non-obvious logic that has *no* explanatory comment. Likewise, flag a function whose purpose isn't clear from its name and signature and that lacks a brief docstring; leave self-explanatory functions undocumented.
+8. **Comments that say "unreachable" or "no-op" should explain why** — the reader needs to know why the case can't happen or why no action is needed.
+9. **Prefer active voice; name the actor** — passive constructions ("the id is assigned", "completions that are reported") force the reader to infer who does what. Say who acts on what ("the runner assigns a new id", "the frontend reports completions"). This is easy to miss because passive prose can still be accurate and concise — check for it explicitly.
+
+## Evaluation Process
+
+1. **Collect** all comments, docstrings, class names, function/method names, and test names in the target scope.
+2. **For each item, ask**:
+   - Would a newcomer understand this on first read?
+   - Is there jargon that isn't defined nearby?
+   - Could it be shorter without losing meaning?
+   - Does it explain the "why" or just the "what"?
+   - Does the first sentence state the main idea, or does it bury it under mechanics?
+   - If it enumerates several cases, would a bulleted list scan better than prose?
+   - Is it in passive voice? Would naming the actor and switching to active voice read more directly?
+   - For names: does it communicate the purpose without reading the body?
+3. **Also scan for missing documentation**: is there complex or non-obvious logic with no explanatory comment, or a function whose purpose isn't clear from its signature and that has no docstring? Any comment or docstring you propose adding must itself follow the principles above — lead with the intent, stay concise, use active voice, and don't narrate the obvious.
+4. **Report** the findings per the Output Format below.
+
+## How much to flag
+
+Readability fixes are cheap — a comment reword or a rename takes seconds, so don't spend effort ranking findings by importance or deciding what's "worth it."
+
+- **Flag everything that makes the code clearer or more concise.** The only thing you skip is a change where it's genuinely ambiguous whether it improves readability (a lateral rewrite that's just a matter of taste). If a change is a clear improvement, include it no matter how small.
+- **Don't categorize by priority or severity.** Leave alone only what's already clear and concise.
+- **Mark minor items with a `[nit]` prefix** to soften the feedback and signal it's low-stakes and optional — but still include it. `[nit]` is how you communicate "this is minor," *not* a reason to drop the item. Reserve un-prefixed feedback for things that are actually misleading or confusing (e.g. a comment that describes deleted behavior).
+
+## Output Format
+
+Produce findings, grouped by file. For each item, give the location (file and line or symbol), the issue, and a concrete proposed rewrite (or, for missing documentation, the comment/docstring to add). Prefix minor/optional items with `[nit]`.
+
+## Common Patterns to Flag
+
+- Complex or non-obvious logic with no explanatory comment
+- A function whose purpose isn't clear from its name and signature and that lacks a brief docstring
+- Comments that open with mechanics or edge cases instead of leading with the main point
+- Comments that explain the implementation history instead of current behavior
+- Docstrings that list every parameter's type when the signature already has type annotations
+- Test names that use internal abbreviations (e.g. `test_dg_inside_fp` instead of `test_write_within_fragment_scope`)
+- "Pass through" / "falls through" without saying what happens instead
+- Passive voice that hides the actor (e.g. "a new id is received", "completions that are reported") where active voice would read more directly
+- Multi-line comments where one line would suffice
+- Several conditions/outcomes packed into prose that would scan better as a bulleted list
+- Comments that were correct when written but now describe deleted/changed behavior
+- Reference comments (spec, RFC, issue number) that aren't needed to understand the code, or that point somewhere a reader can't reach (dead links, private/internal tickets or docs) — flag them, proposing to drop the unneeded ones and repoint the rest to a public GitHub issue or an in-repo spec
+
+## What NOT to Change
+
+- Type annotations (those aren't documentation)
+- Inline comments that mark a subtle correctness constraint (e.g. ordering dependencies)
+- Reference comments (spec, RFC, issue number) that a reader needs to understand the code **and** point somewhere accessible (a public GitHub issue or an in-repo spec) — keep the identifier intact rather than trimming or vague-ifying it
+- Legal headers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `generating-changelog` | When preparing release notes between two git tags |
 | `improving-frontend-coverage` | When you want to systematically improve frontend test coverage with high-value test cases |
 | `improving-python-coverage` | When you want to systematically improve Python test coverage with high-value test cases |
+| `reviewing-readability` | When reviewing a PR, branch, or changes for comment, docstring, and naming readability — produces findings with concrete proposed rewrites |
+| `reviewing-pr-description` | When reviewing a PR's title and description for clarity and conciseness |
 
 ### Subagents
 

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -30,8 +30,9 @@
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
-6. Perform a thorough code review based on the checklist above.
-7. Write your review following the output format below.
+6. Evaluate readability: run the `reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
+7. Perform a thorough code review based on the checklist above.
+8. Write your review following the output format below.
 
 ## Output Format
 
@@ -65,6 +66,10 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 ## Accessibility
 
 [Assessment of accessibility considerations for frontend changes.]
+
+## Readability
+
+[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite. Prefix minor items with `[nit]`.]
 
 ## Recommendations
 

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -69,7 +69,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Readability
 
-[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite. Prefix minor items with `[nit]`.]
+[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
 
 ## Recommendations
 

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -30,7 +30,7 @@
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
-6. Evaluate readability: run the `reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
+6. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
 7. Perform a thorough code review based on the checklist above.
 8. Write your review following the output format below.
 
@@ -69,7 +69,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Readability
 
-[Findings from the `reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
+[Findings from the `/reviewing-readability` skill (comments, docstrings, naming) and, if a PR exists, the `/reviewing-pr-description` skill (title/description). Group by file; give the location, the issue, and the proposed rewrite.]
 
 ## Recommendations
 


### PR DESCRIPTION
## Describe your changes

Introduces two reusable readability **evaluator** skills and wires them into the existing agent workflows.

- **New skills** (mode-agnostic evaluators — they produce findings with concrete proposed rewrites/additions and leave delivery to the caller):
  - `reviewing-readability` — comments, docstrings, and naming. Also flags non-obvious logic or unclear function purpose that lacks documentation; any proposed additions must themselves follow the readability principles.
  - `reviewing-pr-description` — a PR's title and description.
- **Wiring:**
  - `finalizing-pr` and `creating-pull-requests` run the evaluators and apply the proposed rewrites directly.
  - `reviewing-local-changes` surfaces their findings as read-only review feedback (new Readability section).
  - `simplifying-local-changes` defers its inline comment/naming rules to `reviewing-readability`, keeping only its unchanged-code scope constraint.
- Documented both skills in `CONTRIBUTING.md`.

These are internal agent-tooling files under `.claude/`; no user-facing behavior changes.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] N/A — documentation/tooling only (Markdown skill and subagent definitions)

Made with [Cursor](https://cursor.com)