### PR TITLE
[feature] Add event-scoped fragment reruns via st.rerun(scope=<key>)

### DIFF
--- a/e2e_playwright/st_fragment_key_rerun.py
+++ b/e2e_playwright/st_fragment_key_rerun.py
@@ -1,0 +1,82 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E app for @st.fragment(key=...) and st.rerun(scope=<key>) scenarios."""
+
+from uuid import uuid4
+
+import streamlit as st
+
+# ------------------------------------------------------------------ #
+# Scenario 1: Widget outside a keyed fragment triggers a fragment-only rerun.
+# ------------------------------------------------------------------ #
+st.header("Scenario 1: single-key rerun")
+
+if "outside_counter" not in st.session_state:
+    st.session_state.outside_counter = 0
+
+st.session_state.outside_counter += 1
+st.write(f"Outside counter: {st.session_state.outside_counter}", key="outside_counter")
+
+
+@st.fragment(key="charts")
+def charts_fragment() -> None:
+    st.write(f"Fragment uuid: {uuid4()}", key="fragment_uuid")
+
+
+charts_fragment()
+
+st.button(
+    "Rerun charts fragment",
+    key="rerun_charts_btn",
+    on_click=lambda: st.rerun("charts"),
+)
+
+# ------------------------------------------------------------------ #
+# Scenario 2: Targeting a list of two fragment keys from one callback.
+# ------------------------------------------------------------------ #
+st.header("Scenario 2: multi-key rerun")
+
+
+@st.fragment(key="frag_alpha")
+def alpha_fragment() -> None:
+    st.write(f"Alpha uuid: {uuid4()}", key="alpha_uuid")
+
+
+@st.fragment(key="frag_beta")
+def beta_fragment() -> None:
+    st.write(f"Beta uuid: {uuid4()}", key="beta_uuid")
+
+
+alpha_fragment()
+beta_fragment()
+
+st.write(f"Stable text outside: {st.session_state.outside_counter}", key="stable_text")
+
+st.button(
+    "Rerun alpha and beta",
+    key="rerun_multi_btn",
+    on_click=lambda: st.rerun(["frag_alpha", "frag_beta"]),
+)
+
+# ------------------------------------------------------------------ #
+# Scenario 3: Unknown key raises a visible exception.
+# ------------------------------------------------------------------ #
+st.header("Scenario 3: unknown key raises")
+
+st.button(
+    "Rerun unknown fragment",
+    key="rerun_unknown_btn",
+    on_click=lambda: st.rerun("nonexistent_key"),
+)

--- a/e2e_playwright/st_fragment_key_rerun.py
+++ b/e2e_playwright/st_fragment_key_rerun.py
@@ -27,12 +27,14 @@ if "outside_counter" not in st.session_state:
     st.session_state.outside_counter = 0
 
 st.session_state.outside_counter += 1
-st.write(f"Outside counter: {st.session_state.outside_counter}", key="outside_counter")
+with st.container(key="outside_counter"):
+    st.write(f"Outside counter: {st.session_state.outside_counter}")
 
 
 @st.fragment(key="charts")
 def charts_fragment() -> None:
-    st.write(f"Fragment uuid: {uuid4()}", key="fragment_uuid")
+    with st.container(key="fragment_uuid"):
+        st.write(f"Fragment uuid: {uuid4()}")
 
 
 charts_fragment()
@@ -51,18 +53,21 @@ st.header("Scenario 2: multi-key rerun")
 
 @st.fragment(key="frag_alpha")
 def alpha_fragment() -> None:
-    st.write(f"Alpha uuid: {uuid4()}", key="alpha_uuid")
+    with st.container(key="alpha_uuid"):
+        st.write(f"Alpha uuid: {uuid4()}")
 
 
 @st.fragment(key="frag_beta")
 def beta_fragment() -> None:
-    st.write(f"Beta uuid: {uuid4()}", key="beta_uuid")
+    with st.container(key="beta_uuid"):
+        st.write(f"Beta uuid: {uuid4()}")
 
 
 alpha_fragment()
 beta_fragment()
 
-st.write(f"Stable text outside: {st.session_state.outside_counter}", key="stable_text")
+with st.container(key="stable_text"):
+    st.write(f"Stable text outside: {st.session_state.outside_counter}")
 
 st.button(
     "Rerun alpha and beta",

--- a/e2e_playwright/st_fragment_key_rerun.py
+++ b/e2e_playwright/st_fragment_key_rerun.py
@@ -76,9 +76,39 @@ st.button(
 )
 
 # ------------------------------------------------------------------ #
-# Scenario 3: Unknown key raises a visible exception.
+# Scenario 3: Compose — widget inside fragment A targets fragment B.
+# Both fragments should rerun; nothing outside should change.
 # ------------------------------------------------------------------ #
-st.header("Scenario 3: unknown key raises")
+st.header("Scenario 3: compose (fragment-to-fragment)")
+
+
+@st.fragment(key="source_frag")
+def source_fragment() -> None:
+    with st.container(key="source_uuid"):
+        st.write(f"Source uuid: {uuid4()}")
+    st.button(
+        "Rerun target from source",
+        key="rerun_target_btn",
+        on_click=lambda: st.rerun("target_frag"),
+    )
+
+
+@st.fragment(key="target_frag")
+def target_fragment() -> None:
+    with st.container(key="target_uuid"):
+        st.write(f"Target uuid: {uuid4()}")
+
+
+source_fragment()
+target_fragment()
+
+with st.container(key="compose_stable_text"):
+    st.write(f"Compose stable text: {st.session_state.outside_counter}")
+
+# ------------------------------------------------------------------ #
+# Scenario 4: Unknown key raises a visible exception.
+# ------------------------------------------------------------------ #
+st.header("Scenario 4: unknown key raises")
 
 st.button(
     "Rerun unknown fragment",

--- a/e2e_playwright/st_fragment_key_rerun.py
+++ b/e2e_playwright/st_fragment_key_rerun.py
@@ -76,10 +76,10 @@ st.button(
 )
 
 # ------------------------------------------------------------------ #
-# Scenario 3: Compose — widget inside fragment A targets fragment B.
-# Both fragments should rerun; nothing outside should change.
+# Scenario 3: Fragment-to-fragment — widget inside fragment A targets B.
+# Only the target fragment should rerun; source and outside stay stable.
 # ------------------------------------------------------------------ #
-st.header("Scenario 3: compose (fragment-to-fragment)")
+st.header("Scenario 3: fragment-to-fragment targeting")
 
 
 @st.fragment(key="source_frag")

--- a/e2e_playwright/st_fragment_key_rerun_test.py
+++ b/e2e_playwright/st_fragment_key_rerun_test.py
@@ -16,7 +16,6 @@
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     click_button,
     expect_exception,
@@ -26,9 +25,8 @@ from e2e_playwright.shared.app_utils import (
 
 
 def _text(app: Page, key: str) -> str:
-    """Return the text content of an element identified by its Streamlit key."""
-    locator = get_element_by_key(app, key)
-    content = locator.text_content()
+    """Return the text content of a container identified by its Streamlit key."""
+    content = get_element_by_key(app, key).text_content()
     assert content is not None
     return content
 

--- a/e2e_playwright/st_fragment_key_rerun_test.py
+++ b/e2e_playwright/st_fragment_key_rerun_test.py
@@ -68,6 +68,25 @@ def test_multi_key_rerun_updates_both_fragments_not_outside(app: Page) -> None:
     expect_no_exception(app)
 
 
+def test_compose_fragment_to_fragment_reruns_both(app: Page) -> None:
+    """A button inside fragment A calling st.rerun('target_frag') reruns both
+    the source fragment (enclosing) and the target fragment; outside text is stable.
+    """
+    initial_source = _text(app, "source_uuid")
+    initial_target = _text(app, "target_uuid")
+    initial_stable = _text(app, "compose_stable_text")
+
+    click_button(app, "Rerun target from source")
+
+    # Both fragments must have rerun (new UUIDs).
+    expect(get_element_by_key(app, "source_uuid")).not_to_have_text(initial_source)
+    expect(get_element_by_key(app, "target_uuid")).not_to_have_text(initial_target)
+    # Outside text must not change — no full-app rerun occurred.
+    expect(get_element_by_key(app, "compose_stable_text")).to_have_text(initial_stable)
+
+    expect_no_exception(app)
+
+
 def test_unknown_key_raises_visible_exception(app: Page) -> None:
     """st.rerun('nonexistent_key') raises StreamlitAPIException shown as an app error."""
     click_button(app, "Rerun unknown fragment")

--- a/e2e_playwright/st_fragment_key_rerun_test.py
+++ b/e2e_playwright/st_fragment_key_rerun_test.py
@@ -68,9 +68,9 @@ def test_multi_key_rerun_updates_both_fragments_not_outside(app: Page) -> None:
     expect_no_exception(app)
 
 
-def test_compose_fragment_to_fragment_reruns_both(app: Page) -> None:
-    """A button inside fragment A calling st.rerun('target_frag') reruns both
-    the source fragment (enclosing) and the target fragment; outside text is stable.
+def test_fragment_to_fragment_reruns_only_target(app: Page) -> None:
+    """A button inside fragment A calling st.rerun('target_frag') reruns only
+    the target fragment; the source fragment and outside text stay stable.
     """
     initial_source = _text(app, "source_uuid")
     initial_target = _text(app, "target_uuid")
@@ -78,9 +78,10 @@ def test_compose_fragment_to_fragment_reruns_both(app: Page) -> None:
 
     click_button(app, "Rerun target from source")
 
-    # Both fragments must have rerun (new UUIDs).
-    expect(get_element_by_key(app, "source_uuid")).not_to_have_text(initial_source)
+    # Only the target fragment must have rerun (new UUID).
     expect(get_element_by_key(app, "target_uuid")).not_to_have_text(initial_target)
+    # Source fragment must NOT have rerun — targeted rerun replaces the default.
+    expect(get_element_by_key(app, "source_uuid")).to_have_text(initial_source)
     # Outside text must not change — no full-app rerun occurred.
     expect(get_element_by_key(app, "compose_stable_text")).to_have_text(initial_stable)
 

--- a/e2e_playwright/st_fragment_key_rerun_test.py
+++ b/e2e_playwright/st_fragment_key_rerun_test.py
@@ -1,0 +1,77 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Playwright tests for @st.fragment(key=...) and st.rerun(scope=<key>)."""
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    expect_exception,
+    expect_no_exception,
+    get_element_by_key,
+)
+
+
+def _text(app: Page, key: str) -> str:
+    """Return the text content of an element identified by its Streamlit key."""
+    locator = get_element_by_key(app, key)
+    content = locator.text_content()
+    assert content is not None
+    return content
+
+
+def test_single_key_rerun_updates_only_fragment(app: Page) -> None:
+    """Clicking a button whose on_click calls st.rerun('charts') reruns only the
+    'charts' fragment; outside_counter does not increment.
+    """
+    initial_outside = _text(app, "outside_counter")
+    initial_fragment_uuid = _text(app, "fragment_uuid")
+
+    click_button(app, "Rerun charts fragment")
+
+    # The fragment's content must have changed (new UUID).
+    expect(get_element_by_key(app, "fragment_uuid")).not_to_have_text(
+        initial_fragment_uuid
+    )
+    # The counter outside the fragment must not have changed (no full rerun).
+    expect(get_element_by_key(app, "outside_counter")).to_have_text(initial_outside)
+
+    expect_no_exception(app)
+
+
+def test_multi_key_rerun_updates_both_fragments_not_outside(app: Page) -> None:
+    """st.rerun(['frag_alpha', 'frag_beta']) reruns both fragments; stable text outside
+    the fragments does not change.
+    """
+    initial_alpha = _text(app, "alpha_uuid")
+    initial_beta = _text(app, "beta_uuid")
+    initial_stable = _text(app, "stable_text")
+
+    click_button(app, "Rerun alpha and beta")
+
+    expect(get_element_by_key(app, "alpha_uuid")).not_to_have_text(initial_alpha)
+    expect(get_element_by_key(app, "beta_uuid")).not_to_have_text(initial_beta)
+    # Outside stable text must not change — no full rerun occurred.
+    expect(get_element_by_key(app, "stable_text")).to_have_text(initial_stable)
+
+    expect_no_exception(app)
+
+
+def test_unknown_key_raises_visible_exception(app: Page) -> None:
+    """st.rerun('nonexistent_key') raises StreamlitAPIException shown as an app error."""
+    click_button(app, "Rerun unknown fragment")
+
+    expect_exception(app, "No fragment found for target 'nonexistent_key'")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -70,6 +70,10 @@ def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
         replaces the default full-app rerun).
       - ``False`` when the widget lives inside a fragment (the keyed target
         composes with the originating fragment's own rerun — both run).
+
+    Note: for main-script keyed targets, callback-vote coalescing may still
+    escalate to a full-app rerun when a callback-less widget also changed;
+    that escalation happens in ``SessionState._call_callbacks``, not here.
     """
     if scope == "app":
         return False
