### PR TITLE
[fix] TypeError in run_every fragments with Sentry threading

### DIFF
--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -393,16 +393,15 @@ def add_script_run_ctx(
         ):
             original_run = thread.run
 
-            # ``original_run`` is the thread's already-bound run() method, which
-            # takes no positional arguments. We still accept (and ignore)
-            # ``*args`` / ``**kwargs`` because third-party thread wrappers — most
-            # notably Sentry's ThreadingIntegration — treat our replacement
-            # ``run`` as an unbound function and re-invoke it with the thread
-            # instance as the first positional argument. Forwarding that spurious
-            # argument to the bound ``original_run`` raises "run() takes 1
-            # positional argument but 2 were given" (GitHub issues #15374,
-            # #16139), so we drop the arguments and call ``original_run`` with
-            # none.
+            # Accept but ignore any arguments: ``original_run`` is the thread's
+            # already-bound run(), which takes none, so we call it with none.
+            # We still tolerate extra arguments because third-party thread
+            # wrappers — notably Sentry's ThreadingIntegration — treat our
+            # replacement ``run`` as an unbound function and re-invoke it with
+            # the thread instance as the first positional argument. Forwarding
+            # that spurious argument to the bound ``original_run`` raises
+            # "run() takes 1 positional argument but 2 were given" (GitHub
+            # issues #15374, #16139).
             def _run_with_thread_state(*_args: object, **_kwargs: object) -> None:
                 fields = getattr(thread, _FRAGMENT_THREAD_STATE_FIELDS_ATTR, None)
                 if fields is not None:

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -393,11 +393,21 @@ def add_script_run_ctx(
         ):
             original_run = thread.run
 
-            def _run_with_thread_state(*args: object, **kwargs: object) -> None:
+            # ``original_run`` is the thread's already-bound run() method, which
+            # takes no positional arguments. We still accept (and ignore)
+            # ``*args`` / ``**kwargs`` because third-party thread wrappers — most
+            # notably Sentry's ThreadingIntegration — treat our replacement
+            # ``run`` as an unbound function and re-invoke it with the thread
+            # instance as the first positional argument. Forwarding that spurious
+            # argument to the bound ``original_run`` raises "run() takes 1
+            # positional argument but 2 were given" (GitHub issues #15374,
+            # #16139), so we drop the arguments and call ``original_run`` with
+            # none.
+            def _run_with_thread_state(*_args: object, **_kwargs: object) -> None:
                 fields = getattr(thread, _FRAGMENT_THREAD_STATE_FIELDS_ATTR, None)
                 if fields is not None:
                     ThreadState.initialize(**fields)
-                original_run(*args, **kwargs)
+                original_run()
 
             thread.run = _run_with_thread_state  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
             setattr(thread, _FRAGMENT_THREAD_STATE_WRAP_INSTALLED_ATTR, True)

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -393,15 +393,11 @@ def add_script_run_ctx(
         ):
             original_run = thread.run
 
-            # Accept but ignore any arguments: ``original_run`` is the thread's
-            # already-bound run(), which takes none, so we call it with none.
-            # We still tolerate extra arguments because third-party thread
-            # wrappers — notably Sentry's ThreadingIntegration — treat our
-            # replacement ``run`` as an unbound function and re-invoke it with
-            # the thread instance as the first positional argument. Forwarding
-            # that spurious argument to the bound ``original_run`` raises
-            # "run() takes 1 positional argument but 2 were given" (GitHub
-            # issues #15374, #16139).
+            # Accept but ignore extra args: ``original_run`` is already bound and
+            # takes none. Some thread wrappers (e.g. Sentry's ThreadingIntegration)
+            # re-invoke our replacement ``run`` with the thread as a positional
+            # arg; forwarding it would raise "run() takes 1 positional argument
+            # but 2 were given" (GitHub issues #15374, #16139).
             def _run_with_thread_state(*_args: object, **_kwargs: object) -> None:
                 fields = getattr(thread, _FRAGMENT_THREAD_STATE_FIELDS_ATTR, None)
                 if fields is not None:

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -472,16 +472,12 @@ class ScriptRunContextTest(unittest.TestCase):
         assert ctx.shared.tracked_commands_count == 0
 
     def test_run_wrapper_tolerates_extra_positional_arg_from_thread_wrapper(self):
-        """The _run_with_thread_state wrapper must tolerate an extra positional
-        argument without forwarding it to the bound original run().
+        """The wrapper must tolerate an extra positional argument without
+        forwarding it to the already-bound original run().
 
