### PR TITLE
[fix] Reject network paths and null bytes in st.Page

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -19,7 +19,9 @@ import types
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from streamlit import env_util
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.path_security import is_windows_unc_path
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
 from streamlit.source_util import page_icon_and_name
@@ -326,6 +328,22 @@ class StreamlitPage:
 
             self._can_be_called: bool = False
             return
+
+        if isinstance(page, (str, Path)):
+            page_path = str(page)
+            if "\x00" in page_path:
+                raise StreamlitAPIException(
+                    "Unable to create Page. Page paths must not contain null bytes."
+                )
+
+            # Reject UNC paths before resolve/is_file can initiate an SMB connection
+            # and disclose the server process's Windows credentials. Absolute and
+            # drive-local paths (e.g. "C:\\...") are intentionally still allowed, as
+            # passing an absolute page path is part of the public st.Page contract.
+            if env_util.IS_WINDOWS and is_windows_unc_path(page_path):
+                raise StreamlitAPIException(
+                    "Unable to create Page. Network paths are not supported."
+                )
 
         main_path = ctx.pages_manager.main_script_parent
         if isinstance(page, str):

--- a/lib/streamlit/path_security.py
+++ b/lib/streamlit/path_security.py
@@ -32,6 +32,19 @@ import os
 import string
 
 
