### PR TITLE
[feature] Add lazy loading for Snowpark dataframes

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/snowflake-connection.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/snowflake-connection.md
@@ -23,6 +23,26 @@ st.dataframe(df)
 - Handles reconnection
 - Works with st.secrets
 
+## Lazy display of large Snowpark results
+
+`conn.query()` materializes its result as a pandas DataFrame. To keep a large
+result in Snowflake, create a Snowpark DataFrame through the connection's session
+and pass it directly to `st.dataframe`:
+
+```python
+conn = st.connection("snowflake")
+orders = conn.session().table("ORDERS")
+
+st.dataframe(orders)
+```
+
+With the default `lazy=None`, Streamlit loads Snowpark results with more than
+10,000 rows in chunks and pushes sorting into the Snowpark query. Use
+`lazy=True` to request lazy loading for smaller results; results with 1,000 rows
+or fewer are still loaded eagerly. Search, CSV download, selections, and Pandas
+Styler formatting aren't available in lazy mode. Deep scrolling uses Snowflake
+`OFFSET` queries and can consume additional time and warehouse credits.
+
 ## Caller's rights connection (Streamlit in Snowflake only)
 
 > **Prerequisite:** This feature requires running your app inside Snowflake (Streamlit in Snowflake). It is not available for OSS Streamlit deployments.

--- a/lib/streamlit/dataframe/lazy_df_adapters.py
+++ b/lib/streamlit/dataframe/lazy_df_adapters.py
@@ -20,6 +20,9 @@ the internal :class:`~streamlit.dataframe.lazy_df_source.DataframeSource` protoc
 
 Available adapters:
 - Polars ``LazyFrame``: ``.slice(offset, limit).collect()`` per chunk.
+- Snowpark ``DataFrame`` / ``Table``: deterministic ``ORDER BY`` + ``LIMIT/OFFSET``
+  ("offset" mode). Efficient deep random access (materialized row-index table)
+  is intentionally out of scope for the first version.
 
 Adapters use optional detection only and never require new dependencies.
 """
@@ -28,9 +31,10 @@ from __future__ import annotations
 
 import threading
 from typing import TYPE_CHECKING, Any, Final
+from weakref import WeakKeyDictionary
 
 from streamlit import dataframe_util
-from streamlit.dataframe.lazy_df_source import AccessMode
+from streamlit.dataframe.lazy_df_source import DEFAULT_PAGE_SIZE, AccessMode
 from streamlit.logger import get_logger
 
 if TYPE_CHECKING:
@@ -40,11 +44,42 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = get_logger(__name__)
 
+# Snowpark query submission was not thread-safe in all versions that Streamlit
+# supports. Share a lock across dataframes from the same session while allowing
+# independent sessions to execute concurrently. Weak keys avoid extending a
+# session's lifetime; the fallback covers unusual non-weak-referenceable session
+# implementations without importing Snowpark.
+_SNOWPARK_SESSION_LOCKS: Final[WeakKeyDictionary[object, threading.Lock]] = (
+    WeakKeyDictionary()
+)
+_SNOWPARK_SESSION_LOCKS_GUARD: Final = threading.Lock()
+_SNOWPARK_FALLBACK_QUERY_LOCK: Final = threading.Lock()
+
+
+def _get_snowpark_query_lock(snowpark_df: object) -> threading.Lock:
+    """Return the lock shared by dataframes from ``snowpark_df``'s session."""
+    session = getattr(snowpark_df, "session", None)
+    if session is None:
+        return _SNOWPARK_FALLBACK_QUERY_LOCK
+
+    with _SNOWPARK_SESSION_LOCKS_GUARD:
+        try:
+            query_lock = _SNOWPARK_SESSION_LOCKS.get(session)
+            if query_lock is None:
+                query_lock = threading.Lock()
+                _SNOWPARK_SESSION_LOCKS[session] = query_lock
+            return query_lock
+        except TypeError:
+            # WeakKeyDictionary requires weak-referenceable, hashable keys.
+            return _SNOWPARK_FALLBACK_QUERY_LOCK
+
 
 def try_create_native_source(data: object) -> DataframeSource | None:
     """Return a native lazy adapter for ``data``, or ``None`` if unsupported."""
     if dataframe_util.is_polars_lazyframe(data):
         return PolarsLazyFrameSource(data)
+    if dataframe_util.is_snowpark_data_object(data):
+        return SnowparkDataframeSource(data)
     return None
 
 
@@ -148,3 +183,226 @@ class PolarsLazyFrameSource:
             ).drop(row_index_column)
         chunk = frame.slice(max(0, offset), max(0, limit)).collect()
         return _align_to_schema(chunk.to_arrow(), self.schema)
