### PR TITLE
[fix] Escape now clears typed search query in st.selectbox

### DIFF
--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -243,6 +243,35 @@ def test_type_to_search_replaces_committed_value(app: Page):
     expect_markdown(app, "value 1: female")
 
 
+def test_escape_clears_typed_query_and_restores_committed_value(app: Page):
+    """Regression test for https://github.com/streamlit/streamlit/issues/16004.
+
+    While the user is actively filtering, pressing Escape must discard the
+    typed query and restore the committed label (matching pre-1.59 BaseWeb
+    behavior). The committed value must not change.
+    """
+    selectbox_input = get_selectbox_input(app, "selectbox 1 (default)")
+    expect(selectbox_input).to_have_value("male")
+
+    selectbox_input.click()
+    selectbox_input.press_sequentially("fem")
+    # The query has replaced the committed label in the input.
+    expect(selectbox_input).to_have_value("fem")
+
+    # Verify the dropdown is filtering on the query before Escape.
+    selection_dropdown = app.get_by_test_id("stSelectboxVirtualDropdown")
+    expect(selection_dropdown).to_be_visible()
+
+    selectbox_input.press("Escape")
+
+    # The typed query is cleared and the committed label is restored.
+    expect(selectbox_input).to_have_value("male")
+    # The dropdown is closed after Escape.
+    expect(selection_dropdown).not_to_be_visible()
+    # The committed selection did not change — no rerun with a new value.
+    expect_markdown(app, "value 1: male")
+
+
 def test_empty_selectbox_behaves_correctly(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -532,6 +532,79 @@ describe("Selectbox widget", () => {
     })
   })
 
