### PR TITLE
[fix] Bundle the skills meta-skill in the wheel; install it locally (no GitHub download)

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -163,6 +163,7 @@ streamlit = [
     ".agents/**/*.md",
     ".agents/skills/**/assets/templates/**/*.py",
     ".agents/skills/**/assets/templates/**/*.toml",
+    ".agents/meta-skill/**/*.py",
     "hello/**/*.py",
 ]
 

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: developing-with-streamlit
+description: "Use for ALL Streamlit tasks: creating, editing, debugging, beautifying, styling, theming, optimizing, or deploying Streamlit apps. Also custom components, st.components.v2, HTML/JS/CSS work. Discovers and loads version-matched reference docs from the user's installed Streamlit (>=1.57). Triggers: streamlit, st., dashboard, app.py, beautify, style, CSS, color, background, theme, button, widget styling, custom component, st.components, CCv2, session state, performance, cache, fragment, slow rerun, deploy."
+allowed-tools: Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py:*) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py:*)
+---
+
+# Developing with Streamlit
+
+Streamlit (>=1.57) ships detailed reference documentation for building Streamlit apps inside its pip package. The bundled skill is a routing `SKILL.md` plus a `references/` folder of topic-specific reference docs (dashboards, themes, layouts, session state, custom components, etc.).
+
+## Usage
+
+Run the discovery script with the user's project directory:
+
+```bash
+python <SKILL_DIR>/scripts/discover.py --project-dir <USER_PROJECT_DIR>
+```
+
+The script prints either:
+
+- **A path on stdout** (exit 0) — the bundled `SKILL.md`. Read it; it points into `references/`.
+- **An `ERROR:` block on stderr** (non-zero exit). Follow the printed instructions and re-run.
+
+`<SKILL_DIR>` is the directory containing this file; `<USER_PROJECT_DIR>` is the absolute path to the user's project. Passing `--project-dir` matters because the script resolves `.venv`, `../.venv`, `Pipfile`, `poetry.lock`, `pdm.lock`, and `uv.lock` relative to it.

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Discover the Streamlit package's bundled agent-skills SKILL.md.
+
+Usage:
+    python scripts/discover.py [--project-dir PATH]
+
+When --project-dir is given, the script resolves `.venv`, `../.venv`,
+`Pipfile`, `poetry.lock`, `pdm.lock`, and `uv.lock` relative to that path (so
+its checks land on the user's project rather than on the script's installed
+location).
+
+Exit codes:
+    0 - success; prints the absolute path to the bundled SKILL.md on stdout.
+    1 - Streamlit is not installed in the detected interpreter.
+    2 - Streamlit is installed but predates bundled skills (no .agents/skills/).
+    3 - no usable Python interpreter was found.
+    4 - .agents/skills/ exists but the expected developing-with-streamlit/SKILL.md
+        is missing from the documented sub-path (likely upstream restructured).
+        The agent should read the listed available skills directly.
+    5 - invalid script argument.
+
+On non-zero exit, a human-readable "ERROR:" block is printed on stderr.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def find_venv_python(venv_root: Path) -> Optional[Path]:
+    """Return the venv's Python executable, cross-platform.
+
+    POSIX venvs put it at bin/python; Windows venvs put it at Scripts/python.exe.
+    """
+    for candidate in (
+        venv_root / "bin" / "python",
+        venv_root / "Scripts" / "python.exe",
+    ):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def find_git_root(start: Path) -> Optional[Path]:
+    """Walk up from `start` looking for a `.git` directory or file.
+
+    Returns the directory containing `.git` (the repo root), or None if no
+    git repository is found above `start`. Handles the worktree case where
+    `.git` is a file pointing at the real repo dir.
+    """
+    for ancestor in [start, *start.parents]:
+        if (ancestor / ".git").exists():
+            return ancestor
+    return None
+
+
+def detect_interpreter(project_dir: Path) -> Optional[Tuple[List[str], str]]:
+    """Pick the right Python interpreter, in documented priority order.
+
+    Returns ``(cmd, tag)`` where ``cmd`` is the command for ``subprocess.run``
+    and ``tag`` identifies which detection branch fired (``virtual-env``,
+    ``venv-local``, ``venv-parent``, ``venv-git-root``, ``conda``, ``pipenv``,
+    ``poetry``, ``pdm``, ``uv``, or ``system``). The tag lets callers give
+    targeted install advice on exit 1 instead of a buffet of unrelated
+    package-manager commands.
+    """
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv:
+        py = find_venv_python(Path(venv))
+        if py:
+            return [str(py)], "virtual-env"
+
+    py = find_venv_python(project_dir / ".venv")
+    if py:
+        return [str(py)], "venv-local"
+
+    py = find_venv_python(project_dir.parent / ".venv")
+    if py:
+        return [str(py)], "venv-parent"
+
+    # Walk up to the git repo root and look for a `.venv` there. Helpful for
+    # monorepos where the project's venv lives at repo root but the agent's
+    # cwd / --project-dir points deep into a subdirectory.
+    git_root = find_git_root(project_dir)
+    if (
+        git_root is not None
+        and git_root != project_dir
+        and git_root != project_dir.parent
+    ):
+        py = find_venv_python(git_root / ".venv")
+        if py:
+            return [str(py)], "venv-git-root"
+
+    conda = os.environ.get("CONDA_PREFIX")
+    if conda:
+        py = find_venv_python(Path(conda))
+        if py:
+            return [str(py)], "conda"
+
+    if shutil.which("pipenv") and (project_dir / "Pipfile").is_file():
+        return ["pipenv", "run", "python"], "pipenv"
+
+    if shutil.which("poetry") and (project_dir / "poetry.lock").is_file():
+        return ["poetry", "run", "python"], "poetry"
+
+    if shutil.which("pdm") and (project_dir / "pdm.lock").is_file():
+        return ["pdm", "run", "python"], "pdm"
+
+    if shutil.which("uv") and (project_dir / "uv.lock").is_file():
+        return ["uv", "run", "--quiet", "python"], "uv"
+
+    for name in ("python3", "python"):
+        if shutil.which(name):
+            return [name], "system"
+
+    return None
+
+
+def install_advice(cmd: List[str], tag: str) -> str:
+    """Return the package-manager-appropriate install command for the
+    detected interpreter.
+
+    ``detect_interpreter`` already chose a branch; we know which tool to
+    suggest. Dumping every install command and asking the agent to "match
+    the tool for your project" is how a poetry project gets a stray
+    ``pip install streamlit`` outside the lockfile.
+    """
+    if tag in {"virtual-env", "venv-local", "venv-parent", "venv-git-root"}:
+        # Use the venv's own python to run pip — independent of activation
+        # state on the user's shell.
+        return f"{cmd[0]} -m pip install streamlit"
+    if tag == "conda":
+        return "conda install -c conda-forge streamlit"
+    if tag == "pipenv":
+        return "pipenv install streamlit"
+    if tag == "poetry":
+        return "poetry add streamlit"
+    if tag == "pdm":
+        return "pdm add streamlit"
+    if tag == "uv":
+        return "uv add streamlit"
+    # tag == "system" (or unknown — defensive)
+    return (
+        f"{cmd[0]} -m pip install streamlit\n"
+        "    (better: create a project venv first with "
+        "`python -m venv .venv && source .venv/bin/activate`)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Discover the bundled developing-with-streamlit SKILL.md.",
+    )
+    parser.add_argument(
+        "--project-dir",
+        default=None,
+        help="Absolute path to the user's project directory. Defaults to cwd.",
+    )
+    try:
+        args = parser.parse_args()
+    except SystemExit as e:
+        return 5 if e.code else 0
+
+    if args.project_dir is not None:
+        project_dir = Path(args.project_dir)
+        if not project_dir.is_dir():
+            print(
+                f"ERROR: --project-dir is not a directory: {project_dir}",
+                file=sys.stderr,
+            )
+            return 5
+    else:
+        project_dir = Path.cwd()
+    project_dir = project_dir.resolve()
+
+    detection = detect_interpreter(project_dir)
+    if detection is None:
+        print(
+            "ERROR: No Python interpreter found.\n"
+            "Install Python 3.10+ (the easiest path is `uv` — see https://docs.astral.sh/uv/),\n"
+            "then install Streamlit (pip install streamlit) and re-run.",
+            file=sys.stderr,
+        )
+        return 3
+
+    cmd, tag = detection
+    py_display = " ".join(cmd)
+
+    probe = "import streamlit; print(streamlit.__path__[0])"
+    try:
+        result = subprocess.run(
+            [*cmd, "-c", probe],
+            capture_output=True,
+            text=True,
+            cwd=project_dir,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"ERROR: import streamlit timed out (interpreter: {py_display})",
+            file=sys.stderr,
+        )
+        return 1
+    except FileNotFoundError:
+        print(
+            f"ERROR: detected interpreter not found on PATH: {py_display}",
+            file=sys.stderr,
+        )
+        return 3
+
+    if result.returncode != 0:
+        combined = (result.stderr or "") + (result.stdout or "")
+        if "ModuleNotFoundError" in combined:
+            advice = install_advice(cmd, tag)
+            extra = ""
+            if tag == "system":
+                # No env-manager artifact found. The user might still have
+                # one (hatch, pyenv-virtualenv, an unactivated conda env)
+                # we couldn't auto-detect.
+                extra = (
+                    "\n\nIf your project uses an environment manager we did not\n"
+                    "auto-detect (hatch, pyenv-virtualenv, an unactivated conda env),\n"
+                    "ACTIVATE it first so the right Python is found, then re-run."
+                )
+            print(
+                "ERROR: Streamlit is not installed in the detected Python environment.\n"
+                f"Interpreter:   {py_display}\n"
+                f"Detected via:  {tag}\n"
+                "\n"
+                f"Install with:  {advice}\n"
+                "\n"
+                f"Then re-run this script.{extra}",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "ERROR: Failed to import streamlit.\n"
+            f"Interpreter: {py_display}\n"
+            "Output:\n"
+            f"{combined}",
+            file=sys.stderr,
+        )
+        return 1
+
+    streamlit_path = Path(result.stdout.strip()).resolve()
+    agents_skills_dir = streamlit_path / ".agents" / "skills"
+    primary_skill = agents_skills_dir / "developing-with-streamlit" / "SKILL.md"
+
+    if primary_skill.is_file():
+        print(primary_skill)
+        return 0
+
+    if agents_skills_dir.is_dir():
+        print(
+            "ERROR: Streamlit's bundled skills directory exists, but the expected\n"
+            "developing-with-streamlit/SKILL.md is missing from the documented sub-path.\n"
+            "This usually means upstream Streamlit reorganized the skill layout.\n"
+            "\n"
+            f"Streamlit path: {streamlit_path}\n"
+            f"Bundled skills directory: {agents_skills_dir}\n"
+            "Available entries:",
+            file=sys.stderr,
+        )
+        for entry in sorted(agents_skills_dir.iterdir()):
+            print(f"  {entry.name}", file=sys.stderr)
+        print(
+            "\n"
+            "Read whichever skill best matches the user's task. If none match,\n"
+            "fall back to the complete Streamlit documentation:\n"
+            "  https://docs.streamlit.io/llms-full.txt",
+            file=sys.stderr,
+        )
+        return 4
+
+    print(
+        f"ERROR: Streamlit is installed but predates bundled skills (< 1.57).\n"
+        f"Interpreter: {py_display}\n"
+        f"Streamlit path: {streamlit_path}\n"
+        "\n"
+        "For best results, upgrade to get version-matched bundled skills:\n"
+        "  pip install --upgrade streamlit\n"
+        "\n"
+        "If upgrading isn't an option, fall back to the complete Streamlit\n"
+        "documentation (full API + guides, formatted for LLMs):\n"
+        "  https://docs.streamlit.io/llms-full.txt",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Discover the Streamlit package's bundled agent-skills SKILL.md.
 
 Usage:
@@ -21,6 +20,7 @@ Exit codes:
 
 On non-zero exit, a human-readable "ERROR:" block is printed on stderr.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -29,10 +29,9 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 
-def find_venv_python(venv_root: Path) -> Optional[Path]:
+def find_venv_python(venv_root: Path) -> Path | None:
     """Return the venv's Python executable, cross-platform.
 
     POSIX venvs put it at bin/python; Windows venvs put it at Scripts/python.exe.
@@ -46,7 +45,7 @@ def find_venv_python(venv_root: Path) -> Optional[Path]:
     return None
 
 
-def find_git_root(start: Path) -> Optional[Path]:
+def find_git_root(start: Path) -> Path | None:
     """Walk up from `start` looking for a `.git` directory or file.
 
     Returns the directory containing `.git` (the repo root), or None if no
@@ -59,7 +58,7 @@ def find_git_root(start: Path) -> Optional[Path]:
     return None
 
 
-def detect_interpreter(project_dir: Path) -> Optional[Tuple[List[str], str]]:
+def detect_interpreter(project_dir: Path) -> tuple[list[str], str] | None:
     """Pick the right Python interpreter, in documented priority order.
 
     Returns ``(cmd, tag)`` where ``cmd`` is the command for ``subprocess.run``
@@ -87,11 +86,7 @@ def detect_interpreter(project_dir: Path) -> Optional[Tuple[List[str], str]]:
     # monorepos where the project's venv lives at repo root but the agent's
     # cwd / --project-dir points deep into a subdirectory.
     git_root = find_git_root(project_dir)
-    if (
-        git_root is not None
-        and git_root != project_dir
-        and git_root != project_dir.parent
-    ):
+    if git_root is not None and git_root not in {project_dir, project_dir.parent}:
         py = find_venv_python(git_root / ".venv")
         if py:
             return [str(py)], "venv-git-root"
@@ -121,7 +116,7 @@ def detect_interpreter(project_dir: Path) -> Optional[Tuple[List[str], str]]:
     return None
 
 
-def install_advice(cmd: List[str], tag: str) -> str:
+def install_advice(cmd: list[str], tag: str) -> str:
     """Return the package-manager-appropriate install command for the
     detected interpreter.
 
@@ -199,6 +194,7 @@ def main() -> int:
             text=True,
             cwd=project_dir,
             timeout=30,
+            check=False,
         )
     except subprocess.TimeoutExpired:
         print(

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -1,3 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Discover the Streamlit package's bundled agent-skills SKILL.md.
 
 Usage:

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: T201 - standalone CLI script: printing to stdout/stderr is its interface.
+
 """Discover the Streamlit package's bundled agent-skills SKILL.md.
 
 Usage:
@@ -40,7 +42,7 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
-import subprocess
+import subprocess  # noqa: S404 - used only to probe the project's own interpreter (see below).
 import sys
 from pathlib import Path
 
@@ -202,7 +204,7 @@ def main() -> int:
 
     probe = "import streamlit; print(streamlit.__path__[0])"
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603 - cmd is a detected interpreter path, not user input.
             [*cmd, "-c", probe],
             capture_output=True,
             text=True,

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -24,6 +24,8 @@ import asyncio
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Final, Protocol
 
+import click
+
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import (
     BackendOperationResponse,
@@ -210,7 +212,7 @@ class InstallSkillsHandler(BackendOperationHandler):
         # predicate. Three conditions make a request anomalous and unsafe to honor:
         #   - headless mode (deployments / CI / SiS): the nudge is never shown
         #     there, so the request is a replayed/spoofed BackMsg; refuse the
-        #     filesystem writes (and the GitHub download in the global fallback).
+        #     filesystem writes.
         #   - no agent harness present: nothing would consume the skills.
         #   - the browser is not on a direct-loopback connection: the same
         #     conservative eligibility rule the nudge display uses, so a
@@ -233,17 +235,24 @@ class InstallSkillsHandler(BackendOperationHandler):
             )
 
         try:
-            # Run off the event loop: installing does filesystem I/O (and, in
-            # the global fallback, a network download). Resolve the install root
+            # Run off the event loop: installing does filesystem I/O (copying
+            # the bundled skill from the local package). Resolve the install root
             # from the app dir so it lands in the tree the nudge detection scans.
             result = await asyncio.to_thread(
                 skills.install_skills, global_mode=False, yes=True, app_dir=app_dir
             )
         except Exception as ex:
             _LOGGER.warning("One-click skills install failed", exc_info=ex)
-            # click.ClickException carries a clean, user-facing message.
-            format_message = getattr(ex, "format_message", None)
-            detail = format_message() if callable(format_message) else str(ex)
+            # Only ``click.ClickException`` messages are safe to show verbatim in
+            # the browser toast — they are developer-authored, never a raw OS
+            # string. For any other exception (e.g. an unexpected OSError whose
+            # message embeds an absolute path) use a generic message so a server
+            # path can't leak into the nudge.
+            detail = (
+                ex.format_message()
+                if isinstance(ex, click.ClickException)
+                else "Failed to install skills."
+            )
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -545,10 +545,9 @@ def main_skills(global_mode: bool, yes: bool) -> None:
 
     \b
     Global mode (--global):
-        Installs a version-agnostic meta skill (bundled with Streamlit, no
-        download) into your user directory. It discovers each project's
-        installed Streamlit at runtime, so a single global install works
-        across all projects and Streamlit versions.
+        Installs a version-agnostic meta skill into your user directory. It
+        discovers each project's installed Streamlit at runtime, so a single
+        global install works across all projects and Streamlit versions.
 
     \b
     Examples:

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -545,8 +545,10 @@ def main_skills(global_mode: bool, yes: bool) -> None:
 
     \b
     Global mode (--global):
-        Installs a meta skill globally (in user directory) that is available
-        to all projects.
+        Installs a version-agnostic meta skill (bundled with Streamlit, no
+        download) into your user directory. It discovers each project's
+        installed Streamlit at runtime, so a single global install works
+        across all projects and Streamlit versions.
 
     \b
     Examples:

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -175,13 +175,6 @@ def _get_project_target_dirs(project_root: Path) -> list[Path]:
 
     Always targets .agents/skills/. Also targets .claude/skills/
     when ~/.claude exists (Claude Code is installed).
-
-    Unlike :func:`_get_global_target_dirs`, this intentionally does NOT fan out
-    to every harness's project dir: a project-level ``.agents/skills`` is read by
-    all supported harnesses, so one symlink there suffices and we avoid littering
-    the repo with per-harness ``.cursor``/``.gemini``/… directories. The global
-    case differs because ``~/.agents/skills`` at home scope is not universally
-    read, so it must reach each harness's own home dir.
     """
     targets = [project_root / ".agents" / "skills"]
 
@@ -195,23 +188,16 @@ def _get_project_target_dirs(project_root: Path) -> list[Path]:
 def _get_global_target_dirs() -> list[Path]:
     """Get target directories for global skill installation.
 
-    Mirrors where the nudge's skill detection LOOKS at home scope: always
-    ``~/.agents/skills`` (the harness-agnostic convention, so ``streamlit skills
-    --global`` still has a target when no harness is installed), plus the home
-    skills directory of every detected harness. Derives those from the same
-    :func:`_harness_skill_subdirs` that :func:`detect_installed_skills` scans, so
-    the installer writes exactly where the toast looks — the two stay symmetrical
-    and cannot drift.
+    Always targets ~/.agents/skills/. Also targets ~/.claude/skills/
+    when ~/.claude exists (Claude Code is installed).
     """
     home = Path.home()
-    # Always include the generic convention. Detection only scans ``~/.agents``
-    # once it exists, but the CLI needs a target even with zero harnesses
-    # installed, so seed it here and let the shared derivation add the rest.
     targets = [home / ".agents" / "skills"]
-    for _harness, skills_subdir in _harness_skill_subdirs(str(home), home_scope=True):
-        target = home / skills_subdir
-        if target not in targets:
-            targets.append(target)
+
+    claude_home = home / ".claude"
+    if claude_home.exists():
+        targets.append(claude_home / "skills")
+
     return targets
 
 
@@ -534,7 +520,7 @@ def _confirm_project_installation(
 def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     """Show global installation plan and confirm with user."""
     click.echo()
-    click.echo("Installing globally from your local Streamlit install (no download)")
+    click.echo("Installing globally")
 
     click.secho("\nSource:", bold=True)
     click.echo(
@@ -936,31 +922,6 @@ _HARNESSES: Final = (
 )
 
 
-def _harness_skill_subdirs(root: str, *, home_scope: bool) -> list[tuple[str, str]]:
-    """Return ``(harness, skills_subdir)`` for each agent harness under ``root``.
-
-    Single source of truth for *which directory each agent harness keeps its
-    skills in*, shared by the nudge's skill detection (:func:`detect_installed_skills`,
-    where it LOOKS for an installed marker) and the global installer's target
-    resolution (:func:`_get_global_target_dirs`, where it WRITES the skill). The
-    two derive from the same list so the toast and the install path stay
-    symmetrical — the installer writes exactly where detection scans, and neither
-    can drift from the other as harnesses are added.
-
-    ``skills_subdir`` is relative to ``root`` (the caller joins it). At home scope
-    a harness is included only when its home config dir exists (e.g. ``~/.claude``)
-    and its *home* skills dir is used; at project scope every harness's *project*
-    skills dir is returned. ``root`` is a string so the hot detection path stays
-    on ``os.path`` without ``Path`` overhead.
-    """
-    subdirs: list[tuple[str, str]] = []
-    for harness, project_dir, home_skills_dir, agent_home_dir in _HARNESSES:
-        if home_scope and not os.path.isdir(os.path.join(root, agent_home_dir)):
-            continue
-        subdirs.append((harness, home_skills_dir if home_scope else project_dir))
-    return subdirs
-
-
 # Max directory levels to walk when searching for a ``.git`` ancestor. Bounded
 # to avoid scanning the entire filesystem on pathological layouts.
 _MAX_REPO_ROOT_WALK_DEPTH: Final = 20
@@ -1037,12 +998,15 @@ def _detect_installed_skills_cached(app_dir: str | None) -> tuple[str, ...]:
 
         tokens: set[str] = set()
         for location, root in roots.items():
-            # Same harness->skills-dir derivation the global installer writes to,
-            # so detection scans exactly where the install lands (see
-            # _harness_skill_subdirs). At home scope absent harnesses are skipped.
-            for harness, harness_dir in _harness_skill_subdirs(
-                root, home_scope=location == "home"
-            ):
+            for harness, project_dir, home_skills_dir, agent_home_dir in _HARNESSES:
+                # At home level, skip harnesses that aren't installed at all
+                # (saves 2 isfile calls per absent harness — common on hosted
+                # apps where no skills or harnesses exist).
+                if location == "home" and not os.path.isdir(
+                    os.path.join(root, agent_home_dir)
+                ):
+                    continue
+                harness_dir = home_skills_dir if location == "home" else project_dir
                 for skill in _STREAMLIT_SKILL_NAMES:
                     marker = os.path.join(
                         root, harness_dir, skill, _SKILL_MARKER_FILENAME
@@ -1073,16 +1037,11 @@ def detect_installed_agents() -> list[str]:
 def _detect_installed_agents_cached() -> tuple[str, ...]:
     try:
         home = os.path.expanduser("~")
-        # Same home-scope presence check the skill detection and the global
-        # installer use, so "which harnesses are present" has one definition.
-        return tuple(
-            sorted(
-                harness
-                for harness, _skills_dir in _harness_skill_subdirs(
-                    home, home_scope=True
-                )
-            )
-        )
+        tokens: set[str] = set()
+        for harness, _project_dir, _home_skills_dir, agent_home_dir in _HARNESSES:
+            if os.path.isdir(os.path.join(home, agent_home_dir)):
+                tokens.add(harness)
+        return tuple(sorted(tokens))
     except Exception as ex:  # pragma: no cover - defensive
         _LOGGER.debug("Failed to detect installed agents", exc_info=ex)
         return ()

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -585,8 +585,12 @@ def _install_project_skills(
     # Discover bundled skills
     source_skills_dir = _get_source_skills_dir()
     if not source_skills_dir.is_dir():
+        # Keep the absolute path in the server log only - this message is shown
+        # verbatim in the in-app nudge, so it must not leak a server path.
+        _LOGGER.warning("Bundled skills directory not found at %s", source_skills_dir)
         raise click.ClickException(
-            f"Bundled skills directory not found: {source_skills_dir}"
+            "Bundled skills were not found in your Streamlit installation. "
+            "Reinstall Streamlit and try again."
         )
 
     skills = _discover_skills(source_skills_dir)
@@ -723,11 +727,20 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
 
     # The meta-skill ships in the wheel; copy it from local disk (no network).
     meta_skill_dir = _get_meta_skill_dir()
-    if not (meta_skill_dir / _GLOBAL_SKILL_NAME / "SKILL.md").is_file():
+    meta_skill = meta_skill_dir / _GLOBAL_SKILL_NAME
+    # The meta-skill is a router (SKILL.md) plus the discover.py it points the
+    # agent at; SKILL.md alone is inert. Require BOTH so a stripped wheel or a
+    # too-narrow package-data glob surfaces as an error instead of a "successful"
+    # install of a skill that fails the moment an agent runs discover.py.
+    if not (
+        (meta_skill / "SKILL.md").is_file()
+        and (meta_skill / "scripts" / "discover.py").is_file()
+    ):
         # Keep the absolute path in the server log only - this message is shown
         # verbatim in the in-app nudge, so it must not leak a server path.
         _LOGGER.warning(
-            "Bundled meta-skill %r not found under %s",
+            "Bundled meta-skill %r is incomplete under %s "
+            "(need SKILL.md + scripts/discover.py)",
             _GLOBAL_SKILL_NAME,
             meta_skill_dir,
         )

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -16,18 +16,14 @@
 
 from __future__ import annotations
 
-import io
 import os
 import shutil
 import sys
-import tarfile
 import tempfile
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Final
-from urllib import request
-from urllib.error import URLError
 
 import click
 
@@ -35,11 +31,6 @@ import streamlit
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
-
-# GitHub URL for downloading global skills (versioned tag)
-_GLOBAL_SKILLS_URL: Final[str] = (
-    "https://github.com/streamlit/agent-skills/archive/refs/tags/v1.tar.gz"
-)
 
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
@@ -76,6 +67,21 @@ def _get_source_skills_dir() -> Path:
     """Get the path to bundled skills in the Streamlit package."""
     package_dir = Path(streamlit.__file__).parent
     return package_dir / ".agents" / "skills"
+
+
+def _get_meta_skill_dir() -> Path:
+    """Get the path to the bundled, version-agnostic meta-skill in the package.
+
+    The meta-skill (a thin ``SKILL.md`` router plus ``scripts/discover.py``) is
+    vendored in the wheel so global installs can copy it from local disk instead
+    of downloading it from GitHub. ``discover.py`` finds the project's installed
+    Streamlit at runtime and points the agent at the version-matched bundled
+    content skills, so a single global install stays correct across Streamlit
+    versions. It lives outside ``.agents/skills`` so project-mode discovery and
+    skill detection never treat it as an installable content skill.
+    """
+    package_dir = Path(streamlit.__file__).parent
+    return package_dir / ".agents" / "meta-skill"
 
 
 def _discover_skills(source_dir: Path) -> list[str]:
@@ -426,61 +432,6 @@ def _install_skill_copy(
         result.skipped.append(f"{rel_target_path} (copy failed: {e})")
 
 
-def _download_global_skill(url: str, skill_name: str) -> Path:
-    """Download and extract global skill from GitHub.
-
-    Returns path to extracted skill directory in a temporary location.
-    Raises click.ClickException on network or extraction errors.
-    """
-    try:
-        with request.urlopen(url, timeout=30) as response:  # noqa: S310
-            data = response.read()
-    except URLError as e:
-        raise click.ClickException(
-            f"Failed to download skills from GitHub: {e}\n"
-            "Check your network connection and try again."
-        ) from e
-
-    # Extract tarball to temp directory
-    temp_dir = Path(tempfile.mkdtemp(prefix="streamlit-skills-"))
-    try:
-        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
-            # Security: prevent path traversal and other attacks by filtering members.
-            # On Python 3.12+, use filter='data' which blocks absolute paths,
-            # parent directory references (..), and special files (devices, fifos, etc.).
-            # On earlier versions, manually filter to regular files and directories only.
-            if sys.version_info >= (3, 12):
-                tar.extractall(temp_dir, filter="data")
-            else:
-                # Manual safe extraction for Python 3.10/3.11
-                safe_members = [
-                    m
-                    for m in tar.getmembers()
-                    if (m.isfile() or m.isdir())
-                    and not os.path.isabs(m.name)
-                    and ".." not in m.name.split("/")
-                ]
-                tar.extractall(temp_dir, members=safe_members)  # noqa: S202
-    except tarfile.TarError as e:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        raise click.ClickException(f"Failed to extract skills archive: {e}") from e
-
-    # Find skill directory - search all top-level directories in case archive has
-    # multiple entries (typically GitHub archives have one: repo-name-tag/)
-    extracted_dirs = [d for d in temp_dir.iterdir() if d.is_dir()]
-    if not extracted_dirs:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        raise click.ClickException("Downloaded archive is empty")
-
-    for archive_root in extracted_dirs:
-        skill_path = archive_root / skill_name
-        if skill_path.is_dir() and (skill_path / "SKILL.md").is_file():
-            return skill_path
-
-    shutil.rmtree(temp_dir, ignore_errors=True)
-    raise click.ClickException(f"Skill '{skill_name}' not found in downloaded archive")
-
-
 def _print_result(result: _InstallResult) -> None:
     """Print the installation result summary."""
     if result.installed:
@@ -569,12 +520,12 @@ def _confirm_project_installation(
 def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     """Show global installation plan and confirm with user."""
     click.echo()
-    click.echo("Installing globally (downloads from GitHub)")
+    click.echo("Installing globally from your local Streamlit install (no download)")
 
     click.secho("\nSource:", bold=True)
     click.echo(
         f"  {click.style('•', fg='magenta')} "
-        f"{click.style(_GLOBAL_SKILLS_URL, fg='cyan')}"
+        f"{click.style(str(_get_meta_skill_dir() / _GLOBAL_SKILL_NAME), fg='cyan')}"
     )
 
     click.secho("\nSkill to install:", bold=True)
@@ -752,7 +703,17 @@ def _install_project_skills(
 
 
 def _install_global_skills(*, yes: bool = False) -> _InstallResult:
-    """Install skills globally by downloading from GitHub."""
+    """Install the version-agnostic meta-skill globally from the local package.
+
+    The meta-skill is vendored inside the installed ``streamlit`` package
+    (:func:`_get_meta_skill_dir`), so we copy it from local disk with no network
+    dependency. The old implementation downloaded it from GitHub, which made the
+    in-app one-click install fail for ~1 in 8 Windows users on locked-down
+    networks (see issue #15933) and raised a security review of runtime external
+    downloads. Copying the bundled meta-skill removes both problems; its
+    ``discover.py`` still resolves the version-matched content skills at runtime,
+    so a single global install stays correct across Streamlit versions.
+    """
     target_dirs = _get_global_target_dirs()
 
     # Confirm installation
@@ -760,54 +721,59 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
         click.echo("Installation cancelled.")
         raise click.Abort()
 
-    # Download skill from GitHub
-    click.echo("Downloading skills from GitHub...")
-    skill_path = _download_global_skill(_GLOBAL_SKILLS_URL, _GLOBAL_SKILL_NAME)
+    # The meta-skill ships in the wheel; copy it from local disk (no network).
+    meta_skill_dir = _get_meta_skill_dir()
+    if not (meta_skill_dir / _GLOBAL_SKILL_NAME / "SKILL.md").is_file():
+        # Keep the absolute path in the server log only - this message is shown
+        # verbatim in the in-app nudge, so it must not leak a server path.
+        _LOGGER.warning(
+            "Bundled meta-skill %r not found under %s",
+            _GLOBAL_SKILL_NAME,
+            meta_skill_dir,
+        )
+        raise click.ClickException(
+            f"The bundled '{_GLOBAL_SKILL_NAME}' meta-skill was not found in your "
+            "Streamlit installation. Reinstall Streamlit and try again."
+        )
 
-    try:
-        # Install to each target directory
-        result = _InstallResult()
-        # For global install, only one skill is installed but we use a set for consistency
-        bundled_skill_names = {_GLOBAL_SKILL_NAME}
-        for target_dir in target_dirs:
-            _install_skill_copy(
-                _GLOBAL_SKILL_NAME,
-                skill_path.parent,
-                target_dir,
-                result,
-                bundled_skill_names,
-            )
+    # Install to each target directory
+    result = _InstallResult()
+    # For global install, only one skill is installed but we use a set for consistency
+    bundled_skill_names = {_GLOBAL_SKILL_NAME}
+    for target_dir in target_dirs:
+        _install_skill_copy(
+            _GLOBAL_SKILL_NAME,
+            meta_skill_dir,
+            target_dir,
+            result,
+            bundled_skill_names,
+        )
 
-        # Report results
-        _print_result(result)
+    # Report results
+    _print_result(result)
 
-        if result.installed or result.up_to_date:
+    if result.installed or result.up_to_date:
+        click.echo()
+        click.secho(
+            "✨ Successfully installed globally",
+            fg="green",
+            bold=True,
+        )
+        if result.installed:
             click.echo()
+            click.secho("Note: ", fg="bright_black", bold=True, nl=False)
             click.secho(
-                "✨ Successfully installed globally",
-                fg="green",
-                bold=True,
+                "Global skills include a discover.py script that finds",
+                fg="bright_black",
             )
-            if result.installed:
-                click.echo()
-                click.secho("Note: ", fg="bright_black", bold=True, nl=False)
-                click.secho(
-                    "Global skills include a discover.py script that finds",
-                    fg="bright_black",
-                )
-                click.secho(
-                    "      project-specific bundled skills at runtime.",
-                    fg="bright_black",
-                )
-        elif result.skipped:
-            raise _conflict_error(result.skipped)
+            click.secho(
+                "      project-specific bundled skills at runtime.",
+                fg="bright_black",
+            )
+    elif result.skipped:
+        raise _conflict_error(result.skipped)
 
-        return result
-    finally:
-        # Clean up temp directory
-        temp_root = skill_path.parent.parent
-        if temp_root.name.startswith("streamlit-skills-"):
-            shutil.rmtree(temp_root, ignore_errors=True)
+    return result
 
 
 def install_skills(

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -188,16 +188,27 @@ def _get_project_target_dirs(project_root: Path) -> list[Path]:
 def _get_global_target_dirs() -> list[Path]:
     """Get target directories for global skill installation.
 
-    Always targets ~/.agents/skills/. Also targets ~/.claude/skills/
-    when ~/.claude exists (Claude Code is installed).
+    Always targets ``~/.agents/skills/`` (the harness-agnostic convention many
+    agents read). Also targets the home skills directory of every other agent
+    harness whose home config directory exists (e.g. ``~/.claude/skills``,
+    ``~/.gemini/skills``, ``~/.codex/skills``), so a one-click global install
+    lands where the harness the developer actually runs looks for skills — not
+    only in ``~/.agents/skills``, which some harnesses do not read. The harness
+    set and the "installed if its home config dir exists" rule mirror the nudge's
+    :func:`detect_installed_agents`/:func:`detect_installed_skills`, so an install
+    is both visible to the harness and detected as installed (no re-nudge loop).
     """
     home = Path.home()
-    targets = [home / ".agents" / "skills"]
-
-    claude_home = home / ".claude"
-    if claude_home.exists():
-        targets.append(claude_home / "skills")
-
+    targets: list[Path] = []
+    for _harness, _project_dir, home_skills_dir, agent_home_dir in _HARNESSES:
+        # ``.agents`` is the generic convention: always install there. Every
+        # other harness only when its home config dir exists (i.e. it is
+        # installed) — the same test detect_installed_agents uses.
+        if agent_home_dir != ".agents" and not (home / agent_home_dir).is_dir():
+            continue
+        target = home / home_skills_dir
+        if target not in targets:
+            targets.append(target)
     return targets
 
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -175,6 +175,13 @@ def _get_project_target_dirs(project_root: Path) -> list[Path]:
 
     Always targets .agents/skills/. Also targets .claude/skills/
     when ~/.claude exists (Claude Code is installed).
+
+    Unlike :func:`_get_global_target_dirs`, this intentionally does NOT fan out
+    to every harness's project dir: a project-level ``.agents/skills`` is read by
+    all supported harnesses, so one symlink there suffices and we avoid littering
+    the repo with per-harness ``.cursor``/``.gemini``/… directories. The global
+    case differs because ``~/.agents/skills`` at home scope is not universally
+    read, so it must reach each harness's own home dir.
     """
     targets = [project_root / ".agents" / "skills"]
 
@@ -188,25 +195,21 @@ def _get_project_target_dirs(project_root: Path) -> list[Path]:
 def _get_global_target_dirs() -> list[Path]:
     """Get target directories for global skill installation.
 
-    Always targets ``~/.agents/skills/`` (the harness-agnostic convention many
-    agents read). Also targets the home skills directory of every other agent
-    harness whose home config directory exists (e.g. ``~/.claude/skills``,
-    ``~/.gemini/skills``, ``~/.codex/skills``), so a one-click global install
-    lands where the harness the developer actually runs looks for skills — not
-    only in ``~/.agents/skills``, which some harnesses do not read. The harness
-    set and the "installed if its home config dir exists" rule mirror the nudge's
-    :func:`detect_installed_agents`/:func:`detect_installed_skills`, so an install
-    is both visible to the harness and detected as installed (no re-nudge loop).
+    Mirrors where the nudge's skill detection LOOKS at home scope: always
+    ``~/.agents/skills`` (the harness-agnostic convention, so ``streamlit skills
+    --global`` still has a target when no harness is installed), plus the home
+    skills directory of every detected harness. Derives those from the same
+    :func:`_harness_skill_subdirs` that :func:`detect_installed_skills` scans, so
+    the installer writes exactly where the toast looks — the two stay symmetrical
+    and cannot drift.
     """
     home = Path.home()
-    targets: list[Path] = []
-    for _harness, _project_dir, home_skills_dir, agent_home_dir in _HARNESSES:
-        # ``.agents`` is the generic convention: always install there. Every
-        # other harness only when its home config dir exists (i.e. it is
-        # installed) — the same test detect_installed_agents uses.
-        if agent_home_dir != ".agents" and not (home / agent_home_dir).is_dir():
-            continue
-        target = home / home_skills_dir
+    # Always include the generic convention. Detection only scans ``~/.agents``
+    # once it exists, but the CLI needs a target even with zero harnesses
+    # installed, so seed it here and let the shared derivation add the rest.
+    targets = [home / ".agents" / "skills"]
+    for _harness, skills_subdir in _harness_skill_subdirs(str(home), home_scope=True):
+        target = home / skills_subdir
         if target not in targets:
             targets.append(target)
     return targets
@@ -931,6 +934,33 @@ _HARNESSES: Final = (
     ("gemini", ".gemini/skills", ".gemini/skills", ".gemini"),
     ("opencode", ".opencode/skills", ".config/opencode/skills", ".config/opencode"),
 )
+
+
+def _harness_skill_subdirs(root: str, *, home_scope: bool) -> list[tuple[str, str]]:
+    """Return ``(harness, skills_subdir)`` for each agent harness under ``root``.
+
+    Single source of truth for *which directory each agent harness keeps its
+    skills in*, shared by the nudge's skill detection (:func:`detect_installed_skills`,
+    where it LOOKS for an installed marker) and the global installer's target
+    resolution (:func:`_get_global_target_dirs`, where it WRITES the skill). The
+    two derive from the same list so the toast and the install path stay
+    symmetrical — the installer writes exactly where detection scans, and neither
+    can drift from the other as harnesses are added.
+
+    ``skills_subdir`` is relative to ``root`` (the caller joins it). At home scope
+    a harness is included only when its home config dir exists (e.g. ``~/.claude``)
+    and its *home* skills dir is used; at project scope every harness's *project*
+    skills dir is returned. ``root`` is a string so the hot detection path stays
+    on ``os.path`` without ``Path`` overhead.
+    """
+    subdirs: list[tuple[str, str]] = []
+    for harness, project_dir, home_skills_dir, agent_home_dir in _HARNESSES:
+        if home_scope and not os.path.isdir(os.path.join(root, agent_home_dir)):
+            continue
+        subdirs.append((harness, home_skills_dir if home_scope else project_dir))
+    return subdirs
+
+
 # Max directory levels to walk when searching for a ``.git`` ancestor. Bounded
 # to avoid scanning the entire filesystem on pathological layouts.
 _MAX_REPO_ROOT_WALK_DEPTH: Final = 20
@@ -1007,15 +1037,12 @@ def _detect_installed_skills_cached(app_dir: str | None) -> tuple[str, ...]:
 
         tokens: set[str] = set()
         for location, root in roots.items():
-            for harness, project_dir, home_skills_dir, agent_home_dir in _HARNESSES:
-                # At home level, skip harnesses that aren't installed at all
-                # (saves 2 isfile calls per absent harness — common on hosted
-                # apps where no skills or harnesses exist).
-                if location == "home" and not os.path.isdir(
-                    os.path.join(root, agent_home_dir)
-                ):
-                    continue
-                harness_dir = home_skills_dir if location == "home" else project_dir
+            # Same harness->skills-dir derivation the global installer writes to,
+            # so detection scans exactly where the install lands (see
+            # _harness_skill_subdirs). At home scope absent harnesses are skipped.
+            for harness, harness_dir in _harness_skill_subdirs(
+                root, home_scope=location == "home"
+            ):
                 for skill in _STREAMLIT_SKILL_NAMES:
                     marker = os.path.join(
                         root, harness_dir, skill, _SKILL_MARKER_FILENAME
@@ -1046,11 +1073,16 @@ def detect_installed_agents() -> list[str]:
 def _detect_installed_agents_cached() -> tuple[str, ...]:
     try:
         home = os.path.expanduser("~")
-        tokens: set[str] = set()
-        for harness, _project_dir, _home_skills_dir, agent_home_dir in _HARNESSES:
-            if os.path.isdir(os.path.join(home, agent_home_dir)):
-                tokens.add(harness)
-        return tuple(sorted(tokens))
+        # Same home-scope presence check the skill detection and the global
+        # installer use, so "which harnesses are present" has one definition.
+        return tuple(
+            sorted(
+                harness
+                for harness, _skills_dir in _harness_skill_subdirs(
+                    home, home_scope=True
+                )
+            )
+        )
     except Exception as ex:  # pragma: no cover - defensive
         _LOGGER.debug("Failed to detect installed agents", exc_info=ex)
         return ()

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -244,6 +244,33 @@ def test_install_skills_handler_reports_failure() -> None:
     assert not response.HasField("install_skills")
 
 
+def test_install_skills_handler_does_not_leak_os_error_path() -> None:
+    """A non-``ClickException`` (e.g. ``OSError``) yields a generic message.
+
+    ``click.ClickException`` messages are developer-authored and safe to show in
+    the browser toast, but a raw ``OSError`` can embed an absolute server path.
+    The handler must forward only the former verbatim and replace anything else
+    with a generic string, so a server path can never leak into the nudge.
+    """
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch(
+            "streamlit.web.skills.install_skills",
+            side_effect=OSError("/absolute/server/path/.agents/skills is not writable"),
+        ),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_msg == "Failed to install skills."
+    assert "/absolute/server/path" not in response.error_msg
+    assert not response.HasField("install_skills")
+
+
 def test_install_skills_handler_refuses_without_agent_harness() -> None:
     """The install ACTION is gated on safety, not the nudge's display predicate:
     with no agent harness present (and not headless) the request is anomalous,

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch
 
 import click
@@ -27,9 +27,6 @@ import pytest
 from click.testing import CliRunner
 
 from streamlit.web import cli, skills
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _skip_if_symlinks_not_supported(tmp_path: Path) -> None:
@@ -960,13 +957,15 @@ class TestInstallSkillsCli:
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
         """Fails when bundled skills directory doesn't exist."""
-        with patch.object(
-            skills, "_get_source_skills_dir", return_value=tmp_path / "nonexistent"
-        ):
+        missing = tmp_path / "nonexistent"
+        with patch.object(skills, "_get_source_skills_dir", return_value=missing):
             result = runner.invoke(cli.main, ["skills", "--yes"])
 
         assert result.exit_code != 0
         assert "not found" in result.output
+        # The absolute server path must not leak into the error (the same message
+        # is shown verbatim in the in-app nudge toast).
+        assert str(missing) not in result.output
 
     def test_skills_installs_to_agents_skills(
         self, runner: CliRunner, tmp_path: Path, mock_source_skills_dir: Path
@@ -2157,6 +2156,75 @@ class TestInstallGlobalSkillsMetaSkill:
         assert "was not found" in result.output
         # The server-side absolute path must not leak into the user-facing error.
         assert str(missing) not in result.output
+
+    def test_global_install_requires_discover_py_not_just_skill_md(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """SKILL.md alone is not enough — discover.py must be present too.
+
+        The meta-skill's SKILL.md is inert without scripts/discover.py (it just
+        routes the agent into that script). If a stripped wheel or a too-narrow
+        package-data glob shipped SKILL.md only, the install must error rather
+        than report success for a skill that fails the moment an agent runs it.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+        # Meta-skill dir with SKILL.md but NO scripts/discover.py.
+        meta_dir = tmp_path / "meta-skill"
+        (meta_dir / "developing-with-streamlit").mkdir(parents=True)
+        (meta_dir / "developing-with-streamlit" / "SKILL.md").write_text(
+            "# Meta Skill\n", encoding="utf-8"
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(skills, "_get_meta_skill_dir", return_value=meta_dir),
+        ):
+            result = runner.invoke(cli.main, ["skills", "-g", "-y"])
+
+        assert result.exit_code != 0
+        assert "was not found" in result.output
+        # Nothing should have been copied to the global target.
+        assert not (home / ".agents" / "skills" / "developing-with-streamlit").exists()
+
+
+class TestMetaSkillPackaging:
+    """Guards that the vendored meta-skill files actually ship in the wheel."""
+
+    def test_package_data_globs_cover_vendored_meta_skill(self) -> None:
+        """The setuptools ``package-data`` globs must match both vendored files.
+
+        Every other test reads the vendored files straight from the on-disk
+        checkout, so they stay green even if the ``package-data`` globs were
+        wrong or removed — the failure would only surface for real pip-installed
+        users, exactly the "global install broken on a real machine" class this
+        change exists to prevent. This asserts the declared globs, applied to the
+        real package dir, include ``SKILL.md`` and ``scripts/discover.py``.
+        """
+        import glob as globmod
+
+        import toml
+
+        pyproject = Path(__file__).resolve().parents[3] / "pyproject.toml"
+        if not pyproject.is_file():  # pragma: no cover - unusual layout
+            pytest.skip("lib/pyproject.toml not found in this layout")
+
+        globs = toml.load(pyproject)["tool"]["setuptools"]["package-data"]["streamlit"]
+        # <streamlit pkg>/.agents/skills -> <streamlit pkg>
+        pkg_dir = skills._get_source_skills_dir().parents[1]
+
+        matched: set[str] = set()
+        for pattern in globs:
+            matched.update(
+                Path(hit).as_posix()
+                for hit in globmod.glob(pattern, root_dir=pkg_dir, recursive=True)
+            )
+
+        assert ".agents/meta-skill/developing-with-streamlit/SKILL.md" in matched
+        assert (
+            ".agents/meta-skill/developing-with-streamlit/scripts/discover.py"
+            in matched
+        )
 
 
 class TestVendoredMetaSkillDiscovery:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -450,77 +450,6 @@ class TestGetGlobalTargetDirs:
 
         assert (home / ".claude" / "skills" in result) == expected_in_result
 
-    def test_includes_detected_harness_home_dirs(self, tmp_path: Path) -> None:
-        """Targets each detected harness's home skills dir, not only agents/claude.
-
-        The nudge fires for any of several harnesses, but the old global install
-        only wrote ~/.agents and ~/.claude — so a Gemini/Codex-only user could
-        get an installed-but-invisible skill. Global targets now follow the same
-        harness set the nudge detects.
-        """
-        home = tmp_path / "home"
-        (home / ".gemini").mkdir(parents=True)  # gemini installed
-        (home / ".codex").mkdir()  # codex installed
-        # cursor is NOT installed (no ~/.cursor).
-
-        with patch("pathlib.Path.home", return_value=home):
-            result = skills._get_global_target_dirs()
-
-        # Always the generic convention, plus each detected harness's home dir.
-        assert home / ".agents" / "skills" in result
-        assert home / ".gemini" / "skills" in result
-        assert home / ".codex" / "skills" in result
-        # An undetected harness must not be targeted.
-        assert home / ".cursor" / "skills" not in result
-
-
-class TestHarnessSkillSubdirs:
-    """Tests for the shared harness->skills-dir derivation used by both the
-    nudge's skill detection and the global installer's target resolution."""
-
-    def test_home_scope_returns_only_present_harnesses(self, tmp_path: Path) -> None:
-        """At home scope, only harnesses whose config dir exists are returned."""
-        (tmp_path / ".gemini").mkdir()
-        (tmp_path / ".claude").mkdir()
-        # ~/.cursor deliberately absent.
-
-        result = dict(skills._harness_skill_subdirs(str(tmp_path), home_scope=True))
-
-        assert result.get("gemini") == ".gemini/skills"
-        assert result.get("claude") == ".claude/skills"
-        assert "cursor" not in result
-
-    def test_project_scope_returns_all_harnesses_ungated(self, tmp_path: Path) -> None:
-        """At project scope every harness's project dir is returned, no presence
-        gate — and the project dir can differ from the home dir (e.g. copilot)."""
-        result = dict(skills._harness_skill_subdirs(str(tmp_path), home_scope=False))
-
-        assert len(result) == len(skills._HARNESSES)
-        assert result["cursor"] == ".cursor/skills"
-        # Copilot's project dir (.github/skills) differs from its home dir.
-        assert result["copilot"] == ".github/skills"
-
-    def test_global_targets_match_detection_home_dirs(self, tmp_path: Path) -> None:
-        """Symmetry guard: every non-generic global target is a home dir that the
-        detection derivation also yields — install writes where the toast looks."""
-        home = tmp_path
-        (home / ".gemini").mkdir()
-        (home / ".codex").mkdir()
-
-        with patch("pathlib.Path.home", return_value=home):
-            targets = skills._get_global_target_dirs()
-        detected = {
-            home / subdir
-            for _harness, subdir in skills._harness_skill_subdirs(
-                str(home), home_scope=True
-            )
-        }
-        # Base ~/.agents/skills is always present; every other target must be a
-        # dir detection scans (no install target the toast can't see).
-        extras = set(targets) - {home / ".agents" / "skills"}
-        assert extras <= detected
-        assert home / ".gemini" / "skills" in extras
-
 
 class TestAreSkillsInstalled:
     """Tests for are_skills_installed."""
@@ -2263,34 +2192,6 @@ class TestInstallGlobalSkillsMetaSkill:
         # Nothing should have been copied to the global target.
         assert not (home / ".agents" / "skills" / "developing-with-streamlit").exists()
 
-    def test_global_install_lands_in_detected_harness_dir(
-        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
-    ) -> None:
-        """Global install reaches a detected non-Claude harness's home dir.
-
-        A Windows user whose project symlink fails falls back to the global
-        install; if they only run e.g. Gemini, the skill must land in
-        ``~/.gemini/skills`` (which the harness reads), not only in
-        ``~/.agents/skills``.
-        """
-        home = tmp_path / "home"
-        (home / ".gemini").mkdir(parents=True)  # gemini installed, no ~/.claude
-
-        with (
-            patch("pathlib.Path.home", return_value=home),
-            patch.object(
-                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
-            ),
-        ):
-            result = runner.invoke(cli.main, ["skills", "-g", "-y"])
-
-        assert result.exit_code == 0
-        agents_skill = home / ".agents" / "skills" / "developing-with-streamlit"
-        gemini_skill = home / ".gemini" / "skills" / "developing-with-streamlit"
-        assert (agents_skill / "SKILL.md").is_file()
-        assert (gemini_skill / "SKILL.md").is_file()
-        assert (gemini_skill / "scripts" / "discover.py").is_file()
-
 
 class TestMetaSkillPackaging:
     """Guards that the vendored meta-skill files actually ship in the wheel."""
@@ -2404,12 +2305,20 @@ class TestVendoredMetaSkillDiscovery:
                 "vendored meta-skill or bundled content not present in this install"
             )
 
+        # Pin discover.py's interpreter detection to this test's own interpreter
+        # (which has Streamlit) by pointing VIRTUAL_ENV at its venv root. discover.py
+        # re-detects the project interpreter from VIRTUAL_ENV/PATH rather than
+        # reusing the launching sys.executable, so without this the test would fail
+        # (not skip) whenever the first python on PATH lacks Streamlit — e.g. when
+        # run outside ``uv``.
+        venv_root = os.path.dirname(os.path.dirname(sys.executable))
         result = subprocess.run(
             [sys.executable, str(discover_py), "--project-dir", str(tmp_path)],
             capture_output=True,
             text=True,
             timeout=60,
             check=False,
+            env={**os.environ, "VIRTUAL_ENV": venv_root},
         )
 
         assert result.returncode == 0, result.stderr

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -16,13 +16,11 @@
 
 from __future__ import annotations
 
-import contextlib
-import io
 import os
-import tarfile
+import subprocess
+import sys
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
-from urllib.error import URLError
+from unittest.mock import patch
 
 import click
 import pytest
@@ -62,6 +60,25 @@ def mock_source_skills_dir(tmp_path: Path) -> Path:
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("# Test Skill\n", encoding="utf-8")
     return source_dir
+
+
+@pytest.fixture
+def mock_meta_skill_dir(tmp_path: Path) -> Path:
+    """Create a mock bundled meta-skill directory.
+
+    Mirrors the layout vendored in the wheel: a thin ``SKILL.md`` router plus a
+    ``scripts/discover.py`` under ``.agents/meta-skill/developing-with-streamlit``.
+    Returns the ``.agents/meta-skill`` dir (the source passed to the copy step),
+    matching what :func:`skills._get_meta_skill_dir` returns.
+    """
+    meta_dir = tmp_path / "streamlit" / ".agents" / "meta-skill"
+    skill_dir = meta_dir / "developing-with-streamlit"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Meta Skill\n", encoding="utf-8")
+    (skill_dir / "scripts" / "discover.py").write_text(
+        "print('discover')\n", encoding="utf-8"
+    )
+    return meta_dir
 
 
 class TestGetSourceSkillsDir:
@@ -894,7 +911,7 @@ class TestInstallSkillsCli:
         assert "Installed:" in result.output
 
     def test_skills_global_flag_triggers_global_install(
-        self, runner: CliRunner, tmp_path: Path, mock_source_skills_dir: Path
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
         """The --global flag triggers global installation mode."""
         home = tmp_path / "home"
@@ -903,9 +920,7 @@ class TestInstallSkillsCli:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
         ):
             result = runner.invoke(cli.main, ["skills", "--global", "--yes"])
@@ -1051,28 +1066,33 @@ class TestInstallSkillsCli:
         assert "Up to date:" in result.output
 
     def test_skills_global_installs_to_home_dirs(
-        self, runner: CliRunner, tmp_path: Path, mock_source_skills_dir: Path
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
-        """Global install copies skills to home directories."""
+        """Global install copies the meta-skill to home directories."""
         home = tmp_path / "home"
         (home / ".claude").mkdir(parents=True)
 
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
         ):
             result = runner.invoke(cli.main, ["skills", "-g", "-y"])
 
         assert result.exit_code == 0
-        assert (home / ".agents" / "skills" / "developing-with-streamlit").is_dir()
-        assert (home / ".claude" / "skills" / "developing-with-streamlit").is_dir()
+        agents_skill = home / ".agents" / "skills" / "developing-with-streamlit"
+        claude_skill = home / ".claude" / "skills" / "developing-with-streamlit"
+        assert agents_skill.is_dir()
+        assert claude_skill.is_dir()
+        # The version-agnostic meta-skill (SKILL.md + scripts/discover.py) is what
+        # lands globally — not the version-matched content skill.
+        assert (agents_skill / "SKILL.md").is_file()
+        assert (agents_skill / "scripts" / "discover.py").is_file()
+        assert (claude_skill / "scripts" / "discover.py").is_file()
 
     def test_skills_global_rerun_reports_up_to_date(
-        self, runner: CliRunner, tmp_path: Path, mock_source_skills_dir: Path
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
         """Global install reports up to date when managed copy is unchanged."""
         home = tmp_path / "home"
@@ -1081,9 +1101,7 @@ class TestInstallSkillsCli:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
         ):
             runner.invoke(cli.main, ["skills", "-g", "-y"])
@@ -1213,138 +1231,6 @@ class TestInstallProjectSkillsCancellation:
         assert not (
             project_dir / ".agents" / "skills" / "developing-with-streamlit"
         ).exists()
-
-
-class TestDownloadGlobalSkill:
-    """Tests for _download_global_skill."""
-
-    def test_raises_on_network_error(self) -> None:
-        """Raises ClickException on network failure."""
-        with patch.object(skills.request, "urlopen", side_effect=URLError("Network")):
-            with pytest.raises(click.ClickException, match="Failed to download"):
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "skill"
-                )
-
-    def test_raises_on_empty_archive(self, tmp_path: Path) -> None:
-        """Raises ClickException when archive is empty."""
-        # Create an empty tar.gz
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz"):
-            pass  # Empty archive
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            with pytest.raises(click.ClickException, match="archive is empty"):
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "skill"
-                )
-
-    def test_raises_on_missing_skill(self, tmp_path: Path) -> None:
-        """Raises ClickException when skill not found in archive."""
-        # Create archive with a different skill
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-            # Add a root directory
-            root_info = tarfile.TarInfo(name="repo-v1/")
-            root_info.type = tarfile.DIRTYPE
-            root_info.mode = 0o755  # Ensure directory is traversable
-            tar.addfile(root_info)
-            # Add a different skill
-            other_skill = tarfile.TarInfo(name="repo-v1/other-skill/")
-            other_skill.type = tarfile.DIRTYPE
-            other_skill.mode = 0o755
-            tar.addfile(other_skill)
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            with pytest.raises(click.ClickException, match="not found in downloaded"):
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "missing-skill"
-                )
-
-    def test_extracts_skill_successfully(self, tmp_path: Path) -> None:
-        """Successfully extracts skill from valid archive."""
-        # Create archive with the expected skill
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-            # Add root directory
-            root_info = tarfile.TarInfo(name="repo-v1/")
-            root_info.type = tarfile.DIRTYPE
-            root_info.mode = 0o755  # Ensure directory is traversable
-            tar.addfile(root_info)
-            # Add skill directory
-            skill_dir = tarfile.TarInfo(name="repo-v1/test-skill/")
-            skill_dir.type = tarfile.DIRTYPE
-            skill_dir.mode = 0o755
-            tar.addfile(skill_dir)
-            # Add SKILL.md file
-            skill_md = tarfile.TarInfo(name="repo-v1/test-skill/SKILL.md")
-            content = b"# Test Skill\n"
-            skill_md.size = len(content)
-            tar.addfile(skill_md, io.BytesIO(content))
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            result = skills._download_global_skill(
-                "https://example.com/test.tar.gz", "test-skill"
-            )
-
-        assert result.name == "test-skill"
-        assert (result / "SKILL.md").is_file()
-
-    def test_blocks_path_traversal_members(self, tmp_path: Path) -> None:
-        """A malicious archive member is never written outside the extraction dir.
-
-        Guards the ``tarfile`` ``data`` filter (Python 3.12+) and the manual
-        absolute-/``..``-path filter (3.10/3.11) in ``_download_global_skill``.
-        An absolute-path member targeting an arbitrary location must not be
-        extracted: on 3.12+ the data filter rejects the archive (ClickException);
-        on 3.10/3.11 the member is silently dropped (and the requested skill is
-        then "not found"). Either way the target file must not exist afterward.
-        """
-        evil_target = tmp_path / "pwned.txt"
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-            root_info = tarfile.TarInfo(name="repo-v1/")
-            root_info.type = tarfile.DIRTYPE
-            root_info.mode = 0o755
-            tar.addfile(root_info)
-            # Malicious absolute-path member attempting an arbitrary file write.
-            evil = tarfile.TarInfo(name=str(evil_target))
-            content = b"pwned"
-            evil.size = len(content)
-            tar.addfile(evil, io.BytesIO(content))
-        tar_buffer.seek(0)
-
-        mock_response = MagicMock()
-        mock_response.read.return_value = tar_buffer.getvalue()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-
-        with patch.object(skills.request, "urlopen", return_value=mock_response):
-            # 3.12+ rejects the unsafe member outright; older versions drop it.
-            with contextlib.suppress(click.ClickException):
-                skills._download_global_skill(
-                    "https://example.com/test.tar.gz", "skill"
-                )
-
-        assert not evil_target.exists()
 
 
 class TestSkillCopyMatches:
@@ -1559,7 +1445,7 @@ class TestGlobalInstallationConflicts:
     """Tests for global installation conflicts."""
 
     def test_raises_when_all_targets_skipped(
-        self, runner: CliRunner, tmp_path: Path, mock_source_skills_dir: Path
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
         """Raises ClickException when all targets are skipped due to conflicts."""
         home = tmp_path / "home"
@@ -1574,9 +1460,7 @@ class TestGlobalInstallationConflicts:
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
         ):
             result = runner.invoke(cli.main, ["skills", "--global", "--yes"])
@@ -1591,7 +1475,7 @@ class TestInteractiveModeSelection:
     """Tests for interactive mode selection."""
 
     def test_interactive_selects_global_mode(
-        self, runner: CliRunner, tmp_path: Path, mock_source_skills_dir: Path
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
         """Interactive prompt can select global installation mode."""
         home = tmp_path / "home"
@@ -1603,9 +1487,7 @@ class TestInteractiveModeSelection:
             patch.object(skills, "_prompt_install_mode", return_value="global"),
             patch.object(skills, "_confirm_global_installation", return_value=True),
             patch.object(
-                skills,
-                "_download_global_skill",
-                return_value=mock_source_skills_dir / "developing-with-streamlit",
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
         ):
             mock_sys.stdin.isatty.return_value = True
@@ -2135,7 +2017,7 @@ class TestInstallProjectSkillsFallbackErrors:
         ("global_install_side_effect", "match"),
         [
             (click.exceptions.Abort(), "Installation incomplete"),
-            (click.ClickException("download failure"), "download failure"),
+            (click.ClickException("global copy failure"), "global copy failure"),
         ],
         ids=["user_aborted_global_install", "global_install_click_exception"],
     )
@@ -2206,30 +2088,113 @@ class TestInstallSkillCopyTempCleanup:
         assert not leftover_temp.exists()
 
 
-class TestInstallGlobalSkillsCleanup:
-    """Tests for temp directory cleanup at the end of _install_global_skills."""
+class TestGetMetaSkillDir:
+    """Tests for _get_meta_skill_dir."""
 
-    def test_cleans_up_streamlit_skills_prefixed_temp_dir(
-        self, tmp_path: Path, mock_source_skills_dir: Path
+    def test_returns_meta_skill_path_in_package(self) -> None:
+        """Returns <streamlit package>/.agents/meta-skill, distinct from content."""
+        result = skills._get_meta_skill_dir()
+        assert result.name == "meta-skill"
+        assert result.parent.name == ".agents"
+        # The meta-skill dir must be separate from the version-matched content
+        # skills dir, so project-mode discovery never treats it as a content skill.
+        assert result != skills._get_source_skills_dir()
+
+
+class TestInstallGlobalSkillsMetaSkill:
+    """Global install copies the bundled meta-skill from local disk (no network)."""
+
+    def test_global_install_never_hits_network(
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
-        """Removes temp directories that follow the streamlit-skills- naming convention."""
+        """A global install must not open a network connection.
+
+        Regression guard for issue #15933: the old implementation downloaded the
+        skill from GitHub, which failed ~12% of the time on locked-down Windows.
+        ``urllib.request.urlopen`` is patched to raise, so any reintroduced
+        download fails the test; the copy-from-local-disk install must succeed.
+        """
         home = tmp_path / "home"
         home.mkdir(parents=True)
 
-        # Simulate the layout created by _download_global_skill:
-        # /tmp/streamlit-skills-XXXX/archive_root/<skill_name>/SKILL.md
-        temp_root = tmp_path / "streamlit-skills-test"
-        archive_root = temp_root / "archive-root"
-        skill_dir = archive_root / "developing-with-streamlit"
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Test Skill\n", encoding="utf-8")
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch(
+                "urllib.request.urlopen",
+                side_effect=AssertionError("global install must not use the network"),
+            ),
+        ):
+            result = runner.invoke(cli.main, ["skills", "-g", "-y"])
+
+        assert result.exit_code == 0
+        assert (
+            home
+            / ".agents"
+            / "skills"
+            / "developing-with-streamlit"
+            / "scripts"
+            / "discover.py"
+        ).is_file()
+
+    def test_global_install_missing_meta_skill_errors_without_leaking_path(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """A missing bundled meta-skill fails with a generic, path-free message."""
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+        missing = tmp_path / "nonexistent-meta-skill"
 
         with (
             patch("pathlib.Path.home", return_value=home),
-            patch.object(skills, "_download_global_skill", return_value=skill_dir),
+            patch.object(skills, "_get_meta_skill_dir", return_value=missing),
         ):
-            skills._install_global_skills(yes=True)
+            result = runner.invoke(cli.main, ["skills", "-g", "-y"])
 
-        # The temp root was cleaned up because its name starts with
-        # "streamlit-skills-".
-        assert not temp_root.exists()
+        assert result.exit_code != 0
+        assert "was not found" in result.output
+        # The server-side absolute path must not leak into the user-facing error.
+        assert str(missing) not in result.output
+
+
+class TestVendoredMetaSkillDiscovery:
+    """Compatibility contract: the vendored discover.py resolves bundled content."""
+
+    def test_discover_py_resolves_bundled_content_skill(self, tmp_path: Path) -> None:
+        """Running the vendored meta-skill ``discover.py`` resolves the installed
+        Streamlit's bundled content ``SKILL.md``.
+
+        This is the contract the global install (and any frozen external copy of
+        the meta-skill) depends on: ``discover.py`` must find
+        ``<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md``. Runs
+        under the test interpreter (which has Streamlit installed), so no network
+        and no reliance on the download path.
+        """
+        discover_py = (
+            skills._get_meta_skill_dir()
+            / "developing-with-streamlit"
+            / "scripts"
+            / "discover.py"
+        )
+        content_skill = (
+            skills._get_source_skills_dir() / "developing-with-streamlit" / "SKILL.md"
+        )
+        if not discover_py.is_file() or not content_skill.is_file():
+            pytest.skip(
+                "vendored meta-skill or bundled content not present in this install"
+            )
+
+        result = subprocess.run(
+            [sys.executable, str(discover_py), "--project-dir", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert os.path.realpath(result.stdout.strip()) == os.path.realpath(
+            content_skill
+        )

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -474,6 +474,54 @@ class TestGetGlobalTargetDirs:
         assert home / ".cursor" / "skills" not in result
 
 
+class TestHarnessSkillSubdirs:
+    """Tests for the shared harness->skills-dir derivation used by both the
+    nudge's skill detection and the global installer's target resolution."""
+
+    def test_home_scope_returns_only_present_harnesses(self, tmp_path: Path) -> None:
+        """At home scope, only harnesses whose config dir exists are returned."""
+        (tmp_path / ".gemini").mkdir()
+        (tmp_path / ".claude").mkdir()
+        # ~/.cursor deliberately absent.
+
+        result = dict(skills._harness_skill_subdirs(str(tmp_path), home_scope=True))
+
+        assert result.get("gemini") == ".gemini/skills"
+        assert result.get("claude") == ".claude/skills"
+        assert "cursor" not in result
+
+    def test_project_scope_returns_all_harnesses_ungated(self, tmp_path: Path) -> None:
+        """At project scope every harness's project dir is returned, no presence
+        gate — and the project dir can differ from the home dir (e.g. copilot)."""
+        result = dict(skills._harness_skill_subdirs(str(tmp_path), home_scope=False))
+
+        assert len(result) == len(skills._HARNESSES)
+        assert result["cursor"] == ".cursor/skills"
+        # Copilot's project dir (.github/skills) differs from its home dir.
+        assert result["copilot"] == ".github/skills"
+
+    def test_global_targets_match_detection_home_dirs(self, tmp_path: Path) -> None:
+        """Symmetry guard: every non-generic global target is a home dir that the
+        detection derivation also yields — install writes where the toast looks."""
+        home = tmp_path
+        (home / ".gemini").mkdir()
+        (home / ".codex").mkdir()
+
+        with patch("pathlib.Path.home", return_value=home):
+            targets = skills._get_global_target_dirs()
+        detected = {
+            home / subdir
+            for _harness, subdir in skills._harness_skill_subdirs(
+                str(home), home_scope=True
+            )
+        }
+        # Base ~/.agents/skills is always present; every other target must be a
+        # dir detection scans (no install target the toast can't see).
+        extras = set(targets) - {home / ".agents" / "skills"}
+        assert extras <= detected
+        assert home / ".gemini" / "skills" in extras
+
+
 class TestAreSkillsInstalled:
     """Tests for are_skills_installed."""
 

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -450,6 +450,29 @@ class TestGetGlobalTargetDirs:
 
         assert (home / ".claude" / "skills" in result) == expected_in_result
 
+    def test_includes_detected_harness_home_dirs(self, tmp_path: Path) -> None:
+        """Targets each detected harness's home skills dir, not only agents/claude.
+
+        The nudge fires for any of several harnesses, but the old global install
+        only wrote ~/.agents and ~/.claude — so a Gemini/Codex-only user could
+        get an installed-but-invisible skill. Global targets now follow the same
+        harness set the nudge detects.
+        """
+        home = tmp_path / "home"
+        (home / ".gemini").mkdir(parents=True)  # gemini installed
+        (home / ".codex").mkdir()  # codex installed
+        # cursor is NOT installed (no ~/.cursor).
+
+        with patch("pathlib.Path.home", return_value=home):
+            result = skills._get_global_target_dirs()
+
+        # Always the generic convention, plus each detected harness's home dir.
+        assert home / ".agents" / "skills" in result
+        assert home / ".gemini" / "skills" in result
+        assert home / ".codex" / "skills" in result
+        # An undetected harness must not be targeted.
+        assert home / ".cursor" / "skills" not in result
+
 
 class TestAreSkillsInstalled:
     """Tests for are_skills_installed."""
@@ -2106,25 +2129,30 @@ class TestInstallGlobalSkillsMetaSkill:
     def test_global_install_never_hits_network(
         self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
-        """A global install must not open a network connection.
+        """A global install must not open a network connection (any transport).
 
         Regression guard for issue #15933: the old implementation downloaded the
         skill from GitHub, which failed ~12% of the time on locked-down Windows.
-        ``urllib.request.urlopen`` is patched to raise, so any reintroduced
-        download fails the test; the copy-from-local-disk install must succeed.
+        Block the network at the socket layer (rather than patching one HTTP
+        client) so a reintroduced download via urllib, requests, httpx, urllib3,
+        etc. all fail the test; the copy-from-local-disk install must still
+        succeed with zero connections.
         """
+        import socket
+
         home = tmp_path / "home"
         home.mkdir(parents=True)
+
+        def _blocked(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("global install must not open a network connection")
 
         with (
             patch("pathlib.Path.home", return_value=home),
             patch.object(
                 skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
-            patch(
-                "urllib.request.urlopen",
-                side_effect=AssertionError("global install must not use the network"),
-            ),
+            patch.object(socket.socket, "connect", _blocked),
+            patch.object(socket.socket, "connect_ex", _blocked),
         ):
             result = runner.invoke(cli.main, ["skills", "-g", "-y"])
 
@@ -2186,6 +2214,34 @@ class TestInstallGlobalSkillsMetaSkill:
         assert "was not found" in result.output
         # Nothing should have been copied to the global target.
         assert not (home / ".agents" / "skills" / "developing-with-streamlit").exists()
+
+    def test_global_install_lands_in_detected_harness_dir(
+        self, runner: CliRunner, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """Global install reaches a detected non-Claude harness's home dir.
+
+        A Windows user whose project symlink fails falls back to the global
+        install; if they only run e.g. Gemini, the skill must land in
+        ``~/.gemini/skills`` (which the harness reads), not only in
+        ``~/.agents/skills``.
+        """
+        home = tmp_path / "home"
+        (home / ".gemini").mkdir(parents=True)  # gemini installed, no ~/.claude
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+        ):
+            result = runner.invoke(cli.main, ["skills", "-g", "-y"])
+
+        assert result.exit_code == 0
+        agents_skill = home / ".agents" / "skills" / "developing-with-streamlit"
+        gemini_skill = home / ".gemini" / "skills" / "developing-with-streamlit"
+        assert (agents_skill / "SKILL.md").is_file()
+        assert (gemini_skill / "SKILL.md").is_file()
+        assert (gemini_skill / "scripts" / "discover.py").is_file()
 
 
 class TestMetaSkillPackaging:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2282,6 +2282,52 @@ class TestMetaSkillPackaging:
             in matched
         )
 
+    @pytest.mark.slow
+    def test_built_wheel_contains_vendored_meta_skill(self, tmp_path: Path) -> None:
+        """A real built wheel must contain SKILL.md AND scripts/discover.py.
+
+        The glob-match test above checks the declared package-data patterns
+        against on-disk files, but not that the build backend actually ships
+        them in the wheel (MANIFEST/include-package-data/backend quirks could
+        still drop a file). A missing ``discover.py`` would break every global
+        install deterministically — the exact failure this change removes — so
+        build the wheel and assert both files are inside it.
+        """
+        import zipfile
+
+        lib_dir = Path(__file__).resolve().parents[3]  # .../lib
+        if not (lib_dir / "pyproject.toml").is_file():  # pragma: no cover
+            pytest.skip("lib/pyproject.toml not found in this layout")
+
+        out_dir = tmp_path / "dist"
+        # --no-isolation reuses the current env's build backend (setuptools is
+        # already installed), so this is a fast file-copy+zip, not a full env
+        # bootstrap. Skip gracefully if the build tooling is unavailable.
+        build = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--wheel",
+                "--no-isolation",
+                "--outdir",
+                str(out_dir),
+                str(lib_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if build.returncode != 0:  # pragma: no cover - env-dependent
+            pytest.skip(f"wheel build unavailable here: {build.stderr[-400:]}")
+
+        wheels = list(out_dir.glob("*.whl"))
+        assert wheels, "no wheel was produced"
+        names = zipfile.ZipFile(wheels[0]).namelist()
+        meta = "streamlit/.agents/meta-skill/developing-with-streamlit"
+        assert f"{meta}/SKILL.md" in names
+        assert f"{meta}/scripts/discover.py" in names
+
 
 class TestVendoredMetaSkillDiscovery:
     """Compatibility contract: the vendored discover.py resolves bundled content."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,15 @@ extend-safe-fixes = ["TC002", "TC003"]
   # misrepresent them as importable modules.
   "INP",
 ]
+"lib/streamlit/.agents/meta-skill/**" = [
+  # The meta-skill's discover.py is a standalone CLI script: it prints its
+  # result to stdout/stderr and shells out to probe the project's Python
+  # interpreter. Same relaxations as scripts/** (INP is already covered above).
+  "T20",
+  "S",
+  "PERF",
+  "TRY002",
+]
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,15 +314,6 @@ extend-safe-fixes = ["TC002", "TC003"]
   # misrepresent them as importable modules.
   "INP",
 ]
-"lib/streamlit/.agents/meta-skill/**" = [
-  # The meta-skill's discover.py is a standalone CLI script: it prints its
-  # result to stdout/stderr and shells out to probe the project's Python
-  # interpreter. Same relaxations as scripts/** (INP is already covered above).
-  "T20",
-  "S",
-  "PERF",
-  "TRY002",
-]
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.


### PR DESCRIPTION
## Describe your changes

The in-app one-click **"install skills"** nudge falls back to a **global** install when project symlinks aren't supported (Windows without Developer Mode). That global install **downloaded** the meta-skill from the `streamlit/agent-skills` GitHub repo, which:

- **failed ~12% of the time on Windows** (vs ~1% macOS / ~0.5% Linux) — deterministically, on locked-down corporate networks that block GitHub egress; and
- **tripped a security review** of runtime external downloads.

See #15933.

### Fix

Stop downloading. **Vendor the thin, version-agnostic meta-skill** (`SKILL.md` + `scripts/discover.py`, ~2 files) into the wheel and have `streamlit skills --global` **copy it from local disk**. This removes the network dependency entirely — fixing both the ~12% Windows failure and the external-download concern — while keeping the meta-skill's `discover.py`, which resolves each project's **version-matched** bundled content skills at runtime. So a single global install stays correct across Streamlit versions (the exact property a frozen copy of the content skill would lose).

> **Meta-skill vs content:** the *meta-skill* is version-agnostic (a router + `discover.py`); the *content* skill (`references/`, `assets/`) is version-matched and already ships in the wheel. Global mode installs the **meta-skill**; project mode still symlinks the **content**. We deliberately do **not** copy the content skill for global installs — that would go stale on upgrade.

### Changes

- **`skills.py`**: add `_get_meta_skill_dir()`; rewrite `_install_global_skills` to copy the meta-skill from the local package via the existing `_install_skill_copy`; **delete** `_download_global_skill`, `_GLOBAL_SKILLS_URL`, and the `urllib`/`tarfile`/`io` imports. Global-install targets are unchanged from `develop` (`~/.agents/skills`, plus `~/.claude/skills` when `~/.claude` exists).
- **Vendored** the meta-skill at `lib/streamlit/.agents/meta-skill/developing-with-streamlit/` (outside `.agents/skills/` so project-mode discovery/detection ignore it) and added a `package-data` glob so `scripts/discover.py` ships in the wheel.
- **CLI strings**: simplified the `--global` help and the global-install confirm prompt (dropped the download / local-copy phrasing — an implementation detail users don't need).
- **`discover.py` lint**: it ships to user machines, so it keeps the full ruff ruleset rather than a blanket per-file ignore — a file-level `# ruff: noqa: T201` (printing is its interface) plus line-level `S404`/`S603` on the two real violations.
- **Handler hardening**: forward only `click.ClickException` messages to the browser toast, so an unexpected `OSError` can't leak an absolute server path into the nudge.

The meta-skill is vendored **once**, and **`streamlit/streamlit` becomes the canonical source of truth** for it — maintained here and shipped in the wheel going forward. Its previous home, [`streamlit/agent-skills`](https://github.com/streamlit/agent-skills), is being deprecated and archived (README deprecation: streamlit/agent-skills#29).

## Testing

- Unit tests updated: removed the download tests; global-install tests assert the **meta-skill** (`SKILL.md` + `scripts/discover.py`) lands with **no network** — the no-network guard blocks at the socket layer, so any reintroduced download (urllib/requests/httpx) fails; added a **compatibility-contract** test that runs the vendored `discover.py` and asserts it resolves `<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md` (pins `VIRTUAL_ENV` so it's deterministic outside `uv`); added a path-leak test on the handler; `package-data` glob + real-wheel-build guards confirm `discover.py` ships. **`skills_test.py`: 130 passed.**
- Ruff + mypy clean.
- Real CLI smoke test: `HOME=$(mktemp -d) streamlit skills --global --yes` installs both files with zero network; the installed `discover.py` resolves the bundled content `SKILL.md`.
- **Wheel build** confirms `scripts/discover.py` is packaged.

## Notes

**Streamlit is now the canonical source of truth for the `developing-with-streamlit` meta-skill** — it is vendored in the wheel here and maintained in this repo going forward. Its previous home, `streamlit/agent-skills`, is being deprecated and archived.

- Supersedes #15965 (which copied the *content* skill for global installs — the frozen-snapshot mistake this PR avoids).
- Telemetry (#15934) + nudge suppression (#15966) stay **parked** — revive only if the 1.60+ install-error rate stays >~1%.

### Action items (rollout)
- [ ] Merge this PR and ship the meta-skill in **1.60**.
- [ ] Merge the `agent-skills` README deprecation PR — streamlit/agent-skills#29 — which points users to this repo as the source of truth.
- [ ] **Archive `streamlit/agent-skills`** after 1.60 ships. Keep the `v1` tag; never delete or make the repo private (existing `npx skills` / `gh skill` / `git clone` installs must keep resolving).

Fixes #15933

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to optional agent-skills CLI/global install and nudge error surfacing; no auth, data, or core runtime behavior beyond safer toast messages and offline global install.
> 
> **Overview**
> **Global `streamlit skills` install no longer hits the network.** The version-agnostic **developing-with-streamlit** meta-skill (`SKILL.md` + `scripts/discover.py`) is vendored under `lib/streamlit/.agents/meta-skill/` and included in the wheel via `package-data`; `--global` copies it from the installed package. The GitHub tarball download path (`_download_global_skill`, related URL/imports) is removed, addressing locked-down Windows failures and runtime external-download concerns (#15933). **`discover.py`** resolves each project’s installed Streamlit and points agents at version-matched bundled content skills at runtime.
> 
> **In-app one-click install** still uses project mode first (with symlink→global fallback on Windows); comments and error handling are tightened so only **`click.ClickException`** text is shown in the browser toast—unexpected errors (e.g. **`OSError`**) get a generic message so server paths don’t leak. User-facing install errors for missing bundled skills no longer embed absolute paths (details go to logs).
> 
> **Tests** drop download/tarball cases; global install is asserted offline (socket-level guard), packaging globs and optional wheel-build checks cover `discover.py`, and a contract test runs the vendored `discover.py` against the bundled content skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37c821d48dea8b8c5f0e9be4069c7fc60c06152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->