+def is_windows_unc_path(path: str) -> bool:
+    r"""Return True if ``path`` is a Windows UNC or device namespace path.
+
+    This is a lexical check that normalizes forward slashes to backslashes
+    first, so any two leading separators are recognized as UNC -- including the
+    mixed spellings (``\\``, ``//``, ``/\``, ``\/``) that Windows path
+    resolution treats as a UNC root. It must be called before filesystem
+    operations such as ``Path.resolve()`` or ``Path.is_file()`` on Windows
+    because those operations can initiate an SMB connection.
+    """
+    return path.replace("/", "\\").startswith("\\\\")
+
+
 def is_unsafe_path_pattern(path: str) -> bool:
     r"""Return True if path contains UNC, absolute, drive, or traversal patterns.
 
@@ -72,7 +85,7 @@ def is_unsafe_path_pattern(path: str) -> bool:
         return True
 
     # UNC paths (Windows network shares, including \\?\ and \\.\ prefixes)
-    if path.startswith(("\\\\", "//")):
+    if is_windows_unc_path(path):
         return True
 
     # Windows drive paths (e.g. C:\, D:foo) - on Windows, os.path.realpath() on a

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -116,11 +116,14 @@ class StPagesTest(DeltaGeneratorTestCase):
             ("path_object", Path("page\x00.py")),
         ]
     )
-    @patch("streamlit.env_util.IS_WINDOWS", False)
     def test_rejects_null_byte_paths_on_all_platforms(
         self, _name: str, page: str | Path
     ) -> None:
-        """Null-byte paths are rejected on every platform before filesystem access."""
+        """Null-byte paths are rejected on every platform before filesystem access.
+
+        The null-byte check runs unconditionally before the Windows-gated UNC
+        check, so this test intentionally uses the real ``IS_WINDOWS`` value.
+        """
         with (
             patch("pathlib.Path.resolve") as resolve,
             pytest.raises(StreamlitAPIException, match="null bytes"),
@@ -133,8 +136,10 @@ class StPagesTest(DeltaGeneratorTestCase):
     def test_allows_network_style_paths_on_non_windows(self) -> None:
         """Network-style paths are only blocked on Windows, where SMB auto-connects."""
         # On POSIX these are ordinary paths with no SMB auto-connect, so st.Page
-        # must not reject them.
-        assert st.Page("//server/share/page.py") is not None
+        # must not reject them. The meaningful assertion is that no exception is
+        # raised and the path is accepted as a regular filesystem page.
+        page = st.Page("//server/share/page.py")
+        assert isinstance(page._page, Path)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -92,7 +92,7 @@ class StPagesTest(DeltaGeneratorTestCase):
             ("path_object", Path("\\\\server\\share\\page.py")),
         ]
     )
-    @patch("streamlit.navigation.page.env_util.IS_WINDOWS", True)
+    @patch("streamlit.env_util.IS_WINDOWS", True)
     def test_rejects_windows_network_paths_before_resolving(
         self, _name: str, page: str | Path
     ) -> None:
@@ -115,7 +115,7 @@ class StPagesTest(DeltaGeneratorTestCase):
             ("path_object", Path("page\x00.py")),
         ]
     )
-    @patch("streamlit.navigation.page.env_util.IS_WINDOWS", False)
+    @patch("streamlit.env_util.IS_WINDOWS", False)
     def test_rejects_null_byte_paths_on_all_platforms(
         self, _name: str, page: str | Path
     ) -> None:
@@ -128,7 +128,7 @@ class StPagesTest(DeltaGeneratorTestCase):
 
         resolve.assert_not_called()
 
-    @patch("streamlit.navigation.page.env_util.IS_WINDOWS", False)
+    @patch("streamlit.env_util.IS_WINDOWS", False)
     def test_allows_network_style_paths_on_non_windows(self) -> None:
         """Network-style paths are only blocked on Windows, where SMB auto-connects."""
         # On POSIX these are ordinary paths with no SMB auto-connect, so st.Page

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -82,6 +82,70 @@ class StPagesTest(DeltaGeneratorTestCase):
             != st.Page(lambda: True, url_path="path_2")._script_hash
         )
 
+    @parameterized.expand(
+        [
+            ("backslash_unc", "\\\\server\\share\\page.py"),
+            ("forward_slash_unc", "//server/share/page.py"),
+            ("forward_then_backslash_unc", "/\\server\\share\\page.py"),
+            ("backslash_then_forward_unc", "\\/server/share/page.py"),
+            ("extended_unc", "\\\\?\\UNC\\server\\share\\page.py"),
+            ("path_object", Path("\\\\server\\share\\page.py")),
+        ]
+    )
+    @patch("streamlit.navigation.page.env_util.IS_WINDOWS", True)
+    def test_rejects_windows_network_paths_before_resolving(
+        self, _name: str, page: str | Path
+    ) -> None:
+        """Windows network paths are rejected before any filesystem access.
+
+        This includes mixed-separator spellings (``/\\``, ``\\/``) that Windows
+        normalizes to a UNC root when resolving.
+        """
+        with (
+            patch("pathlib.Path.resolve") as resolve,
+            pytest.raises(StreamlitAPIException, match="Network paths"),
+        ):
+            st.Page(page)
+
+        resolve.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("string", "page\x00.py"),
+            ("path_object", Path("page\x00.py")),
+        ]
+    )
+    @patch("streamlit.navigation.page.env_util.IS_WINDOWS", False)
+    def test_rejects_null_byte_paths_on_all_platforms(
+        self, _name: str, page: str | Path
+    ) -> None:
+        """Null-byte paths are rejected on every platform before filesystem access."""
+        with (
+            patch("pathlib.Path.resolve") as resolve,
+            pytest.raises(StreamlitAPIException, match="null bytes"),
+        ):
+            st.Page(page)
+
+        resolve.assert_not_called()
+
+    @patch("streamlit.navigation.page.env_util.IS_WINDOWS", False)
+    def test_allows_network_style_paths_on_non_windows(self) -> None:
+        """Network-style paths are only blocked on Windows, where SMB auto-connects."""
+        # On POSIX these are ordinary paths with no SMB auto-connect, so st.Page
+        # must not reject them.
+        assert st.Page("//server/share/page.py") is not None
+
+    @parameterized.expand(
+        [
+            ("string", str(Path.cwd() / "page.py")),
+            ("path_object", Path.cwd() / "page.py"),
+        ]
+    )
+    def test_allows_absolute_local_paths(self, _name: str, page: str | Path) -> None:
+        """Absolute local paths are part of the public st.Page contract."""
+        streamlit_page = st.Page(page)
+        assert streamlit_page._page == Path(page).resolve()
+
     def test_url_path_is_inferred_from_filename(self):
         """Tests that url path is inferred from filename if not provided"""
         page = st.Page("page_8.py")

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -89,6 +89,7 @@ class StPagesTest(DeltaGeneratorTestCase):
             ("forward_then_backslash_unc", "/\\server\\share\\page.py"),
             ("backslash_then_forward_unc", "\\/server/share/page.py"),
             ("extended_unc", "\\\\?\\UNC\\server\\share\\page.py"),
+            ("device_namespace", "\\\\.\\device\\page.py"),
             ("path_object", Path("\\\\server\\share\\page.py")),
         ]
     )

--- a/lib/tests/streamlit/path_security_test.py
+++ b/lib/tests/streamlit/path_security_test.py
@@ -32,6 +32,7 @@ class TestIsWindowsUncPath:
             pytest.param("/\\server\\share\\page.py", id="forward_then_backslash_unc"),
             pytest.param("\\/server/share/page.py", id="backslash_then_forward_unc"),
             pytest.param("\\\\?\\UNC\\server\\share\\page.py", id="extended_unc"),
+            pytest.param("\\\\?\\C:\\Windows\\page.py", id="extended_length_local"),
             pytest.param("\\\\.\\device\\page.py", id="device_namespace"),
         ],
     )
@@ -40,6 +41,8 @@ class TestIsWindowsUncPath:
 
         Windows normalizes ``/`` to ``\\`` before resolving, so mixed leading
         separators (``/\\``, ``\\/``) are UNC roots too and must be caught.
+        Extended-length local paths (``\\\\?\\C:\\...``) are also rejected
+        fail-closed: any ``\\\\``-prefixed input is treated as a network path.
         """
         assert is_windows_unc_path(path)
 

