### PR TITLE
fix: restore input value on Escape for non-clearable selectbox

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -495,6 +495,19 @@ const Selectbox: FC<Props> = ({
         e.preventDefault()
         commitSelection(null)
       }
+      if (
+        e.key === "Escape" &&
+        !clearable
+      ) {
+        // Restore the input text to the committed value instead of leaving
+        // the typed query visible (regression from BaseWeb → react-aria
+        // ComboBox migration in 1.59.0).
+        const target = valueRef.current ?? ""
+        if (inputValueRef.current !== target) {
+          setInputValue(target)
+        }
+        setFilterActive(false)
+      }
     },
     [clearable, commitSelection, isFilterNone, selectDisabled]
   )


### PR DESCRIPTION
Pressing Escape while filtering in a non-clearable selectbox left the typed query visible in the input instead of restoring the committed value. Regression from the BaseWeb -> react-aria ComboBox migration in 1.59.0.

The blur path (click away) correctly restored the value via handleBlur. This adds the same restore logic to the Escape path for non-clearable selectboxes.

Fixes #16004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized keyboard handler change in Selectbox with no auth, data, or API impact.
> 
> **Overview**
> Fixes a **react-aria ComboBox** regression where **Escape** during filter typing left the draft query in a **non-clearable** selectbox instead of reverting to the committed option.
> 
> **Escape** in `handleInputKeyDownCapture` now mirrors **`handleBlur`**: reset `inputValue` to `valueRef` when it diverges and clear **`filterActive`**. Clearable selectboxes are unchanged—**Escape** still clears the value when allowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0790410f4f7200bf05962f23ef2dccf24efe9965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->