### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -107,3 +107,10 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+- The environment ships with the toolchain already provisioned (Node 24 matching `.nvmrc`, `uv`, `protoc`, `rsync`), and the startup update script runs `make init INSTALL_PLAYWRIGHT=false` to refresh Python deps, frontend deps, and protobufs. Playwright browsers are pre-installed, so e2e/debug screenshots work without extra setup.
+- Non-obvious gotcha: `make frontend-lint`, `make frontend-types`, `make frontend-knip`, and any frontend unit test that imports `@streamlit/*` packages require the frontend workspace libraries to be built first. Otherwise imports like `@streamlit/utils` fail with `import-x/no-unresolved`. Build them once with `cd frontend && yarn workspaces foreach --recursive --topological --from @streamlit/lib run build` (or run `make frontend` / `make frontend-fast`, which additionally bundle the static assets into `lib/streamlit/static/`). `make debug` builds them automatically on first run.
+- If `import-x/no-unresolved` errors persist even after building the workspace libs, delete stale `.eslintcache` files under `frontend/` and re-run the lint.
+- To run the app in dev mode, use `make debug <script.py>` (see the "Debugging backend & frontend" section above); the app is served at `http://localhost:3001` and the backend at `http://localhost:8501`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,3 +101,10 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+- The environment ships with the toolchain already provisioned (Node 24 matching `.nvmrc`, `uv`, `protoc`, `rsync`), and the startup update script runs `make init INSTALL_PLAYWRIGHT=false` to refresh Python deps, frontend deps, and protobufs. Playwright browsers are pre-installed, so e2e/debug screenshots work without extra setup.
+- Non-obvious gotcha: `make frontend-lint`, `make frontend-types`, `make frontend-knip`, and any frontend unit test that imports `@streamlit/*` packages require the frontend workspace libraries to be built first. Otherwise imports like `@streamlit/utils` fail with `import-x/no-unresolved`. Build them once with `cd frontend && yarn workspaces foreach --recursive --topological --from @streamlit/lib run build` (or run `make frontend` / `make frontend-fast`, which additionally bundle the static assets into `lib/streamlit/static/`). `make debug` builds them automatically on first run.
+- If `import-x/no-unresolved` errors persist even after building the workspace libs, delete stale `.eslintcache` files under `frontend/` and re-run the lint.
+- To run the app in dev mode, use `make debug <script.py>` (see the "Debugging backend & frontend" section above); the app is served at `http://localhost:3001` and the backend at `http://localhost:8501`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,10 @@ Selection of `make` commands for development (run in the repo root):
 - **E2E Tests**: Test the entire app logic end-to-end with Playwright. Located at `e2e_playwright/<name>_test.py` with app code in `e2e_playwright/<name>.py`. User-facing features should be covered by E2E tests (e.g., parameters and commands in the public `st.` API).
 - **(Python) Type Tests**: Verify public API typing with mypy `assert_type`. Located at `lib/tests/streamlit/typing/<command>_types.py`.
 - Prefer running specific tests / test scripts for newly added tests instead the entire test suite.
+
+## Cursor Cloud specific instructions
+
+- The environment ships with the toolchain already provisioned (Node 24 matching `.nvmrc`, `uv`, `protoc`, `rsync`), and the startup update script runs `make init INSTALL_PLAYWRIGHT=false` to refresh Python deps, frontend deps, and protobufs. Playwright browsers are pre-installed, so e2e/debug screenshots work without extra setup.
+- Non-obvious gotcha: `make frontend-lint`, `make frontend-types`, `make frontend-knip`, and any frontend unit test that imports `@streamlit/*` packages require the frontend workspace libraries to be built first. Otherwise imports like `@streamlit/utils` fail with `import-x/no-unresolved`. Build them once with `cd frontend && yarn workspaces foreach --recursive --topological --from @streamlit/lib run build` (or run `make frontend` / `make frontend-fast`, which additionally bundle the static assets into `lib/streamlit/static/`). `make debug` builds them automatically on first run.
+- If `import-x/no-unresolved` errors persist even after building the workspace libs, delete stale `.eslintcache` files under `frontend/` and re-run the lint.
+- To run the app in dev mode, use `make debug <script.py>` (see the "Debugging backend & frontend" section above); the app is served at `http://localhost:3001` and the backend at `http://localhost:8501`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this repo and records durable, non-obvious notes for future agents in `AGENTS.md` (plus the generated `.cursor/rules/overview.mdc` and `.github/copilot-instructions.md`).

No product/library code was modified — only agent documentation.

## What was set up (in the VM/snapshot)

- **Node 24** (matching `.nvmrc`) installed via nvm and symlinked into an early `PATH` dir so it takes precedence.
- **`uv`**, **`protoc`** (protobuf-compiler `3.21.12`), and **`rsync`** installed (the devcontainer Dockerfile expects these).
- `make all` run to install Python deps, frontend deps, compile protobufs, and build the frontend static bundle. Playwright browsers pre-installed.

## Verification

| Area | Command | Result |
|------|---------|--------|
| Python lint | `make python-lint` | pass |
| Frontend lint | `make frontend-lint` | pass (after building workspace libs) |
| Python tests | `uv run pytest lib/tests/streamlit/elements/markdown_test.py` | 36 passed |
| Frontend tests | `yarn workspace @streamlit/utils run test` | 27 passed |
| Run (dev) | `make debug work-tmp/debug/hello.py` | app served on `http://localhost:3001` |

**Hello-world end-to-end:** started the app in dev mode, filled a `st.text_input`, clicked a `st.button`, and confirmed `Hello, Cloud Agent!` rendered with balloons — exercising the full BackMsg → server rerun → ForwardMsg → frontend round-trip.

[Streamlit dev env hello-world](https://cursor.com/agents/bc-20d6c0a8-4bd9-4f97-a76c-bf6d94453d50/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fenv_check.png)

## Startup update script

`make init INSTALL_PLAYWRIGHT=false` (refreshes Python deps, frontend deps, and protobufs; skips the brittle Playwright `--with-deps` apt step since browsers/system deps live in the snapshot).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20d6c0a8-4bd9-4f97-a76c-bf6d94453d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20d6c0a8-4bd9-4f97-a76c-bf6d94453d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

