### PR TITLE
[bugfix] Higher-DPI Altair PNG export (#8177)

### DIFF
--- a/e2e_playwright/st_altair_chart_test.py
+++ b/e2e_playwright/st_altair_chart_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pathlib
+import struct
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -141,7 +144,27 @@ def test_download_chart_as_png(app: Page):
     with app.expect_download() as download_info:
         download_button.click()
 
-    assert download_info.value.suggested_filename.endswith("_chart.png")
+    download = download_info.value
+    assert download.suggested_filename.endswith("_chart.png")
+
+    # Assert the exported PNG is at least 2x the on-screen canvas size so a
+    # regression in `toImageURL`'s scaleFactor semantics can't slip through.
+    # Playwright's headless Chromium reports `devicePixelRatio == 1`, so the
+    # `Math.max(2, dpr || 1)` floor in `useVegaEmbed` deterministically applies
+    # a 2x scale here.
+    canvas_bbox = chart.locator("canvas").first.bounding_box()
+    assert canvas_bbox is not None
+    png_bytes = pathlib.Path(download.path()).read_bytes()
+    # PNG IHDR: 8-byte signature + 4-byte length + 4-byte type ("IHDR"), then
+    # width (u32 big-endian) and height (u32 big-endian) at bytes 16..24.
+    png_width, png_height = struct.unpack(">II", png_bytes[16:24])
+    assert png_width == round(canvas_bbox["width"] * 2), (
+        f"expected PNG width {round(canvas_bbox['width'] * 2)}, got {png_width}"
+    )
+    assert png_height == round(canvas_bbox["height"] * 2), (
+        f"expected PNG height {round(canvas_bbox['height'] * 2)}, "
+        f"got {png_height}"
+    )
 
 
 def test_show_chart_data_button(app: Page, assert_snapshot: ImageCompareFunction):

--- a/e2e_playwright/st_altair_chart_test.py
+++ b/e2e_playwright/st_altair_chart_test.py
@@ -147,23 +147,36 @@ def test_download_chart_as_png(app: Page):
     download = download_info.value
     assert download.suggested_filename.endswith("_chart.png")
 
-    # Assert the exported PNG is at least 2x the on-screen canvas size so a
-    # regression in `toImageURL`'s scaleFactor semantics can't slip through.
-    # Playwright's headless Chromium reports `devicePixelRatio == 1`, so the
-    # `Math.max(2, dpr || 1)` floor in `useVegaEmbed` deterministically applies
-    # a 2x scale here.
-    canvas_bbox = chart.locator("canvas").first.bounding_box()
-    assert canvas_bbox is not None
+    # Assert the exported PNG's dimensions correspond to ~2x the on-screen
+    # chart size so a regression in `toImageURL`'s scaleFactor semantics can't
+    # slip through. Playwright's headless Chromium reports
+    # `devicePixelRatio == 1`, so the `Math.max(2, dpr || 1)` floor in
+    # `useVegaEmbed` deterministically applies a 2x scale here.
+    graphics_doc = get_vega_graphics_document(chart)
+    expect(graphics_doc).to_be_visible()
+    gd_bbox = graphics_doc.bounding_box()
+    assert gd_bbox is not None
     png_bytes = pathlib.Path(download.path()).read_bytes()
+    assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n", "downloaded file is not a PNG"
     # PNG IHDR: 8-byte signature + 4-byte length + 4-byte type ("IHDR"), then
     # width (u32 big-endian) and height (u32 big-endian) at bytes 16..24.
     png_width, png_height = struct.unpack(">II", png_bytes[16:24])
-    assert png_width == round(canvas_bbox["width"] * 2), (
-        f"expected PNG width {round(canvas_bbox['width'] * 2)}, got {png_width}"
+    # Vega's `toImageURL` scales the view's width/height by scaleFactor; on-
+    # screen the same view is laid out inside the graphics-document. A tight
+    # tolerance handles Vega's internal padding differing by a few pixels from
+    # the CSS bounding box. A 1x export would fall far outside this window.
+    tolerance = 8
+    expected_width = round(gd_bbox["width"] * 2)
+    expected_height = round(gd_bbox["height"] * 2)
+    assert abs(png_width - expected_width) <= tolerance, (
+        f"PNG width {png_width} is not ~2x graphics-document width "
+        f"{gd_bbox['width']:.1f} (expected ~{expected_width}, tolerance "
+        f"{tolerance})"
     )
-    assert png_height == round(canvas_bbox["height"] * 2), (
-        f"expected PNG height {round(canvas_bbox['height'] * 2)}, "
-        f"got {png_height}"
+    assert abs(png_height - expected_height) <= tolerance, (
+        f"PNG height {png_height} is not ~2x graphics-document height "
+        f"{gd_bbox['height']:.1f} (expected ~{expected_height}, tolerance "
+        f"{tolerance})"
     )
 
 

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
@@ -713,7 +713,7 @@ describe("useVegaEmbed hook", () => {
       await expect(result.current.exportToPng()).resolves.toBeNull()
     })
 
-    it("exports the vega view as a PNG data URL at HiDPI scale", async () => {
+    it("exports the vega view as a PNG with at least 2x scale", async () => {
       const element: VegaLiteChartElement = {
         id: "chartId",
         data: null,
@@ -725,24 +725,32 @@ describe("useVegaEmbed hook", () => {
         formId: "",
       }
 
-      const { result } = renderHook(() => useVegaEmbed(element, mockWidgetMgr))
-
-      const containerRef = { current: document.createElement("div") }
-      await act(async () => {
-        await result.current.createView(containerRef, {})
+      const originalDpr = window.devicePixelRatio
+      Object.defineProperty(window, "devicePixelRatio", {
+        value: 1,
+        configurable: true,
       })
 
-      await expect(result.current.exportToPng()).resolves.toBe(
-        "data:image/png;base64,mock"
-      )
-      // We upscale the exported PNG to avoid blurry downloads on HiDPI
-      // displays. The scale factor is at least 2x, matching
-      // `Math.max(2, window.devicePixelRatio || 1)` in useVegaEmbed.
-      const expectedScaleFactor = Math.max(2, window.devicePixelRatio || 1)
-      expect(mockVegaView.toImageURL).toHaveBeenCalledWith(
-        "png",
-        expectedScaleFactor
-      )
+      try {
+        const { result } = renderHook(() =>
+          useVegaEmbed(element, mockWidgetMgr)
+        )
+
+        const containerRef = { current: document.createElement("div") }
+        await act(async () => {
+          await result.current.createView(containerRef, {})
+        })
+
+        await expect(result.current.exportToPng()).resolves.toBe(
+          "data:image/png;base64,mock"
+        )
+        expect(mockVegaView.toImageURL).toHaveBeenCalledWith("png", 2)
+      } finally {
+        Object.defineProperty(window, "devicePixelRatio", {
+          value: originalDpr,
+          configurable: true,
+        })
+      }
     })
 
     it("uses window.devicePixelRatio when it exceeds 2x", async () => {

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.test.ts
@@ -713,7 +713,7 @@ describe("useVegaEmbed hook", () => {
       await expect(result.current.exportToPng()).resolves.toBeNull()
     })
 
-    it("exports the vega view as a PNG data URL", async () => {
+    it("exports the vega view as a PNG data URL at HiDPI scale", async () => {
       const element: VegaLiteChartElement = {
         id: "chartId",
         data: null,
@@ -735,7 +735,52 @@ describe("useVegaEmbed hook", () => {
       await expect(result.current.exportToPng()).resolves.toBe(
         "data:image/png;base64,mock"
       )
-      expect(mockVegaView.toImageURL).toHaveBeenCalledWith("png")
+      // We upscale the exported PNG to avoid blurry downloads on HiDPI
+      // displays. The scale factor is at least 2x, matching
+      // `Math.max(2, window.devicePixelRatio || 1)` in useVegaEmbed.
+      const expectedScaleFactor = Math.max(2, window.devicePixelRatio || 1)
+      expect(mockVegaView.toImageURL).toHaveBeenCalledWith(
+        "png",
+        expectedScaleFactor
+      )
+    })
+
+    it("uses window.devicePixelRatio when it exceeds 2x", async () => {
+      const element: VegaLiteChartElement = {
+        id: "chartId",
+        data: null,
+        datasets: [],
+        spec: "",
+        useContainerWidth: false,
+        vegaLiteTheme: "",
+        selectionMode: [],
+        formId: "",
+      }
+
+      const originalDpr = window.devicePixelRatio
+      Object.defineProperty(window, "devicePixelRatio", {
+        value: 3,
+        configurable: true,
+      })
+
+      try {
+        const { result } = renderHook(() =>
+          useVegaEmbed(element, mockWidgetMgr)
+        )
+
+        const containerRef = { current: document.createElement("div") }
+        await act(async () => {
+          await result.current.createView(containerRef, {})
+        })
+
+        await result.current.exportToPng()
+        expect(mockVegaView.toImageURL).toHaveBeenCalledWith("png", 3)
+      } finally {
+        Object.defineProperty(window, "devicePixelRatio", {
+          value: originalDpr,
+          configurable: true,
+        })
+      }
     })
   })
 })

--- a/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
+++ b/frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts
@@ -311,7 +311,13 @@ export function useVegaEmbed(
     }
 
     try {
-      return await vegaViewRef.current.toImageURL("png")
+      // Vega's default PNG export is at 1x, which produces a blurry image on
+      // HiDPI/retina displays where the on-screen canvas is rendered at
+      // `window.devicePixelRatio`. We upscale the PNG to at least 2x so the
+      // exported file matches (or exceeds) the perceived on-screen fidelity.
+      // See https://github.com/streamlit/streamlit/issues/8177.
+      const scaleFactor = Math.max(2, window.devicePixelRatio || 1)
+      return await vegaViewRef.current.toImageURL("png", scaleFactor)
     } catch (error) {
       LOG.warn("Failed to export Vega view as PNG:", error)
       return null


### PR DESCRIPTION
## Summary
Part of #8177.

Downloading an Altair / Vega-Lite chart as PNG produced a low-resolution (1×) image regardless of the user's display DPR, so exports looked pixelated on HiDPI screens.

## Repro
Render any `st.altair_chart` on a HiDPI display, use the chart menu → "Save as PNG". The exported file is 1× DPR and appears blurry when viewed at native size.

## Fix
- `frontend/lib/src/components/elements/ArrowVegaLiteChart/useVegaEmbed.ts` — pass `Math.max(2, window.devicePixelRatio || 1)` as the `scaleFactor` argument to `view.toImageURL("png", …)` so PNG output honours device pixel ratio (with a floor of 2× so non-HiDPI environments still get a crisp export).

## Verification
- [x] Bug reproduces on develop
- [x] Fixed on this branch
- [x] `make check` passes
- [x] Regression test in `useVegaEmbed.test.ts`
- [x] E2E assertion on exported PNG dimensions in `st_altair_chart_test.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Vega PNG export scale only; behavior is covered by unit and E2E tests with no security or data-path changes.
> 
> **Overview**
> Fixes blurry **Download as PNG** exports for `st.altair_chart` by passing a **`scaleFactor`** into Vega’s `toImageURL` instead of the default 1× output.
> 
> In `useVegaEmbed`, `exportToPng` now uses `Math.max(2, window.devicePixelRatio || 1)` so exports match HiDPI on-screen fidelity, with a **2× floor** when DPR is 1 (e.g. headless CI).
> 
> **Tests:** `useVegaEmbed.test.ts` asserts `toImageURL("png", 2)` at DPR 1 and scale 3 at DPR 3. The Playwright download test reads the PNG IHDR and checks width/height are ~2× the on-screen graphics-document size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d8f88ff1b2c8dc722d53f91e230acb52bf283f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->