### PR TITLE
[fix] st.expander clipped after interrupted animation

### DIFF
--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -480,3 +480,36 @@ def test_programmatic_close_does_not_reopen_other_expander(app: Page):
 
     # Expander A must NOT have reopened (the bug from #14943)
     expect(exp_a.get_by_text("Expander A content")).not_to_be_visible()
+
+
+def test_rapid_toggle_does_not_clip_content(app: Page):
+    """Rapid open/close should not leave inline height/overflow locks on the
+    <details> element that clip content.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/16027.
+    """
+    expander = get_expander(app, "Long expanded")
+    details = expander.locator("details")
+    summary = details.locator(EXPANDER_HEADER_IDENTIFIER)
+
+    # Rapid toggle sequence: close → open → close → open, without waiting
+    # for the ~500ms height animation to settle between clicks. Each click
+    # interrupts the previous animation via cancelAnimation.
+    for _ in range(4):
+        summary.click(no_wait_after=True)
+
+    # Allow the final open animation to fully settle (duration is 500ms).
+    app.wait_for_timeout(800)
+
+    # Content must be visible (final state is open) and NOT clipped by a
+    # stale inline height / overflow lock left behind by an interrupted
+    # animation.
+    body_text = expander.get_by_text("Integer et justo orci", exact=False)
+    expect(body_text).to_be_visible()
+
+    height_style = details.evaluate("el => el.style.height")
+    overflow_style = details.evaluate("el => el.style.overflow")
+    assert height_style == "", f"expected no inline height lock, got {height_style!r}"
+    assert overflow_style == "", (
+        f"expected no inline overflow lock, got {overflow_style!r}"
+    )

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -507,8 +507,7 @@ def test_rapid_toggle_does_not_clip_content(app: Page):
 
     def styles_cleared() -> bool:
         return bool(
-            details.evaluate("el => el.style.height") == ""
-            and details.evaluate("el => el.style.overflow") == ""
+            details.evaluate("el => el.style.height === '' && el.style.overflow === ''")
         )
 
     wait_until(app, styles_cleared, timeout=3000)

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -511,3 +511,10 @@ def test_rapid_toggle_does_not_clip_content(app: Page):
         )
 
     wait_until(app, styles_cleared, timeout=3000)
+
+    # After the ~1.5s stall-guard window, a superseded close animation must not
+    # have force-finished and slammed the expander shut. The <details> must
+    # still be open and the body text still visible.
+    app.wait_for_timeout(1600)
+    expect(details).to_have_attribute("open", "")
+    expect(body_text).to_be_visible()

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -506,7 +506,7 @@ def test_rapid_toggle_does_not_clip_content(app: Page):
     expect(body_text).to_be_visible()
 
     def styles_cleared() -> bool:
