### PR TITLE
[bugfix] Fix widgets inside popover-in-dialog being unclickable

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -366,3 +366,18 @@ if st.button("Open Fast Dialog"):
 
 if st.button("Open Slow Dialog"):
     slow_dialog()
+
+
+# Regression coverage for #16005: widgets inside an st.popover that is opened
+# inside an st.dialog should be interactable (the popover body must not be
+# occluded by the dialog's React Aria overlay).
+@st.dialog("Dialog with popover")
+def dialog_with_popover() -> None:
+    st.write("dialog content")
+    with st.popover("Open popover"):
+        fruit = st.selectbox("Fruit", ["Apple", "Banana", "Cherry"])
+        st.write(f"picked: {fruit}")
+
+
+if st.button("Open Dialog with Popover"):
+    dialog_with_popover()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -237,6 +237,31 @@ def test_dialog_allows_interacting_with_date_input_calendar(app: Page):
     expect_markdown(dialog, "Tags Value: ['Utilities']")
 
 
+def test_dialog_allows_interacting_with_widget_in_popover(app: Page):
+    """Widgets inside an st.popover opened inside an st.dialog must be
+    interactable — the popover body must not be occluded by the dialog's
+    React Aria overlay (regression coverage for #16005).
+    """
+    click_button(app, "Open Dialog with Popover")
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+
+    dialog.get_by_role("button", name="Open popover").click()
+    popover_body = app.get_by_test_id("stPopoverBody")
+    expect(popover_body).to_be_visible()
+
+    # The popover body must land above the dialog for hit-testing: its parent
+    # container (the FloatingPortal host) must not be `inert`. Without the fix,
+    # the popover body's own DIV is above the dialog visually, but its parent
+    # is marked inert by React Aria's ModalOverlay — so `elementFromPoint` at
+    # the widget's center returns the dialog rather than the widget.
+    select_selectbox_option(popover_body, "Fruit", "Banana")
+    expect_markdown(popover_body, "picked: Banana")
+
+    # The dialog must not be dismissed by the interaction inside the popover.
+    expect(dialog).to_be_visible()
+
+
 def test_dialog_stays_dismissed_when_interacting_with_different_fragment(app: Page):
     """Dismissing a dialog is a UI-only interaction as of today (the Python backend does
     not know about this). We use a deltaMsgReceivedAt to differentiate React renders

--- a/frontend/lib/src/components/core/Portal/PortalProvider.test.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalProvider.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "~lib/test_util"
+
+import { DATAFRAME_PORTAL_ID, FLOATING_OVERLAY_PORTAL_ID } from "./constants"
+import { PortalProvider } from "./PortalProvider"
+
+describe("PortalProvider", () => {
+  it("mounts the dataframe overlay host tagged as a top layer overlay root", () => {
+    render(
+      <PortalProvider>
+        <div>content</div>
+      </PortalProvider>
+    )
+
+    const host = document.getElementById(DATAFRAME_PORTAL_ID)
+    expect(host).not.toBeNull()
+    expect(host).toHaveAttribute("data-react-aria-top-layer", "true")
+    expect(host).toHaveAttribute("data-st-overlay-root", "true")
+  })
+
+  it("mounts the floating overlay host so popover-in-dialog widgets are interactable (fixes #16005)", () => {
+    // The host must be a sibling of the dialog under `document.body` and
+    // must carry `data-react-aria-top-layer` so React Aria's `ModalOverlay`
+    // does not mark it (or its subtree) as `inert` when a dialog is open —
+    // that is what makes widgets inside a popover-in-dialog unclickable.
+    // It must also carry `data-st-overlay-root` so interacting with its
+    // children does not dismiss the enclosing dialog or popover.
+    render(
+      <PortalProvider>
+        <div>content</div>
+      </PortalProvider>
+    )
+
+    const host = document.getElementById(FLOATING_OVERLAY_PORTAL_ID)
+    expect(host).not.toBeNull()
+    expect(host).toHaveAttribute("data-react-aria-top-layer", "true")
+    expect(host).toHaveAttribute("data-st-overlay-root", "true")
+    // The host lives directly under document.body so it is a sibling of the
+    // dialog (not a descendant that inherits the dialog's inert subtree).
+    expect(host?.parentElement).toBe(document.body)
+  })
+})

--- a/frontend/lib/src/components/core/Portal/PortalProvider.tsx
+++ b/frontend/lib/src/components/core/Portal/PortalProvider.tsx
@@ -19,7 +19,7 @@ import { createPortal } from "react-dom"
 
 import { StyledDataFrameOverlay } from "~lib/styled-components"
 
-import { DATAFRAME_PORTAL_ID } from "./constants"
+import { DATAFRAME_PORTAL_ID, FLOATING_OVERLAY_PORTAL_ID } from "./constants"
 import { PortalContext } from "./PortalContext"
 
 export const PortalProvider: FC<PropsWithChildren> = ({ children }) => {
@@ -39,6 +39,21 @@ export const PortalProvider: FC<PropsWithChildren> = ({ children }) => {
           data-testid="portal"
           id={DATAFRAME_PORTAL_ID}
           ref={overlayRef}
+        />,
+        document.body
+      )}
+      {/*
+       * Shared host for `@floating-ui/react` `FloatingPortal` mounts (e.g. the
+       * st.popover body). Tagged so React Aria's dialog does not mark it inert
+       * when the dialog is open — this is what makes widgets inside a
+       * popover-in-dialog interactable (fixes #16005). The host has no
+       * dimensions of its own; each floating child positions itself.
+       */}
+      {createPortal(
+        <div
+          data-react-aria-top-layer="true"
+          data-st-overlay-root="true"
+          id={FLOATING_OVERLAY_PORTAL_ID}
         />,
         document.body
       )}

--- a/frontend/lib/src/components/core/Portal/constants.ts
+++ b/frontend/lib/src/components/core/Portal/constants.ts
@@ -35,3 +35,17 @@
  * positioned independently via explicit coordinates.
  */
 export const DATAFRAME_PORTAL_ID = "portal"
+
+/**
+ * The DOM `id` of the shared, app-level host for `@floating-ui/react`'s
+ * `FloatingPortal` mounts (e.g. the `st.popover` body).
+ *
+ * The host is created once by `PortalProvider` and portaled to `document.body`,
+ * tagged with `data-react-aria-top-layer` so React Aria's dialog does not mark
+ * it (or its subtree) as `inert` when the dialog is open — which would
+ * otherwise make widgets inside a popover-in-dialog unclickable (see #16005) —
+ * and with `data-st-overlay-root` so interacting with its children does not
+ * dismiss the enclosing dialog or popover. The host has no dimensions of its
+ * own; each floating child positions itself and carries its own `z-index`.
+ */
+export const FLOATING_OVERLAY_PORTAL_ID = "stFloatingOverlayPortal"

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -28,6 +28,7 @@ import { FloatingPortal } from "@floating-ui/react"
 import { Block as BlockProto } from "@streamlit/protobuf"
 import { notNullOrUndefined } from "@streamlit/utils"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { Box } from "~lib/components/shared/Base/styled-components"
 import BaseButton, {
   BaseButtonKind,
@@ -350,7 +351,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         </BaseButtonTooltip>
       </div>
       {open && (
-        <FloatingPortal>
+        <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
           <StyledPopoverBody
             ref={setFloatingRef}
             data-testid="stPopoverBody"


### PR DESCRIPTION
## Describe your changes

Widgets inside an `st.popover` opened inside an `st.dialog` were unclickable — clicks landed on the dialog instead of the widget. The popover's own dismiss behavior and any nested overlay (selectbox dropdown, date picker, etc.) were affected the same way.

**Root cause:** `@floating-ui/react`'s `FloatingPortal` (used by `st.popover`) creates its host `<div>` directly under `document.body`, which makes it a sibling of the dialog. React Aria's `ModalOverlay` (introduced in the dialog migration) applies `inert` to all siblings of the open dialog to enforce modal focus containment. The popover body's subtree becomes inert and loses hit-testing even though it visually renders on top of the dialog.

**Fix:** create a persistent portal host in `PortalProvider` tagged with:
- `data-react-aria-top-layer="true"` — opts the subtree out of React Aria's inert sweep
- `data-st-overlay-root="true"` — signals to dialog/popover dismissal handlers that interactions inside are "inside the overlay stack" (matches the existing pattern for the dataframe portal)

Route `Popover`'s `FloatingPortal` through this host via its stable `id`. Same shape as the existing dataframe overlay host.

Supersedes #16063 (fork PR — reopened from same-repo branch so CI runs with full permissions).

## GitHub Issue Link (if applicable)

- Closes #16005

## Testing Plan

- Unit test: `PortalProvider.test.tsx` verifies both portal hosts are mounted with the correct top-layer + overlay-root attributes and that the floating overlay host is a direct child of `document.body` (sibling of the dialog).
- E2E test: `test_dialog_allows_interacting_with_widget_in_popover` opens a dialog with a popover containing a selectbox, picks an option, and verifies (a) the widget is interactable, (b) the picked value renders, (c) the enclosing dialog stays open.
- Manual: reproduced with the exact snippet from #16005 before the fix (selectbox unclickable, `elementFromPoint` returns the dialog); confirmed working after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global overlay stacking and React Aria top-layer behavior for all popovers; risk is mitigated by matching an existing portal pattern and targeted E2E coverage, but could affect dismissal/stacking edge cases.
> 
> **Overview**
> Fixes **#16005**: widgets inside an `st.popover` opened from an `st.dialog` were unclickable because React Aria’s dialog overlay marks sibling DOM nodes `inert`, which broke hit-testing on the default `FloatingPortal` host under `document.body`.
> 
> **PortalProvider** now mounts a second body-level host (`stFloatingOverlayPortal`) with `data-react-aria-top-layer` and `data-st-overlay-root`, mirroring the existing dataframe portal pattern. **`st.popover`** routes its `FloatingPortal` through that host so the popover subtree stays interactive and clicks don’t dismiss the dialog.
> 
> Adds **unit** coverage on the new host’s attributes/placement and a **Playwright** regression (dialog → popover → selectbox).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54e713b8b780b5ab9fcbf7a34d961f98993b683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->