### PR TITLE
Remove widget state duplication warning

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -393,19 +393,6 @@ def _delete_option(key: str) -> None:
 _create_section("global", "Global options that apply across all of Streamlit.")
 
 
-_create_option(
-    "global.disableWidgetStateDuplicationWarning",
-    description="""
-        By default, Streamlit logs a warning when a user sets both a widget
-        default value in the function defining the widget and a widget value via
-        the widget's key in `st.session_state`.
-
-        If you'd like to turn off this warning, set this to True.
-    """,
-    default_val=False,
-    type_=bool,
-)
-
 
 _create_option(
     "global.showWarningOnDirectExecution",

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -395,6 +395,18 @@ _create_section("global", "Global options that apply across all of Streamlit.")
 
 
 _create_option(
+    "global.disableWidgetStateDuplicationWarning",
+    description="""
+        No longer has any effect. The widget state duplication warning was
+        removed since setting both a default value and a session state value
+        is valid usage.
+    """,
+    default_val=False,
+    type_=bool,
+)
+
+
+_create_option(
     "global.showWarningOnDirectExecution",
     description="""
         If True, will show a warning when you run a Streamlit-enabled script

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final
 
-from streamlit import config, errors, logger, runtime
+from streamlit import errors, logger, runtime
 from streamlit.elements.lib.form_utils import is_in_form
 from streamlit.errors import (
     StreamlitAPIWarning,
@@ -52,25 +52,17 @@ def check_callback_rules(dg: DeltaGenerator, on_change: WidgetCallback | None) -
         raise StreamlitInvalidFormCallbackError()
 
 
-_shown_default_value_warning: bool = False
-
-
 def check_session_state_rules(
     default_value: Any, key: str | None, writes_allowed: bool = True
 ) -> None:
     """Ensures that no values are set for widgets with the given key when writing
     is not allowed.
 
-    Additionally, if `global.disableWidgetStateDuplicationWarning` is False, logs a
-    warning when a widget has a default value but its value is also set via session state.
-
     Raises
     ------
     StreamlitValueAssignmentNotAllowedError:
         Raised when writing is not allowed but session state contains a new value.
     """
-    global _shown_default_value_warning  # noqa: PLW0603
-
     if key is None or not runtime.exists():
         return
 
@@ -80,19 +72,6 @@ def check_session_state_rules(
 
     if not writes_allowed:
         raise StreamlitValueAssignmentNotAllowedError(key=key)
-
-    if (
-        default_value is not None
-        and not _shown_default_value_warning
-        and not config.get_option("global.disableWidgetStateDuplicationWarning")
-    ):
-        _LOGGER.warning(
-            'The widget with key "%s" was created with a default value but also had '
-            "its value set via the Session State API.",
-            key,
-            stack_info=True,
-        )
-        _shown_default_value_warning = True
 
 
 class CachedWidgetWarning(StreamlitAPIWarning):

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -768,6 +768,7 @@ class ConfigTest(unittest.TestCase):
                 *dark_sidebar_config_options,
                 "global.appTest",
                 "global.developmentMode",
+                "global.disableWidgetStateDuplicationWarning",
                 "global.e2eTest",
                 "global.maxCachedMessageAge",
                 "global.minCachedMessageSize",

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -768,7 +768,6 @@ class ConfigTest(unittest.TestCase):
                 *dark_sidebar_config_options,
                 "global.appTest",
                 "global.developmentMode",
-                "global.disableWidgetStateDuplicationWarning",
                 "global.e2eTest",
                 "global.maxCachedMessageAge",
                 "global.minCachedMessageSize",

--- a/lib/tests/streamlit/elements/datetime_input_test.py
+++ b/lib/tests/streamlit/elements/datetime_input_test.py
@@ -424,7 +424,6 @@ def test_datetime_input_callback():
     assert at.session_state.dt == new_value
 
 
-@patch("streamlit.elements.lib.policies._shown_default_value_warning", new=False)
 def test_session_state_takes_precedence():
     """Test that session state value takes precedence over default value."""
 

--- a/lib/tests/streamlit/elements/element_policies_test.py
+++ b/lib/tests/streamlit/elements/element_policies_test.py
@@ -99,22 +99,6 @@ class CheckSessionStateRules(ElementPoliciesTest):
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
     @patch("streamlit.elements.lib.policies.get_session_state")
-    @patch("streamlit.elements.lib.policies._LOGGER")
-    def test_check_session_state_rules_hide_warning_if_state_duplication_disabled(
-        self, patched_logger, patched_get_session_state
-    ):
-        config._set_option("global.disableWidgetStateDuplicationWarning", True, "test")
-
-        mock_session_state = MagicMock()
-        mock_session_state.is_new_state_value.return_value = True
-        patched_get_session_state.return_value = mock_session_state
-
-        check_session_state_rules(5, key=_KEY)
-
-        patched_logger.warning.assert_not_called()
-
-    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
-    @patch("streamlit.elements.lib.policies.get_session_state")
     def test_check_session_state_rules_writes_not_allowed(
         self, patched_get_session_state
     ):
@@ -153,29 +137,6 @@ class SpecialSessionStatesTest(ElementPoliciesTest):
             p.stop()
 
         config._delete_option("_test.tomlTest")
-
-    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
-    @patch("streamlit.elements.lib.policies.get_session_state")
-    @patch("streamlit.elements.lib.policies._LOGGER")
-    def test_check_session_state_rules_prints_warning(
-        self, patched_logger, patched_get_session_state
-    ):
-        import streamlit.elements.lib.policies as policies_module
-
-        mock_session_state = MagicMock()
-        mock_session_state.is_new_state_value.return_value = True
-        patched_get_session_state.return_value = mock_session_state
-        # Reset global flag:
-        policies_module._shown_default_value_warning = False
-
-        check_session_state_rules(5, key=_KEY)
-
-        patched_logger.warning.assert_called_once()
-        args, kwargs = patched_logger.warning.call_args
-        warning_msg = args[0]
-        assert 'The widget with key "%s"' in warning_msg
-        assert args[1] == _KEY
-        assert kwargs.get("stack_info") is True
 
 
 class CheckCacheReplayTest(ElementPoliciesTest):


### PR DESCRIPTION
## Describe your changes

Removes the warning *'The widget with key "..." was created with a default value but also had its value set via the Session State API.'* — setting both a default value and a session state value is valid usage.

The `global.disableWidgetStateDuplicationWarning` config option is kept as deprecated no-op so users with it in their `config.toml` don't get errors on startup.

## GitHub Issue Link (if applicable)

Fixes #15544

## Testing Plan

- Removed the warning-specific tests that are no longer relevant
- Existing tests for `check_session_state_rules` (writes-not-allowed, no-key, no-state-value) remain untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to dropping a log warning; widget session-state validation and errors for disallowed writes are unchanged.
> 
> **Overview**
> Stops logging when a widget has both a **default value** and a value for the same **key** in `st.session_state`, treating that pattern as supported instead of suspicious.
> 
> `check_session_state_rules` in `policies.py` now only enforces the **writes-not-allowed** path (`StreamlitValueAssignmentNotAllowedError`); the one-time logger warning, global `_shown_default_value_warning` flag, and `config` import are removed. **`global.disableWidgetStateDuplicationWarning`** remains in `config.toml` with an updated description as a **no-op** so existing configs still load.
> 
> Tests that asserted the warning or the config toggle are deleted; session-state precedence behavior (e.g. datetime input) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db52e17474dccd358023d157bf155b5f96f0ab31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->