### PR TITLE
[fix] Stabilize nested run_every hide e2e test

### DIFF
--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -52,7 +52,15 @@ def test_nested_fragment_run_every_can_hide_without_crash(app: Page):
     assert nested_text is not None
 
     click_checkbox(app, "Show nested auto fragment")
-    expect(nested_fragment).not_to_be_attached()
+    # The nested ``run_every`` timer keeps firing on the frontend even after the
+    # outer fragment stops rendering the nested chain (fragment-only reruns don't
+    # cancel the interval). An in-flight auto-rerun tick can therefore briefly
+    # re-attach ``.st-key-nested_auto_fragment`` around the uncheck before the
+    # backend evicts the orphaned fragment and the frontend prunes the stale
+    # node. Allow extra time for the tree to settle so this transient race
+    # doesn't flake; a genuine regression (#15084) keeps the container attached
+    # and still fails this assertion (plus the stException checks below).
+    expect(nested_fragment).not_to_be_attached(timeout=15000)
 
     expect(app.get_by_test_id("stException")).to_have_count(0)
 

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -52,19 +52,15 @@ def test_nested_fragment_run_every_can_hide_without_crash(app: Page):
     assert nested_text is not None
 
     click_checkbox(app, "Show nested auto fragment")
-    # The nested ``run_every`` timer keeps firing on the frontend even after the
-    # outer fragment stops rendering the nested chain (fragment-only reruns don't
-    # cancel the interval). An in-flight auto-rerun tick can therefore briefly
-    # re-attach ``.st-key-nested_auto_fragment`` around the uncheck before the
-    # backend evicts the orphaned fragment and the frontend prunes the stale
-    # node. Allow extra time for the tree to settle so this transient race
-    # doesn't flake; a genuine regression (#15084) keeps the container attached
-    # and still fails this assertion (plus the stException checks below).
-    expect(nested_fragment).not_to_be_attached(timeout=15000)
-
     expect(app.get_by_test_id("stException")).to_have_count(0)
 
-    # Standalone auto fragment keeps ticking; no frontend exception across ticks.
+    # After hiding, let the app run through several run_every cycles (observed via
+    # the standalone auto fragment still ticking) before asserting the nested
+    # fragment is gone. This drains any in-flight nested run_every tick that can
+    # briefly re-render ``.st-key-nested_auto_fragment`` right after the uncheck,
+    # so we assert the settled state instead of racing the transient. A genuine
+    # #15084 regression keeps the nested container attached and still fails the
+    # not_to_be_attached check below (as well as the stException checks).
     for _ in range(3):
         expect(standalone_fragment.get_by_test_id("stMarkdown").first).not_to_have_text(
             standalone_text
@@ -74,6 +70,9 @@ def test_nested_fragment_run_every_can_hide_without_crash(app: Page):
         ).first.text_content()
         assert standalone_text is not None
         expect(app.get_by_test_id("stException")).to_have_count(0)
+
+    expect(nested_fragment).not_to_be_attached()
+    expect(app.get_by_test_id("stException")).to_have_count(0)
 
     click_checkbox(app, "Show nested auto fragment")
     expect(get_element_by_key(app, "nested_auto_fragment")).to_be_visible()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

`test_nested_fragment_run_every_can_hide_without_crash` intermittently failed on `expect(nested_fragment).not_to_be_attached()` right after unchecking "Show nested auto fragment" (regression coverage for #15084).

The nested `run_every` fragment can have an in-flight auto-rerun tick around the uncheck that briefly re-renders `.st-key-nested_auto_fragment` before the hide-rerun evicts the fragment and prunes the node. Asserting detachment on the exact instant of the uncheck races that transient.

This reorders the test to assert the **settled** state: after hiding, let the app run through several `run_every` cycles (observed via the standalone auto fragment still ticking, which also guards against a white-screen regression), then assert the nested fragment is detached. The detachment assertion is kept, so a genuine #15084 regression (nested container stays attached) still fails the test — this does not mask a real bug, unlike a blanket longer timeout.

## GitHub Issue Link (if applicable)

Regression coverage for https://github.com/streamlit/streamlit/issues/15084

## Testing Plan

- E2E Tests: reorders the existing `test_nested_fragment_run_every_can_hide_without_crash`; no product code changes. Verified by running the test repeatedly on chromium.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ae6397c-c22f-4309-a6a3-a73022da5c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ae6397c-c22f-4309-a6a3-a73022da5c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

