### PR TITLE
[bugfix] Include decorators in st.echo output

### DIFF
--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -87,8 +87,17 @@ def echo(
         collect_body_statements(root_node)
 
         # In AST module the lineno (line numbers) are 1-indexed,
-        # so we decrease it by 1 to lookup in source lines list
-        echo_block_start_line = line_to_node_map[start_line].body[0].lineno - 1
+        # so we decrease it by 1 to lookup in source lines list.
+        # For a decorated function/class as the first body statement, ast
+        # points `lineno` at `def`/`class` — the decorators are one or more
+        # lines above. Use the earliest of the node and its decorators so the
+        # @decorator lines are included in the echoed source (#9252).
+        first_body_node = line_to_node_map[start_line].body[0]
+        first_body_lineno = min(
+            [first_body_node.lineno]
+            + [d.lineno for d in getattr(first_body_node, "decorator_list", [])]
+        )
+        echo_block_start_line = first_body_lineno - 1
         echo_block_end_line = line_to_node_map[start_line].end_lineno
         lines_to_display = source_lines[echo_block_start_line:echo_block_end_line]
 

--- a/lib/tests/streamlit/elements/echo_test.py
+++ b/lib/tests/streamlit/elements/echo_test.py
@@ -145,6 +145,41 @@ class MyClass:
         assert element.markdown.body == "Dual"
         self.clear_queue()
 
+    def test_decorated_function_as_first_statement(self):
+        """A decorated function/class as the first body statement must include
+        the @decorator lines in the echoed source (regression for #9252).
+
+        ast reports `FunctionDef.lineno` as the `def` line, so a naive
+        `body[0].lineno` skips the decorator lines above it.
+        """
+
+        def decorator(fn):
+            return fn
+
+        with st.echo():
+
+            @decorator
+            def function():
+                pass
+
+            @decorator
+            @decorator
+            class MultiDecorated:
+                pass
+
+        echo_str = """@decorator
+def function():
+    pass
+
+@decorator
+@decorator
+class MultiDecorated:
+    pass"""
+
+        element = self.get_delta_from_queue(0).new_element
+        assert echo_str == element.code.code_text
+        self.clear_queue()
+
     def test_root_level_echo(self):
         import tests.streamlit.echo_test_data.root_level_echo  # noqa: F401
 


### PR DESCRIPTION
## Describe your changes

When a decorated function/class was the first statement inside `with st.echo():`, the `@decorator` lines were missing from the echoed source:

```python
with st.echo():
    @decorator
    def function():
        pass
```

...rendered just `def function(): / pass`. Adding any statement above the decorated node — even a bare string — happened to "fix" it, because the source range then started at that earlier statement's line.

**Root cause:** `ast.FunctionDef.lineno` (and `ClassDef`, `AsyncFunctionDef`) points at the `def`/`class` line — the decorators sit on the lines above. The existing code used `body[0].lineno` as the echo block start, which skipped the decorators.

**Fix:** for the first body node, use the min of `node.lineno` and each `decorator_list[i].lineno`. Single decorator, stacked decorators, and non-decorated first statements all take the correct start line.

## GitHub Issue Link (if applicable)

- Closes #9252

## Testing Plan

- Unit test: `test_decorated_function_as_first_statement` in `lib/tests/streamlit/elements/echo_test.py` covers both a single-decorator function and a class with two stacked decorators as the first body statement. All 17 existing tests still pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to how echoed source line ranges are computed for display, with regression tests and no security or data impact.
> 
> **Overview**
> Fixes **`st.echo`** so the displayed source includes **`@decorator`** lines when the first statement in the `with` block is a decorated function or class (closes #9252).
> 
> Previously the echo range started at **`body[0].lineno`**, which for AST **`FunctionDef`/`ClassDef`** is the **`def`/`class`** line, so decorator lines above were dropped. The start line is now the minimum of that node’s line and every **`decorator_list`** entry’s line.
> 
> Adds **`test_decorated_function_as_first_statement`** covering a single-decorator function and a class with two stacked decorators as the first body statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2b22fc0804eb53ca3198ce5ab217c713e47495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| subagent | fixing-pr | 2 |

</details>
<!-- agent-metrics-end -->