+
+
+class SnowparkDataframeSource:
+    """Lazy source backed by a Snowpark ``DataFrame`` or ``Table``.
+
+    Uses deterministic ``ORDER BY`` + ``LIMIT/OFFSET`` ("offset" mode). Deep
+    offsets can be slow on Snowflake; this is acceptable for browsing and as a
+    fallback, but it is not efficient arbitrary random access. A materialized
+    row-index mode is reserved for a later phase.
+
+    If a dataframe contains a column that cannot appear in an ``ORDER BY`` (for
+    example ``GEOGRAPHY``/``GEOMETRY``), the source degrades to a less strict
+    ordering, so pagination for that dataframe may not be fully deterministic.
+
+    .. note::
+        Snowpark execution cannot be tested locally without a Snowflake account.
+        Unit tests mock the Snowpark object.
+    """
+
+    # Warn when a chunk offset gets deep enough that Snowflake must skip many
+    # rows before the requested window.
+    _DEEP_OFFSET_WARNING_THRESHOLD: Final = 100_000
+
+    def __init__(self, snowpark_df: object) -> None:
+        # Typed as Any because Snowpark is an optional dependency without stubs
+        # in the type-checking environment.
+        self._df: Any = snowpark_df
+        self._row_count: int | None = None
+        self._schema: pa.Schema | None = None
+        # The first page is loaded to derive a canonical schema; cache it so the
+        # initial chunk request does not re-query.
+        self._initial_table: pa.Table | None = None
+        self._warned_deep_offset = False
+        # Whether ordering by every column works for this dataframe. Flipped to
+        # False the first time a full ORDER BY fails at query time (e.g. an
+        # unorderable column type like GEOGRAPHY) so later chunks skip straight
+        # to the degraded path instead of re-running—and re-logging—the
+        # known-bad query on every page. Orderability is a property of the
+        # dataframe's columns, so this is safe to reuse across chunks and sort
+        # specs. A one-off non-ordering failure would also disable the full
+        # ordering for this short-lived, per-render source, which we accept over
+        # paying the failed query on every page.
+        self._all_columns_orderable = True
+        # Guards lazy metadata initialization and the one-shot warning flag.
+        # Chunk requests run in worker threads (asyncio.to_thread), so concurrent
+        # first accesses could otherwise issue duplicate queries or warnings.
+        self._lock = threading.Lock()
+        self._query_lock = _get_snowpark_query_lock(snowpark_df)
+
+    @property
+    def row_count(self) -> int:
+        if self._row_count is None:
+            with self._lock:
+                if self._row_count is None:
+                    with self._query_lock:
+                        self._row_count = int(self._df.count())
+        return self._row_count
+
+    @property
+    def schema(self) -> pa.Schema:
+        if self._schema is None:
+            with self._lock:
+                if self._schema is None:
+                    # Loading (and caching) the first page also derives a stable
+                    # Arrow schema and avoids a second query on the initial
+                    # render.
+                    self._initial_table = self._query_chunk(
+                        0, DEFAULT_PAGE_SIZE, sort=None
+                    )
+                    self._schema = self._initial_table.schema
+        return self._schema
+
+    @property
+    def sortable(self) -> bool:
+        return True
+
+    @property
+    def access_mode(self) -> AccessMode:
+        return AccessMode.RANDOM_ACCESS
+
+    def load_rows(
+        self,
+        offset: int,
+        limit: int,
+        *,
+        sort: SortSpec | None = None,
+    ) -> pa.Table:
+        # Resolve the schema first; this also caches the unsorted first page.
+        schema = self.schema
+        offset = max(0, offset)
+        limit = max(0, limit)
+
+        # Reuse the cached first page (used to derive the schema) when it fully
+        # covers the requested window: either it holds at least ``limit`` rows,
+        # or it is the entire dataset (fewer than a full page exists). Otherwise
+        # (e.g. a client requesting a window larger than the cached page) fall
+        # through to a fresh query so we don't under-return rows.
+        cached = self._initial_table
+        if (
+            sort is None
+            and offset == 0
+            and cached is not None
+            and (limit <= cached.num_rows or cached.num_rows < DEFAULT_PAGE_SIZE)
+        ):
+            return cached.slice(0, limit)
+
+        if offset > self._DEEP_OFFSET_WARNING_THRESHOLD:
+            with self._lock:
+                if not self._warned_deep_offset:
+                    self._warned_deep_offset = True
+                    _LOGGER.warning(
+                        "Requesting a deep offset (%s) from a Snowpark dataframe. "
+                        "Deep offsets can be slow and consume warehouse credits.",
+                        offset,
+                    )
+
+        return _align_to_schema(self._query_chunk(offset, limit, sort=sort), schema)
+
+    def _query_chunk(
+        self, offset: int, limit: int, *, sort: SortSpec | None
+    ) -> pa.Table:
+        # Offset pagination over Snowflake is non-deterministic without an
+        # ORDER BY, which can return duplicate or missing rows across chunks.
+        # Ordering by every column (active sort column first) keeps the row
+        # order stable across requests; rows identical across all columns are
+        # interchangeable, so pagination stays consistent even without a unique
+        # key. Some column types (e.g. GEOGRAPHY/GEOMETRY) cannot appear in an
+        # ORDER BY, so the query below degrades gracefully instead of failing.
+
+        # Resolving ``DataFrame.columns`` can trigger session-backed schema
+        # analysis in older Snowpark versions, so protect this metadata access
+        # with the same session lock as query execution.
+        with self._query_lock:
+            column_names = [str(name) for name in self._df.columns]
+        # Snowpark retains quotes around case-sensitive identifiers in
+        # ``DataFrame.columns``, while ``to_pandas`` (and therefore Arrow and
+        # SortSpec) exposes the unquoted display name. Once the canonical schema
+        # exists, use its positional relationship to map the frontend name back
+        # to the exact identifier Snowpark expects.
+        schema_names = (
+            self._schema.names
+            if self._schema is not None and len(self._schema.names) == len(column_names)
+            else column_names
+        )
+        sort_column_index = (
+            schema_names.index(sort.column)
+            if sort is not None and sort.column in schema_names
+            else None
+        )
+        if sort is not None and sort_column_index is not None:
+            sort_column = column_names[sort_column_index]
+            others = [
+                name
+                for index, name in enumerate(column_names)
+                if index != sort_column_index
+            ]
+            full_ordering = (
+                [sort_column, *others],
+                [not sort.descending, *([True] * len(others))],
+            )
+            primary_ordering: tuple[list[str], list[bool]] = (
+                [sort_column],
+                [not sort.descending],
+            )
+        else:
+            full_ordering = (column_names, [True] * len(column_names))
+            # No active sort column, so there is no intermediate fallback.
+            primary_ordering = ([], [])
+
+        # Prefer the fully deterministic ordering. If it fails at query time
+        # (e.g. an unorderable Snowflake column type like GEOGRAPHY), degrade to
+        # ordering by just the active sort column, then to no ORDER BY. The final
+        # unordered query runs outside a try/except so a genuine, non-ordering
+        # failure surfaces to the caller.
+        #
+        # The first full-ordering failure is remembered in
+        # ``_all_columns_orderable`` so subsequent chunks skip the known-bad
+        # query (and its warning) instead of retrying it on every page.
+        if self._all_columns_orderable:
+            try:
+                return self._execute_chunk(*full_ordering, offset, limit)
+            except Exception as ex:
+                # A plain bool write/read is atomic under the GIL, and the
+                # double-check keeps the warning to a single log even if a
+                # concurrent first chunk also just failed.
+                if self._all_columns_orderable:
+                    self._all_columns_orderable = False
+                    _LOGGER.warning(
+                        "Failed to order a Snowpark dataframe by all columns; "
+                        "degrading to a less strict ordering for later chunks. "
+                        "Pagination may be less deterministic.",
+                        exc_info=ex,
+                    )
+
+        if primary_ordering[0]:
+            try:
+                return self._execute_chunk(*primary_ordering, offset, limit)
+            except Exception as ex:
+                _LOGGER.warning(
+                    "Failed to query a Snowpark chunk ordered by the sort "
+                    "column; retrying without any ORDER BY.",
+                    exc_info=ex,
+                )
+
+        return self._execute_chunk([], [], offset, limit)
+
+    def _execute_chunk(
+        self, order_by: list[str], ascending: list[bool], offset: int, limit: int
+    ) -> pa.Table:
+        import pyarrow as pa
+
+        with self._query_lock:
+            frame = self._df
+            if order_by:
+                # Snowpark's ``DataFrame.sort`` accepts column names plus a
+                # per-column ``ascending`` flag, so we avoid importing
+                # ``snowflake.snowpark``.
+                frame = frame.sort(*order_by, ascending=ascending)
+
+            # Snowpark's limit supports an offset keyword for range queries.
+            chunk_df = frame.limit(limit, offset=offset)
+            pandas_df = chunk_df.to_pandas()
+        return pa.Table.from_pandas(pandas_df, preserve_index=False)

