### PR TITLE
[refactor] Replace FragmentThreadState.in_fragment_callback with a RunLocation enum

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -37,6 +37,7 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     StopException,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    RunLocation,
     ScriptRunContext,
     ThreadState,
     get_script_run_ctx,
@@ -541,7 +542,11 @@ def _fragment(
             # is established below, this will be initialized with the fragment's
             # delta path. Without this, we would inherit the delta path from the
             # parent scope.
-            with ThreadState.scoped(fragment_id=fragment_id, delta_path=None):
+            with ThreadState.scoped(
+                fragment_id=fragment_id,
+                delta_path=None,
+                run_location=RunLocation.FRAGMENT,
+            ):
                 result = None
                 with active_hash_context:
                     container_ctx = (

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -20,6 +20,7 @@ import dataclasses
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Final,
@@ -64,6 +65,26 @@ _LOGGER: Final = get_logger(__name__)
 UserInfoType: TypeAlias = dict[str, str | bool | dict[str, str] | None]
 
 
+class RunLocation(Enum):
+    """The execution phase of the current call site.
+
+    There are two orthogonal axes when code runs inside Streamlit:
+
+    * **Phase** — whether we are in the main script body, a fragment body, or a
+      widget/event callback.  ``RunLocation`` tracks the phase.
+    * **Fragment identity** — which ``@st.fragment`` we are associated with, if
+      any.  ``FragmentThreadState.fragment_id`` tracks this independently.
+
+    The two axes are independent: a callback for a widget defined inside
+    fragment ``bar`` has ``run_location=CALLBACK`` *and*
+    ``fragment_id="bar"``.
+    """
+
+    MAIN_SCRIPT = "main_script"
+    FRAGMENT = "fragment"
+    CALLBACK = "callback"
+
+
 # If true, it indicates that we are in a cached function that disallows the usage of
 # widgets. Using contextvars to be thread-safe.
 in_cached_function: contextvars.ContextVar[bool] = contextvars.ContextVar(
@@ -82,7 +103,7 @@ class FragmentThreadState:
 
     fragment_id: str | None = None
     delta_path: tuple[int, ...] | None = None
-    in_fragment_callback: bool = False
+    run_location: RunLocation = RunLocation.MAIN_SCRIPT
     active_script_hash: str = ""
     # Set on parallel-fragment workers so wrapped_fragment() skips creating a
     # second st.container(); the main thread already pre-allocated one before
@@ -92,6 +113,17 @@ class FragmentThreadState:
     # _check_not_parallel_worker() to gate APIs that are unsafe during
     # concurrent execution (e.g. st.dialog, st.switch_page).
     is_parallel_worker: bool = False
+
+    @property
+    def in_fragment_callback(self) -> bool:
+        """True when executing inside a widget callback for a fragment widget.
+
+        Derived from ``run_location`` and ``fragment_id`` so that all existing
+        consumers of this flag keep working without change.
+        """
+        return (
+            self.run_location is RunLocation.CALLBACK and self.fragment_id is not None
+        )
 
 
 class _FragmentThreadStateFields(TypedDict, total=False):
@@ -104,7 +136,7 @@ class _FragmentThreadStateFields(TypedDict, total=False):
 
     fragment_id: str | None
     delta_path: tuple[int, ...] | None
-    in_fragment_callback: bool
+    run_location: RunLocation
     active_script_hash: str
     pre_allocated_container_fragment_id: str | None
     is_parallel_worker: bool

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -74,11 +74,6 @@ class RunLocation(Enum):
     - ``FRAGMENT`` — a ``@st.fragment`` body is executing.
     - ``CALLBACK`` — a widget callback (``on_change``, ``on_click``, etc.)
       is executing.
-
-    ``CALLBACK`` does not encode whether the triggering widget belongs to a
-    fragment; ``FragmentThreadState.fragment_id`` tracks that separately.
-    A callback for a widget inside a fragment has ``run_location=CALLBACK``
-    *and* a non-``None`` ``fragment_id``.
     """
 
     MAIN_SCRIPT = "main_script"

--- a/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_run_context.py
@@ -66,18 +66,19 @@ UserInfoType: TypeAlias = dict[str, str | bool | dict[str, str] | None]
 
 
 class RunLocation(Enum):
-    """The execution phase of the current call site.
+    """The execution phase of the currently running Streamlit code.
 
-    There are two orthogonal axes when code runs inside Streamlit:
+    Tracks which of three phases is active on the current thread:
 
-    * **Phase** — whether we are in the main script body, a fragment body, or a
-      widget/event callback.  ``RunLocation`` tracks the phase.
-    * **Fragment identity** — which ``@st.fragment`` we are associated with, if
-      any.  ``FragmentThreadState.fragment_id`` tracks this independently.
+    - ``MAIN_SCRIPT`` — the top-level app script body is running.
+    - ``FRAGMENT`` — a ``@st.fragment`` body is executing.
+    - ``CALLBACK`` — a widget callback (``on_change``, ``on_click``, etc.)
+      is executing.
 
-    The two axes are independent: a callback for a widget defined inside
-    fragment ``bar`` has ``run_location=CALLBACK`` *and*
-    ``fragment_id="bar"``.
+    ``CALLBACK`` does not encode whether the triggering widget belongs to a
+    fragment; ``FragmentThreadState.fragment_id`` tracks that separately.
+    A callback for a widget inside a fragment has ``run_location=CALLBACK``
+    *and* a non-``None`` ``fragment_id``.
     """
 
     MAIN_SCRIPT = "main_script"

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -893,23 +893,15 @@ class SessionState:
         cb_args: WidgetArgs,
         cb_kwargs: dict[str, Any],
     ) -> None:
-        """Execute a widget callback with fragment-aware context.
+        """Execute a widget callback in callback run context.
 
-        If the widget belongs to a fragment, temporarily marks the current
-        script context as being inside a fragment callback to adapt rerun
-        semantics. Attempts to call ``st.rerun()`` inside a widget callback are
-        converted to a user-visible warning and treated as a no-op.
+        Sets ``run_location=RunLocation.CALLBACK`` and binds ``fragment_id``
+        from the widget's metadata for the duration of the callback. The
+        derived ``in_fragment_callback`` property gates fragment-specific
+        behavior when ``fragment_id`` is non-None.
 
-        Parameters
-        ----------
-        callback_fn : WidgetCallback
-            The user-provided callback to execute.
-        cb_metadata : WidgetMetadata[Any]
-            Metadata of the widget associated with the callback.
-        cb_args : WidgetArgs
-            Positional arguments passed to the callback.
-        cb_kwargs : dict[str, Any]
-            Keyword arguments passed to the callback.
+        Attempts to call ``st.rerun()`` inside a widget callback are converted
+        to a user-visible warning and treated as a no-op.
         """
         from streamlit.runtime.scriptrunner import RerunException
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -46,6 +46,7 @@ from streamlit.runtime.runtime_util import (
     get_max_widget_state_size_bytes,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    RunLocation,
     ThreadState,
     get_script_run_ctx,
 )
@@ -341,11 +342,10 @@ class WStates(MutableMapping[str, Any]):
         args = metadata.callback_args or ()
         kwargs = metadata.callback_kwargs or {}
 
-        ctx = get_script_run_ctx()
-        if ctx and metadata.fragment_id is not None:
-            with ThreadState.scoped(in_fragment_callback=True):
-                callback(*args, **kwargs)
-        else:
+        with ThreadState.scoped(
+            run_location=RunLocation.CALLBACK,
+            fragment_id=metadata.fragment_id,
+        ):
             callback(*args, **kwargs)
 
 
@@ -913,16 +913,10 @@ class SessionState:
         """
         from streamlit.runtime.scriptrunner import RerunException
 
-        ctx = get_script_run_ctx()
-        if ctx and cb_metadata.fragment_id is not None:
-            with ThreadState.scoped(in_fragment_callback=True):
-                try:
-                    callback_fn(*cb_args, **cb_kwargs)
-                except RerunException:
-                    get_dg_singleton_instance().main_dg.warning(
-                        "Calling st.rerun() within a callback is a no-op."
-                    )
-        else:
+        with ThreadState.scoped(
+            run_location=RunLocation.CALLBACK,
+            fragment_id=cb_metadata.fragment_id,
+        ):
             try:
                 callback_fn(*cb_args, **cb_kwargs)
             except RerunException:

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/fragment_thread_state_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/fragment_thread_state_test.py
@@ -25,6 +25,7 @@ from streamlit.runtime.fragment import MemoryFragmentStorage
 from streamlit.runtime.memory_uploaded_file_manager import MemoryUploadedFileManager
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    RunLocation,
     ScriptRunContext,
     ThreadState,
 )
@@ -46,12 +47,13 @@ class ThreadStateUnitTest(unittest.TestCase):
         ThreadState.initialize(
             fragment_id="frag-1",
             delta_path=(0, 1, 2),
-            in_fragment_callback=True,
+            run_location=RunLocation.CALLBACK,
             active_script_hash="hash123",
         )
         ts = ThreadState.get()
         assert ts.fragment_id == "frag-1"
         assert ts.delta_path == (0, 1, 2)
+        assert ts.run_location is RunLocation.CALLBACK
         assert ts.in_fragment_callback is True
         assert ts.active_script_hash == "hash123"
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -134,6 +134,7 @@ def _create_persist_state_metadata(
 
 class WStateTests(unittest.TestCase):
     def setUp(self):
+        ThreadState.initialize()
         wstates = WStates()
         self.wstates = wstates
 
@@ -557,8 +558,8 @@ def test_callbacks_with_rerun():
 def test_fragment_callback_flag_resets_on_rerun_exception() -> None:
     """Ensure fragment callback context flag is cleared on RerunException.
 
-    This guards against leaving `ctx.in_fragment_callback` stuck to True if
-    a callback raises, which could contaminate subsequent runs.
+    This guards against leaving ``ThreadState.get().in_fragment_callback`` stuck
+    to True if a callback raises, which could contaminate subsequent runs.
     """
     from streamlit.runtime.scriptrunner import RerunException
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -52,7 +52,10 @@ from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
 from streamlit.runtime import runtime_util
 from streamlit.runtime.runtime_util import WidgetStateSizeError
 from streamlit.runtime.scriptrunner import get_script_run_ctx
-from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    RunLocation,
+    ThreadState,
+)
 from streamlit.runtime.scriptrunner_utils.shared_run_state import SharedRunState
 from streamlit.runtime.state import SessionState, get_session_state
 from streamlit.runtime.state.common import (
@@ -582,7 +585,7 @@ def test_fragment_callback_flag_resets_on_rerun_exception() -> None:
     mock_ctx = MagicMock()
     # Self-contained: initialize ThreadState so this test doesn't depend on
     # test ordering or another fixture having seeded the ContextVar.
-    ThreadState.initialize(in_fragment_callback=False)
+    ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
 
     with patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

This is PR 1/3 of a split of #15794 ("event-scoped fragment reruns"). 

Replaces the boolean `FragmentThreadState.in_fragment_callback` field with a 3-state `RunLocation` enum (`MAIN_SCRIPT` / `FRAGMENT` / `CALLBACK`). `in_fragment_callback` is now a derived property so all existing callers keep working without change.

- `RunLocation` enum added to `script_run_context.py` with values `MAIN_SCRIPT`, `FRAGMENT`, `CALLBACK`.
- `FragmentThreadState.run_location` replaces the old `in_fragment_callback: bool` field; `_FragmentThreadStateFields` TypedDict updated to match.
- `fragment.py` scopes fragment body execution with `run_location=FRAGMENT`.
- `session_state.py` unconditionally scopes callbacks with `run_location=CALLBACK` (removing the `fragment_id is not None` guard that previously left non-fragment widget callbacks without location context — no behavior change since nothing reads `run_location` directly yet).

The two axes — execution phase (`run_location`) and fragment identity (`fragment_id`) — are now tracked independently, enabling PR 3 to distinguish "inside a fragment body" from "inside any widget callback."

## GitHub Issue Link (if applicable)


## Testing Plan

- Unit Tests: Updated `fragment_thread_state_test.py` and `session_state_test.py` to use `run_location=RunLocation.CALLBACK` in place of `in_fragment_callback=True/False`. No new test scenarios added — this PR has no new behavior.
- All checks pass (`make check`).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae1b945b-0741-4c93-8247-fbb7b3d4c8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae1b945b-0741-4c93-8247-fbb7b3d4c8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

