### PR TITLE
[bugfix] Preserve IME composition in data_editor NumberColumn (#16129)

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -976,7 +976,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: @linaria/core. A copy of the source code may be downloaded from git@github.com:callstack/linaria.git. This software contains the following license and notice below:
+The following software may be included in this product: @linaria/core, @linaria/react. A copy of the source code may be downloaded from git@github.com:callstack/linaria.git (@linaria/core), git@github.com:callstack/linaria.git (@linaria/react). This software contains the following license and notice below:
 
 MIT License
 
@@ -12005,6 +12005,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: react-number-format. A copy of the source code may be downloaded from https://github.com/s-yadav/react-number-format. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020-present Sudhanshu Yadav
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -----
 

--- a/e2e_playwright/st_data_editor_editing_test.py
+++ b/e2e_playwright/st_data_editor_editing_test.py
@@ -394,6 +394,50 @@ def test_number_cell_editing_performance(
     _test_number_cell_editing(app, assert_snapshot, skip_snapshot=True)
 
 
+def test_number_cell_editor_ignores_ime_composing_enter(app: Page) -> None:
+    """Enter during IME composition must not commit the cell.
+
+    Regression test for streamlit/streamlit#16129: with a CJK IME active,
+    the Enter that confirms the composition fires a keydown with
+    ``isComposing=true``. The overlay editor used to treat that as a
+    cell-commit, closing the editor after the first composed digit and
+    making multi-digit input impossible.
+    """
+    cell_editor = _get_editor(app, "cell_editor")
+    expect_canvas_to_be_visible(cell_editor)
+
+    click_on_cell(cell_editor, 1, 0, double_click=True, column_width="medium")
+    cell_overlay = get_open_cell_overlay(app)
+    input_field = cell_overlay.locator(".gdg-input")
+    expect(input_field).to_be_visible()
+
+    # Simulate the Enter that confirms an IME composition. In real browsers
+    # this fires with ``isComposing=true`` / ``keyCode=229`` and must be a
+    # no-op for the cell overlay.
+    input_field.evaluate(
+        """el => {
+            el.focus();
+            el.dispatchEvent(new KeyboardEvent("keydown", {
+                key: "Enter",
+                code: "Enter",
+                keyCode: 229,
+                which: 229,
+                bubbles: true,
+                cancelable: true,
+                isComposing: true,
+            }));
+        }"""
+    )
+
+    # The editor must remain open after a composing Enter.
+    expect(cell_overlay).to_be_visible()
+    expect(input_field).to_be_visible()
+
+    # A regular (non-composing) Enter should still commit the cell.
+    app.keyboard.press("Enter")
+    expect(cell_overlay).not_to_be_visible()
+
+
 def test_text_cell_editing(themed_app: Page, assert_snapshot: ImageCompareFunction):
     """Test that the text cell can be edited."""
     cell_editor = _get_editor(themed_app, "cell_editor")

--- a/frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch
+++ b/frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch
@@ -1,0 +1,36 @@
+diff --git a/dist/cjs/internal/data-grid-overlay-editor/data-grid-overlay-editor.js b/dist/cjs/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
+index face64122d35e884020eeabc6d96514141fc18d1..1e71f5198f0685882e1282cc2abd606d6d64a68b 100644
+--- a/dist/cjs/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
++++ b/dist/cjs/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
+@@ -45,6 +45,13 @@ const DataGridOverlayEditor = p => {
+         finished.current = true;
+     }, [onFinishEditing]);
+     const onKeyDown = React.useCallback(async (event) => {
++        // Ignore keys that are part of an in-progress IME composition
++        // (e.g. Enter that confirms a CJK IME candidate). Committing the
++        // cell here would close the editor after the first composed
++        // character. See streamlit/streamlit#16129.
++        if (event.nativeEvent?.isComposing === true || event.keyCode === 229) {
++            return;
++        }
+         let save = false;
+         if (event.key === "Escape") {
+             event.stopPropagation();
+diff --git a/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js b/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
+index face64122d35e884020eeabc6d96514141fc18d1..1e71f5198f0685882e1282cc2abd606d6d64a68b 100644
+--- a/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
++++ b/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
+@@ -45,6 +45,13 @@ const DataGridOverlayEditor = p => {
+         finished.current = true;
+     }, [onFinishEditing]);
+     const onKeyDown = React.useCallback(async (event) => {
++        // Ignore keys that are part of an in-progress IME composition
++        // (e.g. Enter that confirms a CJK IME candidate). Committing the
++        // cell here would close the editor after the first composed
++        // character. See streamlit/streamlit#16129.
++        if (event.nativeEvent?.isComposing === true || event.keyCode === 229) {
++            return;
++        }
+         let save = false;
+         if (event.key === "Escape") {
+             event.stopPropagation();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,8 @@
     "@swc/core": "^1.15.3",
     "@typescript-eslint/utils": "^8.58.2",
     "@typescript-eslint/scope-manager": "^8.58.2",
-    "@typescript-eslint/types": "^8.58.2"
+    "@typescript-eslint/types": "^8.58.2",
+    "@glideapps/glide-data-grid@npm:6.0.4-alpha24": "patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch"
   },
   "browserslist": [
     ">0.2%",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1273,6 +1273,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch":
+  version: 6.0.4-alpha24
+  resolution: "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch::version=6.0.4-alpha24&hash=8b6f4e"
+  dependencies:
+    "@linaria/react": "npm:^6.3.0"
+    canvas-hypertxt: "npm:^1.0.3"
+    react-number-format: "npm:^5.4.4"
+  peerDependencies:
+    lodash: ^4.17.19
+    marked: ^16.0.10
+    react: ^16.12.0 || 17.x || 18.x || 19.x
+    react-dom: ^16.12.0 || 17.x || 18.x || 19.x
+    react-responsive-carousel: ^3.2.7
+  checksum: 10c0/caf10dc82f75567e918f58cca10c960aec481e4f2c5cf6c9881984dbadf521a7a32c27199e6758dbf142b503b6c49bd064ced5286e498e11c05c8b00558e7155
+  languageName: node
+  linkType: hard
+
 "@hpcc-js/wasm@npm:^2.20.0":
   version: 2.22.4
   resolution: "@hpcc-js/wasm@npm:2.22.4"


### PR DESCRIPTION
## Summary
Fixes #16129.

The bundled `@glideapps/glide-data-grid` overlay editor treated the Enter that confirms a CJK IME composition (fired with `KeyboardEvent.isComposing === true` / `keyCode === 229`) as a cell-commit, closing the `st.data_editor` NumberColumn cell editor after the first composed digit and making multi-digit input via a Japanese/Korean IME impossible.

## Repro
Open an `st.data_editor` NumberColumn cell, switch to a Japanese/Korean IME, type multiple digits — the editor commits and closes on the composition-Enter before the composed value is finalised.

## Fix
- `frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch`: bail out of the overlay editor's `onKeyDown` when `event.nativeEvent.isComposing === true` (or `event.keyCode === 229`). Mirrors the guard Streamlit already applies in `inputUtils.isEnterKeyPressed` and the fix previously landed for `st.chat_input` in #6988. Patch is applied via the existing yarn `resolutions` pattern (same mechanism used for `color2k`).
- `frontend/package.json` / `frontend/yarn.lock`: register the patch via `resolutions`.
- `e2e_playwright/st_data_editor_editing_test.py`: add `test_number_cell_editor_ignores_ime_composing_enter`, which dispatches a composing Enter into the open cell overlay and asserts the editor stays visible, then confirms a plain Enter still commits.

## Verification
- [x] Bug reproduces on develop
- [x] Fixed on this branch
- [x] `make check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow keyboard-handling change in a vendored dependency patch; normal Enter commit behavior is covered by the new e2e test.
> 
> **Overview**
> Fixes **#16129**: `st.data_editor` **NumberColumn** cells closed on the Enter that confirms a CJK IME composition, so users could not enter multi-digit numbers with a Japanese/Korean IME.
> 
> A **yarn patch** on `@glideapps/glide-data-grid` makes the overlay editor’s `onKeyDown` return early when `nativeEvent.isComposing` is true or `keyCode === 229`, so composition Enter no longer commits the cell (aligned with Streamlit’s `inputUtils.isEnterKeyPressed` / `st.chat_input`). The patch is wired through `frontend/package.json` **resolutions** and `yarn.lock`; **NOTICES** picks up related transitive license entries.
> 
> Playwright adds **`test_number_cell_editor_ignores_ime_composing_enter`**, which dispatches a composing Enter and asserts the overlay stays open until a normal Enter commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c3f42dfcb0cd534023bd0df875a79e62ff5b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->