--- a/lib/streamlit/dataframe/lazy_df_adapters.py
+++ b/lib/streamlit/dataframe/lazy_df_adapters.py
@@ -279,13 +279,14 @@ class SnowparkDataframeSource:
         # (e.g. a client requesting a window larger than the cached page) fall
         # through to a fresh query so we don't under-return rows.
         cached = self._initial_table
-        if (
-            sort is None
-            and offset == 0
-            and cached is not None
-            and (limit <= cached.num_rows or cached.num_rows < DEFAULT_PAGE_SIZE)
-        ):
-            return cached.slice(0, limit)
+        if sort is None and offset == 0 and cached is not None:
+            # The cached page covers the request when it holds at least
+            # ``limit`` rows, or it already is the entire (sub-page) dataset.
+            cache_covers_request = (
+                limit <= cached.num_rows or cached.num_rows < DEFAULT_PAGE_SIZE
+            )
+            if cache_covers_request:
+                return cached.slice(0, limit)
 
         if offset > self._DEEP_OFFSET_WARNING_THRESHOLD:
             with self._lock:
@@ -337,13 +338,16 @@ class SnowparkDataframeSource:
                 for index, name in enumerate(column_names)
                 if index != sort_column_index
             ]
+            # Snowpark's ``sort`` takes an ``ascending`` flag, the inverse of
+            # SortSpec's ``descending``.
+            sort_ascending = not sort.descending
             full_ordering = (
                 [sort_column, *others],
-                [not sort.descending, *([True] * len(others))],
+                [sort_ascending, *([True] * len(others))],
             )
             primary_ordering: tuple[list[str], list[bool]] = (
                 [sort_column],
-                [not sort.descending],
+                [sort_ascending],
             )
         else:
             full_ordering = (column_names, [True] * len(column_names))

--- a/lib/streamlit/dataframe/lazy_df_adapters.py
+++ b/lib/streamlit/dataframe/lazy_df_adapters.py
@@ -216,15 +216,13 @@ class SnowparkDataframeSource:
         # initial chunk request does not re-query.
         self._initial_table: pa.Table | None = None
         self._warned_deep_offset = False
-        # Whether ordering by every column works for this dataframe. Flipped to
-        # False the first time a full ORDER BY fails at query time (e.g. an
-        # unorderable column type like GEOGRAPHY) so later chunks skip straight
-        # to the degraded path instead of re-running—and re-logging—the
-        # known-bad query on every page. Orderability is a property of the
-        # dataframe's columns, so this is safe to reuse across chunks and sort
-        # specs. A one-off non-ordering failure would also disable the full
-        # ordering for this short-lived, per-render source, which we accept over
-        # paying the failed query on every page.
+        # Whether a full ORDER BY works for this dataframe. Orderability depends
+        # on column types (e.g. GEOGRAPHY cannot be ordered), not the query, so
+        # this is safe to reuse across chunks and sort specs. Set to False on
+        # the first failure so later chunks skip the known-bad query instead of
+        # retrying (and re-logging) it on every page. A one-off non-ordering
+        # error also disables full ordering for this short-lived, per-render
+        # source, which we accept over paying the failed query per page.
         self._all_columns_orderable = True
         # Guards lazy metadata initialization and the one-shot warning flag.
         # Chunk requests run in worker threads (asyncio.to_thread), so concurrent
@@ -397,9 +395,9 @@ class SnowparkDataframeSource:
         with self._query_lock:
             frame = self._df
             if order_by:
-                # Snowpark's ``DataFrame.sort`` accepts column names plus a
-                # per-column ``ascending`` flag, so we avoid importing
-                # ``snowflake.snowpark``.
+                # Pass column names directly to avoid importing
+                # ``snowflake.snowpark``; ``DataFrame.sort`` accepts names plus
+                # a per-column ``ascending`` flag.
                 frame = frame.sort(*order_by, ascending=ascending)
 
             # Snowpark's limit supports an offset keyword for range queries.

--- a/lib/streamlit/dataframe/lazy_df_source.py
+++ b/lib/streamlit/dataframe/lazy_df_source.py
@@ -336,9 +336,10 @@ def _validate_lazy_columns(data: object) -> None:
 def _try_create_native_source(data: object) -> DataframeSource | None:
     """Return a native lazy adapter for an unevaluated object, or ``None``.
 
-    Available adapters (currently Polars ``LazyFrame``) are registered here.
-    Objects without a ready adapter return ``None`` so the caller can fall back
-    to the capped-preview path (``lazy=None``) or raise (``lazy=True``).
+    Available adapters (Polars ``LazyFrame``, Snowpark ``DataFrame``/``Table``)
+    are registered here. Objects without a ready adapter return ``None`` so the
+    caller can fall back to the capped-preview path (``lazy=None``) or raise
+    (``lazy=True``).
     """
     from streamlit.dataframe import lazy_df_adapters
 
