### PR TITLE
[bugfix] Fix inconsistent checkbox margin in horizontal container within column (#13162)

### DIFF
--- a/e2e_playwright/st_columns.py
+++ b/e2e_playwright/st_columns.py
@@ -106,9 +106,7 @@ with st.expander("Vertical alignment - top", expanded=True):
     col3.checkbox("Checkbox 1 (top)")
     col3.checkbox("Checkbox 2 (top)")
 
-with st.expander(
-    "Vertical alignment - top with nested horizontal container", expanded=True
-):
+with st.expander("Nested horizontal container in top-aligned column", expanded=True):
     # Regression coverage for #13162: checkboxes nested inside a horizontal
     # container within a TOP-aligned column should NOT receive the
     # alignment margin-top — only direct-child checkboxes of the column

--- a/e2e_playwright/st_columns.py
+++ b/e2e_playwright/st_columns.py
@@ -106,6 +106,23 @@ with st.expander("Vertical alignment - top", expanded=True):
     col3.checkbox("Checkbox 1 (top)")
     col3.checkbox("Checkbox 2 (top)")
 
+with st.expander(
+    "Vertical alignment - top with nested horizontal container", expanded=True
+):
+    # Regression coverage for #13162: checkboxes nested inside a horizontal
+    # container within a TOP-aligned column should NOT receive the
+    # alignment margin-top — only direct-child checkboxes of the column
+    # should.
+    col1, col2 = st.columns(2, vertical_alignment="top")
+    with col1:
+        st.button("Button 1 (nested)", width="stretch")
+        st.button("Button 2 (nested)", width="stretch")
+    with col2:
+        with st.container(horizontal=True):
+            st.checkbox("Nested checkbox 1", key="cb_nested_1")
+            st.checkbox("Nested checkbox 2", key="cb_nested_2")
+            st.checkbox("Nested checkbox 3", key="cb_nested_3")
+
 with st.expander("Vertical alignment - center", expanded=True):
     col1, col2, col3 = st.columns(3, vertical_alignment="center")
     col1.text_input("Text input (center)")

--- a/e2e_playwright/st_columns_test.py
+++ b/e2e_playwright/st_columns_test.py
@@ -168,7 +168,7 @@ def test_column_top_alignment_does_not_leak_into_nested_horizontal_container(
     only apply to direct-child first checkboxes of the column.
     """
     column_container = (
-        get_expander(app, "Vertical alignment - top with nested horizontal container")
+        get_expander(app, "Nested horizontal container in top-aligned column")
         .get_by_test_id("stHorizontalBlock")
         .nth(0)
     )

--- a/e2e_playwright/st_columns_test.py
+++ b/e2e_playwright/st_columns_test.py
@@ -158,6 +158,31 @@ def test_column_vertical_alignment_top(
     )
 
 
+def test_column_top_alignment_does_not_leak_into_nested_horizontal_container(
+    app: Page,
+):
+    """Regression test for #13162.
+
+    Checkboxes inside a horizontal container nested inside a TOP-aligned
+    column must not receive the alignment `margin-top`. The margin should
+    only apply to direct-child first checkboxes of the column.
+    """
+    column_container = (
+        get_expander(app, "Vertical alignment - top with nested horizontal container")
+        .get_by_test_id("stHorizontalBlock")
+        .nth(0)
+    )
+
+    checkboxes = column_container.get_by_test_id("stCheckbox")
+    expect(checkboxes).to_have_count(3)
+
+    # None of the checkboxes in the nested horizontal container should have
+    # the alignment margin — previously the first-of-type inside the nested
+    # container was incorrectly picking it up.
+    for i in range(3):
+        expect(checkboxes.nth(i)).to_have_css("margin-top", "0px")
+
+
 def test_column_vertical_alignment_center(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -176,7 +176,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
         // Scoped to the column's own stVerticalBlock so nested containers
         // (e.g. horizontal containers of checkboxes) do not also get matched
         // (issue #13162).
-        [`& > [data-testid="stVerticalBlock"] > ${StyledElementContainer}:last-of-type > ${StyledCheckbox}`]:
+        [`& > .stVerticalBlock > ${StyledElementContainer}:last-of-type > ${StyledCheckbox}`]:
           {
             marginBottom: theme.spacing.sm,
           },
@@ -186,7 +186,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
         // widgets. Scoped to the column's own stVerticalBlock so nested
         // containers (e.g. horizontal containers of checkboxes) do not also
         // get matched (issue #13162).
-        [`& > [data-testid="stVerticalBlock"] > ${StyledElementContainer}:first-of-type > ${StyledCheckbox}`]:
+        [`& > .stVerticalBlock > ${StyledElementContainer}:first-of-type > ${StyledCheckbox}`]:
           {
             marginTop: theme.spacing.sm,
           },

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -172,18 +172,24 @@ export const StyledColumn = styled.div<StyledColumnProps>(
       },
       ...(verticalAlignment === VerticalAlignment.BOTTOM && {
         marginTop: "auto",
-        // Add margin to the first checkbox/toggle within the column to align it
-        // better with other input widgets.
-        [`& ${StyledElementContainer}:last-of-type > ${StyledCheckbox}`]: {
-          marginBottom: theme.spacing.sm,
-        },
+        // Align the last direct-child checkbox/toggle with other input widgets.
+        // Scoped to the column's own stVerticalBlock so nested containers
+        // (e.g. horizontal containers of checkboxes) do not also get matched
+        // (issue #13162).
+        [`& > [data-testid="stVerticalBlock"] > ${StyledElementContainer}:last-of-type > ${StyledCheckbox}`]:
+          {
+            marginBottom: theme.spacing.sm,
+          },
       }),
       ...(verticalAlignment === VerticalAlignment.TOP && {
-        // Add margin to the first checkbox/toggle within the column to align it
-        // better with other input widgets.
-        [`& ${StyledElementContainer}:first-of-type > ${StyledCheckbox}`]: {
-          marginTop: theme.spacing.sm,
-        },
+        // Align the first direct-child checkbox/toggle with other input
+        // widgets. Scoped to the column's own stVerticalBlock so nested
+        // containers (e.g. horizontal containers of checkboxes) do not also
+        // get matched (issue #13162).
+        [`& > [data-testid="stVerticalBlock"] > ${StyledElementContainer}:first-of-type > ${StyledCheckbox}`]:
+          {
+            marginTop: theme.spacing.sm,
+          },
       }),
       ...(verticalAlignment === VerticalAlignment.CENTER && {
         marginTop: "auto",


### PR DESCRIPTION
## Describe your changes

Fixes an inconsistent `margin-top` (and mirrored `margin-bottom`) on checkboxes when they are placed inside an `st.container(horizontal=True)` that is itself inside an `st.columns()` column.

The alignment margin applied to the first-of-type / last-of-type checkbox in a TOP or BOTTOM aligned column was using a descendant selector, so it matched *any* first-of-type element container inside the column — including ones nested inside a horizontal container. As a result the first checkbox in each nested horizontal container was getting an extra `0.5rem` of `margin-top` while its siblings were not, producing visibly misaligned rows.

Scope the selector to direct children of the column's own `stVerticalBlock` so the margin only applies to the intended direct-child checkboxes.

## Screenshot or video (only for visual changes)

Before
<img width="839" height="243" alt="image" src="https://github.com/user-attachments/assets/058883b3-7659-49fd-9ae9-819e0f6430d9" />

After:
<img width="836" height="237" alt="image" src="https://github.com/user-attachments/assets/652b3631-ffef-401d-a860-1bbebf7215ac" />

## GitHub Issue Link (if applicable)

Closes #13162

## Testing Plan

- **New E2E test**: added `test_column_top_alignment_does_not_leak_into_nested_horizontal_container` in `e2e_playwright/st_columns_test.py`, backed by a new "Vertical alignment - top with nested horizontal container" section in `e2e_playwright/st_columns.py`. The test asserts every checkbox in the nested horizontal container has `margin-top: 0px`.
- **Existing E2E tests preserved**: `test_column_vertical_alignment_top` still asserts that a direct-child first checkbox in a TOP-aligned column has `margin-top: 8px`, and `test_column_vertical_alignment_bottom` still asserts the mirrored case — so the intended alignment behavior is not regressed.
- **Manual verification**: ran the reproducer from the issue locally and confirmed via `getComputedStyle` that all six checkboxes now report `margin-top: 0px` while the intended direct-child cases still report `margin-top: 8px` / `margin-bottom: 8px`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only scoping change for column layout with targeted E2E coverage; no auth, data, or API impact.
> 
> **Overview**
> Fixes misaligned checkbox rows when `st.container(horizontal=True)` sits inside a **top**- or **bottom**-aligned `st.columns()` column.
> 
> Column vertical-alignment styles previously used broad descendant selectors, so the first checkbox in a nested horizontal container incorrectly picked up the same `margin-top` / `margin-bottom` meant for direct column widgets. Selectors in `styled-components.ts` are now limited to `& > .stVerticalBlock > …`, so only direct-child checkboxes in the column get the alignment margin.
> 
> Adds a Playwright regression (`test_column_top_alignment_does_not_leak_into_nested_horizontal_container`) and a matching demo expander asserting nested horizontal checkboxes keep `margin-top: 0px`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4586b3b0dc60569c3d6ee1d816cae5f1cb06116d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 1 |

</details>
<!-- agent-metrics-end -->