### PR TITLE
[fix] Commit open data_editor cell edit on outside click

### DIFF
--- a/e2e_playwright/st_data_editor_editing.py
+++ b/e2e_playwright/st_data_editor_editing.py
@@ -172,9 +172,7 @@ overlay_submit_result = st.data_editor(
 if st.button("Submit edit"):
     st.session_state.submitted_value = overlay_submit_result.loc[0, "value"]
 
-st.markdown(
-    "<div data-testid='submitted-value'>"
-    f"{st.session_state.get('submitted_value', 'not submitted')}"
-    "</div>",
-    unsafe_allow_html=True,
+st.write(
+    "Submitted value:",
+    st.session_state.get("submitted_value", "not submitted"),
 )

--- a/e2e_playwright/st_data_editor_editing.py
+++ b/e2e_playwright/st_data_editor_editing.py
@@ -160,3 +160,21 @@ cell_editing_result = st.data_editor(
 )
 
 st.write("Edited DF:", str(cell_editing_result))
+
+overlay_submit_result = st.data_editor(
+    pd.DataFrame({"value": ["original"]}),
+    hide_index=True,
+    width="content",
+    column_config={"value": st.column_config.TextColumn(width="small")},
+    key="overlay_submit_editor",
+)
+
+if st.button("Submit edit"):
+    st.session_state.submitted_value = overlay_submit_result.loc[0, "value"]
+
+st.markdown(
+    "<div data-testid='submitted-value'>"
+    f"{st.session_state.get('submitted_value', 'not submitted')}"
+    "</div>",
+    unsafe_allow_html=True,
+)

--- a/e2e_playwright/st_data_editor_editing_test.py
+++ b/e2e_playwright/st_data_editor_editing_test.py
@@ -337,7 +337,7 @@ def test_clicking_button_commits_open_cell_editor(app: Page) -> None:
     cell_overlay.locator(".gdg-input").fill("edited")
 
     # Sanity check that nothing has been submitted yet.
-    expect(app.locator("[data-testid='submitted-value']")).to_have_text("not submitted")
+    expect_prefixed_markdown(app, "Submitted value:", "not submitted")
 
     # Clicking the button closes the overlay during pointerdown and triggers a
     # rerun during click. The pending edit must be synced before that rerun.
@@ -346,7 +346,7 @@ def test_clicking_button_commits_open_cell_editor(app: Page) -> None:
 
     # Without flushing the pending edit, the button click would commit the
     # pre-edit value ("original") instead of "edited".
-    expect(app.locator("[data-testid='submitted-value']")).to_have_text("edited")
+    expect_prefixed_markdown(app, "Submitted value:", "edited")
 
 
 def _test_number_cell_editing(

--- a/e2e_playwright/st_data_editor_editing_test.py
+++ b/e2e_playwright/st_data_editor_editing_test.py
@@ -322,6 +322,33 @@ def test_data_editor_keeps_state_after_unmounting(
 # ---------------------------------------------------------------------------
 
 
+def test_clicking_button_commits_open_cell_editor(app: Page) -> None:
+    data_editor = _get_editor(app, "overlay_submit_editor")
+    expect_canvas_to_be_visible(data_editor)
+    click_on_cell(
+        data_editor,
+        row_pos=1,
+        col_pos=0,
+        column_width="small",
+        double_click=True,
+    )
+
+    cell_overlay = get_open_cell_overlay(app)
+    cell_overlay.locator(".gdg-input").fill("edited")
+
+    # Sanity check that nothing has been submitted yet.
+    expect(app.locator("[data-testid='submitted-value']")).to_have_text("not submitted")
+
+    # Clicking the button closes the overlay during pointerdown and triggers a
+    # rerun during click. The pending edit must be synced before that rerun.
+    app.get_by_role("button", name="Submit edit").click()
+    wait_for_app_run(app)
+
+    # Without flushing the pending edit, the button click would commit the
+    # pre-edit value ("original") instead of "edited".
+    expect(app.locator("[data-testid='submitted-value']")).to_have_text("edited")
+
+
 def _test_number_cell_editing(
     themed_app: Page,
     assert_snapshot: ImageCompareFunction,

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.test.tsx
@@ -16,6 +16,7 @@
 
 import { forwardRef } from "react"
 
+import { type GridCell } from "@glideapps/glide-data-grid"
 import { act, screen } from "@testing-library/react"
 
 import { Dataframe as DataframeProto } from "@streamlit/protobuf"
@@ -76,6 +77,7 @@ describe("DataFrame widget", () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -161,6 +163,107 @@ describe("DataFrame widget", () => {
       })
     )
   })
+
+  const renderEditableDataFrame = (): {
+    widgetMgr: WidgetStateManager
+    updatedCell: GridCell
+  } => {
+    vi.useFakeTimers()
+    const widgetMgr = {
+      getStringValue: vi.fn(),
+      setStringValue: vi.fn(),
+    } as unknown as WidgetStateManager
+
+    render(
+      <DataFrame
+        {...getProps(TEN_BY_TEN, DataframeProto.EditingMode.FIXED)}
+        widgetMgr={widgetMgr}
+      />
+    )
+
+    const dataEditorProps = dataEditorMockFn.mock.lastCall?.[0]
+    const updatedCell = {
+      ...dataEditorProps.getCellContent([1, 0]),
+      data: 999,
+      displayData: "999",
+    }
+    return { widgetMgr, updatedCell }
+  }
+
+  it("flushes a pending edit when clicking outside the data editor", () => {
+    const { widgetMgr, updatedCell } = renderEditableDataFrame()
+    const dataEditorProps = dataEditorMockFn.mock.lastCall?.[0]
+
+    act(() => {
+      const pointerDownEvent = new MouseEvent("pointerdown")
+      Object.defineProperty(pointerDownEvent, "target", {
+        value: document.body,
+      })
+      expect(dataEditorProps.isOutsideClick(pointerDownEvent)).toBe(true)
+      dataEditorProps.onCellEdited([1, 0], updatedCell)
+      dataEditorProps.onFinishedEditing(updatedCell, [0, 0])
+    })
+    expect(widgetMgr.setStringValue).toHaveBeenCalledOnce()
+
+    act(() => {
+      vi.runAllTimers()
+    })
+    expect(widgetMgr.setStringValue).toHaveBeenCalledOnce()
+  })
+
+  it("keeps a pending edit debounced when clicking another grid cell", () => {
+    const { widgetMgr, updatedCell } = renderEditableDataFrame()
+    const dataEditorProps = dataEditorMockFn.mock.lastCall?.[0]
+
+    const pointerDownEvent = new MouseEvent("pointerdown")
+    Object.defineProperty(pointerDownEvent, "target", {
+      value: screen.getByTestId("mock-data-editor"),
+    })
+
+    act(() => {
+      expect(dataEditorProps.isOutsideClick(pointerDownEvent)).toBe(true)
+      dataEditorProps.onCellEdited([1, 0], updatedCell)
+      dataEditorProps.onFinishedEditing(updatedCell, [0, 0])
+    })
+    expect(widgetMgr.setStringValue).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.runAllTimers()
+    })
+    expect(widgetMgr.setStringValue).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ["Enter", [0, 1], true],
+    ["Tab", [1, 0], true],
+    ["a zero-movement editor completion", [0, 0], false],
+  ] as const)(
+    "keeps pending edits debounced for %s",
+    (_key, movement, armOutsideClick) => {
+      const { widgetMgr, updatedCell } = renderEditableDataFrame()
+      const dataEditorProps = dataEditorMockFn.mock.lastCall?.[0]
+      let outsideClickResult: boolean | undefined
+
+      act(() => {
+        if (armOutsideClick) {
+          const pointerDownEvent = new MouseEvent("pointerdown")
+          Object.defineProperty(pointerDownEvent, "target", {
+            value: document.body,
+          })
+          outsideClickResult = dataEditorProps.isOutsideClick(pointerDownEvent)
+        }
+        dataEditorProps.onCellEdited([1, 0], updatedCell)
+        dataEditorProps.onFinishedEditing(updatedCell, movement)
+      })
+      expect(outsideClickResult).toBe(armOutsideClick ? true : undefined)
+      expect(widgetMgr.setStringValue).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.runAllTimers()
+      })
+      expect(widgetMgr.setStringValue).toHaveBeenCalledOnce()
+    }
+  )
 
   it("shows search when Ctrl+F is pressed and search is enabled", () => {
     render(<DataFrame {...props} />)

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -312,6 +312,7 @@ function DataFrame({
     editStateHydrationCount,
     updateNumRows,
     syncEditState,
+    flushEditState,
     createSyncSelectionState,
     onFormCleared: handleFormCleared,
     loadInitialSelectionState,
@@ -323,6 +324,47 @@ function DataFrame({
     originalNumRows,
     originalColumns,
   })
+
+  const flushEditStateOnFinishedEditingRef = useRef(false)
+  const handleOutsideClick = useCallback(
+    (event: MouseEvent | TouchEvent): boolean => {
+      const target = event.target
+      flushEditStateOnFinishedEditingRef.current =
+        target instanceof Node &&
+        resizableContainerRef.current !== null &&
+        !resizableContainerRef.current.contains(target)
+
+      // Glide calls onFinishedEditing synchronously for an outside click. Clear
+      // the flag after the current event so other ways of closing the editor
+      // keep the normal debounce behavior.
+      queueMicrotask(() => {
+        flushEditStateOnFinishedEditingRef.current = false
+      })
+      // Always return true to keep glide's default containment check. This
+      // callback is used only for its side effect of arming the flush flag, not
+      // to change whether the click is treated as outside the editor.
+      return true
+    },
+    [resizableContainerRef]
+  )
+
+  const handleFinishedEditing = useCallback(
+    (_newValue: GridCell | undefined, [moveX, moveY]: Item): void => {
+      // moveX/moveY are non-zero only for keyboard completions (e.g. Enter/Tab),
+      // which never arm the flag. The guard is belt-and-suspenders to ensure we
+      // only flush on the outside-click path.
+      const shouldFlush =
+        flushEditStateOnFinishedEditingRef.current &&
+        moveX === 0 &&
+        moveY === 0
+      flushEditStateOnFinishedEditingRef.current = false
+
+      if (shouldFlush) {
+        flushEditState()
+      }
+    },
+    [flushEditState]
+  )
 
   const { getCellContent: getOriginalCellContent } = useDataLoader(
     data,
@@ -1324,6 +1366,9 @@ function DataFrame({
             fillHandle: supportsFillHandle,
             // Support editing:
             onCellEdited,
+            // Flush edits before an outside click can trigger a rerun.
+            isOutsideClick: handleOutsideClick,
+            onFinishedEditing: handleFinishedEditing,
             // Support pasting data for bulk editing:
             onPaste,
             // Support deleting cells & rows:

--- a/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/DataFrame.tsx
@@ -350,9 +350,9 @@ function DataFrame({
 
   const handleFinishedEditing = useCallback(
     (_newValue: GridCell | undefined, [moveX, moveY]: Item): void => {
-      // moveX/moveY are non-zero only for keyboard completions (e.g. Enter/Tab),
-      // which never arm the flag. The guard is belt-and-suspenders to ensure we
-      // only flush on the outside-click path.
+      // Keyboard completions (Enter/Tab) report non-zero movement and do not
+      // arm the flag. This guard ensures we flush only for the outside-click
+      // path.
       const shouldFlush =
         flushEditStateOnFinishedEditingRef.current &&
         moveX === 0 &&

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useWidgetState.ts
@@ -186,6 +186,8 @@ interface UseWidgetStateReturn {
   updateNumRows: () => void
   // Debounced callback to sync editing state with widget manager
   syncEditState: () => void
+  // Immediately syncs a pending edit and cancels its debounce timeout
+  flushEditState: () => void
   // Creates a sync selection state callback for the given columns and getOriginalIndex
   // This needs to be called after useColumnSort since it needs the sorted columns and getOriginalIndex
   createSyncSelectionState: (
@@ -352,10 +354,8 @@ function useWidgetState({
   }, [originalColumns, element.id, element.formId, widgetMgr, fragmentId])
 
   // Debounced version of syncEditState to prevent rapid updates
-  const { debouncedCallback: syncEditState } = useDebouncedCallback(
-    innerSyncEditState,
-    DEBOUNCE_TIME_MS
-  )
+  const { debouncedCallback: syncEditState, flush: flushEditState } =
+    useDebouncedCallback(innerSyncEditState, DEBOUNCE_TIME_MS)
 
   /**
    * Creates a function to sync selection state with the widget manager.
@@ -664,6 +664,7 @@ function useWidgetState({
     resetEditingState,
     updateNumRows,
     syncEditState,
+    flushEditState,
     createSyncSelectionState,
     onFormCleared,
     loadInitialSelectionState,

--- a/frontend/lib/src/hooks/useDebouncedCallback.test.ts
+++ b/frontend/lib/src/hooks/useDebouncedCallback.test.ts
@@ -73,6 +73,67 @@ describe("useDebouncedCallback hook", () => {
     expect(callback).not.toHaveBeenCalled()
   })
 
+  it("should immediately invoke a pending callback when flush is called", () => {
+    const callback = vi.fn()
+    const delay = 100
+
+    const { result } = renderHook(() => useDebouncedCallback(callback, delay))
+    const { debouncedCallback, flush } = result.current
+
+    debouncedCallback("test")
+    flush()
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith("test")
+
+    vi.advanceTimersByTime(delay)
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  it("should do nothing when flush is called without a pending callback", () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useDebouncedCallback(callback, 100))
+
+    result.current.flush()
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it("should do nothing when flush is called after cancel", () => {
+    const callback = vi.fn()
+    const delay = 100
+
+    const { result } = renderHook(() => useDebouncedCallback(callback, delay))
+    const { debouncedCallback, cancel, flush } = result.current
+
+    debouncedCallback("test")
+    cancel()
+    flush()
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it("should invoke the latest callback when flushed after the callback changes", () => {
+    const callback1 = vi.fn()
+    const callback2 = vi.fn()
+    let callback = callback1
+    const delay = 100
+
+    const { result, rerender } = renderHook(() =>
+      useDebouncedCallback(callback, delay)
+    )
+
+    result.current.debouncedCallback("test")
+
+    // Swap callback before flushing
+    callback = callback2
+    rerender()
+
+    result.current.flush()
+    expect(callback1).not.toHaveBeenCalled()
+    expect(callback2).toHaveBeenCalledWith("test")
+  })
+
   it("should handle multiple arguments correctly", () => {
     const callback = vi.fn()
     const delay = 100

--- a/frontend/lib/src/hooks/useDebouncedCallback.ts
+++ b/frontend/lib/src/hooks/useDebouncedCallback.ts
@@ -30,25 +30,31 @@ interface UseDebouncedCallbackReturn<A extends unknown[]> {
    * A function to cancel any pending invocation of the debounced callback.
    */
   cancel: () => void
+  /**
+   * Immediately invokes a pending callback and cancels its timeout.
+   * Does nothing when no callback is pending.
+   */
+  flush: () => void
 }
 
 /**
- * A custom hook that provides a debounced callback function and a cancel function.
+ * A custom hook that provides a debounced callback function and functions to
+ * cancel or flush it.
  *
  * The debounced callback will only execute after a specified delay has passed
  * since the last time it was invoked. This can be useful for preventing
  * expensive operations from being called too frequently, such as API calls
  * triggered by user input.
  *
- * The cancel function can be used to cancel any pending invocation of the
- * debounced callback.
+ * The cancel function cancels a pending invocation. The flush function invokes
+ * a pending callback immediately and cancels its timeout.
  *
  * @param {function} callback - The function to be debounced.
  * @param {number} delay - The delay in milliseconds.
- * @returns {UseDebouncedCallbackReturn<A>} An object containing the debounced callback function and the cancel function.
+ * @returns {UseDebouncedCallbackReturn<A>} An object containing the debounced callback function and controls to cancel or flush it.
  *
  * @example
- * const { debouncedCallback, cancel } = useDebouncedCallback(
+ * const { debouncedCallback, cancel, flush } = useDebouncedCallback(
  *   (value) => console.log('Debounced value:', value),
  *   500
  * );
@@ -58,6 +64,9 @@ interface UseDebouncedCallbackReturn<A extends unknown[]> {
  *
  * // Cancel any pending invocation:
  * cancel();
+ *
+ * // Or invoke it immediately:
+ * flush();
  */
 export function useDebouncedCallback<A extends unknown[]>(
   callback: (...args: A) => void,
@@ -74,21 +83,26 @@ export function useDebouncedCallback<A extends unknown[]>(
     callbackRef.current = callback
   }, [callback])
 
-  const { clear, restart } = useTimeout(
-    () => {
-      if (argsRef.current) {
-        callbackRef.current(...argsRef.current)
-        argsRef.current = undefined
-      }
-    },
-    delay,
-    { autoStart: false }
-  )
+  const invokePending = useCallback((): void => {
+    if (argsRef.current) {
+      callbackRef.current(...argsRef.current)
+      argsRef.current = undefined
+    }
+  }, [])
+
+  const { clear, restart } = useTimeout(invokePending, delay, {
+    autoStart: false,
+  })
 
   const cancel = useCallback((): void => {
     clear()
     argsRef.current = undefined
   }, [clear])
+
+  const flush = useCallback((): void => {
+    clear()
+    invokePending()
+  }, [clear, invokePending])
 
   const debouncedCallback = useCallback(
     (...args: A) => {
@@ -101,5 +115,6 @@ export function useDebouncedCallback<A extends unknown[]>(
   return {
     debouncedCallback,
     cancel,
+    flush,
   }
 }


### PR DESCRIPTION
## Describe your changes

Editing a `st.data_editor` cell and then clicking an element outside the grid (e.g. an `st.button`) discarded the in-progress edit: the outside click triggered a rerun before the 150ms-debounced edit sync had run, so the pre-edit value was sent to the backend.

- Adds a `flush()` control to the `useDebouncedCallback` hook that runs a pending callback immediately and cancels its timer.
- Wires glide-data-grid's `isOutsideClick`/`onFinishedEditing` in the data editor to flush the pending edit synchronously on outside clicks. All other close paths (Enter/Tab/Escape, clicks inside the grid) keep the normal debounce, so rapid edits are still batched.

## GitHub Issue Link (if applicable)

- Closes https://github.com/streamlit/streamlit/issues/7868

## Testing Plan

- Unit Tests (JS): `useDebouncedCallback.test.ts` covers the new `flush` behavior; `DataFrame.test.tsx` covers flushing on outside clicks vs. staying debounced on other close paths.
- E2E Tests: `st_data_editor_editing_test.py::test_clicking_button_commits_open_cell_editor` opens a cell editor, edits it, clicks a button, and asserts the edited value is committed.

Made with [Cursor](https://cursor.com)