@@ -428,10 +429,11 @@ def resolve_lazy_source(
         return None
 
     # 1) Native adapter for supported unevaluated objects (currently Polars
-    # LazyFrame). For ``lazy=True``, known small sources keep eager rendering as
-    # the bounded small-data optimization. For ``lazy=None``, compatible
-    # unevaluated sources auto-switch to lazy only above the existing
-    # capped-preview threshold; smaller sources preserve today's eager path.
+    # LazyFrame and Snowpark DataFrame/Table). For ``lazy=True``, known small
+    # sources keep eager rendering as the bounded small-data optimization. For
+    # ``lazy=None``, compatible unevaluated sources auto-switch to lazy only
+    # above the existing capped-preview threshold; smaller sources preserve
+    # today's eager path.
     native = _try_create_native_source(data)
     if native is not None:
         # TODO(lazy-dataframe): For ``lazy=None`` this reads ``row_count`` on
@@ -440,7 +442,8 @@ def resolve_lazy_source(
         # count/scan re-run each time, even when the size hasn't changed.
         # Consider caching the count across reruns, gating auto-lazy on a cheap
         # row-count capability, or deferring the count until the frontend first
-        # requests a chunk.
+        # requests a chunk. A Snowpark source has the same cost concern because
+        # ``DataFrame.count()`` executes a separate Snowflake query.
         native_row_count = _get_native_row_count(native, lazy)
         if native_row_count is None:
             return None

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -838,18 +838,18 @@ class ArrowMixin:
             - ``None`` (default): Streamlit chooses automatically. In-memory
               ``pandas`` and ``polars`` dataframes and ``pyarrow.Table`` objects
               are loaded lazily when they have more than 150,000 rows.
-              Unevaluated objects, such as a Polars ``LazyFrame``, are loaded
-              lazily when they have more than 10,000 rows. Everything else is
-              loaded eagerly, including the capped preview for unsupported
-              unevaluated objects.
+              Unevaluated objects, such as a Polars ``LazyFrame`` or Snowpark
+              dataframe, are loaded lazily when they have more than 10,000
+              rows. Everything else is loaded eagerly, including the capped
+              preview for unsupported unevaluated objects.
             - ``True``: Always load rows lazily. For inputs that support lazy
-              access natively (for example, a Polars ``LazyFrame``), Streamlit
-              reads rows directly from the source. Other supported inputs are
-              held in the app server's memory and served in chunks. Small
-              datasets (1,000 rows or fewer) are still loaded eagerly as an
-              optimization. If lazy loading is incompatible with the data or the
-              other parameters (for example, dataframes with multi-level,
-              ``MultiIndex``, column headers), Streamlit raises a
+              access natively (for example, a Polars ``LazyFrame`` or Snowpark
+              dataframe), Streamlit reads rows directly from the source. Other
+              supported inputs are held in the app server's memory and served
+              in chunks. Small datasets (1,000 rows or fewer) are still loaded
+              eagerly as an optimization. If lazy loading is incompatible with
+              the data or the other parameters (for example, dataframes with
+              multi-level, ``MultiIndex``, column headers), Streamlit raises a
               ``StreamlitAPIException``.
             - ``False``: Never load rows lazily. Streamlit loads data eagerly
               and uses the capped preview for unevaluated data objects.

--- a/lib/streamlit/runtime/dataframe_source_manager.py
+++ b/lib/streamlit/runtime/dataframe_source_manager.py
@@ -178,7 +178,7 @@ class DataframeSourceManager:
 
         # Short-circuit out-of-bounds requests with an empty (schema-only) chunk
         # instead of running a row query. This avoids unnecessary work for deep
-        # offsets, which can be expensive for some native lazy sources.
+        # offsets, which can be expensive for sources like Snowpark.
         #
         # Known-size sources report an integer ``row_count``. Future unknown-size
         # sequential sources report ``row_count=None``; for those the offset can

--- a/lib/tests/streamlit/dataframe/lazy_df_adapters_test.py
+++ b/lib/tests/streamlit/dataframe/lazy_df_adapters_test.py
@@ -293,7 +293,7 @@ def test_snowpark_schema_caches_first_page_and_exposes_capabilities() -> None:
     source = SnowparkDataframeSource(fake)
 
     assert source.schema.names == ["a", "b"]
-    assert source.schema.names == ["a", "b"]
+    _ = source.schema  # A second access must reuse the cache, not re-query.
     assert fake.limit_calls == [(DEFAULT_PAGE_SIZE, 0)]
     assert source.sortable is True
     assert source.access_mode is AccessMode.RANDOM_ACCESS

--- a/lib/tests/streamlit/dataframe/lazy_df_adapters_test.py
+++ b/lib/tests/streamlit/dataframe/lazy_df_adapters_test.py
@@ -14,21 +14,621 @@
 
 """Unit tests for the native lazy dataframe adapters.
 
-The Polars ``LazyFrame`` adapter requires the optional ``polars`` dependency, so
-its tests are marked ``require_integration`` and import Polars inside the test
-functions.
+The Snowpark adapter cannot execute against a real Snowflake account locally, so
+its query building is exercised through a lightweight fake that mimics the
+Snowpark ``DataFrame`` fluent API (``columns``/``count``/``sort``/``limit``/
+``to_pandas``).
+
+The Polars ``LazyFrame`` tests need the optional ``polars`` dependency, so they
+import it inside the test function and are marked ``require_integration`` to skip
+gracefully when it is not installed.
 """
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pandas as pd
 import pyarrow as pa
 import pytest
 
+from streamlit.dataframe import lazy_df_adapters
 from streamlit.dataframe.lazy_df_adapters import (
+    PolarsLazyFrameSource,
+    SnowparkDataframeSource,
     _align_to_schema,
     try_create_native_source,
 )
-from streamlit.dataframe.lazy_df_source import AccessMode, SortSpec
+from streamlit.dataframe.lazy_df_source import (
+    DEFAULT_PAGE_SIZE,
+    AccessMode,
+    SortSpec,
+)
+
+
+class _FakeSnowparkSession:
+    """Tracks concurrent query execution shared by dataframes from one session."""
+
+    def __init__(self) -> None:
+        self.query_barrier: threading.Barrier | None = None
+        self.query_counter_lock = threading.Lock()
+        self.active_queries = 0
+        self.max_active_queries = 0
+
+    def begin_query(self) -> None:
+        with self.query_counter_lock:
+            self.active_queries += 1
+            self.max_active_queries = max(self.max_active_queries, self.active_queries)
+
+        if self.query_barrier is not None:
+            try:
+                self.query_barrier.wait(timeout=0.2)
+            except threading.BrokenBarrierError:
+                pass
+
+    def end_query(self) -> None:
+        with self.query_counter_lock:
+            self.active_queries -= 1
+
+
+class _FakeSnowparkState:
+    """Data and recorded calls shared across clones of one fake query plan."""
+
+    def __init__(
+        self,
+        pdf: pd.DataFrame,
+        *,
+        row_count: int | None = None,
+        session: _FakeSnowparkSession | None = None,
+        snowpark_columns: list[str] | None = None,
+        unsortable_columns: set[str] | None = None,
+        fail_unordered: bool = False,
+        count_started: threading.Event | None = None,
+        release_count: threading.Event | None = None,
+    ) -> None:
+        self.pdf = pdf
+        self.explicit_count = row_count
+        self.session = session or _FakeSnowparkSession()
+        self.snowpark_columns = snowpark_columns or [
+            str(column) for column in pdf.columns
+        ]
+        assert len(self.snowpark_columns) == len(pdf.columns)
+        self.unsortable_columns = unsortable_columns or set()
+        self.fail_unordered = fail_unordered
+        self.count_started = count_started
+        self.release_count = release_count
+        self.sort_calls: list[tuple[tuple[str, ...], list[bool] | None]] = []
+        self.limit_calls: list[tuple[int, int]] = []
+        self.to_pandas_calls: list[
+            tuple[tuple[str, ...] | None, list[bool] | None, int, int]
+        ] = []
+        self.count_calls = 0
+
+
+class _FakeSnowparkDataFrame:
+    """Minimal stand-in for Snowpark's immutable fluent ``DataFrame`` API."""
+
+    def __init__(
+        self,
+        pdf: pd.DataFrame,
+        *,
+        row_count: int | None = None,
+        session: _FakeSnowparkSession | None = None,
+        snowpark_columns: list[str] | None = None,
+        unsortable_columns: set[str] | None = None,
+        fail_unordered: bool = False,
+        count_started: threading.Event | None = None,
+        release_count: threading.Event | None = None,
+    ) -> None:
+        self._state = _FakeSnowparkState(
+            pdf,
+            row_count=row_count,
+            session=session,
+            snowpark_columns=snowpark_columns,
+            unsortable_columns=unsortable_columns,
+            fail_unordered=fail_unordered,
+            count_started=count_started,
+            release_count=release_count,
+        )
+        self._ordering: tuple[tuple[str, ...], list[bool] | None] | None = None
+        self._window: tuple[int, int] | None = None
+
+    def _clone(self) -> _FakeSnowparkDataFrame:
+        clone = object.__new__(type(self))
+        clone._state = self._state
+        clone._ordering = self._ordering
+        clone._window = self._window
+        return clone
+
+    @property
+    def columns(self) -> list[str]:
+        session = self._state.session
+        session.begin_query()
+        try:
+            return self._state.snowpark_columns
+        finally:
+            session.end_query()
+
+    @property
+    def session(self) -> _FakeSnowparkSession:
+        return self._state.session
+
+    @property
+    def sort_calls(self) -> list[tuple[tuple[str, ...], list[bool] | None]]:
+        return self._state.sort_calls
+
+    @property
+    def limit_calls(self) -> list[tuple[int, int]]:
+        return self._state.limit_calls
+
+    @property
+    def to_pandas_calls(
+        self,
+    ) -> list[tuple[tuple[str, ...] | None, list[bool] | None, int, int]]:
+        return self._state.to_pandas_calls
+
+    @property
+    def count_calls(self) -> int:
+        return self._state.count_calls
+
+    def count(self) -> int:
+        self._state.count_calls += 1
+        if self._state.count_started is not None:
+            self._state.count_started.set()
+        if self._state.release_count is not None:
+            assert self._state.release_count.wait(timeout=5)
+        if self._state.explicit_count is not None:
+            return self._state.explicit_count
+        return len(self._state.pdf)
+
+    def sort(
+        self, *cols: str, ascending: list[bool] | None = None
+    ) -> _FakeSnowparkDataFrame:
+        self._state.sort_calls.append((cols, ascending))
+        clone = self._clone()
+        clone._ordering = (cols, ascending)
+        return clone
+
+    def limit(self, n: int, offset: int = 0) -> _FakeSnowparkDataFrame:
+        self._state.limit_calls.append((n, offset))
+        clone = self._clone()
+        clone._window = (n, offset)
+        return clone
+
+    def to_pandas(self) -> pd.DataFrame:
+        session = self._state.session
+        session.begin_query()
+
+        try:
+            n, offset = self._window or (len(self._state.pdf), 0)
+            if self._ordering is None:
+                ordered = None
+                ascending = None
+            else:
+                ordered, ascending = self._ordering
+            self._state.to_pandas_calls.append((ordered, ascending, n, offset))
+
+            if ordered is None:
+                if self._state.fail_unordered:
+                    raise RuntimeError("unordered query failed")
+                result = self._state.pdf
+            else:
+                unorderable = self._state.unsortable_columns.intersection(ordered)
+                if unorderable:
+                    raise ValueError(
+                        f"Columns {sorted(unorderable)} cannot be used in an ORDER BY."
+                    )
+                ordered_labels = [
+                    self._state.pdf.columns[self._state.snowpark_columns.index(column)]
+                    for column in ordered
+                ]
+                result = self._state.pdf.sort_values(
+                    ordered_labels, ascending=ascending, kind="stable"
+                )
+            return result.iloc[offset : offset + n].reset_index(drop=True)
+        finally:
+            session.end_query()
+
+
+def _make_pdf(num_rows: int = 10) -> pd.DataFrame:
+    return pd.DataFrame(
+        {"a": list(range(num_rows)), "b": [value * 2 for value in range(num_rows)]}
+    )
+
+
+def _make_fake(num_rows: int = 10) -> _FakeSnowparkDataFrame:
+    return _FakeSnowparkDataFrame(_make_pdf(num_rows))
+
+
+def test_snowpark_row_count_uses_count_once() -> None:
+    """row_count delegates to ``count()``, coerces, and caches the result."""
+    fake = _FakeSnowparkDataFrame(_make_pdf(), row_count=42)
+    source = SnowparkDataframeSource(fake)
+
+    assert source.row_count == 42
+    assert source.row_count == 42
+    assert fake.count_calls == 1
+
+
+def test_snowpark_row_count_is_fresh_for_each_source() -> None:
+    """A new source recounts because the same query plan may have changed."""
+    first = _make_fake(10)
+    second = _make_fake(11)
+
+    assert SnowparkDataframeSource(first).row_count == 10
+    assert SnowparkDataframeSource(second).row_count == 11
+    assert first.count_calls == 1
+    assert second.count_calls == 1
+
+
+def test_snowpark_row_count_is_thread_safe() -> None:
+    """Concurrent first row-count reads issue only one Snowflake count query."""
+    count_started = threading.Event()
+    release_count = threading.Event()
+    fake = _FakeSnowparkDataFrame(
+        _make_pdf(),
+        count_started=count_started,
+        release_count=release_count,
+    )
+    source = SnowparkDataframeSource(fake)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(lambda: source.row_count)
+        assert count_started.wait(timeout=5)
+        second = executor.submit(lambda: source.row_count)
+        try:
+            assert fake.count_calls == 1
+        finally:
+            release_count.set()
+        assert first.result() == 10
+        assert second.result() == 10
+
+    assert fake.count_calls == 1
+
+
+def test_snowpark_schema_caches_first_page_and_exposes_capabilities() -> None:
+    """The first page defines the cached schema and source capabilities."""
+    fake = _make_fake()
+    source = SnowparkDataframeSource(fake)
+
+    assert source.schema.names == ["a", "b"]
+    assert source.schema.names == ["a", "b"]
+    assert fake.limit_calls == [(DEFAULT_PAGE_SIZE, 0)]
+    assert source.sortable is True
+    assert source.access_mode is AccessMode.RANDOM_ACCESS
+
+
+def test_snowpark_load_rows_returns_requested_rows() -> None:
+    """load_rows sends the requested range and returns it as an Arrow table."""
+    fake = _make_fake(10)
+    source = SnowparkDataframeSource(fake)
+
+    chunk = source.load_rows(2, 3)
+
+    assert isinstance(chunk, pa.Table)
+    assert chunk.column("a").to_pylist() == [2, 3, 4]
+    assert fake.limit_calls[-1] == (3, 2)
+
+
+def test_snowpark_load_rows_clamps_negative_range() -> None:
+    """Direct source calls clamp negative offsets and limits."""
+    fake = _make_fake()
+    source = SnowparkDataframeSource(fake)
+
+    assert source.load_rows(-5, -5).num_rows == 0
+
+
+def test_snowpark_orders_by_all_columns_when_unsorted() -> None:
+    """Unsorted paging applies a deterministic ORDER BY over every column."""
+    fake = _make_fake()
+    source = SnowparkDataframeSource(fake)
+
+    source.load_rows(2, 2)
+
+    assert fake.sort_calls[-1] == (("a", "b"), [True, True])
+
+
+@pytest.mark.parametrize(
+    ("descending", "expected_ascending", "expected_values"),
+    [
+        (False, [True, True], [0, 2]),
+        (True, [False, True], [18, 16]),
+    ],
+)
+def test_snowpark_sort_puts_active_column_first(
+    descending: bool,
+    expected_ascending: list[bool],
+    expected_values: list[int],
+) -> None:
+    """The active sort column leads, with all others as ascending tiebreakers."""
+    fake = _make_fake()
+    source = SnowparkDataframeSource(fake)
+
+    chunk = source.load_rows(0, 2, sort=SortSpec("b", descending=descending))
+
+    assert fake.sort_calls[-1] == (("b", "a"), expected_ascending)
+    assert chunk.column("b").to_pylist() == expected_values
+
+
+@pytest.mark.parametrize(
+    ("snowpark_name", "arrow_name"),
+    [
+        ('"lower"', "lower"),
+        ('"id with space"', "id with space"),
+        ('"embedded""quote"', 'embedded"quote'),
+    ],
+)
+def test_snowpark_sort_maps_arrow_names_to_quoted_identifiers(
+    snowpark_name: str,
+    arrow_name: str,
+) -> None:
+    """Frontend sort names map back to Snowpark's quoted identifiers."""
+    fake = _FakeSnowparkDataFrame(
+        pd.DataFrame({arrow_name: [1, 3, 2], "VALUE": [10, 20, 30]}),
+        snowpark_columns=[snowpark_name, "VALUE"],
+    )
+    source = SnowparkDataframeSource(fake)
+
+    chunk = source.load_rows(0, 3, sort=SortSpec(arrow_name, descending=True))
+
+    assert chunk.column(arrow_name).to_pylist() == [3, 2, 1]
+    assert fake.sort_calls[-1] == (
+        (snowpark_name, "VALUE"),
+        [False, True],
+    )
+
+
+def test_snowpark_unknown_sort_column_uses_default_order() -> None:
+    """An unknown sort column is ignored in favor of deterministic base order."""
+    fake = _make_fake()
+    source = SnowparkDataframeSource(fake)
+
+    source.load_rows(2, 2, sort=SortSpec("missing", descending=True))
+
+    assert fake.sort_calls[-1] == (("a", "b"), [True, True])
+
+
+def test_snowpark_falls_back_to_primary_sort_column_on_order_error() -> None:
+    """A full-order failure degrades to only the valid active sort column.
+
+    ``load_rows`` first resolves the schema, whose unsorted probe already
+    discovers that a full ORDER BY fails, so the sorted chunk skips the
+    known-bad full ordering and queries with just the active sort column.
+    """
+    fake = _FakeSnowparkDataFrame(
+        pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]}),
+        unsortable_columns={"a"},
+    )
+    source = SnowparkDataframeSource(fake)
+
+    chunk = source.load_rows(0, 3, sort=SortSpec("b"))
+
+    assert chunk.column("b").to_pylist() == [1, 2, 3]
+    assert (("b", "a"), [True, True]) not in fake.sort_calls
+    assert fake.sort_calls[-1] == (("b",), [True])
+
+
+def test_snowpark_memoizes_full_order_failure_across_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once a full ORDER BY fails, later chunks skip it and warn only once."""
+    fake = _FakeSnowparkDataFrame(
+        pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]}),
+        unsortable_columns={"a"},
+    )
+    source = SnowparkDataframeSource(fake)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        lazy_df_adapters._LOGGER,
+        "warning",
+        lambda message, *args, **_kwargs: warnings.append(message % args),
+    )
+
+    source.load_rows(0, 2, sort=SortSpec("b"))
+    source.load_rows(2, 2, sort=SortSpec("b"))
+
+    # The known-bad full ordering is never attempted for either sorted chunk.
+    assert [call for call in fake.sort_calls if call[0] == ("b", "a")] == []
+    assert sum("by all columns" in warning for warning in warnings) == 1
+
+
+def test_snowpark_falls_back_to_unordered_after_primary_order_error() -> None:
+    """Failures in full and primary ordering degrade to an unordered query."""
+    fake = _FakeSnowparkDataFrame(
+        pd.DataFrame({"a": [1, 2, 3], "b": [3, 2, 1]}),
+        unsortable_columns={"a"},
+    )
+    source = SnowparkDataframeSource(fake)
+
+    chunk = source.load_rows(0, 2, sort=SortSpec("a"))
+
+    assert chunk.column("a").to_pylist() == [1, 2]
+    assert fake.sort_calls[-2:] == [
+        (("a", "b"), [True, True]),
+        (("a",), [True]),
+    ]
+    assert fake.to_pandas_calls[-1][0] is None
+
+
+def test_snowpark_final_unordered_query_error_propagates() -> None:
+    """A genuine failure in the final unordered attempt reaches the caller."""
+    fake = _FakeSnowparkDataFrame(
+        pd.DataFrame({"a": [1, 2], "b": [2, 1]}),
+        unsortable_columns={"a"},
+        fail_unordered=True,
+    )
+    source = SnowparkDataframeSource(fake)
+
+    with pytest.raises(RuntimeError, match="unordered query failed"):
+        source._query_chunk(0, 2, sort=SortSpec("a"))
+
+
+def test_snowpark_schema_probe_degrades_when_ordering_unsupported() -> None:
+    """The first-page schema probe falls back when no column is orderable."""
+    fake = _FakeSnowparkDataFrame(
+        pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
+        unsortable_columns={"a", "b"},
+    )
+    source = SnowparkDataframeSource(fake)
+
+    assert source.schema.names == ["a", "b"]
+    assert fake.sort_calls == [(("a", "b"), [True, True])]
+    assert fake.to_pandas_calls[-1][0] is None
+
+
+def test_snowpark_reuses_and_slices_initial_page() -> None:
+    """A covered page-zero request reuses and slices the schema probe result."""
+    fake = _make_fake(DEFAULT_PAGE_SIZE + 1)
+    source = SnowparkDataframeSource(fake)
+    _ = source.schema
+
+    chunk = source.load_rows(0, 7)
+
+    assert chunk.num_rows == 7
+    assert len(fake.limit_calls) == 1
+
+
+def test_snowpark_oversized_initial_request_issues_fresh_query() -> None:
+    """A request larger than a full cached page is not under-returned."""
+    fake = _make_fake(DEFAULT_PAGE_SIZE + 1)
+    source = SnowparkDataframeSource(fake)
+    _ = source.schema
+
+    chunk = source.load_rows(0, DEFAULT_PAGE_SIZE + 1)
+
+    assert chunk.num_rows == DEFAULT_PAGE_SIZE + 1
+    assert fake.limit_calls == [
+        (DEFAULT_PAGE_SIZE, 0),
+        (DEFAULT_PAGE_SIZE + 1, 0),
+    ]
+
+
+def test_snowpark_short_initial_page_is_known_to_be_complete() -> None:
+    """A short cached first page satisfies an oversized page-zero request."""
+    fake = _make_fake(10)
+    source = SnowparkDataframeSource(fake)
+    _ = source.schema
+
+    chunk = source.load_rows(0, DEFAULT_PAGE_SIZE + 1)
+
+    assert chunk.num_rows == 10
+    assert fake.limit_calls == [(DEFAULT_PAGE_SIZE, 0)]
+
+
+def test_snowpark_later_chunks_align_to_canonical_schema() -> None:
+    """Later query results are reordered to the first page's canonical schema."""
+    source = SnowparkDataframeSource(_make_fake())
+    _ = source.schema
+
+    def query_with_reordered_columns(
+        offset: int, limit: int, *, sort: SortSpec | None
+    ) -> pa.Table:
+        return pa.table(
+            {
+                "b": pa.array([4], type=pa.int32()),
+                "a": pa.array([2], type=pa.int32()),
+            }
+        )
+
+    source._query_chunk = query_with_reordered_columns  # type: ignore[method-assign]
+    chunk = source.load_rows(1, 1)
+
+    assert chunk.schema.names == ["a", "b"]
+    assert chunk.schema.equals(source.schema)
+    assert chunk.column("a").to_pylist() == [2]
+
+
+def test_snowpark_warns_once_for_concurrent_deep_offsets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent deep-offset requests emit one warning per source."""
+    source = SnowparkDataframeSource(_make_fake())
+    warnings: list[str] = []
+
+    def record_warning(message: str, *args: object, **_kwargs: object) -> None:
+        warnings.append(message % args)
+
+    monkeypatch.setattr(lazy_df_adapters._LOGGER, "warning", record_warning)
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(source.load_rows, 100_001 + offset, 1)
+            for offset in range(4)
+        ]
+        for future in futures:
+            future.result()
+
+    assert len(warnings) == 1
+    assert "Requesting a deep offset" in warnings[0]
+
+
+def test_snowpark_serializes_concurrent_queries() -> None:
+    """Chunk execution is serialized for supported non-thread-safe sessions."""
+    fake = _make_fake()
+    source = SnowparkDataframeSource(fake)
+    _ = source.schema
+    fake.session.query_barrier = threading.Barrier(2)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(source.load_rows, 1, 1)
+        second = executor.submit(source.load_rows, 2, 1)
+        first.result()
+        second.result()
+
+    assert fake.session.max_active_queries == 1
+
+
+def test_snowpark_serializes_queries_across_sources_for_same_session() -> None:
+    """Cold dataframes sharing a session serialize schema and row queries."""
+    session = _FakeSnowparkSession()
+    first_fake = _FakeSnowparkDataFrame(_make_pdf(), session=session)
+    second_fake = _FakeSnowparkDataFrame(_make_pdf(), session=session)
+    first_source = SnowparkDataframeSource(first_fake)
+    second_source = SnowparkDataframeSource(second_fake)
+    session.query_barrier = threading.Barrier(2)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(first_source.load_rows, 1, 1)
+        second = executor.submit(second_source.load_rows, 2, 1)
+        first.result()
+        second.result()
+
+    assert session.max_active_queries == 1
+
+
+def test_snowpark_query_lock_without_session_uses_fallback() -> None:
+    """A dataframe without a session shares the process-wide fallback lock."""
+
+    class _NoSession:
+        session = None
+
+    assert (
+        lazy_df_adapters._get_snowpark_query_lock(_NoSession())
+        is lazy_df_adapters._SNOWPARK_FALLBACK_QUERY_LOCK
+    )
+
+
+def test_snowpark_query_lock_non_weakreferenceable_session_uses_fallback() -> None:
+    """A session that cannot be weak-referenced falls back to the shared lock."""
+
+    class _IntSession:
+        # ``int`` is hashable but not weak-referenceable, so WeakKeyDictionary
+        # raises TypeError when it is used as a key.
+        session = 12345
+
+    assert (
+        lazy_df_adapters._get_snowpark_query_lock(_IntSession())
+        is lazy_df_adapters._SNOWPARK_FALLBACK_QUERY_LOCK
+    )
+
+
+def test_snowpark_schema_from_empty_result() -> None:
+    """Schema derivation and paging work when the first page returns no rows."""
+    fake = _make_fake(0)
+    source = SnowparkDataframeSource(fake)
+
+    assert source.schema.names == ["a", "b"]
+    assert source.load_rows(0, 5).num_rows == 0
 
 
 def test_align_to_schema_reorders_columns() -> None:
@@ -55,12 +655,46 @@ def test_try_create_native_source_returns_none_for_plain_object() -> None:
     assert try_create_native_source([1, 2, 3]) is None
 
 
+def test_try_create_native_source_detects_snowpark(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional-dependency-safe Snowpark detection creates the native source."""
+    monkeypatch.setattr(
+        lazy_df_adapters.dataframe_util,
+        "is_polars_lazyframe",
+        lambda _data: False,
+    )
+    monkeypatch.setattr(
+        lazy_df_adapters.dataframe_util,
+        "is_snowpark_data_object",
+        lambda _data: True,
+    )
+
+    assert isinstance(try_create_native_source(_make_fake()), SnowparkDataframeSource)
+
+
+def test_try_create_native_source_prioritizes_polars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Polars detection remains first if detector predicates ever overlap."""
+    monkeypatch.setattr(
+        lazy_df_adapters.dataframe_util,
+        "is_polars_lazyframe",
+        lambda _data: True,
+    )
+    monkeypatch.setattr(
+        lazy_df_adapters.dataframe_util,
+        "is_snowpark_data_object",
+        lambda _data: True,
+    )
+
+    assert isinstance(try_create_native_source(object()), PolarsLazyFrameSource)
+
+
 @pytest.mark.require_integration
 def test_try_create_native_source_detects_polars_lazyframe() -> None:
     """A Polars LazyFrame yields a PolarsLazyFrameSource."""
     import polars as pl
-
-    from streamlit.dataframe.lazy_df_adapters import PolarsLazyFrameSource
 
     source = try_create_native_source(pl.LazyFrame({"a": [1, 2, 3]}))
     assert isinstance(source, PolarsLazyFrameSource)
@@ -76,8 +710,6 @@ def test_polars_lazyframe_sort_is_deterministic_across_chunks() -> None:
     tiebreaker column does not leak into the returned schema.
     """
     import polars as pl