+  it("clears the typed query on Escape and restores the committed label", async () => {
+    // Regression test for https://github.com/streamlit/streamlit/issues/16004
+    // With a value already committed, typing a query then pressing Escape
+    // must drop the typed query and restore the committed label — matching
+    // pre-1.59 (BaseWeb) behavior. The committed value must not change.
+    const user = userEvent.setup()
+    props = getProps({
+      options: ["Apple", "Banana", "Cherry"],
+      value: "Banana",
+    })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+    expect(input).toHaveValue("Banana")
+
+    await user.click(input)
+    await user.keyboard("Che")
+    // The type-to-search behavior replaces the committed label with the query.
+    expect(input).toHaveValue("Che")
+
+    await user.keyboard("{Escape}")
+
+    // The typed query is discarded; the committed label is restored.
+    expect(input).toHaveValue("Banana")
+    // No commit was made (Escape only discards the query).
+    expect(props.onChange).not.toHaveBeenCalled()
+  })
+
+  it("clears the typed query on Escape when no value is committed", async () => {
+    // Same as above, but with no initial value — Escape must empty the input
+    // (restoring the empty "committed" state) rather than leaving the query.
+    const user = userEvent.setup()
+    props = getProps({
+      options: ["Apple", "Banana", "Cherry"],
+      value: null,
+    })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+    expect(input).toHaveValue("")
+
+    await user.click(input)
+    await user.keyboard("App")
+    expect(input).toHaveValue("App")
+
+    await user.keyboard("{Escape}")
+
+    expect(input).toHaveValue("")
+    expect(props.onChange).not.toHaveBeenCalled()
+  })
+
+  it("Escape without a typed query still clears a clearable committed value", async () => {
+    // Escape has two contracts on a clearable selectbox:
+    //  - while typing: discard the query, keep the committed value (see above)
+    //  - while NOT typing: clear the committed value (pre-existing behavior,
+    //    covered by the e2e test test_empty_selectbox_behaves_correctly)
+    // This test guards the second contract so the #16004 fix does not
+    // regress it.
+    const user = userEvent.setup()
+    props = getProps({
+      options: ["Apple", "Banana", "Cherry"],
+      value: "Banana",
+      clearable: true,
+    })
+    render(<Selectbox {...props} />)
+    const input = screen.getByRole("combobox")
+
+    await user.click(input)
+    // No typing — press Escape immediately.
+    await user.keyboard("{Escape}")
+
+    expect(props.onChange).toHaveBeenCalledTimes(1)
+    expect(props.onChange).toHaveBeenCalledWith(null)
+  })
+
   it("updates value if new value provided from parent", () => {
     const { rerender } = render(<Selectbox {...props} />)
     expect(screen.getByDisplayValue(props.options[0])).toBeVisible()

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -463,7 +463,9 @@ const Selectbox: FC<Props> = ({
    *   whether the dropdown was open before RAC may have closed it.
    * - Opens the dropdown on ArrowUp/Down when closed.
    * - Blocks character input for FILTER_MODE_NONE (can't use readOnly — see above).
-   * - Clears the value on Escape when clearable.
+   * - On Escape while filtering, discards the typed query and restores the
+   *   committed label.
+   * - On Escape when not filtering and clearable, clears the committed value.
    */
   const handleInputKeyDownCapture = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>): void => {

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -487,13 +487,28 @@ const Selectbox: FC<Props> = ({
       ) {
         openDropdownRef.current?.()
       }
-      if (
-        e.key === "Escape" &&
-        clearable &&
-        !isNullOrUndefined(valueRef.current)
-      ) {
-        e.preventDefault()
-        commitSelection(null)
+      if (e.key === "Escape") {
+        // While the user is actively filtering (typed query diverges from the
+        // committed value), Escape discards the query and restores the input
+        // to the committed label — matching pre-1.59 BaseWeb behavior and
+        // React Aria's own ComboBox contract. See #16004. This must run
+        // BEFORE the clear-on-Escape branch below, otherwise typing then
+        // pressing Escape on a clearable selectbox would wipe the committed
+        // value instead of just the typed query.
+        if (filterActiveRef.current) {
+          e.preventDefault()
+          const committed = valueRef.current ?? ""
+          setInputValue(committed)
+          inputValueRef.current = committed
+          setFilterActive(false)
+          filterActiveRef.current = false
+          closeDropdownRef.current?.()
+          return
+        }
+        if (clearable && !isNullOrUndefined(valueRef.current)) {
+          e.preventDefault()
+          commitSelection(null)
+        }
       }
     },
     [clearable, commitSelection, isFilterNone, selectDisabled]


### PR DESCRIPTION
## Describe your changes

Since 1.59.0 (BaseWeb → react-aria migration), pressing Escape in `st.selectbox` no longer restored the committed label when the user was typing a filter — the typed query stayed stuck in the input.

The capture-phase `onKeyDown` in `Selectbox.tsx` only handled Escape when the input was clearable AND had a committed value. It had no branch for the "user is actively typing a filter" case, and RAC can't restore the committed label from our controlled `inputValue` on its own.

Fix: add a branch that clears the active filter and re-syncs `inputValue` from the currently selected option when Escape is pressed with a non-empty filter. The existing clear-on-Escape contract is preserved (that branch only fires when the input is clearable and the query is empty).

## GitHub Issue Link (if applicable)

- Closes #16004

## Testing Plan

- Unit Tests (JS): 54/54 Selectbox vitest pass (3 new tests covering filter-active Escape)
- E2E Tests: new e2e case exercises the typed-then-escape flow
- Manual: verified in `make debug` that Escape restores the committed label without dropping focus

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard handling in the shared Selectbox component with explicit tests for the clearable Escape contract; no backend or auth changes.
> 
> **Overview**
> Fixes **Escape** during type-to-search in `st.selectbox` so the input drops the filter query and shows the committed option again, without firing `onChange` or changing the widget value (#16004).
> 
> `Selectbox.tsx` now handles **Escape** in capture-phase `onKeyDown` when `filterActiveRef` is true: reset `inputValue` from the committed value, clear filter state, and close the dropdown. The existing **clear-on-Escape** path for clearable widgets runs only when the user is not actively filtering, so typing then Escape no longer clears the selection.
> 
> Coverage adds three Vitest cases (committed value, empty value, clearable without typing) and a Playwright regression for type-then-Escape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb7dac0f89422fd635473bb9cbeb843bc13b213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->