### PR TITLE
[fix] Keep popover children mounted to eliminate reopen cost (#16069)

### DIFF
--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -103,7 +103,9 @@ describe("Popover container", () => {
     await new Promise(resolve => setTimeout(resolve, 60))
 
     await user.click(screen.getByText("outside"))
-    expect(screen.queryByText("test")).not.toBeInTheDocument()
+    // Children stay mounted (display: none) after close so heavy widgets don't
+    // pay their mount cost again on reopen — assert on visibility, not presence.
+    expect(screen.queryByText("test")).not.toBeVisible()
   })
 
   it("stays open when interacting with a Streamlit overlay root", async () => {

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -100,6 +100,15 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // Single state with optimistic updates for instant UI feedback.
   const [open, setOpen] = useState(initialOpen)
 
+  // Once opened, keep the popover body mounted so its children (which may
+  // include heavy widgets like large selectboxes) don't pay their mount cost
+  // again on every reopen. Visibility is controlled by CSS + aria-hidden.
+  // Defers the initial mount cost until the popover is first opened.
+  const [hasEverOpened, setHasEverOpened] = useState(initialOpen)
+  if (open && !hasEverOpened) {
+    setHasEverOpened(true)
+  }
+
   // Sync backend state changes (for programmatic control via session_state).
   // Uses render-time comparison instead of useEffect — no DOM side effects needed.
   useExecuteWhenChanged(() => {
@@ -402,7 +411,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
           </BaseButton>
         </BaseButtonTooltip>
       </div>
-      {open && (
+      {hasEverOpened && (
         <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
           <StyledPopoverBody
             ref={setFloatingRef}
@@ -413,9 +422,11 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
             data-st-overlay-root="true"
             role="dialog"
             aria-label={element.label}
+            aria-hidden={!open}
             style={floatingStyles}
             $stretchWidth={stretchWidth}
             $calculatedWidth={calculatedWidth}
+            $hidden={!open}
           >
             {children}
           </StyledPopoverBody>

--- a/frontend/lib/src/components/elements/Popover/styled-components.ts
+++ b/frontend/lib/src/components/elements/Popover/styled-components.ts
@@ -22,7 +22,8 @@ import { hasLightBackgroundColor } from "~lib/theme/getColors"
 export const StyledPopoverBody = styled.div<{
   $stretchWidth?: boolean
   $calculatedWidth?: number
-}>(({ theme, $stretchWidth, $calculatedWidth = 0 }) => {
+  $hidden?: boolean
+}>(({ theme, $stretchWidth, $calculatedWidth = 0, $hidden }) => {
   const isLight = hasLightBackgroundColor(theme)
   return {
     boxSizing: "border-box",
@@ -41,6 +42,7 @@ export const StyledPopoverBody = styled.div<{
     [`@media (max-width: ${theme.breakpoints.sm})`]: {
       maxWidth: `calc(100% - ${theme.spacing.threeXL})`,
     },
+    ...($hidden && { display: "none" }),
   }
 })
 


### PR DESCRIPTION
## Summary
Fixes #16069.

Inside `st.popover`, opening the popover re-mounts all children from scratch every time. When a child is a heavy widget — e.g. an `st.selectbox` with thousands of options — `react-aria-components`' Collection build dominates the open latency (~650ms per open on a modern machine). Closing and reopening the popover paid that full mount cost again, every time.

## Repro

`st.popover(...)` containing an `st.selectbox` with 10,000 options. First open feels slow (expected — real work); every reopen pays the same 600ms+ delay even though the content hasn't changed.

## Fix

`frontend/lib/src/components/elements/Popover/Popover.tsx` — render the popover body on first open and keep it mounted across close/reopen cycles. Visibility is controlled by `display: none` + `aria-hidden={!open}`, so subsequent reopens are a CSS toggle instead of a full remount.

- Initial mount cost is paid once, on first open (not on component mount, to avoid regressing initial page load).
- Any heavy widget inside a popover benefits from this fix, not just selectbox — it removes the entire class of "popover reopen is slow because of my expensive child" bugs.

## Measurements

10k-option selectbox inside `st.popover`:

| Open | Before | After |
| ---- | -----: | ----: |
| 1st  | ~650ms | ~650ms |
| 2nd  | ~650ms | ~2ms |
| 3rd  | ~650ms | ~2ms |

## Verification

- [x] Bug reproduces on develop
- [x] Fixed on this branch
- [x] All existing `Popover.test.tsx` cases pass (with one assertion updated from `not.toBeInTheDocument()` → `not.toBeVisible()` to reflect the mount-once semantics)
- [x] Positioning, focus management, outside-click dismissal, and Escape handling all still work