### PR TITLE
[fix] Stop dumping a traceback when cache hashing falls back to pickle

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -434,8 +434,10 @@ class _CacheFuncHasher:
                 return h.digest()
             except TypeError:
                 _LOGGER.warning(
-                    "Pandas Series hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Failed to hash a pandas Series because it contains values "
+                    "that cannot be hashed (for example, cells holding lists or "
+                    "other unhashable objects). Falling back to pickling the "
+                    "object for caching."
                 )
 
                 # Use pickle if pandas cannot hash the object for example if
@@ -460,8 +462,10 @@ class _CacheFuncHasher:
 
             except TypeError:
                 _LOGGER.warning(
-                    "Pandas DataFrame hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Failed to hash a pandas DataFrame because it contains values "
+                    "that cannot be hashed (for example, cells holding lists or "
+                    "other unhashable objects). Falling back to pickling the "
+                    "object for caching."
                 )
 
                 # Use pickle if pandas cannot hash the object for example if
@@ -484,8 +488,10 @@ class _CacheFuncHasher:
 
             except TypeError:
                 _LOGGER.warning(
-                    "Polars Series hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Failed to hash a polars Series because it contains values "
+                    "that cannot be hashed (for example, cells holding lists or "
+                    "other unhashable objects). Falling back to pickling the "
+                    "object for caching."
                 )
 
                 # Use pickle if polars cannot hash the object for example if
@@ -514,8 +520,10 @@ class _CacheFuncHasher:
 
             except TypeError:
                 _LOGGER.warning(
-                    "Polars DataFrame hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Failed to hash a polars DataFrame because it contains values "
+                    "that cannot be hashed (for example, cells holding lists or "
+                    "other unhashable objects). Falling back to pickling the "
+                    "object for caching."
                 )
 
                 # Use pickle if polars cannot hash the object for example if

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -463,6 +463,42 @@ class HashTest(unittest.TestCase):
 
         assert get_hash(series4) == get_hash(series5)
 
+    def test_pandas_dataframe_with_unhashable_column_hashes_without_traceback(self):
+        """A DataFrame holding unhashable cells still hashes via the pickle
+        fallback and warns without dumping a traceback (gh-10957)."""
+        df = pd.DataFrame({"col": [[1, 2]]}, index=[1])
+
+        with self.assertLogs(
+            "streamlit.runtime.caching.hashing", level="WARNING"
+        ) as logs:
+            first = get_hash(df)
+            second = get_hash(df)
+
+        # The fallback still yields a stable, non-empty hash.
+        assert first
+        assert first == second
+        # A warning is emitted, but never with an exception traceback: users
+        # were being shown a scary pandas stack trace for a handled fallback.
+        assert logs.records
+        assert all(record.exc_info is None for record in logs.records)
+        assert all(
+            "unhashable" in record.getMessage().lower() for record in logs.records
+        )
+
+    def test_pandas_series_with_unhashable_value_hashes_without_traceback(self):
+        """A Series holding unhashable values still hashes via the pickle
+        fallback and warns without dumping a traceback (gh-10957)."""
+        series = pd.Series([[1, 2], [3, 4]])
+
+        with self.assertLogs(
+            "streamlit.runtime.caching.hashing", level="WARNING"
+        ) as logs:
+            digest = get_hash(series)
+
+        assert digest
+        assert logs.records
+        assert all(record.exc_info is None for record in logs.records)
+
     @pytest.mark.require_integration
     def test_polars_series(self):
         import polars as pl


### PR DESCRIPTION
## Describe your changes

Hashing a `pandas`/`polars` `DataFrame` or `Series` that holds unhashable cell
values (for example a column of Python `list`s) makes `hash_pandas_object` raise
`TypeError: unhashable type: 'list'`. Streamlit already catches this and falls
back to pickling the object, so `@st.cache_data` keeps working correctly — the
value is cached and the app renders. The remaining problem is purely diagnostic:
the fallback `_LOGGER.warning(...)` was called with `exc_info=True`, so Streamlit
printed the entire internal pandas traceback to the console. That traceback looks
exactly like an unhandled crash and has repeatedly led users to think their app
is broken (see #10957, where a maintainer confirmed the fallback itself works
fine).

This removes `exc_info=True` from the four hash-fallback warnings
(pandas/polars × Series/DataFrame) and rewords them to explain what happened and
that the object was pickled instead. It is a logging-only change — the hashing
logic, the resulting cache-key bytes, and the pickle fallback are all unchanged.

## Screenshot or video (only for visual changes)

N/A — backend logging only, no visual change.

## GitHub Issue Link (if applicable)

Closes #10957

## Testing Plan

- **Unit Tests (Python):** added
  `test_pandas_dataframe_with_unhashable_column_hashes_without_traceback` and
  `test_pandas_series_with_unhashable_value_hashes_without_traceback` to
  `lib/tests/streamlit/runtime/caching/hashing_test.py`. They assert the object
  still hashes deterministically through the pickle fallback and that the emitted
  warning record carries no exception traceback (`record.exc_info is None`).
- Ran the full `hashing_test.py` suite (81 passed, 7 skipped) to confirm cache-key
  hashing is unchanged.
- **E2E Tests:** not needed — backend-only logging behavior with no UI surface.
- **Manual testing:** reproduced the original console traceback with the issue's
  snippet and confirmed it is gone after the change while caching still works.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no changes to cache key computation or pickle fallback logic; covered by new unit tests.
> 
> **Overview**
> When `@st.cache_data` hashes a pandas or polars **Series** or **DataFrame** that contains unhashable cell values (e.g. lists), Streamlit already falls back to pickling for the cache key. The change is **diagnostics only**: the four fallback `_LOGGER.warning` calls no longer pass `exc_info=True`, so users no longer see a full pandas/polars stack trace that looked like a crash.
> 
> Warning text now states that hashing failed because of unhashable values and that pickling is used for caching. **Hash bytes and pickle fallback behavior are unchanged.**
> 
> Tests assert stable hashes through the fallback and that warning log records have `exc_info is None` (fixes #10957).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269b39697f8dd2be4579824d819bc8346df524d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->