### PR TITLE
[feature] Add WebSocket Host allow-list

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
@@ -31,8 +31,9 @@ allowedHosts = ["app.example.com", "*.example.com"]
 
 Entries match hostnames without ports and are case-insensitive. A leading `*.`
 matches subdomains but not the base domain, so add the base domain separately when
-both should be allowed. The default empty list accepts any Host header for
-compatibility with dynamic reverse proxies and custom domains.
+both should be allowed. An entry of `*` accepts any syntactically valid Host
+header. The default empty list disables Host validation for compatibility with
+dynamic reverse proxies and custom domains.
 
 ## Basic ASGI wrapper
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
@@ -17,24 +17,6 @@ Use `st.App` for:
 
 Do not use it just to set ports, headless mode, theme options, or regular Streamlit config. Use `.streamlit/config.toml` or `streamlit run` flags for those.
 
-## WebSocket Host allow-list
-
-For an app exposed at known hostnames, configure `server.allowedHosts` to restrict
-the Host headers accepted for incoming WebSocket connections and help protect against
-DNS rebinding attacks:
-
-```toml
-# .streamlit/config.toml
-[server]
-allowedHosts = ["app.example.com", "*.example.com"]
-```
-
-Entries match hostnames without ports and are case-insensitive. A leading `*.`
-matches subdomains but not the base domain, so add the base domain separately when
-both should be allowed. An entry of `*` accepts any syntactically valid Host
-header. The default empty list disables Host validation for compatibility with
-dynamic reverse proxies and custom domains.
-
 ## Basic ASGI wrapper
 
 Keep the Streamlit UI in a normal script, then create a separate ASGI wrapper.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
@@ -17,6 +17,23 @@ Use `st.App` for:
 
 Do not use it just to set ports, headless mode, theme options, or regular Streamlit config. Use `.streamlit/config.toml` or `streamlit run` flags for those.
 
