### PR TITLE
[fix] Lock Mermaid init config overrides

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/MermaidChart.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/MermaidChart.test.tsx
@@ -64,6 +64,47 @@ describe("MermaidChart", () => {
     vi.doUnmock("mermaid")
   })
 
+  it("locks security-sensitive config keys against %%{init}%% directive overrides", async () => {
+    const initialize = vi.fn()
+
+    vi.doMock("mermaid", () => ({
+      default: {
+        initialize,
+        render: vi.fn().mockResolvedValue({ svg: "<svg></svg>" }),
+      },
+    }))
+
+    render(<MermaidChart source="graph TD\nA-->B" />)
+
+    await waitFor(
+      () => {
+        expect(initialize).toHaveBeenCalled()
+      },
+      { timeout: 5000 }
+    )
+
+    const config = initialize.mock.calls[0][0]
+    expect(config.securityLevel).toBe("strict")
+    // Locked set must include Mermaid defaults plus Streamlit hardening keys.
+    expect(config.secure).toEqual([
+      // Mermaid defaults
+      "secure",
+      "securityLevel",
+      "startOnLoad",
+      "maxTextSize",
+      "suppressErrorRendering",
+      "maxEdges",
+      // Streamlit hardening
+      "htmlLabels",
+      "themeCSS",
+      "fontFamily",
+      "altFontFamily",
+      "dompurifyConfig",
+    ])
+
+    vi.doUnmock("mermaid")
+  })
+
   // Note: Full rendering tests with mermaid SVG output are covered by E2E tests
   // because mocking dynamic imports is complex and the real mermaid rendering
   // is best tested in a browser environment.

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/MermaidChart.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/MermaidChart.tsx
@@ -158,6 +158,31 @@ function getAltText(source: string): string {
  */
 const THEME_CONFIG_KEY = Symbol.for("streamlit.mermaid.themeConfigKey")
 
+/**
+ * Config keys locked against `%%{init}%%` directive overrides.
+ *
+ * Includes Mermaid's documented defaults plus Streamlit hardening keys Mermaid
+ * does not lock. Without the extras, diagram source can re-enable `htmlLabels`
+ * or inject page-wide CSS via `themeCSS`. Mermaid walks nested objects, so
+ * keys like `flowchart.htmlLabels` are covered. Prefer this static list over
+ * deprecated/internal `mermaid.mermaidAPI`.
+ */
+const SECURE_CONFIG_KEYS = [
+  // Mermaid defaults: https://mermaid.js.org/config/schema-docs/config-properties-secure.html
+  "secure",
+  "securityLevel",
+  "startOnLoad",
+  "maxTextSize",
+  "suppressErrorRendering",
+  "maxEdges",
+  // Streamlit hardening beyond Mermaid's defaults
+  "htmlLabels",
+  "themeCSS",
+  "fontFamily",
+  "altFontFamily",
+  "dompurifyConfig",
+]
+
 interface MermaidChartProps {
   /**
    * The mermaid diagram source code
@@ -468,6 +493,7 @@ const MermaidChart = memo(function MermaidChart({
           mermaid.initialize({
             startOnLoad: false,
             securityLevel: "strict",
+            secure: SECURE_CONFIG_KEYS,
             suppressErrorRendering: true,
             ...themeConfig,
           })


### PR DESCRIPTION
## Describe your changes

Locks Mermaid config keys that Streamlit hardens (`htmlLabels`, `themeCSS`, `fontFamily`, `altFontFamily`, `dompurifyConfig`) so inline `%%{init}%%` directives in diagram source cannot undo them (e.g. re-enable HTML labels or inject page-wide CSS). Restates Mermaid's documented `secure` defaults alongside those keys.

**Behavior note:** apps that relied on `%%{init}%%` to override those specific keys will no longer be able to; theme/config via `mermaid.initialize` (Streamlit's path) is unchanged.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] `frontend/lib/src/components/shared/StreamlitMarkdown/MermaidChart.test.tsx` — asserts `initialize` receives the hardened `secure` list
- [ ] E2E Tests — not added; existing Mermaid e2e are visual-only. Real directive-stripping is enforced by Mermaid's own sanitizer once keys are in `secure`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)