### PR TITLE
Add page_lang parameter to st.set_page_config

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1106,6 +1106,7 @@ export class App extends PureComponent<Props, State> {
       initialSidebarState,
       initialSidebarWidth,
       menuItems,
+      lang,
     } = pageConfig
 
     this.appNavigation.handlePageConfigChanged(pageConfig)
@@ -1121,6 +1122,10 @@ export class App extends PureComponent<Props, State> {
 
     if (favicon) {
       this.onPageIconChanged(favicon)
+    }
+
+    if (lang) {
+      document.documentElement.lang = lang
     }
 
     // Only change layout/sidebar when the page config has changed.

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1124,7 +1124,7 @@ export class App extends PureComponent<Props, State> {
       this.onPageIconChanged(favicon)
     }
 
-    if (lang) {
+    if (lang != null) {
       document.documentElement.lang = lang
     }
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1124,7 +1124,7 @@ export class App extends PureComponent<Props, State> {
       this.onPageIconChanged(favicon)
     }
 
-    if (lang != null) {
+    if (lang) {
       document.documentElement.lang = lang
     }
 

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -116,6 +116,7 @@ def set_page_config(
     layout: Layout | None = None,
     initial_sidebar_state: InitialSideBarState | None = None,
     menu_items: MenuItems | None = None,
+    page_lang: str | None = None,
 ) -> None:
     """
     Configure the default settings of the page.
@@ -218,6 +219,18 @@ def set_page_config(
         item that was specified in a previous call to ``st.set_page_config``,
         set its value to ``None`` in the dictionary.
 
+    page_lang: str or None
+        The page language, set as the ``lang`` attribute on the root
+        ``<html>`` element. This is used by browsers for translation prompts
+        and by screen readers for pronunciation. If ``None`` (default), the
+        language is inherited from the previous call of ``st.set_page_config``.
+        If no previous call exists, the value defaults to ``"en"``.
+
+        Must be a valid `BCP 47 language tag`_ (e.g. ``"en"``, ``"ja"``,
+        ``"fr"``, ``"zh-CN"``).
+
+        .. _BCP 47 language tag: https://tools.ietf.org/html/bcp47
+
     Examples
     --------
     >>> import streamlit as st
@@ -292,6 +305,9 @@ def set_page_config(
         validate_menu_items(lowercase_menu_items)
         menu_items_proto = msg.page_config_changed.menu_items
         set_menu_items_proto(lowercase_menu_items, menu_items_proto)
+
+    if page_lang is not None:
+        msg.page_config_changed.lang = page_lang
 
     ctx = get_script_run_ctx()
     if ctx is None:

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -306,7 +306,7 @@ def set_page_config(
         menu_items_proto = msg.page_config_changed.menu_items
         set_menu_items_proto(lowercase_menu_items, menu_items_proto)
 
-    if page_lang is not None:
+    if page_lang is not None and page_lang != "":
         msg.page_config_changed.lang = page_lang
 
     ctx = get_script_run_ctx()

--- a/proto/streamlit/proto/PageConfig.proto
+++ b/proto/streamlit/proto/PageConfig.proto
@@ -24,6 +24,7 @@ message PageConfig {
   SidebarState initial_sidebar_state = 4;
   MenuItems menu_items = 5;
   optional SidebarWidthConfig initial_sidebar_width = 6;
+  string lang = 7;
 
   message MenuItems {
     string get_help_url = 1;


### PR DESCRIPTION
## Describe your changes

Adds a `page_lang` parameter to `st.set_page_config()` that sets the `lang` attribute on the root `<html>` element. Previously this was hardcoded to `"en"`, causing unwanted browser translation prompts for non-English apps and incorrect screen reader pronunciation.

## GitHub Issue Link (if applicable)

Fixes #15726

## Testing Plan

Changes follow the exact same pattern as the existing `title` / `favicon` handling. Proto field added, Python backend wires it, frontend sets it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API and DOM attribute change with no auth or data-path impact; behavior matches existing page config patterns.
> 
> **Overview**
> Adds **`page_lang`** to `st.set_page_config()` so apps can set the root `<html>` `lang` attribute instead of relying on the static **`en`** in the shell HTML.
> 
> The value flows through a new **`PageConfig.lang`** proto field; Python forwards non-empty tags on `page_config_changed`, and the frontend updates **`document.documentElement.lang`** when `pageConfigChanged` includes `lang`. Docs describe BCP 47 tags and the same additive/inherit behavior as other page config options (default **`en`** when never set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e6b33879b2d1276a5fabacfa1ab47a839a3f08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->