+## WebSocket Host allow-list
+
+For an app exposed at known hostnames, configure `server.allowedHosts` to restrict
+the Host headers accepted for incoming WebSocket connections and help protect against
+DNS rebinding attacks:
+
+```toml
+# .streamlit/config.toml
+[server]
+allowedHosts = ["app.example.com", "*.example.com"]
+```
+
+Entries match hostnames without ports and are case-insensitive. A leading `*.`
+matches subdomains but not the base domain, so add the base domain separately when
+both should be allowed. The default empty list accepts any Host header for
+compatibility with dynamic reverse proxies and custom domains.
+
 ## Basic ASGI wrapper
 
 Keep the Streamlit UI in a normal script, then create a separate ASGI wrapper.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1027,6 +1027,25 @@ _create_option(
 )
 
 _create_option(
+    "server.allowedHosts",
+    description="""
+        Allowed list of hostnames for incoming WebSocket connections.
+
+        Use this option to protect against DNS rebinding attacks when the
+        hostnames used to access the app are known. Ports in the Host header are
+        ignored. Wildcard subdomains are supported with a leading `*.`.
+
+        If this list is empty (the default), Streamlit accepts any Host header
+        to preserve compatibility with dynamically configured reverse proxies
+        and custom domains.
+
+        Example: ['localhost', 'app.example.com', '*.example.com']
+    """,
+    default_val=[],
+    multiple=True,
+)
+
+_create_option(
     "server.enableXsrfProtection",
     description="""
         Enables support for Cross-Site Request Forgery (XSRF) protection, for

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1029,7 +1029,7 @@ _create_option(
 _create_option(
     "server.allowedHosts",
     description="""
-        Allowed list of hostnames for incoming WebSocket connections.
+        Allow-list of hostnames for incoming WebSocket connections.
 
         Use this option to protect against DNS rebinding attacks when the
         hostnames used to access the app are known. Ports in the Host header are

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1033,7 +1033,8 @@ _create_option(
 
         Use this option to protect against DNS rebinding attacks when the
         hostnames used to access the app are known. Ports in the Host header are
-        ignored. Wildcard subdomains are supported with a leading `*.`.
+        ignored. Wildcard subdomains are supported with a leading `*.`. Use `*`
+        to accept any valid Host header.
 
         If this list is empty (the default), Streamlit accepts any Host header
         to preserve compatibility with dynamically configured reverse proxies

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -163,8 +163,7 @@ def _is_origin_allowed(origin: str | None, host: str | None) -> bool:
     Returns
     -------
     bool
-        True if:
-        - The Host header is allowed (or server.allowedHosts is not configured)
+        False if the Host header is disallowed. Otherwise, True if:
         - The origin is None (browser didn't send Origin header, allowed per spec)
         - The origin matches the host (same-origin request)
         - The origin is in the allowed origins list (is_url_from_allowed_origins)

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -104,10 +104,52 @@ def _gather_user_info(headers: Headers) -> dict[str, str | bool | None]:
     return user_info
 
 
+def _is_host_allowed(host: str | None) -> bool:
+    """Check the request Host header against the configured allow-list."""
+    allowed_hosts: list[str] = config.get_option("server.allowedHosts")
+    if not allowed_hosts:
+        return True
+
+    if host is None:
+        return False
+
+    try:
+        parsed_host = urlparse(f"//{host}")
+        hostname = parsed_host.hostname
+        # Accessing port also validates that a supplied port is numeric and in range.
+        _ = parsed_host.port
+    except ValueError:
+        return False
+
+    if (
+        hostname is None
+        or parsed_host.username is not None
+        or parsed_host.password is not None
+        or parsed_host.path
+        or parsed_host.query
+        or parsed_host.fragment
+    ):
+        return False
+
+    hostname = hostname.lower().rstrip(".")
+    for allowed_host in allowed_hosts:
+        pattern = allowed_host.strip().lower().rstrip(".")
+        if pattern == "*":
+            return True
+        if pattern.startswith("*."):
+            if hostname.endswith(pattern[1:]):
+                return True
+        elif hostname == pattern:
+            return True
+
+    return False
+
+
 def _is_origin_allowed(origin: str | None, host: str | None) -> bool:
     """Check if the WebSocket Origin header is allowed.
 
-    Allows same-origin connections by default and delegates to
+    Validates the Host header when server.allowedHosts is configured, allows
+    same-origin connections by default, and delegates to
     is_url_from_allowed_origins for cross-origin requests.
 
     Parameters
@@ -122,10 +164,14 @@ def _is_origin_allowed(origin: str | None, host: str | None) -> bool:
     -------
     bool
         True if:
+        - The Host header is allowed (or server.allowedHosts is not configured)
         - The origin is None (browser didn't send Origin header, allowed per spec)
         - The origin matches the host (same-origin request)
         - The origin is in the allowed origins list (is_url_from_allowed_origins)
     """
+    if not _is_host_allowed(host):
+        return False
+
     # If no Origin header is present, allow the connection.
     # Per the WebSocket spec, browsers should always send Origin, but non-browser
     # clients may not. Connections without Origin are allowed by default.
@@ -391,7 +437,10 @@ def create_websocket_handler(runtime: Runtime) -> Any:
         host = websocket.headers.get("Host")
         if not _is_origin_allowed(origin, host):
             _LOGGER.warning(
-                "Rejecting WebSocket connection from disallowed origin: %s", origin
+                "Rejecting WebSocket connection with disallowed Origin or Host "
+                "header: origin=%s, host=%s",
+                origin,
+                host,
             )
             await websocket.close(code=1008)  # 1008 = Policy Violation
             return

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -790,6 +790,7 @@ class ConfigTest(unittest.TestCase):
                 "mapbox.token",
                 "secrets.files",
                 "server.address",
+                "server.allowedHosts",
                 "server.allowRunOnSave",
                 "server.baseUrlPath",
                 "server.cookieSecret",

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -30,6 +30,7 @@ from streamlit.web.server.starlette.starlette_websocket import (
     StarletteSessionClient,
     _gather_user_info,
     _get_signed_cookie_with_chunks,
+    _is_host_allowed,
     _is_origin_allowed,
     _parse_decoded_user_cookie,
     _parse_subprotocols,
@@ -364,6 +365,59 @@ class TestParseUserCookieSigned:
 
 class TestIsOriginAllowed:
     """Tests for _is_origin_allowed function (Origin validation for WebSocket)."""
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("app.example.com:8501", True),
+            ("APP.EXAMPLE.COM.", True),
+            ("sub.example.org:443", True),
+            ("example.org", False),
+            ("attacker.example.net:8501", False),
+            ("[::1]:8501", True),
+            ("app.example.com:not-a-port", False),
+            (None, False),
+        ],
+        ids=[
+            "exact_host_with_port",
+            "host_case_and_trailing_dot",
+            "wildcard_subdomain",
+            "wildcard_excludes_base_domain",
+            "disallowed_host",
+            "ipv6_host",
+            "invalid_port",
+            "missing_host",
+        ],
+    )
+    @patch_config_options(
+        {
+            "server.allowedHosts": [
+                "app.example.com",
+                "*.example.org",
+                "::1",
+            ]
+        }
+    )
+    def test_host_allowlist(self, host: str | None, expected: bool) -> None:
+        """Test exact, wildcard, and IP Host allow-list entries."""
+        assert _is_host_allowed(host) is expected
+
+    @patch_config_options({"server.allowedHosts": []})
+    def test_empty_host_allowlist_preserves_existing_behavior(self) -> None:
+        """Test that Host validation remains opt-in for compatibility."""
+        assert _is_host_allowed("dynamic-proxy.example.com:8501") is True
+        assert _is_host_allowed(None) is True
+
+    @patch_config_options({"server.allowedHosts": ["app.example.com"]})
+    def test_rejects_same_origin_connection_with_disallowed_host(self) -> None:
+        """Test that same-origin comparison cannot bypass Host validation."""
+        assert (
+            _is_origin_allowed(
+                "http://rebind.attacker.example:8501",
+                "rebind.attacker.example:8501",
+            )
+            is False
+        )
 
     @pytest.mark.parametrize(
         ("origin", "host", "expected"),

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -363,8 +363,8 @@ class TestParseUserCookieSigned:
         assert result["is_logged_in"] is True
 
 
-class TestIsOriginAllowed:
-    """Tests for _is_origin_allowed function (Origin validation for WebSocket)."""
+class TestIsHostAllowed:
+    """Tests for _is_host_allowed function."""
 
     @pytest.mark.parametrize(
         ("host", "expected"),
@@ -377,6 +377,7 @@ class TestIsOriginAllowed:
             ("[::1]:8501", True),
             ("app.example.com:not-a-port", False),
             ("user:pass@app.example.com:8501", False),
+            ("app.example.com/evil", False),
             (None, False),
         ],
         ids=[
@@ -388,6 +389,7 @@ class TestIsOriginAllowed:
             "ipv6_host",
             "invalid_port",
             "embedded_credentials",
+            "path_component",
             "missing_host",
         ],
     )
@@ -416,6 +418,10 @@ class TestIsOriginAllowed:
         assert _is_host_allowed("dynamic-proxy.example.com:8501") is True
         assert _is_host_allowed("dynamic-proxy.example.com:not-a-port") is False
         assert _is_host_allowed(None) is False
+
+
+class TestIsOriginAllowed:
+    """Tests for _is_origin_allowed function (Origin validation for WebSocket)."""
 
     @patch_config_options({"server.allowedHosts": ["app.example.com"]})
     def test_rejects_same_origin_connection_with_disallowed_host(self) -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -376,6 +376,7 @@ class TestIsOriginAllowed:
             ("attacker.example.net:8501", False),
             ("[::1]:8501", True),
             ("app.example.com:not-a-port", False),
+            ("user:pass@app.example.com:8501", False),
             (None, False),
         ],
         ids=[
@@ -386,6 +387,7 @@ class TestIsOriginAllowed:
             "disallowed_host",
             "ipv6_host",
             "invalid_port",
+            "embedded_credentials",
             "missing_host",
         ],
     )

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -408,6 +408,13 @@ class TestIsOriginAllowed:
         assert _is_host_allowed("dynamic-proxy.example.com:8501") is True
         assert _is_host_allowed(None) is True
 
