### PR TITLE
Apply skill copy feedback to developing-with-streamlit

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -96,7 +96,7 @@ Run this with the Streamlit installation relevant to the app being edited. Use `
 
 Apply these defaults unless the user's app or request clearly needs a different approach. For examples, read `references/best-practices.md`.
 - Do not use `use_container_width`; use `width="stretch"` or `width="content"` instead.
-- Prefer native Streamlit elements over recreating UI with custom HTML. This includes UI created with `st.html`, `st.markdown(..., unsafe_allow_html=True)`, or `st.components.v1.html`. Use custom HTML only when no native element provides the required UI or behavior.
+- Prefer native Streamlit elements over recreating UI with custom HTML. This includes UI created with `st.html`, `st.markdown(..., unsafe_allow_html=True)`, or deprecated `st.components.v1.html`. Use custom HTML only when no native element provides the required UI or behavior.
 - Do not use the deprecated `st.components.v1.html` or `st.components.v1.iframe` commands. Use `st.iframe` for iframe-based rendering of URLs or HTML, and use `st.html` for HTML/CSS that should render directly in the app; `st.html` ignores JavaScript by default unless `unsafe_allow_javascript=True`.
 - Do not apply CSS to style the app unless the user actively requests it. Use native Streamlit features and `.streamlit/config.toml` to customize the appearance; see the [theming reference](references/theme.md).
 - Prefer Material Symbols icons (`:material/icon_name:`) over emojis for navigation, buttons, and labels. Use emojis sparingly, only when they add a special touch.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
@@ -53,7 +53,7 @@ query = st.text_input(
 
 ## HTML and iframes
 
-Prefer native Streamlit elements over recreating UI with custom HTML. This includes UI created with `st.html`, `st.markdown(..., unsafe_allow_html=True)`, or `st.components.v1.html`. Use custom HTML only when no native element provides the required UI or behavior.
+Prefer native Streamlit elements over recreating UI with custom HTML. This includes UI created with `st.html`, `st.markdown(..., unsafe_allow_html=True)`, or deprecated `st.components.v1.html`. Use custom HTML only when no native element provides the required UI or behavior.
 
 Do not use the deprecated `st.components.v1.html` or `st.components.v1.iframe` commands.
 
@@ -171,7 +171,7 @@ def load_model():
     return SentenceTransformer("all-MiniLM-L6-v2")
 ```
 
-Render stable layout before slow calls. Streamlit emits UI updates top to bottom during each rerun, so slow code before downstream elements leaves faded stale content from the previous run on screen while it runs. Render fast UI first, reserve the slow result's position with `st.container()`, then fill that slot once the work completes — wrap the slow work in `with container.skeleton():` to show a loading placeholder, and write results explicitly to the container (e.g. `container.dataframe(...)`), since the block doesn't redirect bare `st.*` calls into it. Avoid standalone `st.empty()`/`st.skeleton()` placeholders that you fill after slow work: the delay unmounts the old element and resets stateful widgets (e.g. a dataframe's scroll, sort, and selection), whereas a reserved container keeps it mounted at a stable position. Give stateful elements a stable `key`.
+Render stable UI before slow calls. Streamlit emits UI updates top to bottom during each rerun, so slow code before downstream elements leaves faded stale content from the previous run on screen while it runs. Render fast UI first, reserve the slow result's position with `st.container()`, then fill that slot once the work completes — wrap the slow work in `with container.skeleton():` to show a loading placeholder, and write results explicitly to the container (e.g. `container.dataframe(...)`), since the block doesn't redirect bare `st.*` calls into it. Avoid standalone `st.empty()`/`st.skeleton()` placeholders that you fill after slow work: the delay unmounts the old element and resets stateful widgets (e.g. a dataframe's scroll, sort, and selection), whereas a reserved container keeps it mounted at a stable position. Give stateful elements a stable `key`.
 
 ```python
 # BAD: The whole page is stuck behind a slow load and greys out

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -341,7 +341,7 @@ For independent slow sections, prefer `@st.fragment(parallel=True)` so each fill
 
 ## Perceived performance (loading states)
 
-The techniques above reduce _actual_ work and keep the UI fresh. When a wait is unavoidable, give immediate loading feedback so the app _feels_ responsive instead of showing greyed, stale content. These don't speed up computation — pair them with caching and fragments. See `layouts.md` for details:
+The techniques above keep the UI fresh and responsive during slow work. When a wait is unavoidable, give immediate loading feedback so the app _feels_ responsive instead of showing greyed, stale content. These don't speed up computation — pair them with caching and fragments to cut the _actual_ work. See `layouts.md` for details:
 
 - `st.spinner` — lightweight indicator wrapped around a block of slow work.
 - `st.skeleton` — animated placeholder that reserves layout space while content loads.


### PR DESCRIPTION
## Why

Maya's review on the bundled OSS sub-skill sync ([cortex-code-skills#3749](https://github.com/snowflake-eng/cortex-code-skills/pull/3749)) raised four good copy nits — but that skill is synced **verbatim** from the Streamlit PyPI wheel, so fixes applied there get overwritten on the next release sync. Fixing them here at the source (`lib/streamlit/.agents/skills/developing-with-streamlit/`) means they flow downstream permanently.

## What changed

- **`SKILL.md` + `references/best-practices.md`** — label `st.components.v1.html` as **deprecated** in the "prefer native elements" guidance, matching the deprecation note on the very next line (and consistent between the two files).
- **`references/performance.md`** — the "Perceived performance" intro claimed the render-ordering techniques "reduce _actual_ work", which contradicts the same sentence's "These don't speed up computation." Reworded to "keep the UI fresh and responsive during slow work," and moved the _actual_ contrast onto caching/fragments (which do cut the work) — preserving the _actual_ vs _feels_ framing.
- **`references/best-practices.md`** — "Render stable **layout**" → "Render stable **UI**", matching `performance.md`'s "Render stable UI before slow work" heading and the more expansive term (the examples cover titles, filters, tabs, headers, sidebar — more than layout).

Copy-only; no code or behavior changes.

## Testing

Docs/skill markdown only — pre-commit hooks pass; nothing to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill documentation; no runtime code, APIs, or behavior changes.
> 
> **Overview**
> Copy-only updates to the bundled **developing-with-streamlit** agent skill so guidance stays consistent and accurate after downstream sync.
> 
> In **`SKILL.md`** and **`references/best-practices.md`**, the “prefer native elements” bullet now calls out **deprecated** `st.components.v1.html`, aligned with the adjacent deprecation line.
> 
> In **`references/best-practices.md`**, “Render stable **layout**” is renamed to “Render stable **UI**” to match **`performance.md`** and the broader examples (titles, filters, tables, not just layout).
> 
> In **`references/performance.md`**, the perceived-performance intro no longer says render-order techniques “reduce _actual_ work” (which conflicted with “These don’t speed up computation”). It now frames those techniques as keeping the UI fresh during slow work, and assigns cutting _actual_ work to caching and fragments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c872a4c3648212d4b22ab4cb631df926274cf91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->