### PR TITLE
[fix] Improve hashing fallback warning messages

### DIFF
--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -432,10 +432,11 @@ class _CacheFuncHasher:
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
                 return h.digest()
-            except TypeError:
+            except TypeError as ex:
                 _LOGGER.warning(
-                    "Pandas Series hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Streamlit's default hashing method failed for a pandas Series, "
+                    "so it is falling back to pickling the object. Original error: %s",
+                    ex,
                 )
 
                 # Use pickle if pandas cannot hash the object for example if
@@ -458,10 +459,11 @@ class _CacheFuncHasher:
                 self.update(h, values_hash_bytes)
                 return h.digest()
 
-            except TypeError:
+            except TypeError as ex:
                 _LOGGER.warning(
-                    "Pandas DataFrame hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Streamlit's default hashing method failed for a pandas DataFrame, "
+                    "so it is falling back to pickling the object. Original error: %s",
+                    ex,
                 )
 
                 # Use pickle if pandas cannot hash the object for example if
@@ -482,10 +484,11 @@ class _CacheFuncHasher:
                 self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
                 return h.digest()
 
-            except TypeError:
+            except TypeError as ex:
                 _LOGGER.warning(
-                    "Polars Series hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Streamlit's default hashing method failed for a polars Series, "
+                    "so it is falling back to pickling the object. Original error: %s",
+                    ex,
                 )
 
                 # Use pickle if polars cannot hash the object for example if
@@ -512,10 +515,11 @@ class _CacheFuncHasher:
                 self.update(h, values_hash_bytes)
                 return h.digest()
 