+    @patch_config_options({"server.allowedHosts": ["*"]})
+    def test_global_host_wildcard_allows_any_valid_host(self) -> None:
+        """Test that the global wildcard accepts any valid Host header."""
+        assert _is_host_allowed("dynamic-proxy.example.com:8501") is True
+        assert _is_host_allowed("dynamic-proxy.example.com:not-a-port") is False
+        assert _is_host_allowed(None) is False
+
     @patch_config_options({"server.allowedHosts": ["app.example.com"]})
     def test_rejects_same_origin_connection_with_disallowed_host(self) -> None:
         """Test that same-origin comparison cannot bypass Host validation."""


### PR DESCRIPTION
## Describe your changes

Adds `server.allowedHosts` so deployments with known hostnames can restrict incoming WebSocket handshakes.

- Keeps the allow-list empty by default to preserve dynamic reverse-proxy and custom-domain setups.
- Supports exact hostnames and wildcard subdomains while ignoring valid ports in the `Host` header.

## GitHub Issue Link (if applicable)

- Snowflake internal issue: SNOW-3688959 (tracks DNS-rebinding Host allow-list support for WebSocket handshakes).

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/config_test.py`
  - `lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py`
- [ ] E2E Tests
  - The external harness cannot configure a per-app Host allow-list or forge a browser `Host` header; the handshake accept/reject paths are covered by Python tests.
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.