### PR TITLE
[fix] Clear stale forward messages in AppTest on each script run

### DIFF
--- a/lib/streamlit/testing/v1/local_script_runner.py
+++ b/lib/streamlit/testing/v1/local_script_runner.py
@@ -85,6 +85,15 @@ class LocalScriptRunner(ScriptRunner):
             self.events.append(event)
             self.event_data.append(kwargs)
 
+            if event == ScriptRunnerEvent.SCRIPT_STARTED:
+                # Each script run starts a fresh render, so clear any stale
+                # deltas from previous runs/iterations. Lifecycle messages are
+                # retained to match AppSession behavior.
+                self.forward_msg_queue.clear(
+                    retain_lifecycle_msgs=True,
+                    fragment_ids_this_run=kwargs.get("fragment_ids_this_run"),
+                )
+
             # Send ENQUEUE_FORWARD_MSGs to our queue
             if event == ScriptRunnerEvent.ENQUEUE_FORWARD_MSG:
                 forward_msg = kwargs["forward_msg"]

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -318,3 +318,43 @@ def test_navigation_resets_pages_manager_state():
         assert "Page content" in at.markdown.values
     finally:
         PagesManager.uses_pages_directory = original_value
+
+
+def test_dynamic_widget_does_not_duplicate_on_rerun():
+    """Dynamically adding an element before an existing widget should not
+    leave stale widgets in the AppTest tree after a rerun.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/12566
+    """
+
+    def script():
+        import streamlit as st
+
+        if "_string_value" not in st.session_state:
+            st.session_state._string_value = "string1"
+
+        if st.session_state.get("_bool_value", False):
+            with st.container(key="k_container"):
+                st.html("<style>color: red;</style>")
+
+        with st.container():
+            st.text_input("Text", value=st.session_state._string_value)
+
+            if st.button("Button", key="k_button"):
+                st.session_state._string_value = "string2"
+                st.session_state._bool_value = True
+                st.rerun()
+
+    at = AppTest.from_function(script).run()
+    assert len(at.text_input) == 1
+    assert at.text_input[0].value == "string1"
+
+    at = at.button(key="k_button").click().run()
+    assert len(at.text_input) == 1
+    assert at.text_input[0].value == "string2"
+
+    # A subsequent run with no interaction should not raise KeyError because
+    # of stale widget ids left over from the prererun tree.
+    at.run()
+    assert len(at.text_input) == 1
+    assert at.text_input[0].value == "string2"


### PR DESCRIPTION
Fixes #12566

AppTest accumulated forward messages across every script iteration inside a single run, so dynamically added elements left stale widgets with orphaned ids in the parsed tree. Clear the queue on each SCRIPT_STARTED event, matching the behavior of AppSession.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change in LocalScriptRunner with a targeted regression test; no production runtime behavior changes.
> 
> **Overview**
> Fixes **AppTest** incorrectly keeping forward messages from earlier script iterations within the same run, which could duplicate widgets or leave stale widget ids after **dynamic UI** changes and **`st.rerun()`**.
> 
> **`LocalScriptRunner`** now clears **`forward_msg_queue`** on **`SCRIPT_STARTED`**, retaining lifecycle messages and honoring **`fragment_ids_this_run`**—aligned with **`AppSession`** queue handling.
> 
> Adds regression coverage for issue **#12566**: insert content before an existing widget, rerun, and assert a single **`text_input`** with no **`KeyError`** on a follow-up run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c42328e40f0555938b172b2a96bd92a8a1abf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->