### PR TITLE
[fix] Plotly chart state restoration and identity

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/references/element-identity.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/element-identity.md
@@ -72,7 +72,7 @@ API:
 
 Current examples include:
 
-- Plotly figure state
+- Plotly figure state for interactive or explicitly keyed charts
 - Vega view state
 - audio/video autoplay guards
 

--- a/e2e_playwright/st_plotly_chart_state.py
+++ b/e2e_playwright/st_plotly_chart_state.py
@@ -1,0 +1,48 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import plotly.graph_objects as go
+
+import streamlit as st
+
+identical_figure = go.Figure(go.Scatter(x=[1, 2, 3], y=[1, 4, 9]))
+st.plotly_chart(identical_figure)
+st.plotly_chart(identical_figure)
+
+if "plotly_update" not in st.session_state:
+    st.session_state.plotly_update = 0
+
+if st.button("Update chart"):
+    st.session_state.plotly_update += 1
+
+offset = st.session_state.plotly_update
+updated_figure = go.Figure(
+    go.Scatter(x=[1, 2, 3], y=[offset + 1, offset + 2, offset + 3])
+)
+updated_figure.update_layout(uirevision="constant")
+st.plotly_chart(updated_figure)
+
+# A keyed passive chart should restore its frontend state (here, legend
+# visibility) when it is unmounted and remounted. Moving the chart between two
+# containers forces a genuine remount while keeping the element present so its
+# frontend state is recovered.
+restore_figure = go.Figure()
+restore_figure.add_scatter(x=[1, 2, 3], y=[1, 2, 3], name="Trace A")
+restore_figure.add_scatter(x=[1, 2, 3], y=[3, 2, 1], name="Trace B")
+
+first_slot = st.container(key="chart_slot_a")
+second_slot = st.container(key="chart_slot_b")
+chart_slot = first_slot if st.checkbox("Move keyed chart") else second_slot
+with chart_slot:
+    st.plotly_chart(restore_figure, key="restore_chart")

--- a/e2e_playwright/st_plotly_chart_state_test.py
+++ b/e2e_playwright/st_plotly_chart_state_test.py
@@ -1,0 +1,80 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_until
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    click_checkbox,
+    get_element_by_key,
+)
+
+
+def test_identical_passive_unkeyed_charts_render(app: Page):
+    charts = app.get_by_test_id("stPlotlyChart")
+
+    # Three unkeyed passive charts plus the keyed restore chart.
+    expect(charts).to_have_count(4)
+    for index in range(4):
+        expect(charts.nth(index)).to_be_visible()
+
+
+def test_passive_unkeyed_chart_updates_without_remounting(app: Page):
+    chart = app.get_by_test_id("stPlotlyChart").nth(2)
+    chart.evaluate("element => { element.dataset.instanceMarker = 'stable' }")
+
+    click_button(app, "Update chart")
+
+    expect(chart).to_have_attribute("data-instance-marker", "stable")
+    plot = chart.locator(".js-plotly-plot")
+    expect(plot).to_be_visible()
+    wait_until(app, lambda: plot.evaluate("element => element.data[0].y") == [2, 3, 4])
+
+
+def test_keyed_chart_restores_frontend_state_after_remount(app: Page):
+    chart = get_element_by_key(app, "restore_chart")
+    plot = chart.locator(".js-plotly-plot")
+    expect(plot).to_be_visible()
+
+    # Hide the second trace by clicking its legend entry. This is a real user
+    # interaction that changes the chart's frontend state. Plotly overlays a
+    # transparent toggle rect on top of the legend text, so target it directly.
+    chart.locator(".traces").filter(has_text="Trace B").locator(".legendtoggle").click()
+    wait_until(
+        app, lambda: plot.evaluate("element => element.data[1].visible") == "legendonly"
+    )
+
+    # Mark the current DOM instance so we can confirm the chart actually
+    # remounts (and does not merely keep a live, never-unmounted instance).
+    chart.evaluate("element => { element.dataset.instanceMarker = 'before' }")
+
+    # Move the chart to the other container to force a genuine unmount/remount.
+    click_checkbox(app, "Move keyed chart")
+
+    remounted_chart = get_element_by_key(app, "restore_chart")
+    expect(remounted_chart).not_to_have_attribute("data-instance-marker", "before")
+    remounted_plot = remounted_chart.locator(".js-plotly-plot")
+    expect(remounted_plot).to_be_visible()
+
+    # The recovered frontend state keeps the second trace hidden, while the
+    # first trace must stay visible (only the intended state was restored).
+    wait_until(
+        app,
+        lambda: (
+            remounted_plot.evaluate("element => element.data[1].visible")
+            == "legendonly"
+        ),
+    )
+    assert remounted_plot.evaluate("element => element.data[0].visible") != "legendonly"

