### PR TITLE
[fix] Stable dataframe header background with alpha (#11950)

### DIFF
--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/ButtonCell.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/ButtonCell.tsx
@@ -432,7 +432,10 @@ const renderer: CustomRenderer<ButtonCell> = {
         textColor = "#ffffff"
         break
       case "secondary":
-        bgColor = isHovered ? theme.bgHeaderHovered : "transparent"
+        bgColor = isHovered
+          ? ((theme as unknown as { bgButtonHovered?: string })
+              .bgButtonHovered ?? theme.bgHeaderHovered)
+          : "transparent"
         borderColor = theme.borderColor
         textColor = theme.textDark
         break

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
@@ -84,4 +84,37 @@ describe("useCustomTheme hook", () => {
     expect(getAlpha(bgHeaderHovered as string)).toBe(1)
     expect(getAlpha(bgHeaderHasFocus as string)).toBe(1)
   })
+
+  it("returns fully opaque header background colors even when the app bgColor itself has an alpha channel (#11950)", () => {
+    // Users can configure theme.backgroundColor with alpha (the config is
+    // a plain string with no opacity guard). In that case, blending the
+    // header color against a translucent bgColor would leave residual
+    // alpha and reintroduce the canvas-stacking bug. The fix composites
+    // bgColor over opaque white first, so the canvas backdrop is always
+    // opaque before header colors layer on top.
+    const themeWithAlphaBg = {
+      ...mockTheme.emotion,
+      colors: {
+        ...mockTheme.emotion.colors,
+        bgColor: "#00000080", // rgba(0, 0, 0, 0.5)
+        dataframeHeaderBackgroundColor: "#FF00001a",
+      },
+    }
+
+    const wrapper = ({
+      children,
+    }: {
+      children: React.ReactNode
+    }): JSX.Element => (
+      <ThemeProvider theme={themeWithAlphaBg}>{children}</ThemeProvider>
+    )
+
+    const { result } = renderHook(() => useCustomTheme(), { wrapper })
+    const { bgHeader, bgHeaderHovered, bgHeaderHasFocus } =
+      result.current.glideTheme
+
+    expect(getAlpha(bgHeader as string)).toBe(1)
+    expect(getAlpha(bgHeaderHovered as string)).toBe(1)
+    expect(getAlpha(bgHeaderHasFocus as string)).toBe(1)
+  })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
@@ -60,6 +60,11 @@ describe("useCustomTheme hook", () => {
     expect(getAlpha(bgHeader as string)).toBe(1)
     expect(getAlpha(bgHeaderHovered as string)).toBe(1)
     expect(getAlpha(bgHeaderHasFocus as string)).toBe(1)
+
+    // Also lock in the actual composited color: #FF00001a (rgba 255,0,0,0.1)
+    // over the mockTheme bgColor (#ffffff) yields #ffe5e5 per the blend()
+    // formula. Guards against future regressions in the color math.
+    expect(bgHeader).toBe("#ffe5e5")
   })
 
   it("returns fully opaque header background colors for the default theme", () => {

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
@@ -117,4 +117,56 @@ describe("useCustomTheme hook", () => {
     expect(getAlpha(bgHeaderHovered as string)).toBe(1)
     expect(getAlpha(bgHeaderHasFocus as string)).toBe(1)
   })
+
+  it("keeps bgButtonHovered independent of dataframeHeaderBackgroundColor customizations", () => {
+    // Regression guard: the pre-#11950 code piped a translucent overlay
+    // through bgHeaderHovered, which was also consumed by body-cell
+    // secondary-button hovers in ButtonCell. Now bgHeaderHovered is
+    // opaque + header-tinted, and body-cell buttons read the separate
+    // bgButtonHovered key. Customizing dataframeHeaderBackgroundColor
+    // must not change bgButtonHovered.
+    const defaultWrapper = ({
+      children,
+    }: {
+      children: React.ReactNode
+    }): JSX.Element => (
+      <ThemeProvider theme={mockTheme.emotion}>{children}</ThemeProvider>
+    )
+    const { result: defaultResult } = renderHook(() => useCustomTheme(), {
+      wrapper: defaultWrapper,
+    })
+    const defaultButtonHover = (
+      defaultResult.current.glideTheme as unknown as {
+        bgButtonHovered: string
+      }
+    ).bgButtonHovered
+
+    const themeWithAlphaHeader = {
+      ...mockTheme.emotion,
+      colors: {
+        ...mockTheme.emotion.colors,
+        dataframeHeaderBackgroundColor: "#FF00001a",
+      },
+    }
+    const customWrapper = ({
+      children,
+    }: {
+      children: React.ReactNode
+    }): JSX.Element => (
+      <ThemeProvider theme={themeWithAlphaHeader}>{children}</ThemeProvider>
+    )
+    const { result: customResult } = renderHook(() => useCustomTheme(), {
+      wrapper: customWrapper,
+    })
+    const customButtonHover = (
+      customResult.current.glideTheme as unknown as {
+        bgButtonHovered: string
+      }
+    ).bgButtonHovered
+
+    expect(customButtonHover).toBe(defaultButtonHover)
+    // And it must differ from bgHeaderHovered when the header has a
+    // custom color, otherwise there is no decoupling.
+    expect(customButtonHover).not.toBe(customResult.current.glideTheme.bgHeaderHovered)
+  })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
@@ -135,11 +135,7 @@ describe("useCustomTheme hook", () => {
     const { result: defaultResult } = renderHook(() => useCustomTheme(), {
       wrapper: defaultWrapper,
     })
-    const defaultButtonHover = (
-      defaultResult.current.glideTheme as unknown as {
-        bgButtonHovered: string
-      }
-    ).bgButtonHovered
+    const defaultButtonHover = defaultResult.current.glideTheme.bgButtonHovered
 
     const themeWithAlphaHeader = {
       ...mockTheme.emotion,
@@ -158,15 +154,13 @@ describe("useCustomTheme hook", () => {
     const { result: customResult } = renderHook(() => useCustomTheme(), {
       wrapper: customWrapper,
     })
-    const customButtonHover = (
-      customResult.current.glideTheme as unknown as {
-        bgButtonHovered: string
-      }
-    ).bgButtonHovered
+    const customButtonHover = customResult.current.glideTheme.bgButtonHovered
 
     expect(customButtonHover).toBe(defaultButtonHover)
     // And it must differ from bgHeaderHovered when the header has a
     // custom color, otherwise there is no decoupling.
-    expect(customButtonHover).not.toBe(customResult.current.glideTheme.bgHeaderHovered)
+    expect(customButtonHover).not.toBe(
+      customResult.current.glideTheme.bgHeaderHovered
+    )
   })
 })

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from "@testing-library/react"
+import { parseToRgba } from "color2k"
+
+import ThemeProvider from "~lib/components/core/ThemeProvider"
+import { mockTheme } from "~lib/mocks/mockTheme"
+
+import useCustomTheme from "./useCustomTheme"
+
+/**
+ * Get the alpha channel of a color (0-1). Fully opaque colors return 1.
+ */
+function getAlpha(color: string): number {
+  const [, , , a] = parseToRgba(color)
+  return a
+}
+
+describe("useCustomTheme hook", () => {
+  it("returns fully opaque header background colors even when the configured header background has an alpha channel (#11950)", () => {
+    // Simulate the user's config from the bug report: a header background
+    // color with an alpha channel ("#FF00001a" = rgba(255, 0, 0, 0.1)).
+    const themeWithAlphaHeader = {
+      ...mockTheme.emotion,
+      colors: {
+        ...mockTheme.emotion.colors,
+        dataframeHeaderBackgroundColor: "#FF00001a",
+      },
+    }
+
+    const wrapper = ({
+      children,
+    }: {
+      children: React.ReactNode
+    }): JSX.Element => (
+      <ThemeProvider theme={themeWithAlphaHeader}>{children}</ThemeProvider>
+    )
+
+    const { result } = renderHook(() => useCustomTheme(), { wrapper })
+    const { bgHeader, bgHeaderHovered, bgHeaderHasFocus } =
+      result.current.glideTheme
+
+    // All three header background colors must be fully opaque so
+    // glide-data-grid's canvas doesn't stack semi-transparent fills
+    // between paints, which is what caused the flicker in #11950.
+    expect(getAlpha(bgHeader as string)).toBe(1)
+    expect(getAlpha(bgHeaderHovered as string)).toBe(1)
+    expect(getAlpha(bgHeaderHasFocus as string)).toBe(1)
+  })
+
+  it("returns fully opaque header background colors for the default theme", () => {
+    const wrapper = ({
+      children,
+    }: {
+      children: React.ReactNode
+    }): JSX.Element => (
+      <ThemeProvider theme={mockTheme.emotion}>{children}</ThemeProvider>
+    )
+
+    const { result } = renderHook(() => useCustomTheme(), { wrapper })
+    const { bgHeader, bgHeaderHovered, bgHeaderHasFocus } =
+      result.current.glideTheme
+
+    expect(getAlpha(bgHeader as string)).toBe(1)
+    expect(getAlpha(bgHeaderHovered as string)).toBe(1)
+    expect(getAlpha(bgHeaderHasFocus as string)).toBe(1)
+  })
+})

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
@@ -24,7 +24,10 @@ import { blend, convertRemToPx } from "~lib/theme/utils"
 export type CustomGridTheme = {
   // The theme configuration for the glide-data-grid
   glideTheme: Partial<GlideTheme> &
-    Pick<GlideTheme, "baseFontStyle" | "cellHorizontalPadding" | "fontFamily"> & {
+    Pick<
+      GlideTheme,
+      "baseFontStyle" | "cellHorizontalPadding" | "fontFamily"
+    > & {
       // Custom (non-glide-native) key consumed by ButtonCell for
       // secondary-button hovers. See #11950.
       bgButtonHovered?: string

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
@@ -78,10 +78,20 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
       theme.colors.dataframeHeaderBackgroundColor,
       opaqueBg
     )
-    const flatHeaderBgHovered = blend(
+    // Drives both bgHeaderHovered and bgHeaderHasFocus — glide paints them
+    // on the canvas, so this must stay opaque (see #11950).
+    const flatHeaderInteractionBg = blend(
       transparentize(theme.colors.darkenedBgMix100, 0.9),
       flatHeaderBg
     )
+    // The pre-flatten translucent overlay that used to drive
+    // bgHeaderHovered before the #11950 fix. `bgHeaderHovered` is now
+    // opaque and header-tinted (required for the canvas paint), but it is
+    // also consumed by body-cell secondary-button hovers in ButtonCell,
+    // which want the original translucent overlay independent of any
+    // header color customization. Expose it as a separate glide-theme key
+    // so ButtonCell can read it directly.
+    const buttonHoverBg = transparentize(theme.colors.darkenedBgMix100, 0.9)
 
     const glideTheme = {
       // Explanations: https://github.com/glideapps/glide-data-grid/blob/main/packages/core/API.md#theme
@@ -97,8 +107,12 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
       bgIconHeader: theme.colors.fadedText60,
       fgIconHeader: theme.colors.white,
       bgHeader: flatHeaderBg,
-      bgHeaderHasFocus: flatHeaderBgHovered,
-      bgHeaderHovered: flatHeaderBgHovered,
+      bgHeaderHasFocus: flatHeaderInteractionBg,
+      bgHeaderHovered: flatHeaderInteractionBg,
+      // Custom (non-glide-native) key consumed by ButtonCell for
+      // secondary-button hovers. Kept separate from `bgHeaderHovered` so
+      // customizing the header color does not restyle body-cell buttons.
+      bgButtonHovered: buttonHoverBg,
       textHeader: theme.colors.fadedText60,
       textHeaderSelected: theme.colors.white,
       textGroupHeader: theme.colors.fadedText60,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
@@ -68,10 +68,15 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
     // header fills (base + hover/focus overlays) without clearing between
     // paints, which produces color shifts / flicker when either color has
     // an alpha channel. Flatten alpha against the app background so
-    // glide-data-grid always receives fully opaque colors. See #11950.
+    // glide-data-grid always receives fully opaque colors. The app
+    // background itself may also carry alpha (users can configure
+    // theme.backgroundColor as a hex+alpha or rgba value), so we first
+    // composite it over opaque white to get a guaranteed-opaque canvas
+    // backdrop before layering the header colors. See #11950.
+    const opaqueBg = blend(theme.colors.bgColor, "#ffffff")
     const flatHeaderBg = blend(
       theme.colors.dataframeHeaderBackgroundColor,
-      theme.colors.bgColor
+      opaqueBg
     )
     const flatHeaderBgHovered = blend(
       transparentize(theme.colors.darkenedBgMix100, 0.9),

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
@@ -19,7 +19,7 @@ import { Theme as GlideTheme, SpriteMap } from "@glideapps/glide-data-grid"
 import { lighten, mix, transparentize } from "color2k"
 
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
-import { convertRemToPx } from "~lib/theme/utils"
+import { blend, convertRemToPx } from "~lib/theme/utils"
 
 export type CustomGridTheme = {
   // The theme configuration for the glide-data-grid
@@ -64,6 +64,20 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
         `<svg xmlns="http://www.w3.org/2000/svg" height="40" viewBox="0 96 960 960" width="40" fill="${p.bgColor}"><path d="m800.641 679.743-64.384-64.384 29-29q7.156-6.948 17.642-6.948 10.485 0 17.742 6.948l29 29q6.948 7.464 6.948 17.95 0 10.486-6.948 17.434l-29 29Zm-310.64 246.256v-64.383l210.82-210.821 64.384 64.384-210.821 210.82h-64.383Zm-360-204.872v-50.254h289.743v50.254H130.001Zm0-162.564v-50.255h454.615v50.255H130.001Zm0-162.307v-50.255h454.615v50.255H130.001Z"/></svg>`,
     }
 
+    // glide-data-grid renders on a canvas and stacks semi-transparent
+    // header fills (base + hover/focus overlays) without clearing between
+    // paints, which produces color shifts / flicker when either color has
+    // an alpha channel. Flatten alpha against the app background so
+    // glide-data-grid always receives fully opaque colors. See #11950.
+    const flatHeaderBg = blend(
+      theme.colors.dataframeHeaderBackgroundColor,
+      theme.colors.bgColor
+    )
+    const flatHeaderBgHovered = blend(
+      transparentize(theme.colors.darkenedBgMix100, 0.9),
+      flatHeaderBg
+    )
+
     const glideTheme = {
       // Explanations: https://github.com/glideapps/glide-data-grid/blob/main/packages/core/API.md#theme
       accentColor: theme.colors.primary,
@@ -77,9 +91,9 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
       // Header styling:
       bgIconHeader: theme.colors.fadedText60,
       fgIconHeader: theme.colors.white,
-      bgHeader: theme.colors.dataframeHeaderBackgroundColor,
-      bgHeaderHasFocus: transparentize(theme.colors.darkenedBgMix100, 0.9),
-      bgHeaderHovered: transparentize(theme.colors.darkenedBgMix100, 0.9),
+      bgHeader: flatHeaderBg,
+      bgHeaderHasFocus: flatHeaderBgHovered,
+      bgHeaderHovered: flatHeaderBgHovered,
       textHeader: theme.colors.fadedText60,
       textHeaderSelected: theme.colors.white,
       textGroupHeader: theme.colors.fadedText60,

--- a/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
+++ b/frontend/lib/src/components/widgets/DataFrame/hooks/useCustomTheme.ts
@@ -24,7 +24,11 @@ import { blend, convertRemToPx } from "~lib/theme/utils"
 export type CustomGridTheme = {
   // The theme configuration for the glide-data-grid
   glideTheme: Partial<GlideTheme> &
-    Pick<GlideTheme, "baseFontStyle" | "cellHorizontalPadding" | "fontFamily">
+    Pick<GlideTheme, "baseFontStyle" | "cellHorizontalPadding" | "fontFamily"> & {
+      // Custom (non-glide-native) key consumed by ButtonCell for
+      // secondary-button hovers. See #11950.
+      bgButtonHovered?: string
+    }
   // The table border radius in pixels
   tableBorderRadius: string
   // The table border size in pixels
@@ -84,13 +88,10 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
       transparentize(theme.colors.darkenedBgMix100, 0.9),
       flatHeaderBg
     )
-    // The pre-flatten translucent overlay that used to drive
-    // bgHeaderHovered before the #11950 fix. `bgHeaderHovered` is now
-    // opaque and header-tinted (required for the canvas paint), but it is
-    // also consumed by body-cell secondary-button hovers in ButtonCell,
-    // which want the original translucent overlay independent of any
-    // header color customization. Expose it as a separate glide-theme key
-    // so ButtonCell can read it directly.
+    // Translucent secondary-button hover for body cells — kept separate
+    // from the opaque `bgHeaderHovered` so header color customizations do
+    // not restyle buttons. Consumed by ButtonCell via a custom
+    // (non-glide-native) `bgButtonHovered` key on the returned theme.
     const buttonHoverBg = transparentize(theme.colors.darkenedBgMix100, 0.9)
 
     const glideTheme = {
@@ -109,9 +110,6 @@ function useCustomTheme(): Readonly<CustomGridTheme> {
       bgHeader: flatHeaderBg,
       bgHeaderHasFocus: flatHeaderInteractionBg,
       bgHeaderHovered: flatHeaderInteractionBg,
-      // Custom (non-glide-native) key consumed by ButtonCell for
-      // secondary-button hovers. Kept separate from `bgHeaderHovered` so
-      // customizing the header color does not restyle body-cell buttons.
       bgButtonHovered: buttonHoverBg,
       textHeader: theme.colors.fadedText60,
       textHeaderSelected: theme.colors.white,


### PR DESCRIPTION
## Summary
Fixes #11950.

When `dataframeHeaderBackgroundColor` is configured with an alpha channel (e.g. `#FF00001a`), the header renders as near-black on first paint and then shifts to a different color on hover/unhover. glide-data-grid draws its header on a canvas and stacks the base `bgHeader` fill and the semi-transparent `bgHeaderHovered` / `bgHeaderHasFocus` overlays without clearing between paints, so any alpha in either color accumulates unpredictably across frames.

## Fix
- In `useCustomTheme`, composite the configured header background against the app `bgColor` before passing it to glide-data-grid.
- Composite the hover/focus overlay against the resulting solid header color so the theme's hover state is also fully opaque.
- All three header theme values (`bgHeader`, `bgHeaderHovered`, `bgHeaderHasFocus`) are now guaranteed opaque, so canvas overdraw cannot shift the color between paints.
- New unit test covers both the alpha-configured case from the bug report and the default theme.

## Screenshots

After the fix, with `dataframeHeaderBackgroundColor = "#FF00001a"` (red at ~10% opacity), the header composites cleanly against the app background and stays stable across paints — no more near-black first paint or hover-driven color shift:

- [after-fix-df-header-alpha.png](https://issues.streamlit.app/agent_wiki_explorer?file=pull-requests/16166/after-fix-df-header-alpha.png)

## Verification
- [x] Header no longer flickers with rgba background
- [x] `make check` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme/color math and dataframe button hover styling only; no auth, data, or API changes.
> 
> **Overview**
> Fixes **#11950** flicker when `dataframeHeaderBackgroundColor` (or app `bgColor`) includes alpha: glide-data-grid stacks semi-transparent header paints on canvas without clearing, so colors shift between frames.
> 
> **`useCustomTheme`** now composites app background over white, then header and hover/focus colors via `blend()`, so `bgHeader`, `bgHeaderHovered`, and `bgHeaderHasFocus` are always fully opaque. Header hover/focus is decoupled from body-cell UI by adding a custom **`bgButtonHovered`** (translucent overlay); **`ButtonCell`** secondary buttons use that key instead of `bgHeaderHovered`.
> 
> New **`useCustomTheme.test.tsx`** locks opacity, expected blended header color, alpha `bgColor`, and independence of `bgButtonHovered` from header customization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5235517e560b57879bdde3ab85d039210d06977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->