### PR TITLE
Preserve MultiIndex column headers in dataframe CSV export

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.test.ts
@@ -93,6 +93,37 @@ const MOCK_COLUMNS: BaseColumn[] = [
   }),
 ]
 
+function createMockNumberColumn(
+  id: string,
+  name: string,
+  indexNumber: number,
+  group?: string
+): BaseColumn {
+  return NumberColumn({
+    id,
+    name,
+    title: name,
+    group,
+    indexNumber,
+    arrowType: {
+      type: DataFrameCellType.DATA,
+      arrowField: new Field(name, new Int64(), true),
+      pandasType: {
+        field_name: name,
+        name,
+        pandas_type: "int64",
+        numpy_type: "int64",
+        metadata: null,
+      },
+    },
+    isEditable: false,
+    isHidden: false,
+    isIndex: false,
+    isPinned: false,
+    isStretched: false,
+  })
+}
+
 const NUM_ROWS = 5
 
 const getCellContentMock = vi
@@ -312,5 +343,156 @@ describe("useDataExporter hook", () => {
 
     // Should handle null values gracefully (empty string in CSV)
     expect(mockWrite).toBeCalledWith(textEncoder.encode(",foo\n"))
+  })
+})
+
+describe("useDataExporter MultiIndex header export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("writes two header rows for a two-level MultiIndex", async () => {
+    const multiIndexColumns: BaseColumn[] = [
+      createMockNumberColumn("col_0", "Q1", 0, "2022"),
+      createMockNumberColumn("col_1", "Q2", 1, "2022"),
+      createMockNumberColumn("col_2", "Q1", 2, "2023"),
+      createMockNumberColumn("col_3", "Q2", 3, "2023"),
+    ]
+
+    const getCellContentMulti = vi
+      .fn()
+      .mockImplementation(([col]: readonly [number]) => {
+        return multiIndexColumns[col].getCell(1)
+      })
+
+    const { result } = renderHook(() => {
+      return useDataExporter(getCellContentMulti, multiIndexColumns, 1, false)
+    })
+
+    result.current.exportToCsv()
+
+    const textEncoder = new TextEncoder()
+
+    await waitFor(() => {
+      expect(getCellContentMulti).toHaveBeenCalled()
+    })
+
+    // Writes: BOM + parent header row + leaf header row + 1 data row
+    expect(mockWrite).toBeCalledTimes(4)
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("\ufeff"))
+    // Parent-level header row:
+    expect(mockWrite).toBeCalledWith(
+      textEncoder.encode("2022,2022,2023,2023\n")
+    )
+    // Leaf-level header row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("Q1,Q2,Q1,Q2\n"))
+    // Data row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("1,1,1,1\n"))
+    expect(mockClose).toBeCalledTimes(1)
+  })
+
+  it("writes three header rows for a three-level MultiIndex", async () => {
+    const threeLevelColumns: BaseColumn[] = [
+      createMockNumberColumn("col_0", "1", 0, "A / X"),
+      createMockNumberColumn("col_1", "2", 1, "A / X"),
+      createMockNumberColumn("col_2", "1", 2, "B / Y"),
+      createMockNumberColumn("col_3", "2", 3, "B / Y"),
+    ]
+
+    const getCellContentThreeLevel = vi
+      .fn()
+      .mockImplementation(([col]: readonly [number]) => {
+        return threeLevelColumns[col].getCell(1)
+      })
+
+    const { result } = renderHook(() => {
+      return useDataExporter(
+        getCellContentThreeLevel,
+        threeLevelColumns,
+        1,
+        false
+      )
+    })
+
+    result.current.exportToCsv()
+
+    const textEncoder = new TextEncoder()
+
+    await waitFor(() => {
+      expect(getCellContentThreeLevel).toHaveBeenCalled()
+    })
+
+    // Writes: BOM + grandparent header + parent header + leaf header + 1 data row
+    expect(mockWrite).toBeCalledTimes(5)
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("\ufeff"))
+    // Grandparent-level header row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("A,A,B,B\n"))
+    // Parent-level header row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("X,X,Y,Y\n"))
+    // Leaf-level header row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("1,2,1,2\n"))
+    // Data row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("1,1,1,1\n"))
+    expect(mockClose).toBeCalledTimes(1)
+  })
+
+  it("writes single header row when no columns have groups", async () => {
+    // This is a regression test: normal columns should produce a single header row
+    const { result } = renderHook(() => {
+      return useDataExporter(getCellContentMock, MOCK_COLUMNS, NUM_ROWS, false)
+    })
+
+    result.current.exportToCsv()
+
+    const textEncoder = new TextEncoder()
+
+    await waitFor(() => {
+      expect(getCellContentMock).toHaveBeenCalled()
+    })
+
+    // Writes: BOM + single header row + NUM_ROWS data rows
+    expect(mockWrite).toBeCalledTimes(NUM_ROWS + 2)
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("\ufeff"))
+    // Single header row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("column_1,column_2\n"))
+    expect(mockClose).toBeCalledTimes(1)
+  })
+
+  it("pads with empty strings when columns have different group depths", async () => {
+    const mixedDepthColumns: BaseColumn[] = [
+      createMockNumberColumn("col_0", "val1", 0, "A / X"),
+      createMockNumberColumn("col_1", "val2", 1, "B"),
+    ]
+
+    const getCellContentMixed = vi
+      .fn()
+      .mockImplementation(([col]: readonly [number]) => {
+        return mixedDepthColumns[col].getCell(1)
+      })
+
+    const { result } = renderHook(() => {
+      return useDataExporter(getCellContentMixed, mixedDepthColumns, 1, false)
+    })
+
+    result.current.exportToCsv()
+
+    const textEncoder = new TextEncoder()
+
+    await waitFor(() => {
+      expect(getCellContentMixed).toHaveBeenCalled()
+    })
+
+    // Writes: BOM + level 0 header + level 1 header + leaf header + 1 data row
+    expect(mockWrite).toBeCalledTimes(5)
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("\ufeff"))
+    // Level 0 header row (col 0 -> "A", col 1 -> "B"):
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("A,B\n"))
+    // Level 1 header row (col 0 -> "X", col 1 -> "" since "B" has only 1 level):
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("X,\n"))
+    // Leaf-level header row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("val1,val2\n"))
+    // Data row:
+    expect(mockWrite).toBeCalledWith(textEncoder.encode("1,1\n"))
+    expect(mockClose).toBeCalledTimes(1)
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -36,6 +36,9 @@ const CSV_ESCAPE_CHAR = '"'
 const CSV_ROW_DELIMITER = "\n"
 // Used to indicate Unicode encoding of a text file (for excel compatibility)
 const CSV_UTF8_BOM = "\ufeff"