--- a/e2e_playwright/st_plotly_chart_state_test.py
+++ b/e2e_playwright/st_plotly_chart_state_test.py
@@ -25,7 +25,8 @@ from e2e_playwright.shared.app_utils import (
 def test_identical_passive_unkeyed_charts_render(app: Page):
     charts = app.get_by_test_id("stPlotlyChart")
 
-    # Three unkeyed passive charts plus the keyed restore chart.
+    # Two identical unkeyed charts plus one updated unkeyed chart (three
+    # unkeyed passive charts) plus the keyed restore chart.
     expect(charts).to_have_count(4)
     for index in range(4):
         expect(charts.nth(index)).to_be_visible()

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -1100,7 +1100,11 @@ const RawElementNodeRenderer = (
           isStale={isStale}
         >
           <PlotlyChart
-            key={plotlyProto.id}
+            // Plotly charts only have an id when they are interactive
+            // (selections activated) or explicitly keyed. Passive unkeyed
+            // charts have an empty id, so fall back to positional keying like
+            // other elements that can be used without an id.
+            key={plotlyProto.id || undefined}
             element={plotlyProto}
             {...widgetProps}
           />

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { ReactElement } from "react"
+
 import { act, render, screen } from "@testing-library/react"
 
 import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"
@@ -92,10 +94,10 @@ describe("PlotlyChart Component", () => {
   // Create fresh widgetMgr for each test to avoid shared state
   let widgetMgr: WidgetStateManager
 
-  const renderComponent = (
+  const getComponent = (
     props: Partial<React.ComponentProps<typeof PlotlyChart>> = {},
     contextValue: Record<string, unknown> = {}
-  ): ReturnType<typeof render> => {
+  ): ReactElement => {
     const finalContext = {
       expanded: false,
       width: 600,
@@ -105,14 +107,8 @@ describe("PlotlyChart Component", () => {
       ...contextValue,
     }
 
-    return render(
-      <ElementFullscreenContext.Provider
-        value={
-          finalContext as React.ComponentProps<
-            typeof ElementFullscreenContext.Provider
-          >["value"]
-        }
-      >
+    return (
+      <ElementFullscreenContext.Provider value={finalContext}>
         <PlotlyChart
           element={DEFAULT_ELEMENT}
           widgetMgr={widgetMgr}
@@ -123,6 +119,11 @@ describe("PlotlyChart Component", () => {
       </ElementFullscreenContext.Provider>
     )
   }
+
+  const renderComponent = (
+    props: Partial<React.ComponentProps<typeof PlotlyChart>> = {},
+    contextValue: Record<string, unknown> = {}
+  ): ReturnType<typeof render> => render(getComponent(props, contextValue))
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -148,12 +149,143 @@ describe("PlotlyChart Component", () => {
 
   it("recovers state from widgetMgr if available", () => {
     const savedFigure = { data: [], layout: { title: "Recovered" } }
-    vi.mocked(widgetMgr.getElementState).mockReturnValue(savedFigure)
+    vi.mocked(widgetMgr.getElementState).mockImplementation((_id, stateKey) =>
+      stateKey === "figure" ? savedFigure : DEFAULT_ELEMENT.spec
+    )
 
     renderComponent()
 
     const lastCallProps = getLastPlotProps()
     expect(lastCallProps.layout.title).toBe("Recovered")
+  })
+
+  it("does not access element state for an id-less chart", () => {
+    const element = new PlotlyChartProto({
+      ...DEFAULT_ELEMENT,
+      id: "",
+    })
+
+    renderComponent({ element })
+    expect(widgetMgr.getElementState).not.toHaveBeenCalled()
+
+    const figure = { data: [], layout: {}, frames: null }
+    let lastCallProps = getLastPlotProps()
+    act(() => {
+      lastCallProps.onInitialized?.(figure, document.createElement("div"))
+    })
+
+    lastCallProps = getLastPlotProps()
+    act(() => {
+      lastCallProps.onUpdate?.(figure, document.createElement("div"))
+    })
+
+    expect(widgetMgr.setElementState).not.toHaveBeenCalled()
+  })
+
+  it("preserves recovered state when its source spec is unchanged", () => {
+    const savedFigure = { data: [], layout: { title: "Recovered" } }
+    vi.mocked(widgetMgr.getElementState).mockImplementation((_id, stateKey) =>
+      stateKey === "figure" ? savedFigure : DEFAULT_ELEMENT.spec
+    )
+
+    renderComponent()
+
+    expect(getLastPlotProps().layout.title).toBe("Recovered")
+    expect(
+      MockPlot.mock.calls.some(
+        ([props]) =>
+          ((props as PlotParams).layout as { title?: string }).title ===
+          "Test Chart"
+      )
+    ).toBe(false)
+  })
+
+  it("synchronizes the current spec after recovering an older spec", () => {
+    const savedFigure = {
+      data: [],
+      layout: { title: { text: "Recovered" } },
+      frames: null,
+    }
+    const previousSpec = "previous backend spec"
+    vi.mocked(widgetMgr.getElementState).mockImplementation((_id, stateKey) =>
+      stateKey === "figure" ? savedFigure : previousSpec
+    )
+
+    renderComponent()
+
+    const recoveredPlotProps = MockPlot.mock.calls
+      .map(([props]) => props as PlotParams)
+      .find(props => props.layout.title?.text === "Recovered")
+    expect(recoveredPlotProps).toBeDefined()
+    expect(getLastPlotProps().layout.title).toBe("Test Chart")
+
+    act(() => {
+      recoveredPlotProps?.onInitialized?.(
+        savedFigure,
+        document.createElement("div")
+      )
+    })
+    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
+      DEFAULT_ELEMENT.id,
+      "spec",
+      previousSpec
+    )
+  })
+
+  it("applies changed specs to an id-less chart", () => {
+    const element = new PlotlyChartProto({ ...DEFAULT_ELEMENT, id: "" })
+    const { rerender } = renderComponent({ element })
+    const updatedElement = new PlotlyChartProto({
+      ...element,
+      spec: JSON.stringify({
+        data: [{ type: "bar", x: [3, 4], y: [5, 6] }],
+        layout: { title: "Updated Chart" },
+        frames: [{ name: "updated" }],
+      }),
+    })
+
+    rerender(getComponent({ element: updatedElement }))
+
+    const lastCallProps = getLastPlotProps()
+    expect(lastCallProps.data[0].type).toBe("bar")
+    expect(lastCallProps.layout.title).toBe("Updated Chart")
+    expect(lastCallProps.frames).toEqual([{ name: "updated" }])
+  })
+
+  it("applies changed specs to a keyed chart with stable identity", () => {
+    const { rerender } = renderComponent()
+    const updatedElement = new PlotlyChartProto({
+      ...DEFAULT_ELEMENT,
+      spec: JSON.stringify({
+        data: [{ type: "scatter", x: [10], y: [20] }],
+        layout: { title: "Updated Keyed Chart" },
+      }),
+    })
+
+    rerender(getComponent({ element: updatedElement }))
+
+    expect(getLastPlotProps().data[0]).toMatchObject({ x: [10] })
+    expect(getLastPlotProps().layout.title).toBe("Updated Keyed Chart")
+  })
+
+  it("recomputes interaction modes when the backend spec changes", () => {
+    const element = new PlotlyChartProto({
+      ...DEFAULT_ELEMENT,
+      selectionMode: [PlotlyChartProto.SelectionMode.POINTS],
+    })
+    const { rerender } = renderComponent({ element })
+    expect(getLastPlotProps().layout.dragmode).toBe("pan")
+
+    const updatedElement = new PlotlyChartProto({
+      ...element,
+      spec: JSON.stringify({
+        data: [{ type: "scatter", x: [1, 2], y: [1, 2] }],
+        layout: { dragmode: "zoom" },
+      }),
+    })
+    rerender(getComponent({ element: updatedElement }))
+
+    expect(getLastPlotProps().layout.dragmode).toBe("zoom")
   })
 
   it("updates dimensions based on context", () => {
@@ -349,6 +481,11 @@ describe("PlotlyChart Component", () => {
       DEFAULT_ELEMENT.id,
       "figure",
       newFigure
+    )
+    expect(widgetMgr.setElementState).toHaveBeenCalledWith(
+      DEFAULT_ELEMENT.id,
+      "spec",
+      DEFAULT_ELEMENT.spec
     )
   })
 

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -21,6 +21,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
@@ -59,6 +60,8 @@ const MIN_WIDTH = 150
 const RESET_SELECTION_TIMEOUT_MS = 50
 // Default height for Plotly charts when no height is specified
 const DEFAULT_PLOTLY_HEIGHT = 450
+const FIGURE_STATE_KEY = "figure"
+const SPEC_STATE_KEY = "spec"
 
 // Custom icon used in the fullscreen expand toolbar button:
 /* eslint-disable streamlit-custom/no-hardcoded-theme-values */
@@ -118,23 +121,38 @@ export function PlotlyChart({
     }
 
     return JSON.parse(element.spec)
-    // We want to reload the initialFigureSpec object whenever the element id changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
-  }, [element.id, element.spec])
+  }, [element.spec])
+
+  // Tracks which backend spec the current figure state was derived from. A
+  // recovered figure can intentionally be older than the incoming spec for one
+  // render so Plotly can reconcile the update and honor layout.uirevision.
+  const lastAppliedSpecRef = useRef(element.spec)
 
   const [plotlyFigure, setPlotlyFigure] = useState<PlotlyFigureType>(() => {
     // If there was already a state with a figure using the same id,
     // use that to recover the state. This happens in some situations
     // where a component un-mounts and mounts again.
-    const initialFigureState = widgetMgr.getElementState<PlotlyFigureType>(
-      element.id,
-      "figure"
-    )
-    if (initialFigureState) {
-      return initialFigureState
+    if (element.id) {
+      const initialFigureState = widgetMgr.getElementState<PlotlyFigureType>(
+        element.id,
+        FIGURE_STATE_KEY
+      )
+      if (initialFigureState) {
+        const savedSpec = widgetMgr.getElementState<string>(
+          element.id,
+          SPEC_STATE_KEY
+        )
+        // Older saved state has no source spec. Its content-derived ID meant it
+        // could only belong to this same spec, so preserve that behavior.
+        lastAppliedSpecRef.current = savedSpec ?? element.spec
+        return initialFigureState
+      }
     }
     return applyTheming(initialFigureSpec, element.theme, theme)
   })
+  // Capture the source spec for this render so asynchronous Plotly callbacks
+  // cannot associate an older rendered figure with a newer backend spec.
+  const plotlyFigureSourceSpec = lastAppliedSpecRef.current
 
   const isSelectionActivated = element.selectionMode.length > 0 && !disabled
   const isLassoSelectionActivated =
@@ -203,10 +221,7 @@ export function PlotlyChart({
       config.modeBarButtonsToRemove = modeBarButtonsToRemove
     }
     return config
-    // We want to reload the plotlyConfig object whenever the element id changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
   }, [
-    element.id,
     element.config,
     isFullScreen,
     disableFullscreenMode,
@@ -223,6 +238,17 @@ export function PlotlyChart({
       return applyTheming(prevState, element.theme, theme)
     })
   }, [element.id, theme, element.theme])
+
+  useEffect(() => {
+    if (lastAppliedSpecRef.current === element.spec) {
+      return
+    }
+
+    // Apply changed backend data to the existing Plotly instance. Plotly.react
+    // can then preserve or reset UI state according to layout.uirevision.
+    lastAppliedSpecRef.current = element.spec
+    setPlotlyFigure(applyTheming(initialFigureSpec, element.theme, theme))
+  }, [element.spec, element.theme, initialFigureSpec, theme])
 
   useEffect(() => {
     let updatedClickMode: typeof initialFigureSpec.layout.clickmode =
@@ -292,11 +318,8 @@ export function PlotlyChart({
         },
       }
     })
-    // We want to reload these options whenever the element id changes
-    // or the selection modes change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
   }, [
-    element.id,
+    initialFigureSpec,
     isSelectionActivated,
     isPointsSelectionActivated,
     isBoxSelectionActivated,
@@ -480,6 +503,21 @@ export function PlotlyChart({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: Update to match React best practices
   }, [plotlyFigure.layout?.dragmode])
 
+  // Persist the figure together with the spec it was derived from so the state
+  // can be recovered and correctly reconciled after the chart remounts. Charts
+  // without an id (passive and unkeyed) are not persisted.
+  const persistFigureState = (figure: Readonly<PlotlyFigureType>): void => {
+    if (!element.id) {
+      return
+    }
+    widgetMgr.setElementState(element.id, FIGURE_STATE_KEY, figure)
+    widgetMgr.setElementState(
+      element.id,
+      SPEC_STATE_KEY,
+      plotlyFigureSourceSpec
+    )
+  }
+
   return (
     <StyledPlotlyChartContainer
       ref={containerRef}
@@ -520,13 +558,10 @@ export function PlotlyChart({
               }
             : undefined
         }
-        onInitialized={figure => {
-          widgetMgr.setElementState(element.id, "figure", figure)
-        }}
+        onInitialized={persistFigureState}
         // Update the figure state on every change to the figure itself:
         onUpdate={figure => {
-          // Save the updated figure state to allow it to be recovered
-          widgetMgr.setElementState(element.id, "figure", figure)
+          persistFigureState(figure)
           setPlotlyFigure(figure)
         }}
       />

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -519,8 +519,13 @@ class PlotlyMixin:
 
         key : str, int, or None
             An optional string to use for giving this element a stable
-            identity. If this is ``None`` (default), the element's identity
-            will be determined based on the values of the other parameters.
+            identity. If a key is provided, Streamlit can restore the chart's
+            frontend state (zoom, pan, legend visibility, and 3D camera
+            position) if the chart is unmounted and remounted. To preserve
+            this state when the chart data changes, set Plotly's
+            ``layout.uirevision`` to a stable value. If this is ``None``
+            (default), the chart's frontend state is not preserved and resets
+            when the chart is unmounted and remounted.
 
             If selections are activated and ``key`` is provided,
             Streamlit will register the key in Session State to store the
@@ -706,22 +711,31 @@ class PlotlyMixin:
 
         ctx = get_script_run_ctx()
 
-        # We are computing the widget id for all plotly uses
-        # to also allow non-widget Plotly charts to keep their state
-        # when the frontend component gets unmounted and remounted.
-        plotly_chart_proto.id = compute_and_register_element_id(
-            "plotly_chart",
-            user_key=key,
-            key_as_main_identity=False,
-            dg=self.dg,
-            plotly_spec=plotly_chart_proto.spec,
-            plotly_config=plotly_chart_proto.config,
-            selection_mode=selection_mode,
-            is_selection_activated=is_selection_activated,
-            theme=theme,
-            width=width,
-            height=height,
-        )
+        if is_selection_activated:
+            # Interactive Plotly charts are widgets. Keep their existing,
+            # content-derived identity behavior for compatibility.
+            plotly_chart_proto.id = compute_and_register_element_id(
+                "plotly_chart",
+                user_key=key,
+                key_as_main_identity=False,
+                dg=self.dg,
+                plotly_spec=plotly_chart_proto.spec,
+                plotly_config=plotly_chart_proto.config,
+                selection_mode=selection_mode,
+                is_selection_activated=is_selection_activated,
+                theme=theme,
+                width=width,
+                height=height,
+            )
+        elif key is not None:
+            # A keyed passive chart has stable identity across content updates,
+            # which lets the frontend restore state after a remount.
+            plotly_chart_proto.id = compute_and_register_element_id(
+                "plotly_chart",
+                user_key=key,
+                key_as_main_identity=True,
+                dg=self.dg,
+            )
 
         # Handle "content" width and height by inspecting the figure's natural dimensions
         final_width = _resolve_content_width(width, figure)

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -26,7 +26,11 @@ from streamlit.elements.plotly_chart import (
     _resolve_content_height,
     _resolve_content_width,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitDuplicateElementId,
+    StreamlitDuplicateElementKey,
+)
 from streamlit.runtime.caching import cached_message_replay
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
@@ -41,6 +45,78 @@ class PyDeckTest(DeltaGeneratorTestCase):
         el = self.get_delta_from_queue().new_element
         assert el.plotly_chart.spec != ""
         assert el.plotly_chart.config != ""
+
+    def test_passive_unkeyed_chart_has_no_id(self):
+        """Test that a passive unkeyed chart uses positional identity."""
+        st.plotly_chart(px.line(x=[1, 2], y=[3, 4]))
+
+        plotly_chart = self.get_delta_from_queue().new_element.plotly_chart
+        assert plotly_chart.id == ""
+
+    def test_identical_passive_unkeyed_charts_are_allowed(self):
+        """Test that identical passive charts don't cause duplicate IDs."""
+        figure = px.line(x=[1, 2], y=[3, 4])
+
+        st.plotly_chart(figure)
+        st.plotly_chart(figure)
+
+        plotly_charts = [
+            delta.new_element.plotly_chart for delta in self.get_all_deltas_from_queue()
+        ]
+        assert len(plotly_charts) == 2
+        assert all(chart.id == "" for chart in plotly_charts)
+
+    def test_passive_keyed_chart_has_id(self):
+        """Test that a keyed passive chart has stable element identity."""
+        st.plotly_chart(px.line(x=[1, 2], y=[3, 4]), key="passive_chart")
+
+        plotly_chart = self.get_delta_from_queue().new_element.plotly_chart
+        assert plotly_chart.id.startswith("$$ID-")
+        assert plotly_chart.id.endswith("-passive_chart")
+
+    def test_passive_keyed_chart_id_is_stable_across_content_changes(self):
+        """Test that passive keyed identity is independent of mutable content."""
+        st.plotly_chart(
+            px.line(x=[1, 2], y=[3, 4]),
+            key="stable_chart",
+            config={"displayModeBar": False},
+            theme="streamlit",
+            width=300,
+            height=400,
+        )
+        first_id = self.get_delta_from_queue().new_element.plotly_chart.id
+
+        # Simulate a separate script run so the same key can be registered again.
+        self.script_run_ctx.shared.widget_ids_this_run.clear()
+        self.script_run_ctx.shared.widget_user_keys_this_run.clear()
+
+        st.plotly_chart(
+            px.bar(x=[10, 20, 30], y=[40, 50, 60]),
+            key="stable_chart",
+            config={"scrollZoom": False},
+            theme=None,
+            width="stretch",
+            height=600,
+        )
+        second_id = self.get_delta_from_queue().new_element.plotly_chart.id
+
+        assert first_id == second_id
+
+    def test_duplicate_passive_keys_raise(self):
+        """Test that passive chart keys still need to be unique per run."""
+        figure = px.line(x=[1, 2], y=[3, 4])
+        st.plotly_chart(figure, key="duplicate_chart")
+
+        with pytest.raises(StreamlitDuplicateElementKey):
+            st.plotly_chart(figure, key="duplicate_chart")
+
+    def test_identical_interactive_unkeyed_charts_still_raise(self):
+        """Test that interactive widget identity behavior is unchanged."""
+        figure = px.line(x=[1, 2], y=[3, 4])
+        st.plotly_chart(figure, on_select="rerun")
+
+        with pytest.raises(StreamlitDuplicateElementId):
+            st.plotly_chart(figure, on_select="rerun")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Describe your changes

`st.plotly_chart` previously computed a content-derived widget id for *every* chart so that frontend state (zoom, pan, legend visibility, 3D camera) could survive a remount. This caused two problems: identical passive charts collided on the same id (duplicate-id errors), and state restoration was tied to the chart's content, so any data update reset the view.

- Interactive (selection-activated) charts keep their existing content-derived identity — no behavior change.
- **Keyed** passive charts now get a stable, key-based identity, so their frontend state is restored across an unmount/remount even when the data changes (pair with Plotly's `layout.uirevision`).
- **Unkeyed** passive charts get no id (positional identity), which fixes duplicate-id errors when the same figure is rendered multiple times.
- The frontend now tracks which backend spec produced the recovered figure and applies a changed spec to the existing Plotly instance in place, so `layout.uirevision` is honored across data updates.

**Behavior change:** unkeyed passive charts no longer restore frontend state across a remount. Pass `key=` to opt back in to state restoration.

## GitHub Issue Link (if applicable)

- Closes #11424
- Closes #8882
- Closes #8782

## Testing Plan

- **Python unit tests** — `lib/tests/streamlit/elements/plotly_chart_test.py`: identity for keyed/unkeyed/interactive charts, stable id across content changes, and duplicate key/id handling.
- **Frontend unit tests** — `frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx`: id-less read/write skip, recovered-state preservation, spec synchronization, and in-place spec updates.
- **E2E tests** — `e2e_playwright/st_plotly_chart_state_test.py`: identical unkeyed charts render, in-place data update without remount, and keyed chart frontend state restored after a genuine remount.
- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests