### PR TITLE
[fix] Clarify AppTest multipage path handling

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -126,18 +126,21 @@ class AppTest:
     ``AppTest.run()``.
 
     ``AppTest`` enables developers to build tests on their app as-is, in the
-    familiar python test format, without major refactoring or abstracting out
+    familiar Python test format, without major refactoring or abstracting out
     logic to be tested separately from the UI. Tests can run quickly with very
     low overhead. A typical pattern is to build a suite of tests for an app
     that ensure consistent functionality as the app evolves, and run the tests
-    locally and/or in a CI environment like Github Actions.
+    locally and/or in a CI environment like GitHub Actions.
 
     .. note::
-        ``AppTest`` only supports testing a single page of an app per
-        instance. For multipage apps using ``st.navigation``, ``AppTest``
-        will render the default page. To test other pages, you can use
-        ``AppTest.switch_page()`` within your test or modify query parameters
-        before running.
+        ``AppTest`` renders one page at a time. For a multipage app, initialize
+        ``AppTest`` with the app's entrypoint script, which is the same file
+        you would pass to ``streamlit run``. This applies to apps that use
+        ``st.navigation`` or a ``pages/`` directory. To test another
+        file-based page, call ``AppTest.switch_page()`` followed by
+        ``AppTest.run()``. Passing a page directly to ``AppTest.from_file()``
+        makes that page the main script and changes how relative page paths
+        are resolved.
 
     .. |st.testing.v1.AppTest.from_file| replace:: ``st.testing.v1.AppTest.from_file``
     .. _st.testing.v1.AppTest.from_file: #apptestfrom_file
@@ -149,7 +152,7 @@ class AppTest:
     Attributes
     ----------
     secrets: dict[str, Any]
-        Dictionary of secrets to be used the simulated app. Use dict-like
+        Dictionary of secrets to be used by the simulated app. Use dict-like
         syntax to set secret values for the simulated app.
 
     session_state: SafeSessionState
@@ -157,7 +160,7 @@ class AppTest:
         read and write operations as usual for Streamlit apps.
 
     query_params: dict[str, Any]
-        Dictionary of query parameters to be used by the simluated app. Use
+        Dictionary of query parameters to be used by the simulated app. Use
         dict-like syntax to set ``query_params`` values for the simulated app.
     """
 
@@ -289,18 +292,21 @@ class AppTest:
         cls, script_path: str | Path, *, default_timeout: float = 3
     ) -> AppTest:
         """
-        Create an instance of ``AppTest`` to simulate an app page defined\
-        within a file.
+        Create an ``AppTest`` for an app entrypoint defined in a file.
 
         This option is most convenient for CI workflows and testing of
         published apps. The script must be executable on its own and so must
-        contain all necessary imports.
+        contain all necessary imports. For a multipage app, pass the main
+        script that you would supply to ``streamlit run``. To test a
+        file-based child page, initialize from the main script and use
+        ``AppTest.switch_page()``.
 
         Parameters
         ----------
         script_path: str | Path
-            Path to a script file. The path should be absolute or relative to
-            the file calling ``.from_file``.
+            Path to the app's entrypoint script. An absolute path is used as
+            given. A relative path is resolved against the Python file that
+            calls ``AppTest.from_file()``.
 
         default_timeout: float
             Default time in seconds before a script run is timed out. Can be
@@ -311,17 +317,33 @@ class AppTest:
         AppTest
             A simulated Streamlit app for testing. The simulated app can be
             executed via ``.run()``.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``script_path`` does not point to an existing file.
+
+        Examples
+        --------
+        Initialize a multipage app from its entrypoint, then switch to a page:
+
+        >>> at = AppTest.from_file("app.py").run()
+        >>> at.switch_page("pages/settings.py").run()
         """
         script_path = Path(script_path)
-        if script_path.is_file():
+        if script_path.is_absolute():
             path = script_path
         else:
-            # TODO: Make this not super fragile
-            # Attempt to find the test file calling this method, so the
-            # path can be relative to there.
             stack = traceback.StackSummary.extract(traceback.walk_stack(None))
-            filepath = Path(stack[1].filename)
-            path = filepath.parent / script_path
+            caller_file = Path(stack[1].filename)
+            path = caller_file.parent / script_path
+
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"AppTest script not found at {path.resolve()}. Relative paths are "
+                "resolved against the file that calls AppTest.from_file()."
+            )
+
         return AppTest(path, default_timeout=default_timeout)
 
     def _run(
@@ -441,10 +463,12 @@ class AppTest:
         return self._tree.run(timeout=timeout)
 
     def switch_page(self, page_path: str) -> AppTest:
-        """Switch to another page of the app.
+        """Switch to a file-based page relative to the app's main script.
 
         This method does not automatically rerun the app. Use a follow-up call
-        to ``AppTest.run()`` to obtain the elements on the selected page.
+        to ``AppTest.run()`` to obtain the elements on the selected page. The
+        main script supplied to ``AppTest.from_file()`` remains the path root
+        after switching pages.
 
         Parameters
         ----------
@@ -457,12 +481,25 @@ class AppTest:
         AppTest
             self
 
+        Raises
+        ------
+        ValueError
+            If ``page_path`` does not point to a file relative to the main
+            script.
+
+        Examples
+        --------
+        >>> at = AppTest.from_file("app.py").run()
+        >>> at.switch_page("pages/settings.py").run()
+
         """
         main_dir = Path(self._script_path).parent
         full_page_path = main_dir / page_path
         if not full_page_path.is_file():
             raise ValueError(
-                f"Unable to find script at {page_path}, make sure the page given is relative to the main script."
+                f"Could not find page {page_path!r} relative to the main script "
+                f"{self._script_path!r}. Resolved page path: "
+                f"{str(full_page_path.resolve())!r}."
             )
         page_path_str = str(full_page_path.resolve())
         _, page_name = page_icon_and_name(Path(page_path_str))

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
@@ -52,6 +51,30 @@ def test_from_file_str():
 def test_from_file_path():
     script = AppTest.from_file(Path("../test_data/widgets_script.py"))
     script.run()
+
+
+def test_from_file_resolves_relative_path_from_calling_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cwd_script = tmp_path / "test_data/main.py"
+    cwd_script.parent.mkdir()
+    cwd_script.write_text(
+        'import streamlit as st\nst.text("wrong main page")\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    at = AppTest.from_file("test_data/main.py").run()
+
+    assert at.text[0].value == "main page"
+
+
+def test_from_file_raises_immediately_for_missing_script():
+    missing_script = Path(__file__).parent / "test_data/missing.py"
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        AppTest.from_file("test_data/missing.py")
+
+    assert str(missing_script.resolve()) in str(exc_info.value)
 
 
 def test_get_query_params():
@@ -207,21 +230,41 @@ def test_trigger_recursion():
     at.button[0].click().run()
 
 
-def test_switch_page():
+def test_switch_page_uses_paths_relative_to_main_script():
     at = AppTest.from_file("test_data/main.py").run()
     assert at.text[0].value == "main page"
 
     at.switch_page("pages/page1.py").run()
     assert at.text[0].value == "page 1"
 
-    with pytest.raises(
-        ValueError,
-        match=re.compile(
-            r".*make sure the page given is relative to the main script.*"
-        ),
-    ):
-        # Pages must be relative to main script path
-        at.switch_page("test_data/pages/page1.py")
+    invalid_page_path = "test_data/pages/page1.py"
+    with pytest.raises(ValueError, match="relative to the main script") as exc_info:
+        at.switch_page(invalid_page_path)
+
+    expected_path = (Path(__file__).parent / "test_data" / invalid_page_path).resolve()
+    assert "relative to the main script" in str(exc_info.value)
+    assert str(expected_path) in str(exc_info.value)
+
+
+def test_switch_page_preserves_main_script_for_page_links(tmp_path: Path):
+    main_script = tmp_path / "main.py"
+    page_script = tmp_path / "pages/register.py"
+    page_script.parent.mkdir()
+    main_script.write_text(
+        'import streamlit as st\nst.page_link("pages/register.py", label="Register")\n',
+        encoding="utf-8",
+    )
+    page_script.write_text(
+        'import streamlit as st\nst.page_link("main.py", label="Main")\n'
+        'st.text("register page")\n',
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(main_script).run()
+    at.switch_page("pages/register.py").run()
+
+    assert not at.exception
+    assert at.text[0].value == "register page"
 
 
 def test_switch_page_widgets():

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -56,6 +56,7 @@ def test_from_file_path():
 def test_from_file_resolves_relative_path_from_calling_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
+    """Verify relative paths resolve against the calling file, not the CWD."""
     cwd_script = tmp_path / "test_data/main.py"
     cwd_script.parent.mkdir()
     cwd_script.write_text(
@@ -69,6 +70,7 @@ def test_from_file_resolves_relative_path_from_calling_file(
 
 
 def test_from_file_raises_immediately_for_missing_script():
+    """Verify from_file raises immediately when the script is missing."""
     missing_script = Path(__file__).parent / "test_data/missing.py"
 
     with pytest.raises(FileNotFoundError) as exc_info:
@@ -231,6 +233,7 @@ def test_trigger_recursion():
 
 
 def test_switch_page_uses_paths_relative_to_main_script():
+    """Verify page paths are resolved relative to the main script."""
     at = AppTest.from_file("test_data/main.py").run()
     assert at.text[0].value == "main page"
 
@@ -242,11 +245,11 @@ def test_switch_page_uses_paths_relative_to_main_script():
         at.switch_page(invalid_page_path)
 
     expected_path = (Path(__file__).parent / "test_data" / invalid_page_path).resolve()
-    assert "relative to the main script" in str(exc_info.value)
     assert str(expected_path) in str(exc_info.value)
 
 
 def test_switch_page_preserves_main_script_for_page_links(tmp_path: Path):
+    """Verify switched pages resolve page links from the main script."""
     main_script = tmp_path / "main.py"
     page_script = tmp_path / "pages/register.py"
     page_script.parent.mkdir()


### PR DESCRIPTION
## Describe your changes

Makes AppTest multipage path handling deterministic and documents how the main script controls page resolution.

- Resolves relative `AppTest.from_file()` paths against the calling Python file, even when the working directory contains the same relative path, and reports missing scripts immediately.
- Clarifies that multipage tests start from the app entrypoint and use `switch_page()`, with errors that show the main script and resolved page path. The API requires an explicit entrypoint because inferring one from a child page is ambiguous.

## GitHub Issue Link (if applicable)

- Closes #8154
- Closes #8429

## Testing Plan

- [x] Unit Tests (JS and/or Python): AppTest path resolution, errors, page switching, and page links
- [ ] E2E Tests — Not needed; the Python AppTest API behavior is covered directly.
- [ ] Any manual testing needed? — No.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