-            except TypeError:
+            except TypeError as ex:
                 _LOGGER.warning(
-                    "Polars DataFrame hash failed. Falling back to pickling the object.",
-                    exc_info=True,
+                    "Streamlit's default hashing method failed for a polars DataFrame, "
+                    "so it is falling back to pickling the object. Original error: %s",
+                    ex,
                 )
 
                 # Use pickle if polars cannot hash the object for example if

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -44,6 +44,7 @@ from streamlit.runtime.caching import cache_data, cache_resource
 from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import (
+    _LOGGER,
     _NP_SIZE_LARGE,
     _PANDAS_ROWS_LARGE,
     UserHashError,
@@ -922,18 +923,36 @@ def test_hash_stack_pretty_print_handles_str_conversion_error() -> None:
     assert "<Unable to convert item to string>" in text
 
 
-def test_pandas_series_hash_pickle_fallback_on_type_error() -> None:
+def test_pandas_series_hash_pickle_fallback_on_type_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Series that ``hash_pandas_object`` cannot hash fall back to pickling."""
     series = pd.Series([[1, 2], [3, 4]])
-    assert get_hash(series) == get_hash(series)
-    assert get_hash(series) != get_hash(pd.Series([[1, 2], [3, 5]]))
+    with mock.patch.object(_LOGGER, "propagate", True):
+        digest = get_hash(series)
+        record = caplog.records[-1]
+
+        assert digest == get_hash(series)
+        assert digest != get_hash(pd.Series([[1, 2], [3, 5]]))
+    assert record.exc_info is None
+    assert "falling back to pickling the object" in record.getMessage()
+    assert "unhashable type: 'list'" in record.getMessage()
 
 
-def test_pandas_dataframe_hash_pickle_fallback_on_type_error() -> None:
+def test_pandas_dataframe_hash_pickle_fallback_on_type_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """DataFrame that ``hash_pandas_object`` cannot hash fall back to pickling."""
     df = pd.DataFrame({"col": [[1], [2]]})
-    assert get_hash(df) == get_hash(df)
-    assert get_hash(df) != get_hash(pd.DataFrame({"col": [[1], [3]]}))
+    with mock.patch.object(_LOGGER, "propagate", True):
+        digest = get_hash(df)
+        record = caplog.records[-1]
+
+        assert digest == get_hash(df)
+        assert digest != get_hash(pd.DataFrame({"col": [[1], [3]]}))
+    assert record.exc_info is None
+    assert "falling back to pickling the object" in record.getMessage()
+    assert "unhashable type: 'list'" in record.getMessage()
 
 
 def test_numpy_ufunc_hashes_by_encoded_name() -> None:

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -969,26 +969,36 @@ def test_module_hashes_via_module_name() -> None:
 
 @pytest.mark.require_integration
 @pytest.mark.parametrize(
-    ("make_obj", "method_name"),
+    ("make_obj", "method_name", "expected_obj_type"),
     [
-        (lambda pl: pl.Series([1, 2, 3]), "hash"),
-        (lambda pl: pl.DataFrame({"a": [1, 2]}), "hash_rows"),
+        (lambda pl: pl.Series([1, 2, 3]), "hash", "polars Series"),
+        (lambda pl: pl.DataFrame({"a": [1, 2]}), "hash_rows", "polars DataFrame"),
     ],
     ids=["series", "dataframe"],
 )
 def test_polars_pickle_fallback_when_hash_raises_typeerror(
     make_obj: Callable[..., Any],
     method_name: str,
+    expected_obj_type: str,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Polars objects fall back to pickle when native hashing raises ``TypeError``."""
     import polars as pl
 
     obj = make_obj(pl)
     cls = type(obj)
-    with mock.patch.object(cls, method_name, side_effect=TypeError("forced")):
+    with (
+        mock.patch.object(cls, method_name, side_effect=TypeError("forced")),
+        mock.patch.object(_LOGGER, "propagate", True),
+    ):
         digest = get_hash(obj)
+        record = caplog.records[-1]
     with mock.patch.object(cls, method_name, side_effect=TypeError("forced")):
         assert get_hash(obj) == digest
+    assert record.exc_info is None
+    assert "falling back to pickling the object" in record.getMessage()
+    assert f"failed for a {expected_obj_type}" in record.getMessage()
+    assert "forced" in record.getMessage()
 
 
 @pytest.mark.require_integration

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -923,36 +923,38 @@ def test_hash_stack_pretty_print_handles_str_conversion_error() -> None:
     assert "<Unable to convert item to string>" in text
 
 
-def test_pandas_series_hash_pickle_fallback_on_type_error(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_pandas_series_hash_pickle_fallback_on_type_error() -> None:
     """Series that ``hash_pandas_object`` cannot hash fall back to pickling."""
     series = pd.Series([[1, 2], [3, 4]])
-    with mock.patch.object(_LOGGER, "propagate", True):
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
         digest = get_hash(series)
-        record = caplog.records[-1]
 
-        assert digest == get_hash(series)
-        assert digest != get_hash(pd.Series([[1, 2], [3, 5]]))
-    assert record.exc_info is None
-    assert "falling back to pickling the object" in record.getMessage()
-    assert "unhashable type: 'list'" in record.getMessage()
+    assert digest == get_hash(series)
+    assert digest != get_hash(pd.Series([[1, 2], [3, 5]]))
+
+    mock_warning.assert_called_once()
+    # The traceback must not be attached anymore (``exc_info`` was removed).
+    assert "exc_info" not in mock_warning.call_args.kwargs
+    logged_message = mock_warning.call_args.args[0] % mock_warning.call_args.args[1:]
+    assert "falling back to pickling the object" in logged_message
+    assert "unhashable type: 'list'" in logged_message
 
 
-def test_pandas_dataframe_hash_pickle_fallback_on_type_error(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_pandas_dataframe_hash_pickle_fallback_on_type_error() -> None:
     """DataFrame that ``hash_pandas_object`` cannot hash fall back to pickling."""
     df = pd.DataFrame({"col": [[1], [2]]})
-    with mock.patch.object(_LOGGER, "propagate", True):
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
         digest = get_hash(df)
-        record = caplog.records[-1]
 
-        assert digest == get_hash(df)
-        assert digest != get_hash(pd.DataFrame({"col": [[1], [3]]}))
-    assert record.exc_info is None
-    assert "falling back to pickling the object" in record.getMessage()
-    assert "unhashable type: 'list'" in record.getMessage()
+    assert digest == get_hash(df)
+    assert digest != get_hash(pd.DataFrame({"col": [[1], [3]]}))
+
+    mock_warning.assert_called_once()
+    # The traceback must not be attached anymore (``exc_info`` was removed).
+    assert "exc_info" not in mock_warning.call_args.kwargs
+    logged_message = mock_warning.call_args.args[0] % mock_warning.call_args.args[1:]
+    assert "falling back to pickling the object" in logged_message
+    assert "unhashable type: 'list'" in logged_message
 
 
 def test_numpy_ufunc_hashes_by_encoded_name() -> None:
@@ -980,7 +982,6 @@ def test_polars_pickle_fallback_when_hash_raises_typeerror(
     make_obj: Callable[..., Any],
     method_name: str,
     expected_obj_type: str,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Polars objects fall back to pickle when native hashing raises ``TypeError``."""
     import polars as pl
@@ -989,16 +990,19 @@ def test_polars_pickle_fallback_when_hash_raises_typeerror(
     cls = type(obj)
     with (
         mock.patch.object(cls, method_name, side_effect=TypeError("forced")),
-        mock.patch.object(_LOGGER, "propagate", True),
+        mock.patch.object(_LOGGER, "warning") as mock_warning,
     ):
         digest = get_hash(obj)
-        record = caplog.records[-1]
     with mock.patch.object(cls, method_name, side_effect=TypeError("forced")):
         assert get_hash(obj) == digest
-    assert record.exc_info is None
-    assert "falling back to pickling the object" in record.getMessage()
-    assert f"failed for a {expected_obj_type}" in record.getMessage()
-    assert "forced" in record.getMessage()
+
+    mock_warning.assert_called_once()
+    # The traceback must not be attached anymore (``exc_info`` was removed).
+    assert "exc_info" not in mock_warning.call_args.kwargs
+    logged_message = mock_warning.call_args.args[0] % mock_warning.call_args.args[1:]
+    assert "falling back to pickling the object" in logged_message
+    assert f"failed for a {expected_obj_type}" in logged_message
+    assert "forced" in logged_message
 
 
 @pytest.mark.require_integration

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -936,6 +936,7 @@ def test_pandas_series_hash_pickle_fallback_on_type_error() -> None:
     # The traceback must not be attached anymore (``exc_info`` was removed).
     assert "exc_info" not in mock_warning.call_args.kwargs
     logged_message = mock_warning.call_args.args[0] % mock_warning.call_args.args[1:]
+    assert "failed for a pandas Series" in logged_message
     assert "falling back to pickling the object" in logged_message
     assert "unhashable type: 'list'" in logged_message
 
@@ -953,6 +954,7 @@ def test_pandas_dataframe_hash_pickle_fallback_on_type_error() -> None:
     # The traceback must not be attached anymore (``exc_info`` was removed).
     assert "exc_info" not in mock_warning.call_args.kwargs
     logged_message = mock_warning.call_args.args[0] % mock_warning.call_args.args[1:]
+    assert "failed for a pandas DataFrame" in logged_message
     assert "falling back to pickling the object" in logged_message
     assert "unhashable type: 'list'" in logged_message
 


### PR DESCRIPTION
## Describe your changes

Improves the warning logged when Streamlit's default hashing fails for a pandas/polars `Series`/`DataFrame` and falls back to pickling (used by `@st.cache_data`/`@st.cache_resource`).

- Clarifies the message to explain that the default hashing method failed and Streamlit is falling back to pickling the object.
- Logs the concise original error (`Original error: ...`) instead of a full traceback, which previously looked like an unexpected failure.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/10957

## Testing Plan

- `lib/tests/streamlit/runtime/caching/hashing_test.py` — Updated the pandas Series/DataFrame fallback tests to assert the new warning message content and that no traceback (`exc_info`) is attached.

Made with [Cursor](https://cursor.com)