-
-    from streamlit.dataframe.lazy_df_adapters import PolarsLazyFrameSource
 
     # Every value in the sort column "k" is a tie, forcing the tiebreaker.
     lf = pl.LazyFrame({"k": [0] * 100, "v": list(range(100))})
@@ -100,8 +732,6 @@ def test_polars_lazyframe_sort_is_deterministic_across_chunks() -> None:
 def test_polars_lazyframe_sort_avoids_row_index_name_collision() -> None:
     """Sorting preserves a user column matching the internal tiebreaker name."""
     import polars as pl
-
-    from streamlit.dataframe.lazy_df_adapters import PolarsLazyFrameSource
 
     internal_name = PolarsLazyFrameSource._ROW_INDEX_COLUMN
     source = PolarsLazyFrameSource(

--- a/lib/tests/streamlit/dataframe/lazy_df_source_test.py
+++ b/lib/tests/streamlit/dataframe/lazy_df_source_test.py
@@ -72,6 +72,20 @@ class _UnknownRowCountSource:
         return pa.table({"a": []}, schema=self.schema)
 
 
+class _SnowparkShapedSource:
+    """Minimal row-count stub for Snowpark resolution behavior."""
+
+    def __init__(self, row_count: int | None, *, count_raises: bool = False) -> None:
+        self._row_count = row_count
+        self._count_raises = count_raises
+
+    @property
+    def row_count(self) -> int | None:
+        if self._count_raises:
+            raise RuntimeError("Snowflake count query failed")
+        return self._row_count
+
+
 def test_in_memory_source_exposes_metadata() -> None:
     """The in-memory source reports row count, schema, and capability flags."""
     source = InMemoryDataframeSource(_make_table(10))
@@ -403,6 +417,89 @@ def test_resolve_forced_lazy_unknown_row_count_native_source_raises(
 
     with pytest.raises(StreamlitAPIException, match="known row count"):
         resolve_lazy_source(object(), True, is_selection_activated=False)
+
+
+@pytest.mark.parametrize(
+    ("lazy", "row_count", "expected_lazy"),
+    [
+        (None, UNEVALUATED_AUTO_LAZY_ROW_THRESHOLD, False),
+        (None, UNEVALUATED_AUTO_LAZY_ROW_THRESHOLD + 1, True),
+        (True, FORCED_LAZY_MIN_ROWS, False),
+        (True, FORCED_LAZY_MIN_ROWS + 1, True),
+    ],
+)
+def test_resolve_snowpark_native_source_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+    lazy: bool | None,
+    row_count: int,
+    expected_lazy: bool,
+) -> None:
+    """Snowpark sources use the generic auto and forced lazy thresholds."""
+    native_source = _SnowparkShapedSource(row_count)
+    monkeypatch.setattr(
+        dataframe_source, "_try_create_native_source", lambda _data: native_source
+    )
+
+    resolved = resolve_lazy_source(object(), lazy, is_selection_activated=False)
+
+    if expected_lazy:
+        assert resolved is native_source
+    else:
+        assert resolved is None
+
+
+def test_resolve_snowpark_count_failure_falls_back_for_auto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable Snowpark count preserves the auto preview fallback."""
+    native_source = _SnowparkShapedSource(None, count_raises=True)
+    info_messages: list[str] = []
+
+    def record_info(message: str, *args: object, **_kwargs: object) -> None:
+        info_messages.append(message % args)
+
+    monkeypatch.setattr(
+        dataframe_source, "_try_create_native_source", lambda _data: native_source
+    )
+    monkeypatch.setattr(dataframe_source._LOGGER, "info", record_info)
+
+    resolved = resolve_lazy_source(object(), None, is_selection_activated=False)
+
+    assert resolved is None
+    assert len(info_messages) == 1
+    assert "Could not determine row count" in info_messages[0]
+
+
+def test_resolve_snowpark_count_failure_raises_when_forced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit lazy request surfaces a failed Snowpark count as an API error."""
+    native_source = _SnowparkShapedSource(None, count_raises=True)
+    monkeypatch.setattr(
+        dataframe_source, "_try_create_native_source", lambda _data: native_source
+    )
+
+    with pytest.raises(StreamlitAPIException, match="could not determine"):
+        resolve_lazy_source(object(), True, is_selection_activated=False)
+
+
+def test_resolve_lazy_false_bypasses_snowpark_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lazy=False preserves the capped preview without constructing an adapter."""
+    adapter_calls = 0
+
+    def create_native_source(_data: object) -> _SnowparkShapedSource:
+        nonlocal adapter_calls
+        adapter_calls += 1
+        return _SnowparkShapedSource(UNEVALUATED_AUTO_LAZY_ROW_THRESHOLD + 1)
+
+    monkeypatch.setattr(
+        dataframe_source, "_try_create_native_source", create_native_source
+    )
+
+    assert resolve_lazy_source(object(), False, is_selection_activated=False) is None
+    assert adapter_calls == 0
 
 
 @pytest.mark.require_integration


### PR DESCRIPTION
## Describe your changes

Adds native lazy loading for unevaluated Snowpark `DataFrame`/`Table` objects passed to `st.dataframe`. Previously these rendered via an eager capped preview (`limit(10_000).to_pandas()`); eligible objects now stay in Snowflake and stream Arrow row chunks as the user scrolls or sorts.

- New `SnowparkDataframeSource` adapter using deterministic `ORDER BY` + `LIMIT/OFFSET` ("offset" mode) pagination. Ordering degrades gracefully (full ordering → active sort column → unordered) when a column type can't appear in an `ORDER BY` (e.g. `GEOGRAPHY`/`GEOMETRY`). The first such failure is memoized, so later chunks skip the known-bad query instead of retrying it per page.
- Per-Snowflake-session query lock (weak-keyed) so chunk loads sharing a session are serialized (older Snowpark isn't thread-safe) while independent sessions run concurrently.
- Registered in the existing generic resolution: auto-lazy (`lazy=None`) engages above the 10,000-row unevaluated threshold, `lazy=True` above 1,000 rows, `lazy=False` keeps the capped preview. Deep offsets warn once about Snowflake `OFFSET` cost.

Detection is optional-dependency-safe (via `dataframe_util.is_snowpark_data_object`) and Polars is still tried first, so nothing changes for other inputs.

## GitHub Issue Link (if applicable)

Part of the dataframe lazy-load effort (spec: `specs/2026-05-07-dataframe-lazy-load`).

## Testing Plan

- [x] Unit Tests (Python)
  - `lib/tests/streamlit/dataframe/lazy_df_adapters_test.py` — query building, ordering fallback + memoization, quoted/case-sensitive identifier mapping, per-session thread-safety, page-0 cache reuse vs. oversized/fresh queries, schema alignment, empty results, one-shot deep-offset warning, and the query-lock fallbacks.
  - `lib/tests/streamlit/dataframe/lazy_df_source_test.py` — auto/forced lazy thresholds and Snowpark `count()`-failure handling.
- Snowpark execution cannot run locally (requires a Snowflake account), so the adapter is exercised through a fake that mimics the Snowpark fluent API. End-to-end coverage against a real Snowflake table is recommended as follow-up external test coverage (see the conversation note).