+// Separator used to join multi-level header names into the `group` property.
+// Must match the separator used in `parseColumnHeaderNames` (arrowUtils.ts).
+const GROUP_HEADER_SEPARATOR = " / "
 // Regex to check if a value contains special characters that need to be escaped
 const CSV_SPECIAL_CHARS_REGEX = new RegExp(
   `[${[CSV_DELIMITER, CSV_QUOTE_CHAR, CSV_ROW_DELIMITER].join("")}]`
@@ -105,8 +108,21 @@ async function writeCsv(
   await writable.write(textEncoder.encode(CSV_UTF8_BOM))
 
   // Write headers:
-  const headers: string[] = columns.map(column => column.name)
-  await writable.write(textEncoder.encode(toCsvRow(headers)))
+  // For MultiIndex columns, each column may have a `group` property containing
+  // parent-level header names joined with GROUP_HEADER_SEPARATOR. We write one
+  // header row per group level, then a final row with the leaf-level names.
+  const groupParts = columns.map(col =>
+    col.group ? col.group.split(GROUP_HEADER_SEPARATOR) : []
+  )
+  const maxGroupDepth = Math.max(0, ...groupParts.map(parts => parts.length))
+  for (let level = 0; level < maxGroupDepth; level++) {
+    const headerRow = groupParts.map(parts =>
+      level < parts.length ? parts[level] : ""
+    )
+    await writable.write(textEncoder.encode(toCsvRow(headerRow)))
+  }
+  const leafHeaders: string[] = columns.map(column => column.name)
+  await writable.write(textEncoder.encode(toCsvRow(leafHeaders)))
 
   for (let row = 0; row < numRows; row++) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Replace 'any' with a more specific type.


### PR DESCRIPTION
## Summary

Fixes #15891.

The built-in **Download to CSV** action for `st.dataframe` previously exported only the leaf level of MultiIndex column headers. Parent header levels were omitted.

This change updates the CSV export logic to emit one header row per hierarchy level before writing the leaf-level column names, matching the behavior of `pandas.DataFrame.to_csv()`.

## Root cause

`writeCsv()` constructed the CSV header using only `column.name`, which contains only the leaf header. Parent-level information available in `column.group` was ignored.

## Implementation

1. Detect MultiIndex columns using the `group` property.
2. Reconstruct parent header rows from the available hierarchy.
3. Write one header row per hierarchy level.
4. Preserve existing behavior for single-level column headers.

## Testing

Added unit tests covering:
1. Two-level MultiIndex export
2. Three-level MultiIndex export
3. Regression test for normal DataFrames
4. Mixed hierarchy depths

Verification:
1. All `useDataExporter` tests pass
2. Full DataFrame frontend test suite passes
3. TypeScript checks pass

Fixes #15891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side export formatting only; behavior is covered by new unit tests and leaves flat-header export unchanged.
> 
> **Overview**
> **`st.dataframe` CSV export** now writes **one header row per MultiIndex level** (from `column.group`, split on `" / "`) plus a final row of leaf `column.name` values, instead of exporting only the leaf names.
> 
> Plain single-level columns are unchanged (`maxGroupDepth` 0 → one leaf header row). Columns with uneven hierarchy depth get **empty cells** padded on shallower levels.
> 
> Unit tests cover two- and three-level MultiIndex, mixed depths, and a regression case for non-grouped columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378c1308c4da4010326105a4e76d9f44184078a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->