-        return (
+        return bool(
             details.evaluate("el => el.style.height") == ""
             and details.evaluate("el => el.style.overflow") == ""
         )

--- a/e2e_playwright/st_expander_test.py
+++ b/e2e_playwright/st_expander_test.py
@@ -17,7 +17,7 @@ from typing import Final
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
+from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run, wait_until
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
@@ -498,18 +498,17 @@ def test_rapid_toggle_does_not_clip_content(app: Page):
     for _ in range(4):
         summary.click(no_wait_after=True)
 
-    # Allow the final open animation to fully settle (duration is 500ms).
-    app.wait_for_timeout(800)
-
     # Content must be visible (final state is open) and NOT clipped by a
     # stale inline height / overflow lock left behind by an interrupted
-    # animation.
+    # animation. Poll until the animation settles instead of a fixed sleep so
+    # the test tolerates slow CI runners.
     body_text = expander.get_by_text("Integer et justo orci", exact=False)
     expect(body_text).to_be_visible()
 
-    height_style = details.evaluate("el => el.style.height")
-    overflow_style = details.evaluate("el => el.style.overflow")
-    assert height_style == "", f"expected no inline height lock, got {height_style!r}"
-    assert overflow_style == "", (
-        f"expected no inline overflow lock, got {overflow_style!r}"
-    )
+    def styles_cleared() -> bool:
+        return (
+            details.evaluate("el => el.style.height") == ""
+            and details.evaluate("el => el.style.overflow") == ""
+        )
+
+    wait_until(app, styles_cleared, timeout=3000)

--- a/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
@@ -236,5 +236,27 @@ describe("animateHeight", () => {
 
       expect(mockAnimation.finish).not.toHaveBeenCalled()
     })
+
+    it("clears the guard when handle.cancel() drives the real wiring", () => {
+      // Wire the mock so animation.cancel() dispatches the registered `cancel`
+      // listener — the same path a real browser takes. This proves the guard
+      // is cleared through handle.cancel() → animation.cancel() → listener,
+      // not just when the listener is invoked directly.
+      mockAnimation.cancel = vi.fn(() => {
+        getListener("cancel")?.()
+      })
+
+      const handle = animateHeight(element, 0, 100, { duration: 500 })
+
+      handle.cancel()
+
+      expect(mockAnimation.cancel).toHaveBeenCalled()
+
+      // If the guard was cleared, it must not force-finish the animation
+      // after the buffer window elapses.
+      vi.advanceTimersByTime(1500)
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.test.ts
@@ -21,9 +21,12 @@ describe("animateHeight", () => {
   let mockAnimation: {
     addEventListener: ReturnType<typeof vi.fn>
     cancel: ReturnType<typeof vi.fn>
+    finish: ReturnType<typeof vi.fn>
+    playState: AnimationPlayState
   }
 
   beforeEach(() => {
+    vi.useFakeTimers()
     element = document.createElement("div")
     document.body.appendChild(element)
 
@@ -31,13 +34,22 @@ describe("animateHeight", () => {
     mockAnimation = {
       addEventListener: vi.fn(),
       cancel: vi.fn(),
+      finish: vi.fn(),
+      playState: "running",
     }
     element.animate = vi.fn().mockReturnValue(mockAnimation)
   })
 
   afterEach(() => {
     document.body.removeChild(element)
+    vi.useRealTimers()
   })
+
+  /** Look up an event listener registered on the mock animation. */
+  const getListener = (event: string): (() => void) | undefined =>
+    mockAnimation.addEventListener.mock.calls.find(
+      call => call[0] === event
+    )?.[1]
 
   describe("animation creation", () => {
     it("calls element.animate with height keyframes", () => {
@@ -170,6 +182,59 @@ describe("animateHeight", () => {
 
       // Should resolve without throwing
       await expect(handle.finished).resolves.toBeUndefined()
+    })
+  })
+
+  describe("stall guard (issue #16027)", () => {
+    it("force-finishes an animation still running well past its duration", () => {
+      animateHeight(element, 0, 100, { duration: 500 })
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+
+      // Advance past duration + guard buffer.
+      vi.advanceTimersByTime(1500)
+
+      expect(mockAnimation.finish).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not force-finish before the guard elapses", () => {
+      animateHeight(element, 0, 100, { duration: 500 })
+
+      // Just past the animation duration but before the guard fires.
+      vi.advanceTimersByTime(600)
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+    })
+
+    it.each<AnimationPlayState>(["finished", "idle"])(
+      "does not force-finish an animation already in %s state",
+      state => {
+        animateHeight(element, 0, 100)
+        mockAnimation.playState = state
+
+        vi.advanceTimersByTime(1500)
+
+        expect(mockAnimation.finish).not.toHaveBeenCalled()
+      }
+    )
+
+    it("clears the guard when the animation finishes normally", () => {
+      animateHeight(element, 0, 100)
+
+      getListener("finish")?.()
+      vi.advanceTimersByTime(1500)
+
+      // finish() came from the browser event, not the guard force-finishing.
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
+    })
+
+    it("clears the guard when the animation is cancelled", () => {
+      animateHeight(element, 0, 100)
+
+      getListener("cancel")?.()
+      vi.advanceTimersByTime(1500)
+
+      expect(mockAnimation.finish).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/lib/src/components/elements/Expander/animateHeight.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.ts
@@ -32,16 +32,12 @@ const DEFAULT_DURATION = 500
 const DEFAULT_EASING = "cubic-bezier(0.23, 1, 0.32, 1)"
 
 /**
- * Extra time (ms) to wait past the animation duration before treating a still-
- * running animation as stalled and force-finishing it.
- *
- * After certain rapid open/close + resize interruption sequences a Web-Animations
- * effect can end up "running" but stalled — never advancing and never firing its
- * `finish` event — which permanently holds the element at a clipped height while
- * the inline `overflow: hidden` lock stays in place (issue #16027). This guard is
- * a safety net that clears such a stall by force-finishing the animation, which
- * runs the normal `finish` cleanup. The buffer is generous so it can never fire
- * for a healthy animation, which always finishes at ~`duration`.
+ * Safety net against stalled Web-Animations effects (issue #16027): some rapid
+ * open/close + resize sequences leave an animation "running" but stalled — never
+ * advancing, never firing `finish` — which permanently holds `<details>` at a
+ * clipped height with `overflow: hidden`. If an animation is still running this
+ * many ms past its duration, `animateHeight` force-finishes it so the normal
+ * `finish` cleanup runs. Generous so it never fires for a healthy animation.
  */
 const STALL_GUARD_BUFFER_MS = 1000
 
@@ -84,13 +80,7 @@ export function animateHeight(
     { duration, easing }
   )
 
-  /**
-   * Safety net for stalled animations (issue #16027). If the animation is still
-   * active well past its duration, force it to finish so the `finish` handler
-   * below clears the inline height/overflow lock instead of leaving the element
-   * permanently clipped. Cleared as soon as the animation finishes or is
-   * cancelled, so it never affects a healthy or interrupted animation.
-   */
+  /** Safety net for stalled animations; see STALL_GUARD_BUFFER_MS. Cleared on finish/cancel. */
   // eslint-disable-next-line no-restricted-globals -- Framework-agnostic animation utility manages its own timer; useTimeout is React-only.
   const stallGuard = setTimeout(() => {
     if (animation.playState !== "finished" && animation.playState !== "idle") {

--- a/frontend/lib/src/components/elements/Expander/animateHeight.ts
+++ b/frontend/lib/src/components/elements/Expander/animateHeight.ts
@@ -32,13 +32,30 @@ const DEFAULT_DURATION = 500
 const DEFAULT_EASING = "cubic-bezier(0.23, 1, 0.32, 1)"
 
 /**
+ * Extra time (ms) to wait past the animation duration before treating a still-
+ * running animation as stalled and force-finishing it.
+ *
+ * After certain rapid open/close + resize interruption sequences a Web-Animations
+ * effect can end up "running" but stalled — never advancing and never firing its
+ * `finish` event — which permanently holds the element at a clipped height while
+ * the inline `overflow: hidden` lock stays in place (issue #16027). This guard is
+ * a safety net that clears such a stall by force-finishing the animation, which
+ * runs the normal `finish` cleanup. The buffer is generous so it can never fire
+ * for a healthy animation, which always finishes at ~`duration`.
+ */
+const STALL_GUARD_BUFFER_MS = 1000
+
+/**
  * Animate an element's height using the Web Animations API.
  *
  * IMPORTANT: On cancel, styles are NOT cleared. The caller is responsible
  * for setting new styles after cancelling (typically to lock at current height
  * before starting a new animation).
  *
- * On finish, styles ARE cleared to allow natural layout.
+ * On finish, styles ARE cleared to allow natural layout. A stall guard force-
+ * finishes the animation if it is still active well past its duration, so a
+ * stuck Web-Animations effect can never leave the element permanently clipped
+ * (issue #16027).
  *
  * @param element - The HTML element to animate
  * @param from - Starting height in pixels
@@ -67,8 +84,23 @@ export function animateHeight(
     { duration, easing }
   )
 
+  /**
+   * Safety net for stalled animations (issue #16027). If the animation is still
+   * active well past its duration, force it to finish so the `finish` handler
+   * below clears the inline height/overflow lock instead of leaving the element
+   * permanently clipped. Cleared as soon as the animation finishes or is
+   * cancelled, so it never affects a healthy or interrupted animation.
+   */
+  // eslint-disable-next-line no-restricted-globals -- Framework-agnostic animation utility manages its own timer; useTimeout is React-only.
+  const stallGuard = setTimeout(() => {
+    if (animation.playState !== "finished" && animation.playState !== "idle") {
+      animation.finish()
+    }
+  }, duration + STALL_GUARD_BUFFER_MS)
+
   const finished = new Promise<void>(resolve => {
     animation.addEventListener("finish", () => {
+      clearTimeout(stallGuard)
       // Clean up styles on successful finish
       element.style.height = ""
       element.style.overflow = ""
@@ -77,6 +109,7 @@ export function animateHeight(
     })
 
     animation.addEventListener("cancel", () => {
+      clearTimeout(stallGuard)
       // DON'T clean up on cancel - caller will set new styles
       resolve()
     })

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -339,120 +339,6 @@ describe("useDetailsAnimation", () => {
 
       expect(() => unmount()).not.toThrow()
     })
-
-    it("clears inline height/overflow when a label change cancels a mid-flight animation (issue #16027)", async () => {
-      // Regression: without the fix, a cancel with no successor animation
-      // (here, a label-change reset) left inline height/overflow locked on
-      // the <details>, clipping content.
-      const user = userEvent.setup()
-
-      const mockAnimation = {
-        addEventListener: vi.fn(),
-        cancel: vi.fn(),
-      }
-      Element.prototype.animate = vi.fn().mockReturnValue(mockAnimation)
-
-      const { rerender } = render(
-        createElement(TestHarness, {
-          backendExpanded: false,
-          label: "Old",
-        })
-      )
-
-      const details = screen.getByTestId("details")
-      const summary = screen.getByTestId("summary")
-      const content = screen.getByTestId("content")
-
-      // Mock non-zero heights so animateTo actually schedules an animation
-      // (the contentHeight === 0 branch would skip animate() entirely).
-      vi.spyOn(details, "getBoundingClientRect").mockReturnValue({
-        x: 0,
-        y: 0,
-        width: 0,
-        height: 42,
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-        toJSON: () => ({}),
-      })
-      vi.spyOn(summary, "getBoundingClientRect").mockReturnValue({
-        x: 0,
-        y: 0,
-        width: 0,
-        height: 40,
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-        toJSON: () => ({}),
-      })
-      vi.spyOn(content, "getBoundingClientRect").mockReturnValue({
-        x: 0,
-        y: 0,
-        width: 0,
-        height: 200,
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-        toJSON: () => ({}),
-      })
-
-      // Click summary to start an open animation. Inline styles are locked
-      // and the WAAPI mock represents the in-flight animation.
-      await user.click(summary)
-      expect(details.style.overflow).toBe("hidden")
-      expect(details.style.height).toBe("42px")
-      expect(Element.prototype.animate).toHaveBeenCalled()
-
-      // Label change triggers cancelAnimation() with no follow-up animation.
-      // The WAAPI mock's `cancel` and `finish` listeners never fire, so the
-      // only cleanup path is inside cancelAnimation itself.
-      rerender(
-        createElement(TestHarness, {
-          backendExpanded: false,
-          label: "New",
-        })
-      )
-
-      expect(mockAnimation.cancel).toHaveBeenCalled()
-      expect(details.style.height).toBe("")
-      expect(details.style.overflow).toBe("")
-    })
-
-    it("clears inline height/overflow when a label change replaces the expander", () => {
-      // Label change ("new expander") calls cancelAnimation() and expects the
-      // element to be visually reset. Guards against future regressions if
-      // the label-change branch stops relying on cancelAnimation for cleanup.
-      Element.prototype.animate = vi.fn().mockReturnValue({
-        addEventListener: vi.fn(),
-        cancel: vi.fn(),
-      })
-
-      const { rerender } = render(
-        createElement(TestHarness, {
-          backendExpanded: true,
-          label: "Old Label",
-        })
-      )
-
-      const details = screen.getByTestId("details")
-      // Simulate an in-flight lock (as would exist mid-animation)
-      details.style.height = "123px"
-      details.style.overflow = "hidden"
-
-      // Label change triggers cancelAnimation() and a full reset.
-      rerender(
-        createElement(TestHarness, {
-          backendExpanded: true,
-          label: "New Label",
-        })
-      )
-
-      expect(details.style.height).toBe("")
-      expect(details.style.overflow).toBe("")
-    })
   })
 
   describe("ResizeObserver", () => {
@@ -651,7 +537,7 @@ describe("useDetailsAnimation", () => {
       expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
     })
 
-    it("locks inline styles when content height is zero so ResizeObserver can animate later", async () => {
+    it("clears the inline lock when content height is zero (no permanent clip)", async () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime,
       })
@@ -667,8 +553,8 @@ describe("useDetailsAnimation", () => {
       const summary = screen.getByTestId("summary")
       const content = screen.getByTestId("content")
 
-      // Summary has height, but content returns 0 (e.g. widget mode where
-      // content hasn't loaded yet)
+      // Summary has height, but content returns 0 (e.g. content hasn't laid
+      // out yet). Pre-seed an inline lock to prove the branch clears it.
       mockElementHeight(details, 42)
       mockElementHeight(summary, 40)
       mockElementHeight(content, 0)
@@ -679,15 +565,16 @@ describe("useDetailsAnimation", () => {
 
       // No animation should have been started (nothing to animate to yet)
       expect(Element.prototype.animate).not.toHaveBeenCalled()
-      // Inline styles should remain LOCKED so the ResizeObserver can later
-      // animate from this height to the full content height once it loads
-      expect(details.style.height).toBe("42px")
-      expect(details.style.overflow).toBe("hidden")
-      // Element should still be set to open for content to render
+      // The lock must be CLEARED, not left in place: leaving overflow:hidden +
+      // a fixed height with no animation to clear it is the permanent-clip bug
+      // (issue #16027). The element sizes to its natural height instead.
+      expect(details.style.height).toBe("")
+      expect(details.style.overflow).toBe("")
+      // Element is still open so the content renders once it lays out.
       expect(details).toHaveAttribute("open")
     })
 
-    it("animates from locked height when content loads after zero-content open", async () => {
+    it("animates the reveal when content loads after a zero-content open", async () => {
       const user = userEvent.setup({
         advanceTimers: vi.advanceTimersByTime,
       })
@@ -708,21 +595,61 @@ describe("useDetailsAnimation", () => {
       mockElementHeight(summary, 40)
       mockElementHeight(content, 0)
 
-      // Click to expand — locks height at 42px (content is 0)
+      // Click to expand — contentHeight is 0, so the lock is cleared and no
+      // animation starts yet.
       await user.click(screen.getByTestId("summary"))
       ;(Element.prototype.animate as ReturnType<typeof vi.fn>).mockClear()
 
-      // Content loads: now content=200, but details is still locked at 42px
-      // (the ResizeObserver reads the locked details height)
+      // Content loads: now content=200. The ResizeObserver reads the current
+      // details height (42) and animates the reveal to the full height.
       mockElementHeight(content, 200)
-      // details stays locked at 42 since style.height="42px"
       // target = 40 + 200 + 2*1 = 242, current = 42, diff = 200 > 5
 
       fireResize()
       vi.advanceTimersByTime(50)
 
-      // ResizeObserver should trigger an animation from locked height to full
+      // ResizeObserver should trigger an animation from the current height to full
       expect(Element.prototype.animate).toHaveBeenCalledTimes(1)
+    })
+
+    it("clears the inline lock when the expander is replaced (label change)", async () => {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      })
+
+      const { rerender } = render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Old Label",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      mockElementHeight(details, 100)
+      mockElementHeight(summary, 40)
+      mockElementHeight(content, 200)
+
+      // Toggle closed: locks height + overflow while the (mock) close animation
+      // "runs" and never fires finish, so the lock persists on the node.
+      await user.click(summary)
+      expect(details.style.height).not.toBe("")
+      expect(details.style.overflow).toBe("hidden")
+
+      // A new expander reuses this <details> node (label change). cancelAnimation
+      // must clear the stale lock so the reused node isn't left clipped from the
+      // previous expander's interrupted animation (issue #16027).
+      rerender(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "New Label",
+        })
+      )
+
+      expect(details.style.height).toBe("")
+      expect(details.style.overflow).toBe("")
     })
 
     it("clears pending debounce timeout on unmount", () => {

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -339,6 +339,120 @@ describe("useDetailsAnimation", () => {
 
       expect(() => unmount()).not.toThrow()
     })
+
+    it("clears inline height/overflow when a label change cancels a mid-flight animation (issue #16027)", async () => {
+      // Regression: without the fix, a cancel with no successor animation
+      // (here, a label-change reset) left inline height/overflow locked on
+      // the <details>, clipping content.
+      const user = userEvent.setup()
+
+      const mockAnimation = {
+        addEventListener: vi.fn(),
+        cancel: vi.fn(),
+      }
+      Element.prototype.animate = vi.fn().mockReturnValue(mockAnimation)
+
+      const { rerender } = render(
+        createElement(TestHarness, {
+          backendExpanded: false,
+          label: "Old",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      const summary = screen.getByTestId("summary")
+      const content = screen.getByTestId("content")
+
+      // Mock non-zero heights so animateTo actually schedules an animation
+      // (the contentHeight === 0 branch would skip animate() entirely).
+      vi.spyOn(details, "getBoundingClientRect").mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 42,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+      vi.spyOn(summary, "getBoundingClientRect").mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 40,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+      vi.spyOn(content, "getBoundingClientRect").mockReturnValue({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 200,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      })
+
+      // Click summary to start an open animation. Inline styles are locked
+      // and the WAAPI mock represents the in-flight animation.
+      await user.click(summary)
+      expect(details.style.overflow).toBe("hidden")
+      expect(details.style.height).toBe("42px")
+      expect(Element.prototype.animate).toHaveBeenCalled()
+
+      // Label change triggers cancelAnimation() with no follow-up animation.
+      // The WAAPI mock's `cancel` and `finish` listeners never fire, so the
+      // only cleanup path is inside cancelAnimation itself.
+      rerender(
+        createElement(TestHarness, {
+          backendExpanded: false,
+          label: "New",
+        })
+      )
+
+      expect(mockAnimation.cancel).toHaveBeenCalled()
+      expect(details.style.height).toBe("")
+      expect(details.style.overflow).toBe("")
+    })
+
+    it("clears inline height/overflow when a label change replaces the expander", () => {
+      // Label change ("new expander") calls cancelAnimation() and expects the
+      // element to be visually reset. Guards against future regressions if
+      // the label-change branch stops relying on cancelAnimation for cleanup.
+      Element.prototype.animate = vi.fn().mockReturnValue({
+        addEventListener: vi.fn(),
+        cancel: vi.fn(),
+      })
+
+      const { rerender } = render(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "Old Label",
+        })
+      )
+
+      const details = screen.getByTestId("details")
+      // Simulate an in-flight lock (as would exist mid-animation)
+      details.style.height = "123px"
+      details.style.overflow = "hidden"
+
+      // Label change triggers cancelAnimation() and a full reset.
+      rerender(
+        createElement(TestHarness, {
+          backendExpanded: true,
+          label: "New Label",
+        })
+      )
+
+      expect(details.style.height).toBe("")
+      expect(details.style.overflow).toBe("")
+    })
   })
 
   describe("ResizeObserver", () => {

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.test.ts
@@ -553,8 +553,8 @@ describe("useDetailsAnimation", () => {
       const summary = screen.getByTestId("summary")
       const content = screen.getByTestId("content")
 
-      // Summary has height, but content returns 0 (e.g. content hasn't laid
-      // out yet). Pre-seed an inline lock to prove the branch clears it.
+      // Summary has height but content measures 0 (content hasn't laid out yet).
+      // animateTo locks the height, then the zero-content branch must clear it.
       mockElementHeight(details, 42)
       mockElementHeight(summary, 40)
       mockElementHeight(content, 0)

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -125,20 +125,24 @@ export function useDetailsAnimation({
   const hasMountedRef = useRef(false)
 
   /**
-   * Cancel any running animation and clear the inline height/overflow lock.
+   * Cancel any running animation and clear the inline height/overflow lock it
+   * left behind.
    *
-   * `animateHeight` intentionally does not clean up on cancel (see its docstring).
-   * The callers that chain a new animation immediately after — `animateTo` and
-   * `animateResize` — capture the current height BEFORE calling
-   * `cancelAnimation()` and re-lock the styles synchronously right after, so
-   * clearing here is safe and makes "locked with no animation running" an
-   * unreachable state. This prevents leftover inline `height`/`overflow` from
-   * clipping content after a cancel with no successor (unmount cleanup, rapid
-   * toggle chains, or ResizeObserver early-returns).
+   * Clearing here (rather than in `animateHeight`'s async `cancel` listener) is
+   * both safe and correct: the WAAPI `cancel` event fires asynchronously, so
+   * clearing in that listener would clobber the fresh lock that callers apply
+   * synchronously right after cancelling. Callers that keep animating
+   * (`animateTo` / `animateResize`) re-apply `height` + `overflow` on the very
+   * next lines, so this clear is immediately overwritten for them. The one
+   * caller that does NOT re-lock — the "new expander" reset on a label change —
+   * relies on this clear so a reused `<details>` node isn't left clipped from
+   * the previous expander's interrupted animation, upholding the invariant that
+   * the element is never locked with no animation to clear it (issue #16027).
    */
   const cancelAnimation = useCallback((): void => {
     animationRef.current?.cancel()
     animationRef.current = null
+
     const details = detailsRef.current
     if (details) {
       details.style.height = ""
@@ -194,14 +198,17 @@ export function useDetailsAnimation({
             currentHeight,
             targetHeight
           )
+        } else {
+          // contentHeight is 0 — the browser hasn't laid out the content yet
+          // (rare: StyledDetailsPanel has padding, so a mounted panel usually
+          // measures > 0). Clear the lock instead of leaving it in place: the
+          // element then sizes to its natural height so content is never
+          // clipped, and the ResizeObserver animates the reveal once layout
+          // settles. Leaving it locked risked a permanent clip if that resize
+          // never fired a healing animation (issue #16027).
+          details.style.height = ""
+          details.style.overflow = ""
         }
-        // If contentHeight is 0, leave inline height + overflow locked.
-        // This is rare in practice — StyledDetailsPanel always has padding,
-        // so even an empty expander measures > 0. It can only happen if
-        // getBoundingClientRect fires before the browser has laid out the
-        // content. Keeping styles locked lets the ResizeObserver animate
-        // from the collapsed height to the full content height once layout
-        // settles.
       } else {
         // Closing: animate to collapsed height, then set open=false
         const targetHeight = summaryHeight + borderOffset
@@ -292,8 +299,8 @@ export function useDetailsAnimation({
     prevLabelRef.current = label
 
     // If label changed, this is a "new expander" - cancel animations and reset.
-    // `cancelAnimation` clears the inline height/overflow lock as part of its
-    // contract, so no explicit style clearing is needed here.
+    // cancelAnimation clears the inline height/overflow lock, so a reused
+    // <details> node isn't left clipped from the previous expander's animation.
     if (labelChanged) {
       cancelAnimation()
       const newOpen = backendExpanded ?? false

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -128,12 +128,13 @@ export function useDetailsAnimation({
    * Cancel any running animation and clear the inline height/overflow lock.
    *
    * `animateHeight` intentionally does not clean up on cancel (see its docstring).
-   * Every in-flow caller here — `animateTo` and `animateResize` — captures the
-   * current height BEFORE calling `cancelAnimation()` and re-locks the styles
-   * synchronously right after, so clearing here is safe and makes "locked with
-   * no animation running" an unreachable state. This prevents leftover inline
-   * `height`/`overflow` from clipping content after a cancel with no successor
-   * (unmount cleanup, rapid toggle chains, or ResizeObserver early-returns).
+   * The callers that chain a new animation immediately after — `animateTo` and
+   * `animateResize` — capture the current height BEFORE calling
+   * `cancelAnimation()` and re-lock the styles synchronously right after, so
+   * clearing here is safe and makes "locked with no animation running" an
+   * unreachable state. This prevents leftover inline `height`/`overflow` from
+   * clipping content after a cancel with no successor (unmount cleanup, rapid
+   * toggle chains, or ResizeObserver early-returns).
    */
   const cancelAnimation = useCallback((): void => {
     animationRef.current?.cancel()

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -125,11 +125,24 @@ export function useDetailsAnimation({
   const hasMountedRef = useRef(false)
 
   /**
-   * Cancel any running animation.
+   * Cancel any running animation and clear the inline height/overflow lock.
+   *
+   * `animateHeight` intentionally does not clean up on cancel (see its docstring).
+   * Every in-flow caller here — `animateTo` and `animateResize` — captures the
+   * current height BEFORE calling `cancelAnimation()` and re-locks the styles
+   * synchronously right after, so clearing here is safe and makes "locked with
+   * no animation running" an unreachable state. This prevents leftover inline
+   * `height`/`overflow` from clipping content after a cancel with no successor
+   * (unmount cleanup, rapid toggle chains, or ResizeObserver early-returns).
    */
   const cancelAnimation = useCallback((): void => {
     animationRef.current?.cancel()
     animationRef.current = null
+    const details = detailsRef.current
+    if (details) {
+      details.style.height = ""
+      details.style.overflow = ""
+    }
   }, [])
 
   /**
@@ -278,7 +291,8 @@ export function useDetailsAnimation({
     prevLabelRef.current = label
 
     // If label changed, this is a "new expander" - cancel animations and reset.
-    // Clear any stale inline styles that cancelAnimation leaves behind.
+    // `cancelAnimation` clears the inline height/overflow lock as part of its
+    // contract, so no explicit style clearing is needed here.
     if (labelChanged) {
       cancelAnimation()
       const newOpen = backendExpanded ?? false
@@ -286,8 +300,6 @@ export function useDetailsAnimation({
 
       setIsOpen(newOpen)
       if (detailsRef.current) {
-        detailsRef.current.style.height = ""
-        detailsRef.current.style.overflow = ""
         detailsRef.current.open = newOpen
       }
       return

--- a/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
+++ b/frontend/lib/src/components/elements/Expander/useDetailsAnimation.ts
@@ -133,11 +133,13 @@ export function useDetailsAnimation({
    * clearing in that listener would clobber the fresh lock that callers apply
    * synchronously right after cancelling. Callers that keep animating
    * (`animateTo` / `animateResize`) re-apply `height` + `overflow` on the very
-   * next lines, so this clear is immediately overwritten for them. The one
-   * caller that does NOT re-lock — the "new expander" reset on a label change —
-   * relies on this clear so a reused `<details>` node isn't left clipped from
-   * the previous expander's interrupted animation, upholding the invariant that
-   * the element is never locked with no animation to clear it (issue #16027).
+   * next lines, so this clear is immediately overwritten for them.
+   *
+   * The one caller that does NOT re-lock is the "new expander" reset on a label
+   * change. It relies on this clear so a reused `<details>` node isn't left
+   * clipped by the previous expander's interrupted animation. This upholds the
+   * invariant that the element is never locked with no animation to clear it
+   * (issue #16027).
    */
   const cancelAnimation = useCallback((): void => {
     animationRef.current?.cancel()

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -155,9 +155,12 @@ console.error = (...args) => {
 }
 
 // Add fake animate method to Elements
-Element.prototype.animate = vi
-  .fn()
-  .mockImplementation(() => ({ addEventListener: vi.fn(), cancel: vi.fn() }))
+Element.prototype.animate = vi.fn().mockImplementation(() => ({
+  addEventListener: vi.fn(),
+  cancel: vi.fn(),
+  finish: vi.fn(),
+  playState: "running",
+}))
 
 // JSDOM does not implement the Web Animations API. RAC's SelectionIndicator uses
 // SharedElementTransition which calls getAnimations() in an async cleanup callback.


### PR DESCRIPTION
## Describe your changes

`st.expander` sometimes stayed clipped — content cut off with `overflow: hidden` and a fixed pixel height on `<details>` — after a rapid interaction (open/close chain, ResizeObserver early-return, label change, or unmount).

Root cause: `useDetailsAnimation.cancelAnimation()` inherited WAAPI's convention that `cancel` doesn't clear inline `height`/`overflow` — the caller is expected to re-lock. When no successor animation followed, the inline lock stayed on `<details>` and clipped content.

Fix: clear inline `height`/`overflow` inside `cancelAnimation()`. Callers that need to re-lock (`animateTo`, `animateResize`) capture the height first and re-set it right after, so their behavior is preserved. Removed the now-redundant explicit clearing in the label-change branch.

## GitHub Issue Link (if applicable)

- Closes #16027

## Testing Plan

- Unit Tests (JS): 2 new tests in `useDetailsAnimation.test.ts` — both verified to fail on pre-fix code
- E2E Tests: rapid-toggle regression case added to `st_expander_test.py`
- Manual repro is non-deterministic — this fix closes the observable invariant hole (inline lock must be cleared on cancel) via the unit test rather than replaying the exact race path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to expander height-animation cleanup in the frontend; no auth, data, or API changes. Residual risk is subtle animation timing regressions on slow devices or unusual resize sequences.
> 
> **Overview**
> Fixes **st.expander** content staying clipped (`overflow: hidden` + fixed `height` on `<details>`) after rapid open/close, resize races, or label-driven reuse of the same node (#16027).
> 
> **`useDetailsAnimation`**: `cancelAnimation()` now synchronously clears inline `height`/`overflow` (callers that keep animating re-lock on the next lines). Opening when measured content height is **0** clears the lock instead of leaving it until a later resize. Label-change “new expander” reset relies on that cancel path.
> 
> **`animateHeight`**: Adds a **stall guard** that `finish()`es Web Animations still “running” ~1s past the nominal duration so stuck effects can run normal finish cleanup.
> 
> Coverage: expanded JS unit tests, global `animate` mock updates, and a Playwright rapid-toggle E2E using `wait_until` for cleared styles plus a post–stall-guard open-state check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099088a076719450daaf5f0df25ed34578b62dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->