@@ -219,13 +223,19 @@ def rerun(  # type: ignore[misc]
           fragment(s). The key must match the ``key`` argument passed to
           ``@st.fragment(key=...)``. This form is only valid from a widget
           callback (``on_change`` / ``on_click``); calling it from the main
-          script body or a fragment body raises ``StreamlitAPIException``. An
-          empty list is a no-op — it does not trigger any rerun.
+          script body or a fragment body raises ``StreamlitAPIException``.
 
     """
-    # An empty scope (empty string, empty list) means "rerun nothing".
-    if not scope:
-        return  # type: ignore[misc]  # ty: ignore[invalid-return-type]
+    if isinstance(scope, str) and scope == "":
+        raise StreamlitAPIException(
+            "st.rerun() was called with an empty string scope. "
+            "Pass a fragment key, a list of keys, 'app', or 'fragment'."
+        )
+    if isinstance(scope, Sequence) and not isinstance(scope, str) and len(scope) == 0:
+        raise StreamlitAPIException(
+            "st.rerun() was called with an empty list scope. "
+            "Pass a fragment key, a list of keys, 'app', or 'fragment'."
+        )
 
     ctx = get_script_run_ctx()
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -230,6 +230,11 @@ def rerun(  # type: ignore[misc]
 
     Rerun multiple fragments at once:
 
+    >>> @st.fragment(key="table")
+    >>> def table():
+    >>>     st.dataframe({"col": [1, 2, 3]})
+    >>>
+    >>> table()
     >>> st.button(
     >>>     "Refresh all",
     >>>     on_click=lambda: st.rerun(["charts", "table"]),

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -48,20 +48,27 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 if TYPE_CHECKING:
     from streamlit.runtime.state.query_params import QueryParams, QueryParamsInput
 
+# Keyed reruns (st.rerun("<key>")) are only valid from widget callbacks.
+# Calling from the main body or a fragment body would abort the current run
+# mid-execution, which is not a supported pattern.
 _KEYED_RERUN_ALLOWED_LOCATIONS: frozenset[RunLocation] = frozenset(
     {RunLocation.CALLBACK}
 )
 
 
 def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
-    """Whether the rerun should preempt the run in progress.
+    """Whether this rerun should preempt the current run or compose with it.
 
-    ``scope="app"`` → ``False`` (full-app rerun, not fragment-scoped).
-    ``scope="fragment"`` → ``True`` (always preempts).
-    Keyed target (anything else) → depends on where the callback's widget lives:
-    a main-script widget returns ``True`` (the keyed target replaces the default
-    full-app rerun), a fragment widget returns ``False`` (the keyed target composes
-    with the fragment's own rerun — both run).
+    Returns ``True`` (preempt) or ``False`` (compose), stored as
+    ``RerunData.is_fragment_scoped_rerun``.
+
+    - ``"app"`` → ``False`` — full-app rerun, not fragment-scoped.
+    - ``"fragment"`` → ``True`` — the current fragment reruns itself.
+    - Keyed target → origin-dependent:
+      - ``True`` when the widget lives in the main script (the keyed target
+        replaces the default full-app rerun).
+      - ``False`` when the widget lives inside a fragment (the keyed target
+        composes with the originating fragment's own rerun — both run).
     """
     if scope == "app":
         return False
@@ -102,6 +109,7 @@ def _new_fragment_id_queue(
     ctx: ScriptRunContext,
     scope: str | Sequence[str],
 ) -> list[str]:
+    """Build the fragment_id_queue for a rerun request from ``scope``."""
     if scope == "app":
         return []
 
@@ -118,7 +126,7 @@ def _new_fragment_id_queue(
             )
         return ctx.fragment_storage.resolve_target(scope)
 
-    # > scope == "fragment"
+    # scope == "fragment": rerun the fragment that is currently executing.
     curr_queue = ctx.fragment_ids_this_run
 
     # If st.rerun(scope="fragment") is called during a full script run, we raise an

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -53,6 +53,25 @@ _KEYED_RERUN_ALLOWED_LOCATIONS: frozenset[RunLocation] = frozenset(
 )
 
 
+def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
+    """Whether the rerun should preempt the run in progress.
+
+    ``scope="app"`` → ``False`` (full-app rerun, not fragment-scoped).
+    ``scope="fragment"`` → ``True`` (always preempts).
+    Keyed target (anything else) → depends on where the callback's widget lives:
+    a main-script widget returns ``True`` (the keyed target replaces the default
+    full-app rerun), a fragment widget returns ``False`` (the keyed target composes
+    with the fragment's own rerun — both run).
+    """
+    if scope == "app":
+        return False
+    if scope == "fragment":
+        return True
+    # Keyed target: origin-dependent.
+    ts = ThreadState.get()
+    return ts.fragment_id is None
+
+
 @gather_metrics("stop")
 def stop() -> NoReturn:  # type: ignore[misc] # ty: ignore[invalid-return-type]
     """Stops execution immediately.
@@ -195,9 +214,8 @@ def rerun(  # type: ignore[misc]
           empty list is a no-op — it does not trigger any rerun.
 
     """
-    # An explicitly empty list of keys means "rerun nothing"; do not degrade to
-    # a full-app rerun just because the caller's list happened to be empty.
-    if not isinstance(scope, str) and not scope:
+    # An empty scope (empty string, empty list) means "rerun nothing".
+    if not scope:
         return  # type: ignore[misc]  # ty: ignore[invalid-return-type]
 
     ctx = get_script_run_ctx()
@@ -213,7 +231,7 @@ def rerun(  # type: ignore[misc]
                 query_string=query_string,
                 page_script_hash=page_script_hash,
                 fragment_id_queue=fragment_id_queue,
-                is_fragment_scoped_rerun=scope != "app",
+                is_fragment_scoped_rerun=_is_fragment_scoped(scope),
                 cached_message_hashes=cached_message_hashes,
                 context_info=ctx.context_info,
             )

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from itertools import dropwhile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NoReturn
@@ -28,7 +28,6 @@ from streamlit.errors import (
     StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
     StreamlitPageNotFoundError,
-    StreamlitValueError,
 )
 from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.navigation.page import Page, _validate_registered_page
@@ -42,11 +41,16 @@ from streamlit.runtime.scriptrunner import (
     get_script_run_ctx,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    RunLocation,
     ThreadState,
 )
 
 if TYPE_CHECKING:
     from streamlit.runtime.state.query_params import QueryParams, QueryParamsInput
+
+_KEYED_RERUN_ALLOWED_LOCATIONS: frozenset[RunLocation] = frozenset(
+    {RunLocation.CALLBACK}
+)
 
 
 @gather_metrics("stop")
@@ -77,10 +81,23 @@ def stop() -> NoReturn:  # type: ignore[misc] # ty: ignore[invalid-return-type]
 
 def _new_fragment_id_queue(
     ctx: ScriptRunContext,
-    scope: Literal["app", "fragment"],
+    scope: str | Sequence[str],
 ) -> list[str]:
     if scope == "app":
         return []
+
+    if scope != "fragment":
+        # Any scope other than the reserved "app"/"fragment" level names is one or
+        # more fragment keys: an event-scoped rerun of the named fragment(s).
+        ts = ThreadState.get()
+        if ts.run_location not in _KEYED_RERUN_ALLOWED_LOCATIONS:
+            raise StreamlitAPIException(
+                "Passing a fragment key to ``st.rerun()`` is only allowed from a "
+                "widget callback (e.g. ``on_change`` / ``on_click``). Calling it "
+                "from the main script body or a fragment body would abort the "
+                "current run."
+            )
+        return ctx.fragment_storage.resolve_target(scope)
 
     # > scope == "fragment"
     curr_queue = ctx.fragment_ids_this_run
@@ -148,8 +165,7 @@ def _set_query_params_for_switch(
 
 @gather_metrics("rerun")
 def rerun(  # type: ignore[misc]
-    *,  # The scope argument can only be passed via keyword.
-    scope: Literal["app", "fragment"] = "app",
+    scope: Literal["app", "fragment"] | str | Sequence[str] = "app",
 ) -> NoReturn:  # ty: ignore[invalid-return-type]
     """Rerun the script immediately.
 
@@ -163,20 +179,26 @@ def rerun(  # type: ignore[misc]
 
     Parameters
     ----------
-    scope : "app" or "fragment"
-        Specifies what part of the app should rerun. If ``scope`` is ``"app"``
-        (default), the full app reruns. If ``scope`` is ``"fragment"``,
-        Streamlit only reruns the fragment from which this command is called.
+    scope : "app", "fragment", str, or list of str
+        Specifies what part of the app should rerun.
 
-        Setting ``scope="fragment"`` is only valid inside a fragment during a
-        fragment rerun. If ``st.rerun(scope="fragment")`` is called during a
-        full-app rerun or outside of a fragment, Streamlit will raise a
-        ``StreamlitAPIException``.
+        - ``"app"`` (default): the full app reruns.
+        - ``"fragment"``: Streamlit only reruns the fragment from which this
+          command is called. Only valid inside a fragment during a fragment
+          rerun. Raises ``StreamlitAPIException`` during a full-app rerun or
+          outside of a fragment.
+        - A fragment key (str) or list of fragment keys: reruns the named
+          fragment(s). The key must match the ``key`` argument passed to
+          ``@st.fragment(key=...)``. This form is only valid from a widget
+          callback (``on_change`` / ``on_click``); calling it from the main
+          script body or a fragment body raises ``StreamlitAPIException``. An
+          empty list is a no-op — it does not trigger any rerun.
 
     """
-
-    if scope not in {"app", "fragment"}:
-        raise StreamlitValueError("scope", ["'app'", "'fragment'"])
+    # An explicitly empty list of keys means "rerun nothing"; do not degrade to
+    # a full-app rerun just because the caller's list happened to be empty.
+    if not isinstance(scope, str) and not scope:
+        return  # type: ignore[misc]  # ty: ignore[invalid-return-type]
 
     ctx = get_script_run_ctx()
 
@@ -184,13 +206,14 @@ def rerun(  # type: ignore[misc]
         query_string = ctx.query_string
         page_script_hash = ctx.page_script_hash
         cached_message_hashes = ctx.cached_message_hashes
+        fragment_id_queue = _new_fragment_id_queue(ctx, scope)
 
         ctx.script_requests.request_rerun(
             RerunData(
                 query_string=query_string,
                 page_script_hash=page_script_hash,
-                fragment_id_queue=_new_fragment_id_queue(ctx, scope),
-                is_fragment_scoped_rerun=scope == "fragment",
+                fragment_id_queue=fragment_id_queue,
+                is_fragment_scoped_rerun=scope != "app",
                 cached_message_hashes=cached_message_hashes,
                 context_info=ctx.context_info,
             )

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -254,18 +254,18 @@ def rerun(  # type: ignore[misc]
             context_info=ctx.context_info,
         )
 
-        ctx.script_requests.request_rerun(rerun_data)
-
         if ThreadState.get().run_location == RunLocation.CALLBACK:
             # Raise directly so the callback halts immediately.
             # _run_callback_and_record_rerun catches this to classify the
-            # rerun and record it on the interaction's votes.  The body-level
-            # compose/preempt decision is already encoded in rerun_data and
-            # queued via request_rerun above.
+            # rerun and record it on the interaction's votes.  The request is
+            # NOT queued here — _call_callbacks flushes votes.pending_reruns
+            # after the last callback returns, which prevents a sibling
+            # callback's yield point from picking up this request early.
             raise RerunException(rerun_data)
 
-        # Body-level calls: halt via a yield point so the script runner can
-        # inspect the request and decide whether to preempt.
+        # Body-level calls: queue the request and halt via a yield point so
+        # the script runner can inspect it and decide whether to preempt.
+        ctx.script_requests.request_rerun(rerun_data)
         st.empty()
 
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -125,8 +125,8 @@ def _new_fragment_id_queue(
         ts = ThreadState.get()
         if ts.run_location not in _KEYED_RERUN_ALLOWED_LOCATIONS:
             raise StreamlitAPIException(
-                "Passing a fragment key to ``st.rerun()`` is only allowed from a "
-                "widget callback (e.g. ``on_change`` / ``on_click``). Calling it "
+                "Passing a fragment key to `st.rerun()` is only allowed from a "
+                "widget callback (e.g. `on_change` / `on_click`). Calling it "
                 "from the main script body or a fragment body would abort the "
                 "current run."
             )
@@ -225,6 +225,29 @@ def rerun(  # type: ignore[misc]
           ``@st.fragment(key=...)``. This form is only valid from a widget
           callback (``on_change`` / ``on_click``); calling it from the main
           script body or a fragment body raises ``StreamlitAPIException``.
+
+    Examples
+    --------
+    Rerun a named fragment from a widget callback:
+
+    >>> import streamlit as st
+    >>>
+    >>> @st.fragment(key="charts")
+    >>> def charts():
+    >>>     st.line_chart({"data": [1, 2, 3]})
+    >>>
+    >>> charts()
+    >>> st.button(
+    >>>     "Refresh charts",
+    >>>     on_click=lambda: st.rerun("charts"),
+    >>> )
+
+    Rerun multiple fragments at once:
+
+    >>> st.button(
+    >>>     "Refresh all",
+    >>>     on_click=lambda: st.rerun(["charts", "table"]),
+    >>> )
 
     """
     if isinstance(scope, str) and scope == "":

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -28,6 +28,7 @@ from streamlit.errors import (
     StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
     StreamlitPageNotFoundError,
+    StreamlitValueError,
 )
 from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.navigation.page import Page, _validate_registered_page
@@ -58,11 +59,13 @@ _KEYED_RERUN_ALLOWED_LOCATIONS: frozenset[RunLocation] = frozenset(
 
 
 def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
-    """Whether this rerun is fragment-scoped (preempts the pending run body).
+    """Whether this rerun targets specific fragments rather than the whole app.
 
-    Returns ``True`` for any scope other than ``"app"`` — fragment self-reruns
-    and keyed targets both replace the interaction's default rerun regardless of
-    where the triggering widget lives.
+    Every scope other than ``"app"`` is a fragment rerun: ``"fragment"`` is the
+    self-targeting variant (rerun the fragment the callback lives in), while a
+    key or list of keys targets other fragments (or self) by name. All of these
+    set ``is_fragment_scoped_rerun=True`` on ``RerunData``, which lets the
+    script runner preempt the current run body.
 
     Note: callback-vote coalescing may still escalate to a full-app rerun if
     another callback returns normally or calls plain ``st.rerun()``; that
@@ -114,7 +117,8 @@ def _new_fragment_id_queue(
                 "Passing a fragment key to `st.rerun()` is only allowed from a "
                 "widget callback (e.g. `on_change` / `on_click`). Calling it "
                 "from the main script body or a fragment body would abort the "
-                "current run."
+                "current run. If you meant to rerun the whole app or the "
+                "current fragment, use `scope='app'` or `scope='fragment'`."
             )
         return ctx.fragment_storage.resolve_target(scope)
 
@@ -184,7 +188,7 @@ def _set_query_params_for_switch(
 
 @gather_metrics("rerun")
 def rerun(  # type: ignore[misc]
-    scope: Literal["app", "fragment"] | str | Sequence[str] = "app",
+    scope: Literal["app", "fragment"] | str | int | Sequence[str | int] = "app",
 ) -> NoReturn:  # ty: ignore[invalid-return-type]
     """Rerun the script immediately.
 
@@ -198,7 +202,7 @@ def rerun(  # type: ignore[misc]
 
     Parameters
     ----------
-    scope : "app", "fragment", str, or list of str
+    scope : "app", "fragment", str, int, or list of str/int
         Specifies what part of the app should rerun.
 
         - ``"app"`` (default): the full app reruns.
@@ -206,15 +210,23 @@ def rerun(  # type: ignore[misc]
           command is called. Only valid inside a fragment during a fragment
           rerun. Raises ``StreamlitAPIException`` during a full-app rerun or
           outside of a fragment.
-        - A fragment key (str) or list of fragment keys: reruns only the named
-          fragment(s), replacing the interaction's default rerun. The key must
-          match the ``key`` argument passed to ``@st.fragment(key=...)``.
+        - A fragment key (str or int) or list of fragment keys: reruns only the
+          named fragment(s), replacing the interaction's default rerun. The key
+          must match the ``key`` argument passed to ``@st.fragment(key=...)``.
+          An ``int`` key is normalized to its string representation.
           An unknown key raises ``StreamlitAPIException``. This form is only
           valid from a widget callback (``on_change`` / ``on_click``);
           calling it from the main script body or a fragment body raises
           ``StreamlitAPIException``. If a sibling callback in the same
           interaction returns normally or calls ``st.rerun()``, the result
           escalates to a full-app rerun.
+
+        .. note::
+            When a keyed rerun replaces the interaction default, only the
+            targeted fragment(s) rerun. Other widgets changed in the same
+            interaction (e.g. form fields submitted alongside the callback)
+            have their values applied to session state, but they won't render
+            until the next full-app rerun.
 
     Examples
     --------
@@ -245,32 +257,54 @@ def rerun(  # type: ignore[misc]
     >>> )
 
     """
+    if isinstance(scope, int):
+        scope = str(scope)
+    if isinstance(scope, (bytes, bytearray)):
+        raise StreamlitInvalidParameterTypeError(
+            "scope",
+            type(scope).__name__,
+            ["str", "int", "list[str | int]"],
+        )
     if not isinstance(scope, (str, Sequence)):
-        raise StreamlitAPIException(
-            f"`scope` must be a string or a list of strings, "
-            f"not `{type(scope).__name__}`."
+        raise StreamlitInvalidParameterTypeError(
+            "scope",
+            type(scope).__name__,
+            ["str", "int", "list[str | int]"],
         )
     if isinstance(scope, str) and scope == "":
-        raise StreamlitAPIException(
-            "st.rerun() was called with an empty string scope. "
-            "Pass a fragment key, a list of keys, 'app', or 'fragment'."
+        raise StreamlitValueError(
+            "scope",
+            ["'app'", "'fragment'", "a fragment key", "a list of keys"],
+            detail="Got an empty string.",
         )
     if isinstance(scope, Sequence) and not isinstance(scope, str) and len(scope) == 0:
-        raise StreamlitAPIException(
-            "st.rerun() was called with an empty list scope. "
-            "Pass a fragment key, a list of keys, 'app', or 'fragment'."
+        raise StreamlitValueError(
+            "scope",
+            ["'app'", "'fragment'", "a fragment key", "a list of keys"],
+            detail="Got an empty list.",
         )
     if isinstance(scope, Sequence) and not isinstance(scope, str):
+        normalized: list[str] = []
         for name in scope:
-            if not isinstance(name, str):
-                raise StreamlitAPIException(
-                    f"Fragment keys must be strings, not `{type(name).__name__}`."
+            if isinstance(name, int):
+                normalized.append(str(name))
+            elif not isinstance(name, str):
+                raise StreamlitInvalidParameterTypeError(
+                    "scope list items",
+                    type(name).__name__,
+                    ["str", "int"],
                 )
+            else:
+                normalized.append(name)
+        for name in normalized:
             if name in {"app", "fragment"}:
-                raise StreamlitAPIException(
-                    f"'{name}' is a reserved scope name and cannot be used inside a list. "
-                    f"Pass '{name}' directly as a string, or use fragment keys only in lists."
+                raise StreamlitValueError(
+                    "scope",
+                    ["fragment keys"],
+                    detail=f"'{name}' is a reserved scope name and cannot appear inside a list. "
+                    f"Pass '{name}' directly as a string.",
                 )
+        scope = normalized
 
     ctx = get_script_run_ctx()
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -58,31 +58,17 @@ _KEYED_RERUN_ALLOWED_LOCATIONS: frozenset[RunLocation] = frozenset(
 
 
 def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
-    """Whether this rerun should preempt the current run or compose with it.
+    """Whether this rerun is fragment-scoped (preempts the pending run body).
 
-    Returns ``True`` (preempt) or ``False`` (compose), stored as
-    ``RerunData.is_fragment_scoped_rerun``.
+    Returns ``True`` for any scope other than ``"app"`` — fragment self-reruns
+    and keyed targets both replace the interaction's default rerun regardless of
+    where the triggering widget lives.
 
-    - ``"app"`` → ``False`` — full-app rerun, not fragment-scoped.
-    - ``"fragment"`` → ``True`` — the current fragment reruns itself.
-    - Keyed target → origin-dependent:
-      - ``True`` when the widget lives in the main script (the keyed target
-        replaces the default full-app rerun).
-      - ``False`` when the widget lives inside a fragment (the keyed target
-        composes with the originating fragment's own rerun — both run).
-
-    Note: for main-script keyed targets, callback-vote coalescing may still
-    escalate to a full-app rerun if another callback returns normally or calls
-    plain ``st.rerun()``; that escalation happens in
-    ``SessionState._call_callbacks``, not here.
+    Note: callback-vote coalescing may still escalate to a full-app rerun if
+    another callback returns normally or calls plain ``st.rerun()``; that
+    escalation happens in ``SessionState._call_callbacks``, not here.
     """
-    if scope == "app":
-        return False
-    if scope == "fragment":
-        return True
-    # Keyed target: origin-dependent.
-    ts = ThreadState.get()
-    return ts.fragment_id is None
+    return scope != "app"
 
 
 @gather_metrics("stop")

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -37,6 +37,7 @@ from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
 from streamlit.runtime.scriptrunner import (
     RerunData,
+    RerunException,
     ScriptRunContext,
     get_script_run_ctx,
 )
@@ -234,17 +235,27 @@ def rerun(  # type: ignore[misc]
         cached_message_hashes = ctx.cached_message_hashes
         fragment_id_queue = _new_fragment_id_queue(ctx, scope)
 
-        ctx.script_requests.request_rerun(
-            RerunData(
-                query_string=query_string,
-                page_script_hash=page_script_hash,
-                fragment_id_queue=fragment_id_queue,
-                is_fragment_scoped_rerun=_is_fragment_scoped(scope),
-                cached_message_hashes=cached_message_hashes,
-                context_info=ctx.context_info,
-            )
+        rerun_data = RerunData(
+            query_string=query_string,
+            page_script_hash=page_script_hash,
+            fragment_id_queue=fragment_id_queue,
+            is_fragment_scoped_rerun=_is_fragment_scoped(scope),
+            cached_message_hashes=cached_message_hashes,
+            context_info=ctx.context_info,
         )
-        # Force a yield point so the runner can do the rerun
+
+        ctx.script_requests.request_rerun(rerun_data)
+
+        if ThreadState.get().run_location == RunLocation.CALLBACK:
+            # Raise directly so the callback halts immediately.
+            # _run_callback_and_record_rerun catches this to classify the
+            # rerun and record it on the interaction's votes.  The body-level
+            # compose/preempt decision is already encoded in rerun_data and
+            # queued via request_rerun above.
+            raise RerunException(rerun_data)
+
+        # Body-level calls: halt via a yield point so the script runner can
+        # inspect the request and decide whether to preempt.
         st.empty()
 
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -118,7 +118,8 @@ def _new_fragment_id_queue(
                 "widget callback (e.g. `on_change` / `on_click`). Calling it "
                 "from the main script body or a fragment body would abort the "
                 "current run. If you meant to rerun the whole app or the "
-                "current fragment, use `scope='app'` or `scope='fragment'`."
+                "current fragment, use `scope='app'` or `scope='fragment'`.",
+                error_id="rerun-keyed-outside-callback",
             )
         return ctx.fragment_storage.resolve_target(scope)
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -72,8 +72,9 @@ def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
         composes with the originating fragment's own rerun — both run).
 
     Note: for main-script keyed targets, callback-vote coalescing may still
-    escalate to a full-app rerun when a callback-less widget also changed;
-    that escalation happens in ``SessionState._call_callbacks``, not here.
+    escalate to a full-app rerun if another callback returns normally or calls
+    plain ``st.rerun()``; that escalation happens in
+    ``SessionState._call_callbacks``, not here.
     """
     if scope == "app":
         return False
@@ -255,12 +256,13 @@ def rerun(  # type: ignore[misc]
         )
 
         if ThreadState.get().run_location == RunLocation.CALLBACK:
-            # Raise directly so the callback halts immediately.
-            # _run_callback_and_record_rerun catches this to classify the
-            # rerun and record it on the interaction's votes.  The request is
-            # NOT queued here — _call_callbacks flushes votes.pending_reruns
-            # after the last callback returns, which prevents a sibling
-            # callback's yield point from picking up this request early.
+            # Halt the callback immediately — _run_callback_and_record_rerun
+            # catches this and records it on the interaction's votes.
+            #
+            # The request is NOT queued via request_rerun here; _call_callbacks
+            # flushes all pending reruns after the last callback returns.
+            # Queueing now would let a sibling callback's yield point pick up
+            # this request and abort prematurely.
             raise RerunException(rerun_data)
 
         # Body-level calls: queue the request and halt via a yield point so

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -260,6 +260,13 @@ def rerun(  # type: ignore[misc]
             "st.rerun() was called with an empty list scope. "
             "Pass a fragment key, a list of keys, 'app', or 'fragment'."
         )
+    if isinstance(scope, Sequence) and not isinstance(scope, str):
+        for name in scope:
+            if name in ("app", "fragment"):
+                raise StreamlitAPIException(
+                    f"'{name}' is a reserved scope name and cannot be used inside a list. "
+                    f"Pass '{name}' directly as a string, or use fragment keys only in lists."
+                )
 
     ctx = get_script_run_ctx()
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -206,11 +206,15 @@ def rerun(  # type: ignore[misc]
           command is called. Only valid inside a fragment during a fragment
           rerun. Raises ``StreamlitAPIException`` during a full-app rerun or
           outside of a fragment.
-        - A fragment key (str) or list of fragment keys: reruns the named
-          fragment(s). The key must match the ``key`` argument passed to
-          ``@st.fragment(key=...)``. This form is only valid from a widget
-          callback (``on_change`` / ``on_click``); calling it from the main
-          script body or a fragment body raises ``StreamlitAPIException``.
+        - A fragment key (str) or list of fragment keys: reruns only the named
+          fragment(s), replacing the interaction's default rerun. The key must
+          match the ``key`` argument passed to ``@st.fragment(key=...)``.
+          An unknown key raises ``StreamlitAPIException``. This form is only
+          valid from a widget callback (``on_change`` / ``on_click``);
+          calling it from the main script body or a fragment body raises
+          ``StreamlitAPIException``. If a sibling callback in the same
+          interaction returns normally or calls ``st.rerun()``, the result
+          escalates to a full-app rerun.
 
     Examples
     --------
@@ -241,6 +245,11 @@ def rerun(  # type: ignore[misc]
     >>> )
 
     """
+    if not isinstance(scope, (str, Sequence)):
+        raise StreamlitAPIException(
+            f"`scope` must be a string or a list of strings, "
+            f"not `{type(scope).__name__}`."
+        )
     if isinstance(scope, str) and scope == "":
         raise StreamlitAPIException(
             "st.rerun() was called with an empty string scope. "

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -262,6 +262,10 @@ def rerun(  # type: ignore[misc]
         )
     if isinstance(scope, Sequence) and not isinstance(scope, str):
         for name in scope:
+            if not isinstance(name, str):
+                raise StreamlitAPIException(
+                    f"Fragment keys must be strings, not `{type(name).__name__}`."
+                )
             if name in {"app", "fragment"}:
                 raise StreamlitAPIException(
                     f"'{name}' is a reserved scope name and cannot be used inside a list. "

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -262,7 +262,7 @@ def rerun(  # type: ignore[misc]
         )
     if isinstance(scope, Sequence) and not isinstance(scope, str):
         for name in scope:
-            if name in ("app", "fragment"):
+            if name in {"app", "fragment"}:
                 raise StreamlitAPIException(
                     f"'{name}' is a reserved scope name and cannot be used inside a list. "
                     f"Pass '{name}' directly as a string, or use fragment keys only in lists."

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -294,6 +294,12 @@ def rerun(  # type: ignore[misc]
                     type(name).__name__,
                     ["str", "int"],
                 )
+            elif name == "":
+                raise StreamlitValueError(
+                    "scope list items",
+                    ["non-empty strings or ints"],
+                    detail="Found an empty string in the list.",
+                )
             else:
                 normalized.append(name)
         for name in normalized:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -18,7 +18,7 @@ import contextlib
 import inspect
 import threading
 from abc import abstractmethod
-from collections.abc import Callable, Container, Iterator
+from collections.abc import Callable, Container, Iterator, Sequence
 from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypeVar, overload
@@ -27,6 +27,8 @@ from streamlit.error_util import handle_user_script_exception
 from streamlit.errors import (
     FragmentHandledException,
     FragmentStorageKeyError,
+    StreamlitAPIException,
+    StreamlitDuplicateElementKey,
     StreamlitInvalidLayoutContextError,
 )
 from streamlit.logger import get_logger
@@ -53,6 +55,10 @@ if TYPE_CHECKING:
     from streamlit.runtime.outside_container_wrapper import OutsideContainerWrapper
 
 _LOGGER: Final = get_logger(__name__)
+
+# ``st.rerun(scope=...)`` reads these two values as level names, so they cannot
+# double as fragment keys.
+_RESERVED_FRAGMENT_KEYS: Final = frozenset({"app", "fragment"})
 
 
 def _check_not_parallel_worker(api_name: str) -> None:
@@ -115,6 +121,7 @@ class FragmentStorage(Protocol):
         fragment: Fragment,
         *,
         parent_fragment_id: str | None = None,
+        target_key: str | None = None,
     ) -> None:
         """Store a fragment definition.
 
@@ -124,6 +131,22 @@ class FragmentStorage(Protocol):
         parent_fragment_id
             The fragment id of the enclosing ``@st.fragment`` when this fragment is
             nested, or ``None`` for a top-level fragment.
+
+        target_key
+            The user-facing name from ``@st.fragment(key=...)``. When set, the
+            fragment id is indexed under this name so ``st.rerun(<key>)`` can
+            resolve it. A name may map to several ids if the fragment function is
+            called from multiple sites.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def resolve_target(self, target: str | Sequence[str]) -> list[str]:
+        """Resolve one or more ``@st.fragment(key=...)`` names to fragment ids.
+
+        Returns the ids in a stable order, with each name expanding to every
+        registered call site of that fragment. Raises ``StreamlitAPIException`` if
+        any name has no registered fragment.
         """
         raise NotImplementedError
 
@@ -240,6 +263,9 @@ class MemoryFragmentStorage(FragmentStorage):
         self._registration_sequence_by_id: dict[str, int] = {}
         self._registration_sequence = 0
         self._outside_wrappers: dict[tuple[str, str], OutsideContainerWrapper] = {}
+        # User-facing fragment name -> registered fragment ids (one per call site).
+        self._ids_by_target_key: dict[str, list[str]] = {}
+        self._target_key_by_id: dict[str, str] = {}
 
     def _iter_ancestor_ids(self, fragment_id: str) -> Iterator[str]:
         """Yield ancestors from the immediate parent outward.
@@ -258,10 +284,35 @@ class MemoryFragmentStorage(FragmentStorage):
             seen_ids.add(parent_id)
             current = parent_id
 
+    def _index_target_key(self, fragment_id: str, target_key: str | None) -> None:
+        """Point the name index at fragment_id under target_key, reconciling any prior
+        name. The id is positional and stable across key changes, so a changed or
+        removed key is detached first.
+        """
+        if self._target_key_by_id.get(fragment_id) != target_key:
+            self._unindex_target_key(fragment_id)
+        if target_key is not None:
+            self._target_key_by_id[fragment_id] = target_key
+            ids = self._ids_by_target_key.setdefault(target_key, [])
+            if fragment_id not in ids:
+                ids.append(fragment_id)
+
+    def _unindex_target_key(self, fragment_id: str) -> None:
+        """Remove fragment_id from the name index entirely (eviction or key change)."""
+        target_key = self._target_key_by_id.pop(fragment_id, None)
+        if target_key is None:
+            return
+        ids = self._ids_by_target_key.get(target_key)
+        if ids and fragment_id in ids:
+            ids.remove(fragment_id)
+            if not ids:
+                del self._ids_by_target_key[target_key]
+
     def _remove(self, fragment_id: str, *, evict_wrappers: bool = True) -> None:
         del self._fragments[fragment_id]
         self._parent_by_id.pop(fragment_id, None)
         self._registration_sequence_by_id.pop(fragment_id, None)
+        self._unindex_target_key(fragment_id)
         if evict_wrappers:
             self._outside_wrappers = {
                 key: wrapper
@@ -290,12 +341,32 @@ class MemoryFragmentStorage(FragmentStorage):
         fragment: Fragment,
         *,
         parent_fragment_id: str | None = None,
+        target_key: str | None = None,
     ) -> None:
         with self._lock:
             self._registration_sequence += 1
             self._fragments[key] = fragment
             self._parent_by_id[key] = parent_fragment_id
             self._registration_sequence_by_id[key] = self._registration_sequence
+            self._index_target_key(key, target_key)
+
+    def resolve_target(self, target: str | Sequence[str]) -> list[str]:
+        """Resolve one or more ``@st.fragment(key=...)`` names to fragment ids."""
+        names = [target] if isinstance(target, str) else list(target)
+        with self._lock:
+            resolved: list[str] = []
+            for name in names:
+                ids = self._ids_by_target_key.get(name)
+                if not ids:
+                    raise StreamlitAPIException(
+                        f"No fragment found for target '{name}'. Pass the same "
+                        f"`key` you set on `@st.fragment(key=...)`, and make sure "
+                        f"that fragment has rendered at least once."
+                    )
+                for fragment_id in ids:
+                    if fragment_id not in resolved:
+                        resolved.append(fragment_id)
+            return resolved
 
     def clear_stale_descendants(
         self,
@@ -469,6 +540,7 @@ def _fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
+    key: str | None = None,
     additional_hash_info: str = "",
 ) -> Callable[[F], F] | F:
     """Contains the actual fragment logic.
@@ -478,6 +550,13 @@ def _fragment(
     (note that the @gather_metrics annotation is only on the publicly exposed function)
     """
 
+    if key in _RESERVED_FRAGMENT_KEYS:
+        raise StreamlitAPIException(
+            f"`{key}` is a reserved name and cannot be used as a fragment key, "
+            "because `st.rerun(scope=...)` reads it as a rerun level. Choose a "
+            "different key for `@st.fragment(key=...)`."
+        )
+
     if func is None:
         # Support passing the params via function decorator
         def wrapper(f: F) -> F:
@@ -485,6 +564,7 @@ def _fragment(
                 func=f,
                 run_every=run_every,
                 parallel=parallel,
+                key=key,
             )
 
         return wrapper
@@ -505,6 +585,17 @@ def _fragment(
         fragment_id = calc_hash(
             f"{non_optional_func.__module__}.{get_object_name(non_optional_func)}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}"
         )
+
+        # Unlike the fragment id, this identifies the fragment function itself
+        # (no delta path), so different call sites of one keyed fragment share it
+        # and don't collide on the per-run key-uniqueness check below.
+        if key is not None:
+            fragment_definition_id = (
+                f"{non_optional_func.__module__}."
+                f"{get_object_name(non_optional_func)}{additional_hash_info}"
+            )
+            if not ctx.shared.register_fragment_user_key(key, fragment_definition_id):
+                raise StreamlitDuplicateElementKey(key)
 
         # We intentionally want to capture the active script hash here to ensure
         # that the fragment is associated with the correct script running.
@@ -631,6 +722,7 @@ def _fragment(
             fragment_id,
             wrapped_fragment,
             parent_fragment_id=parent_fragment_id_at_def,
+            target_key=key,
         )
 
         if run_every:
@@ -661,6 +753,7 @@ def fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
+    key: str | None = None,
 ) -> F: ...
 
 
@@ -672,6 +765,7 @@ def fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
+    key: str | None = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -681,6 +775,7 @@ def fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
+    key: str | None = None,
 ) -> Callable[[F], F] | F:
     """Decorator to turn a function into a fragment which can rerun independently\
     of the full app.
@@ -763,6 +858,18 @@ def fragment(
             unsynchronized mutations of shared mutable resources across fragments
             unless you coordinate access explicitly.
 
+    key : str or None
+        An optional name for the fragment. When set, ``st.rerun(key)``
+        re-runs this fragment from a widget callback (``on_change`` /
+        ``on_click``). If the fragment function is called from multiple
+        sites, every call site re-runs together. If this is ``None``
+        (default), the fragment can only be re-run from within itself via
+        ``st.rerun(scope="fragment")``.
+
+        A fragment key must be unique among the fragments that render in a
+        single run, just like a widget ``key``. The names ``"app"`` and
+        ``"fragment"`` are reserved and cannot be used as fragment keys.
+
     Examples
     --------
     The following example demonstrates basic usage of
@@ -843,8 +950,25 @@ def fragment(
         https://doc-fragment-rerun.streamlit.app/
         height: 400px
 
+    Use ``key`` to let a widget callback outside the fragment trigger a
+    fragment-only rerun:
+
+    >>> import streamlit as st
+    >>>
+    >>> @st.fragment(key="charts")
+    >>> def show_charts():
+    >>>     st.write(f"Data: {st.session_state.get('filter', 'all')}")
+    >>>
+    >>> show_charts()
+    >>> st.selectbox(
+    >>>     "Filter",
+    >>>     ["all", "recent"],
+    >>>     key="filter",
+    >>>     on_change=lambda: st.rerun("charts"),
+    >>> )
+
     """
-    return _fragment(func, run_every=run_every, parallel=parallel)
+    return _fragment(func, run_every=run_every, parallel=parallel, key=key)
 
 
 def _prepare_dg_stack_for_worker(

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -860,9 +860,9 @@ def fragment(
             unless you coordinate access explicitly.
 
     key : str or None
-        An optional name for the fragment. When set, ``st.rerun(key)``
-        re-runs this fragment from a widget callback (``on_change`` /
-        ``on_click``). If the fragment function is called from multiple
+        An optional name for the fragment. When set,
+        ``st.rerun(scope="<key>")`` re-runs this fragment from a widget
+        callback (``on_change`` / ``on_click``). If the fragment function is called from multiple
         sites, every call site re-runs together. If this is ``None``
         (default), the fragment can only be re-run from within itself via
         ``st.rerun(scope="fragment")``.

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -122,7 +122,6 @@ class FragmentStorage(Protocol):
         *,
         parent_fragment_id: str | None = None,
         target_key: str | None = None,
-        definition_id: str | None = None,
     ) -> None:
         """Store a fragment definition.
 
@@ -268,10 +267,6 @@ class MemoryFragmentStorage(FragmentStorage):
         # Uses dict[str, None] for O(1) membership checks with stable insertion order.
         self._ids_by_target_key: dict[str, dict[str, None]] = {}
         self._target_key_by_id: dict[str, str] = {}
-        # Durable mapping from user key to fragment definition id.  Survives
-        # fragment-only reruns so a partial rerun cannot steal a key owned by a
-        # non-re-executing fragment with a different definition.
-        self._definition_id_by_key: dict[str, str] = {}
 
     def _iter_ancestor_ids(self, fragment_id: str) -> Iterator[str]:
         """Yield ancestors from the immediate parent outward.
@@ -312,7 +307,6 @@ class MemoryFragmentStorage(FragmentStorage):
             del ids[fragment_id]
             if not ids:
                 del self._ids_by_target_key[target_key]
-                self._definition_id_by_key.pop(target_key, None)
 
     def _remove(self, fragment_id: str, *, evict_wrappers: bool = True) -> None:
         del self._fragments[fragment_id]
@@ -348,14 +342,8 @@ class MemoryFragmentStorage(FragmentStorage):
         *,
         parent_fragment_id: str | None = None,
         target_key: str | None = None,
-        definition_id: str | None = None,
     ) -> None:
         with self._lock:
-            if target_key is not None and definition_id is not None:
-                existing = self._definition_id_by_key.get(target_key)
-                if existing is not None and existing != definition_id:
-                    raise StreamlitDuplicateElementKey(target_key)
-                self._definition_id_by_key[target_key] = definition_id
             self._registration_sequence += 1
             self._fragments[key] = fragment
             self._parent_by_id[key] = parent_fragment_id
@@ -615,6 +603,8 @@ def _fragment(
                 f"{non_optional_func.__module__}."
                 f"{get_object_name(non_optional_func)}{additional_hash_info}"
             )
+            if not ctx.shared.register_fragment_user_key(key, fragment_definition_id):
+                raise StreamlitDuplicateElementKey(key)
 
         # We intentionally want to capture the active script hash here to ensure
         # that the fragment is associated with the correct script running.
@@ -742,7 +732,6 @@ def _fragment(
             wrapped_fragment,
             parent_fragment_id=parent_fragment_id_at_def,
             target_key=key,
-            definition_id=fragment_definition_id,
         )
 
         if run_every:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -122,6 +122,7 @@ class FragmentStorage(Protocol):
         *,
         parent_fragment_id: str | None = None,
         target_key: str | None = None,
+        definition_id: str | None = None,
     ) -> None:
         """Store a fragment definition.
 
@@ -267,6 +268,10 @@ class MemoryFragmentStorage(FragmentStorage):
         # Uses dict[str, None] for O(1) membership checks with stable insertion order.
         self._ids_by_target_key: dict[str, dict[str, None]] = {}
         self._target_key_by_id: dict[str, str] = {}
+        # Durable mapping from user key to fragment definition id.  Survives
+        # fragment-only reruns so a partial rerun cannot steal a key owned by a
+        # non-re-executing fragment with a different definition.
+        self._definition_id_by_key: dict[str, str] = {}
 
     def _iter_ancestor_ids(self, fragment_id: str) -> Iterator[str]:
         """Yield ancestors from the immediate parent outward.
@@ -307,6 +312,7 @@ class MemoryFragmentStorage(FragmentStorage):
             del ids[fragment_id]
             if not ids:
                 del self._ids_by_target_key[target_key]
+                self._definition_id_by_key.pop(target_key, None)
 
     def _remove(self, fragment_id: str, *, evict_wrappers: bool = True) -> None:
         del self._fragments[fragment_id]
@@ -342,8 +348,14 @@ class MemoryFragmentStorage(FragmentStorage):
         *,
         parent_fragment_id: str | None = None,
         target_key: str | None = None,
+        definition_id: str | None = None,
     ) -> None:
         with self._lock:
+            if target_key is not None and definition_id is not None:
+                existing = self._definition_id_by_key.get(target_key)
+                if existing is not None and existing != definition_id:
+                    raise StreamlitDuplicateElementKey(target_key)
+                self._definition_id_by_key[target_key] = definition_id
             self._registration_sequence += 1
             self._fragments[key] = fragment
             self._parent_by_id[key] = parent_fragment_id
@@ -544,7 +556,7 @@ def _fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
-    key: str | None = None,
+    key: str | int | None = None,
     additional_hash_info: str = "",
 ) -> Callable[[F], F] | F:
     """Contains the actual fragment logic.
@@ -555,12 +567,10 @@ def _fragment(
     """
 
     if key is not None:
-        if not isinstance(key, str):
-            raise StreamlitAPIException(
-                f"The fragment `key` must be a string, not `{type(key).__name__}`."
-            )
+        from streamlit.elements.lib.utils import to_key
         from streamlit.runtime.state.common import require_valid_user_key
 
+        key = to_key(key)
         require_valid_user_key(key)
 
     if key in _RESERVED_FRAGMENT_KEYS:
@@ -599,16 +609,12 @@ def _fragment(
             f"{non_optional_func.__module__}.{get_object_name(non_optional_func)}{dg_stack_snapshot[-1]._get_delta_path_str()}{additional_hash_info}"
         )
 
-        # Unlike the fragment id, this identifies the fragment function itself
-        # (no delta path), so different call sites of one keyed fragment share it
-        # and don't collide on the per-run key-uniqueness check below.
+        fragment_definition_id: str | None = None
         if key is not None:
             fragment_definition_id = (
                 f"{non_optional_func.__module__}."
                 f"{get_object_name(non_optional_func)}{additional_hash_info}"
             )
-            if not ctx.shared.register_fragment_user_key(key, fragment_definition_id):
-                raise StreamlitDuplicateElementKey(key)
 
         # We intentionally want to capture the active script hash here to ensure
         # that the fragment is associated with the correct script running.
@@ -736,6 +742,7 @@ def _fragment(
             wrapped_fragment,
             parent_fragment_id=parent_fragment_id_at_def,
             target_key=key,
+            definition_id=fragment_definition_id,
         )
 
         if run_every:
@@ -766,7 +773,7 @@ def fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
-    key: str | None = None,
+    key: str | int | None = None,
 ) -> F: ...
 
 
@@ -778,7 +785,7 @@ def fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
-    key: str | None = None,
+    key: str | int | None = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -788,7 +795,7 @@ def fragment(
     *,
     run_every: int | float | timedelta | str | None = None,
     parallel: bool = False,
-    key: str | None = None,
+    key: str | int | None = None,
 ) -> Callable[[F], F] | F:
     """Decorator to turn a function into a fragment which can rerun independently\
     of the full app.
@@ -871,13 +878,13 @@ def fragment(
             unsynchronized mutations of shared mutable resources across fragments
             unless you coordinate access explicitly.
 
-    key : str or None
+    key : str, int, or None
         An optional name for the fragment. If this is ``None`` (default),
         the fragment cannot be targeted by ``st.rerun``. When set, a widget
         callback can rerun this fragment with ``st.rerun("<key>")``.
         Each fragment function rendered in a run must use a unique key;
         multiple call sites of the same function share that key and rerun
-        together.
+        together. An ``int`` key is normalized to its string representation.
 
         A fragment key must be unique among the fragments that render in a
         single run, just like a widget ``key``. The names ``"app"`` and

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -285,9 +285,10 @@ class MemoryFragmentStorage(FragmentStorage):
             current = parent_id
 
     def _index_target_key(self, fragment_id: str, target_key: str | None) -> None:
-        """Point the name index at fragment_id under target_key, reconciling any prior
-        name. The id is positional and stable across key changes, so a changed or
-        removed key is detached first.
+        """Add or update the mapping from ``target_key`` to ``fragment_id``.
+
+        If this fragment was previously indexed under a different key, the old
+        entry is removed first so each fragment id maps to at most one key.
         """
         if self._target_key_by_id.get(fragment_id) != target_key:
             self._unindex_target_key(fragment_id)
@@ -298,7 +299,7 @@ class MemoryFragmentStorage(FragmentStorage):
                 ids.append(fragment_id)
 
     def _unindex_target_key(self, fragment_id: str) -> None:
-        """Remove fragment_id from the name index entirely (eviction or key change)."""
+        """Remove fragment_id from the key-to-id index."""
         target_key = self._target_key_by_id.pop(fragment_id, None)
         if target_key is None:
             return

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -555,6 +555,10 @@ def _fragment(
     """
 
     if key is not None:
+        if not isinstance(key, str):
+            raise StreamlitAPIException(
+                f"The fragment `key` must be a string, not `{type(key).__name__}`."
+            )
         from streamlit.runtime.state.common import require_valid_user_key
 
         require_valid_user_key(key)
@@ -868,10 +872,12 @@ def fragment(
             unless you coordinate access explicitly.
 
     key : str or None
-        An optional name for the fragment. When set,
-        ``st.rerun("<key>")`` re-runs this fragment from a widget
-        callback (``on_change`` / ``on_click``). If the fragment function
-        is called from multiple sites, every call site re-runs together.
+        An optional name for the fragment. If this is ``None`` (default),
+        the fragment cannot be targeted by ``st.rerun``. When set, a widget
+        callback can rerun this fragment with ``st.rerun("<key>")``.
+        Each fragment function rendered in a run must use a unique key;
+        multiple call sites of the same function share that key and rerun
+        together.
 
         A fragment key must be unique among the fragments that render in a
         single run, just like a widget ``key``. The names ``"app"`` and

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -555,6 +555,8 @@ def _fragment(
     """
 
     if key is not None:
+        from streamlit.runtime.state.common import require_valid_user_key
+
         require_valid_user_key(key)
 
     if key in _RESERVED_FRAGMENT_KEYS:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -264,7 +264,8 @@ class MemoryFragmentStorage(FragmentStorage):
         self._registration_sequence = 0
         self._outside_wrappers: dict[tuple[str, str], OutsideContainerWrapper] = {}
         # User-facing fragment name -> registered fragment ids (one per call site).
-        self._ids_by_target_key: dict[str, list[str]] = {}
+        # Uses dict[str, None] for O(1) membership checks with stable insertion order.
+        self._ids_by_target_key: dict[str, dict[str, None]] = {}
         self._target_key_by_id: dict[str, str] = {}
 
     def _iter_ancestor_ids(self, fragment_id: str) -> Iterator[str]:
@@ -294,9 +295,7 @@ class MemoryFragmentStorage(FragmentStorage):
             self._unindex_target_key(fragment_id)
         if target_key is not None:
             self._target_key_by_id[fragment_id] = target_key
-            ids = self._ids_by_target_key.setdefault(target_key, [])
-            if fragment_id not in ids:
-                ids.append(fragment_id)
+            self._ids_by_target_key.setdefault(target_key, {})[fragment_id] = None
 
     def _unindex_target_key(self, fragment_id: str) -> None:
         """Remove fragment_id from the key-to-id index."""
@@ -304,8 +303,8 @@ class MemoryFragmentStorage(FragmentStorage):
         if target_key is None:
             return
         ids = self._ids_by_target_key.get(target_key)
-        if ids and fragment_id in ids:
-            ids.remove(fragment_id)
+        if ids is not None and fragment_id in ids:
+            del ids[fragment_id]
             if not ids:
                 del self._ids_by_target_key[target_key]
 
@@ -354,8 +353,13 @@ class MemoryFragmentStorage(FragmentStorage):
     def resolve_target(self, target: str | Sequence[str]) -> list[str]:
         """Resolve one or more ``@st.fragment(key=...)`` names to fragment ids."""
         names = [target] if isinstance(target, str) else list(target)
+        if not names:
+            raise StreamlitAPIException(
+                "st.rerun() was called with an empty scope. "
+                "Pass a fragment key, a list of keys, 'app', or 'fragment'."
+            )
         with self._lock:
-            resolved: list[str] = []
+            resolved: dict[str, None] = {}
             for name in names:
                 ids = self._ids_by_target_key.get(name)
                 if not ids:
@@ -365,9 +369,8 @@ class MemoryFragmentStorage(FragmentStorage):
                         f"that fragment has rendered at least once."
                     )
                 for fragment_id in ids:
-                    if fragment_id not in resolved:
-                        resolved.append(fragment_id)
-            return resolved
+                    resolved[fragment_id] = None
+            return list(resolved)
 
     def clear_stale_descendants(
         self,
@@ -550,6 +553,9 @@ def _fragment(
     under-the-hood, so that fragment metrics are not tracked for those elements
     (note that the @gather_metrics annotation is only on the publicly exposed function)
     """
+
+    if key is not None:
+        require_valid_user_key(key)
 
     if key in _RESERVED_FRAGMENT_KEYS:
         raise StreamlitAPIException(
@@ -861,11 +867,9 @@ def fragment(
 
     key : str or None
         An optional name for the fragment. When set,
-        ``st.rerun(scope="<key>")`` re-runs this fragment from a widget
-        callback (``on_change`` / ``on_click``). If the fragment function is called from multiple
-        sites, every call site re-runs together. If this is ``None``
-        (default), the fragment can only be re-run from within itself via
-        ``st.rerun(scope="fragment")``.
+        ``st.rerun("<key>")`` re-runs this fragment from a widget
+        callback (``on_change`` / ``on_click``). If the fragment function
+        is called from multiple sites, every call site re-runs together.
 
         A fragment key must be unique among the fragments that render in a
         single run, just like a widget ``key``. The names ``"app"`` and

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -356,7 +356,8 @@ class MemoryFragmentStorage(FragmentStorage):
         if not names:
             raise StreamlitAPIException(
                 "st.rerun() was called with an empty scope. "
-                "Pass a fragment key, a list of keys, 'app', or 'fragment'."
+                "Pass a fragment key, a list of keys, 'app', or 'fragment'.",
+                error_id="rerun-empty-scope",
             )
         with self._lock:
             resolved: dict[str, None] = {}
@@ -366,7 +367,8 @@ class MemoryFragmentStorage(FragmentStorage):
                     raise StreamlitAPIException(
                         f"No fragment found for target '{name}'. Pass the same "
                         f"`key` you set on `@st.fragment(key=...)`, and make sure "
-                        f"that fragment has rendered at least once."
+                        f"that fragment has rendered at least once.",
+                        error_id="rerun-unknown-fragment-key",
                     )
                 for fragment_id in ids:
                     resolved[fragment_id] = None
@@ -565,7 +567,8 @@ def _fragment(
         raise StreamlitAPIException(
             f"`{key}` is a reserved name and cannot be used as a fragment key, "
             "because `st.rerun(scope=...)` reads it as a rerun level. Choose a "
-            "different key for `@st.fragment(key=...)`."
+            "different key for `@st.fragment(key=...)`.",
+            error_id="fragment-reserved-key",
         )
 
     if func is None:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -699,12 +699,15 @@ class ScriptRunner:
                     # Run callbacks for widgets whose values have changed.
                     if rerun_data.widget_states is not None:
                         self._session_state.on_script_will_rerun(
-                            rerun_data.widget_states
+                            rerun_data.widget_states,
+                            suppress_callbacks=rerun_data.suppress_callbacks,
                         )
-                        # Callbacks above may have queued an st.rerun(). Honor it before
-                        # on_script_start() below: leaving has_script_started False is
-                        # what tells on_script_finished to keep this run's widget values.
-                        self._maybe_handle_execution_control_request()
+                        if not rerun_data.suppress_callbacks:
+                            # Callbacks above may have queued an st.rerun(). Honor
+                            # it before on_script_start() below: leaving
+                            # has_script_started False is what tells
+                            # on_script_finished to keep this run's widget values.
+                            self._maybe_handle_execution_control_request()
 
                     ctx.on_script_start()
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -702,11 +702,13 @@ class ScriptRunner:
                             rerun_data.widget_states,
                             suppress_callbacks=rerun_data.suppress_callbacks,
                         )
-                        if not rerun_data.suppress_callbacks:
-                            # A callback may have queued an st.rerun(). Check now
-                            # — while has_script_started is still False — so
-                            # on_script_finished preserves this run's widget values.
-                            self._maybe_handle_execution_control_request()
+                        # Check for pending rerun/stop requests while
+                        # has_script_started is still False so on_script_finished
+                        # preserves this run's widget values.  On the normal path a
+                        # callback may have queued st.rerun(); on the suppressed path
+                        # an external request (e.g. new client interaction) may have
+                        # arrived during state application.
+                        self._maybe_handle_execution_control_request()
 
                     ctx.on_script_start()
 

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -703,10 +703,9 @@ class ScriptRunner:
                             suppress_callbacks=rerun_data.suppress_callbacks,
                         )
                         if not rerun_data.suppress_callbacks:
-                            # Callbacks above may have queued an st.rerun(). Honor
-                            # it before on_script_start() below: leaving
-                            # has_script_started False is what tells
-                            # on_script_finished to keep this run's widget values.
+                            # A callback may have queued an st.rerun(). Check now
+                            # — while has_script_started is still False — so
+                            # on_script_finished preserves this run's widget values.
                             self._maybe_handle_execution_control_request()
 
                     ctx.on_script_start()

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -57,10 +57,9 @@ class RerunData:
     is_fragment_scoped_rerun: bool = False
     # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
-    # When True, widget_states carry values but callbacks should not re-fire.
-    # Used by the forced full-app rerun that escalates a targeted rerun from a
-    # main-script interaction: the callbacks already ran, and the body just needs
-    # to see the submitted values (including form submit triggers).
+    # When True, apply widget_states but skip callback dispatch.
+    # Set by _request_full_app_rerun when a callback-less widget vote adds a
+    # full-app rerun after callbacks have already run in this interaction.
     suppress_callbacks: bool = False
     # Hashes of messages that are cached in the client browser:
     cached_message_hashes: frozenset[str] = field(default_factory=frozenset)

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -58,8 +58,8 @@ class RerunData:
     # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
     # When True, apply widget_states but skip callback dispatch.
-    # Set by _request_full_app_rerun when a callback-less widget vote adds a
-    # full-app rerun after callbacks have already run in this interaction.
+    # Set by _request_full_app_rerun when a normally returning callback
+    # requests the interaction default after callbacks have already run.
     suppress_callbacks: bool = False
     # Hashes of messages that are cached in the client browser:
     cached_message_hashes: frozenset[str] = field(default_factory=frozenset)

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -116,16 +116,12 @@ def _coalesce_widget_states(
     *,
     old_suppress_callbacks: bool = False,
 ) -> WidgetStates | None:
-    """Coalesce an older WidgetStates into a newer one, and return a new
-    WidgetStates containing the result.
+    """Merge an older WidgetStates into a newer one, returning the result.
 
-    For most widget values, we just take the latest version.
-
-    However, any trigger_values (which are set by buttons) that are True in
-    `old_states` will be set to True in the coalesced result, so that button
-    presses don't go missing — unless the old request had
-    ``suppress_callbacks=True``, meaning those triggers' callbacks already ran
-    and preserving them would cause duplicate execution on the merged run.
+    For most widgets the newer value wins.  Button and chat-input triggers are
+    special: an active trigger in ``old_states`` carries forward so rapid clicks
+    aren't lost — unless ``old_suppress_callbacks`` is True, meaning those
+    triggers' callbacks already ran and re-preserving them would fire duplicates.
     """
     if not old_states and not new_states:
         return None

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -57,6 +57,11 @@ class RerunData:
     is_fragment_scoped_rerun: bool = False
     # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
+    # When True, widget_states carry values but callbacks should not re-fire.
+    # Used by the forced full-app rerun that escalates a targeted rerun from a
+    # main-script interaction: the callbacks already ran, and the body just needs
+    # to see the submitted values (including form submit triggers).
+    suppress_callbacks: bool = False
     # Hashes of messages that are cached in the client browser:
     cached_message_hashes: frozenset[str] = field(default_factory=frozenset)
     # context_info is used to store information from the user browser (e.g. timezone)
@@ -263,6 +268,10 @@ class ScriptRequests:
                     cached_message_hashes=new_data.cached_message_hashes,
                     is_fragment_scoped_rerun=is_fragment_scoped_rerun,
                     is_auto_rerun=new_data.is_auto_rerun,
+                    suppress_callbacks=(
+                        self._rerun_data.suppress_callbacks
+                        or new_data.suppress_callbacks
+                    ),
                     context_info=new_data.context_info,
                 )
 

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -54,6 +54,10 @@ class RerunData:
     fragment_id: str | None = None
     # The queue of fragment_ids waiting to be run.
     fragment_id_queue: list[str] = field(default_factory=list)
+    # True when the user explicitly scoped the rerun to fragment(s) — via
+    # scope="fragment" (self-targeting) or a key / list of keys (targeting
+    # other fragments by name). False for default widget-interaction reruns
+    # inside a fragment, even though those also populate fragment_id_queue.
     is_fragment_scoped_rerun: bool = False
     # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -267,10 +267,7 @@ class ScriptRequests:
                     cached_message_hashes=new_data.cached_message_hashes,
                     is_fragment_scoped_rerun=is_fragment_scoped_rerun,
                     is_auto_rerun=new_data.is_auto_rerun,
-                    suppress_callbacks=(
-                        self._rerun_data.suppress_callbacks
-                        or new_data.suppress_callbacks
-                    ),
+                    suppress_callbacks=new_data.suppress_callbacks,
                     context_info=new_data.context_info,
                 )
 

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -111,7 +111,10 @@ def _fragment_run_should_not_preempt_script(
 
 
 def _coalesce_widget_states(
-    old_states: WidgetStates | None, new_states: WidgetStates | None
+    old_states: WidgetStates | None,
+    new_states: WidgetStates | None,
+    *,
+    old_suppress_callbacks: bool = False,
 ) -> WidgetStates | None:
     """Coalesce an older WidgetStates into a newer one, and return a new
     WidgetStates containing the result.
@@ -120,7 +123,9 @@ def _coalesce_widget_states(
 
     However, any trigger_values (which are set by buttons) that are True in
     `old_states` will be set to True in the coalesced result, so that button
-    presses don't go missing.
+    presses don't go missing — unless the old request had
+    ``suppress_callbacks=True``, meaning those triggers' callbacks already ran
+    and preserving them would cause duplicate execution on the merged run.
     """
     if not old_states and not new_states:
         return None
@@ -133,33 +138,37 @@ def _coalesce_widget_states(
         wstate.id: wstate for wstate in new_states.widgets
     }
 
-    trigger_value_types = [
-        ("trigger_value", False),
-        ("chat_input_value", ChatInputValueProto(data=None)),
-    ]
-    for old_state in old_states.widgets:
-        for trigger_value_type, unset_value in trigger_value_types:
-            if (
-                old_state.WhichOneof("value") == trigger_value_type
-                and getattr(old_state, trigger_value_type) != unset_value
-            ):
-                new_trigger_val = states_by_id.get(old_state.id)
-                # It should nearly always be the case that new_trigger_val is None
-                # here as trigger values are deleted from the client's WidgetStateManager
-                # as soon as a rerun_script BackMsg is sent to the server. Since it's
-                # impossible to test that the client sends us state in the expected
-                # format in a unit test, we test for this behavior in
-                # e2e_playwright/test_fragment_queue_test.py
-                if not new_trigger_val or (
-                    # Ensure the corresponding new_state is also a trigger;
-                    # otherwise, a widget that was previously a button/chat_input but no
-                    # longer is could get a bad value.
-                    new_trigger_val.WhichOneof("value") == trigger_value_type
-                    # We only want to take the value of old_state if new_trigger_val is
-                    # unset as the old value may be stale if a newer one was entered.
-                    and getattr(new_trigger_val, trigger_value_type) == unset_value
+    if not old_suppress_callbacks:
+        trigger_value_types = [
+            ("trigger_value", False),
+            ("chat_input_value", ChatInputValueProto(data=None)),
+        ]
+        for old_state in old_states.widgets:
+            for trigger_value_type, unset_value in trigger_value_types:
+                if (
+                    old_state.WhichOneof("value") == trigger_value_type
+                    and getattr(old_state, trigger_value_type) != unset_value
                 ):
-                    states_by_id[old_state.id] = old_state
+                    new_trigger_val = states_by_id.get(old_state.id)
+                    # It should nearly always be the case that new_trigger_val
+                    # is None here as trigger values are deleted from the
+                    # client's WidgetStateManager as soon as a rerun_script
+                    # BackMsg is sent to the server. Since it's impossible to
+                    # test that the client sends us state in the expected
+                    # format in a unit test, we test for this behavior in
+                    # e2e_playwright/test_fragment_queue_test.py
+                    if not new_trigger_val or (
+                        # Ensure the corresponding new_state is also a trigger;
+                        # otherwise, a widget that was previously a
+                        # button/chat_input but no longer is could get a bad
+                        # value.
+                        new_trigger_val.WhichOneof("value") == trigger_value_type
+                        # We only want to take the value of old_state if
+                        # new_trigger_val is unset as the old value may be
+                        # stale if a newer one was entered.
+                        and getattr(new_trigger_val, trigger_value_type) == unset_value
+                    ):
+                        states_by_id[old_state.id] = old_state
 
     coalesced = WidgetStates()
     coalesced.widgets.extend(states_by_id.values())
@@ -223,7 +232,9 @@ class ScriptRequests:
                 # rerun request into the existing one.
 
                 coalesced_states = _coalesce_widget_states(
-                    self._rerun_data.widget_states, new_data.widget_states
+                    self._rerun_data.widget_states,
+                    new_data.widget_states,
+                    old_suppress_callbacks=self._rerun_data.suppress_callbacks,
                 )
 
                 # Fold a bare fragment_id into fragment_id_queue so the coalescing

--- a/lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py
@@ -38,6 +38,12 @@ class SharedRunState:
         self.form_ids_this_run: ThreadSafeSet[str] = ThreadSafeSet()
         self.new_fragment_ids: ThreadSafeSet[str] = ThreadSafeSet()
 
+        # Maps each fragment user key to the id of the fragment definition that
+        # claimed it this run, so multiple call sites of one keyed fragment don't
+        # collide while two different definitions sharing a key do.
+        self._fragment_user_keys_lock = threading.Lock()
+        self._fragment_user_keys_this_run: dict[str, str] = {}
+
         self._telemetry_lock = threading.Lock()
         self._tracked_commands: list[Command] = []
         self._tracked_commands_counter: collections.Counter[str] = collections.Counter()
@@ -52,6 +58,9 @@ class SharedRunState:
         self.widget_user_keys_this_run.clear()
         self.form_ids_this_run.clear()
         self.new_fragment_ids.clear()
+
+        with self._fragment_user_keys_lock:
+            self._fragment_user_keys_this_run.clear()
 
         with self._telemetry_lock:
             self._tracked_commands = []
@@ -84,3 +93,17 @@ class SharedRunState:
         """Return how many times a command name has been tracked."""
         with self._telemetry_lock:
             return self._tracked_commands_counter[name]
+
+    def register_fragment_user_key(self, user_key: str, definition_id: str) -> bool:
+        """Atomically claim a fragment user key for the given definition this run.
+
+        Returns True if the key is free or already held by the same fragment
+        definition (multiple call sites of one keyed fragment), and False if a
+        different definition already claimed it this run (a duplicate-key
+        collision).
+        """
+        with self._fragment_user_keys_lock:
+            existing_definition_id = self._fragment_user_keys_this_run.setdefault(
+                user_key, definition_id
+            )
+            return existing_definition_id == definition_id

--- a/lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/shared_run_state.py
@@ -38,12 +38,6 @@ class SharedRunState:
         self.form_ids_this_run: ThreadSafeSet[str] = ThreadSafeSet()
         self.new_fragment_ids: ThreadSafeSet[str] = ThreadSafeSet()
 
-        # Maps each fragment user key to the id of the fragment definition that
-        # claimed it this run, so multiple call sites of one keyed fragment don't
-        # collide while two different definitions sharing a key do.
-        self._fragment_user_keys_lock = threading.Lock()
-        self._fragment_user_keys_this_run: dict[str, str] = {}
-
         self._telemetry_lock = threading.Lock()
         self._tracked_commands: list[Command] = []
         self._tracked_commands_counter: collections.Counter[str] = collections.Counter()
@@ -58,9 +52,6 @@ class SharedRunState:
         self.widget_user_keys_this_run.clear()
         self.form_ids_this_run.clear()
         self.new_fragment_ids.clear()
-
-        with self._fragment_user_keys_lock:
-            self._fragment_user_keys_this_run.clear()
 
         with self._telemetry_lock:
             self._tracked_commands = []
@@ -93,17 +84,3 @@ class SharedRunState:
         """Return how many times a command name has been tracked."""
         with self._telemetry_lock:
             return self._tracked_commands_counter[name]
-
-    def register_fragment_user_key(self, user_key: str, definition_id: str) -> bool:
-        """Atomically claim a fragment user key for the given definition this run.
-
-        Returns True if the key is free or already held by the same fragment
-        definition (multiple call sites of one keyed fragment), and False if a
-        different definition already claimed it this run (a duplicate-key
-        collision).
-        """
-        with self._fragment_user_keys_lock:
-            existing_definition_id = self._fragment_user_keys_this_run.setdefault(
-                user_key, definition_id
-            )
-            return existing_definition_id == definition_id

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -58,14 +58,21 @@ class SafeSessionState:
         with self._lock:
             return self._state.register_widget(metadata, user_key)
 
-    def on_script_will_rerun(self, latest_widget_states: WidgetStatesProto) -> None:
+    def on_script_will_rerun(
+        self,
+        latest_widget_states: WidgetStatesProto,
+        *,
+        suppress_callbacks: bool = False,
+    ) -> None:
         self._yield_callback()
         with self._lock:
             # TODO: rewrite this to copy the callbacks list into a local
             #  variable so that we don't need to hold our lock for the
             #  duration. (This will also allow us to downgrade our RLock
             #  to a Lock.)
-            self._state.on_script_will_rerun(latest_widget_states)
+            self._state.on_script_will_rerun(
+                latest_widget_states, suppress_callbacks=suppress_callbacks
+            )
 
     def on_script_finished(
         self,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1281,26 +1281,18 @@ class SessionState:
         """Set all trigger values in our state dictionary to False."""
         for state_id in self._new_widget_state:
             metadata = self._new_widget_state.widget_metadata.get(state_id)
-            if metadata is not None:
+            if metadata is not None and metadata.value_type in _TRIGGER_PROTO_FIELDS:
                 if metadata.value_type == "trigger_value":
                     self._new_widget_state[state_id] = Value(False)
-                elif metadata.value_type in {
-                    "string_trigger_value",
-                    "chat_input_value",
-                    "json_trigger_value",
-                }:
+                else:
                     self._new_widget_state[state_id] = Value(None)
 
         for state_id in self._old_state:
             metadata = self._new_widget_state.widget_metadata.get(state_id)
-            if metadata is not None:
+            if metadata is not None and metadata.value_type in _TRIGGER_PROTO_FIELDS:
                 if metadata.value_type == "trigger_value":
                     self._old_state[state_id] = False
-                elif metadata.value_type in {
-                    "string_trigger_value",
-                    "chat_input_value",
-                    "json_trigger_value",
-                }:
+                else:
                     self._old_state[state_id] = None
 
     def _remove_stale_widgets(self, active_widget_ids: frozenset[str]) -> None:

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -90,6 +90,15 @@ SCRIPT_RUN_WITHOUT_ERRORS_KEY: Final = (
     f"{STREAMLIT_INTERNAL_KEY_PREFIX}_SCRIPT_RUN_WITHOUT_ERRORS"
 )
 
+_TRIGGER_PROTO_FIELDS: Final = frozenset(
+    {
+        "trigger_value",
+        "string_trigger_value",
+        "chat_input_value",
+        "json_trigger_value",
+    }
+)
+
 
 def _sanitize_url_array(
     parsed: list[str],
@@ -1060,12 +1069,13 @@ class SessionState:
             votes.wants_interaction_default = True
 
     def _request_full_app_rerun(self) -> None:
-        """Queue a full-app rerun that replays widget values without re-firing callbacks.
+        """Queue a full-app rerun that replays trigger values without re-firing callbacks.
 
         Called when a normally-returning callback's default vote coexists with
-        a targeted rerun in a main-script interaction. Forwards the current
-        interaction's ``widget_states`` with ``suppress_callbacks=True`` so the
-        body sees submitted values (including form triggers) in the follow-up run.
+        a targeted rerun in a main-script interaction. Only trigger widget
+        states are forwarded — non-trigger values already live in session state
+        from callback execution. Replaying the full proto would overwrite any
+        mutations callbacks made via ``st.session_state["key"] = new_value``.
 
         This differs from a plain ``st.rerun()`` in a callback, which starts a
         *new* script run with ``widget_states=None`` — the interaction's values
@@ -1078,16 +1088,38 @@ class SessionState:
 
         ctx = get_script_run_ctx()
         if ctx and ctx.script_requests:
+            trigger_only_states = self._filter_trigger_widget_states(
+                self._current_interaction_widget_states
+            )
             ctx.script_requests.request_rerun(
                 RerunData(
                     query_string=ctx.query_string,
                     page_script_hash=ctx.page_script_hash,
-                    widget_states=self._current_interaction_widget_states,
+                    widget_states=trigger_only_states,
                     suppress_callbacks=True,
                     cached_message_hashes=ctx.cached_message_hashes,
                     context_info=ctx.context_info,
                 )
             )
+
+    def _filter_trigger_widget_states(
+        self, widget_states: WidgetStatesProto | None
+    ) -> WidgetStatesProto | None:
+        """Return a new WidgetStatesProto containing only trigger-type entries.
+
+        Trigger widgets have ephemeral values that reset after each run, so
+        they must be replayed for the script body to observe them. Non-trigger
+        values persist in session state and replaying them would overwrite
+        any callback mutations.
+        """
+        if widget_states is None:
+            return None
+
+        filtered = WidgetStatesProto()
+        for widget in widget_states.widgets:
+            if widget.WhichOneof("value") in _TRIGGER_PROTO_FIELDS:
+                filtered.widgets.append(widget)
+        return filtered if filtered.widgets else None
 
     def _dispatch_trigger_callbacks(
         self,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1076,13 +1076,6 @@ class SessionState:
         states are forwarded — non-trigger values already live in session state
         from callback execution. Replaying the full proto would overwrite any
         mutations callbacks made via ``st.session_state["key"] = new_value``.
-
-        This differs from a plain ``st.rerun()`` in a callback, which starts a
-        *new* script run with ``widget_states=None`` — the interaction's values
-        are already in session state, and triggers were consumed during this run.
-        The escalated run is a *continuation* of the same interaction: the body
-        hasn't executed yet, so triggers must be re-applied to produce the
-        output the un-escalated interaction would have shown.
         """
         from streamlit.runtime.scriptrunner import RerunData
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -911,10 +911,12 @@ class SessionState:
         self._compact_state()
         self.set_widgets_from_proto(latest_widget_states)
         if suppress_callbacks:
-            self._current_interaction_widget_states = None
             return
         self._current_interaction_widget_states = latest_widget_states
-        self._call_callbacks()
+        try:
+            self._call_callbacks()
+        finally:
+            self._current_interaction_widget_states = None
 
     def _call_callbacks(self) -> None:
         """Call callbacks for widgets whose value changed or whose trigger fired,
@@ -1064,6 +1066,13 @@ class SessionState:
         a targeted rerun in a main-script interaction. Forwards the current
         interaction's ``widget_states`` with ``suppress_callbacks=True`` so the
         body sees submitted values (including form triggers) in the follow-up run.
+
+        This differs from a plain ``st.rerun()`` in a callback, which starts a
+        *new* script run with ``widget_states=None`` — the interaction's values
+        are already in session state, and triggers were consumed during this run.
+        The escalated run is a *continuation* of the same interaction: the body
+        hasn't executed yet, so triggers must be re-applied to produce the
+        output the un-escalated interaction would have shown.
         """
         from streamlit.runtime.scriptrunner import RerunData
 

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -621,8 +621,8 @@ class _CallbackRerunVotes:
     the requests and decide the interaction's rerun scope.
     """
 
-    # A callback asked to rerun specific fragments rather than the whole app
-    # (``is_fragment_scoped_rerun=True``, i.e. ``scope="fragment"``).
+    # A callback requested specific fragment targets (non-empty fragment_id_queue),
+    # whether via scope="fragment" or a keyed scope like scope="charts".
     requested_targeted: bool = False
     # A callback explicitly expects the interaction's default rerun: it returned
     # normally or called plain st.rerun().

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -683,7 +683,7 @@ class SessionState:
     # on_script_will_rerun stashes this so _request_full_app_rerun can forward
     # the values (including triggers) in its follow-up rerun.  Without the
     # stash the proto would be a local variable unreachable by the time the
-    # callback-less vote fires.  Cleared after callbacks finish or when
+    # escalation fires.  Cleared after callbacks finish or when
     # suppress_callbacks skips dispatch.
     _current_interaction_widget_states: WidgetStatesProto | None = field(
         default=None, repr=False

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -679,6 +679,12 @@ class SessionState:
         default_factory=PersistedWidgetTracker
     )
 
+    # The proto widget_states from the current interaction, stashed during
+    # on_script_will_rerun so _request_full_app_rerun can forward them.
+    _current_interaction_widget_states: WidgetStatesProto | None = field(
+        default=None, repr=False
+    )
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -879,16 +885,32 @@ class SessionState:
         for state in widget_states.widgets:
             self._new_widget_state.set_widget_from_proto(state)
 
-    def on_script_will_rerun(self, latest_widget_states: WidgetStatesProto) -> None:
+    def on_script_will_rerun(
+        self,
+        latest_widget_states: WidgetStatesProto,
+        *,
+        suppress_callbacks: bool = False,
+    ) -> None:
         """Called by ScriptRunner before its script re-runs.
 
         Update widget data and call callbacks on widgets whose value changed
         between the previous and current script runs.
+
+        Parameters
+        ----------
+        suppress_callbacks
+            When True, apply the widget values but skip callback dispatch.
+            Used by the forced full-app rerun that escalates a targeted rerun:
+            the callbacks already ran, and the body just needs to see the
+            submitted values (including form submit triggers).
         """
-        # Clear any triggers that weren't reset because the script was disconnected
         self._reset_triggers()
         self._compact_state()
         self.set_widgets_from_proto(latest_widget_states)
+        if suppress_callbacks:
+            self._current_interaction_widget_states = None
+            return
+        self._current_interaction_widget_states = latest_widget_states
         self._call_callbacks()
 
     def _call_callbacks(self) -> None:
@@ -1015,7 +1037,7 @@ class SessionState:
         the last callback has run (see the comment there for why it waits), and the
         callback's rerun scope is recorded as:
 
-        - a fragment-scoped rerun → ``requested_targeted``
+        - a targeted rerun (non-empty ``fragment_id_queue``) → ``requested_targeted``
         - a plain ``st.rerun()``, or a normal return → ``wants_interaction_default``
         """
         from streamlit.runtime.scriptrunner import RerunException
@@ -1024,7 +1046,7 @@ class SessionState:
             run()
         except RerunException as e:
             rerun_data = e.rerun_data
-            if rerun_data.is_fragment_scoped_rerun:
+            if rerun_data.fragment_id_queue:
                 votes.requested_targeted = True
             else:
                 votes.wants_interaction_default = True
@@ -1036,7 +1058,9 @@ class SessionState:
         """Queue a full-app rerun that replays widget values without re-firing callbacks.
 
         Called when a normally-returning callback's default vote coexists with
-        a targeted rerun in a main-script interaction.
+        a targeted rerun in a main-script interaction. Forwards the current
+        interaction's ``widget_states`` with ``suppress_callbacks=True`` so the
+        body sees submitted values (including form triggers) in the follow-up run.
         """
         from streamlit.runtime.scriptrunner import RerunData
 
@@ -1046,6 +1070,8 @@ class SessionState:
                 RerunData(
                     query_string=ctx.query_string,
                     page_script_hash=ctx.page_script_hash,
+                    widget_states=self._current_interaction_widget_states,
+                    suppress_callbacks=True,
                     cached_message_hashes=ctx.cached_message_hashes,
                     context_info=ctx.context_info,
                 )

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -679,8 +679,12 @@ class SessionState:
         default_factory=PersistedWidgetTracker
     )
 
-    # The proto widget_states from the current interaction, stashed during
-    # on_script_will_rerun so _request_full_app_rerun can forward them.
+    # The widget_states proto for the current interaction.
+    # on_script_will_rerun stashes this so _request_full_app_rerun can forward
+    # the values (including triggers) in its follow-up rerun.  Without the
+    # stash the proto would be a local variable unreachable by the time the
+    # callback-less vote fires.  Cleared after callbacks finish or when
+    # suppress_callbacks skips dispatch.
     _current_interaction_widget_states: WidgetStatesProto | None = field(
         default=None, repr=False
     )
@@ -899,10 +903,9 @@ class SessionState:
         Parameters
         ----------
         suppress_callbacks
-            When True, apply the widget values but skip callback dispatch.
-            Used by the forced full-app rerun that escalates a targeted rerun:
-            the callbacks already ran, and the body just needs to see the
-            submitted values (including form submit triggers).
+            When True, apply widget values but skip callback dispatch.
+            Set on the full-app rerun queued by ``_request_full_app_rerun``
+            after callbacks have already run in this interaction.
         """
         self._reset_triggers()
         self._compact_state()

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -173,13 +173,13 @@ def test_key_scope_resolves_target_without_queueing(patched_get_script_run_ctx) 
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
-def test_key_scope_from_fragment_callback_composes(
+def test_key_scope_from_fragment_callback_preempts(
     patched_get_script_run_ctx,
 ) -> None:
-    """st.rerun('charts') from a fragment widget sets is_fragment_scoped_rerun=False.
+    """st.rerun('charts') from a fragment widget sets is_fragment_scoped_rerun=True.
 
-    A fragment-origin keyed target composes with the enclosing fragment: the fragment
-    finishes, then the target runs.
+    A keyed target always replaces the interaction's default rerun, regardless of
+    whether the triggering widget lives in the main script or inside a fragment.
     """
     ctx = MagicMock()
     ctx.fragment_storage.resolve_target.return_value = ["frag_id_1"]
@@ -193,7 +193,7 @@ def test_key_scope_from_fragment_callback_composes(
     ctx.script_requests.request_rerun.assert_not_called()
     data = exc_info.value.rerun_data
     assert data.fragment_id_queue == ["frag_id_1"]
-    assert data.is_fragment_scoped_rerun is False
+    assert data.is_fragment_scoped_rerun is True
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -164,6 +164,12 @@ def test_st_rerun_list_with_fragment_raises() -> None:
         rerun(["fragment"])
 
 
+def test_st_rerun_list_with_non_string_raises() -> None:
+    """st.rerun([1, 2]) raises StreamlitAPIException for non-string items."""
+    with pytest.raises(StreamlitAPIException, match="strings"):
+        rerun([1, 2])
+
+
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
 def test_key_scope_resolves_target_without_queueing(patched_get_script_run_ctx) -> None:
     """st.rerun('charts') resolves the key via fragment_storage but does not

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -124,21 +124,6 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_true(patched_get_script_run_ctx)
     )
 
 
-def test_st_rerun_key_scope_outside_callback_throws_error() -> None:
-    """A string scope other than 'app'/'fragment' (a fragment key) raises when
-    called from outside a widget callback (e.g. the main script body).
-    """
-    with patch(
-        "streamlit.commands.execution_control.get_script_run_ctx"
-    ) as mock_ctx_fn:
-        ctx = MagicMock()
-        mock_ctx_fn.return_value = ctx
-        ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
-
-        with pytest.raises(StreamlitAPIException, match="widget callback"):
-            rerun(scope="foo")
-
-
 def test_st_rerun_scope_positional() -> None:
     """scope can be passed positionally, not just as a keyword argument."""
     with patch(
@@ -161,6 +146,17 @@ def test_st_rerun_empty_list_is_noop() -> None:
         ctx = MagicMock()
         mock_ctx_fn.return_value = ctx
         rerun([])
+        ctx.script_requests.request_rerun.assert_not_called()
+
+
+def test_st_rerun_empty_string_is_noop() -> None:
+    """st.rerun('') does not raise and does not request a rerun."""
+    with patch(
+        "streamlit.commands.execution_control.get_script_run_ctx"
+    ) as mock_ctx_fn:
+        ctx = MagicMock()
+        mock_ctx_fn.return_value = ctx
+        rerun("")
         ctx.script_requests.request_rerun.assert_not_called()
 
 
@@ -218,6 +214,7 @@ def test_list_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> N
     ctx.fragment_storage.resolve_target.assert_called_once_with(["charts", "table"])
     call = ctx.script_requests.request_rerun.call_args[0][0]
     assert call.fragment_id_queue == ["frag_1", "frag_2"]
+    assert call.is_fragment_scoped_rerun is True
 
 
 def test_key_scope_raises_outside_callback() -> None:

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -31,11 +31,13 @@ from streamlit.errors import (
     StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
     StreamlitPageNotFoundError,
-    StreamlitValueError,
 )
 from streamlit.navigation.page import Page
 from streamlit.runtime.scriptrunner import RerunData
-from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    RunLocation,
+    ThreadState,
+)
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -122,9 +124,121 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_true(patched_get_script_run_ctx)
     )
 
 
-def test_st_rerun_invalid_scope_throws_error():
-    with pytest.raises(StreamlitValueError):
-        rerun(scope="foo")
+def test_st_rerun_key_scope_outside_callback_throws_error() -> None:
+    """A string scope other than 'app'/'fragment' (a fragment key) raises when
+    called from outside a widget callback (e.g. the main script body).
+    """
+    with patch(
+        "streamlit.commands.execution_control.get_script_run_ctx"
+    ) as mock_ctx_fn:
+        ctx = MagicMock()
+        mock_ctx_fn.return_value = ctx
+        ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
+
+        with pytest.raises(StreamlitAPIException, match="widget callback"):
+            rerun(scope="foo")
+
+
+def test_st_rerun_scope_positional() -> None:
+    """scope can be passed positionally, not just as a keyword argument."""
+    with patch(
+        "streamlit.commands.execution_control.get_script_run_ctx"
+    ) as mock_ctx_fn:
+        ctx = MagicMock()
+        mock_ctx_fn.return_value = ctx
+        # "app" positionally should produce is_fragment_scoped_rerun=False.
+        rerun("app")
+        ctx.script_requests.request_rerun.assert_called_once()
+        call = ctx.script_requests.request_rerun.call_args[0][0]
+        assert call.is_fragment_scoped_rerun is False
+
+
+def test_st_rerun_empty_list_is_noop() -> None:
+    """st.rerun([]) does not raise and does not request a rerun."""
+    with patch(
+        "streamlit.commands.execution_control.get_script_run_ctx"
+    ) as mock_ctx_fn:
+        ctx = MagicMock()
+        mock_ctx_fn.return_value = ctx
+        rerun([])
+        ctx.script_requests.request_rerun.assert_not_called()
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_key_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> None:
+    """st.rerun('charts') calls fragment_storage.resolve_target and queues the result."""
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_id_1"]
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize(run_location=RunLocation.CALLBACK)
+
+    rerun("charts")
+
+    ctx.fragment_storage.resolve_target.assert_called_once_with("charts")
+    ctx.script_requests.request_rerun.assert_called_once()
+    call = ctx.script_requests.request_rerun.call_args[0][0]
+    assert call.fragment_id_queue == ["frag_id_1"]
+    assert call.is_fragment_scoped_rerun is True
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_list_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> None:
+    """st.rerun(['charts', 'table']) passes the list to resolve_target."""
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_1", "frag_2"]
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize(run_location=RunLocation.CALLBACK)
+
+    rerun(["charts", "table"])
+
+    ctx.fragment_storage.resolve_target.assert_called_once_with(["charts", "table"])
+    call = ctx.script_requests.request_rerun.call_args[0][0]
+    assert call.fragment_id_queue == ["frag_1", "frag_2"]
+
+
+def test_key_scope_raises_outside_callback() -> None:
+    """Passing a fragment key from the main script body raises StreamlitAPIException."""
+    with patch(
+        "streamlit.commands.execution_control.get_script_run_ctx"
+    ) as mock_ctx_fn:
+        ctx = MagicMock()
+        mock_ctx_fn.return_value = ctx
+        ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
+
+        with pytest.raises(StreamlitAPIException, match="widget callback"):
+            rerun("charts")
+
+
+def test_key_scope_raises_from_fragment_body() -> None:
+    """Passing a fragment key from inside a fragment body raises StreamlitAPIException."""
+    with patch(
+        "streamlit.commands.execution_control.get_script_run_ctx"
+    ) as mock_ctx_fn:
+        ctx = MagicMock()
+        mock_ctx_fn.return_value = ctx
+        ThreadState.initialize(run_location=RunLocation.FRAGMENT)
+
+        with pytest.raises(StreamlitAPIException, match="widget callback"):
+            rerun("charts")
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_key_scope_unknown_name_propagates_exception(
+    patched_get_script_run_ctx,
+) -> None:
+    """resolve_target's StreamlitAPIException propagates uncaught from st.rerun()."""
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.side_effect = StreamlitAPIException(
+        "No fragment found for target 'unknown'"
+    )
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize(run_location=RunLocation.CALLBACK)
+
+    with pytest.raises(StreamlitAPIException, match="No fragment found"):
+        rerun("unknown")
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -160,6 +160,12 @@ def test_st_rerun_list_with_reserved_name_raises(reserved: str) -> None:
         rerun([reserved])
 
 
+def test_st_rerun_list_with_empty_string_raises() -> None:
+    """st.rerun(["charts", ""]) raises StreamlitValueError for empty string items."""
+    with pytest.raises(StreamlitValueError, match="empty string"):
+        rerun(["charts", ""])
+
+
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
 def test_st_rerun_list_with_int_items_normalizes(
     patched_get_script_run_ctx: MagicMock,

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -140,17 +140,6 @@ def test_st_rerun_scope_positional() -> None:
         assert call.is_fragment_scoped_rerun is False
 
 
-def test_st_rerun_empty_list_is_noop() -> None:
-    """st.rerun([]) does not raise and does not request a rerun."""
-    with patch(
-        "streamlit.commands.execution_control.get_script_run_ctx"
-    ) as mock_ctx_fn:
-        ctx = MagicMock()
-        mock_ctx_fn.return_value = ctx
-        rerun([])
-        ctx.script_requests.request_rerun.assert_not_called()
-
-
 def test_st_rerun_empty_string_raises() -> None:
     """st.rerun('') raises StreamlitAPIException."""
     with pytest.raises(StreamlitAPIException, match="empty string scope"):
@@ -176,11 +165,10 @@ def test_key_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> No
         rerun("charts")
 
     ctx.fragment_storage.resolve_target.assert_called_once_with("charts")
-    ctx.script_requests.request_rerun.assert_called_once()
-    call = ctx.script_requests.request_rerun.call_args[0][0]
-    assert call.fragment_id_queue == ["frag_id_1"]
-    assert call.is_fragment_scoped_rerun is True
-    assert exc_info.value.rerun_data is call
+    ctx.script_requests.request_rerun.assert_not_called()
+    data = exc_info.value.rerun_data
+    assert data.fragment_id_queue == ["frag_id_1"]
+    assert data.is_fragment_scoped_rerun is True
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
@@ -201,10 +189,10 @@ def test_key_scope_from_fragment_callback_composes(
     with pytest.raises(RerunException) as exc_info:
         rerun("charts")
 
-    call = ctx.script_requests.request_rerun.call_args[0][0]
-    assert call.fragment_id_queue == ["frag_id_1"]
-    assert call.is_fragment_scoped_rerun is False
-    assert exc_info.value.rerun_data is call
+    ctx.script_requests.request_rerun.assert_not_called()
+    data = exc_info.value.rerun_data
+    assert data.fragment_id_queue == ["frag_id_1"]
+    assert data.is_fragment_scoped_rerun is False
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
@@ -241,13 +229,14 @@ def test_list_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> N
 
     ThreadState.initialize(run_location=RunLocation.CALLBACK)
 
-    with pytest.raises(RerunException):
+    with pytest.raises(RerunException) as exc_info:
         rerun(["charts", "table"])
 
     ctx.fragment_storage.resolve_target.assert_called_once_with(["charts", "table"])
-    call = ctx.script_requests.request_rerun.call_args[0][0]
-    assert call.fragment_id_queue == ["frag_1", "frag_2"]
-    assert call.is_fragment_scoped_rerun is True
+    ctx.script_requests.request_rerun.assert_not_called()
+    data = exc_info.value.rerun_data
+    assert data.fragment_id_queue == ["frag_1", "frag_2"]
+    assert data.is_fragment_scoped_rerun is True
 
 
 def test_key_scope_raises_outside_callback() -> None:

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -31,6 +31,7 @@ from streamlit.errors import (
     StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
     StreamlitPageNotFoundError,
+    StreamlitValueError,
 )
 from streamlit.navigation.page import Page
 from streamlit.runtime.scriptrunner import RerunData, RerunException
@@ -141,33 +142,77 @@ def test_st_rerun_scope_positional() -> None:
 
 
 def test_st_rerun_empty_string_raises() -> None:
-    """st.rerun('') raises StreamlitAPIException."""
-    with pytest.raises(StreamlitAPIException, match="empty string scope"):
+    """st.rerun('') raises StreamlitValueError."""
+    with pytest.raises(StreamlitValueError, match="empty string"):
         rerun("")
 
 
 def test_st_rerun_empty_list_raises() -> None:
-    """st.rerun([]) raises StreamlitAPIException."""
-    with pytest.raises(StreamlitAPIException, match="empty list scope"):
+    """st.rerun([]) raises StreamlitValueError."""
+    with pytest.raises(StreamlitValueError, match="empty list"):
         rerun([])
 
 
-def test_st_rerun_list_with_app_raises() -> None:
-    """st.rerun(['app']) raises StreamlitAPIException for reserved name."""
-    with pytest.raises(StreamlitAPIException, match="reserved"):
-        rerun(["app"])
+@pytest.mark.parametrize("reserved", ["app", "fragment"])
+def test_st_rerun_list_with_reserved_name_raises(reserved: str) -> None:
+    """st.rerun([<reserved>]) raises StreamlitValueError for reserved names."""
+    with pytest.raises(StreamlitValueError, match="reserved scope name"):
+        rerun([reserved])
 
 
-def test_st_rerun_list_with_fragment_raises() -> None:
-    """st.rerun(['fragment']) raises StreamlitAPIException for reserved name."""
-    with pytest.raises(StreamlitAPIException, match="reserved"):
-        rerun(["fragment"])
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_st_rerun_list_with_int_items_normalizes(
+    patched_get_script_run_ctx: MagicMock,
+) -> None:
+    """st.rerun([1, 2]) normalizes int items to strings and resolves them."""
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_1", "frag_2"]
+    patched_get_script_run_ctx.return_value = ctx
 
+    ThreadState.initialize(run_location=RunLocation.CALLBACK)
 
-def test_st_rerun_list_with_non_string_raises() -> None:
-    """st.rerun([1, 2]) raises StreamlitAPIException for non-string items."""
-    with pytest.raises(StreamlitAPIException, match="strings"):
+    with pytest.raises(RerunException) as exc_info:
         rerun([1, 2])
+
+    ctx.fragment_storage.resolve_target.assert_called_once_with(["1", "2"])
+    data = exc_info.value.rerun_data
+    assert data.fragment_id_queue == ["frag_1", "frag_2"]
+
+
+def test_st_rerun_list_with_invalid_type_raises() -> None:
+    """st.rerun([3.14]) raises StreamlitInvalidParameterTypeError for non-string/non-int items."""
+    with pytest.raises(StreamlitInvalidParameterTypeError):
+        rerun([3.14])
+
+
+def test_st_rerun_invalid_scope_type_raises() -> None:
+    """st.rerun(scope=3.14) raises StreamlitInvalidParameterTypeError for unsupported types."""
+    with pytest.raises(StreamlitInvalidParameterTypeError):
+        rerun(3.14)
+
+
+def test_st_rerun_bytes_scope_raises() -> None:
+    """st.rerun(b"charts") raises StreamlitInvalidParameterTypeError."""
+    with pytest.raises(StreamlitInvalidParameterTypeError):
+        rerun(b"charts")
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_st_rerun_int_scope_normalizes(patched_get_script_run_ctx: MagicMock) -> None:
+    """st.rerun(scope=42) normalizes the int to '42' and resolves it."""
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_42"]
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize(run_location=RunLocation.CALLBACK)
+
+    with pytest.raises(RerunException) as exc_info:
+        rerun(42)
+
+    ctx.fragment_storage.resolve_target.assert_called_once_with("42")
+    data = exc_info.value.rerun_data
+    assert data.fragment_id_queue == ["frag_42"]
+    assert data.is_fragment_scoped_rerun is True
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -152,6 +152,18 @@ def test_st_rerun_empty_list_raises() -> None:
         rerun([])
 
 
+def test_st_rerun_list_with_app_raises() -> None:
+    """st.rerun(['app']) raises StreamlitAPIException for reserved name."""
+    with pytest.raises(StreamlitAPIException, match="reserved"):
+        rerun(["app"])
+
+
+def test_st_rerun_list_with_fragment_raises() -> None:
+    """st.rerun(['fragment']) raises StreamlitAPIException for reserved name."""
+    with pytest.raises(StreamlitAPIException, match="reserved"):
+        rerun(["fragment"])
+
+
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
 def test_key_scope_resolves_target_without_queueing(patched_get_script_run_ctx) -> None:
     """st.rerun('charts') resolves the key via fragment_storage but does not

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -153,8 +153,9 @@ def test_st_rerun_empty_list_raises() -> None:
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
-def test_key_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> None:
-    """st.rerun('charts') calls fragment_storage.resolve_target and queues the result."""
+def test_key_scope_resolves_target_without_queueing(patched_get_script_run_ctx) -> None:
+    """st.rerun('charts') resolves the key via fragment_storage but does not
+    call request_rerun — the request is deferred to _call_callbacks."""
     ctx = MagicMock()
     ctx.fragment_storage.resolve_target.return_value = ["frag_id_1"]
     patched_get_script_run_ctx.return_value = ctx

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -151,15 +151,16 @@ def test_st_rerun_empty_list_is_noop() -> None:
         ctx.script_requests.request_rerun.assert_not_called()
 
 
-def test_st_rerun_empty_string_is_noop() -> None:
-    """st.rerun('') does not raise and does not request a rerun."""
-    with patch(
-        "streamlit.commands.execution_control.get_script_run_ctx"
-    ) as mock_ctx_fn:
-        ctx = MagicMock()
-        mock_ctx_fn.return_value = ctx
+def test_st_rerun_empty_string_raises() -> None:
+    """st.rerun('') raises StreamlitAPIException."""
+    with pytest.raises(StreamlitAPIException, match="empty string scope"):
         rerun("")
-        ctx.script_requests.request_rerun.assert_not_called()
+
+
+def test_st_rerun_empty_list_raises() -> None:
+    """st.rerun([]) raises StreamlitAPIException."""
+    with pytest.raises(StreamlitAPIException, match="empty list scope"):
+        rerun([])
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -33,7 +33,7 @@ from streamlit.errors import (
     StreamlitPageNotFoundError,
 )
 from streamlit.navigation.page import Page
-from streamlit.runtime.scriptrunner import RerunData
+from streamlit.runtime.scriptrunner import RerunData, RerunException
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
     RunLocation,
     ThreadState,
@@ -86,6 +86,7 @@ class NewFragmentIdQueueTest(unittest.TestCase):
 def test_st_rerun_is_fragment_scoped_rerun_flag_false(patched_get_script_run_ctx):
     ctx = MagicMock()
     patched_get_script_run_ctx.return_value = ctx
+    ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
 
     rerun(scope="app")
 
@@ -109,6 +110,7 @@ def test_st_rerun_is_fragment_scoped_rerun_flag_false(patched_get_script_run_ctx
 def test_st_rerun_is_fragment_scoped_rerun_flag_true(patched_get_script_run_ctx):
     ctx = MagicMock()
     patched_get_script_run_ctx.return_value = ctx
+    ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
 
     rerun(scope="fragment")
 
@@ -131,7 +133,7 @@ def test_st_rerun_scope_positional() -> None:
     ) as mock_ctx_fn:
         ctx = MagicMock()
         mock_ctx_fn.return_value = ctx
-        # "app" positionally should produce is_fragment_scoped_rerun=False.
+        ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
         rerun("app")
         ctx.script_requests.request_rerun.assert_called_once()
         call = ctx.script_requests.request_rerun.call_args[0][0]
@@ -169,13 +171,15 @@ def test_key_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> No
 
     ThreadState.initialize(run_location=RunLocation.CALLBACK)
 
-    rerun("charts")
+    with pytest.raises(RerunException) as exc_info:
+        rerun("charts")
 
     ctx.fragment_storage.resolve_target.assert_called_once_with("charts")
     ctx.script_requests.request_rerun.assert_called_once()
     call = ctx.script_requests.request_rerun.call_args[0][0]
     assert call.fragment_id_queue == ["frag_id_1"]
     assert call.is_fragment_scoped_rerun is True
+    assert exc_info.value.rerun_data is call
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
@@ -193,11 +197,38 @@ def test_key_scope_from_fragment_callback_composes(
 
     ThreadState.initialize(run_location=RunLocation.CALLBACK, fragment_id="enclosing")
 
-    rerun("charts")
+    with pytest.raises(RerunException) as exc_info:
+        rerun("charts")
 
     call = ctx.script_requests.request_rerun.call_args[0][0]
     assert call.fragment_id_queue == ["frag_id_1"]
     assert call.is_fragment_scoped_rerun is False
+    assert exc_info.value.rerun_data is call
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_callback_rerun_always_raises_rerun_exception(
+    patched_get_script_run_ctx,
+) -> None:
+    """st.rerun() from a callback raises RerunException directly for all scopes.
+
+    This ensures the callback halts immediately and _run_callback_and_record_rerun
+    can classify the request, regardless of the compose/preempt flag.
+    """
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_id"]
+    patched_get_script_run_ctx.return_value = ctx
+
+    for scope, fragment_id in [
+        ("app", None),
+        ("charts", None),
+        ("charts", "enclosing"),
+    ]:
+        ThreadState.initialize(
+            run_location=RunLocation.CALLBACK, fragment_id=fragment_id
+        )
+        with pytest.raises(RerunException):
+            rerun(scope)
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
@@ -209,7 +240,8 @@ def test_list_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> N
 
     ThreadState.initialize(run_location=RunLocation.CALLBACK)
 
-    rerun(["charts", "table"])
+    with pytest.raises(RerunException):
+        rerun(["charts", "table"])
 
     ctx.fragment_storage.resolve_target.assert_called_once_with(["charts", "table"])
     call = ctx.script_requests.request_rerun.call_args[0][0]

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -183,6 +183,28 @@ def test_key_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> No
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_key_scope_from_fragment_callback_composes(
+    patched_get_script_run_ctx,
+) -> None:
+    """st.rerun('charts') from a fragment widget sets is_fragment_scoped_rerun=False.
+
+    A fragment-origin keyed target composes with the enclosing fragment: the fragment
+    finishes, then the target runs.
+    """
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_id_1"]
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize(run_location=RunLocation.CALLBACK, fragment_id="enclosing")
+
+    rerun("charts")
+
+    call = ctx.script_requests.request_rerun.call_args[0][0]
+    assert call.fragment_id_queue == ["frag_id_1"]
+    assert call.is_fragment_scoped_rerun is False
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
 def test_list_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> None:
     """st.rerun(['charts', 'table']) passes the list to resolve_target."""
     ctx = MagicMock()

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -485,6 +485,66 @@ class MemoryFragmentStorageTest(unittest.TestCase):
         assert self._storage.contains("some_key")
         assert not self._storage.contains("some_other_key")
 
+    def test_resolve_target_returns_ids_for_named_fragment(self):
+        """resolve_target with a single name returns the registered fragment id."""
+        self._storage.register("frag_a", "fragment_a", target_key="charts")
+
+        result = self._storage.resolve_target("charts")
+
+        assert result == ["frag_a"]
+
+    def test_resolve_target_multiple_call_sites(self):
+        """One key registered at multiple call sites resolves to all ids."""
+        self._storage.register("frag_a", "fragment_a", target_key="charts")
+        self._storage.register("frag_b", "fragment_b", target_key="charts")
+
+        result = self._storage.resolve_target("charts")
+
+        assert result == ["frag_a", "frag_b"]
+
+    def test_resolve_target_list_of_names(self):
+        """A list of keys resolves to the union in stable order with deduplication."""
+        self._storage.register("frag_a", "fragment_a", target_key="charts")
+        self._storage.register("frag_b", "fragment_b", target_key="table")
+
+        result = self._storage.resolve_target(["charts", "table"])
+
+        assert result == ["frag_a", "frag_b"]
+
+    def test_resolve_target_unknown_name_raises(self):
+        """Resolving a name with no registered fragment raises StreamlitAPIException."""
+        with pytest.raises(StreamlitAPIException, match="No fragment found for target"):
+            self._storage.resolve_target("unknown")
+
+    def test_remove_prunes_target_key_index(self):
+        """Removing a fragment drops it from the name index."""
+        self._storage.register("frag_a", "fragment_a", target_key="charts")
+
+        self._storage.delete("frag_a")
+
+        with pytest.raises(StreamlitAPIException):
+            self._storage.resolve_target("charts")
+
+    def test_clear_prunes_target_key_index(self):
+        """clear() drops all fragments from the name index."""
+        self._storage.register("frag_a", "fragment_a", target_key="charts")
+
+        self._storage.clear()
+
+        with pytest.raises(StreamlitAPIException):
+            self._storage.resolve_target("charts")
+
+    def test_reregister_with_new_key_repoints_index(self):
+        """Re-registering the same fragment id under a new key detaches the old name."""
+        self._storage.register("frag_a", "fragment_a", target_key="old_name")
+
+        # Re-register with a different key.
+        self._storage.register("frag_a", "fragment_a", target_key="new_name")
+
+        assert self._storage.resolve_target("new_name") == ["frag_a"]
+        with pytest.raises(StreamlitAPIException):
+            self._storage.resolve_target("old_name")
+
 
 def test_has_lock() -> None:
     """MemoryFragmentStorage should expose a threading.Lock for concurrent register/clear."""
@@ -2390,3 +2450,66 @@ class NestedFragmentContainerRerunTest(DeltaGeneratorTestCase):
             f"{recorded_fragment_ids[0]!r}."
         )
         assert recorded_fragment_ids == initial_run_ids
+
+
+@pytest.mark.parametrize("reserved_key", ["app", "fragment"])
+def test_fragment_reserved_key_raises(reserved_key: str) -> None:
+    """@st.fragment(key=<reserved>) raises StreamlitAPIException immediately."""
+    with pytest.raises(StreamlitAPIException, match="reserved name"):
+        fragment(key=reserved_key)
+
+
+def test_fragment_duplicate_key_different_definitions_raises() -> None:
+    """Two different fragment definitions sharing a key raise StreamlitDuplicateElementKey."""
+    from streamlit.errors import StreamlitDuplicateElementKey
+
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.shared = SharedRunState()
+    mock_ctx.cursors = {}
+
+    ThreadState.initialize()
+
+    @fragment(key="shared_key")
+    def fragment_alpha() -> None:
+        pass
+
+    @fragment(key="shared_key")
+    def fragment_beta() -> None:
+        pass
+
+    with patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx):
+        fragment_alpha()
+        with pytest.raises(StreamlitDuplicateElementKey):
+            fragment_beta()
+
+
+def test_fragment_same_definition_multiple_call_sites_no_collision() -> None:
+    """The same fragment definition called from multiple sites (e.g. in a loop)
+    does not raise a duplicate-key error: register_fragment_user_key returns True
+    for the same definition_id even if called multiple times with the same key.
+    """
+    shared = SharedRunState()
+
+    definition_id = "mymodule.my_fragment"
+
+    assert shared.register_fragment_user_key("multi_site", definition_id) is True
+    # Second call site of the same fragment definition — must succeed (not a collision).
+    assert shared.register_fragment_user_key("multi_site", definition_id) is True
+
+
+def test_fragment_different_definitions_same_key_collide() -> None:
+    """Two different fragment definitions using the same key in one run collide:
+    register_fragment_user_key returns False for the second definition_id.
+    """
+    shared = SharedRunState()
+
+    assert (
+        shared.register_fragment_user_key("shared_key", "mymodule.fragment_alpha")
+        is True
+    )
+    assert (
+        shared.register_fragment_user_key("shared_key", "mymodule.fragment_beta")
+        is False
+    )

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -2514,40 +2514,29 @@ def test_fragment_same_definition_multiple_call_sites_no_collision() -> None:
         my_fragment()
 
 
-def test_partial_rerun_rejects_duplicate_key_from_different_definition() -> None:
-    """A fragment-only rerun cannot steal a key owned by a non-re-executing fragment."""
-    storage = MemoryFragmentStorage()
-    storage.register(
-        "frag_a_id", lambda: None, target_key="charts", definition_id="module.func_a"
-    )
-    with pytest.raises(StreamlitDuplicateElementKey):
-        storage.register(
-            "frag_c_id",
-            lambda: None,
-            target_key="charts",
-            definition_id="module.func_c",
-        )
+def test_shared_run_state_reset_clears_fragment_user_keys() -> None:
+    """reset() frees previously-claimed fragment user keys for the next run."""
+    shared = SharedRunState()
+
+    assert shared.register_fragment_user_key("my_key", "definition_a") is True
+    assert shared.register_fragment_user_key("my_key", "definition_b") is False
+
+    shared.reset()
+
+    assert shared.register_fragment_user_key("my_key", "definition_b") is True
 
 
-def test_same_definition_can_reregister_key() -> None:
-    """Multiple call sites of one keyed fragment share the key without collision."""
-    storage = MemoryFragmentStorage()
-    storage.register(
-        "frag_id_1", lambda: None, target_key="charts", definition_id="module.func_a"
-    )
-    storage.register(
-        "frag_id_2", lambda: None, target_key="charts", definition_id="module.func_a"
-    )
+def test_fragment_different_definitions_same_key_collide() -> None:
+    """Two different fragment definitions using the same key in one run collide:
+    register_fragment_user_key returns False for the second definition_id.
+    """
+    shared = SharedRunState()
 
-
-def test_definition_id_cleaned_up_when_last_fragment_removed() -> None:
-    """After all fragments for a key are removed, a new definition can claim it."""
-    storage = MemoryFragmentStorage()
-    storage.register(
-        "frag_a", lambda: None, target_key="charts", definition_id="module.func_a"
+    assert (
+        shared.register_fragment_user_key("shared_key", "mymodule.fragment_alpha")
+        is True
     )
-    storage.clear(new_fragment_ids=frozenset())
-    storage.register(
-        "frag_b", lambda: None, target_key="charts", definition_id="module.func_b"
+    assert (
+        shared.register_fragment_user_key("shared_key", "mymodule.fragment_beta")
+        is False
     )
-    assert storage.resolve_target("charts") == ["frag_b"]

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -32,6 +32,8 @@ from streamlit.delta_generator_singletons import context_dg_stack
 from streamlit.errors import (
     FragmentHandledException,
     FragmentStorageKeyError,
+    StreamlitAPIException,
+    StreamlitDuplicateElementKey,
     StreamlitInvalidLayoutContextError,
 )
 from streamlit.proto.Block_pb2 import Block
@@ -2469,7 +2471,6 @@ def test_fragment_reserved_key_raises(reserved_key: str) -> None:
 
 def test_fragment_duplicate_key_different_definitions_raises() -> None:
     """Two different fragment definitions sharing a key raise StreamlitDuplicateElementKey."""
-    from streamlit.errors import StreamlitDuplicateElementKey
 
     mock_ctx = MagicMock()
     mock_ctx.fragment_storage = MemoryFragmentStorage()
@@ -2513,29 +2514,40 @@ def test_fragment_same_definition_multiple_call_sites_no_collision() -> None:
         my_fragment()
 
 
-def test_shared_run_state_reset_clears_fragment_user_keys() -> None:
-    """reset() frees previously-claimed fragment user keys for the next run."""
-    shared = SharedRunState()
-
-    assert shared.register_fragment_user_key("my_key", "definition_a") is True
-    assert shared.register_fragment_user_key("my_key", "definition_b") is False
-
-    shared.reset()
-
-    assert shared.register_fragment_user_key("my_key", "definition_b") is True
-
-
-def test_fragment_different_definitions_same_key_collide() -> None:
-    """Two different fragment definitions using the same key in one run collide:
-    register_fragment_user_key returns False for the second definition_id.
-    """
-    shared = SharedRunState()
-
-    assert (
-        shared.register_fragment_user_key("shared_key", "mymodule.fragment_alpha")
-        is True
+def test_partial_rerun_rejects_duplicate_key_from_different_definition() -> None:
+    """A fragment-only rerun cannot steal a key owned by a non-re-executing fragment."""
+    storage = MemoryFragmentStorage()
+    storage.register(
+        "frag_a_id", lambda: None, target_key="charts", definition_id="module.func_a"
     )
-    assert (
-        shared.register_fragment_user_key("shared_key", "mymodule.fragment_beta")
-        is False
+    with pytest.raises(StreamlitDuplicateElementKey):
+        storage.register(
+            "frag_c_id",
+            lambda: None,
+            target_key="charts",
+            definition_id="module.func_c",
+        )
+
+
+def test_same_definition_can_reregister_key() -> None:
+    """Multiple call sites of one keyed fragment share the key without collision."""
+    storage = MemoryFragmentStorage()
+    storage.register(
+        "frag_id_1", lambda: None, target_key="charts", definition_id="module.func_a"
     )
+    storage.register(
+        "frag_id_2", lambda: None, target_key="charts", definition_id="module.func_a"
+    )
+
+
+def test_definition_id_cleaned_up_when_last_fragment_removed() -> None:
+    """After all fragments for a key are removed, a new definition can claim it."""
+    storage = MemoryFragmentStorage()
+    storage.register(
+        "frag_a", lambda: None, target_key="charts", definition_id="module.func_a"
+    )
+    storage.clear(new_fragment_ids=frozenset())
+    storage.register(
+        "frag_b", lambda: None, target_key="charts", definition_id="module.func_b"
+    )
+    assert storage.resolve_target("charts") == ["frag_b"]

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -2494,17 +2494,23 @@ def test_fragment_duplicate_key_different_definitions_raises() -> None:
 
 
 def test_fragment_same_definition_multiple_call_sites_no_collision() -> None:
-    """The same fragment definition called from multiple sites (e.g. in a loop)
-    does not raise a duplicate-key error: register_fragment_user_key returns True
-    for the same definition_id even if called multiple times with the same key.
-    """
-    shared = SharedRunState()
+    """Calling the same keyed fragment from two call sites does not raise."""
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_storage = MemoryFragmentStorage()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.shared = SharedRunState()
+    mock_ctx.cursors = {}
 
-    definition_id = "mymodule.my_fragment"
+    ThreadState.initialize()
 
-    assert shared.register_fragment_user_key("multi_site", definition_id) is True
-    # Second call site of the same fragment definition — must succeed (not a collision).
-    assert shared.register_fragment_user_key("multi_site", definition_id) is True
+    @fragment(key="multi_site")
+    def my_fragment() -> None:
+        pass
+
+    with patch("streamlit.runtime.fragment.get_script_run_ctx", return_value=mock_ctx):
+        my_fragment()
+        # Second call site of the same definition — must not raise.
+        my_fragment()
 
 
 def test_shared_run_state_reset_clears_fragment_user_keys() -> None:

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -511,6 +511,14 @@ class MemoryFragmentStorageTest(unittest.TestCase):
 
         assert result == ["frag_a", "frag_b"]
 
+    def test_resolve_target_deduplicates_overlapping_keys(self):
+        """resolve_target(['a', 'a']) returns each fragment id only once."""
+        self._storage.register("frag_a", "fragment_a", target_key="charts")
+
+        result = self._storage.resolve_target(["charts", "charts"])
+
+        assert result == ["frag_a"]
+
     def test_resolve_target_unknown_name_raises(self):
         """Resolving a name with no registered fragment raises StreamlitAPIException."""
         with pytest.raises(StreamlitAPIException, match="No fragment found for target"):
@@ -2497,6 +2505,18 @@ def test_fragment_same_definition_multiple_call_sites_no_collision() -> None:
     assert shared.register_fragment_user_key("multi_site", definition_id) is True
     # Second call site of the same fragment definition — must succeed (not a collision).
     assert shared.register_fragment_user_key("multi_site", definition_id) is True
+
+
+def test_shared_run_state_reset_clears_fragment_user_keys() -> None:
+    """reset() frees previously-claimed fragment user keys for the next run."""
+    shared = SharedRunState()
+
+    assert shared.register_fragment_user_key("my_key", "definition_a") is True
+    assert shared.register_fragment_user_key("my_key", "definition_b") is False
+
+    shared.reset()
+
+    assert shared.register_fragment_user_key("my_key", "definition_b") is True
 
 
 def test_fragment_different_definitions_same_key_collide() -> None:

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
@@ -311,6 +311,7 @@ class ScriptRequestsTest(unittest.TestCase):
         rerun_data = RerunData(fragment_id_queue=["target-frag"])
         reqs.request_rerun(rerun_data)
 
+        assert reqs._rerun_data.is_fragment_scoped_rerun is False
         assert reqs.on_scriptrunner_yield() is None
         assert reqs._state == ScriptRequestType.RERUN
 

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
@@ -284,6 +284,57 @@ class ScriptRequestsTest(unittest.TestCase):
         reqs.request_rerun(RerunData(query_string="new"))
         assert reqs._rerun_data.suppress_callbacks is False
 
+    def test_suppressed_old_triggers_not_preserved_during_coalescing(self):
+        """Old triggers whose callbacks already ran are dropped during coalescing.
+
+        When the old request had suppress_callbacks=True (an escalated replay),
+        its button triggers should not carry forward into the merged request —
+        preserving them would cause duplicate callback execution.
+        """
+        reqs = ScriptRequests()
+
+        old_states = WidgetStates()
+        _create_widget("btn_a", old_states).trigger_value = True
+        _create_widget("slider", old_states).int_value = 50
+        reqs.request_rerun(RerunData(widget_states=old_states, suppress_callbacks=True))
+
+        new_states = WidgetStates()
+        _create_widget("btn_b", new_states).trigger_value = True
+        _create_widget("slider", new_states).int_value = 75
+        reqs.request_rerun(
+            RerunData(widget_states=new_states, suppress_callbacks=False)
+        )
+
+        result = reqs._rerun_data.widget_states
+        assert _get_widget("btn_a", result) is None
+        assert _get_widget("btn_b", result).trigger_value is True
+        assert _get_widget("slider", result).int_value == 75
+        assert reqs._rerun_data.suppress_callbacks is False
+
+    def test_normal_old_triggers_preserved_during_coalescing(self):
+        """Old triggers from a non-suppressed request are still preserved.
+
+        Rapid clicks where neither request has suppress_callbacks should
+        continue preserving both triggers (the existing behavior).
+        """
+        reqs = ScriptRequests()
+
+        old_states = WidgetStates()
+        _create_widget("btn_a", old_states).trigger_value = True
+        reqs.request_rerun(
+            RerunData(widget_states=old_states, suppress_callbacks=False)
+        )
+
+        new_states = WidgetStates()
+        _create_widget("btn_b", new_states).trigger_value = True
+        reqs.request_rerun(
+            RerunData(widget_states=new_states, suppress_callbacks=False)
+        )
+
+        result = reqs._rerun_data.widget_states
+        assert _get_widget("btn_a", result).trigger_value is True
+        assert _get_widget("btn_b", result).trigger_value is True
+
     def test_on_script_yield_with_no_request(self):
         """Return None; remain in the CONTINUE state."""
         reqs = ScriptRequests()

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
@@ -268,6 +268,22 @@ class ScriptRequestsTest(unittest.TestCase):
         assert reqs._rerun_data.fragment_id_queue == []
         assert reqs._rerun_data.is_fragment_scoped_rerun is False
 
+    def test_suppress_callbacks_preserved_during_coalescing(self):
+        """suppress_callbacks=True survives coalescing with a regular request."""
+        reqs = ScriptRequests()
+        reqs.request_rerun(
+            RerunData(fragment_id_queue=["frag"], is_fragment_scoped_rerun=True)
+        )
+        reqs.request_rerun(RerunData(suppress_callbacks=True))
+        assert reqs._rerun_data.suppress_callbacks is True
+
+    def test_suppress_callbacks_false_when_neither_sets_it(self):
+        """Two non-suppressing requests coalesce to suppress_callbacks=False."""
+        reqs = ScriptRequests()
+        reqs.request_rerun(RerunData())
+        reqs.request_rerun(RerunData(query_string="new"))
+        assert reqs._rerun_data.suppress_callbacks is False
+
     def test_on_script_yield_with_no_request(self):
         """Return None; remain in the CONTINUE state."""
         reqs = ScriptRequests()
@@ -284,6 +300,23 @@ class ScriptRequestsTest(unittest.TestCase):
         assert None is result
         assert reqs._state == ScriptRequestType.RERUN
         assert reqs._rerun_data == RerunData(fragment_id_queue=["my_fragment_id"])
+
+    def test_compose_fragment_rerun_lets_body_finish_then_serves_target(self):
+        """A non-scoped fragment rerun composes: body finishes, then target runs.
+
+        on_scriptrunner_yield returns None (body not preempted), and
+        on_scriptrunner_ready returns the pending fragment rerun afterwards.
+        """
+        reqs = ScriptRequests()
+        rerun_data = RerunData(fragment_id_queue=["target-frag"])
+        reqs.request_rerun(rerun_data)
+
+        assert reqs.on_scriptrunner_yield() is None
+        assert reqs._state == ScriptRequestType.RERUN
+
+        result = reqs.on_scriptrunner_ready()
+        assert result == ScriptRequest(ScriptRequestType.RERUN, rerun_data)
+        assert reqs._state == ScriptRequestType.CONTINUE
 
     def test_on_script_yield_with_is_fragment_scoped_rerun(self):
         """Return RERUN; transition to the CONTINUE state."""

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
@@ -302,10 +302,10 @@ class ScriptRequestsTest(unittest.TestCase):
         assert reqs._rerun_data == RerunData(fragment_id_queue=["my_fragment_id"])
 
     def test_compose_fragment_rerun_lets_body_finish_then_serves_target(self):
-        """A non-scoped fragment rerun composes: body finishes, then target runs.
+        """A composing fragment rerun lets the body finish before running the target.
 
-        on_scriptrunner_yield returns None (body not preempted), and
-        on_scriptrunner_ready returns the pending fragment rerun afterwards.
+        on_scriptrunner_yield returns None (the runner does not preempt the body),
+        and on_scriptrunner_ready returns the pending fragment rerun afterwards.
         """
         reqs = ScriptRequests()
         rerun_data = RerunData(fragment_id_queue=["target-frag"])

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1029,10 +1029,10 @@ def _call_callbacks_in_main_script(ss: SessionState) -> list[RerunData]:
 
 
 def _raise_targeted_rerun() -> None:
-    """Raise what a main-script-origin targeted rerun sends (preempts).
+    """Simulate ``st.rerun("<key>")`` from a main-script widget callback.
 
-    Stands in for ``st.rerun(scope="<key>")`` from a main-script widget callback.
-    ``is_fragment_scoped_rerun=True`` causes the target to preempt the run in progress.
+    ``is_fragment_scoped_rerun=True`` tells the runner to preempt the current
+    run and execute the targeted fragment immediately.
     """
     raise RerunException(
         RerunData(
@@ -1044,11 +1044,10 @@ def _raise_targeted_rerun() -> None:
 
 
 def _raise_composing_targeted_rerun() -> None:
-    """Raise what a fragment-origin targeted rerun sends (composes).
+    """Simulate ``st.rerun("<key>")`` from a fragment widget callback.
 
-    Stands in for ``st.rerun(scope="<key>")`` from a fragment widget callback.
-    ``is_fragment_scoped_rerun=False`` lets the enclosing fragment finish first, then
-    the target runs.
+    ``is_fragment_scoped_rerun=False`` lets the enclosing fragment finish before
+    the targeted fragment runs (composing, not preempting).
     """
     raise RerunException(
         RerunData(
@@ -1079,12 +1078,13 @@ def test_changed_widget_without_callback_does_not_escalate() -> None:
 
 
 def test_composing_target_with_callback_less_vote_does_not_escalate() -> None:
-    """A composing targeted rerun (flag False) is not escalated by the vote.
+    """A callback-less vote does not escalate a composing targeted rerun.
 
-    When the keyed target has is_fragment_scoped_rerun=False (fragment-origin
-    interaction), the target does not preempt the body. The vote fires because a
-    callback-less field changed, but the flag stays False — there is no preemption to
-    escape, so the vote has no effect.
+    When the keyed target originates from a fragment callback
+    (``is_fragment_scoped_rerun=False``), it composes rather than preempts.
+    The vote still fires (a callback-less field changed), but there is no
+    preemption to override, so the vote adds a full-app rerun with
+    ``suppress_callbacks=True`` that simply replays the values.
     """
     ss = _state_with_changed_widgets(
         [("field", None), ("submit", _raise_composing_targeted_rerun)]

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1077,29 +1077,40 @@ def test_changed_widget_without_callback_does_not_escalate() -> None:
     assert requeue_calls[0].fragment_id_queue == ["other-frag"]
 
 
-def test_composing_target_with_callback_less_vote_does_not_escalate() -> None:
-    """A callback-less vote does not escalate a composing targeted rerun.
+def test_composing_target_with_callback_less_change_does_not_escalate() -> None:
+    """A callback-less widget change does not escalate a composing targeted rerun.
 
-    When the keyed target originates from a fragment callback
-    (``is_fragment_scoped_rerun=False``), it composes rather than preempts.
-    The vote still fires (a callback-less field changed), but there is no
-    preemption to override, so the vote adds a full-app rerun with
-    ``suppress_callbacks=True`` that simply replays the values.
+    When the interaction originates inside a fragment, the default rerun
+    covers only that fragment — not the full app.  A composing targeted
+    rerun (``is_fragment_scoped_rerun=False``) plus a callback-less widget
+    change should NOT trigger ``_request_full_app_rerun``.
     """
+
+    requeue_calls: list[RerunData] = []
+
     ss = _state_with_changed_widgets(
         [("field", None), ("submit", _raise_composing_targeted_rerun)]
     )
 
-    requeue_calls = _call_callbacks_in_main_script(ss)
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_ids_this_run = ["enclosing-frag"]
+    mock_ctx.page_script_hash = _CURRENT_PAGE_HASH
+    mock_ctx.script_requests.request_rerun.side_effect = lambda d: requeue_calls.append(
+        d
+    )
+    ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
 
-    # The composing targeted re-queue plus the forced app-wide default.
-    assert len(requeue_calls) == 2
+    with patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        ss._call_callbacks()
+
+    # Only the composing targeted re-queue; no full-app escalation.
+    assert len(requeue_calls) == 1
     targeted = requeue_calls[0]
     assert targeted.fragment_id_queue == ["other-frag"]
     assert targeted.is_fragment_scoped_rerun is False
-    forced = requeue_calls[-1]
-    assert not forced.fragment_id_queue
-    assert forced.suppress_callbacks is True
 
 
 def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:
@@ -1120,19 +1131,51 @@ def test_forced_full_app_rerun_carries_widget_states_with_suppress() -> None:
     The forced full-app rerun that escalates a targeted rerun carries the current
     interaction's widget_states so the body sees submitted values (including triggers),
     and suppress_callbacks=True so callbacks are not re-dispatched.
+
+    Escalation requires a callback that explicitly wants the default (returns normally)
+    alongside a targeted rerun.
     """
-    ss = _state_with_changed_widgets(
-        [("field", None), ("submit", _raise_targeted_rerun)]
-    )
+
+    requeue_calls: list[RerunData] = []
+
+    ss = SessionState()
+    for wid, cb in [
+        ("targeted_btn", _raise_targeted_rerun),
+        ("normal_btn", lambda: None),
+    ]:
+        ss._set_widget_metadata(
+            WidgetMetadata(
+                id=wid,
+                deserializer=lambda v: v,
+                serializer=lambda v: v,
+                value_type="int_value",
+                callback=cb,
+            )
+        )
+        ss._old_state[wid] = 0
+        ss._new_widget_state.set_from_value(wid, 1)
+
     # Simulate on_script_will_rerun stashing the proto.
     proto_states = WidgetStatesProto()
-    for wid in ("field", "submit"):
+    for wid in ("targeted_btn", "normal_btn"):
         ws = proto_states.widgets.add()
         ws.id = wid
         ws.int_value = 1
     ss._current_interaction_widget_states = proto_states
 
-    requeue_calls = _call_callbacks_in_main_script(ss)
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.page_script_hash = _CURRENT_PAGE_HASH
+    mock_ctx.script_requests.request_rerun.side_effect = lambda d: requeue_calls.append(
+        d
+    )
+    ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
+
+    with patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        ss._call_callbacks()
 
     assert len(requeue_calls) == 2
     forced = requeue_calls[-1]

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1124,12 +1124,13 @@ def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:
     assert _call_callbacks_in_main_script(ss) == []
 
 
-def test_forced_full_app_rerun_carries_widget_states_with_suppress() -> None:
-    """_request_full_app_rerun forwards widget_states with suppress_callbacks=True.
+def test_forced_full_app_rerun_carries_only_trigger_states_with_suppress() -> None:
+    """_request_full_app_rerun forwards only trigger widget_states with suppress_callbacks.
 
-    The forced full-app rerun that escalates a targeted rerun carries the current
-    interaction's widget_states so the body sees submitted values (including triggers),
-    and suppress_callbacks=True so callbacks are not re-dispatched.
+    The forced full-app rerun that escalates a targeted rerun carries only trigger-type
+    widget states (whose values are ephemeral and must be replayed for the body). Non-
+    trigger values already live in session state from callback execution; replaying them
+    would overwrite callback mutations.
 
     Escalation requires a callback that explicitly wants the default (returns normally)
     alongside a targeted rerun.
@@ -1138,28 +1139,39 @@ def test_forced_full_app_rerun_carries_widget_states_with_suppress() -> None:
     requeue_calls: list[RerunData] = []
 
     ss = SessionState()
-    for wid, cb in [
-        ("targeted_btn", _raise_targeted_rerun),
-        ("normal_btn", lambda: None),
-    ]:
-        ss._set_widget_metadata(
-            WidgetMetadata(
-                id=wid,
-                deserializer=lambda v: v,
-                serializer=lambda v: v,
-                value_type="int_value",
-                callback=cb,
-            )
+    # targeted_btn uses trigger_value (a button); normal_btn uses int_value (non-trigger)
+    ss._set_widget_metadata(
+        WidgetMetadata(
+            id="targeted_btn",
+            deserializer=lambda v: v,
+            serializer=lambda v: v,
+            value_type="trigger_value",
+            callback=_raise_targeted_rerun,
         )
-        ss._old_state[wid] = 0
-        ss._new_widget_state.set_from_value(wid, 1)
+    )
+    ss._old_state["targeted_btn"] = False
+    ss._new_widget_state.set_from_value("targeted_btn", True)
+
+    ss._set_widget_metadata(
+        WidgetMetadata(
+            id="normal_btn",
+            deserializer=lambda v: v,
+            serializer=lambda v: v,
+            value_type="int_value",
+            callback=lambda: None,
+        )
+    )
+    ss._old_state["normal_btn"] = 0
+    ss._new_widget_state.set_from_value("normal_btn", 1)
 
     # Simulate on_script_will_rerun stashing the proto.
     proto_states = WidgetStatesProto()
-    for wid in ("targeted_btn", "normal_btn"):
-        ws = proto_states.widgets.add()
-        ws.id = wid
-        ws.int_value = 1
+    trigger_ws = proto_states.widgets.add()
+    trigger_ws.id = "targeted_btn"
+    trigger_ws.trigger_value = True
+    nontrigger_ws = proto_states.widgets.add()
+    nontrigger_ws.id = "normal_btn"
+    nontrigger_ws.int_value = 1
     ss._current_interaction_widget_states = proto_states
 
     mock_ctx = MagicMock()
@@ -1181,7 +1193,89 @@ def test_forced_full_app_rerun_carries_widget_states_with_suppress() -> None:
     assert not forced.fragment_id_queue
     assert not forced.is_fragment_scoped_rerun
     assert forced.suppress_callbacks is True
-    assert forced.widget_states is proto_states
+    # Only the trigger widget should be forwarded; non-trigger filtered out.
+    assert forced.widget_states is not None
+    assert len(forced.widget_states.widgets) == 1
+    assert forced.widget_states.widgets[0].id == "targeted_btn"
+    assert forced.widget_states.widgets[0].trigger_value is True
+
+
+def test_callback_session_state_mutation_survives_escalation_replay() -> None:
+    """Callback writes to st.session_state are not overwritten by the escalated rerun.
+
+    Scenario: A form has a text_input (on_change strips whitespace via
+    st.session_state["name"] = stripped) and a submit button (on_click targets a
+    fragment). The escalated full-app rerun must NOT replay the original un-stripped
+    value from the proto — only trigger values should be replayed.
+    """
+
+    requeue_calls: list[RerunData] = []
+
+    ss = SessionState()
+
+    # text_input widget: callback mutates session state
+    ss._set_widget_metadata(
+        WidgetMetadata(
+            id="text_input_wid",
+            deserializer=lambda v: v,
+            serializer=lambda v: v,
+            value_type="string_value",
+            callback=lambda: ss.__setitem__("name", "stripped"),
+        )
+    )
+    ss._old_state["text_input_wid"] = "old"
+    ss._new_widget_state.set_from_value("text_input_wid", "  not stripped  ")
+
+    # submit button: targets a fragment
+    ss._set_widget_metadata(
+        WidgetMetadata(
+            id="submit_btn_wid",
+            deserializer=lambda v: v,
+            serializer=lambda v: v,
+            value_type="trigger_value",
+            callback=_raise_targeted_rerun,
+        )
+    )
+    ss._old_state["submit_btn_wid"] = False
+    ss._new_widget_state.set_from_value("submit_btn_wid", True)
+
+    # Proto that the frontend sent (before callbacks ran)
+    proto_states = WidgetStatesProto()
+    ws_text = proto_states.widgets.add()
+    ws_text.id = "text_input_wid"
+    ws_text.string_value = "  not stripped  "
+    ws_submit = proto_states.widgets.add()
+    ws_submit.id = "submit_btn_wid"
+    ws_submit.trigger_value = True
+    ss._current_interaction_widget_states = proto_states
+
+    mock_ctx = MagicMock()
+    mock_ctx.fragment_ids_this_run = None
+    mock_ctx.page_script_hash = _CURRENT_PAGE_HASH
+    mock_ctx.query_string = ""
+    mock_ctx.cached_message_hashes = frozenset()
+    mock_ctx.context_info = None
+    mock_ctx.script_requests.request_rerun.side_effect = lambda d: requeue_calls.append(
+        d
+    )
+    ThreadState.initialize(run_location=RunLocation.MAIN_SCRIPT)
+
+    with patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=mock_ctx,
+    ):
+        ss._call_callbacks()
+
+    # The escalated rerun must NOT include the text_input's string_value.
+    assert len(requeue_calls) == 2
+    forced = requeue_calls[-1]
+    assert forced.suppress_callbacks is True
+    forwarded_ids = [w.id for w in forced.widget_states.widgets]
+    assert "submit_btn_wid" in forwarded_ids
+    assert "text_input_wid" not in forwarded_ids
+
+    # Verify the callback's mutation is in session state.
+    assert ss["name"] == "stripped"
 
 
 def test_suppress_callbacks_skips_dispatch_but_applies_values() -> None:

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1029,16 +1029,32 @@ def _call_callbacks_in_main_script(ss: SessionState) -> list[RerunData]:
 
 
 def _raise_targeted_rerun() -> None:
-    """Raise what a targeted rerun at another fragment sends.
+    """Raise what a main-script-origin targeted rerun sends (preempts).
 
-    Stands in for ``st.rerun(scope="<key>")``, per
-    specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md.
+    Stands in for ``st.rerun(scope="<key>")`` from a main-script widget callback.
+    ``is_fragment_scoped_rerun=True`` causes the target to preempt the run in progress.
     """
     raise RerunException(
         RerunData(
             page_script_hash=_CURRENT_PAGE_HASH,
             fragment_id_queue=["other-frag"],
             is_fragment_scoped_rerun=True,
+        )
+    )
+
+
+def _raise_composing_targeted_rerun() -> None:
+    """Raise what a fragment-origin targeted rerun sends (composes).
+
+    Stands in for ``st.rerun(scope="<key>")`` from a fragment widget callback.
+    ``is_fragment_scoped_rerun=False`` lets the enclosing fragment finish first, then
+    the target runs.
+    """
+    raise RerunException(
+        RerunData(
+            page_script_hash=_CURRENT_PAGE_HASH,
+            fragment_id_queue=["other-frag"],
+            is_fragment_scoped_rerun=False,
         )
     )
 
@@ -1062,6 +1078,30 @@ def test_changed_widget_without_callback_does_not_escalate() -> None:
     assert requeue_calls[0].fragment_id_queue == ["other-frag"]
 
 
+def test_composing_target_with_callback_less_vote_does_not_escalate() -> None:
+    """A composing targeted rerun (flag False) is not escalated by the vote.
+
+    When the keyed target has is_fragment_scoped_rerun=False (fragment-origin
+    interaction), the target does not preempt the body. The vote fires because a
+    callback-less field changed, but the flag stays False — there is no preemption to
+    escape, so the vote has no effect.
+    """
+    ss = _state_with_changed_widgets(
+        [("field", None), ("submit", _raise_composing_targeted_rerun)]
+    )
+
+    requeue_calls = _call_callbacks_in_main_script(ss)
+
+    # The composing targeted re-queue plus the forced app-wide default.
+    assert len(requeue_calls) == 2
+    targeted = requeue_calls[0]
+    assert targeted.fragment_id_queue == ["other-frag"]
+    assert targeted.is_fragment_scoped_rerun is False
+    forced = requeue_calls[-1]
+    assert not forced.fragment_id_queue
+    assert forced.suppress_callbacks is True
+
+
 def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:
     """Callback-less widget changes alone do not queue any extra rerun.
 
@@ -1072,6 +1112,60 @@ def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:
     ss = _state_with_changed_widgets([("field", None), ("other_field", None)])
 
     assert _call_callbacks_in_main_script(ss) == []
+
+
+def test_forced_full_app_rerun_carries_widget_states_with_suppress() -> None:
+    """_request_full_app_rerun forwards widget_states with suppress_callbacks=True.
+
+    The forced full-app rerun that escalates a targeted rerun carries the current
+    interaction's widget_states so the body sees submitted values (including triggers),
+    and suppress_callbacks=True so callbacks are not re-dispatched.
+    """
+    ss = _state_with_changed_widgets(
+        [("field", None), ("submit", _raise_targeted_rerun)]
+    )
+    # Simulate on_script_will_rerun stashing the proto.
+    proto_states = WidgetStatesProto()
+    for wid in ("field", "submit"):
+        ws = proto_states.widgets.add()
+        ws.id = wid
+        ws.int_value = 1
+    ss._current_interaction_widget_states = proto_states
+
+    requeue_calls = _call_callbacks_in_main_script(ss)
+
+    assert len(requeue_calls) == 2
+    forced = requeue_calls[-1]
+    assert not forced.fragment_id_queue
+    assert not forced.is_fragment_scoped_rerun
+    assert forced.suppress_callbacks is True
+    assert forced.widget_states is proto_states
+
+
+def test_suppress_callbacks_skips_dispatch_but_applies_values() -> None:
+    """on_script_will_rerun with suppress_callbacks applies values without callbacks.
+
+    The trigger value is set (so the body sees it) but no callback fires.
+    """
+    ss = SessionState()
+    trigger_wid = "submit_btn"
+    meta = WidgetMetadata(
+        id=trigger_wid,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="trigger_value",
+        callback=lambda: (_ for _ in ()).throw(AssertionError("should not fire")),
+    )
+    ss._set_widget_metadata(meta)
+
+    proto_states = WidgetStatesProto()
+    ws = proto_states.widgets.add()
+    ws.id = trigger_wid
+    ws.trigger_value = True
+
+    ss.on_script_will_rerun(proto_states, suppress_callbacks=True)
+
+    assert ss[trigger_wid] is True
 
 
 def test_disabled_widget_change_does_not_force_app_wide_rerun() -> None:

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1109,7 +1109,7 @@ def test_fragment_origin_target_with_callback_less_change_does_not_escalate() ->
     assert len(requeue_calls) == 1
     targeted = requeue_calls[0]
     assert targeted.fragment_id_queue == ["other-frag"]
-    assert targeted.is_fragment_scoped_rerun is False
+    assert targeted.is_fragment_scoped_rerun is True
 
 
 def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1043,17 +1043,17 @@ def _raise_targeted_rerun() -> None:
     )
 
 
-def _raise_composing_targeted_rerun() -> None:
+def _raise_fragment_origin_targeted_rerun() -> None:
     """Simulate ``st.rerun("<key>")`` from a fragment widget callback.
 
-    ``is_fragment_scoped_rerun=False`` lets the enclosing fragment finish before
-    the targeted fragment runs (composing, not preempting).
+    ``is_fragment_scoped_rerun=True`` — keyed targets always preempt the
+    interaction's default rerun, regardless of where the widget lives.
     """
     raise RerunException(
         RerunData(
             page_script_hash=_CURRENT_PAGE_HASH,
             fragment_id_queue=["other-frag"],
-            is_fragment_scoped_rerun=False,
+            is_fragment_scoped_rerun=True,
         )
     )
 
@@ -1077,19 +1077,18 @@ def test_changed_widget_without_callback_does_not_escalate() -> None:
     assert requeue_calls[0].fragment_id_queue == ["other-frag"]
 
 
-def test_composing_target_with_callback_less_change_does_not_escalate() -> None:
-    """A callback-less widget change does not escalate a composing targeted rerun.
+def test_fragment_origin_target_with_callback_less_change_does_not_escalate() -> None:
+    """A callback-less widget change does not escalate a fragment-origin targeted rerun.
 
-    When the interaction originates inside a fragment, the default rerun
-    covers only that fragment — not the full app.  A composing targeted
-    rerun (``is_fragment_scoped_rerun=False``) plus a callback-less widget
-    change should NOT trigger ``_request_full_app_rerun``.
+    When the interaction originates inside a fragment, a keyed targeted
+    rerun replaces the default fragment-scoped rerun.  A callback-less
+    widget change should NOT trigger ``_request_full_app_rerun``.
     """
 
     requeue_calls: list[RerunData] = []
 
     ss = _state_with_changed_widgets(
-        [("field", None), ("submit", _raise_composing_targeted_rerun)]
+        [("field", None), ("submit", _raise_fragment_origin_targeted_rerun)]
     )
 
     mock_ctx = MagicMock()

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1166,6 +1166,7 @@ def test_suppress_callbacks_skips_dispatch_but_applies_values() -> None:
     ss.on_script_will_rerun(proto_states, suppress_callbacks=True)
 
     assert ss[trigger_wid] is True
+    assert ss._current_interaction_widget_states is None
 
 
 def test_disabled_widget_change_does_not_force_app_wide_rerun() -> None:

--- a/lib/tests/streamlit/typing/fragment_types.py
+++ b/lib/tests/streamlit/typing/fragment_types.py
@@ -46,12 +46,19 @@ if TYPE_CHECKING:
 
     assert_type(timed_fragment_str(), str)
 
-    # With key parameter
+    # With key parameter (str)
     @st.fragment(key="charts")
     def keyed_fragment() -> None:
         pass
 
     assert_type(keyed_fragment(), None)
+
+    # With key parameter (int)
+    @st.fragment(key=42)
+    def keyed_fragment_int() -> None:
+        pass
+
+    assert_type(keyed_fragment_int(), None)
 
     # With key=None (default)
     @st.fragment(key=None)

--- a/lib/tests/streamlit/typing/fragment_types.py
+++ b/lib/tests/streamlit/typing/fragment_types.py
@@ -1,0 +1,82 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    import streamlit as st
+
+    # =====================================================================
+    # @st.fragment decorator type tests
+    # =====================================================================
+
+    # Bare decorator - preserves function signature
+    @st.fragment
+    def bare_fragment() -> None:
+        pass
+
+    assert_type(bare_fragment(), None)
+
+    # With run_every parameter
+    @st.fragment(run_every=5.0)
+    def timed_fragment() -> int:
+        return 42
+
+    assert_type(timed_fragment(), int)
+
+    # With run_every as string
+    @st.fragment(run_every="1m")
+    def timed_fragment_str() -> str:
+        return "result"
+
+    assert_type(timed_fragment_str(), str)
+
+    # With key parameter
+    @st.fragment(key="charts")
+    def keyed_fragment() -> None:
+        pass
+
+    assert_type(keyed_fragment(), None)
+
+    # With key=None (default)
+    @st.fragment(key=None)
+    def fragment_no_key() -> None:
+        pass
+
+    assert_type(fragment_no_key(), None)
+
+    # With parallel parameter
+    @st.fragment(parallel=True)
+    def parallel_fragment() -> list[int]:
+        return [1, 2, 3]
+
+    assert_type(parallel_fragment(), list[int])
+
+    # With all parameters
+    @st.fragment(run_every=10, parallel=False, key="dashboard")
+    def full_fragment() -> bool:
+        return True
+
+    assert_type(full_fragment(), bool)
+
+    # Fragment with arguments - preserves callable signature
+    @st.fragment(key="parameterized")
+    def fragment_with_args(x: int, y: str) -> float:
+        return float(x)
+
+    assert_type(fragment_with_args(1, "a"), float)

--- a/lib/tests/streamlit/typing/rerun_types.py
+++ b/lib/tests/streamlit/typing/rerun_types.py
@@ -30,3 +30,7 @@ if TYPE_CHECKING:
 
     # st.rerun() returns NoReturn for all scope variants.
     assert_type(rerun(), NoReturn)
+    assert_type(rerun(scope="app"), NoReturn)
+    assert_type(rerun(scope=42), NoReturn)
+    assert_type(rerun(scope=["charts", "table"]), NoReturn)
+    assert_type(rerun(scope=[1, 2]), NoReturn)

--- a/lib/tests/streamlit/typing/rerun_types.py
+++ b/lib/tests/streamlit/typing/rerun_types.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Type tests for st.rerun.
+
+``st.rerun()`` returns ``NoReturn``, so mypy marks all code after the first
+call unreachable.  Import the unwrapped function directly so the signature
+isn't erased by ``@gather_metrics``, and keep a single positive assertion.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, NoReturn
@@ -19,28 +26,7 @@ from typing import TYPE_CHECKING, NoReturn
 from typing_extensions import assert_type
 
 if TYPE_CHECKING:
-    import streamlit as st
+    from streamlit.commands.execution_control import rerun
 
-    # =====================================================================
-    # st.rerun return type tests
-    # =====================================================================
-
-    # Default scope ("app") - returns NoReturn
-    assert_type(st.rerun(), NoReturn)
-
-    # Explicit scope literals
-    assert_type(st.rerun(scope="app"), NoReturn)
-    assert_type(st.rerun(scope="fragment"), NoReturn)
-
-    # Positional scope (str key)
-    assert_type(st.rerun("app"), NoReturn)
-    assert_type(st.rerun("fragment"), NoReturn)
-    assert_type(st.rerun("charts"), NoReturn)
-
-    # Keyed scope - single key
-    assert_type(st.rerun(scope="charts"), NoReturn)
-    assert_type(st.rerun(scope="sidebar-filters"), NoReturn)
-
-    # Keyed scope - list of keys
-    assert_type(st.rerun(scope=["charts", "summary"]), NoReturn)
-    assert_type(st.rerun(scope=["charts"]), NoReturn)
+    # st.rerun() returns NoReturn for all scope variants.
+    assert_type(rerun(), NoReturn)

--- a/lib/tests/streamlit/typing/rerun_types.py
+++ b/lib/tests/streamlit/typing/rerun_types.py
@@ -1,0 +1,46 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    import streamlit as st
+
+    # =====================================================================
+    # st.rerun return type tests
+    # =====================================================================
+
+    # Default scope ("app") - returns NoReturn
+    assert_type(st.rerun(), NoReturn)
+
+    # Explicit scope literals
+    assert_type(st.rerun(scope="app"), NoReturn)
+    assert_type(st.rerun(scope="fragment"), NoReturn)
+
+    # Positional scope (str key)
+    assert_type(st.rerun("app"), NoReturn)
+    assert_type(st.rerun("fragment"), NoReturn)
+    assert_type(st.rerun("charts"), NoReturn)
+
+    # Keyed scope - single key
+    assert_type(st.rerun(scope="charts"), NoReturn)
+    assert_type(st.rerun(scope="sidebar-filters"), NoReturn)
+
+    # Keyed scope - list of keys
+    assert_type(st.rerun(scope=["charts", "summary"]), NoReturn)
+    assert_type(st.rerun(scope=["charts"]), NoReturn)

--- a/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
+++ b/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
@@ -164,9 +164,10 @@ any app that relied on that no-op.)
 This is a deliberate starting point we may relax later. For now the restriction buys four things:
 
 - **Execution stays easy to reason about.** Callbacks run as a distinct phase *before* the run body,
-  so a targeted rerun is applied at that clean boundary. For a main-script interaction, the callback
-  phase finishes, the full-app body runs (rendering submitted values), and the targeted fragments
-  re-execute as part of the full pass. For a fragment interaction, the enclosing fragment finishes
+  so a targeted rerun is applied at that clean boundary. For a main-script interaction, the
+  targeted rerun preempts the full-app body — only the targeted fragments re-execute. Escalation
+  to a full-app rerun happens only when another callback explicitly expects the default (returns
+  normally or calls plain `st.rerun()`). For a fragment interaction, the enclosing fragment finishes
   and then the target runs — both fragments execute. Allowing the call mid-body would instead
   abandon a partially-executed script or fragment and jump elsewhere — a "goto" style of control
   flow that is hard to follow and at odds with the deterministic, top-to-bottom model.
@@ -334,10 +335,12 @@ reasons:
 **How a targeted rerun interacts with the default depends on where the interaction originates:**
 
 - **Main-script interaction (widget outside any fragment).** The default rerun is a full-app rerun.
-  A targeted rerun from the callback does not cancel that default — a changed form field or another
-  callback that returns normally still expects the body to run. The targeted rerun is additive: the
-  full-app rerun runs the body (rendering the submitted values) and the targeted fragments re-execute
-  as part of the full pass. The coalescing rules below collapse this to a single full-app rerun.
+  A targeted rerun alone **replaces** that default (preempt): the full-app body is skipped and only
+  the targeted fragment(s) run. Callback-less widget changes (e.g. form fields) do not override
+  this — their values are already in session state and will render on the next full rerun.
+  Escalation to a full-app rerun happens only when another callback explicitly expects the default
+  (returns normally or calls plain `st.rerun()`); the escalated run replays widget values with
+  callbacks suppressed to avoid re-firing. The coalescing rules below collapse this to one run.
 - **Fragment interaction (widget inside a fragment).** The default rerun covers only the enclosing
   fragment. A targeted rerun from the callback **composes**: the enclosing fragment finishes its
   current run, and then the target runs afterwards. Both fragments execute, because the target's

--- a/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
+++ b/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
@@ -117,8 +117,8 @@ st.selectbox(
 )
 ```
 
-`scope` therefore accepts `"app"`, `"fragment"`, a **single fragment key**, or a **list of keys**
-(`Literal["app", "fragment"] | Key | list[Key]`); passing a list reruns all of them in one ordered
+`scope` therefore accepts `"app"`, `"fragment"`, a **single fragment key**, or a **sequence of keys**
+(`Literal["app", "fragment"] | Key | Sequence[Key]`); passing a sequence reruns all of them in one ordered
 pass. `"app"` and `"fragment"` remain reserved level names — any other value is read as a fragment
 key. Every key must match a fragment that has rendered at least once — an unknown key (a single
 `scope` or anywhere in a list) raises a `StreamlitAPIException`, so a typo or stale key fails loudly

--- a/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
+++ b/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
@@ -164,11 +164,12 @@ any app that relied on that no-op.)
 This is a deliberate starting point we may relax later. For now the restriction buys four things:
 
 - **Execution stays easy to reason about.** Callbacks run as a distinct phase *before* the run body,
-  so a targeted rerun is applied at that clean boundary: the callback phase finishes and then — before
-  the pending run's body executes — Streamlit preempts the run and executes only the target(s), with
-  no partially-rendered output. Allowing the call mid-body would instead abandon a partially-executed
-  script or fragment and jump elsewhere — a "goto" style of control flow that is hard to follow and at
-  odds with the deterministic, top-to-bottom model.
+  so a targeted rerun is applied at that clean boundary. For a main-script interaction, the callback
+  phase finishes, the full-app body runs (rendering submitted values), and the targeted fragments
+  re-execute as part of the full pass. For a fragment interaction, the enclosing fragment finishes
+  and then the target runs — both fragments execute. Allowing the call mid-body would instead
+  abandon a partially-executed script or fragment and jump elsewhere — a "goto" style of control
+  flow that is hard to follow and at odds with the deterministic, top-to-bottom model.
 - **It covers the use cases people actually ask for.** The requests behind this feature — dashboard
   filters, cross-filtering, fragment-to-fragment updates — are all "when the user does X, update
   region Y," which is exactly what a widget callback expresses.
@@ -330,11 +331,18 @@ reasons:
 
 ### Rerun handling: skipping the default rerun, coalescing, and precedence
 
-**A targeted rerun replaces the interaction's default rerun.** A widget interaction normally schedules
-a full-app rerun once its callbacks have run (or a fragment-scoped rerun, if the triggering widget
-already lives inside a fragment). When a callback issues a targeted rerun, that default full-app rerun
-is **skipped** — Streamlit runs only the targeted fragment(s), not the whole app; running the full app
-in addition would just redo those fragments and erase the partial-update benefit.
+**How a targeted rerun interacts with the default depends on where the interaction originates:**
+
+- **Main-script interaction (widget outside any fragment).** The default rerun is a full-app rerun.
+  A targeted rerun from the callback does not cancel that default — a changed form field or another
+  callback that returns normally still expects the body to run. The targeted rerun is additive: the
+  full-app rerun runs the body (rendering the submitted values) and the targeted fragments re-execute
+  as part of the full pass. The coalescing rules below collapse this to a single full-app rerun.
+- **Fragment interaction (widget inside a fragment).** The default rerun covers only the enclosing
+  fragment. A targeted rerun from the callback **composes**: the enclosing fragment finishes its
+  current run, and then the target runs afterwards. Both fragments execute, because the target's
+  scope does not subsume the enclosing fragment — the justification for skipping ("would just redo
+  those fragments") does not apply when the default is fragment-scoped rather than app-wide.
 
 Beyond replacing that default rerun, targeted reruns make it normal for a **single interaction to
 produce several rerun requests at once** — a list of keys, multiple `st.rerun` calls, or reruns from

--- a/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
+++ b/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
@@ -164,13 +164,11 @@ any app that relied on that no-op.)
 This is a deliberate starting point we may relax later. For now the restriction buys four things:
 
 - **Execution stays easy to reason about.** Callbacks run as a distinct phase *before* the run body,
-  so a targeted rerun is applied at that clean boundary. For a main-script interaction, the
-  targeted rerun preempts the full-app body — only the targeted fragments re-execute. Escalation
-  to a full-app rerun happens only when another callback explicitly expects the default (returns
-  normally or calls plain `st.rerun()`). For a fragment interaction, the enclosing fragment finishes
-  and then the target runs — both fragments execute. Allowing the call mid-body would instead
-  abandon a partially-executed script or fragment and jump elsewhere — a "goto" style of control
-  flow that is hard to follow and at odds with the deterministic, top-to-bottom model.
+  so a targeted rerun is applied at that clean boundary: the callback phase finishes and then — before
+  the pending run's body executes — Streamlit preempts the run and executes only the target(s), with
+  no partially-rendered output. Allowing the call mid-body would instead abandon a partially-executed
+  script or fragment and jump elsewhere — a "goto" style of control flow that is hard to follow and at
+  odds with the deterministic, top-to-bottom model.
 - **It covers the use cases people actually ask for.** The requests behind this feature — dashboard
   filters, cross-filtering, fragment-to-fragment updates — are all "when the user does X, update
   region Y," which is exactly what a widget callback expresses.
@@ -332,20 +330,15 @@ reasons:
 
 ### Rerun handling: skipping the default rerun, coalescing, and precedence
 
-**How a targeted rerun interacts with the default depends on where the interaction originates:**
-
-- **Main-script interaction (widget outside any fragment).** The default rerun is a full-app rerun.
-  A targeted rerun alone **replaces** that default (preempt): the full-app body is skipped and only
-  the targeted fragment(s) run. Callback-less widget changes (e.g. form fields) do not override
-  this — their values are already in session state and will render on the next full rerun.
-  Escalation to a full-app rerun happens only when another callback explicitly expects the default
-  (returns normally or calls plain `st.rerun()`); the escalated run replays widget values with
-  callbacks suppressed to avoid re-firing. The coalescing rules below collapse this to one run.
-- **Fragment interaction (widget inside a fragment).** The default rerun covers only the enclosing
-  fragment. A targeted rerun from the callback **composes**: the enclosing fragment finishes its
-  current run, and then the target runs afterwards. Both fragments execute, because the target's
-  scope does not subsume the enclosing fragment — the justification for skipping ("would just redo
-  those fragments") does not apply when the default is fragment-scoped rather than app-wide.
+**A targeted rerun replaces the interaction's default rerun.** A widget interaction normally schedules
+a full-app rerun once its callbacks have run (or a fragment-scoped rerun, if the triggering widget
+already lives inside a fragment). When a callback issues a targeted rerun, that default rerun is
+**skipped** — Streamlit runs only the targeted fragment(s), not the whole app or enclosing fragment;
+running the default in addition would just redo those fragments and erase the partial-update benefit.
+Callback-less widget changes (e.g. form fields) do not override this — their values are already in
+session state and will render on the next full rerun. Escalation to a full-app rerun happens only when
+another callback explicitly expects the default (returns normally or calls plain `st.rerun()`); the
+escalated run replays widget values with callbacks suppressed to avoid re-firing.
 
 Beyond replacing that default rerun, targeted reruns make it normal for a **single interaction to
 produce several rerun requests at once** — a list of keys, multiple `st.rerun` calls, or reruns from


### PR DESCRIPTION
## Describe your changes

Adds the public API for event-scoped fragment reruns: name a fragment with `@st.fragment(key=...)`, then rerun it from a widget callback with `st.rerun(scope=<key>)`.

```python
@st.fragment(key="filters")
def filters():
    ...

st.button("Apply", on_click=lambda: st.rerun("filters"))
# also: st.rerun(scope="filters") or st.rerun(["alpha", "beta"])
```

### Behavior rules

- Keyed reruns are **callback-only** (`on_change` / `on_click`). Calling from the main script body or a fragment body raises `StreamlitAPIException`.
- `scope` is now positional, so `st.rerun("filters")` works alongside `st.rerun(scope="filters")`.
- Unknown keys fail fast. `st.rerun("")` and `st.rerun([])` raise `StreamlitAPIException`.
- `"app"` and `"fragment"` are reserved keys and raise `StreamlitAPIException` — including when they appear inside a list (`st.rerun(["app", "x"])` is rejected).
- Fragment keys accept `str | int` (consistent with widget keys) and are normalized via `to_key()`. `st.rerun(scope=...)` accepts `str`, `int`, or `Sequence[str | int]`; other types raise `StreamlitAPIException`.
- Fragment keys are validated with `require_valid_user_key` (same as widget keys) and stored in a dict for O(1) membership lookup.
- Duplicate keys across different fragment definitions raise `StreamlitDuplicateElementKey` (same as widget key collisions). Multiple call sites of **one** keyed fragment function do not collide — every call site of that function shares the name and reruns together (loops, tabs, MPA pages).

### Rerun semantics

- **Keyed targets always preempt** the interaction's default rerun — they replace, never compose. This applies regardless of where the interaction originates (main-script widget or fragment widget).
- **Escalation to full-app rerun** happens when the triggering interaction has multiple callbacks and a sibling callback returns normally (expects the default full-app rerun). The escalated run sets `suppress_callbacks=True` to avoid re-firing callbacks that already ran.
- **Escalation replay forwards only trigger widget states**, not the full proto — only the specific widget states from the triggering interaction are replayed, preventing session-state mutations from being overwritten.
- **`suppress_callbacks` coalescing**: when a new rerun request arrives while a suppressed request is pending, the newest request wins and stale trigger widget states from the old request are stripped.
- **Post-update execution control**: the check for pending rerun requests runs even when the callback path was suppressed, ensuring escalation is not missed.
- **`_current_interaction_widget_states`** is cleared in a `finally` block to prevent leaking into subsequent callbacks.

### Stack

PR 3/3 of a feature split of draft [#15794](https://github.com/streamlit/streamlit/pull/15794) (event-scoped fragment reruns).

- PR 1: Added `RunLocation` enum to track execution phase (main script / fragment / callback) — no behavior change.
- PR 2 ([#16158](https://github.com/streamlit/streamlit/pull/16158)): Makes `st.rerun()` from `on_change` / `on_click` take effect instead of being discarded; fixes order-independent rerun coalescing. This PR builds the public keyed API on top of that.

### Known follow-ups

- **`suppress_callbacks` coalescing race**: there is a narrow window where concurrent interactions could interleave coalescing. Planned to be addressed by a batching fix.
- **`module.qualname` fragment identity not unique**: fragment identity derived from module-qualified name is not globally unique when the same function name appears in different modules. This is a pre-existing limitation, not introduced by this PR.

## GitHub Issue Link (if applicable)

Spec [#15755](https://github.com/streamlit/streamlit/issues/15755) (event-scoped fragment reruns: name fragments and rerun them from callbacks). Split from draft [#15794](https://github.com/streamlit/streamlit/pull/15794).

## Testing Plan

- **Unit**: key indexing/collision, reserved keys (including inside lists), callback-only enforcement, positional `scope`, empty-scope fail-fast, origin-dependent `is_fragment_scoped_rerun`, suppress_callbacks coalescing with trigger stripping, compose vs preempt, post-update execution control for suppressed paths, type guards for key and scope (`fragment_test.py`, `execution_control_test.py`, `session_state_test.py`, `script_requests_test.py`)
- **E2E**: single-key, multi-key, fragment-to-fragment targeting, unknown-key (`st_fragment_key_rerun_test.py`)
- **Typing**: `st.rerun(scope=...)` and `@st.fragment(key=...)` signatures (`rerun_types.py`, `fragment_types.py`)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core rerun, callback dispatch, and fragment execution paths; incorrect coalescing or replay could cause missed reruns, duplicate callbacks, or stale UI.
> 
> **Overview**
> Adds **named fragment reruns**: decorate with `@st.fragment(key=...)`, then from a widget callback call `st.rerun("key")`, `st.rerun(scope="key")`, or `st.rerun(["alpha", "beta"])`. **`scope` is positional** (no longer keyword-only) and accepts `str`, `int`, or a sequence of keys; `"app"` / `"fragment"` stay reserved level names and cannot be used as keys.
> 
> **Runtime behavior:** fragment storage indexes keys to fragment ids (`resolve_target`); keyed `st.rerun` is **callback-only** (main script or fragment body raises `StreamlitAPIException`). In callbacks, rerun requests raise **`RerunException`** and are flushed after all callbacks finish so sibling handlers can vote. Keyed targets **replace** the interaction default (fragment-only rerun, not full app). If another callback still wants the default, escalation queues a **full-app rerun** with **`suppress_callbacks`** and replays **trigger widget states only** so session-state mutations from callbacks are not overwritten. Coalescing respects `suppress_callbacks` when merging rapid rerun requests.
> 
> **Supporting changes:** duplicate fragment keys across different definitions raise `StreamlitDuplicateElementKey`; Playwright E2E and expanded unit/typing tests; product spec wording updated for sequence-based scopes and escalation rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96f6c6955e8953f8da4c2a14f7555fab80b03e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

