### PR TITLE
[fix] Prevent st.expander content from being clipped

### DIFF
--- a/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
@@ -21,9 +21,12 @@ describe("animateHeight", () => {
   let mockAnimation: {
     addEventListener: ReturnType<typeof vi.fn>
     cancel: ReturnType<typeof vi.fn>
+    finish: ReturnType<typeof vi.fn>
+    playState: AnimationPlayState
   }
 
   beforeEach(() => {
+    vi.useFakeTimers()
     element = document.createElement("div")
     document.body.appendChild(element)
 
@@ -31,13 +34,22 @@ describe("animateHeight", () => {
     mockAnimation = {
       addEventListener: vi.fn(),
       cancel: vi.fn(),
+      finish: vi.fn(),
+      playState: "running",
     }
     element.animate = vi.fn().mockReturnValue(mockAnimation)
   })
 
   afterEach(() => {
     document.body.removeChild(element)
+    vi.useRealTimers()
   })
+
+  /** Look up an event listener registered on the mock animation. */
+  const getListener = (event: string): (() => void) | undefined =>
+    mockAnimation.addEventListener.mock.calls.find(
+      call => call[0] === event
+    )?.[1]
 
   describe("animation creation", () => {
     it("calls element.animate with height keyframes", () => {
@@ -170,6 +182,59 @@ describe("animateHeight", () => {
 
       // Should resolve without throwing
       await expect(handle.finished).resolves.toBeUndefined()
+    })
+  })
+
+  describe("stall guard (issue #16027)", () => {
+    it("force-finishes an animation still running well past its duration", () => {
+      animateHeight(element, 0, 100, { duration: 500 })
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+
+      // Advance past duration + guard buffer.
+      vi.advanceTimersByTime(1500)
+
+      expect(mockAnimation.finish).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not force-finish before the guard elapses", () => {
+      animateHeight(element, 0, 100, { duration: 500 })
+
+      // Just past the animation duration but before the guard fires.
+      vi.advanceTimersByTime(600)
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+    })
+
+    it.each<AnimationPlayState>(["finished", "idle"])(
+      "does not force-finish an animation already in %s state",
+      state => {
+        animateHeight(element, 0, 100)
+        mockAnimation.playState = state
+
+        vi.advanceTimersByTime(1500)
+
+        expect(mockAnimation.finish).not.toHaveBeenCalled()
+      }
+    )
+
+    it("clears the guard when the animation finishes normally", () => {
+      animateHeight(element, 0, 100)
+
+      getListener("finish")?.()
+      vi.advanceTimersByTime(1500)
+
+      // finish() came from the browser event, not the guard force-finishing.
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+    })
+
+    it("clears the guard when the animation is cancelled", () => {
+      animateHeight(element, 0, 100)
+
+      getListener("cancel")?.()
+      vi.advanceTimersByTime(1500)
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/elements/Expander/animateHeight.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.ts
@@ -32,13 +32,30 @@ const DEFAULT_DURATION = 500
 const DEFAULT_EASING = "cubic-bezier(0.23, 1, 0.32, 1)"
 
 /**
+ * Extra time (ms) to wait past the animation duration before treating a still-
+ * running animation as stalled and force-finishing it.
+ *
+ * After certain rapid open/close + resize interruption sequences a Web-Animations
+ * effect can end up "running" but stalled — never advancing and never firing its
+ * `finish` event — which permanently holds the element at a clipped height while
+ * the inline `overflow: hidden` lock stays in place (issue #16027). This guard is
+ * a safety net that clears such a stall by force-finishing the animation, which
+ * runs the normal `finish` cleanup. The buffer is generous so it can never fire
+ * for a healthy animation, which always finishes at ~`duration`.
+ */
+const STALL_GUARD_BUFFER_MS = 1000
+
+/**
  * Animate an element's height using the Web Animations API.
  *
  * IMPORTANT: On cancel, styles are NOT cleared. The caller is responsible
  * for setting new styles after cancelling (typically to lock at current height
  * before starting a new animation).
  *
- * On finish, styles ARE cleared to allow natural layout.
+ * On finish, styles ARE cleared to allow natural layout. A stall guard force-
+ * finishes the animation if it is still active well past its duration, so a
+ * stuck Web-Animations effect can never leave the element permanently clipped
+ * (issue #16027).
  *
  * @param element - The HTML element to animate
  * @param from - Starting height in pixels
@@ -67,8 +84,23 @@ export function animateHeight(
     { duration, easing }
   )
 
+  /**
+   * Safety net for stalled animations (issue #16027). If the animation is still
+   * active well past its duration, force it to finish so the `finish` handler
+   * below clears the inline height/overflow lock instead of leaving the element
+   * permanently clipped. Cleared as soon as the animation finishes or is
+   * cancelled, so it never affects a healthy or interrupted animation.
+   */
+  // eslint-disable-next-line no-restricted-globals -- Framework-agnostic animation utility manages its own timer; useTimeout is React-only.
+  const stallGuard = setTimeout(() => {
+    if (animation.playState !== "finished" && animation.playState !== "idle") {
+      animation.finish()
+    }
+  }, duration + STALL_GUARD_BUFFER_MS)
+
   const finished = new Promise<void>(resolve => {
     animation.addEventListener("finish", () => {
+      clearTimeout(stallGuard)
       // Clean up styles on successful finish
       element.style.height = ""
       element.style.overflow = ""
@@ -77,6 +109,7 @@ export function animateHeight(
     })
 
     animation.addEventListener("cancel", () => {
+      clearTimeout(stallGuard)
       // DON'T clean up on cancel - caller will set new styles
       resolve()
     })

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -537,7 +537,7 @@ describe("useDetailsAnimation", () => {
       expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
     })
 
-    it("locks inline styles when content height is zero so ResizeObserver can animate later", async () => {
+    it("clears the inline lock when content height is zero (no permanent clip)", async () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime,
       })
@@ -553,8 +553,8 @@ describe("useDetailsAnimation", () => {
       const summary = screen.getByTestId("summary")
       const content = screen.getByTestId("content")
 
-      // Summary has height, but content returns 0 (e.g. widget mode where
-      // content hasn't loaded yet)
+      // Summary has height, but content returns 0 (e.g. content hasn't laid
+      // out yet). Pre-seed an inline lock to prove the branch clears it.
       mockElementHeight(details, 42)
       mockElementHeight(summary, 40)
       mockElementHeight(content, 0)
@@ -565,15 +565,16 @@ describe("useDetailsAnimation", () => {
 
       // No animation should have been started (nothing to animate to yet)
       expect(Element.prototype.animate).not.toHaveBeenCalled()
-      // Inline styles should remain LOCKED so the ResizeObserver can later
-      // animate from this height to the full content height once it loads
-      expect(details.style.height).toBe("42px")
-      expect(details.style.overflow).toBe("hidden")
-      // Element should still be set to open for content to render
+      // The lock must be CLEARED, not left in place: leaving overflow:hidden +
+      // a fixed height with no animation to clear it is the permanent-clip bug
+      // (issue #16027). The element sizes to its natural height instead.
+      expect(details.style.height).toBe("")
+      expect(details.style.overflow).toBe("")
+      // Element is still open so the content renders once it lays out.
       expect(details).toHaveAttribute("open")
     })
 
-    it("animates from locked height when content loads after zero-content open", async () => {
+    it("animates the reveal when content loads after a zero-content open", async () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime,
       })
@@ -594,21 +595,61 @@ describe("useDetailsAnimation", () => {
       mockElementHeight(summary, 40)
       mockElementHeight(content, 0)
 
-      // Click to expand — locks height at 42px (content is 0)
+      // Click to expand — contentHeight is 0, so the lock is cleared and no
+      // animation starts yet.
       await user.click(screen.getByTestId("summary"))
       ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
 
-      // Content loads: now content=200, but details is still locked at 42px
-      // (the ResizeObserver reads the locked details height)
+      // Content loads: now content=200. The ResizeObserver reads the current
+      // details height (42) and animates the reveal to the full height.
       mockElementHeight(content, 200)
-      // details stays locked at 42 since style.height="42px"
       // target = 40 + 200 + 2*1 = 242, current = 42, diff = 200 > 5
 
       fireResize()
       vi.advanceTimersByTime(50)
 
-      // ResizeObserver should trigger an animation from locked height to full
+      // ResizeObserver should trigger an animation from the current height to full
       expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
+    })
+
+    it("clears the inline lock when the expander is replaced (label change)", async () => {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      })
+
+      const { rerender } = render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Old Label",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      mockElementHeight(details, 100)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 200)
+
+      // Toggle closed: locks height + overflow while the (mock) close animation
+      // "runs" and never fires finish, so the lock persists on the node.
+      await user.click(summary)
+      expect(details.style.height).not.toBe("")
+      expect(details.style.overflow).toBe("hidden")
+
+      // A new expander reuses this <details> node (label change). cancelAnimation
+      // must clear the stale lock so the reused node isn't left clipped from the
+      // previous expander's interrupted animation (issue #16027).
+      rerender(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "New Label",
+        })
+      )
+
+      expect(details.style.height).toBe("")
+      expect(details.style.overflow).toBe("")
     })
 
     it("clears pending debounce timeout on unmount", () => {

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -125,11 +125,29 @@ export function useDetailsAnimation({
   const hasMountedRef = useRef(false)
 
   /**
-   * Cancel any running animation.
+   * Cancel any running animation and clear the inline height/overflow lock it
+   * left behind.
+   *
+   * Clearing here (rather than in `animateHeight`'s async `cancel` listener) is
+   * both safe and correct: the WAAPI `cancel` event fires asynchronously, so
+   * clearing in that listener would clobber the fresh lock that callers apply
+   * synchronously right after cancelling. Callers that keep animating
+   * (`animateTo` / `animateResize`) re-apply `height` + `overflow` on the very
+   * next lines, so this clear is immediately overwritten for them. The one
+   * caller that does NOT re-lock — the "new expander" reset on a label change —
+   * relies on this clear so a reused `<details>` node isn't left clipped from
+   * the previous expander's interrupted animation, upholding the invariant that
+   * the element is never locked with no animation to clear it (issue #16027).
    */
   const cancelAnimation = useCallback((): void => {
     animationRef.current?.cancel()
     animationRef.current = null
+
+    const details = detailsRef.current
+    if (details) {
+      details.style.height = ""
+      details.style.overflow = ""
+    }
   }, [])
 
   /**
@@ -180,14 +198,17 @@ export function useDetailsAnimation({
             currentHeight,
             targetHeight
           )
+        } else {
+          // contentHeight is 0 — the browser hasn't laid out the content yet
+          // (rare: StyledDetailsPanel has padding, so a mounted panel usually
+          // measures > 0). Clear the lock instead of leaving it in place: the
+          // element then sizes to its natural height so content is never
+          // clipped, and the ResizeObserver animates the reveal once layout
+          // settles. Leaving it locked risked a permanent clip if that resize
+          // never fired a healing animation (issue #16027).
+          details.style.height = ""
+          details.style.overflow = ""
         }
-        // If contentHeight is 0, leave inline height + overflow locked.
-        // This is rare in practice — StyledDetailsPanel always has padding,
-        // so even an empty expander measures > 0. It can only happen if
-        // getBoundingClientRect fires before the browser has laid out the
-        // content. Keeping styles locked lets the ResizeObserver animate
-        // from the collapsed height to the full content height once layout
-        // settles.
       } else {
         // Closing: animate to collapsed height, then set open=false
         const targetHeight = summaryHeight + borderOffset
@@ -278,7 +299,8 @@ export function useDetailsAnimation({
     prevLabelRef.current = label
 
     // If label changed, this is a "new expander" - cancel animations and reset.
-    // Clear any stale inline styles that cancelAnimation leaves behind.
+    // cancelAnimation clears the inline height/overflow lock, so a reused
+    // <details> node isn't left clipped from the previous expander's animation.
     if (labelChanged) {
       cancelAnimation()
       const newOpen = backendExpanded ?? false
@@ -286,8 +308,6 @@ export function useDetailsAnimation({
 
       setIsOpen(newOpen)
       if (detailsRef.current) {
-        detailsRef.current.style.height = ""
-        detailsRef.current.style.overflow = ""
         detailsRef.current.open = newOpen
       }
       return

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -155,9 +155,12 @@ console.error = (...args) => {
 }
 
 // Add fake animate method to Elements
-Element.prototype.animate = vi
-  .fn()
-  .mockImplementation(() => ({ addEventListener: vi.fn(), cancel: vi.fn() }))
+Element.prototype.animate = vi.fn().mockImplementation(() => ({
+  addEventListener: vi.fn(),
+  cancel: vi.fn(),
+  finish: vi.fn(),
+  playState: "running",
+}))
 
 // JSDOM does not implement the Web Animations API. RAC's SelectionIndicator uses
 // SharedElementTransition which calls getAnimations() in an async cleanup callback.


### PR DESCRIPTION
## Describe your changes

After certain rapid expand/collapse/resize sequences across multiple `st.expander`s, one expander could be left **permanently clipped** — its `<details>` stuck with `overflow: hidden` and a fixed height that hides the tail of its content, unreachable until a rerun/reload replaces the element.

Root cause: the height-animation cleanup only clears the inline `height`/`overflow` lock on a WAAPI `finish` event, so any path that ends without a finishing animation leaves the lock in place. This closes those gaps so the element is never left locked with nothing running to clear it:

- **Stall guard** in `animateHeight` — force-finishes an animation still running well past its duration, covering Web-Animations effects that get stuck `running` and never fire `finish` (observed holding the collapsed height indefinitely).
- **Zero-content open** in `useDetailsAnimation` — the rare `contentHeight === 0` path now clears the lock instead of leaving it and relying on a resize that may never fire.
- **New-expander reset** — `cancelAnimation` now clears the inline lock, so a reused `<details>` node (label change) isn't left clipped from the previous expander's interrupted animation (replaces the duplicated explicit clear in that path).

## Screenshot or video (only for visual changes)

N/A — the fix removes leftover inline styles; there is no visual change on the healthy path.

## GitHub Issue Link (if applicable)

Closes #16027

## Testing Plan

- **Frontend unit tests**: stall-guard behavior (force-finishes when stalled; no-op before the buffer and when already `finished`/`idle`; cleared on finish/cancel), the zero-content open now clearing the lock, and the label-change reset clearing a reused node's lock.
- **No E2E test**: the failure is a timing race between interrupted animations and content resize, so a deterministic Playwright test would be flaky (noted in the issue). The two underlying mechanisms are covered by unit tests instead.
- **Manual testing**: reproduced the permanent clip on the issue's repro app (7 expanders × 3 charts) and confirmed the animation-cleanup gap; recommend a manual soak of rapid toggling to confirm end-to-end before ready-for-review.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
