### PR TITLE
[feature] Add st.scatterplot_matrix_chart element

### DIFF
--- a/e2e_playwright/st_scatterplot_matrix_chart.py
+++ b/e2e_playwright/st_scatterplot_matrix_chart.py
@@ -1,0 +1,43 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+import streamlit as st
+
+rng = np.random.default_rng(0)
+num_points = 120
+df = pd.DataFrame(
+    {
+        "mpg": rng.normal(23, 8, num_points).round(1),
+        "horsepower": rng.normal(105, 40, num_points).round(0),
+        "weight": rng.normal(2970, 850, num_points).round(0),
+        "acceleration": rng.normal(15.5, 2.8, num_points).round(1),
+    }
+)
+df["name"] = [f"car {index}" for index in range(num_points)]
+
+st.header("Basic scatterplot matrix")
+st.scatterplot_matrix_chart(df, title="Cars", label="name")
+
+st.header("Scatterplot matrix with selections")
+event = st.scatterplot_matrix_chart(
+    df,
+    columns=["mpg", "horsepower", "weight"],
+    query_colors=["#e74c3c", "#2d7ff9"],
+    key="selectable_splom",
+    on_select="rerun",
+)
+st.markdown(f"Selected points: {len(event.selection.indices)}")

--- a/e2e_playwright/st_scatterplot_matrix_chart_test.py
+++ b/e2e_playwright/st_scatterplot_matrix_chart_test.py
@@ -1,0 +1,133 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import check_top_level_class, get_element_by_key
+
+# Fixed layout values replicated from the engine (getDetailLayout in
+# scatterplotMatrixEngine.ts). Only valid while the scene renders at
+# identity zoom (i.e. the content fits the canvas without scaling).
+_MATRIX_X = 64
+_MATRIX_Y = 74
+_CELL_GAP = 8
+_QUERY_PANEL_ROW_HEIGHT = 26
+
+
+def _get_canvas(app: Page, index: int) -> Locator:
+    return app.get_by_test_id("stScatterplotMatrixChartCanvas").nth(index)
+
+
+def _get_matrix_width(canvas_width: float, num_atts: int) -> float:
+    """Replicates the engine's layout to compute the small-plot matrix width."""
+    available = max(300.0, min(430.0, canvas_width * 0.42))
+    cell_size = min(
+        max(int((available - _CELL_GAP * (num_atts - 1)) // num_atts), 24), 56
+    )
+    return cell_size * num_atts + _CELL_GAP * (num_atts - 1)
+
+
+def _get_large_plot_rect(
+    canvas_width: float, canvas_height: float, num_atts: int
+) -> tuple[float, float, float]:
+    """Replicates the engine's layout to locate the large plot.
+
+    Returns (x, y, size) of the large detail plot in canvas coordinates.
+    """
+    large_x = _MATRIX_X + _get_matrix_width(canvas_width, num_atts) + 54
+    large_size = min(
+        max(min(canvas_width - large_x - 36, canvas_height - 150), 260), 430
+    )
+    return large_x, _MATRIX_Y, large_size
+
+
+def _get_clear_button_pos(
+    canvas_width: float, num_atts: int, num_layers: int
+) -> tuple[float, float]:
+    """Replicates the engine's layout to locate the "Clear All Queries" button.
+
+    Returns (x, y) of a point inside the button in canvas coordinates.
+    """
+    panel_y = _MATRIX_Y + _get_matrix_width(canvas_width, num_atts) + 24
+    panel_height = 32 + num_layers * _QUERY_PANEL_ROW_HEIGHT + 30
+    return _MATRIX_X + 20, panel_y + panel_height - 24
+
+
+def test_scatterplot_matrix_charts_render(app: Page):
+    """Both scatterplot matrix charts render a visible canvas."""
+    charts = app.get_by_test_id("stScatterplotMatrixChart")
+    expect(charts).to_have_count(2)
+    expect(_get_canvas(app, 0)).to_be_visible()
+    expect(_get_canvas(app, 1)).to_be_visible()
+
+
+def test_check_top_level_class(app: Page):
+    """The custom top level class is correctly set."""
+    check_top_level_class(app, "stScatterplotMatrixChart")
+
+
+def test_lasso_selection_triggers_rerun(app: Page):
+    """Lasso-selecting points in the large plot reruns the app with the
+    selected row indices, and clearing the queries resets the selection.
+    """
+    expect(app.get_by_text("Selected points: 0")).to_be_visible()
+
+    canvas = get_element_by_key(app, "selectable_splom").get_by_test_id(
+        "stScatterplotMatrixChartCanvas"
+    )
+    canvas.scroll_into_view_if_needed()
+    bounding_box = canvas.bounding_box()
+    assert bounding_box is not None
+
+    large_x, large_y, large_size = _get_large_plot_rect(
+        bounding_box["width"], bounding_box["height"], num_atts=3
+    )
+
+    def to_page(x: float, y: float) -> tuple[float, float]:
+        return bounding_box["x"] + x, bounding_box["y"] + y
+
+    # Lasso a rectangle covering most of the large plot (the first query
+    # layer is selected by default):
+    inset = 5
+    corners = [
+        (large_x + inset, large_y + inset),
+        (large_x + large_size - inset, large_y + inset),
+        (large_x + large_size - inset, large_y + large_size - inset),
+        (large_x + inset, large_y + large_size - inset),
+    ]
+    app.mouse.move(*to_page(*corners[0]))
+    app.mouse.down()
+    for corner_x, corner_y in corners[1:]:
+        # Move in small steps so the lasso path has enough points:
+        app.mouse.move(*to_page(corner_x, corner_y), steps=10)
+    app.mouse.up()
+    wait_for_app_run(app)
+
+    selection_text = app.get_by_text(re.compile(r"^Selected points: \d+$"))
+    expect(selection_text).to_be_visible()
+    expect(app.get_by_text("Selected points: 0")).not_to_be_visible()
+
+    # Click "Clear All Queries" at the bottom of the query panel:
+    clear_x, clear_y = to_page(
+        *_get_clear_button_pos(bounding_box["width"], num_atts=3, num_layers=2)
+    )
+    app.mouse.click(clear_x, clear_y)
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Selected points: 0")).to_be_visible()

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -55,6 +55,7 @@ import {
   PlotlyChart as PlotlyChartProto,
   Progress as ProgressProto,
   Radio as RadioProto,
+  ScatterplotMatrixChart as ScatterplotMatrixChartProto,
   Selectbox as SelectboxProto,
   Skeleton as SkeletonProto,
   Slider as SliderProto,
@@ -131,6 +132,10 @@ const PlotlyChart = lazy(
 )
 const Progress = lazy(
   () => import("~lib/components/elements/Progress/Progress")
+)
+const ScatterplotMatrixChart = lazy(
+  () =>
+    import("~lib/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart")
 )
 const Snow = lazy(() => import("~lib/components/elements/Snow/Snow"))
 const Spinner = lazy(() => import("~lib/components/elements/Spinner/Spinner"))
@@ -1102,6 +1107,24 @@ const RawElementNodeRenderer = (
           <PlotlyChart
             key={plotlyProto.id}
             element={plotlyProto}
+            {...widgetProps}
+          />
+        </ElementContainer>
+      )
+    }
+
+    case "scatterplotMatrixChart": {
+      const scatterplotMatrixProto = node.element
+        .scatterplotMatrixChart as ScatterplotMatrixChartProto
+      return (
+        <ElementContainer
+          node={node}
+          config={ElementContainerConfig.LARGE_ELEMENT}
+          isStale={isStale}
+        >
+          <ScatterplotMatrixChart
+            key={scatterplotMatrixProto.id}
+            element={scatterplotMatrixProto}
             {...widgetProps}
           />
         </ElementContainer>

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
@@ -36,6 +36,7 @@ const mockEngineInstances: Array<{
   options: ScatterplotMatrixEngineOptions
   dispose: ReturnType<typeof vi.fn>
   clearAllQueries: ReturnType<typeof vi.fn>
+  setDisabled: ReturnType<typeof vi.fn>
 }> = []
 
 vi.mock("./scatterplotMatrixEngine", async importOriginal => {
@@ -49,6 +50,8 @@ vi.mock("./scatterplotMatrixEngine", async importOriginal => {
       dispose = vi.fn()
 
       clearAllQueries = vi.fn()
+
+      setDisabled = vi.fn()
 
       constructor(options: ScatterplotMatrixEngineOptions) {
         this.options = options
@@ -269,6 +272,62 @@ describe("ScatterplotMatrixChart", () => {
     const canvas = screen.getByTestId("stScatterplotMatrixChartCanvas")
     expect(canvas).toHaveAttribute("tabindex", "-1")
     expect(canvas).toHaveStyle("pointer-events: none")
+    // The engine's own keyboard handling must also be turned off, not just
+    // the CSS/tabIndex (which don't affect an already-focused element):
+    expect(mockEngineInstances[0].setDisabled).toHaveBeenCalledWith(true)
+  })
+
+  it("blurs an already-focused canvas when it becomes disabled", () => {
+    const element = makeProto()
+    const widgetMgr = makeWidgetMgr()
+    // Reuse the same element/widgetMgr across the rerender (as a real app
+    // would across reruns) so only `disabled` changes and the existing
+    // engine is reused via setDisabled, instead of being torn down/rebuilt.
+    const { rerender } = render(
+      <ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />
+    )
+
+    const canvas = screen.getByTestId("stScatterplotMatrixChartCanvas")
+    act(() => canvas.focus())
+    expect(canvas).toHaveFocus()
+
+    rerender(
+      <ScatterplotMatrixChart
+        element={element}
+        widgetMgr={widgetMgr}
+        disabled
+      />
+    )
+
+    // tabIndex alone wouldn't remove focus from an already-focused element;
+    // the component must explicitly blur it so keydown events stop
+    // targeting the (now disabled) canvas.
+    expect(canvas).not.toHaveFocus()
+    expect(mockEngineInstances).toHaveLength(1)
+    expect(mockEngineInstances[0].setDisabled).toHaveBeenLastCalledWith(true)
+  })
+
+  it("does not blur the canvas when it remains enabled", () => {
+    const element = makeProto()
+    const widgetMgr = makeWidgetMgr()
+    const { rerender } = render(
+      <ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />
+    )
+
+    const canvas = screen.getByTestId("stScatterplotMatrixChartCanvas")
+    act(() => canvas.focus())
+    expect(canvas).toHaveFocus()
+
+    rerender(
+      <ScatterplotMatrixChart
+        element={element}
+        widgetMgr={widgetMgr}
+        disabled={false}
+      />
+    )
+
+    expect(canvas).toHaveFocus()
+    expect(mockEngineInstances).toHaveLength(1)
   })
 
   it("disposes the engine on unmount", () => {

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
@@ -15,7 +15,12 @@
  */
 
 import { act, screen } from "@testing-library/react"
-import { tableFromArrays, tableToIPC } from "apache-arrow"
+import {
+  Table,
+  tableFromArrays,
+  tableToIPC,
+  vectorFromArray,
+} from "apache-arrow"
 
 import { ScatterplotMatrixChart as ScatterplotMatrixChartProto } from "@streamlit/protobuf"
 
@@ -147,6 +152,25 @@ describe("extractChartData", () => {
       "third",
       "fourth",
     ])
+  })
+
+  it("skips rows with a null (missing) value instead of plotting it as zero", () => {
+    // Number(null) is 0, which is finite — a plain "is this finite" check
+    // would silently plot a missing value as zero, so nulls (e.g. a pandas
+    // NA in a nullable numeric column) need their own explicit check.
+    // tableFromArrays with a plain array doesn't preserve nulls in this
+    // arrow version, so the nullable column is built via vectorFromArray.
+    const table = new Table({
+      alpha: vectorFromArray([1, null, 3, 4]),
+      beta: vectorFromArray([10, 20, 30, 40]),
+    })
+    const quiverData = new Quiver({ data: tableToIPC(table) })
+
+    const { points } = extractChartData(quiverData, ["alpha", "beta"], "")
+
+    // Row 1 (alpha=null) must be skipped entirely, not kept with alpha
+    // coerced to 0:
+    expect(points.map(point => point.id)).toEqual([0, 2, 3])
   })
 })
 

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, screen } from "@testing-library/react"
+import { tableFromArrays, tableToIPC } from "apache-arrow"
+
+import { ScatterplotMatrixChart as ScatterplotMatrixChartProto } from "@streamlit/protobuf"
+
+import { Quiver } from "~lib/dataframes/Quiver"
+import { render } from "~lib/test_util"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import ScatterplotMatrixChart, {
+  extractChartData,
+  parseStoredSelection,
+} from "./ScatterplotMatrixChart"
+import type {
+  ScatterplotMatrixEngineOptions,
+  ScatterplotMatrixSelection,
+} from "./scatterplotMatrixEngine"
+
+const mockEngineInstances: Array<{
+  options: ScatterplotMatrixEngineOptions
+  dispose: ReturnType<typeof vi.fn>
+  clearAllQueries: ReturnType<typeof vi.fn>
+}> = []
+
+vi.mock("./scatterplotMatrixEngine", async importOriginal => {
+  const original =
+    await importOriginal<typeof import("./scatterplotMatrixEngine")>()
+  return {
+    ...original,
+    ScatterplotMatrixEngine: class {
+      options: ScatterplotMatrixEngineOptions
+
+      dispose = vi.fn()
+
+      clearAllQueries = vi.fn()
+
+      constructor(options: ScatterplotMatrixEngineOptions) {
+        this.options = options
+        mockEngineInstances.push(this)
+      }
+    },
+  }
+})
+
+function makeArrowData(): Uint8Array {
+  const table = tableFromArrays({
+    alpha: Float64Array.from([1, 2, Number.NaN, 4]),
+    beta: Float64Array.from([10, 20, 30, 40]),
+    name: ["first", "second", "third", "fourth"],
+  })
+  return tableToIPC(table)
+}
+
+function makeProto(
+  overrides: Partial<ScatterplotMatrixChartProto> = {}
+): ScatterplotMatrixChartProto {
+  return ScatterplotMatrixChartProto.create({
+    id: "chart_id",
+    data: { data: makeArrowData() },
+    columns: ["alpha", "beta"],
+    label: "",
+    title: "My matrix",
+    queryColors: [],
+    rollSpeed: 1,
+    selectionsActivated: false,
+    formId: "",
+    ...overrides,
+  })
+}
+
+function makeWidgetMgr(): WidgetStateManager {
+  return new WidgetStateManager({
+    sendRerunBackMsg: vi.fn(),
+    formsDataChanged: vi.fn(),
+  })
+}
+
+describe("extractChartData", () => {
+  it("extracts numeric rows and skips rows with non-finite values", () => {
+    const quiverData = new Quiver({ data: makeArrowData() })
+    const { attributes, points } = extractChartData(
+      quiverData,
+      ["alpha", "beta"],
+      ""
+    )
+
+    expect(attributes).toEqual(["alpha", "beta"])
+    // The third row contains NaN and must be skipped:
+    expect(points.map(point => point.id)).toEqual([0, 1, 3])
+    expect(points[0].atts).toEqual([1, 10])
+    // Without a label column, the positional row index is used:
+    expect(points.map(point => point.label)).toEqual(["0", "1", "3"])
+  })
+
+  it("uses the label column when provided", () => {
+    const quiverData = new Quiver({ data: makeArrowData() })
+    const { points } = extractChartData(quiverData, ["beta"], "name")
+
+    expect(points.map(point => point.label)).toEqual([
+      "first",
+      "second",
+      "third",
+      "fourth",
+    ])
+  })
+})
+
+describe("parseStoredSelection", () => {
+  it("parses per-layer indices from a stored widget state", () => {
+    const stored = JSON.stringify({
+      selection: {
+        indices: [1, 2],
+        query_layers: [
+          { label: "Query 1", indices: [1, 2] },
+          { label: "Query 2", indices: [] },
+        ],
+      },
+    })
+    expect(parseStoredSelection(stored, 4)).toEqual([[1, 2], []])
+  })
+
+  it("returns an empty selection for missing or invalid values", () => {
+    expect(parseStoredSelection(undefined, 4)).toEqual([])
+    expect(parseStoredSelection("not json", 4)).toEqual([])
+    expect(parseStoredSelection("{}", 4)).toEqual([])
+  })
+})
+
+describe("ScatterplotMatrixChart", () => {
+  beforeEach(() => {
+    mockEngineInstances.length = 0
+  })
+
+  it("renders a focusable canvas and initializes the engine", () => {
+    render(
+      <ScatterplotMatrixChart
+        element={makeProto()}
+        widgetMgr={makeWidgetMgr()}
+      />
+    )
+
+    expect(screen.getByTestId("stScatterplotMatrixChart")).toBeVisible()
+    const canvas = screen.getByTestId("stScatterplotMatrixChartCanvas")
+    expect(canvas).toHaveAttribute("tabindex", "0")
+    expect(canvas).toHaveAccessibleName("My matrix")
+
+    expect(mockEngineInstances).toHaveLength(1)
+    const { options } = mockEngineInstances[0]
+    expect(options.attributes).toEqual(["alpha", "beta"])
+    expect(options.points).toHaveLength(3)
+    expect(options.title).toBe("My matrix")
+    // Selections are not activated, so no selection listener is wired up:
+    expect(options.onSelectionChange).toBeUndefined()
+  })
+
+  it("sends the selection state to the widget manager", () => {
+    const widgetMgr = makeWidgetMgr()
+    const setStringValueSpy = vi.spyOn(widgetMgr, "setStringValue")
+    const element = makeProto({ selectionsActivated: true })
+
+    render(
+      <ScatterplotMatrixChart
+        element={element}
+        widgetMgr={widgetMgr}
+        fragmentId="my_fragment"
+      />
+    )
+
+    const { options } = mockEngineInstances[0]
+    expect(options.onSelectionChange).toBeDefined()
+
+    const selection: ScatterplotMatrixSelection = {
+      indices: [0, 1],
+      query_layers: [{ label: "Query 1", indices: [0, 1] }],
+    }
+    act(() => options.onSelectionChange?.(selection))
+
+    expect(setStringValueSpy).toHaveBeenCalledWith(
+      element,
+      JSON.stringify({ selection }),
+      { fromUi: true },
+      "my_fragment"
+    )
+  })
+
+  it("does not resend an unchanged selection state", () => {
+    const widgetMgr = makeWidgetMgr()
+    const element = makeProto({ selectionsActivated: true })
+
+    render(<ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />)
+
+    const { options } = mockEngineInstances[0]
+    const selection: ScatterplotMatrixSelection = {
+      indices: [2],
+      query_layers: [{ label: "Query 1", indices: [2] }],
+    }
+    act(() => options.onSelectionChange?.(selection))
+
+    const setStringValueSpy = vi.spyOn(widgetMgr, "setStringValue")
+    act(() => options.onSelectionChange?.(selection))
+    expect(setStringValueSpy).not.toHaveBeenCalled()
+  })
+
+  it("restores a stored selection on remount", () => {
+    const widgetMgr = makeWidgetMgr()
+    const element = makeProto({ selectionsActivated: true })
+    widgetMgr.setStringValue(
+      element,
+      JSON.stringify({
+        selection: {
+          indices: [1],
+          query_layers: [{ label: "Query 1", indices: [1] }],
+        },
+      }),
+      { fromUi: false },
+      undefined
+    )
+
+    render(<ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />)
+
+    const { options } = mockEngineInstances[0]
+    expect(options.initialSelection).toEqual([[1]])
+  })
+
+  it("persists and restores the navigation state across remounts", () => {
+    const widgetMgr = makeWidgetMgr()
+    const element = makeProto()
+
+    const { unmount } = render(
+      <ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />
+    )
+    const viewState = {
+      selectedPlot: { col: 1, row: 0 },
+      selectedQueryIndex: 2,
+      view: { zoom: 2, panX: -10, panY: 5, autoFit: false },
+    }
+    act(() => mockEngineInstances[0].options.onViewStateChange?.(viewState))
+    unmount()
+
+    render(<ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />)
+    expect(mockEngineInstances[1].options.initialViewState).toEqual(viewState)
+  })
+
+  it("blocks interactions when disabled", () => {
+    render(
+      <ScatterplotMatrixChart
+        element={makeProto()}
+        widgetMgr={makeWidgetMgr()}
+        disabled
+      />
+    )
+
+    const canvas = screen.getByTestId("stScatterplotMatrixChartCanvas")
+    expect(canvas).toHaveAttribute("tabindex", "-1")
+    expect(canvas).toHaveStyle("pointer-events: none")
+  })
+
+  it("disposes the engine on unmount", () => {
+    const { unmount } = render(
+      <ScatterplotMatrixChart
+        element={makeProto()}
+        widgetMgr={makeWidgetMgr()}
+      />
+    )
+    const instance = mockEngineInstances[0]
+    expect(instance.dispose).not.toHaveBeenCalled()
+    unmount()
+    expect(instance.dispose).toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx
@@ -39,6 +39,13 @@ const mockEngineInstances: Array<{
   setDisabled: ReturnType<typeof vi.fn>
 }> = []
 
+// A plain module-level `let` wouldn't be visible to the mock factory below:
+// vitest hoists vi.mock calls above regular imports/declarations, so the
+// factory needs vi.hoisted() to share mutable state with the test bodies.
+const { engineConstructionState } = vi.hoisted(() => ({
+  engineConstructionState: { shouldThrow: false },
+}))
+
 vi.mock("./scatterplotMatrixEngine", async importOriginal => {
   const original =
     await importOriginal<typeof import("./scatterplotMatrixEngine")>()
@@ -54,12 +61,31 @@ vi.mock("./scatterplotMatrixEngine", async importOriginal => {
       setDisabled = vi.fn()
 
       constructor(options: ScatterplotMatrixEngineOptions) {
+        if (engineConstructionState.shouldThrow) {
+          throw new Error("WebGL 2 is not supported in this browser.")
+        }
         this.options = options
         mockEngineInstances.push(this)
       }
     },
   }
 })
+
+let capturedFormClearListener: (() => void) | undefined
+
+vi.mock("~lib/components/widgets/Form/FormClearHelper", () => ({
+  FormClearHelper: class {
+    manageFormClearListener(
+      _widgetMgr: WidgetStateManager,
+      _formId: string,
+      listener: () => void
+    ): void {
+      capturedFormClearListener = listener
+    }
+
+    disconnect(): void {}
+  },
+}))
 
 function makeArrowData(): Uint8Array {
   const table = tableFromArrays({
@@ -135,19 +161,38 @@ describe("parseStoredSelection", () => {
         ],
       },
     })
-    expect(parseStoredSelection(stored, 4)).toEqual([[1, 2], []])
+    expect(parseStoredSelection(stored)).toEqual([[1, 2], []])
   })
 
   it("returns an empty selection for missing or invalid values", () => {
-    expect(parseStoredSelection(undefined, 4)).toEqual([])
-    expect(parseStoredSelection("not json", 4)).toEqual([])
-    expect(parseStoredSelection("{}", 4)).toEqual([])
+    expect(parseStoredSelection(undefined)).toEqual([])
+    expect(parseStoredSelection("not json")).toEqual([])
+    expect(parseStoredSelection("{}")).toEqual([])
+  })
+
+  it("does not truncate to any layer count", () => {
+    // Truncation (if the current query_colors is smaller) is the engine's
+    // job, not the parser's — see the "reconciles when a restored layer no
+    // longer exists" component test below.
+    const stored = JSON.stringify({
+      selection: {
+        indices: [1, 2, 3],
+        query_layers: [
+          { label: "Query 1", indices: [1] },
+          { label: "Query 2", indices: [2] },
+          { label: "Query 3", indices: [3] },
+        ],
+      },
+    })
+    expect(parseStoredSelection(stored)).toEqual([[1], [2], [3]])
   })
 })
 
 describe("ScatterplotMatrixChart", () => {
   beforeEach(() => {
     mockEngineInstances.length = 0
+    engineConstructionState.shouldThrow = false
+    capturedFormClearListener = undefined
   })
 
   it("renders a focusable canvas and initializes the engine", () => {
@@ -241,6 +286,38 @@ describe("ScatterplotMatrixChart", () => {
     expect(options.initialSelection).toEqual([[1]])
   })
 
+  it("passes a restored selection to the engine untruncated even when query_colors shrank", () => {
+    // The engine (not the wrapper) is responsible for reconciling a
+    // restored selection against the current layer count, so that it can
+    // also report the reconciled result back to Python. If the wrapper
+    // truncated here instead, the extra layers would be dropped from the
+    // engine's input without ever being written back to the widget state.
+    const widgetMgr = makeWidgetMgr()
+    const element = makeProto({
+      selectionsActivated: true,
+      queryColors: ["#ff0000"],
+    })
+    widgetMgr.setStringValue(
+      element,
+      JSON.stringify({
+        selection: {
+          indices: [1, 2],
+          query_layers: [
+            { label: "Query 1", indices: [1] },
+            { label: "Query 2", indices: [2] },
+          ],
+        },
+      }),
+      { fromUi: false },
+      undefined
+    )
+
+    render(<ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />)
+
+    const { options } = mockEngineInstances[0]
+    expect(options.initialSelection).toEqual([[1], [2]])
+  })
+
   it("persists and restores the navigation state across remounts", () => {
     const widgetMgr = makeWidgetMgr()
     const element = makeProto()
@@ -328,6 +405,64 @@ describe("ScatterplotMatrixChart", () => {
 
     expect(canvas).toHaveFocus()
     expect(mockEngineInstances).toHaveLength(1)
+  })
+
+  it("clears the engine's queries when the enclosing form is cleared", () => {
+    render(
+      <ScatterplotMatrixChart
+        element={makeProto({ selectionsActivated: true, formId: "my_form" })}
+        widgetMgr={makeWidgetMgr()}
+      />
+    )
+
+    expect(capturedFormClearListener).toBeDefined()
+    act(() => capturedFormClearListener?.())
+
+    expect(mockEngineInstances[0].clearAllQueries).toHaveBeenCalled()
+  })
+
+  it("resets the widget selection on form clear when the engine failed to initialize", () => {
+    engineConstructionState.shouldThrow = true
+    const widgetMgr = makeWidgetMgr()
+    const element = makeProto({
+      selectionsActivated: true,
+      formId: "my_form",
+      queryColors: ["#ff0000", "#00ff00"],
+    })
+    widgetMgr.setStringValue(
+      element,
+      JSON.stringify({
+        selection: {
+          indices: [1],
+          query_layers: [
+            { label: "Query 1", indices: [1] },
+            { label: "Query 2", indices: [] },
+          ],
+        },
+      }),
+      { fromUi: false },
+      undefined
+    )
+
+    render(<ScatterplotMatrixChart element={element} widgetMgr={widgetMgr} />)
+
+    // The engine failed to construct, so there's no mock instance to clear:
+    expect(mockEngineInstances).toHaveLength(0)
+    expect(capturedFormClearListener).toBeDefined()
+
+    act(() => capturedFormClearListener?.())
+
+    expect(widgetMgr.getStringValue(element)).toEqual(
+      JSON.stringify({
+        selection: {
+          indices: [],
+          query_layers: [
+            { label: "Query 1", indices: [] },
+            { label: "Query 2", indices: [] },
+          ],
+        },
+      })
+    )
   })
 
   it("disposes the engine on unmount", () => {

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  memo,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+import { getLogger } from "loglevel"
+
+import { ScatterplotMatrixChart as ScatterplotMatrixChartProto } from "@streamlit/protobuf"
+
+import ErrorElement from "~lib/components/shared/ErrorElement/ErrorElement"
+import { FormClearHelper } from "~lib/components/widgets/Form/FormClearHelper"
+import { Quiver } from "~lib/dataframes/Quiver"
+import { WidgetStateManager } from "~lib/WidgetStateManager"
+
+import {
+  DEFAULT_QUERY_COLORS,
+  ScatterplotMatrixEngine,
+  ScatterplotMatrixPoint,
+  ScatterplotMatrixSelection,
+  ScatterplotMatrixViewState,
+} from "./scatterplotMatrixEngine"
+import {
+  StyledScatterplotMatrixCanvas,
+  StyledScatterplotMatrixChart,
+} from "./styled-components"
+
+const LOG = getLogger("ScatterplotMatrixChart")
+
+export interface ScatterplotMatrixChartProps {
+  element: ScatterplotMatrixChartProto
+  widgetMgr: WidgetStateManager
+  disabled?: boolean
+  fragmentId?: string
+}
+
+/** Key under which the navigation/viewport state is stored in the element state. */
+const VIEW_STATE_KEY = "viewState"
+
+interface ChartData {
+  attributes: string[]
+  points: ScatterplotMatrixPoint[]
+}
+
+/**
+ * Extracts the matrix dimension values and point labels from the
+ * Arrow-serialized dataframe. Rows containing non-finite values in any
+ * dimension are skipped, but ids keep referencing the original positional
+ * row indices.
+ */
+export function extractChartData(
+  quiverData: Quiver,
+  columns: string[],
+  labelColumn: string
+): ChartData {
+  const { numDataRows, numDataColumns, numIndexColumns } =
+    quiverData.dimensions
+
+  const columnPositions = new Map<string, number>()
+  for (let colIndex = 0; colIndex < numDataColumns; colIndex += 1) {
+    const colPos = colIndex + numIndexColumns
+    columnPositions.set(String(quiverData.columnNames[0][colPos]), colPos)
+  }
+
+  const attributePositions = columns.map(column => columnPositions.get(column))
+  const labelPosition =
+    labelColumn !== "" ? columnPositions.get(labelColumn) : undefined
+
+  const points: ScatterplotMatrixPoint[] = []
+  for (let rowIndex = 0; rowIndex < numDataRows; rowIndex += 1) {
+    const atts: number[] = []
+    let isValid = true
+    for (const position of attributePositions) {
+      if (position === undefined) {
+        isValid = false
+        break
+      }
+      const { content } = quiverData.getCell(rowIndex, position)
+      const value = Number(content)
+      if (!Number.isFinite(value)) {
+        isValid = false
+        break
+      }
+      atts.push(value)
+    }
+    if (!isValid) {
+      continue
+    }
+    let label = String(rowIndex)
+    if (labelPosition !== undefined) {
+      const { content } = quiverData.getCell(rowIndex, labelPosition)
+      label = String(content ?? rowIndex)
+    }
+    points.push({ id: rowIndex, label, atts })
+  }
+
+  return { attributes: columns, points }
+}
+
+/** Parses the per-layer point ids from a stored widget selection state. */
+export function parseStoredSelection(
+  storedValue: string | undefined,
+  numLayers: number
+): number[][] {
+  if (!storedValue) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(storedValue)
+    const layers: unknown = parsed?.selection?.query_layers
+    if (!Array.isArray(layers)) {
+      return []
+    }
+    return layers
+      .slice(0, numLayers)
+      .map(layer =>
+        Array.isArray(layer?.indices)
+          ? layer.indices.filter((index: unknown) => typeof index === "number")
+          : []
+      )
+  } catch (error) {
+    LOG.warn("Failed to parse the stored selection state.", error)
+    return []
+  }
+}
+
+function ScatterplotMatrixChart({
+  element,
+  widgetMgr,
+  disabled,
+  fragmentId,
+}: Readonly<ScatterplotMatrixChartProps>): ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const engineRef = useRef<ScatterplotMatrixEngine | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+
+  const chartData = useMemo(
+    () =>
+      element.data
+        ? extractChartData(
+            new Quiver(element.data),
+            element.columns,
+            element.label
+          )
+        : { attributes: element.columns, points: [] },
+    [element.data, element.columns, element.label]
+  )
+
+  // The engine synchronizes an external system (a WebGL canvas with its own
+  // event handling and render loop), hence the imperative setup effect.
+  useEffect(() => {
+    if (canvasRef.current === null) {
+      return undefined
+    }
+
+    const numQueryLayers =
+      element.queryColors.length || DEFAULT_QUERY_COLORS.length
+    const initialSelection = element.selectionsActivated
+      ? parseStoredSelection(widgetMgr.getStringValue(element), numQueryLayers)
+      : []
+
+    let engine: ScatterplotMatrixEngine | null = null
+    try {
+      engine = new ScatterplotMatrixEngine({
+        canvas: canvasRef.current,
+        attributes: chartData.attributes,
+        points: chartData.points,
+        title: element.title,
+        queryColors: element.queryColors,
+        rollSpeed: element.rollSpeed || 1,
+        initialSelection,
+        // Keep navigation/zoom state across app reruns (which rebuild the
+        // engine): the element id is stable for identical inputs.
+        initialViewState:
+          widgetMgr.getElementState<ScatterplotMatrixViewState>(
+            element.id,
+            VIEW_STATE_KEY
+          ),
+        onViewStateChange: (viewState: ScatterplotMatrixViewState) =>
+          widgetMgr.setElementState(element.id, VIEW_STATE_KEY, viewState),
+        onSelectionChange: element.selectionsActivated
+          ? (selection: ScatterplotMatrixSelection) => {
+              const newValue = JSON.stringify({ selection })
+              if (widgetMgr.getStringValue(element) !== newValue) {
+                widgetMgr.setStringValue(
+                  element,
+                  newValue,
+                  { fromUi: true },
+                  fragmentId
+                )
+              }
+            }
+          : undefined,
+      })
+    } catch (engineError) {
+      LOG.error(
+        "Failed to initialize the scatterplot matrix engine.",
+        engineError
+      )
+      setError(
+        engineError instanceof Error
+          ? engineError
+          : new Error(String(engineError))
+      )
+      return undefined
+    }
+    engineRef.current = engine
+    setError(null)
+
+    return () => {
+      engineRef.current = null
+      engine?.dispose()
+    }
+  }, [element, widgetMgr, fragmentId, chartData])
+
+  // Reset all query layers when the enclosing form is cleared.
+  useEffect(() => {
+    if (!element.selectionsActivated || !element.formId) {
+      return undefined
+    }
+    const formClearHelper = new FormClearHelper()
+    formClearHelper.manageFormClearListener(widgetMgr, element.formId, () => {
+      engineRef.current?.clearAllQueries()
+    })
+    return () => formClearHelper.disconnect()
+  }, [element.selectionsActivated, element.formId, widgetMgr])
+
+  if (error !== null) {
+    return (
+      <ErrorElement
+        name="Scatterplot matrix chart error"
+        message={error.message}
+      />
+    )
+  }
+
+  return (
+    <StyledScatterplotMatrixChart
+      className="stScatterplotMatrixChart"
+      data-testid="stScatterplotMatrixChart"
+    >
+      <StyledScatterplotMatrixCanvas
+        ref={canvasRef}
+        isDisabled={disabled ?? false}
+        tabIndex={disabled ? -1 : 0}
+        aria-label={element.title || "Scatterplot matrix chart"}
+        data-testid="stScatterplotMatrixChartCanvas"
+      />
+    </StyledScatterplotMatrixChart>
+  )
+}
+
+export default memo(ScatterplotMatrixChart)

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
@@ -63,9 +63,10 @@ interface ChartData {
 
 /**
  * Extracts the matrix dimension values and point labels from the
- * Arrow-serialized dataframe. Rows containing non-finite values in any
- * dimension are skipped, but ids keep referencing the original positional
- * row indices.
+ * Arrow-serialized dataframe. Rows are skipped if any dimension is missing
+ * (Arrow null, e.g. a pandas NA in a nullable numeric column) or otherwise
+ * not a finite number, but ids keep referencing the original positional row
+ * indices.
  */
 export function extractChartData(
   quiverData: Quiver,
@@ -95,6 +96,13 @@ export function extractChartData(
         break
       }
       const { content } = quiverData.getCell(rowIndex, position)
+      // Number(null) is 0 (finite), so a missing value must be rejected
+      // explicitly before the numeric conversion below — otherwise an Arrow
+      // null is silently plotted as zero instead of skipping the row.
+      if (content === null || content === undefined) {
+        isValid = false
+        break
+      }
       const value = Number(content)
       if (!Number.isFinite(value)) {
         isValid = false

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
@@ -210,6 +210,7 @@ function ScatterplotMatrixChart({
               }
             }
           : undefined,
+        disabled: disabled ?? false,
       })
     } catch (engineError) {
       LOG.error(
@@ -230,6 +231,11 @@ function ScatterplotMatrixChart({
       engineRef.current = null
       engine?.dispose()
     }
+    // `disabled` is intentionally omitted: rebuilding the engine (and its
+    // WebGL context) just to toggle a boolean would be wasteful. The
+    // dedicated effect below keeps an existing engine's disabled state in
+    // sync via `setDisabled` instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [element, widgetMgr, fragmentId, chartData])
 
   // Reset all query layers when the enclosing form is cleared.
@@ -243,6 +249,18 @@ function ScatterplotMatrixChart({
     })
     return () => formClearHelper.disconnect()
   }, [element.selectionsActivated, element.formId, widgetMgr])
+
+  // Sync disabled state into the existing engine without rebuilding it (a
+  // full rebuild would recreate the WebGL context for a boolean flag). Also
+  // blur the canvas so an already-focused canvas can't keep receiving
+  // keyboard events after becoming disabled (tabIndex alone only prevents
+  // *future* focusing, it doesn't remove existing focus).
+  useEffect(() => {
+    engineRef.current?.setDisabled(disabled ?? false)
+    if (disabled) {
+      canvasRef.current?.blur()
+    }
+  }, [disabled])
 
   if (error !== null) {
     return (

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.tsx
@@ -116,10 +116,18 @@ export function extractChartData(
   return { attributes: columns, points }
 }
 
-/** Parses the per-layer point ids from a stored widget selection state. */
+/**
+ * Parses the per-layer point ids from a stored widget selection state.
+ *
+ * Deliberately does not truncate to the current query layer count: the
+ * engine consumes exactly as many leading entries as it has layers for
+ * (see its constructor) and treats any extra restored layers as part of
+ * the same reconciliation that already handles rows no longer present in
+ * the data, so a shrunk `query_colors` also gets written back correctly
+ * instead of leaving stale layers/indices in the widget state.
+ */
 export function parseStoredSelection(
-  storedValue: string | undefined,
-  numLayers: number
+  storedValue: string | undefined
 ): number[][] {
   if (!storedValue) {
     return []
@@ -130,13 +138,11 @@ export function parseStoredSelection(
     if (!Array.isArray(layers)) {
       return []
     }
-    return layers
-      .slice(0, numLayers)
-      .map(layer =>
-        Array.isArray(layer?.indices)
-          ? layer.indices.filter((index: unknown) => typeof index === "number")
-          : []
-      )
+    return layers.map(layer =>
+      Array.isArray(layer?.indices)
+        ? layer.indices.filter((index: unknown) => typeof index === "number")
+        : []
+    )
   } catch (error) {
     LOG.warn("Failed to parse the stored selection state.", error)
     return []
@@ -172,10 +178,8 @@ function ScatterplotMatrixChart({
       return undefined
     }
 
-    const numQueryLayers =
-      element.queryColors.length || DEFAULT_QUERY_COLORS.length
     const initialSelection = element.selectionsActivated
-      ? parseStoredSelection(widgetMgr.getStringValue(element), numQueryLayers)
+      ? parseStoredSelection(widgetMgr.getStringValue(element))
       : []
 
     let engine: ScatterplotMatrixEngine | null = null
@@ -245,10 +249,39 @@ function ScatterplotMatrixChart({
     }
     const formClearHelper = new FormClearHelper()
     formClearHelper.manageFormClearListener(widgetMgr, element.formId, () => {
-      engineRef.current?.clearAllQueries()
+      if (engineRef.current) {
+        engineRef.current.clearAllQueries()
+        return
+      }
+      // The engine failed to initialize (e.g. WebGL 2 unavailable), so
+      // there's no canvas selection to clear — but the widget's stored
+      // selection must still reset like any other form field would.
+      const numQueryLayers =
+        element.queryColors.length || DEFAULT_QUERY_COLORS.length
+      const emptySelection: ScatterplotMatrixSelection = {
+        indices: [],
+        query_layers: Array.from({ length: numQueryLayers }, (_, index) => ({
+          label: `Query ${index + 1}`,
+          indices: [],
+        })),
+      }
+      const newValue = JSON.stringify({ selection: emptySelection })
+      if (widgetMgr.getStringValue(element) !== newValue) {
+        widgetMgr.setStringValue(
+          element,
+          newValue,
+          { fromUi: true },
+          fragmentId
+        )
+      }
     })
     return () => formClearHelper.disconnect()
-  }, [element.selectionsActivated, element.formId, widgetMgr])
+    // Depend on the full `element` (not just individual fields): the
+    // fallback branch above reads/writes widget state keyed by
+    // `element.id`, which changes whenever any marshalled parameter does
+    // (see compute_and_register_element_id), so a stale `element` closure
+    // here could read or write the wrong widget's state.
+  }, [element, widgetMgr, fragmentId])
 
   // Sync disabled state into the existing engine without rebuilding it (a
   // full rebuild would recreate the WebGL context for a boolean flag). Also

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.test.ts
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.test.ts
@@ -17,7 +17,35 @@
 import {
   buildNavigationSteps,
   pointInPolygon,
+  reconcileSelectionIds,
 } from "./scatterplotMatrixEngine"
+
+describe("reconcileSelectionIds", () => {
+  it("keeps ids that are still present and reports no reconciliation", () => {
+    const pointIds = new Set([1, 2, 3])
+    expect(reconcileSelectionIds([1, 3], pointIds)).toEqual({
+      keptIds: [1, 3],
+      wasReconciled: false,
+    })
+  })
+
+  it("drops ids that are no longer present and reports reconciliation", () => {
+    // E.g. a row that used to be selected but now has a non-finite value in
+    // one of the matrix dimensions and was excluded from `points`.
+    const pointIds = new Set([1, 3])
+    expect(reconcileSelectionIds([1, 2, 3], pointIds)).toEqual({
+      keptIds: [1, 3],
+      wasReconciled: true,
+    })
+  })
+
+  it("handles an empty restored selection", () => {
+    expect(reconcileSelectionIds([], new Set([1, 2]))).toEqual({
+      keptIds: [],
+      wasReconciled: false,
+    })
+  })
+})
 
 describe("buildNavigationSteps", () => {
   it("returns no steps when source and target are the same", () => {

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.test.ts
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  buildNavigationSteps,
+  pointInPolygon,
+} from "./scatterplotMatrixEngine"
+
+describe("buildNavigationSteps", () => {
+  it("returns no steps when source and target are the same", () => {
+    expect(
+      buildNavigationSteps({ col: 2, row: 3 }, { col: 2, row: 3 })
+    ).toEqual([])
+  })
+
+  it("rolls one axis at a time towards the target", () => {
+    expect(
+      buildNavigationSteps({ col: 0, row: 0 }, { col: 2, row: 0 })
+    ).toEqual([
+      { col: 1, row: 0, axis: "x" },
+      { col: 2, row: 0, axis: "x" },
+    ])
+  })
+
+  it("rolls rows first only when the column distance is greater", () => {
+    const rowsFirst = buildNavigationSteps(
+      { col: 0, row: 0 },
+      { col: 3, row: 1 }
+    )
+    // Column distance (3) > row distance (1), so row steps come first:
+    expect(rowsFirst).toEqual([
+      { col: 0, row: 1, axis: "y" },
+      { col: 1, row: 1, axis: "x" },
+      { col: 2, row: 1, axis: "x" },
+      { col: 3, row: 1, axis: "x" },
+    ])
+
+    const columnsFirst = buildNavigationSteps(
+      { col: 0, row: 0 },
+      { col: 1, row: 2 }
+    )
+    expect(columnsFirst).toEqual([
+      { col: 1, row: 0, axis: "x" },
+      { col: 1, row: 1, axis: "y" },
+      { col: 1, row: 2, axis: "y" },
+    ])
+  })
+
+  it("supports moving towards smaller indices", () => {
+    expect(
+      buildNavigationSteps({ col: 2, row: 1 }, { col: 0, row: 1 })
+    ).toEqual([
+      { col: 1, row: 1, axis: "x" },
+      { col: 0, row: 1, axis: "x" },
+    ])
+  })
+})
+
+describe("pointInPolygon", () => {
+  const square = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ]
+
+  it("detects points inside the polygon", () => {
+    expect(pointInPolygon(5, 5, square)).toBe(true)
+  })
+
+  it("detects points outside the polygon", () => {
+    expect(pointInPolygon(15, 5, square)).toBe(false)
+    expect(pointInPolygon(-1, 5, square)).toBe(false)
+  })
+
+  it("handles concave polygons", () => {
+    const concave = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 5, y: 5 },
+      { x: 0, y: 10 },
+    ]
+    // Inside the notch, outside the polygon:
+    expect(pointInPolygon(5, 8, concave)).toBe(false)
+    expect(pointInPolygon(2, 2, concave)).toBe(true)
+  })
+})

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.ts
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.ts
@@ -79,6 +79,8 @@ export interface ScatterplotMatrixEngineOptions {
   /** Navigation/viewport state used to restore a previous engine instance. */
   initialViewState?: ScatterplotMatrixViewState
   onViewStateChange?: (viewState: ScatterplotMatrixViewState) => void
+  /** When true, keyboard shortcuts are ignored. See {@link ScatterplotMatrixEngine.setDisabled}. */
+  disabled?: boolean
 }
 
 interface Point {
@@ -257,6 +259,8 @@ export class ScatterplotMatrixEngine {
 
   private disposed = false
 
+  private disabled = false
+
   // Pre-baked static labels atlas. The title/axis labels never change
   // frame-to-frame within a given layout, so we rasterize them once into
   // this canvas and blit the result as a single textured quad until the
@@ -278,6 +282,7 @@ export class ScatterplotMatrixEngine {
       `${options.points.length} points • left-click a small plot to jump` +
       ` • right-click to roll • lasso the large plot to select`
     this.onSelectionChange = options.onSelectionChange ?? null
+    this.disabled = options.disabled ?? false
     this.labelAtlasCanvas = document.createElement("canvas")
     const atlasCtx = this.labelAtlasCanvas.getContext("2d")
     if (atlasCtx === null) {
@@ -305,16 +310,27 @@ export class ScatterplotMatrixEngine {
       ? options.queryColors
       : DEFAULT_QUERY_COLORS
     const pointIds = new Set(this.points.map(point => point.id))
-    this.queries = colors.map((color, index) => ({
-      index,
-      color,
-      label: `Query ${index + 1}`,
-      members: new Set(
-        (options.initialSelection?.[index] ?? []).filter(id =>
-          pointIds.has(id)
-        )
-      ),
-    }))
+    // Ids from a restored selection can be missing from `this.points` when a
+    // row that used to be selected no longer has finite values in every
+    // matrix dimension (see extractChartData). Track whether that happened
+    // so the reconciled (shrunk) selection is reported back to Python below,
+    // instead of leaving stale ids in the widget state indefinitely.
+    let selectionWasReconciled = false
+    this.queries = colors.map((color, index) => {
+      const { keptIds, wasReconciled } = reconcileSelectionIds(
+        options.initialSelection?.[index] ?? [],
+        pointIds
+      )
+      if (wasReconciled) {
+        selectionWasReconciled = true
+      }
+      return {
+        index,
+        color,
+        label: `Query ${index + 1}`,
+        members: new Set(keptIds),
+      }
+    })
     this.selectedQueryIndex = 0
 
     this.selectedPlot = { col: 0, row: Math.max(0, numAtts - 1) }
@@ -327,6 +343,10 @@ export class ScatterplotMatrixEngine {
     this.view = this.computeDetailFit()
     this.restoreViewState(options.initialViewState)
     this.render()
+
+    if (selectionWasReconciled) {
+      this.emitSelection()
+    }
   }
 
   /** Restores navigation/viewport state from a previous engine instance. */
@@ -368,6 +388,19 @@ export class ScatterplotMatrixEngine {
   setRollSpeed(speed: number): void {
     const safe = Number.isFinite(speed) && speed > 0 ? speed : 1
     this.rollFrames = Math.max(1, Math.round(ROLL_FRAMES_DEFAULT / safe))
+  }
+
+  /**
+   * Toggles whether keyboard shortcuts are handled. Pointer interactions are
+   * already blocked via `pointer-events: none` on the disabled canvas, but
+   * that alone doesn't affect an element that was focused *before* becoming
+   * disabled — the browser keeps delivering keydown events to it since
+   * `tabIndex={-1}` doesn't blur an already-focused element. The caller is
+   * expected to also blur the canvas on this transition (belt and suspenders
+   * against any focus that persists or gets restored).
+   */
+  setDisabled(disabled: boolean): void {
+    this.disabled = disabled
   }
 
   getSelection(): ScatterplotMatrixSelection {
@@ -542,6 +575,9 @@ export class ScatterplotMatrixEngine {
     )
 
     const onKeyDown = (event: KeyboardEvent): void => {
+      if (this.disabled) {
+        return
+      }
       let handled = true
       if (event.key === "ArrowUp") {
         this.moveSelectedPlot(0, -1)
@@ -966,6 +1002,14 @@ export class ScatterplotMatrixEngine {
   }
 
   private moveSelectedPlot(deltaX: number, deltaY: number): void {
+    // Mirror the right-click "roll to" rule (see handlePointerUp): don't
+    // start a new route while one is still animating. Without this, a key
+    // repeat mid-roll would replace pendingSteps relative to the *pending*
+    // destination while the in-flight step keeps animating toward its own
+    // target, producing a visibly discontinuous path.
+    if (this.hasActiveAnimation()) {
+      return
+    }
     const maxIndex = this.attributes.length - 1
     this.startNavigationToPlot({
       col: clamp(this.selectedPlot.col + deltaX, 0, maxIndex),
@@ -2934,6 +2978,21 @@ function drawQuadStrip(
     triangles.push([last - 2, 1, 0])
   }
   renderer.polygonFromTriangulation(pts, triangles, fillColor)
+}
+
+/**
+ * Filters a restored query layer's point ids down to those still present in
+ * the current dataset (e.g. after a row was excluded for having a
+ * non-finite value in a matrix dimension), and reports whether anything was
+ * dropped so the caller can push the reconciled selection back to Python
+ * instead of leaving stale ids in the widget state.
+ */
+export function reconcileSelectionIds(
+  restoredIds: number[],
+  pointIds: ReadonlySet<number>
+): { keptIds: number[]; wasReconciled: boolean } {
+  const keptIds = restoredIds.filter(id => pointIds.has(id))
+  return { keptIds, wasReconciled: keptIds.length !== restoredIds.length }
 }
 
 export function buildNavigationSteps(

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.ts
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.ts
@@ -1,0 +1,3022 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Canvas/WebGL engine for the scatterplot matrix navigation chart.
+ *
+ * This is a generic port of the "Scatterplot Matrix Navigation"
+ * visualization: a scatterplot matrix (SPLOM) with an attached large detail
+ * plot that can be navigated by jumping (left-click) or by "rolling" through
+ * neighboring plots with an animated transition (right-click / arrow keys),
+ * plus persistent lasso query layers and an excentric label lens.
+ */
+
+/* eslint-disable streamlit-custom/no-hardcoded-theme-values --
+ * All chrome is painted onto a WebGL canvas with a fixed light "paper"
+ * palette (matching the original visualization design); Emotion theme
+ * tokens are not applicable to canvas drawing. */
+
+/* eslint-disable streamlit-custom/no-force-reflow-access --
+ * The engine must measure the canvas inside pointer/touch/resize handlers
+ * to map event coordinates into canvas space; the reads are event-driven
+ * and not part of a render loop. */
+
+export interface ScatterplotMatrixPoint {
+  /** Positional row index in the user-provided data. */
+  id: number
+  /** Label shown in the excentric label lens. */
+  label: string
+  /** One numeric value per matrix attribute. */
+  atts: number[]
+}
+
+interface ScatterplotMatrixQueryLayerSelection {
+  label: string
+  indices: number[]
+}
+
+export interface ScatterplotMatrixSelection {
+  indices: number[]
+  query_layers: ScatterplotMatrixQueryLayerSelection[]
+}
+
+/**
+ * Navigation and viewport state that survives engine rebuilds (e.g. app
+ * reruns): the selected plot, the active query layer, and the zoom/pan view.
+ */
+export interface ScatterplotMatrixViewState {
+  selectedPlot: { col: number; row: number }
+  selectedQueryIndex: number
+  view: { zoom: number; panX: number; panY: number; autoFit: boolean }
+}
+
+export interface ScatterplotMatrixEngineOptions {
+  canvas: HTMLCanvasElement
+  /** Names of the matrix dimensions (N x N cells). */
+  attributes: string[]
+  points: ScatterplotMatrixPoint[]
+  title?: string
+  /** One CSS color per query layer. */
+  queryColors?: string[]
+  /** Speed multiplier for the rolling animation. */
+  rollSpeed?: number
+  /** Per-layer point ids used to restore a previous selection. */
+  initialSelection?: number[][]
+  onSelectionChange?: (selection: ScatterplotMatrixSelection) => void
+  /** Navigation/viewport state used to restore a previous engine instance. */
+  initialViewState?: ScatterplotMatrixViewState
+  onViewStateChange?: (viewState: ScatterplotMatrixViewState) => void
+}
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface PlotCoords {
+  col: number
+  row: number
+}
+
+interface QueryLayer {
+  index: number
+  color: string
+  label: string
+  members: Set<number>
+}
+
+interface DetailView {
+  zoom: number
+  panX: number
+  panY: number
+  autoFit: boolean
+}
+
+interface DetailLayout {
+  matrixX: number
+  matrixY: number
+  cellSize: number
+  gap: number
+  matrixWidth: number
+  largePlot: Rect
+  queryPanel: Rect
+}
+
+interface RollAnimation {
+  fromPlot: PlotCoords
+  toPlot: PlotCoords
+  axis: "x" | "y"
+  frame: number
+  frames: number
+}
+
+interface RollStep extends PlotCoords {
+  axis: "x" | "y"
+}
+
+interface LensCandidate {
+  point: ScatterplotMatrixPoint
+  x: number
+  y: number
+  distance: number
+}
+
+interface ProjectedPoint {
+  point: ScatterplotMatrixPoint
+  coords: Point
+}
+
+interface LayerCoordinate extends Point {
+  id: number
+}
+
+type RGBA = [number, number, number, number]
+
+export const DEFAULT_QUERY_COLORS = [
+  "#e74c3c",
+  "#f39c12",
+  "#2d7ff9",
+  "#2bb673",
+]
+
+const LENS_SIZE = 56
+const MAX_LENS_LABELS = 14
+const ROLL_FRAMES_DEFAULT = 10
+const CLICK_DRAG_TOLERANCE = 4
+const QUERY_PANEL_ROW_HEIGHT = 26
+
+// The chart keeps its light "paper" styling in both Streamlit themes; its
+// ~35 plot/label colors are tuned for a light artboard.
+const FRAME_COLOR = "#f7f3ec"
+const TITLE_FONT = "600 22px Georgia"
+const BODY_FONT_FAMILY = "'Avenir Next', 'Trebuchet MS', sans-serif"
+
+export class ScatterplotMatrixEngine {
+  private readonly canvas: HTMLCanvasElement
+
+  private readonly renderer: WebGLRenderer
+
+  private readonly attributes: string[]
+
+  private readonly points: ScatterplotMatrixPoint[]
+
+  private readonly title: string
+
+  private readonly subtitle: string
+
+  private readonly minAtt: number[]
+
+  private readonly maxAtt: number[]
+
+  private readonly queries: QueryLayer[]
+
+  private readonly onSelectionChange:
+    | ((selection: ScatterplotMatrixSelection) => void)
+    | null
+
+  private readonly onViewStateChange:
+    | ((viewState: ScatterplotMatrixViewState) => void)
+    | null
+
+  private selectedPlot: PlotCoords
+
+  private selectedQueryIndex: number
+
+  private hoverPlot: PlotCoords | null = null
+
+  private pathPreview: { from: PlotCoords; to: PlotCoords } | null = null
+
+  private pendingSteps: RollStep[] = []
+
+  private animation: RollAnimation | null = null
+
+  private readonly lens = { active: false, x: 0, y: 0 }
+
+  private lasso: Point[] | null = null
+
+  private view: DetailView = { zoom: 1, panX: 0, panY: 0, autoFit: true }
+
+  private layout: DetailLayout
+
+  private dragState:
+    | {
+        type: "pointer"
+        button: number
+        startX: number
+        startY: number
+        moved: boolean
+      }
+    | { type: "lasso"; points: Point[]; queryIndex: number }
+    | null = null
+
+  private touchState:
+    | {
+        type: "pinch"
+        startDist: number
+        startZoom: number
+        centerX: number
+        centerY: number
+        startPan: Point
+      }
+    | {
+        type: "single"
+        startX: number
+        startY: number
+        moved: boolean
+        startPan: Point
+      }
+    | { type: "lasso"; points: Point[]; queryIndex: number }
+    | { type: "consumed" }
+    | null = null
+
+  private rollFrames = ROLL_FRAMES_DEFAULT
+
+  private renderQueued = false
+
+  private disposers: Array<() => void> = []
+
+  private disposed = false
+
+  // Pre-baked static labels atlas. The title/axis labels never change
+  // frame-to-frame within a given layout, so we rasterize them once into
+  // this canvas and blit the result as a single textured quad until the
+  // layout signature changes.
+  private readonly labelAtlasCanvas: HTMLCanvasElement
+
+  private readonly labelAtlasCtx: CanvasRenderingContext2D
+
+  private labelAtlasSig: string | null = null
+
+  constructor(options: ScatterplotMatrixEngineOptions) {
+    this.canvas = options.canvas
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- the renderer class is co-located below the engine
+    this.renderer = new WebGLRenderer(options.canvas)
+    this.attributes = options.attributes
+    this.points = options.points
+    this.title = options.title ?? ""
+    this.subtitle =
+      `${options.points.length} points • left-click a small plot to jump` +
+      ` • right-click to roll • lasso the large plot to select`
+    this.onSelectionChange = options.onSelectionChange ?? null
+    this.labelAtlasCanvas = document.createElement("canvas")
+    const atlasCtx = this.labelAtlasCanvas.getContext("2d")
+    if (atlasCtx === null) {
+      throw new Error("Could not create a 2D canvas context.")
+    }
+    this.labelAtlasCtx = atlasCtx
+
+    const numAtts = this.attributes.length
+    this.minAtt = Array.from(
+      { length: numAtts },
+      () => Number.POSITIVE_INFINITY
+    )
+    this.maxAtt = Array.from(
+      { length: numAtts },
+      () => Number.NEGATIVE_INFINITY
+    )
+    for (const point of this.points) {
+      for (let i = 0; i < numAtts; i += 1) {
+        this.minAtt[i] = Math.min(this.minAtt[i], point.atts[i])
+        this.maxAtt[i] = Math.max(this.maxAtt[i], point.atts[i])
+      }
+    }
+
+    const colors = options.queryColors?.length
+      ? options.queryColors
+      : DEFAULT_QUERY_COLORS
+    const pointIds = new Set(this.points.map(point => point.id))
+    this.queries = colors.map((color, index) => ({
+      index,
+      color,
+      label: `Query ${index + 1}`,
+      members: new Set(
+        (options.initialSelection?.[index] ?? []).filter(id =>
+          pointIds.has(id)
+        )
+      ),
+    }))
+    this.selectedQueryIndex = 0
+
+    this.selectedPlot = { col: 0, row: Math.max(0, numAtts - 1) }
+    this.setRollSpeed(options.rollSpeed ?? 1)
+    this.onViewStateChange = options.onViewStateChange ?? null
+
+    this.layout = this.getDetailLayout()
+    this.bindEvents()
+    this.resizeCanvas()
+    this.view = this.computeDetailFit()
+    this.restoreViewState(options.initialViewState)
+    this.render()
+  }
+
+  /** Restores navigation/viewport state from a previous engine instance. */
+  private restoreViewState(
+    viewState: ScatterplotMatrixViewState | undefined
+  ): void {
+    if (viewState === undefined) {
+      return
+    }
+    const maxIndex = this.attributes.length - 1
+    this.selectedPlot = {
+      col: clamp(Math.round(viewState.selectedPlot.col), 0, maxIndex),
+      row: clamp(Math.round(viewState.selectedPlot.row), 0, maxIndex),
+    }
+    this.selectedQueryIndex = clamp(
+      Math.round(viewState.selectedQueryIndex),
+      0,
+      this.queries.length - 1
+    )
+    // Auto-fitted views are recomputed for the current canvas size; only a
+    // manually zoomed/panned view is restored verbatim.
+    if (
+      !viewState.view.autoFit &&
+      Number.isFinite(viewState.view.zoom) &&
+      viewState.view.zoom > 0
+    ) {
+      this.view = { ...viewState.view }
+    }
+  }
+
+  private persistViewState(): void {
+    this.onViewStateChange?.({
+      selectedPlot: { ...this.selectedPlot },
+      selectedQueryIndex: this.selectedQueryIndex,
+      view: { ...this.view },
+    })
+  }
+
+  setRollSpeed(speed: number): void {
+    const safe = Number.isFinite(speed) && speed > 0 ? speed : 1
+    this.rollFrames = Math.max(1, Math.round(ROLL_FRAMES_DEFAULT / safe))
+  }
+
+  getSelection(): ScatterplotMatrixSelection {
+    const union = new Set<number>()
+    const queryLayers = this.queries.map(layer => {
+      const indices = Array.from(layer.members).sort((a, b) => a - b)
+      indices.forEach(id => union.add(id))
+      return { label: layer.label, indices }
+    })
+    return {
+      indices: Array.from(union).sort((a, b) => a - b),
+      query_layers: queryLayers,
+    }
+  }
+
+  clearAllQueries(): void {
+    let hadMembers = false
+    for (const layer of this.queries) {
+      if (layer.members.size > 0) {
+        hadMembers = true
+      }
+      layer.members.clear()
+    }
+    this.scheduleRender()
+    if (hadMembers) {
+      this.emitSelection()
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true
+    for (const disposer of this.disposers) {
+      try {
+        disposer()
+      } catch {
+        // Ignore disposal errors.
+      }
+    }
+    this.disposers = []
+    // Free GPU resources — the canvas (and its WebGL context) outlives the
+    // engine across app reruns, so leaked programs/textures would accumulate.
+    this.renderer.dispose()
+  }
+
+  private emitSelection(): void {
+    this.onSelectionChange?.(this.getSelection())
+  }
+
+  // --- Event binding -------------------------------------------------------
+
+  private bindEvents(): void {
+    const resizeObserver = new ResizeObserver(() => {
+      this.resizeCanvas()
+      this.scheduleRender()
+    })
+    resizeObserver.observe(this.canvas)
+    this.disposers.push(() => resizeObserver.disconnect())
+
+    const onMouseMove = (event: MouseEvent): void => {
+      const point = this.getCanvasPoint(event)
+      if (
+        this.dragState?.type === "pointer" &&
+        !this.dragState.moved &&
+        distanceBetween(
+          point.x,
+          point.y,
+          this.dragState.startX,
+          this.dragState.startY
+        ) > CLICK_DRAG_TOLERANCE
+      ) {
+        this.dragState.moved = true
+      }
+      this.handleDetailMove(point)
+    }
+    this.canvas.addEventListener("mousemove", onMouseMove)
+    this.disposers.push(() =>
+      this.canvas.removeEventListener("mousemove", onMouseMove)
+    )
+
+    const onMouseLeave = (): void => {
+      // Cancel an in-progress lasso so it doesn't keep growing when the
+      // button is released outside the canvas.
+      if (this.dragState?.type === "lasso") {
+        this.dragState = null
+        this.lasso = null
+      }
+      this.lens.active = false
+      this.hoverPlot = null
+      this.pathPreview = null
+      this.scheduleRender()
+    }
+    this.canvas.addEventListener("mouseleave", onMouseLeave)
+    this.disposers.push(() =>
+      this.canvas.removeEventListener("mouseleave", onMouseLeave)
+    )
+
+    const onMouseDown = (event: MouseEvent): void => {
+      this.canvas.focus()
+      const point = this.getCanvasPoint(event)
+      if (event.button === 0) {
+        const layoutPoint = this.screenToLayout(point)
+        const hit = this.getQueryPanelHit(layoutPoint)
+        if (hit !== null) {
+          this.dragState = null
+          this.handleQueryPanelHit(hit)
+          return
+        }
+        const largeRect = this.layout.largePlot
+        if (
+          pointInRect(layoutPoint, largeRect) &&
+          !this.hasActiveAnimation()
+        ) {
+          this.dragState = {
+            type: "lasso",
+            points: [layoutPoint],
+            queryIndex: this.selectedQueryIndex,
+          }
+          this.lasso = [layoutPoint]
+          this.lens.active = false
+          this.scheduleRender()
+          return
+        }
+      }
+      this.dragState = {
+        type: "pointer",
+        button: event.button,
+        startX: point.x,
+        startY: point.y,
+        moved: false,
+      }
+    }
+    this.canvas.addEventListener("mousedown", onMouseDown)
+    this.disposers.push(() =>
+      this.canvas.removeEventListener("mousedown", onMouseDown)
+    )
+
+    const onMouseUp = (event: MouseEvent): void => {
+      const point = this.getCanvasPoint(event)
+      if (this.dragState?.type === "lasso") {
+        if (this.dragState.points.length > 2) {
+          this.applyLassoSelection(
+            this.dragState.queryIndex,
+            this.dragState.points
+          )
+        }
+        this.dragState = null
+        this.lasso = null
+        this.scheduleRender()
+        return
+      }
+      const dragState = this.dragState
+      this.dragState = null
+      if (
+        dragState?.type === "pointer" &&
+        dragState.button === event.button &&
+        !dragState.moved
+      ) {
+        this.handlePointerUp(point, event.button)
+      }
+    }
+    this.canvas.addEventListener("mouseup", onMouseUp)
+    this.disposers.push(() =>
+      this.canvas.removeEventListener("mouseup", onMouseUp)
+    )
+
+    const onContextMenu = (event: Event): void => {
+      event.preventDefault()
+    }
+    this.canvas.addEventListener("contextmenu", onContextMenu)
+    this.disposers.push(() =>
+      this.canvas.removeEventListener("contextmenu", onContextMenu)
+    )
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      let handled = true
+      if (event.key === "ArrowUp") {
+        this.moveSelectedPlot(0, -1)
+      } else if (event.key === "ArrowDown") {
+        this.moveSelectedPlot(0, 1)
+      } else if (event.key === "ArrowLeft") {
+        this.moveSelectedPlot(-1, 0)
+      } else if (event.key === "ArrowRight") {
+        this.moveSelectedPlot(1, 0)
+      } else if (event.key.toLowerCase() === "r") {
+        this.clearAllQueries()
+      } else {
+        handled = false
+      }
+      if (handled) {
+        event.preventDefault()
+        this.scheduleRender()
+      }
+    }
+    this.canvas.addEventListener("keydown", onKeyDown)
+    this.disposers.push(() =>
+      this.canvas.removeEventListener("keydown", onKeyDown)
+    )
+
+    this.bindTouchEvents()
+  }
+
+  private bindTouchEvents(): void {
+    const getTouchPoint = (touch: Touch): Point => {
+      const rect = this.canvas.getBoundingClientRect()
+      return { x: touch.clientX - rect.left, y: touch.clientY - rect.top }
+    }
+
+    const onTouchStart = (event: TouchEvent): void => {
+      // We fully own touch gestures over the canvas; prevent the browser
+      // from scrolling/zooming the page and from synthesizing duplicate
+      // mouse events.
+      event.preventDefault()
+      this.canvas.focus()
+      const touches = event.touches
+
+      if (touches.length === 2) {
+        const a = getTouchPoint(touches[0])
+        const b = getTouchPoint(touches[1])
+        this.touchState = {
+          type: "pinch",
+          startDist: Math.max(1, distanceBetween(a.x, a.y, b.x, b.y)),
+          startZoom: this.view.zoom,
+          centerX: (a.x + b.x) / 2,
+          centerY: (a.y + b.y) / 2,
+          startPan: { x: this.view.panX, y: this.view.panY },
+        }
+        return
+      }
+
+      if (touches.length !== 1) {
+        return
+      }
+
+      const point = getTouchPoint(touches[0])
+      const layoutPoint = this.screenToLayout(point)
+      const hit = this.getQueryPanelHit(layoutPoint)
+      if (hit !== null) {
+        this.handleQueryPanelHit(hit)
+        this.touchState = { type: "consumed" }
+        return
+      }
+      if (
+        pointInRect(layoutPoint, this.layout.largePlot) &&
+        !this.hasActiveAnimation()
+      ) {
+        this.touchState = {
+          type: "lasso",
+          points: [layoutPoint],
+          queryIndex: this.selectedQueryIndex,
+        }
+        this.lasso = [layoutPoint]
+        this.lens.active = false
+        this.scheduleRender()
+        return
+      }
+
+      this.touchState = {
+        type: "single",
+        startX: point.x,
+        startY: point.y,
+        moved: false,
+        startPan: { x: this.view.panX, y: this.view.panY },
+      }
+    }
+
+    const onTouchMove = (event: TouchEvent): void => {
+      if (this.touchState === null) {
+        return
+      }
+      event.preventDefault()
+      const touches = event.touches
+
+      if (this.touchState.type === "pinch" && touches.length >= 2) {
+        const a = getTouchPoint(touches[0])
+        const b = getTouchPoint(touches[1])
+        const dist = Math.max(1, distanceBetween(a.x, a.y, b.x, b.y))
+        const nextZoom = clamp(
+          this.touchState.startZoom * (dist / this.touchState.startDist),
+          0.3,
+          6
+        )
+        this.zoomAround(
+          nextZoom,
+          this.touchState.centerX,
+          this.touchState.centerY,
+          this.touchState.startPan,
+          this.touchState.startZoom
+        )
+        return
+      }
+
+      if (touches.length !== 1) {
+        return
+      }
+      const point = getTouchPoint(touches[0])
+
+      if (this.touchState.type === "single") {
+        const dx = point.x - this.touchState.startX
+        const dy = point.y - this.touchState.startY
+        if (
+          !this.touchState.moved &&
+          Math.hypot(dx, dy) > CLICK_DRAG_TOLERANCE
+        ) {
+          this.touchState.moved = true
+        }
+        // One-finger drag pans the scene (more useful on touch than the
+        // desktop hover lens).
+        this.view = {
+          ...this.view,
+          panX: this.touchState.startPan.x + dx,
+          panY: this.touchState.startPan.y + dy,
+          autoFit: false,
+        }
+        this.persistViewState()
+        this.scheduleRender()
+        return
+      }
+
+      if (this.touchState.type === "lasso") {
+        this.touchState.points.push(this.screenToLayout(point))
+        this.lasso = this.touchState.points
+        this.scheduleRender()
+      }
+    }
+
+    const onTouchEnd = (event: TouchEvent): void => {
+      const state = this.touchState
+      if (state === null) {
+        return
+      }
+
+      if (state.type === "lasso") {
+        if (state.points.length > 2) {
+          this.applyLassoSelection(state.queryIndex, state.points)
+        }
+        this.lasso = null
+        this.scheduleRender()
+      } else if (state.type === "single" && !state.moved) {
+        const layoutPoint = this.screenToLayout({
+          x: state.startX,
+          y: state.startY,
+        })
+        const plot = this.getMatrixPlotAt(layoutPoint)
+        if (plot !== null) {
+          this.jumpToPlot(plot)
+        }
+      }
+
+      // Keep panning fluid when one finger lifts after a two-finger gesture.
+      if (event.touches.length === 1) {
+        const point = getTouchPoint(event.touches[0])
+        this.touchState = {
+          type: "single",
+          startX: point.x,
+          startY: point.y,
+          moved: true,
+          startPan: { x: this.view.panX, y: this.view.panY },
+        }
+      } else if (event.touches.length === 0) {
+        this.touchState = null
+      }
+    }
+
+    this.canvas.addEventListener("touchstart", onTouchStart, {
+      passive: false,
+    })
+    this.canvas.addEventListener("touchmove", onTouchMove, { passive: false })
+    this.canvas.addEventListener("touchend", onTouchEnd, { passive: false })
+    this.canvas.addEventListener("touchcancel", onTouchEnd, { passive: false })
+    this.disposers.push(() => {
+      this.canvas.removeEventListener("touchstart", onTouchStart)
+      this.canvas.removeEventListener("touchmove", onTouchMove)
+      this.canvas.removeEventListener("touchend", onTouchEnd)
+      this.canvas.removeEventListener("touchcancel", onTouchEnd)
+    })
+  }
+
+  // --- View handling -------------------------------------------------------
+
+  private resizeCanvas(): void {
+    const width = Math.max(280, Math.floor(this.canvas.clientWidth))
+    const height = Math.max(280, Math.floor(this.canvas.clientHeight))
+    if (this.canvas.width !== width) {
+      this.canvas.width = width
+    }
+    if (this.canvas.height !== height) {
+      this.canvas.height = height
+    }
+    this.renderer.resize(width, height)
+    // Keep the scene fitted to the new size unless the user has taken
+    // manual control of the zoom.
+    if (this.view.autoFit) {
+      this.view = this.computeDetailFit()
+    }
+  }
+
+  /** Re-zoom the scene around a focal screen point, keeping it put. */
+  private zoomAround(
+    nextZoom: number,
+    screenX: number,
+    screenY: number,
+    startPan: Point,
+    startZoom: number
+  ): void {
+    const layoutX = (screenX - startPan.x) / startZoom
+    const layoutY = (screenY - startPan.y) / startZoom
+    this.view = {
+      zoom: nextZoom,
+      panX: screenX - layoutX * nextZoom,
+      panY: screenY - layoutY * nextZoom,
+      autoFit: false,
+    }
+    this.persistViewState()
+    this.scheduleRender()
+  }
+
+  /**
+   * Bounds of everything drawn in the scene, in layout (pre-view)
+   * coordinates, so the view can be fit to the canvas.
+   */
+  private contentBounds(): {
+    left: number
+    top: number
+    width: number
+    height: number
+  } {
+    const layout = this.getDetailLayout()
+    const right = Math.max(
+      layout.largePlot.x + layout.largePlot.width,
+      layout.matrixX + layout.matrixWidth
+    )
+    const bottom = Math.max(
+      layout.matrixY + layout.matrixWidth,
+      layout.largePlot.y + layout.largePlot.height,
+      layout.queryPanel.y + layout.queryPanel.height
+    )
+    const margin = 20
+    return {
+      left: 20,
+      top: 20,
+      width: right + margin - 20,
+      height: bottom + margin - 20,
+    }
+  }
+
+  /**
+   * Fit the scene to the canvas. When it already fits at 1:1, keep the
+   * identity transform so the layout is pixel-identical.
+   */
+  private computeDetailFit(): DetailView {
+    const bounds = this.contentBounds()
+    const fitZoom = Math.min(
+      1,
+      this.canvas.width / bounds.width,
+      this.canvas.height / bounds.height
+    )
+    if (fitZoom >= 1) {
+      return { zoom: 1, panX: 0, panY: 0, autoFit: true }
+    }
+    return {
+      zoom: fitZoom,
+      panX:
+        (this.canvas.width - bounds.width * fitZoom) / 2 -
+        bounds.left * fitZoom,
+      panY:
+        (this.canvas.height - bounds.height * fitZoom) / 2 -
+        bounds.top * fitZoom,
+      autoFit: true,
+    }
+  }
+
+  /**
+   * Map a screen-space pointer position into layout space, undoing the
+   * current zoom/pan so all hit-testing stays in untransformed coordinates.
+   */
+  private screenToLayout(point: Point): Point {
+    return {
+      x: (point.x - this.view.panX) / this.view.zoom,
+      y: (point.y - this.view.panY) / this.view.zoom,
+    }
+  }
+
+  private getCanvasPoint(event: MouseEvent): Point {
+    const rect = this.canvas.getBoundingClientRect()
+    return { x: event.clientX - rect.left, y: event.clientY - rect.top }
+  }
+
+  private getDetailLayout(): DetailLayout {
+    const width = this.canvas.width || 1
+    const height = this.canvas.height || 1
+    const numAtts = this.attributes.length
+    const matrixX = 64
+    const matrixY = 74
+    const gap = 8
+    const availableMatrixWidth = Math.max(300, Math.min(430, width * 0.42))
+    const cellSize = clamp(
+      Math.floor((availableMatrixWidth - gap * (numAtts - 1)) / numAtts),
+      24,
+      56
+    )
+    const matrixWidth = cellSize * numAtts + gap * (numAtts - 1)
+    const largeX = matrixX + matrixWidth + 54
+    const largeSize = clamp(
+      Math.min(width - largeX - 36, height - 150),
+      260,
+      430
+    )
+    return {
+      matrixX,
+      matrixY,
+      cellSize,
+      gap,
+      matrixWidth,
+      largePlot: {
+        x: largeX,
+        y: matrixY,
+        width: largeSize,
+        height: largeSize,
+      },
+      queryPanel: {
+        x: matrixX,
+        y: matrixY + matrixWidth + 24,
+        width: matrixWidth,
+        height: 32 + this.queries.length * QUERY_PANEL_ROW_HEIGHT + 30,
+      },
+    }
+  }
+
+  // --- Navigation ----------------------------------------------------------
+
+  private hasActiveAnimation(): boolean {
+    return this.animation !== null || this.pendingSteps.length > 0
+  }
+
+  private jumpToPlot(targetPlot: PlotCoords): void {
+    if (samePlot(targetPlot, this.selectedPlot)) {
+      return
+    }
+    this.selectedPlot = { ...targetPlot }
+    this.pendingSteps = []
+    this.animation = null
+    this.pathPreview = null
+    this.lens.active = false
+    this.persistViewState()
+    this.scheduleRender()
+  }
+
+  private startNavigationToPlot(targetPlot: PlotCoords): void {
+    if (samePlot(targetPlot, this.selectedPlot)) {
+      return
+    }
+    this.pendingSteps = buildNavigationSteps(this.selectedPlot, targetPlot)
+    this.pathPreview = null
+    this.lens.active = false
+    if (this.pendingSteps.length === 0) {
+      return
+    }
+    if (this.animation === null) {
+      this.beginNextAnimation()
+    }
+    this.scheduleRender()
+  }
+
+  private beginNextAnimation(): boolean {
+    const nextStep = this.pendingSteps.shift()
+    if (nextStep === undefined) {
+      return false
+    }
+    const fromPlot = { ...this.selectedPlot }
+    this.selectedPlot = { col: nextStep.col, row: nextStep.row }
+    this.animation = {
+      fromPlot,
+      toPlot: { ...this.selectedPlot },
+      axis: nextStep.axis,
+      frame: 0,
+      frames: this.rollFrames,
+    }
+    this.persistViewState()
+    return true
+  }
+
+  private advanceAnimation(): boolean {
+    if (this.animation === null) {
+      return false
+    }
+    this.animation.frame += 1
+    if (this.animation.frame < this.animation.frames) {
+      return true
+    }
+    this.animation = null
+    if (this.pendingSteps.length > 0) {
+      this.beginNextAnimation()
+      return true
+    }
+    return false
+  }
+
+  private moveSelectedPlot(deltaX: number, deltaY: number): void {
+    const maxIndex = this.attributes.length - 1
+    this.startNavigationToPlot({
+      col: clamp(this.selectedPlot.col + deltaX, 0, maxIndex),
+      row: clamp(this.selectedPlot.row + deltaY, 0, maxIndex),
+    })
+  }
+
+  // --- Pointer handling ----------------------------------------------------
+
+  private handleDetailMove(point: Point): void {
+    const layoutPoint = this.screenToLayout(point)
+    if (this.dragState?.type === "lasso") {
+      this.dragState.points.push(layoutPoint)
+      this.lasso = this.dragState.points.slice()
+      this.scheduleRender()
+      return
+    }
+
+    const hoverPlot = this.getMatrixPlotAt(layoutPoint)
+    this.hoverPlot = hoverPlot
+    if (
+      !this.hasActiveAnimation() &&
+      hoverPlot !== null &&
+      !samePlot(hoverPlot, this.selectedPlot)
+    ) {
+      this.pathPreview = { from: this.selectedPlot, to: hoverPlot }
+    } else {
+      this.pathPreview = null
+    }
+
+    if (
+      !this.hasActiveAnimation() &&
+      pointInRect(layoutPoint, this.layout.largePlot)
+    ) {
+      this.lens.active = true
+      this.lens.x = layoutPoint.x
+      this.lens.y = layoutPoint.y
+    } else {
+      this.lens.active = false
+    }
+    this.scheduleRender()
+  }
+
+  private handlePointerUp(point: Point, button: number): void {
+    const layoutPoint = this.screenToLayout(point)
+    const plot = this.getMatrixPlotAt(layoutPoint)
+    if (plot === null) {
+      return
+    }
+    if (button === 0) {
+      this.jumpToPlot(plot)
+    } else if (button === 2 && !this.hasActiveAnimation()) {
+      this.startNavigationToPlot(plot)
+    }
+  }
+
+  private getMatrixPlotAt(point: Point): PlotCoords | null {
+    const { matrixX, matrixY, cellSize, gap } = this.layout
+    const numAtts = this.attributes.length
+    const pitch = cellSize + gap
+    const x = point.x - matrixX
+    const y = point.y - matrixY
+    if (x < 0 || y < 0) {
+      return null
+    }
+    const col = Math.floor(x / pitch)
+    const row = Math.floor(y / pitch)
+    if (col < 0 || row < 0 || col >= numAtts || row >= numAtts) {
+      return null
+    }
+    if (x - col * pitch > cellSize || y - row * pitch > cellSize) {
+      return null
+    }
+    return { col, row }
+  }
+
+  private getQueryPanelHit(
+    point: Point
+  ): { type: "layer"; index: number } | { type: "clear" } | null {
+    const panel = this.layout.queryPanel
+    if (!pointInRect(point, panel)) {
+      return null
+    }
+    for (let index = 0; index < this.queries.length; index += 1) {
+      const top = panel.y + 32 + index * QUERY_PANEL_ROW_HEIGHT
+      if (
+        point.x >= panel.x + 10 &&
+        point.x <= panel.x + panel.width - 10 &&
+        point.y >= top - 14 &&
+        point.y <= top + 8
+      ) {
+        return { type: "layer", index }
+      }
+    }
+    const clearTop = panel.y + panel.height - 24
+    if (
+      point.x >= panel.x + 10 &&
+      point.x <= panel.x + panel.width - 10 &&
+      point.y >= clearTop - 14 &&
+      point.y <= clearTop + 6
+    ) {
+      return { type: "clear" }
+    }
+    return null
+  }
+
+  private handleQueryPanelHit(
+    hit: { type: "layer"; index: number } | { type: "clear" }
+  ): void {
+    if (hit.type === "clear") {
+      this.clearAllQueries()
+      return
+    }
+    this.selectedQueryIndex = hit.index
+    this.persistViewState()
+    this.scheduleRender()
+  }
+
+  private applyLassoSelection(queryIndex: number, points: Point[]): void {
+    const layer = this.queries[queryIndex]
+    layer.members.clear()
+    const rect = this.layout.largePlot
+    for (const point of this.points) {
+      const coords = this.projectToRect(
+        this.selectedPlot.col,
+        this.selectedPlot.row,
+        rect,
+        point
+      )
+      if (pointInPolygon(coords.x, coords.y, points)) {
+        layer.members.add(point.id)
+      }
+    }
+    this.emitSelection()
+  }
+
+  // --- Projection ----------------------------------------------------------
+
+  private projectToRect(
+    col: number,
+    row: number,
+    rect: Rect,
+    point: ScatterplotMatrixPoint
+  ): Point {
+    return projectPointToRect(
+      point.atts[col],
+      this.minAtt[col],
+      this.maxAtt[col],
+      point.atts[row],
+      this.minAtt[row],
+      this.maxAtt[row],
+      rect
+    )
+  }
+
+  private projectAxisDistance(
+    value: number,
+    min: number,
+    max: number,
+    edge: number
+  ): number {
+    const range = max - min
+    if (range === 0) {
+      return edge / 2
+    }
+    return ((value - min) / range) * edge
+  }
+
+  // --- Rendering -----------------------------------------------------------
+
+  private scheduleRender(): void {
+    if (this.renderQueued) {
+      return
+    }
+    this.renderQueued = true
+    window.requestAnimationFrame(() => {
+      this.renderQueued = false
+      if (!this.disposed) {
+        this.render()
+      }
+    })
+  }
+
+  private render(): void {
+    this.renderer.beginFrame(parseColor(FRAME_COLOR))
+    // Scale/translate the whole scene (matrix, large plot, labels, query
+    // panel) uniformly so it can be zoomed and panned on small screens.
+    this.renderer.setViewTransform(
+      this.view.zoom,
+      this.view.panX,
+      this.view.panY
+    )
+    this.layout = this.getDetailLayout()
+    // Keep the pre-baked label atlas in sync before drawing so the in-canvas
+    // label positions match the current layout on the very first frame.
+    this.ensureLabelAtlas(this.layout)
+    this.drawMatrix(this.layout)
+    this.drawQueryPanel(this.layout)
+    if (!this.hasActiveAnimation() && this.pathPreview !== null) {
+      this.drawPathPreview(this.layout, this.pathPreview)
+    }
+    // Blit the static labels (header + matrix axes + large-plot axes) as one
+    // textured quad. Must happen before drawLargePlot so the dynamic lens
+    // overlay (drawn inside drawLargePlot) stays on top.
+    this.renderer.blitCanvasAtlas(
+      "detail-labels",
+      this.labelAtlasSig ?? "",
+      this.labelAtlasCanvas,
+      0,
+      0
+    )
+    this.drawLargePlot(this.layout)
+    if (this.advanceAnimation()) {
+      this.scheduleRender()
+    }
+  }
+
+  private ensureLabelAtlas(layout: DetailLayout): void {
+    const width = this.canvas.width
+    const height = this.canvas.height
+    const selected = this.selectedPlot
+    const animating = this.hasActiveAnimation()
+    // Signature captures every input that affects a static label's pixels or
+    // position. If any of these change we repaint the atlas canvas.
+    const sig = [
+      width,
+      height,
+      this.title,
+      this.points.length,
+      layout.matrixX,
+      layout.matrixY,
+      layout.cellSize,
+      layout.gap,
+      layout.largePlot.x,
+      layout.largePlot.y,
+      layout.largePlot.width,
+      layout.largePlot.height,
+      selected.col,
+      selected.row,
+      animating ? 1 : 0,
+    ].join("|")
+    if (this.labelAtlasSig === sig) {
+      return
+    }
+    const canvas = this.labelAtlasCanvas
+    if (canvas.width !== width) {
+      canvas.width = width
+    }
+    if (canvas.height !== height) {
+      canvas.height = height
+    }
+    const ctx = this.labelAtlasCtx
+    ctx.clearRect(0, 0, width, height)
+    ctx.textBaseline = "alphabetic"
+    ctx.textAlign = "left"
+
+    // Header title + subtitle.
+    let subtitleY = 34
+    if (this.title !== "") {
+      ctx.font = TITLE_FONT
+      ctx.fillStyle = "#1f2b28"
+      ctx.fillText(this.title, layout.matrixX, 34)
+      subtitleY = 54
+    }
+    ctx.font = `13px ${BODY_FONT_FAMILY}`
+    ctx.fillStyle = "rgba(86, 104, 102, 0.95)"
+    ctx.fillText(this.subtitle, layout.matrixX, subtitleY)
+
+    // Matrix column labels (top row) and row labels (left column).
+    ctx.font = `8px ${BODY_FONT_FAMILY}`
+    ctx.fillStyle = "rgba(27, 39, 36, 0.84)"
+    for (let i = 0; i < this.attributes.length; i += 1) {
+      const colRect = getMatrixCellRect(layout, i, 0)
+      ctx.fillText(this.attributes[i], colRect.x, colRect.y - 4)
+    }
+    for (let i = 0; i < this.attributes.length; i += 1) {
+      const rowRect = getMatrixCellRect(layout, 0, i)
+      const label = this.attributes[i]
+      const textWidth = ctx.measureText(label).width
+      ctx.fillText(
+        label,
+        rowRect.x - textWidth - 4,
+        rowRect.y + rowRect.height / 2 + 3
+      )
+    }
+
+    // Large-plot axis labels — only static when not mid-animation (the
+    // rolling animation doesn't render axis labels at all).
+    if (!animating) {
+      const rect = layout.largePlot
+      ctx.font = `600 12px ${BODY_FONT_FAMILY}`
+      ctx.fillStyle = "#23302e"
+      ctx.textAlign = "center"
+      ctx.fillText(
+        this.attributes[selected.col],
+        rect.x + rect.width / 2,
+        rect.y + rect.height + 24
+      )
+      ctx.save()
+      ctx.translate(rect.x - 30, rect.y + rect.height / 2)
+      ctx.rotate(-Math.PI / 2)
+      ctx.fillText(this.attributes[selected.row], 0, 0)
+      ctx.restore()
+      ctx.textAlign = "left"
+    }
+    this.labelAtlasSig = sig
+  }
+
+  private drawMatrix(layout: DetailLayout): void {
+    const numAtts = this.attributes.length
+    // Pass 1: cell chrome (background, border) per cell.
+    for (let row = 0; row < numAtts; row += 1) {
+      for (let col = 0; col < numAtts; col += 1) {
+        this.drawSmallPlotChrome(col, row, getMatrixCellRect(layout, col, row))
+      }
+    }
+    // Pass 2: scatter dots across ALL cells in a single batched draw call.
+    const dotPoints: Point[] = []
+    for (let row = 0; row < numAtts; row += 1) {
+      for (let col = 0; col < numAtts; col += 1) {
+        const rect = getMatrixCellRect(layout, col, row)
+        for (const point of this.points) {
+          dotPoints.push(this.projectToRect(col, row, rect, point))
+        }
+      }
+    }
+    this.renderer.batchFillRects(dotPoints, 1.4, parseColor("#182321"))
+  }
+
+  private drawSmallPlotChrome(col: number, row: number, rect: Rect): void {
+    const isSelected =
+      this.selectedPlot.col === col && this.selectedPlot.row === row
+    const isAttainable =
+      (this.selectedPlot.col === col || this.selectedPlot.row === row) &&
+      !isSelected
+    const isHovered =
+      this.hoverPlot?.col === col && this.hoverPlot?.row === row
+    let fill = "rgba(32, 43, 41, 0.08)"
+    if (isSelected) {
+      fill = "rgba(228, 87, 72, 0.24)"
+    } else if (isAttainable) {
+      fill = "rgba(31, 146, 115, 0.18)"
+    }
+    if (isHovered) {
+      fill = "rgba(52, 97, 190, 0.18)"
+    }
+    this.renderer.fillRect(
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      parseColor(fill)
+    )
+    this.renderer.strokeRect(
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      parseColor("rgba(42, 53, 52, 0.25)")
+    )
+  }
+
+  private drawPathPreview(
+    layout: DetailLayout,
+    preview: { from: PlotCoords; to: PlotCoords }
+  ): void {
+    const start = getMatrixCellCenter(
+      layout,
+      preview.from.col,
+      preview.from.row
+    )
+    const end = getMatrixCellCenter(layout, preview.to.col, preview.to.row)
+    const color = parseColor("rgba(60, 80, 78, 0.7)")
+    if (Math.abs(start.x - end.x) > Math.abs(start.y - end.y)) {
+      this.renderer.dashedLine(start.x, start.y, start.x, end.y, color)
+      this.renderer.dashedLine(start.x, end.y, end.x, end.y, color)
+    } else {
+      this.renderer.dashedLine(start.x, start.y, end.x, start.y, color)
+      this.renderer.dashedLine(end.x, start.y, end.x, end.y, color)
+    }
+  }
+
+  private drawLargePlot(layout: DetailLayout): void {
+    const rect = layout.largePlot
+    if (this.animation !== null) {
+      this.drawRollingLargePlot(rect, this.animation)
+      return
+    }
+    this.renderer.fillRect(
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      parseColor("rgba(40, 54, 54, 0.08)")
+    )
+    this.renderer.strokeRect(
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      parseColor("rgba(30, 39, 39, 0.24)")
+    )
+    // Axis lines only — the x/y text labels are baked into the label atlas.
+    const axisColor = parseColor("rgba(35, 45, 43, 0.28)")
+    this.renderer.line(
+      rect.x,
+      rect.y + rect.height,
+      rect.x + rect.width,
+      rect.y + rect.height,
+      axisColor
+    )
+    this.renderer.line(rect.x, rect.y, rect.x, rect.y + rect.height, axisColor)
+
+    const projectedPoints = this.collectProjectedPoints(point =>
+      this.projectToRect(
+        this.selectedPlot.col,
+        this.selectedPlot.row,
+        rect,
+        point
+      )
+    )
+    const layerCoordinates = this.buildLayerCoordinates(projectedPoints)
+    this.drawLayerPointHighlights(layerCoordinates)
+    const lensCandidates: LensCandidate[] = []
+    const dotColor = parseColor("#101a18")
+    const dotCenters: Point[] = []
+    for (let i = 0; i < projectedPoints.length; i += 1) {
+      const { point, coords } = projectedPoints[i]
+      dotCenters.push(coords)
+      if (
+        this.lens.active &&
+        Math.abs(coords.x - this.lens.x) <= LENS_SIZE / 2 &&
+        Math.abs(coords.y - this.lens.y) <= LENS_SIZE / 2
+      ) {
+        lensCandidates.push({
+          point,
+          x: coords.x,
+          y: coords.y,
+          distance: distanceBetween(
+            coords.x,
+            coords.y,
+            this.lens.x,
+            this.lens.y
+          ),
+        })
+      }
+    }
+    this.renderer.batchDiscs(dotCenters, 2.3, dotColor)
+
+    this.drawQuerySelectionOverlays(layerCoordinates)
+
+    if (this.lasso !== null && this.lasso.length > 1) {
+      this.renderer.polyline(
+        this.lasso,
+        parseColor(this.queries[this.selectedQueryIndex].color)
+      )
+    }
+
+    if (this.lens.active) {
+      this.drawLensOverlay(lensCandidates, rect)
+    }
+  }
+
+  private drawRollingLargePlot(rect: Rect, animation: RollAnimation): void {
+    const progress = (animation.frame + 1) / animation.frames
+    const rotation = progress * (Math.PI / 2)
+    const sine = Math.sin(rotation)
+    const cosine = Math.cos(rotation)
+    const fillColor = parseColor("rgba(40, 54, 54, 0.08)")
+    const strokeColor = parseColor("rgba(30, 39, 39, 0.24)")
+    const dotColor = parseColor("#101a18")
+
+    if (animation.axis === "y") {
+      const animatedHeight = rect.height * (sine + cosine)
+      const top = rect.y + rect.height / 2 - animatedHeight / 2
+      this.renderer.fillRect(
+        rect.x,
+        top,
+        rect.width,
+        animatedHeight,
+        fillColor
+      )
+      this.renderer.strokeRect(
+        rect.x,
+        top,
+        rect.width,
+        animatedHeight,
+        strokeColor
+      )
+      const projectedPoints = this.collectProjectedPoints(point => {
+        const x = this.projectAxisDistance(
+          point.atts[animation.toPlot.col],
+          this.minAtt[animation.toPlot.col],
+          this.maxAtt[animation.toPlot.col],
+          rect.width
+        )
+        const nextY = this.projectAxisDistance(
+          point.atts[animation.toPlot.row],
+          this.minAtt[animation.toPlot.row],
+          this.maxAtt[animation.toPlot.row],
+          rect.height
+        )
+        const previousY = this.projectAxisDistance(
+          point.atts[animation.fromPlot.row],
+          this.minAtt[animation.fromPlot.row],
+          this.maxAtt[animation.fromPlot.row],
+          rect.height
+        )
+        const blendedY = previousY * cosine + nextY * sine
+        return { x: rect.x + x, y: top + animatedHeight - blendedY }
+      })
+      const layerCoordinates = this.buildLayerCoordinates(projectedPoints)
+      this.drawLayerPointHighlights(layerCoordinates)
+      this.renderer.batchDiscs(
+        projectedPoints.map(p => p.coords),
+        2.3,
+        dotColor
+      )
+      this.drawQuerySelectionOverlays(layerCoordinates)
+
+      const foldHeight =
+        Math.sin(Math.PI / 4 - rotation) * rect.height * Math.SQRT2
+      const midY = rect.y + rect.height / 2
+      const rightX = rect.x + rect.width
+      this.renderer.lineSegments(
+        [
+          {
+            x1: rect.x,
+            y1: midY - foldHeight / 2,
+            x2: rightX,
+            y2: midY - foldHeight / 2,
+          },
+          {
+            x1: rect.x,
+            y1: midY + foldHeight / 2,
+            x2: rightX,
+            y2: midY + foldHeight / 2,
+          },
+        ],
+        strokeColor
+      )
+    } else {
+      const animatedWidth = rect.width * (sine + cosine)
+      const left = rect.x + rect.width / 2 - animatedWidth / 2
+      this.renderer.fillRect(
+        left,
+        rect.y,
+        animatedWidth,
+        rect.height,
+        fillColor
+      )
+      this.renderer.strokeRect(
+        left,
+        rect.y,
+        animatedWidth,
+        rect.height,
+        strokeColor
+      )
+      const projectedPoints = this.collectProjectedPoints(point => {
+        const previousX = this.projectAxisDistance(
+          point.atts[animation.fromPlot.col],
+          this.minAtt[animation.fromPlot.col],
+          this.maxAtt[animation.fromPlot.col],
+          rect.width
+        )
+        const nextX = this.projectAxisDistance(
+          point.atts[animation.toPlot.col],
+          this.minAtt[animation.toPlot.col],
+          this.maxAtt[animation.toPlot.col],
+          rect.width
+        )
+        const y = this.projectAxisDistance(
+          point.atts[animation.toPlot.row],
+          this.minAtt[animation.toPlot.row],
+          this.maxAtt[animation.toPlot.row],
+          rect.height
+        )
+        const blendedX = previousX * cosine + nextX * sine
+        return { x: left + blendedX, y: rect.y + rect.height - y }
+      })
+      const layerCoordinates = this.buildLayerCoordinates(projectedPoints)
+      this.drawLayerPointHighlights(layerCoordinates)
+      this.renderer.batchDiscs(
+        projectedPoints.map(p => p.coords),
+        2.3,
+        dotColor
+      )
+      this.drawQuerySelectionOverlays(layerCoordinates)
+
+      const foldWidth =
+        Math.sin(Math.PI / 4 - rotation) * rect.width * Math.SQRT2
+      const midX = rect.x + rect.width / 2
+      const bottomY = rect.y + rect.height
+      this.renderer.lineSegments(
+        [
+          {
+            x1: midX - foldWidth / 2,
+            y1: rect.y,
+            x2: midX - foldWidth / 2,
+            y2: bottomY,
+          },
+          {
+            x1: midX + foldWidth / 2,
+            y1: rect.y,
+            x2: midX + foldWidth / 2,
+            y2: bottomY,
+          },
+        ],
+        strokeColor
+      )
+    }
+  }
+
+  private collectProjectedPoints(
+    projectPoint: (point: ScatterplotMatrixPoint) => Point
+  ): ProjectedPoint[] {
+    return this.points.map(point => ({ point, coords: projectPoint(point) }))
+  }
+
+  private buildLayerCoordinates(
+    projectedPoints: ProjectedPoint[]
+  ): LayerCoordinate[][] {
+    const coordinatesByLayer: LayerCoordinate[][] = this.queries.map(() => [])
+    for (const projected of projectedPoints) {
+      const { point, coords } = projected
+      for (const layer of this.queries) {
+        if (layer.members.has(point.id)) {
+          coordinatesByLayer[layer.index].push({
+            id: point.id,
+            x: coords.x,
+            y: coords.y,
+          })
+        }
+      }
+    }
+    return coordinatesByLayer
+  }
+
+  private drawLayerPointHighlights(
+    layerCoordinates: LayerCoordinate[][]
+  ): void {
+    // One batched draw per layer collapses what would otherwise be one disc
+    // per member-per-layer into at most `queries.length` draw calls.
+    for (const layer of this.queries) {
+      const coords = layerCoordinates[layer.index]
+      if (coords.length === 0) {
+        continue
+      }
+      this.renderer.batchDiscs(coords, 5.2, rgba(layer.color, 0.18))
+    }
+  }
+
+  private drawQuerySelectionOverlays(
+    layerCoordinates: LayerCoordinate[][]
+  ): void {
+    for (const layer of this.queries) {
+      const pts = layerCoordinates[layer.index]
+      if (pts.length === 0) {
+        continue
+      }
+      const fillColor = rgba(layer.color, 0.12)
+      if (pts.length === 1) {
+        this.renderer.disc(pts[0].x, pts[0].y, 7, fillColor)
+        continue
+      }
+      if (pts.length === 2) {
+        this.renderer.line(
+          pts[0].x,
+          pts[0].y,
+          pts[1].x,
+          pts[1].y,
+          rgba(layer.color, 0.3)
+        )
+        continue
+      }
+      drawQuadStrip(this.renderer, pts, fillColor)
+    }
+  }
+
+  private drawLensOverlay(lensCandidates: LensCandidate[], rect: Rect): void {
+    const candidates = lensCandidates
+      .sort((left, right) => left.distance - right.distance)
+      .slice(0, MAX_LENS_LABELS)
+    const lensX = this.lens.x - LENS_SIZE / 2
+    const lensY = this.lens.y - LENS_SIZE / 2
+    this.renderer.fillRect(
+      lensX,
+      lensY,
+      LENS_SIZE,
+      LENS_SIZE,
+      parseColor("rgba(255, 255, 255, 0.35)")
+    )
+    this.renderer.strokeRect(
+      lensX,
+      lensY,
+      LENS_SIZE,
+      LENS_SIZE,
+      parseColor("rgba(40, 51, 50, 0.7)")
+    )
+    const font = `12px ${BODY_FONT_FAMILY}`
+
+    const left: LensCandidate[] = []
+    const right: LensCandidate[] = []
+    for (const candidate of candidates) {
+      if (candidate.x <= this.lens.x) {
+        left.push(candidate)
+      } else {
+        right.push(candidate)
+      }
+    }
+
+    const leftStartY = clamp(
+      this.lens.y - (left.length * 14) / 2,
+      rect.y + 16,
+      rect.y + rect.height - 18
+    )
+    const rightStartY = clamp(
+      this.lens.y - (right.length * 14) / 2,
+      rect.y + 16,
+      rect.y + rect.height - 18
+    )
+
+    let widestLeft = 0
+    for (const candidate of left) {
+      widestLeft = Math.max(
+        widestLeft,
+        this.renderer.measureText(candidate.point.label, font)
+      )
+    }
+
+    const leftLineColor = parseColor("rgba(212, 108, 47, 0.78)")
+    left.forEach((candidate, index) => {
+      const labelY = leftStartY + index * 14
+      const labelX = rect.x - widestLeft - 34
+      this.renderer.line(
+        candidate.x,
+        candidate.y,
+        labelX + widestLeft,
+        labelY - 4,
+        leftLineColor
+      )
+      this.renderer.drawText(candidate.point.label, labelX, labelY, {
+        font,
+        color: "#9f4c24",
+      })
+    })
+
+    const rightLineColor = parseColor("rgba(11, 110, 98, 0.75)")
+    right.forEach((candidate, index) => {
+      const labelY = rightStartY + index * 14
+      const labelX = rect.x + rect.width + 20
+      this.renderer.line(
+        candidate.x,
+        candidate.y,
+        labelX - 6,
+        labelY - 4,
+        rightLineColor
+      )
+      this.renderer.drawText(candidate.point.label, labelX, labelY, {
+        font,
+        color: "#0a665b",
+      })
+    })
+  }
+
+  private drawQueryPanel(layout: DetailLayout): void {
+    const panel = layout.queryPanel
+    this.renderer.fillRect(
+      panel.x,
+      panel.y,
+      panel.width,
+      panel.height,
+      parseColor("rgba(255, 255, 255, 0.44)")
+    )
+    this.renderer.strokeRect(
+      panel.x,
+      panel.y,
+      panel.width,
+      panel.height,
+      parseColor("rgba(28, 39, 37, 0.18)")
+    )
+    this.renderer.drawText("Query Layers", panel.x + 12, panel.y + 20, {
+      font: `600 14px ${BODY_FONT_FAMILY}`,
+      color: "#1f2b28",
+    })
+
+    const bodyFont = `12px ${BODY_FONT_FAMILY}`
+    const numPoints = Math.max(1, this.points.length)
+    this.queries.forEach((layer, index) => {
+      const top = panel.y + 32 + index * QUERY_PANEL_ROW_HEIGHT
+      const rowFill =
+        index === this.selectedQueryIndex
+          ? "rgba(11, 110, 98, 0.12)"
+          : "rgba(255, 255, 255, 0.12)"
+      this.renderer.fillRect(
+        panel.x + 10,
+        top - 14,
+        panel.width - 20,
+        22,
+        parseColor(rowFill)
+      )
+      this.renderer.fillRect(
+        panel.x + 18,
+        top - 9,
+        18,
+        12,
+        rgba(layer.color, index === this.selectedQueryIndex ? 0.78 : 0.08)
+      )
+      this.renderer.drawText(
+        `${layer.label} (${layer.members.size})`,
+        panel.x + 46,
+        top,
+        { font: bodyFont, color: "#243230" }
+      )
+      const percentage = Math.round((layer.members.size / numPoints) * 100)
+      const barMaxWidth = 36
+      const barX = panel.x + panel.width - barMaxWidth - 42
+      const barHeight = 12
+      this.renderer.fillRect(
+        barX,
+        top - 9,
+        barMaxWidth,
+        barHeight,
+        parseColor("rgba(255, 255, 255, 0.3)")
+      )
+      this.renderer.strokeRect(
+        barX,
+        top - 9,
+        barMaxWidth,
+        barHeight,
+        parseColor("rgba(28, 39, 37, 0.18)")
+      )
+      const barFill = (layer.members.size / numPoints) * barMaxWidth
+      if (barFill > 0) {
+        this.renderer.fillRect(
+          barX,
+          top - 9,
+          barFill,
+          barHeight,
+          parseColor("rgba(45, 80, 180, 0.7)")
+        )
+      }
+      this.renderer.drawText(
+        `${percentage}%`,
+        panel.x + panel.width - 38,
+        top,
+        {
+          font: bodyFont,
+          color: "#243230",
+        }
+      )
+    })
+
+    const clearTop = panel.y + panel.height - 24
+    this.renderer.fillRect(
+      panel.x + 10,
+      clearTop - 14,
+      panel.width - 20,
+      20,
+      parseColor("rgba(212, 108, 47, 0.14)")
+    )
+    this.renderer.drawText("Clear All Queries", panel.x + 18, clearTop, {
+      font: bodyFont,
+      color: "#a64a18",
+    })
+  }
+}
+
+// ===========================================================================
+// WebGL renderer
+//
+// Immediate-mode 2D renderer over WebGL 2. Two programs (solid colour and
+// textured) with VAOs bound once at init, all geometry streamed through a
+// pair of DYNAMIC_DRAW buffers. Colours are stored premultiplied; the blend
+// func matches so translucent fills composite correctly over each other.
+// Text is rasterised on an offscreen 2D canvas and uploaded as a per-string
+// texture (LRU-evicted) since WebGL has no native text.
+// ===========================================================================
+
+interface TextEntry {
+  tex: WebGLTexture
+  width: number
+  height: number
+  textWidth: number
+  ascent: number
+  padding: number
+}
+
+interface AtlasEntry {
+  tex: WebGLTexture
+  version: string | null
+  width: number
+  height: number
+}
+
+interface DrawTextOptions {
+  font?: string
+  color?: string
+  align?: "left" | "center" | "right"
+}
+
+class WebGLRenderer {
+  private readonly gl: WebGL2RenderingContext
+
+  private viewportWidth = 1
+
+  private viewportHeight = 1
+
+  // Pixel-space view transform (scale + translate) applied in the vertex
+  // shaders so the whole scene can be zoomed and panned.
+  private viewScale = 1
+
+  private viewTranslateX = 0
+
+  private viewTranslateY = 0
+
+  private readonly textCanvas: HTMLCanvasElement
+
+  private readonly textCtx: CanvasRenderingContext2D
+
+  private readonly textCache = new Map<string, TextEntry>()
+
+  private readonly textCacheOrder: string[] = []
+
+  private readonly textCacheLimit = 512
+
+  private readonly measureCache = new Map<string, number>()
+
+  private readonly atlasCache = new Map<string, AtlasEntry>()
+
+  private solidProgram!: WebGLProgram
+
+  private texProgram!: WebGLProgram
+
+  private solidVars!: {
+    a_position: number
+    a_color: number
+    u_resolution: WebGLUniformLocation | null
+    u_view: WebGLUniformLocation | null
+  }
+
+  private texVars!: {
+    a_position: number
+    a_uv: number
+    u_resolution: WebGLUniformLocation | null
+    u_view: WebGLUniformLocation | null
+    u_texture: WebGLUniformLocation | null
+  }
+
+  private solidBuffer!: WebGLBuffer
+
+  private texBuffer!: WebGLBuffer
+
+  private solidVao!: WebGLVertexArrayObject
+
+  private texVao!: WebGLVertexArrayObject
+
+  constructor(canvas: HTMLCanvasElement) {
+    const gl = canvas.getContext("webgl2", {
+      premultipliedAlpha: true,
+      antialias: true,
+      alpha: false,
+    })
+    if (!gl) {
+      throw new Error("WebGL 2 is not supported in this browser.")
+    }
+    this.gl = gl
+    this.textCanvas = document.createElement("canvas")
+    const textCtx = this.textCanvas.getContext("2d")
+    if (textCtx === null) {
+      throw new Error("Could not create a 2D canvas context.")
+    }
+    this.textCtx = textCtx
+    this.initPrograms()
+
+    gl.enable(gl.BLEND)
+    gl.blendFuncSeparate(
+      gl.ONE,
+      gl.ONE_MINUS_SRC_ALPHA,
+      gl.ONE,
+      gl.ONE_MINUS_SRC_ALPHA
+    )
+    gl.disable(gl.DEPTH_TEST)
+  }
+
+  private initPrograms(): void {
+    const gl = this.gl
+    const solidVs = `#version 300 es
+      in vec2 a_position;
+      in vec4 a_color;
+      uniform vec2 u_resolution;
+      uniform vec4 u_view;
+      out vec4 v_color;
+      void main() {
+        vec2 pos = a_position * u_view.xy + u_view.zw;
+        vec2 clip = (pos / u_resolution) * 2.0 - 1.0;
+        gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);
+        v_color = a_color;
+      }
+    `
+    const solidFs = `#version 300 es
+      precision mediump float;
+      in vec4 v_color;
+      out vec4 outColor;
+      void main() {
+        outColor = vec4(v_color.rgb * v_color.a, v_color.a);
+      }
+    `
+    this.solidProgram = makeProgram(gl, solidVs, solidFs)
+    this.solidVars = {
+      a_position: gl.getAttribLocation(this.solidProgram, "a_position"),
+      a_color: gl.getAttribLocation(this.solidProgram, "a_color"),
+      u_resolution: gl.getUniformLocation(this.solidProgram, "u_resolution"),
+      u_view: gl.getUniformLocation(this.solidProgram, "u_view"),
+    }
+
+    const texVs = `#version 300 es
+      in vec2 a_position;
+      in vec2 a_uv;
+      uniform vec2 u_resolution;
+      uniform vec4 u_view;
+      out vec2 v_uv;
+      void main() {
+        vec2 pos = a_position * u_view.xy + u_view.zw;
+        vec2 clip = (pos / u_resolution) * 2.0 - 1.0;
+        gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);
+        v_uv = a_uv;
+      }
+    `
+    const texFs = `#version 300 es
+      precision mediump float;
+      in vec2 v_uv;
+      uniform sampler2D u_texture;
+      out vec4 outColor;
+      void main() {
+        outColor = texture(u_texture, v_uv);
+      }
+    `
+    this.texProgram = makeProgram(gl, texVs, texFs)
+    this.texVars = {
+      a_position: gl.getAttribLocation(this.texProgram, "a_position"),
+      a_uv: gl.getAttribLocation(this.texProgram, "a_uv"),
+      u_resolution: gl.getUniformLocation(this.texProgram, "u_resolution"),
+      u_view: gl.getUniformLocation(this.texProgram, "u_view"),
+      u_texture: gl.getUniformLocation(this.texProgram, "u_texture"),
+    }
+
+    this.solidBuffer = gl.createBuffer()
+    this.texBuffer = gl.createBuffer()
+
+    const solidStride = 6 * 4
+    this.solidVao = gl.createVertexArray()
+    gl.bindVertexArray(this.solidVao)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.solidBuffer)
+    gl.enableVertexAttribArray(this.solidVars.a_position)
+    gl.vertexAttribPointer(
+      this.solidVars.a_position,
+      2,
+      gl.FLOAT,
+      false,
+      solidStride,
+      0
+    )
+    gl.enableVertexAttribArray(this.solidVars.a_color)
+    gl.vertexAttribPointer(
+      this.solidVars.a_color,
+      4,
+      gl.FLOAT,
+      false,
+      solidStride,
+      8
+    )
+
+    const texStride = 4 * 4
+    this.texVao = gl.createVertexArray()
+    gl.bindVertexArray(this.texVao)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.texBuffer)
+    gl.enableVertexAttribArray(this.texVars.a_position)
+    gl.vertexAttribPointer(
+      this.texVars.a_position,
+      2,
+      gl.FLOAT,
+      false,
+      texStride,
+      0
+    )
+    gl.enableVertexAttribArray(this.texVars.a_uv)
+    gl.vertexAttribPointer(this.texVars.a_uv, 2, gl.FLOAT, false, texStride, 8)
+
+    gl.bindVertexArray(null)
+  }
+
+  /**
+   * Deletes all GPU resources owned by this renderer. Required because the
+   * canvas and its WebGL context outlive the renderer across app reruns.
+   */
+  dispose(): void {
+    const gl = this.gl
+    for (const entry of this.textCache.values()) {
+      gl.deleteTexture(entry.tex)
+    }
+    this.textCache.clear()
+    this.textCacheOrder.length = 0
+    for (const entry of this.atlasCache.values()) {
+      gl.deleteTexture(entry.tex)
+    }
+    this.atlasCache.clear()
+    gl.deleteBuffer(this.solidBuffer)
+    gl.deleteBuffer(this.texBuffer)
+    gl.deleteVertexArray(this.solidVao)
+    gl.deleteVertexArray(this.texVao)
+    gl.deleteProgram(this.solidProgram)
+    gl.deleteProgram(this.texProgram)
+  }
+
+  resize(width: number, height: number): void {
+    this.viewportWidth = width
+    this.viewportHeight = height
+    this.gl.viewport(0, 0, width, height)
+  }
+
+  setViewTransform(
+    scale: number,
+    translateX: number,
+    translateY: number
+  ): void {
+    this.viewScale = scale
+    this.viewTranslateX = translateX
+    this.viewTranslateY = translateY
+  }
+
+  beginFrame(backgroundColor: RGBA): void {
+    // Every frame starts at identity; the caller opts into a transform
+    // after beginFrame.
+    this.setViewTransform(1, 0, 0)
+    const gl = this.gl
+    const [r, g, b, a] = backgroundColor
+    gl.clearColor(r * a, g * a, b * a, a)
+    gl.clear(gl.COLOR_BUFFER_BIT)
+  }
+
+  private useSolid(): void {
+    const gl = this.gl
+    gl.useProgram(this.solidProgram)
+    gl.uniform2f(
+      this.solidVars.u_resolution,
+      this.viewportWidth,
+      this.viewportHeight
+    )
+    gl.uniform4f(
+      this.solidVars.u_view,
+      this.viewScale,
+      this.viewScale,
+      this.viewTranslateX,
+      this.viewTranslateY
+    )
+  }
+
+  private drawSolid(verts: Float32Array, mode: number): void {
+    if (verts.length === 0) {
+      return
+    }
+    const gl = this.gl
+    this.useSolid()
+    gl.bindVertexArray(this.solidVao)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.solidBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW)
+    gl.drawArrays(mode, 0, verts.length / 6)
+    gl.bindVertexArray(null)
+  }
+
+  fillRect(x: number, y: number, w: number, h: number, color: RGBA): void {
+    const [r, g, b, a] = color
+    const verts = new Float32Array([
+      x,
+      y,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y,
+      r,
+      g,
+      b,
+      a,
+      x,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+      x,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+    ])
+    this.drawSolid(verts, this.gl.TRIANGLES)
+  }
+
+  strokeRect(x: number, y: number, w: number, h: number, color: RGBA): void {
+    const [r, g, b, a] = color
+    const verts = new Float32Array([
+      x,
+      y,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+      x + w,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+      x,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+      x,
+      y + h,
+      r,
+      g,
+      b,
+      a,
+      x,
+      y,
+      r,
+      g,
+      b,
+      a,
+    ])
+    this.drawSolid(verts, this.gl.LINES)
+  }
+
+  line(x1: number, y1: number, x2: number, y2: number, color: RGBA): void {
+    const [r, g, b, a] = color
+    const verts = new Float32Array([x1, y1, r, g, b, a, x2, y2, r, g, b, a])
+    this.drawSolid(verts, this.gl.LINES)
+  }
+
+  /**
+   * Emits an array of disjoint line segments in a single draw call. Cheap
+   * replacement for multiple `line()` calls that share a color.
+   */
+  lineSegments(
+    segments: Array<{ x1: number; y1: number; x2: number; y2: number }>,
+    color: RGBA
+  ): void {
+    const n = segments.length
+    if (n === 0) {
+      return
+    }
+    const [r, g, b, a] = color
+    const verts = new Float32Array(n * 12)
+    let o = 0
+    for (let i = 0; i < n; i += 1) {
+      const s = segments[i]
+      verts[o++] = s.x1
+      verts[o++] = s.y1
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+      verts[o++] = s.x2
+      verts[o++] = s.y2
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+    }
+    this.drawSolid(verts, this.gl.LINES)
+  }
+
+  polyline(points: Point[], color: RGBA, closed = false): void {
+    if (points.length < 2) {
+      return
+    }
+    const [r, g, b, a] = color
+    const verts: number[] = []
+    for (let i = 0; i < points.length - 1; i += 1) {
+      verts.push(
+        points[i].x,
+        points[i].y,
+        r,
+        g,
+        b,
+        a,
+        points[i + 1].x,
+        points[i + 1].y,
+        r,
+        g,
+        b,
+        a
+      )
+    }
+    if (closed) {
+      const last = points.length - 1
+      verts.push(
+        points[last].x,
+        points[last].y,
+        r,
+        g,
+        b,
+        a,
+        points[0].x,
+        points[0].y,
+        r,
+        g,
+        b,
+        a
+      )
+    }
+    this.drawSolid(new Float32Array(verts), this.gl.LINES)
+  }
+
+  dashedLine(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    color: RGBA,
+    dashLen = 5,
+    gapLen = 4
+  ): void {
+    const dx = x2 - x1
+    const dy = y2 - y1
+    const length = Math.hypot(dx, dy)
+    if (length === 0) {
+      return
+    }
+    const ux = dx / length
+    const uy = dy / length
+    const step = dashLen + gapLen
+    const [r, g, b, a] = color
+    const verts: number[] = []
+    for (let t = 0; t < length; t += step) {
+      const end = Math.min(t + dashLen, length)
+      verts.push(
+        x1 + ux * t,
+        y1 + uy * t,
+        r,
+        g,
+        b,
+        a,
+        x1 + ux * end,
+        y1 + uy * end,
+        r,
+        g,
+        b,
+        a
+      )
+    }
+    this.drawSolid(new Float32Array(verts), this.gl.LINES)
+  }
+
+  disc(
+    x: number,
+    y: number,
+    radius: number,
+    color: RGBA,
+    segments = 20
+  ): void {
+    const [r, g, b, a] = color
+    const verts: number[] = []
+    for (let i = 0; i < segments; i += 1) {
+      const a1 = (i / segments) * Math.PI * 2
+      const a2 = ((i + 1) / segments) * Math.PI * 2
+      verts.push(
+        x,
+        y,
+        r,
+        g,
+        b,
+        a,
+        x + Math.cos(a1) * radius,
+        y + Math.sin(a1) * radius,
+        r,
+        g,
+        b,
+        a,
+        x + Math.cos(a2) * radius,
+        y + Math.sin(a2) * radius,
+        r,
+        g,
+        b,
+        a
+      )
+    }
+    this.drawSolid(new Float32Array(verts), this.gl.TRIANGLES)
+  }
+
+  /**
+   * Emits one top-left-anchored `size`x`size` square per entry in `points`
+   * in a single draw call. Drop-in batched replacement for thousands of
+   * tiny fillRect calls (e.g. matrix scatter dots).
+   */
+  batchFillRects(points: Point[], size: number, color: RGBA): void {
+    const n = points.length
+    if (n === 0) {
+      return
+    }
+    const [r, g, b, a] = color
+    const verts = new Float32Array(n * 36)
+    let o = 0
+    for (let i = 0; i < n; i += 1) {
+      const p = points[i]
+      const x0 = p.x
+      const y0 = p.y
+      const x1 = x0 + size
+      const y1 = y0 + size
+      verts[o++] = x0
+      verts[o++] = y0
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+      verts[o++] = x1
+      verts[o++] = y0
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+      verts[o++] = x0
+      verts[o++] = y1
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+      verts[o++] = x1
+      verts[o++] = y0
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+      verts[o++] = x1
+      verts[o++] = y1
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+      verts[o++] = x0
+      verts[o++] = y1
+      verts[o++] = r
+      verts[o++] = g
+      verts[o++] = b
+      verts[o++] = a
+    }
+    this.drawSolid(verts, this.gl.TRIANGLES)
+  }
+
+  /**
+   * Emits one triangle-fan disc per center in a single draw call. The unit
+   * circle is precomputed once per call so the inner loop is branch-free.
+   */
+  batchDiscs(
+    centers: Point[],
+    radius: number,
+    color: RGBA,
+    segments = 20
+  ): void {
+    const n = centers.length
+    if (n === 0) {
+      return
+    }
+    const [r, g, b, a] = color
+    const cos = new Float32Array(segments)
+    const sin = new Float32Array(segments)
+    for (let s = 0; s < segments; s += 1) {
+      const angle = (s / segments) * Math.PI * 2
+      cos[s] = Math.cos(angle)
+      sin[s] = Math.sin(angle)
+    }
+    const verts = new Float32Array(n * segments * 18)
+    let o = 0
+    for (let i = 0; i < n; i += 1) {
+      const cx = centers[i].x
+      const cy = centers[i].y
+      for (let s = 0; s < segments; s += 1) {
+        const s2 = (s + 1) % segments
+        verts[o++] = cx
+        verts[o++] = cy
+        verts[o++] = r
+        verts[o++] = g
+        verts[o++] = b
+        verts[o++] = a
+        verts[o++] = cx + cos[s] * radius
+        verts[o++] = cy + sin[s] * radius
+        verts[o++] = r
+        verts[o++] = g
+        verts[o++] = b
+        verts[o++] = a
+        verts[o++] = cx + cos[s2] * radius
+        verts[o++] = cy + sin[s2] * radius
+        verts[o++] = r
+        verts[o++] = g
+        verts[o++] = b
+        verts[o++] = a
+      }
+    }
+    this.drawSolid(verts, this.gl.TRIANGLES)
+  }
+
+  polygonFromTriangulation(
+    points: Point[],
+    triangles: number[][],
+    color: RGBA
+  ): void {
+    if (triangles.length === 0) {
+      return
+    }
+    const [r, g, b, a] = color
+    const verts = new Float32Array(triangles.length * 3 * 6)
+    let offset = 0
+    for (const tri of triangles) {
+      for (const idx of tri) {
+        const p = points[idx]
+        verts[offset] = p.x
+        verts[offset + 1] = p.y
+        verts[offset + 2] = r
+        verts[offset + 3] = g
+        verts[offset + 4] = b
+        verts[offset + 5] = a
+        offset += 6
+      }
+    }
+    this.drawSolid(verts, this.gl.TRIANGLES)
+  }
+
+  measureText(text: string, font: string): number {
+    // Cache measurements — the 2D context's measureText / font-state setup
+    // isn't free and this method is called in tight per-frame loops.
+    const key = `${font}|${text}`
+    const cached = this.measureCache.get(key)
+    if (cached !== undefined) {
+      return cached
+    }
+    this.textCtx.font = font
+    const width = this.textCtx.measureText(text).width
+    this.measureCache.set(key, width)
+    return width
+  }
+
+  /**
+   * Uploads or refreshes a named atlas texture from an offscreen canvas and
+   * blits it as a single textured quad at viewport-space (x, y). Callers
+   * pass a stable `key` plus a `version` string; if the version matches the
+   * cached one the canvas upload is skipped and only the draw happens.
+   */
+  blitCanvasAtlas(
+    key: string,
+    version: string,
+    canvas: HTMLCanvasElement,
+    x: number,
+    y: number
+  ): void {
+    const gl = this.gl
+    let entry = this.atlasCache.get(key)
+    if (entry === undefined) {
+      entry = {
+        tex: gl.createTexture(),
+        version: null,
+        width: 0,
+        height: 0,
+      }
+      this.atlasCache.set(key, entry)
+    }
+    if (
+      entry.version !== version ||
+      entry.width !== canvas.width ||
+      entry.height !== canvas.height
+    ) {
+      gl.bindTexture(gl.TEXTURE_2D, entry.tex)
+      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true)
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        canvas
+      )
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+      entry.version = version
+      entry.width = canvas.width
+      entry.height = canvas.height
+    }
+    const w = entry.width
+    const h = entry.height
+    const verts = new Float32Array([
+      x,
+      y,
+      0,
+      0,
+      x + w,
+      y,
+      1,
+      0,
+      x,
+      y + h,
+      0,
+      1,
+      x + w,
+      y,
+      1,
+      0,
+      x + w,
+      y + h,
+      1,
+      1,
+      x,
+      y + h,
+      0,
+      1,
+    ])
+    this.drawTextured(entry.tex, verts)
+  }
+
+  private getTextEntry(text: string, font: string, color: string): TextEntry {
+    const key = `${text}|${font}|${color}`
+    const existing = this.textCache.get(key)
+    if (existing !== undefined) {
+      return existing
+    }
+    const ctx = this.textCtx
+    ctx.font = font
+    const metrics = ctx.measureText(text)
+    const ascent = metrics.actualBoundingBoxAscent || 10
+    const descent = metrics.actualBoundingBoxDescent || 4
+    const textWidth = metrics.width
+    const padding = 2
+    const w = Math.max(1, Math.ceil(textWidth) + padding * 2)
+    const h = Math.max(1, Math.ceil(ascent + descent) + padding * 2)
+    this.textCanvas.width = w
+    this.textCanvas.height = h
+    ctx.clearRect(0, 0, w, h)
+    ctx.font = font
+    ctx.textBaseline = "alphabetic"
+    ctx.fillStyle = color
+    ctx.fillText(text, padding, ascent + padding)
+    const gl = this.gl
+    const tex = gl.createTexture()
+    gl.bindTexture(gl.TEXTURE_2D, tex)
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true)
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      this.textCanvas
+    )
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    const entry: TextEntry = {
+      tex,
+      width: w,
+      height: h,
+      textWidth,
+      ascent,
+      padding,
+    }
+    this.textCache.set(key, entry)
+    this.textCacheOrder.push(key)
+    if (this.textCacheOrder.length > this.textCacheLimit) {
+      const evictKey = this.textCacheOrder.shift()
+      if (evictKey !== undefined) {
+        const evicted = this.textCache.get(evictKey)
+        if (evicted) {
+          gl.deleteTexture(evicted.tex)
+          this.textCache.delete(evictKey)
+        }
+      }
+    }
+    return entry
+  }
+
+  drawText(
+    text: string,
+    x: number,
+    y: number,
+    options: DrawTextOptions = {}
+  ): void {
+    if (text === "") {
+      return
+    }
+    const font = options.font || "12px sans-serif"
+    const color = options.color || "#000"
+    const align = options.align || "left"
+    const entry = this.getTextEntry(String(text), font, color)
+
+    let originX = -entry.padding
+    if (align === "center") {
+      originX = -entry.textWidth / 2 - entry.padding
+    } else if (align === "right") {
+      originX = -entry.textWidth - entry.padding
+    }
+    const originY = -entry.ascent - entry.padding
+
+    const w = entry.width
+    const h = entry.height
+    const x0 = x + originX
+    const y0 = y + originY
+    const verts = new Float32Array([
+      x0,
+      y0,
+      0,
+      0,
+      x0 + w,
+      y0,
+      1,
+      0,
+      x0,
+      y0 + h,
+      0,
+      1,
+      x0 + w,
+      y0,
+      1,
+      0,
+      x0 + w,
+      y0 + h,
+      1,
+      1,
+      x0,
+      y0 + h,
+      0,
+      1,
+    ])
+    this.drawTextured(entry.tex, verts)
+  }
+
+  private drawTextured(tex: WebGLTexture, verts: Float32Array): void {
+    const gl = this.gl
+    gl.useProgram(this.texProgram)
+    gl.uniform2f(
+      this.texVars.u_resolution,
+      this.viewportWidth,
+      this.viewportHeight
+    )
+    gl.uniform4f(
+      this.texVars.u_view,
+      this.viewScale,
+      this.viewScale,
+      this.viewTranslateX,
+      this.viewTranslateY
+    )
+    gl.activeTexture(gl.TEXTURE0)
+    gl.bindTexture(gl.TEXTURE_2D, tex)
+    gl.uniform1i(this.texVars.u_texture, 0)
+    gl.bindVertexArray(this.texVao)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.texBuffer)
+    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW)
+    gl.drawArrays(gl.TRIANGLES, 0, 6)
+    gl.bindVertexArray(null)
+  }
+}
+
+function compileShader(
+  gl: WebGL2RenderingContext,
+  type: number,
+  source: string
+): WebGLShader {
+  const shader = gl.createShader(type)
+  if (shader === null) {
+    throw new Error("Could not create a WebGL shader.")
+  }
+  gl.shaderSource(shader, source)
+  gl.compileShader(shader)
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const info = gl.getShaderInfoLog(shader)
+    gl.deleteShader(shader)
+    throw new Error(`Shader compile error: ${info}`)
+  }
+  return shader
+}
+
+function makeProgram(
+  gl: WebGL2RenderingContext,
+  vs: string,
+  fs: string
+): WebGLProgram {
+  const vsShader = compileShader(gl, gl.VERTEX_SHADER, vs)
+  const fsShader = compileShader(gl, gl.FRAGMENT_SHADER, fs)
+  const program = gl.createProgram()
+  if (program === null) {
+    throw new Error("Could not create a WebGL program.")
+  }
+  gl.attachShader(program, vsShader)
+  gl.attachShader(program, fsShader)
+  gl.linkProgram(program)
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(program)
+    gl.deleteProgram(program)
+    throw new Error(`Program link error: ${info}`)
+  }
+  return program
+}
+
+// ===========================================================================
+// Color and geometry utilities
+// ===========================================================================
+
+const colorCache = new Map<string, RGBA>()
+
+let colorParseCtx: CanvasRenderingContext2D | null = null
+
+function getColorParseCtx(): CanvasRenderingContext2D | null {
+  if (colorParseCtx === null && typeof document !== "undefined") {
+    const canvas = document.createElement("canvas")
+    canvas.width = 1
+    canvas.height = 1
+    colorParseCtx = canvas.getContext("2d")
+  }
+  return colorParseCtx
+}
+
+function parseColor(value: string): RGBA {
+  const cached = colorCache.get(value)
+  if (cached !== undefined) {
+    return cached
+  }
+  let result: RGBA
+  const ctx = getColorParseCtx()
+  if (ctx) {
+    ctx.fillStyle = "#000"
+    ctx.fillStyle = value
+    const normalized = ctx.fillStyle
+    if (normalized.startsWith("#")) {
+      const [r, g, b] = hexToRgb(normalized)
+      result = [r / 255, g / 255, b / 255, 1]
+    } else {
+      const parts = (normalized.match(/[\d.]+/g) ?? ["0", "0", "0"]).map(
+        Number
+      )
+      result = [
+        parts[0] / 255,
+        parts[1] / 255,
+        parts[2] / 255,
+        parts.length > 3 ? parts[3] : 1,
+      ]
+    }
+  } else {
+    result = [0, 0, 0, 1]
+  }
+  colorCache.set(value, result)
+  return result
+}
+
+function rgba(value: string, alpha: number): RGBA {
+  const [r, g, b] = parseColor(value)
+  return [r, g, b, alpha]
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.replace("#", "")
+  const value =
+    normalized.length === 3
+      ? normalized
+          .split("")
+          .map(character => character + character)
+          .join("")
+      : normalized
+  return [
+    Number.parseInt(value.slice(0, 2), 16),
+    Number.parseInt(value.slice(2, 4), 16),
+    Number.parseInt(value.slice(4, 6), 16),
+  ]
+}
+
+function getMatrixCellRect(
+  layout: DetailLayout,
+  col: number,
+  row: number
+): Rect {
+  return {
+    x: layout.matrixX + col * (layout.cellSize + layout.gap),
+    y: layout.matrixY + row * (layout.cellSize + layout.gap),
+    width: layout.cellSize,
+    height: layout.cellSize,
+  }
+}
+
+function getMatrixCellCenter(
+  layout: DetailLayout,
+  col: number,
+  row: number
+): Point {
+  const rect = getMatrixCellRect(layout, col, row)
+  return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+}
+
+function projectPointToRect(
+  xValue: number,
+  xMin: number,
+  xMax: number,
+  yValue: number,
+  yMin: number,
+  yMax: number,
+  rect: Rect
+): Point {
+  const xRange = xMax - xMin
+  const yRange = yMax - yMin
+  const x =
+    rect.x +
+    (xRange === 0 ? rect.width / 2 : ((xValue - xMin) / xRange) * rect.width)
+  const y =
+    rect.y +
+    rect.height -
+    (yRange === 0 ? rect.height / 2 : ((yValue - yMin) / yRange) * rect.height)
+  return { x, y }
+}
+
+function drawQuadStrip(
+  renderer: WebGLRenderer,
+  pts: Point[],
+  fillColor: RGBA
+): void {
+  const triangles: number[][] = []
+  for (let i = 0; i + 3 < pts.length; i += 2) {
+    triangles.push([i, i + 1, i + 3])
+    triangles.push([i, i + 3, i + 2])
+  }
+  if (pts.length >= 4) {
+    const last = pts.length % 2 === 0 ? pts.length : pts.length - 1
+    triangles.push([last - 2, last - 1, 1])
+    triangles.push([last - 2, 1, 0])
+  }
+  renderer.polygonFromTriangulation(pts, triangles, fillColor)
+}
+
+export function buildNavigationSteps(
+  fromPlot: PlotCoords,
+  toPlot: PlotCoords
+): RollStep[] {
+  const steps: RollStep[] = []
+  let column = fromPlot.col
+  let row = fromPlot.row
+  const moveRowsFirst =
+    Math.abs(column - toPlot.col) > Math.abs(toPlot.row - row)
+
+  const addColumnSteps = (): void => {
+    while (column !== toPlot.col) {
+      column += Math.sign(toPlot.col - column)
+      steps.push({ col: column, row, axis: "x" })
+    }
+  }
+
+  const addRowSteps = (): void => {
+    while (row !== toPlot.row) {
+      row += Math.sign(toPlot.row - row)
+      steps.push({ col: column, row, axis: "y" })
+    }
+  }
+
+  if (moveRowsFirst) {
+    addRowSteps()
+    addColumnSteps()
+  } else {
+    addColumnSteps()
+    addRowSteps()
+  }
+  return steps
+}
+
+export function pointInPolygon(
+  x: number,
+  y: number,
+  polygon: Point[]
+): boolean {
+  let inside = false
+  for (
+    let index = 0, previous = polygon.length - 1;
+    index < polygon.length;
+    previous = index, index += 1
+  ) {
+    const xi = polygon[index].x
+    const yi = polygon[index].y
+    const xj = polygon[previous].x
+    const yj = polygon[previous].y
+    const intersects =
+      yi > y !== yj > y &&
+      x < ((xj - xi) * (y - yi)) / (yj - yi || Number.EPSILON) + xi
+    if (intersects) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
+function pointInRect(point: Point, rect: Rect): boolean {
+  return (
+    point.x >= rect.x &&
+    point.x <= rect.x + rect.width &&
+    point.y >= rect.y &&
+    point.y <= rect.y + rect.height
+  )
+}
+
+function samePlot(left: PlotCoords, right: PlotCoords): boolean {
+  return left.col === right.col && left.row === right.row
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function distanceBetween(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number
+): number {
+  return Math.hypot(x2 - x1, y2 - y1)
+}

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.ts
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.ts
@@ -315,7 +315,14 @@ export class ScatterplotMatrixEngine {
     // matrix dimension (see extractChartData). Track whether that happened
     // so the reconciled (shrunk) selection is reported back to Python below,
     // instead of leaving stale ids in the widget state indefinitely.
-    let selectionWasReconciled = false
+    //
+    // A restored selection can also have *more layers* than `colors` (e.g.
+    // `query_colors` shrank between reruns); those extra layers are never
+    // read below (colors.map only visits index < colors.length), so they
+    // must count as reconciliation too, or their members would silently
+    // linger in the widget state despite no longer having a UI layer.
+    let selectionWasReconciled =
+      (options.initialSelection?.length ?? 0) > colors.length
     this.queries = colors.map((color, index) => {
       const { keptIds, wasReconciled } = reconcileSelectionIds(
         options.initialSelection?.[index] ?? [],

--- a/frontend/lib/src/components/elements/ScatterplotMatrixChart/styled-components.ts
+++ b/frontend/lib/src/components/elements/ScatterplotMatrixChart/styled-components.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from "@emotion/styled"
+
+export const StyledScatterplotMatrixChart = styled.div(({ theme }) => ({
+  width: "100%",
+  height: "100%",
+  minHeight: "17.5rem",
+  position: "relative",
+  overflow: "hidden",
+  borderRadius: theme.radii.default,
+}))
+
+export interface StyledScatterplotMatrixCanvasProps {
+  isDisabled: boolean
+}
+
+export const StyledScatterplotMatrixCanvas =
+  styled.canvas<StyledScatterplotMatrixCanvasProps>(({ isDisabled }) => ({
+    display: "block",
+    width: "100%",
+    height: "100%",
+    touchAction: "none",
+    outline: "none",
+    pointerEvents: isDisabled ? "none" : "auto",
+  }))

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
@@ -108,6 +108,7 @@ Run this command with the Streamlit installation relevant to the code being edit
 | `st.radio` | Display a radio button widget. Use it when users should choose exactly one option from a small visible set. |
 | `st.rerun` | Rerun the app or current fragment immediately. Use it to force a rerun after state changes or navigation-like actions. |
 | `st.scatter_chart` | Display a scatterplot chart. Use it for relationships between numeric variables, optionally with size and color encodings. |
+| `st.scatterplot_matrix_chart` | Display an interactive scatterplot matrix (SPLOM) with rolling navigation. Use it to explore pairwise relationships across 2-10 numeric columns, optionally reacting to lasso selections via `on_select`. |
 | `st.segmented_control` | Display a segmented control widget. Use it for compact mutually exclusive choices, especially mode or view switching. |
 | `st.select_slider` | Display a slider widget to select items from a list. Use it when options are ordered but not necessarily numeric. |
 | `st.selectbox` | Display a select widget. Use it for selecting one item from a medium or large set. |

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -30,6 +30,17 @@ st.line_chart(df, x="date", y="revenue")
 st.line_chart(df, x="dt", y="rev", x_label="Date", y_label="Revenue")
 ```
 
+## Scatterplot matrix for multidimensional data
+
+Use `st.scatterplot_matrix_chart` to explore pairwise relationships across several numeric columns (2-10 dimensions) in a single element. It shows a small scatterplot for every column pair next to one large detail plot; users can navigate between plots and lasso points into persistent query layers.
+
+```python
+event = st.scatterplot_matrix_chart(df, columns=["a", "b", "c"], on_select="rerun")
+selected_data = df.iloc[event.selection.indices]
+```
+
+Key parameters: `columns` limits the numeric dimensions (all numeric columns by default, up to 10), `label` picks the column used for point labels, and `on_select` (`"ignore"` by default) makes the chart return lasso-selection state (`selection.indices` and per-layer `selection.query_layers`) when set to `"rerun"` or a callback.
+
 ## Altair for complex charts
 
 Use Altair when you need more control. Altair is bundled with Streamlit (no extra install), while Plotly requires an additional package. Pick one and stay consistent throughout your app.

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -243,6 +243,7 @@ progress = _main.progress
 pyplot = _main.pyplot
 radio = _main.radio
 scatter_chart = _main.scatter_chart
+scatterplot_matrix_chart = _main.scatterplot_matrix_chart
 selectbox = _main.selectbox
 select_slider = _main.select_slider
 segmented_control = _main.segmented_control

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -77,6 +77,7 @@ from streamlit.elements.pdf import PdfMixin
 from streamlit.elements.plotly_chart import PlotlyMixin
 from streamlit.elements.progress import ProgressMixin
 from streamlit.elements.pyplot import PyplotMixin
+from streamlit.elements.scatterplot_matrix_chart import ScatterplotMatrixChartMixin
 from streamlit.elements.skeleton import SkeletonMixin
 from streamlit.elements.snow import SnowMixin
 from streamlit.elements.space import SpaceMixin
@@ -230,6 +231,7 @@ class DeltaGenerator(
     PydeckMixin,
     PyplotMixin,
     RadioMixin,
+    ScatterplotMatrixChartMixin,
     SelectboxMixin,
     SelectSliderMixin,
     SkeletonMixin,

--- a/lib/streamlit/elements/scatterplot_matrix_chart.py
+++ b/lib/streamlit/elements/scatterplot_matrix_chart.py
@@ -1,0 +1,510 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Final,
+    Literal,
+    TypedDict,
+    cast,
+    overload,
+)
+
+from typing_extensions import Required
+
+from streamlit import dataframe_util
+from streamlit.elements.lib.form_utils import current_form_id
+from streamlit.elements.lib.layout_utils import (
+    HeightWithoutContent,
+    LayoutConfig,
+    WidthWithoutContent,
+    validate_height,
+    validate_width,
+)
+from streamlit.elements.lib.policies import check_widget_policies
+from streamlit.elements.lib.utils import Key, compute_and_register_element_id, to_key
+from streamlit.errors import StreamlitAPIException
+from streamlit.proto.ScatterplotMatrixChart_pb2 import (
+    ScatterplotMatrixChart as ScatterplotMatrixChartProto,
+)
+from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+from streamlit.runtime.state import WidgetCallback, register_widget
+from streamlit.util import AttributeDictionary
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import pandas as pd
+
+    from streamlit.dataframe_util import Data
+    from streamlit.delta_generator import DeltaGenerator
+
+_MIN_DIMENSIONS: Final = 2
+_MAX_DIMENSIONS: Final = 10
+_MAX_QUERY_LAYERS: Final = 8
+_DEFAULT_HEIGHT: Final = 520
+
+
+class ScatterplotMatrixQueryLayerState(TypedDict, total=False):
+    """
+    The schema for a single query layer in the scatterplot matrix
+    selection state.
+
+    Attributes
+    ----------
+    label : str
+        The label of the query layer (e.g. ``"Query 1"``).
+
+    indices : list[int]
+        The positional row indices of the data points captured by this
+        query layer's lasso selection.
+    """
+
+    label: Required[str]
+    indices: Required[list[int]]
+
+
+class ScatterplotMatrixSelectionState(TypedDict, total=False):
+    """
+    The schema for the scatterplot matrix chart selection state.
+
+    The selection state is stored in a dictionary-like object that supports
+    both key and attribute notation. Selection states cannot be
+    programmatically changed or set through Session State.
+
+    Attributes
+    ----------
+    indices : list[int]
+        The positional row indices of all data points that are part of at
+        least one query layer selection.
+
+    query_layers : list[dict[str, Any]]
+        One entry per query layer, in layer order. Each entry contains the
+        layer's ``label`` and the ``indices`` of the rows captured by the
+        layer's lasso selection.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> import streamlit as st
+    >>>
+    >>> df = pd.DataFrame(
+    ...     np.random.default_rng(0).standard_normal((60, 3)),
+    ...     columns=["a", "b", "c"],
+    ... )
+    >>>
+    >>> event = st.scatterplot_matrix_chart(df, key="splom", on_select="rerun")
+    >>>
+    >>> event.selection
+    """
+
+    indices: Required[list[int]]
+    query_layers: Required[list[ScatterplotMatrixQueryLayerState]]
+
+
+class ScatterplotMatrixState(TypedDict, total=False):
+    """
+    The schema for the scatterplot matrix chart event state.
+
+    The event state is stored in a dictionary-like object that supports both
+    key and attribute notation. Event states cannot be programmatically
+    changed or set through Session State.
+
+    Only selection events are supported at this time.
+
+    Attributes
+    ----------
+    selection : dict
+        The state of the ``on_select`` event. This attribute returns a
+        dictionary-like object that supports both key and attribute notation.
+        The attributes are described by the ``ScatterplotMatrixSelectionState``
+        dictionary schema.
+    """
+
+    selection: Required[ScatterplotMatrixSelectionState]
+
+
+@dataclass
+class ScatterplotMatrixSelectionSerde:
+    """Serialize and deserialize the scatterplot matrix chart selection state."""
+
+    def deserialize(self, ui_value: str | None) -> ScatterplotMatrixState:
+        empty_selection_state: ScatterplotMatrixState = {
+            "selection": {
+                "indices": [],
+                "query_layers": [],
+            },
+        }
+
+        selection_state = (
+            empty_selection_state
+            if ui_value is None
+            else cast(
+                "ScatterplotMatrixState", AttributeDictionary(json.loads(ui_value))
+            )
+        )
+
+        if "selection" not in selection_state:  # pragma: no cover - defensive
+            selection_state = empty_selection_state  # type: ignore[unreachable]
+
+        return cast("ScatterplotMatrixState", AttributeDictionary(selection_state))
+
+    def serialize(self, selection_state: ScatterplotMatrixState) -> str:
+        return json.dumps(selection_state, default=str)
+
+
+def _parse_dimension_columns(
+    data_df: pd.DataFrame, columns: Sequence[str] | None
+) -> list[str]:
+    """Determine and validate the numeric dimension columns of the matrix."""
+    from pandas.api.types import is_numeric_dtype
+
+    if columns is None:
+        parsed_columns = [
+            str(column)
+            for column in data_df.columns
+            if is_numeric_dtype(data_df[column])
+        ][:_MAX_DIMENSIONS]
+    else:
+        parsed_columns = [str(column) for column in columns]
+        missing_columns = [
+            column for column in parsed_columns if column not in data_df.columns
+        ]
+        if missing_columns:
+            raise StreamlitAPIException(
+                f"The following columns were not found in the data: "
+                f"{missing_columns}. Available columns: "
+                f"{[str(column) for column in data_df.columns]}."
+            )
+        non_numeric_columns = [
+            column for column in parsed_columns if not is_numeric_dtype(data_df[column])
+        ]
+        if non_numeric_columns:
+            raise StreamlitAPIException(
+                f"The following columns are not numeric and cannot be used as "
+                f"matrix dimensions: {non_numeric_columns}. All matrix "
+                f"dimensions must be numeric columns."
+            )
+
+    if len(parsed_columns) < _MIN_DIMENSIONS:
+        raise StreamlitAPIException(
+            f"The scatterplot matrix chart requires at least {_MIN_DIMENSIONS} "
+            f"numeric columns, but only got: {parsed_columns}."
+        )
+    if len(parsed_columns) > _MAX_DIMENSIONS:
+        raise StreamlitAPIException(
+            f"The scatterplot matrix chart supports at most {_MAX_DIMENSIONS} "
+            f"dimensions, but got {len(parsed_columns)}. Please select a "
+            f"subset via the `columns` parameter."
+        )
+    return parsed_columns
+
+
+class ScatterplotMatrixChartMixin:
+    @overload
+    def scatterplot_matrix_chart(
+        self,
+        data: Data,
+        *,
+        columns: Sequence[str] | None = None,
+        label: str | None = None,
+        title: str | None = None,
+        query_colors: Sequence[str] | None = None,
+        roll_speed: float = 1.0,
+        width: WidthWithoutContent = "stretch",
+        height: HeightWithoutContent = _DEFAULT_HEIGHT,
+        key: Key | None = None,
+        on_select: Literal["ignore"],  # No default to make it work with mypy
+    ) -> DeltaGenerator: ...
+
+    @overload
+    def scatterplot_matrix_chart(
+        self,
+        data: Data,
+        *,
+        columns: Sequence[str] | None = None,
+        label: str | None = None,
+        title: str | None = None,
+        query_colors: Sequence[str] | None = None,
+        roll_speed: float = 1.0,
+        width: WidthWithoutContent = "stretch",
+        height: HeightWithoutContent = _DEFAULT_HEIGHT,
+        key: Key | None = None,
+        on_select: Literal["rerun"] | WidgetCallback = "rerun",
+    ) -> ScatterplotMatrixState: ...
+
+    @gather_metrics("scatterplot_matrix_chart")
+    def scatterplot_matrix_chart(
+        self,
+        data: Data,
+        *,
+        columns: Sequence[str] | None = None,
+        label: str | None = None,
+        title: str | None = None,
+        query_colors: Sequence[str] | None = None,
+        roll_speed: float = 1.0,
+        width: WidthWithoutContent = "stretch",
+        height: HeightWithoutContent = _DEFAULT_HEIGHT,
+        key: Key | None = None,
+        on_select: Literal["rerun", "ignore"] | WidgetCallback = "ignore",
+    ) -> DeltaGenerator | ScatterplotMatrixState:
+        """Display an interactive scatterplot matrix (SPLOM) with rolling navigation.
+
+        The chart shows a small scatterplot for every pair of the selected
+        numeric columns next to one large detail plot. Users can left-click a
+        small plot to jump to it, right-click (or use the arrow keys) to
+        "roll" to it through an animated sequence of neighboring plots, and
+        inspect points through an excentric label lens. With a query layer
+        selected, users can lasso points in the large plot to build up to
+        several persistent selections that stay visible while navigating.
+
+        The interaction design follows the classic scatterplot matrix
+        navigation technique for exploring multidimensional datasets.
+
+        Parameters
+        ----------
+        data : Anything supported by st.dataframe
+            The dataset to explore. Non-numeric columns are ignored unless
+            referenced via ``label``.
+
+        columns : Sequence of str or None
+            The numeric columns to use as matrix dimensions. If this is
+            ``None`` (default), all numeric columns are used (up to 10).
+            The matrix has one row and one column per dimension, so between
+            2 and 10 dimensions are supported.
+
+        label : str or None
+            The column to use for point labels in the excentric label lens
+            of the large plot. If this is ``None`` (default), the positional
+            row number is used as the label.
+
+        title : str or None
+            An optional title to display above the matrix.
+
+        query_colors : Sequence of str or None
+            The CSS colors of the query layers. Each color adds one query
+            layer that users can lasso points into. If this is ``None``
+            (default), four default colors are used. A maximum of 8 query
+            layers is supported.
+
+        roll_speed : float
+            A speed multiplier for the rolling animation between plots.
+            This is ``1.0`` by default; larger values roll faster.
+
+        width : "stretch" or int
+            The width of the chart element. This can be one of the following:
+
+            - ``"stretch"`` (default): The width of the element matches the
+              width of the parent container.
+            - An integer specifying the width in pixels: The element has a
+              fixed width. If the specified width is greater than the width
+              of the parent container, the width of the element matches the
+              width of the parent container.
+
+        height : int or "stretch"
+            The height of the chart element. This can be one of the following:
+
+            - An integer specifying the height in pixels: The chart has a
+              fixed height. This is ``520`` by default.
+            - ``"stretch"``: The height of the chart matches the height of
+              the parent container.
+
+        key : str, int, or None
+            An optional string to use for giving this element a stable
+            identity. If this is ``None`` (default), the element's identity
+            will be determined based on the values of the other parameters.
+
+        on_select : "ignore" or "rerun" or callable
+            How the chart should respond to user selection events. This
+            controls whether or not the chart behaves like an input widget.
+            ``on_select`` can be one of the following:
+
+            - ``"ignore"`` (default): Streamlit will not react to any
+              selection events in the chart. The chart will not behave like
+              an input widget.
+            - ``"rerun"``: Streamlit will rerun the app when the user
+              changes a lasso selection in the chart. In this case,
+              ``st.scatterplot_matrix_chart`` will return the selection data
+              as a dictionary.
+            - A ``callable``: Streamlit will rerun the app and execute the
+              ``callable`` as a callback function before the rest of the
+              app. In this case, ``st.scatterplot_matrix_chart`` will return
+              the selection data as a dictionary.
+
+        Returns
+        -------
+        element or dict
+            If ``on_select`` is ``"ignore"`` (default), this command returns
+            an internal placeholder for the chart element. Otherwise, this
+            command returns a dictionary-like object that supports both key
+            and attribute notation. The attributes are described by the
+            ``ScatterplotMatrixState`` dictionary schema.
+
+        Examples
+        --------
+        **Example 1: Explore a dataset**
+
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> import streamlit as st
+        >>>
+        >>> rng = np.random.default_rng(0)
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "mpg": rng.normal(23, 8, 200),
+        ...         "horsepower": rng.normal(105, 40, 200),
+        ...         "weight": rng.normal(2970, 850, 200),
+        ...         "acceleration": rng.normal(15.5, 2.8, 200),
+        ...     }
+        ... )
+        >>>
+        >>> st.scatterplot_matrix_chart(df, title="Cars")
+
+        **Example 2: React to lasso selections**
+
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> import streamlit as st
+        >>>
+        >>> rng = np.random.default_rng(0)
+        >>> df = pd.DataFrame(rng.standard_normal((150, 3)), columns=["a", "b", "c"])
+        >>>
+        >>> event = st.scatterplot_matrix_chart(df, key="splom", on_select="rerun")
+        >>> st.dataframe(df.iloc[event.selection.indices])
+        """
+        validate_width(width)
+        validate_height(height)
+
+        if on_select not in {"ignore", "rerun"} and not callable(on_select):
+            raise StreamlitAPIException(
+                f"You have passed {on_select} to `on_select`. But only 'ignore', "
+                "'rerun', or a callable is supported."
+            )
+
+        if not isinstance(roll_speed, (int, float)) or roll_speed <= 0:
+            raise StreamlitAPIException(
+                f"Invalid roll_speed: {roll_speed}. The roll speed must be a "
+                "positive number."
+            )
+
+        key = to_key(key)
+        is_selection_activated = on_select != "ignore"
+
+        if is_selection_activated:
+            # Run some checks that are only relevant when selections are activated
+            is_callback = callable(on_select)
+            check_widget_policies(
+                self.dg,
+                key,
+                on_change=cast("WidgetCallback", on_select) if is_callback else None,
+                default_value=None,
+                writes_allowed=False,
+                enable_check_callback_rules=is_callback,
+            )
+
+        data_df = dataframe_util.convert_anything_to_pandas_df(data, ensure_copy=False)
+        # Stringify column names (e.g. a default RangeIndex produces integer
+        # column names) so column lookups and the marshalled Arrow data are
+        # consistent. rename returns a new frame, so user data is not mutated.
+        data_df = data_df.rename(columns=str)
+
+        parsed_columns = _parse_dimension_columns(data_df, columns)
+
+        if label is not None and label not in data_df.columns:
+            raise StreamlitAPIException(
+                f'The label column "{label}" was not found in the data. '
+                f"Available columns: {[str(column) for column in data_df.columns]}."
+            )
+
+        parsed_query_colors = (
+            [str(color) for color in query_colors] if query_colors else []
+        )
+        if len(parsed_query_colors) > _MAX_QUERY_LAYERS:
+            raise StreamlitAPIException(
+                f"The scatterplot matrix chart supports at most "
+                f"{_MAX_QUERY_LAYERS} query layers, but got "
+                f"{len(parsed_query_colors)} colors."
+            )
+
+        # Only marshall the columns that are actually used by the chart:
+        marshalled_columns = list(parsed_columns)
+        if label is not None and label not in marshalled_columns:
+            marshalled_columns.append(label)
+        chart_df = data_df[marshalled_columns].reset_index(drop=True)
+
+        proto = ScatterplotMatrixChartProto()
+        proto.data.data = dataframe_util.convert_pandas_df_to_arrow_bytes(chart_df)
+        proto.columns.extend(parsed_columns)
+        proto.label = label or ""
+        proto.title = title or ""
+        proto.query_colors.extend(parsed_query_colors)
+        proto.roll_speed = float(roll_speed)
+        proto.selections_activated = is_selection_activated
+        proto.form_id = current_form_id(self.dg)
+
+        ctx = get_script_run_ctx()
+
+        # We compute the element id for all uses (widget or not) so the
+        # frontend component can keep its navigation state when it gets
+        # unmounted and remounted.
+        proto.id = compute_and_register_element_id(
+            "scatterplot_matrix_chart",
+            user_key=key,
+            key_as_main_identity=False,
+            dg=self.dg,
+            data=proto.data.data,
+            columns=parsed_columns,
+            label=label,
+            title=title,
+            query_colors=parsed_query_colors,
+            roll_speed=roll_speed,
+            is_selection_activated=is_selection_activated,
+            width=width,
+            height=height,
+        )
+
+        layout_config = LayoutConfig(width=width, height=height)
+
+        if is_selection_activated:
+            # Selections are activated, treat the chart as a widget:
+            serde = ScatterplotMatrixSelectionSerde()
+
+            widget_state = register_widget(
+                proto.id,
+                on_change_handler=on_select if callable(on_select) else None,
+                deserializer=serde.deserialize,
+                serializer=serde.serialize,
+                ctx=ctx,
+                value_type="string_value",
+            )
+
+            self.dg._enqueue(
+                "scatterplot_matrix_chart", proto, layout_config=layout_config
+            )
+            return widget_state.value
+
+        return self.dg._enqueue(
+            "scatterplot_matrix_chart", proto, layout_config=layout_config
+        )
+
+    @property
+    def dg(self) -> DeltaGenerator:
+        """The associated DeltaGenerator."""
+        return cast("DeltaGenerator", self)

--- a/lib/streamlit/elements/scatterplot_matrix_chart.py
+++ b/lib/streamlit/elements/scatterplot_matrix_chart.py
@@ -425,6 +425,19 @@ class ScatterplotMatrixChartMixin:
         # consistent. rename returns a new frame, so user data is not mutated.
         data_df = data_df.rename(columns=str)
 
+        # Stringification can collapse distinct columns into the same name
+        # (e.g. an integer column 0 and a string column "0"). Duplicate names
+        # make column selection ambiguous (data_df[name] returns every
+        # matching column), so reject them explicitly rather than silently
+        # reading the wrong column.
+        duplicate_columns = data_df.columns[data_df.columns.duplicated()].unique()
+        if len(duplicate_columns) > 0:
+            raise StreamlitAPIException(
+                f"The data contains duplicate column names after converting "
+                f"them to strings: {list(duplicate_columns)}. Please rename "
+                f"the columns to unique values before passing the data."
+            )
+
         parsed_columns = _parse_dimension_columns(data_df, columns)
 
         if label is not None and label not in data_df.columns:

--- a/lib/tests/streamlit/element_mocks.py
+++ b/lib/tests/streamlit/element_mocks.py
@@ -129,6 +129,10 @@ WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
         lambda: st.plotly_chart(px.line(pd.DataFrame()), on_select="rerun"),
     ),
     (
+        "scatterplot_matrix_chart",
+        lambda: st.scatterplot_matrix_chart(_CHART_DATA, on_select="rerun"),
+    ),
+    (
         "pydeck_chart",
         lambda: st.pydeck_chart(
             pdk.Deck(
@@ -233,6 +237,10 @@ NON_WIDGET_ELEMENTS: list[tuple[str, ELEMENT_PRODUCER]] = [
     (
         "plotly_chart",
         lambda: st.plotly_chart(px.line(_CHART_DATA), on_select="ignore"),
+    ),
+    (
+        "scatterplot_matrix_chart",
+        lambda: st.scatterplot_matrix_chart(_CHART_DATA, on_select="ignore"),
     ),
     ("pydeck_chart", lambda: st.pydeck_chart(pdk.Deck())),
     (

--- a/lib/tests/streamlit/elements/scatterplot_matrix_chart_test.py
+++ b/lib/tests/streamlit/elements/scatterplot_matrix_chart_test.py
@@ -1,0 +1,235 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""st.scatterplot_matrix_chart unit tests."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+from parameterized import parameterized
+
+import streamlit as st
+from streamlit import dataframe_util
+from streamlit.elements.scatterplot_matrix_chart import (
+    ScatterplotMatrixSelectionSerde,
+    ScatterplotMatrixState,
+)
+from streamlit.errors import StreamlitAPIException
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+def _test_data() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(rng.standard_normal((20, 3)), columns=["alpha", "beta", "gamma"])
+    df["name"] = [f"point {index}" for index in range(20)]
+    return df
+
+
+class TestScatterplotMatrixSelectionSerde:
+    """Tests for the selection state serializer/deserializer."""
+
+    def test_deserialize_none_returns_empty_selection(self):
+        """Deserializing None returns an empty selection state."""
+        serde = ScatterplotMatrixSelectionSerde()
+        state = serde.deserialize(None)
+        assert state["selection"]["indices"] == []
+        assert state["selection"]["query_layers"] == []
+
+    def test_deserialize_roundtrip(self):
+        """A serialized selection state deserializes to the same value."""
+        serde = ScatterplotMatrixSelectionSerde()
+        state: ScatterplotMatrixState = {
+            "selection": {
+                "indices": [1, 3],
+                "query_layers": [
+                    {"label": "Query 1", "indices": [1, 3]},
+                    {"label": "Query 2", "indices": []},
+                ],
+            },
+        }
+        deserialized = serde.deserialize(serde.serialize(state))
+        assert deserialized["selection"]["indices"] == [1, 3]
+        assert deserialized["selection"]["query_layers"][0]["label"] == "Query 1"
+        assert deserialized["selection"]["query_layers"][0]["indices"] == [1, 3]
+
+    def test_deserialize_supports_attribute_notation(self):
+        """The deserialized state supports attribute access."""
+        serde = ScatterplotMatrixSelectionSerde()
+        state = serde.deserialize(
+            json.dumps({"selection": {"indices": [2], "query_layers": []}})
+        )
+        assert state.selection.indices == [2]
+
+
+class TestScatterplotMatrixChart(DeltaGeneratorTestCase):
+    """Tests for the st.scatterplot_matrix_chart command."""
+
+    def test_basic_element(self):
+        """The command marshalls data, columns, and defaults into the proto."""
+        st.scatterplot_matrix_chart(_test_data())
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert proto.columns == ["alpha", "beta", "gamma"]
+        assert proto.label == ""
+        assert proto.title == ""
+        assert list(proto.query_colors) == []
+        assert proto.roll_speed == 1.0
+        assert proto.selections_activated is False
+        assert proto.id != ""
+
+        # The marshalled data only contains the dimension columns:
+        marshalled = dataframe_util.convert_arrow_bytes_to_pandas_df(proto.data.data)
+        assert list(marshalled.columns) == ["alpha", "beta", "gamma"]
+        assert len(marshalled) == 20
+
+    def test_explicit_parameters(self):
+        """Explicit columns, label, title, and colors are marshalled."""
+        st.scatterplot_matrix_chart(
+            _test_data(),
+            columns=["beta", "alpha"],
+            label="name",
+            title="My matrix",
+            query_colors=["#ff0000", "#00ff00"],
+            roll_speed=2.5,
+        )
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert proto.columns == ["beta", "alpha"]
+        assert proto.label == "name"
+        assert proto.title == "My matrix"
+        assert list(proto.query_colors) == ["#ff0000", "#00ff00"]
+        assert proto.roll_speed == 2.5
+
+        # The label column is included in the marshalled data:
+        marshalled = dataframe_util.convert_arrow_bytes_to_pandas_df(proto.data.data)
+        assert list(marshalled.columns) == ["beta", "alpha", "name"]
+
+    def test_supports_non_string_column_names(self):
+        """DataFrames with default integer column names work."""
+        st.scatterplot_matrix_chart(
+            pd.DataFrame(np.random.default_rng(0).standard_normal((10, 3)))
+        )
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert proto.columns == ["0", "1", "2"]
+        marshalled = dataframe_util.convert_arrow_bytes_to_pandas_df(proto.data.data)
+        assert list(marshalled.columns) == ["0", "1", "2"]
+
+    def test_does_not_mutate_user_dataframe(self):
+        """Marshalling must not rename the columns of the user's DataFrame."""
+        df = pd.DataFrame(np.zeros((5, 2)))
+        st.scatterplot_matrix_chart(df)
+        assert list(df.columns) == [0, 1]
+
+    def test_non_numeric_columns_are_excluded_by_default(self):
+        """Auto-detected dimensions must not include non-numeric columns."""
+        st.scatterplot_matrix_chart(_test_data())
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert "name" not in proto.columns
+
+    def test_on_select_rerun_registers_widget(self):
+        """Activating selections registers the element as a widget."""
+        state = st.scatterplot_matrix_chart(_test_data(), on_select="rerun")
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert proto.selections_activated is True
+        assert state.selection.indices == []
+        assert state.selection.query_layers == []
+
+    def test_on_select_ignore_returns_delta_generator(self):
+        """With on_select='ignore' no selection state is returned."""
+        return_value = st.scatterplot_matrix_chart(_test_data())
+        assert not isinstance(return_value, dict)
+
+    def test_throws_on_unknown_columns(self):
+        """Unknown dimension columns raise a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="not found in the data"):
+            st.scatterplot_matrix_chart(_test_data(), columns=["alpha", "unknown"])
+
+    def test_throws_on_non_numeric_columns(self):
+        """Non-numeric dimension columns raise a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="not numeric"):
+            st.scatterplot_matrix_chart(_test_data(), columns=["alpha", "name"])
+
+    def test_throws_on_too_few_columns(self):
+        """Fewer than two dimensions raise a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="at least 2"):
+            st.scatterplot_matrix_chart(_test_data(), columns=["alpha"])
+
+    def test_throws_on_too_many_explicit_columns(self):
+        """More than ten explicit dimensions raise a StreamlitAPIException."""
+        column_names = [f"col{index}" for index in range(11)]
+        many_columns = pd.DataFrame(np.zeros((5, 11)), columns=column_names)
+        with pytest.raises(StreamlitAPIException, match="at most 10"):
+            st.scatterplot_matrix_chart(many_columns, columns=column_names)
+
+    def test_auto_detected_columns_are_capped(self):
+        """Auto-detected dimensions are capped at ten columns."""
+        many_columns = pd.DataFrame(
+            np.zeros((5, 12)), columns=[f"col{index}" for index in range(12)]
+        )
+        st.scatterplot_matrix_chart(many_columns)
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert len(proto.columns) == 10
+
+    def test_throws_on_unknown_label_column(self):
+        """An unknown label column raises a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="label column"):
+            st.scatterplot_matrix_chart(_test_data(), label="unknown")
+
+    def test_throws_on_too_many_query_colors(self):
+        """More than eight query colors raise a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="at most 8 query layers"):
+            st.scatterplot_matrix_chart(
+                _test_data(), query_colors=[f"#00000{index}" for index in range(9)]
+            )
+
+    @parameterized.expand([(0,), (-1.5,)])
+    def test_throws_on_invalid_roll_speed(self, roll_speed: float):
+        """A non-positive roll speed raises a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="roll_speed"):
+            st.scatterplot_matrix_chart(_test_data(), roll_speed=roll_speed)
+
+    @parameterized.expand([(0,), (-100,), ("content",)])
+    def test_throws_on_invalid_height(self, height: int | str):
+        """A non-positive or unsupported height raises a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="height"):
+            st.scatterplot_matrix_chart(_test_data(), height=height)  # type: ignore[call-overload]
+
+    def test_accepts_stretch_height(self):
+        """A "stretch" height is valid and does not raise."""
+        st.scatterplot_matrix_chart(_test_data(), height="stretch")
+
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert proto.id != ""
+
+    def test_throws_on_invalid_on_select(self):
+        """An invalid on_select value raises a StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="on_select"):
+            st.scatterplot_matrix_chart(_test_data(), on_select="invalid")  # type: ignore[call-overload]
+
+    def test_form_id_is_marshalled_inside_form(self):
+        """The enclosing form id is marshalled into the proto."""
+        with st.form("my_form"):
+            st.scatterplot_matrix_chart(_test_data())
+
+        # The form element is enqueued first; the chart is the last delta.
+        proto = self.get_delta_from_queue().new_element.scatterplot_matrix_chart
+        assert proto.form_id != ""

--- a/lib/tests/streamlit/elements/scatterplot_matrix_chart_test.py
+++ b/lib/tests/streamlit/elements/scatterplot_matrix_chart_test.py
@@ -136,6 +136,17 @@ class TestScatterplotMatrixChart(DeltaGeneratorTestCase):
         st.scatterplot_matrix_chart(df)
         assert list(df.columns) == [0, 1]
 
+    def test_throws_on_columns_colliding_after_stringification(self):
+        """Distinct columns that stringify to the same name are rejected.
+
+        E.g. an int column named 0 and a str column named "0" would
+        otherwise silently collapse into a single ambiguous "0" column.
+        """
+        df = pd.DataFrame(np.random.default_rng(0).standard_normal((10, 3)))
+        df.columns = [0, "0", 1]
+        with pytest.raises(StreamlitAPIException, match="duplicate column names"):
+            st.scatterplot_matrix_chart(df)
+
     def test_non_numeric_columns_are_excluded_by_default(self):
         """Auto-detected dimensions must not include non-numeric columns."""
         st.scatterplot_matrix_chart(_test_data())

--- a/lib/tests/streamlit/typing/scatterplot_matrix_chart_types.py
+++ b/lib/tests/streamlit/typing/scatterplot_matrix_chart_types.py
@@ -1,0 +1,137 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from typing_extensions import assert_type
+
+# Perform type checking tests for st.scatterplot_matrix_chart.
+# The return type depends on the on_select parameter:
+# - no on_select / on_select="rerun" / callable -> returns ScatterplotMatrixState
+# - on_select="ignore" -> returns DeltaGenerator
+# Note: because the "ignore" overload has no default value, omitting on_select
+# resolves to the "rerun" overload and therefore returns ScatterplotMatrixState.
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from streamlit.delta_generator import DeltaGenerator
+    from streamlit.elements.scatterplot_matrix_chart import (
+        ScatterplotMatrixChartMixin,
+        ScatterplotMatrixState,
+    )
+
+    scatterplot_matrix_chart = ScatterplotMatrixChartMixin().scatterplot_matrix_chart
+
+    df = cast("pd.DataFrame", object())
+
+    # =====================================================================
+    # Basic return type tests
+    # (no on_select -> resolves to the "rerun" overload -> state)
+    # =====================================================================
+
+    assert_type(scatterplot_matrix_chart(df), ScatterplotMatrixState)
+
+    # =====================================================================
+    # Return type tests with on_select="ignore" -> DeltaGenerator
+    # =====================================================================
+
+    assert_type(scatterplot_matrix_chart(df, on_select="ignore"), DeltaGenerator)
+
+    # =====================================================================
+    # Return type tests with on_select="rerun" -> state
+    # =====================================================================
+
+    assert_type(scatterplot_matrix_chart(df, on_select="rerun"), ScatterplotMatrixState)
+
+    # =====================================================================
+    # Return type tests with callback function -> state
+    # =====================================================================
+
+    def my_callback() -> None:
+        pass
+
+    assert_type(
+        scatterplot_matrix_chart(df, on_select=my_callback), ScatterplotMatrixState
+    )
+    assert_type(
+        scatterplot_matrix_chart(df, on_select=lambda: None), ScatterplotMatrixState
+    )
+
+    # =====================================================================
+    # Test width ("stretch" or int) and height (int or "stretch")
+    # =====================================================================
+
+    assert_type(
+        scatterplot_matrix_chart(df, on_select="ignore", width="stretch"),
+        DeltaGenerator,
+    )
+    assert_type(
+        scatterplot_matrix_chart(df, on_select="ignore", width=500), DeltaGenerator
+    )
+    assert_type(
+        scatterplot_matrix_chart(df, on_select="ignore", height=400), DeltaGenerator
+    )
+    assert_type(
+        scatterplot_matrix_chart(df, on_select="ignore", height="stretch"),
+        DeltaGenerator,
+    )
+    assert_type(
+        scatterplot_matrix_chart(df, height=400, on_select="rerun"),
+        ScatterplotMatrixState,
+    )
+
+    # =====================================================================
+    # Test remaining keyword parameters
+    # =====================================================================
+
+    assert_type(
+        scatterplot_matrix_chart(
+            df,
+            columns=["a", "b"],
+            label="name",
+            title="My matrix",
+            query_colors=["#ff0000", "#00ff00"],
+            roll_speed=2.0,
+            key="my_chart",
+            on_select="ignore",
+        ),
+        DeltaGenerator,
+    )
+    assert_type(
+        scatterplot_matrix_chart(
+            df,
+            columns=("a", "b"),
+            label=None,
+            title=None,
+            query_colors=None,
+            roll_speed=1.0,
+            key=123,
+            on_select="rerun",
+        ),
+        ScatterplotMatrixState,
+    )
+
+    # =====================================================================
+    # Invalid usages - should NOT type check
+    # =====================================================================
+
+    # Invalid width / height values
+    scatterplot_matrix_chart(df, width="invalid")  # type: ignore[call-overload]
+    scatterplot_matrix_chart(df, height="content")  # type: ignore[call-overload]
+    scatterplot_matrix_chart(df, height=None)  # type: ignore[call-overload]
+
+    # Invalid on_select value
+    scatterplot_matrix_chart(df, on_select="invalid")  # type: ignore[call-overload]

--- a/proto/streamlit/proto/Element.proto
+++ b/proto/streamlit/proto/Element.proto
@@ -58,6 +58,7 @@ import "streamlit/proto/Pagination.proto";
 import "streamlit/proto/PlotlyChart.proto";
 import "streamlit/proto/Progress.proto";
 import "streamlit/proto/Radio.proto";
+import "streamlit/proto/ScatterplotMatrixChart.proto";
 import "streamlit/proto/Selectbox.proto";
 import "streamlit/proto/Skeleton.proto";
 import "streamlit/proto/Slider.proto";
@@ -144,7 +145,8 @@ message Element {
     Code code = 48;
     MenuButton menu_button = 64;
     Pagination pagination = 66;
-    // Next ID: 67
+    ScatterplotMatrixChart scatterplot_matrix_chart = 67;
+    // Next ID: 68
   }
 
   reserved 3, 9, 10, 11, 17;

--- a/proto/streamlit/proto/ScatterplotMatrixChart.proto
+++ b/proto/streamlit/proto/ScatterplotMatrixChart.proto
@@ -1,0 +1,55 @@
+/**!
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+import "streamlit/proto/ArrowData.proto";
+
+// Proto message for the st.scatterplot_matrix_chart element: an interactive
+// scatterplot matrix (SPLOM) with rolling navigation, query layers, and
+// lasso selections.
+message ScatterplotMatrixChart {
+  // The unique element ID of this chart.
+  string id = 1;
+
+  // The Arrow-serialized dataframe backing the chart. Contains the dimension
+  // columns and (optionally) the label column.
+  ArrowData data = 2;
+
+  // Names of the numeric columns used as matrix dimensions. The matrix is
+  // len(columns) x len(columns) cells.
+  repeated string columns = 3;
+
+  // Optional name of the column holding point labels (shown in the
+  // excentric label lens). Empty string means row positions are used.
+  string label = 4;
+
+  // Optional title rendered above the matrix.
+  string title = 5;
+
+  // CSS colors of the query layers; the number of layers equals the number
+  // of colors. Empty means the default four-layer palette.
+  repeated string query_colors = 6;
+
+  // Speed multiplier for the rolling animation (1.0 = default speed).
+  double roll_speed = 7;
+
+  // Whether lasso selection events are sent back to the backend.
+  bool selections_activated = 8;
+
+  // Form ID, filled if selections are activated.
+  string form_id = 9;
+}

--- a/wiki/new-feature-guide.md
+++ b/wiki/new-feature-guide.md
@@ -18,7 +18,7 @@ New features should include:
    - New elements: add to `proto/streamlit/proto/Element.proto`
 
 2. **Backend** in `lib/streamlit/`
-   - New elements: add to `lib/streamlit/__init__.py`
+   - New elements: implement a mixin in `lib/streamlit/elements/`, register it on the `DeltaGenerator` class in `lib/streamlit/delta_generator.py`, and add the command to `lib/streamlit/__init__.py`
 
 3. **Python unit tests** in `lib/tests`
    - Run: `uv run pytest lib/tests/streamlit/the_test_name.py`


### PR DESCRIPTION

## Describe your changes

Adds `st.scatterplot_matrix_chart`, an interactive scatterplot matrix (SPLOM) for exploring pairwise relationships across numeric columns (my original implementation was in Java back in 2012).

- Left-click a matrix cell to jump to it, right-click (or arrow keys) to "roll" to it with an animated transition, and hover the enlarged plot for an excentric label lens.
- Lasso the enlarged plot to build up to 8 persistent, colored query-layer selections; selections return to Python as row indices via `on_select="rerun"`, following the `st.plotly_chart` pattern.
- Renders through a self-contained WebGL 2 engine (no new dependencies); navigation, zoom, and selection state all persist across reruns.

```python
event = st.scatterplot_matrix_chart(
    df,
    columns=["mpg", "hp", ...],
    label="name",
    on_select="rerun",
)
st.dataframe(df.iloc[event.selection.indices])
```

## Screenshot or video (only for visual changes)

![Demo of st.scatterplot_matrix_chart: jumping/rolling between matrix cells, the excentric label lens, and a lasso query selection](https://raw.githubusercontent.com/m-hu/streamlit/demo-assets/scatterplot-matrix-chart/work-tmp/scatterplot_matrix_chart_demo.gif)

## GitHub Issue Link (if applicable)

- Closes #16085

## Testing Plan

- `lib/tests/streamlit/elements/scatterplot_matrix_chart_test.py` — marshalling, column/label/query-color/height/roll_speed validation, selection serde, forms
- `lib/tests/streamlit/typing/scatterplot_matrix_chart_types.py` — mypy `assert_type` checks for the `on_select` overloads
- `frontend/lib/src/components/elements/ScatterplotMatrixChart/ScatterplotMatrixChart.test.tsx` — Arrow extraction (incl. null handling), selection wiring/restore, view-state persistence, disabled/form-clear behavior
- `frontend/lib/src/components/elements/ScatterplotMatrixChart/scatterplotMatrixEngine.test.ts` — navigation path building, lasso polygon hit-testing, selection reconciliation
- `e2e_playwright/st_scatterplot_matrix_chart_test.py` — render, top-level CSS class, lasso → rerun → selection → clear-all roundtrip
- Manual testing: verified visually in a running app (see demo above)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface area (new public API, widget state, WebGL runtime) but isolated to a new element with extensive tests; selection/form edge cases are explicitly handled.
> 
> **Overview**
> Introduces **`st.scatterplot_matrix_chart`**, an interactive scatterplot matrix for exploring 2–10 numeric columns: a grid of pairwise small plots, a large detail view with jump/roll navigation, query layers with lasso selection, and an excentric label lens.
> 
> **Python API** marshals only the needed columns over Arrow, validates dimensions/labels/query colors, and optionally registers a widget when `on_select` is `"rerun"` or a callback—returning `event.selection.indices` and per-layer `query_layers` (same pattern as Plotly selections). Forms, stable element ids for view-state persistence, and docs/skills updates are included.
> 
> **Frontend** adds a new `scatterplotMatrixChart` element in `ElementNodeRenderer`, a React wrapper that wires Arrow data, widget state, form clear, and disabled handling to a **~3k-line WebGL 2 engine** (with `ErrorElement` fallback). Selection and navigation state reconcile across reruns and shrinking `query_colors`.
> 
> **Tests**: Python unit + typing tests, Vitest for the component/engine helpers, and Playwright E2E for render, class, and lasso → rerun → clear-all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c96f13b555154507cfa5b063963272d6fc5f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


