### PR TITLE
[fix] Redact secrets from implicit display

### DIFF
--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, cast
 from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.secrets import AttrDict, Secrets, _redact_secrets
 from streamlit.type_util import (
     dump_pydantic_sequence,
     is_custom_dict,
@@ -37,10 +38,12 @@ if TYPE_CHECKING:
     from streamlit.elements.lib.layout_utils import WidthWithoutContent
 
 
-def _ensure_serialization(o: object) -> str | list[Any]:
+def _ensure_serialization(o: object) -> str | list[Any] | dict[str, Any]:
     """A repr function for json.dumps default arg, which tries to serialize sets
     as lists.
     """
+    if isinstance(o, (AttrDict, Secrets)):
+        return _redact_secrets(o)
     return list(o) if isinstance(o, set) else repr(o)
 
 
@@ -108,14 +111,16 @@ class JsonMixin:
 
         """
 
-        if is_custom_dict(body):
+        if isinstance(body, (AttrDict, Secrets)):
+            body = _redact_secrets(body)
+        elif is_custom_dict(body):
             is_user = isinstance(body, UserInfoProxy)
-            body = body.to_dict()  # ty: ignore[unresolved-attribute]
+            body = body.to_dict()
             if is_user and "tokens" in body:
                 body["tokens"] = dict.fromkeys(body["tokens"], "***")
 
         if is_namedtuple(body):
-            body = body._asdict()  # ty: ignore[unresolved-attribute]
+            body = body._asdict()
 
         if isinstance(
             body, (ChainMap, types.MappingProxyType, UserDict)
@@ -128,9 +133,9 @@ class JsonMixin:
                     body = dump_pydantic_sequence(body)
                 except AttributeError:
                     # Fallback to list(body) if it contains non-Pydantic models:
-                    body = list(body)  # ty: ignore[invalid-argument-type]
+                    body = list(body)
             else:
-                body = list(body)  # ty: ignore[invalid-argument-type]
+                body = list(body)
 
         if not isinstance(body, str):
             try:

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -39,9 +39,7 @@ if TYPE_CHECKING:
 
 
 def _ensure_serialization(o: object) -> str | list[Any] | dict[str, Any]:
-    """A repr function for json.dumps default arg, which tries to serialize sets
-    as lists.
-    """
+    """Redact secrets and serialize sets for the json.dumps default argument."""
     if isinstance(o, (AttrDict, Secrets)):
         return _redact_secrets(o)
     return list(o) if isinstance(o, set) else repr(o)

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -41,6 +41,7 @@ SecretsValue = (
 
 # Allowed scalar types for secrets values
 _ALLOWED_SCALAR_TYPES: Final[frozenset[type]] = frozenset({str, int, float, bool})
+_REDACTED_VALUE: Final = "***"
 
 
 def _validate_secrets_value(value: Any, path: str = "") -> None:
@@ -186,6 +187,19 @@ def _convert_to_dict(obj: Mapping[str, Any] | AttrDict) -> dict[str, Any]:
     return {k: v.to_dict() if isinstance(v, AttrDict) else v for k, v in obj.items()}
 
 
+def _redact_secrets(obj: Mapping[str, Any]) -> dict[str, Any]:
+    """Replace secret values with a display-safe placeholder."""
+
+    def redact(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return _redact_secrets(value)
+        if isinstance(value, list):
+            return [redact(item) for item in value]
+        return _REDACTED_VALUE
+
+    return {key: redact(value) for key, value in obj.items()}
+
+
 def _missing_attr_error_message(attr_name: str) -> str:
     return secret_error_messages_singleton.get_missing_attr_message(attr_name)
 
@@ -229,7 +243,7 @@ class AttrDict(Mapping[str, Any]):
             raise AttributeError(_missing_attr_error_message(attr_name))
 
     def __repr__(self) -> str:
-        return repr(self.__nested_secrets__)
+        return repr(_redact_secrets(self.__nested_secrets__))
 
     def __setitem__(self, key: str, value: Any) -> NoReturn:
         raise TypeError("Secrets does not support item assignment.")
@@ -613,12 +627,12 @@ class Secrets(Mapping[str, Any]):
     def __repr__(self) -> str:
         # If the runtime is NOT initialized, it is a method call outside
         # the streamlit app, so we avoid reading the secrets file as it may not exist.
-        # If the runtime is initialized, display the contents of the file and
-        # the file must already exist.
-        """A string representation of the contents of the dict. Thread-safe."""
+        # If the runtime is initialized, preserve the store's structure but redact
+        # values so implicit rendering cannot disclose credentials.
+        """A redacted string representation of the secrets store. Thread-safe."""
         if not runtime.exists():
             return f"{self.__class__.__name__}"
-        return repr(self._parse())
+        return repr(_redact_secrets(self._parse()))
 
     def __len__(self) -> int:
         """The number of entries in the dict. Thread-safe."""

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -627,8 +627,6 @@ class Secrets(Mapping[str, Any]):
     def __repr__(self) -> str:
         # If the runtime is NOT initialized, it is a method call outside
         # the streamlit app, so we avoid reading the secrets file as it may not exist.
-        # If the runtime is initialized, preserve the store's structure but redact
-        # values so implicit rendering cannot disclose credentials.
         """A redacted string representation of the secrets store. Thread-safe."""
         if not runtime.exists():
             return f"{self.__class__.__name__}"

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -21,6 +21,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.errors import StreamlitInvalidWidthError
+from streamlit.runtime.secrets import AttrDict, Secrets
 from streamlit.user_info import UserInfoProxy
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
@@ -144,6 +145,51 @@ class StJsonAPITest(DeltaGeneratorTestCase):
             assert body["name"] == "Test User"
             assert body["tokens"]["id"] == "***"
             assert body["tokens"]["access"] == "***"
+
+    def test_st_json_masks_secrets(self):
+        """Test that st.json masks all values when displaying Secrets."""
+        secrets = Secrets()
+        secrets._secrets = {
+            "api_key": "secret-api-key",
+            "auth": {
+                "cookie_secret": "secret-cookie-key",
+                "allowed_emails": ["admin@example.com"],
+            },
+        }
+
+        st.json(secrets)
+
+        el = self.get_delta_from_queue().new_element
+        assert json.loads(el.json.body) == {
+            "api_key": "***",
+            "auth": {
+                "cookie_secret": "***",
+                "allowed_emails": ["***"],
+            },
+        }
+
+    def test_st_json_masks_nested_secrets_section(self):
+        """Test that st.json masks an AttrDict nested in another value."""
+        st.json(
+            {
+                "public": "visible",
+                "credentials": AttrDict(
+                    {
+                        "username": "streamlit",
+                        "password": "secret-password",
+                    }
+                ),
+            }
+        )
+
+        el = self.get_delta_from_queue().new_element
+        assert json.loads(el.json.body) == {
+            "public": "visible",
+            "credentials": {
+                "username": "***",
+                "password": "***",
+            },
+        }
 
     def test_st_json_with_namedtuple(self):
         """Test st.json converts namedtuple to dict via _asdict."""

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -163,8 +163,8 @@ class SecretsTest(unittest.TestCase):
             [
                 True,
                 (
-                    "{'db_username': 'Jane', 'db_password': '12345qwerty', "
-                    "'subsection': {'email': 'eng@streamlit.io'}}"
+                    "{'db_username': '***', 'db_password': '***', "
+                    "'subsection': {'email': '***'}}"
                 ),
             ],
         ]
@@ -710,10 +710,12 @@ def test_convert_to_dict(
 
 
 def test_attr_dict_repr() -> None:
-    """``AttrDict.__repr__`` mirrors the wrapped nested mapping."""
-    data = {"k": "v", "n": {"inner": 1}}
+    """``AttrDict.__repr__`` preserves structure while redacting values."""
+    data = {"k": "v", "n": {"inner": 1, "items": ["a", "b"]}}
     attr_dict = AttrDict(data)
-    assert repr(attr_dict) == repr(data)
+    assert repr(attr_dict) == (
+        "{'k': '***', 'n': {'inner': '***', 'items': ['***', '***']}}"
+    )
     assert len(attr_dict) == 2
 
 


### PR DESCRIPTION
## Describe your changes

Prevents `st.secrets` and nested secret sections from exposing credential values
when rendered by `st.write`, Streamlit magic, or `st.json`.

- Redacts scalar values recursively while retaining key and container structure,
  so accidental display remains useful for debugging.
- Keeps explicit mapping and attribute access, iteration, and `to_dict()`
  unchanged for apps that intentionally consume secrets.

## GitHub Issue Link (if applicable)

- SNOW-3715984 (internal)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/elements/json_test.py`
  - `lib/tests/streamlit/runtime/secrets_test.py`
- [ ] E2E Tests — backend serialization is covered by Python unit tests.
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project
are made under the Apache 2.0 license.