-        Regression test for GitHub issues #15374 and #16139: third-party thread
-        wrappers (most notably Sentry's ThreadingIntegration) treat our
-        replacement ``run`` as an unbound function and re-invoke it with the
-        thread instance as the first positional argument. The original ``run``
-        we captured is already bound and takes no positional arguments, so
-        forwarding that argument raised ``TypeError: run() takes 1 positional
-        argument but 2 were given``.
+        Regression test for GitHub issues #15374 and #16139, where a thread
+        wrapper (Sentry's ThreadingIntegration) re-invokes the wrapper with the
+        thread as an extra positional arg; forwarding it raised a TypeError.
         """
         pages_manager = PagesManager("/main/script/path")
         enable_mpa_v2_mode(pages_manager)

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_run_context_test.py
@@ -471,12 +471,17 @@ class ScriptRunContextTest(unittest.TestCase):
         assert ctx.shared.tracked_commands == ()
         assert ctx.shared.tracked_commands_count == 0
 
-    def test_run_wrapper_accepts_positional_args(self):
-        """The _run_with_thread_state wrapper must accept positional arguments.
+    def test_run_wrapper_tolerates_extra_positional_arg_from_thread_wrapper(self):
+        """The _run_with_thread_state wrapper must tolerate an extra positional
+        argument without forwarding it to the bound original run().
 
-        Regression test for GitHub issue #15374: some threading patterns call
-        thread.run() with positional arguments. The wrapper installed by
-        add_script_run_ctx must handle this gracefully to avoid TypeError.
+        Regression test for GitHub issues #15374 and #16139: third-party thread
+        wrappers (most notably Sentry's ThreadingIntegration) treat our
+        replacement ``run`` as an unbound function and re-invoke it with the
+        thread instance as the first positional argument. The original ``run``
+        we captured is already bound and takes no positional arguments, so
+        forwarding that argument raised ``TypeError: run() takes 1 positional
+        argument but 2 were given``.
         """
         pages_manager = PagesManager("/main/script/path")
         enable_mpa_v2_mode(pages_manager)
@@ -484,20 +489,22 @@ class ScriptRunContextTest(unittest.TestCase):
 
         ThreadState.initialize(fragment_id="test_fragment")
 
-        received_args: list[object] = []
+        run_calls: list[object] = []
 
-        class ThreadWithRunArgs(threading.Thread):
-            """Thread subclass whose run() accepts extra arguments."""
+        class NoArgRunThread(threading.Thread):
+            """Thread whose run() takes no args, like threading.Thread/Timer."""
 
-            def run(self, *args: object) -> None:
-                received_args.extend(args)
+            def run(self) -> None:
+                run_calls.append(ThreadState.get().fragment_id)
 
-        t = ThreadWithRunArgs()
+        t = NoArgRunThread()
         add_script_run_ctx(t, ctx)
 
-        t.run("test_arg")
+        # Simulate the Sentry ThreadingIntegration calling pattern: the wrapper
+        # is invoked with the thread instance as an extra positional argument.
+        t.run(t)
 
-        assert received_args == ["test_arg"]
+        assert run_calls == ["test_fragment"]
 
 
 def test_script_run_context_attr_name_reexported_from_leaf_module() -> None:


### PR DESCRIPTION
## Describe your changes

`@st.fragment(run_every=...)` raises `TypeError: Timer.run() takes 1 positional argument but 2 were given` when Sentry's `ThreadingIntegration` is enabled.

The thread-state wrapper installed by `add_script_run_ctx` captures the thread's **already-bound** `run()` as `original_run`. Sentry treats the replacement `run` as an unbound function and re-invokes it with the thread instance as an extra positional argument. The previous fix (#15376) forwarded `*args`/`**kwargs` to `original_run`, so that spurious `self` was passed to the bound method, causing the double-argument `TypeError`.

The wrapper still accepts extra arguments (so third-party wrappers can call it), but no longer forwards them — `Thread.run()`/`Timer.run()` take no positional arguments, so the extra argument is dropped.

## GitHub Issue Link (if applicable)

- Closes #16139

## Testing Plan

- Unit test (`test_run_wrapper_tolerates_extra_positional_arg_from_thread_wrapper`) mimics the Sentry calling pattern against a no-arg `run()`; it reproduces the exact `TypeError` without the fix and passes with it. This replaces the prior test that used a contrived `run(*args)` subclass which masked the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to thread `run` wrapping in `add_script_run_ctx`; behavior for normal `Thread.start()` is unchanged and covered by an updated regression test.
> 
> **Overview**
> Fixes **`TypeError: Timer.run() takes 1 positional argument but 2 were given`** when **`@st.fragment(run_every=...)`** runs alongside **Sentry's `ThreadingIntegration`**.
> 
> `add_script_run_ctx` wraps a child thread's **`run`** so **`FragmentThreadState`** is initialized before the real **`run`**. The captured **`original_run`** is already bound and takes no arguments. A prior fix forwarded **`*args`/`**kwargs`** into **`original_run`**, so when Sentry re-invoked the wrapper with the thread instance as an extra positional arg, that arg was passed through and broke standard **`Thread`/`Timer.run()`**.
> 
> The wrapper still accepts arbitrary positional/keyword args for third-party hooks but **drops** them and always calls **`original_run()`** with no arguments. The regression test now uses a no-arg **`run()`** and invokes **`t.run(t)`** to match Sentry's calling pattern (replacing a contrived **`run(*args)`** subclass that hid the bug).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfd5890ab8fd5f03f384700870a2078002d757b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->