### PR TITLE
Fix #15891: Include hierarchical headers in DataFrame CSV export

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -102,10 +102,33 @@ async function writeCsv(
   // Write UTF-8 BOM for excel compatibility:
   await writable.write(textEncoder.encode(CSV_UTF8_BOM))
 
-  // Write headers (skip button columns as they are not exportable):
-  const headers: string[] = columns
-    .filter(column => column.kind !== "button")
-    .map(column => column.name)
+  // 1. Get the columns we actually want to export
+  const exportableColumns = columns.filter(column => column.kind !== "button")
+
+  // 2. Find out how many rows of upper-level headers we need
+  const maxDepth = Math.max(
+    ...exportableColumns.map(col => {
+      if (!col.group) return 0
+      return Array.isArray(col.group) ? col.group.length : 1
+    }),
+    0
+  )
+
+  // 3. Write each level of the group headers as a separate row in the CSV
+  for (let i = 0; i < maxDepth; i++) {
+    const groupRow = exportableColumns.map(col => {
+      const groupArray = Array.isArray(col.group)
+        ? col.group
+        : col.group
+          ? [col.group]
+          : []
+      return groupArray[i] || ""
+    })
+    await writable.write(textEncoder.encode(toCsvRow(groupRow)))
+  }
+
+  // 4. Write the final base headers (the lowest level)
+  const headers: string[] = exportableColumns.map(column => column.name)
   await writable.write(textEncoder.encode(toCsvRow(headers)))
 
   for (let row = 0; row < numRows; row++) {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useDataExporter.ts
@@ -105,11 +105,13 @@ async function writeCsv(
   // 1. Get the columns we actually want to export
   const exportableColumns = columns.filter(column => column.kind !== "button")
 
-  // 2. Find out how many rows of upper-level headers we need
+  // 2. Find out how many rows of upper-level headers we need, splitting the flattened string
   const maxDepth = Math.max(
     ...exportableColumns.map(col => {
       if (!col.group) return 0
-      return Array.isArray(col.group) ? col.group.length : 1
+      return Array.isArray(col.group)
+        ? col.group.length
+        : String(col.group).split(" / ").length
     }),
     0
   )
@@ -117,11 +119,10 @@ async function writeCsv(
   // 3. Write each level of the group headers as a separate row in the CSV
   for (let i = 0; i < maxDepth; i++) {
     const groupRow = exportableColumns.map(col => {
+      if (!col.group) return ""
       const groupArray = Array.isArray(col.group)
         ? col.group
-        : col.group
-          ? [col.group]
-          : []
+        : String(col.group).split(" / ")
       return groupArray[i] || ""
     })
     await writable.write(textEncoder.encode(toCsvRow(groupRow)))
@@ -129,8 +130,8 @@ async function writeCsv(
 
   // 4. Write the final base headers (the lowest level)
   const headers: string[] = exportableColumns.map(column => column.name)
-  await writable.write(textEncoder.encode(toCsvRow(headers)))
 
+  await writable.write(textEncoder.encode(toCsvRow(headers)))
   for (let row = 0; row < numRows; row++) {
     const rowData: unknown[] = []
     // Button columns are skipped because they are not exportable, but we still


### PR DESCRIPTION
## Describe your changes
The current `useDataExporter.ts` ignores the upper levels of a `pd.MultiIndex` dataframe because the CSV writer only maps `column.name`. This PR fixes the regression by updating the exporter to:
1. Extract the `column.group` arrays.
2. Calculate the maximum header depth.
3. Write each level of the hierarchical index as a separate row before writing the base column names.

## Screenshot or video (only for visual changes)
*Note: I am contributing via a standard 8GB GitHub Codespace, which unfortunately runs out of memory (Exit Code 129/143) during Vite's dependency bundling, preventing me from grabbing a local UI screenshot. I will gladly test the CI preview environment once this PR generates one!*

Here is the exact CSV text transformation this logic applies to the reproducible code in the original issue:

** Before (Current Bug):**
```csv
"Q1","Q2","Q3","Q4","Q1","Q2","Q3","Q4"
"Sales",23,33,22,44,45,66,31,18
"Marketing",11,16,47,53,78,82,9,14

After(with pr)
"2022","2022","2022","2022","2023","2023","2023","2023"
"Q1","Q2","Q3","Q4","Q1","Q2","Q3","Q4"
"Sales",23,33,22,44,45,66,31,18
"Marketing",11,16,47,53,78,82,9,14
Github Issue Link:https://github.com/streamlit/streamlit/issues/15891
Testing Plan
Explanation of why no additional tests are needed: This is a direct logic fix to the existing CSV export utility. It restores the previously expected behavior of multi-index CSV exports without altering the public API.

Unit Tests (JS and/or Python): N/A

E2E Tests: N/A

Any manual testing needed?: Yes. A reviewer can run the Python reproduction script provided in Issue #15891, hover over the rendered dataframe, click the "Download to CSV" button, and verify that the downloaded CSV contains all levels of the multi-index headers.

Contribution License Agreement

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to client-side CSV formatting in the DataFrame exporter; no API or data-pipeline changes.
> 
> **Overview**
> **DataFrame “Download to CSV”** now emits multi-level column headers that match on-screen `pd.MultiIndex` tables, instead of only the bottom-level `column.name` row.
> 
> `writeCsv` in `useDataExporter.ts` derives exportable columns (still skipping button columns), computes header depth from each column’s `group` (array or `" / "`-split string), writes one CSV row per upper level, then writes the existing base header row and data rows unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72a5764e4845875a34a6fd83ffe3826057e43f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->