--- a/lib/tests/streamlit/path_security_test.py
+++ b/lib/tests/streamlit/path_security_test.py
@@ -18,7 +18,44 @@ from __future__ import annotations
 
 import pytest
 
-from streamlit.path_security import is_unsafe_path_pattern
+from streamlit.path_security import is_unsafe_path_pattern, is_windows_unc_path
+
+
+class TestIsWindowsUncPath:
+    """Tests for the is_windows_unc_path function."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            pytest.param("\\\\server\\share\\page.py", id="backslash_unc"),
+            pytest.param("//server/share/page.py", id="forward_slash_unc"),
+            pytest.param("/\\server\\share\\page.py", id="forward_then_backslash_unc"),
+            pytest.param("\\/server/share/page.py", id="backslash_then_forward_unc"),
+            pytest.param("\\\\?\\UNC\\server\\share\\page.py", id="extended_unc"),
+            pytest.param("\\\\.\\device\\page.py", id="device_namespace"),
+        ],
+    )
+    def test_detects_windows_network_paths(self, path: str) -> None:
+        """UNC and device-namespace prefixes are recognized as network paths.
+
+        Windows normalizes ``/`` to ``\\`` before resolving, so mixed leading
+        separators (``/\\``, ``\\/``) are UNC roots too and must be caught.
+        """
+        assert is_windows_unc_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            pytest.param("/absolute/page.py", id="posix_absolute"),
+            pytest.param("C:\\absolute\\page.py", id="windows_drive_absolute"),
+            pytest.param("\\rooted\\page.py", id="windows_rooted"),
+            pytest.param("../relative/page.py", id="parent_relative"),
+            pytest.param("relative/page.py", id="relative"),
+        ],
+    )
+    def test_allows_local_paths(self, path: str) -> None:
+        """Absolute, drive, rooted, and relative local paths are not network paths."""
+        assert not is_windows_unc_path(path)
 
 
 class TestIsUnsafePathPattern:


### PR DESCRIPTION
## Describe your changes

Hardens `st.Page()` path handling to run validation **before** any filesystem
access (`Path.resolve()` / `Path.is_file()`):

- Rejects Windows UNC/network paths (e.g. `\\server\share`, `//server/share`,
  and the mixed-separator spellings `/\...` and `\/...` that Windows also
  resolves as a UNC root). On Windows, resolving such a path would initiate an
  SMB connection to an attacker-controlled host, enabling SSRF and NTLM hash
  disclosure. Absolute/drive-local paths remain allowed (part of the public
  `st.Page` contract).
- Rejects page paths containing null bytes on all platforms, surfacing a clear
  `StreamlitAPIException` instead of a raw `ValueError`.

The UNC check is factored into a shared `is_windows_unc_path()` helper in
`path_security.py` (reused by `is_unsafe_path_pattern`).

## GitHub Issue Link (if applicable)

Internal security ticket: SNOW-3715977

## Testing Plan

- Unit Tests (Python)
  - `lib/tests/streamlit/path_security_test.py` — `is_windows_unc_path()`, incl. mixed-separator spellings.
  - `lib/tests/streamlit/navigation/page_test.py` — `st.Page` rejects network paths (asserting `resolve()` is not called) and null bytes, while still allowing absolute local paths and non-Windows network-style paths.
- No E2E tests: the behavior is Windows-SMB-specific and cannot be meaningfully exercised by the Linux-based e2e harness; unit tests with `env_util.IS_WINDOWS` patched are the correct layer.

Made with [Cursor](https://cursor.com)