### PR TITLE
[bugfix] Multiselect dropdown background matches sidebar theme (#11348)

### DIFF
--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -112,6 +112,11 @@ const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
             // one on the popover, so we need to remove it here.
             boxShadow: "none",
             overflow: "hidden",
+            // Match the current region's background instead of BaseWeb's
+            // `menuFill`, which resolves to the sidebar's
+            // `secondaryBackgroundColor` when both sidebar bg colors are
+            // configured — causing the goldenrod dropdown in #11348.
+            backgroundColor: theme.colors.bgColor,
           }}
           ref={ref}
           data-testid="stSelectboxVirtualDropdownEmpty"
@@ -180,6 +185,11 @@ const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
           // Somehow this adds an additional shadow, even though we already have
           // one on the popover, so we need to remove it here.
           boxShadow: "none",
+          // Match the current region's background instead of BaseWeb's
+          // `menuFill`, which resolves to the sidebar's
+          // `secondaryBackgroundColor` when both sidebar bg colors are
+          // configured — causing the goldenrod dropdown in #11348.
+          backgroundColor: theme.colors.bgColor,
         }}
         data-testid="stSelectboxVirtualDropdown"
       >

--- a/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/VirtualDropdown.tsx
@@ -91,6 +91,11 @@ const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
     const scrollbarGutterSize = useScrollbarGutterSize()
     const { innerHeight: windowHeight } = useWindowDimensionsContext()
 
+    // Match this region's own background. BaseWeb's `menuFill` resolves to
+    // the sidebar's `secondaryBackgroundColor` (not its `backgroundColor`)
+    // when both sidebar colors are set, giving the wrong surface. See #11348.
+    const menuFillOverride = { backgroundColor: theme.colors.bgColor }
+
     // TODO: Update to match React best practices
     // eslint-disable-next-line @eslint-react/no-children-to-array
     const children = Children.toArray(props.children) as ReactElement[]
@@ -112,11 +117,7 @@ const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
             // one on the popover, so we need to remove it here.
             boxShadow: "none",
             overflow: "hidden",
-            // Match the current region's background instead of BaseWeb's
-            // `menuFill`, which resolves to the sidebar's
-            // `secondaryBackgroundColor` when both sidebar bg colors are
-            // configured — causing the goldenrod dropdown in #11348.
-            backgroundColor: theme.colors.bgColor,
+            ...menuFillOverride,
           }}
           ref={ref}
           data-testid="stSelectboxVirtualDropdownEmpty"
@@ -185,11 +186,7 @@ const VirtualDropdown = forwardRef<HTMLUListElement, VirtualDropdownProps>(
           // Somehow this adds an additional shadow, even though we already have
           // one on the popover, so we need to remove it here.
           boxShadow: "none",
-          // Match the current region's background instead of BaseWeb's
-          // `menuFill`, which resolves to the sidebar's
-          // `secondaryBackgroundColor` when both sidebar bg colors are
-          // configured — causing the goldenrod dropdown in #11348.
-          backgroundColor: theme.colors.bgColor,
+          ...menuFillOverride,
         }}
         data-testid="stSelectboxVirtualDropdown"
       >


### PR DESCRIPTION
## Summary
Fixes #11348.

Root cause: BaseWeb's `menuFill` (used by the Select dropdown list) resolves to `secondaryBg` when rendered inside the sidebar. See `frontend/lib/src/theme/createBaseUiTheme.ts` — `mainPaneBgColor = inSidebar ? colors.secondaryBg : colors.bgColor`. The intent of that swap was to compensate for the sidebar's default bg/secondaryBg inversion, but when the user explicitly sets both `[theme.sidebar] backgroundColor` and `secondaryBackgroundColor`, the fallback paints the multiselect dropdown with the sidebar's `secondaryBackgroundColor` (goldenrod in the issue's repro) instead of its `backgroundColor`.

The multiselect popover is portalled to `document.body`, so no ancestor CSS variable cascade can help — the fix has to be in the component itself.

## Repro
Set the theme colours from the issue in `.streamlit/config.toml`, place a multiselect in the sidebar, open the dropdown, and observe the mismatched background.

## Fix
- Override the `StyledList` `backgroundColor` in `VirtualDropdown` with `theme.colors.bgColor`, which — inside the sidebar-scoped emotion theme — resolves to the sidebar's configured `backgroundColor`, and in the main body resolves to the app's `backgroundColor` (unchanged).
- The override applies to both the populated list and the empty state to keep them consistent.

## Screenshots

After the fix (repro config: sidebar `backgroundColor = "#262730"`, sidebar `secondaryBackgroundColor = "goldenrod"`), the open sidebar multiselect dropdown paints on the sidebar's `backgroundColor` and no longer picks up goldenrod:

- [after-fix-sidebar-multiselect.png](https://issues.streamlit.app/agent_wiki_explorer?file=pull-requests/16163/after-fix-sidebar-multiselect.png)

## Verification
- [x] Sidebar dropdown bg matches sidebar bg after fix (`#262730` in repro)
- [x] Main-area dropdown bg unchanged (`#0e1117` in repro)
- [x] `make check` passes (frontend format, lint, knip, tsc, VirtualDropdown vitest)
- [x] Full Multiselect + VirtualDropdown vitest suites pass (57/57)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized styling override in the virtualized select dropdown with no auth, data, or API changes.
> 
> **Overview**
> Fixes sidebar multiselect dropdowns painting with the wrong surface when both `[theme.sidebar] backgroundColor` and `secondaryBackgroundColor` are set.
> 
> **`VirtualDropdown`** now sets `StyledList` `backgroundColor` to `theme.colors.bgColor` (via a shared `menuFillOverride`) on both the populated list and the empty state. That bypasses BaseWeb’s `menuFill`, which in sidebar context maps to `secondaryBg` and showed the secondary color (e.g. goldenrod) instead of the sidebar’s primary background. Main-area dropdowns stay on the app `backgroundColor` because the same token resolves correctly there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f115932e0a54e8a29bb2cd7d06278820b94af425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->