### PR TITLE
[fix] Preserve fragment children across container reruns (#12514)

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -502,10 +502,21 @@ def _fragment(
             if ctx is None:  # pragma: no cover - defensive
                 raise RuntimeError("ctx is None. This should never happen.")
 
-            if ctx.fragment_ids_this_run:
-                # This script run is a run of one or more fragments. We restore the
-                # state of ctx.cursors and dg_stack to the snapshots we took when this
-                # fragment was declared.
+            if ctx.fragment_ids_this_run and fragment_id in ctx.fragment_ids_this_run:
+                # This wrapped_fragment is being invoked directly by the script
+                # runner as a top-level fragment rerun (not through ``wrap`` from
+                # an enclosing scope). Restore the ctx.cursors and dg_stack state
+                # to the snapshots we took when this fragment was declared.
+                #
+                # Nested fragments called via ``wrap`` from an already-rerunning
+                # parent (i.e. ``fragment_ids_this_run`` is set but doesn't
+                # include this fragment) must NOT restore here: the parent's
+                # execution has already advanced the enclosing cursors, and
+                # replacing the dg_stack with deep copies would sever the
+                # nested fragment's writes from the enclosing scope's cursor
+                # state. That in turn can cause sibling nested fragments to
+                # compute colliding fragment ids and overwrite each other's
+                # deltas (see #12514).
                 ctx.cursors = deepcopy(cursors_snapshot)
                 context_dg_stack.set(deepcopy(dg_stack_snapshot))
 

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -502,24 +502,35 @@ def _fragment(
             if ctx is None:  # pragma: no cover - defensive
                 raise RuntimeError("ctx is None. This should never happen.")
 
-            if ctx.fragment_ids_this_run and fragment_id in ctx.fragment_ids_this_run:
-                # This wrapped_fragment is being invoked directly by the script
-                # runner as a top-level fragment rerun (not through ``wrap`` from
-                # an enclosing scope). Restore the ctx.cursors and dg_stack state
-                # to the snapshots we took when this fragment was declared.
-                #
-                # Nested fragments called via ``wrap`` from an already-rerunning
-                # parent (i.e. ``fragment_ids_this_run`` is set but doesn't
-                # include this fragment) must NOT restore here: the parent's
-                # execution has already advanced the enclosing cursors, and
-                # replacing the dg_stack with deep copies would sever the
-                # nested fragment's writes from the enclosing scope's cursor
-                # state. That in turn can cause sibling nested fragments to
-                # compute colliding fragment ids and overwrite each other's
-                # deltas (see #12514).
+            # True only when the ScriptRunner invokes this fragment directly as a
+            # queued top-level rerun. ``fragment_id is None`` distinguishes that
+            # from an inline call via ``wrap`` from an enclosing fragment, which
+            # matters when a parent and its own descendant are both queued: the
+            # descendant's id is still in ``fragment_ids_this_run`` while the
+            # parent runs it inline, so queue membership alone is not enough.
+            is_queued_toplevel_rerun = bool(
+                ctx.fragment_ids_this_run
+                and fragment_id in ctx.fragment_ids_this_run
+                and ThreadState.get().fragment_id is None
+            )
+
+            if is_queued_toplevel_rerun:
+                # Restore ctx.cursors and dg_stack to the snapshots taken when
+                # this fragment was declared. Nested fragments called via ``wrap``
+                # from an already-rerunning parent must keep the parent's
+                # already-advanced cursor state instead; replacing the dg_stack
+                # with deep copies would sever their writes from the enclosing
+                # scope, making sibling nested fragments compute colliding
+                # fragment ids and overwrite each other's deltas (see #12514).
                 ctx.cursors = deepcopy(cursors_snapshot)
                 context_dg_stack.set(deepcopy(dg_stack_snapshot))
 
+            if ctx.fragment_ids_this_run:
+                # Wrapper bookkeeping runs for every fragment executing during a
+                # fragment rerun, including nested ones reached via ``wrap``:
+                # their outside-container wrappers still need their cursors reset
+                # so writes overwrite in place rather than accumulate.
+                #
                 # Evict wrappers whose outside containers will be rebuilt by this
                 # fragment, then re-emit and reset the surviving wrappers. Order
                 # matters: eviction must happen first so we don't re-emit a wrapper

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -52,7 +52,10 @@ from streamlit.runtime.scriptrunner_utils.exceptions import (
     RerunException,
     StopException,
 )
-from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    ScriptRunContext,
+    ThreadState,
+)
 from streamlit.runtime.scriptrunner_utils.shared_run_state import SharedRunState
 from tests.conftest import enable_mpa_v2_mode
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -2227,6 +2230,28 @@ class NestedFragmentContainerRerunTest(DeltaGeneratorTestCase):
     on rerender when the parent fragment is rerun.
     """
 
+    @staticmethod
+    def _lookup_parent_fragment_id(
+        ctx: ScriptRunContext, child_fragment_ids: list[str]
+    ) -> str:
+        """Return the id of the only registered fragment that has no parent.
+
+        The nested ``b`` fragments are registered with ``a`` as their parent, so
+        ``a`` is the sole entry in the storage's parent map pointing at ``None``.
+        """
+        parent_ids = [
+            fid
+            for fid, parent_id in ctx.fragment_storage._parent_by_id.items()
+            if parent_id is None
+        ]
+        assert len(parent_ids) == 1, (
+            f"Expected exactly one top-level fragment, got {parent_ids!r}."
+        )
+        assert parent_ids[0] not in child_fragment_ids, (
+            "The top-level fragment id must be distinct from its children's ids."
+        )
+        return parent_ids[0]
+
     def test_sibling_nested_fragments_get_distinct_ids_on_parent_rerun(
         self,
     ) -> None:
@@ -2274,13 +2299,7 @@ class NestedFragmentContainerRerunTest(DeltaGeneratorTestCase):
         # wrapped_fragment and invoke it directly, mirroring what
         # ScriptRunner does when processing a fragment rerun.
         ctx = self.script_run_ctx
-        (a_fragment_id,) = [
-            fid
-            for fid, fn in ctx.fragment_storage._fragments.items()
-            if fn.__name__ == "wrapped_fragment"
-            # Filter to the top-level fragment (a): its delta path is short.
-            and fid not in initial_run_ids
-        ]
+        a_fragment_id = self._lookup_parent_fragment_id(ctx, initial_run_ids)
         ctx.fragment_ids_this_run = [a_fragment_id]
 
         wrapped_a = ctx.fragment_storage.lookup(a_fragment_id)
@@ -2297,4 +2316,60 @@ class NestedFragmentContainerRerunTest(DeltaGeneratorTestCase):
         # The recomputed ids should match the ids assigned during the
         # initial run — deterministic identity across reruns is what makes
         # fragment storage/lookup work.
+        assert recorded_fragment_ids == initial_run_ids
+
+    def test_sibling_nested_fragments_keep_distinct_ids_when_parent_and_children_queued(
+        self,
+    ) -> None:
+        """A coalesced queue holding both the parent and its nested children must
+        still produce distinct sibling ids.
+
+        ``order_fragment_ids`` runs queued ancestors before queued descendants,
+        so the parent executes first and invokes its children inline via
+        ``wrap`` while their ids are *still* in ``fragment_ids_this_run``. Queue
+        membership alone therefore can't distinguish a ScriptRunner-driven
+        top-level replay from an inline nested call; without the additional
+        ``ThreadState.get().fragment_id is None`` guard the children would
+        restore their declaration-time snapshots mid-parent-run and collide
+        exactly as in #12514.
+        """
+        recorded_fragment_ids: list[str] = []
+
+        @fragment
+        def b(i: int) -> None:
+            recorded_fragment_ids.append(ThreadState.get().fragment_id or "")
+
+        @fragment
+        def a() -> None:
+            container = st.container()
+            with container:
+                b(1)
+            with container:
+                b(2)
+
+        # Initial full app run — registers a, b(1), b(2) with distinct ids.
+        a()
+        assert len(recorded_fragment_ids) == 2
+        initial_run_ids = recorded_fragment_ids.copy()
+        recorded_fragment_ids.clear()
+
+        ctx = self.script_run_ctx
+        a_fragment_id = self._lookup_parent_fragment_id(ctx, initial_run_ids)
+
+        # Queue the parent *and* both children, ancestors first — the ordering
+        # ScriptRunner applies via ``order_fragment_ids``.
+        ctx.fragment_ids_this_run = [a_fragment_id, *initial_run_ids]
+
+        # ScriptRunner invokes the parent first; the children are reached inline
+        # from the parent's body rather than by a second direct invocation.
+        ctx.fragment_storage.lookup(a_fragment_id)()
+
+        assert len(recorded_fragment_ids) == 2, (
+            "Both nested fragments should re-execute during the parent's rerun."
+        )
+        assert recorded_fragment_ids[0] != recorded_fragment_ids[1], (
+            "Sibling nested fragments must keep distinct ids when the parent and "
+            "children are queued together; got a collision at "
+            f"{recorded_fragment_ids[0]!r}."
+        )
         assert recorded_fragment_ids == initial_run_ids

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -872,7 +872,13 @@ class FragmentTest(unittest.TestCase):
         self, patched_get_script_run_ctx
     ):
         ctx = MagicMock()
-        ctx.fragment_ids_this_run = ["my_fragment_id"]
+        # Populated below with the fragment's actual id once available. The
+        # snapshot-restore branch runs only when the currently executing
+        # fragment is a top-level fragment being rerun (its id appears in
+        # ``fragment_ids_this_run``); nested fragments called via ``wrap`` from
+        # an already-rerunning parent skip the restore to avoid detaching
+        # their writes from the enclosing scope's cursor state. See #12514.
+        ctx.fragment_ids_this_run = []
         ctx.fragment_storage = MemoryFragmentStorage()
         patched_get_script_run_ctx.return_value = ctx
 
@@ -905,7 +911,13 @@ class FragmentTest(unittest.TestCase):
 
             call_count += 1
 
+        # Initial registration: acts like a full app run (no restore).
         my_fragment()
+
+        # Register the fragment id so that subsequent standalone invocations
+        # of ``saved_fragment`` are treated as top-level fragment reruns.
+        fragment_id = next(iter(ctx.fragment_storage._fragments.keys()))
+        ctx.fragment_ids_this_run = [fragment_id]
 
         # Reach inside our MemoryFragmentStorage internals to pull out our saved
         # fragment.
@@ -1095,7 +1107,16 @@ class FragmentTest(unittest.TestCase):
         """Test that the internal function can be called with an
         additional hash info parameter."""
         ctx = MagicMock()
+        # Emulate a full app run so wrapped_fragment doesn't try to restore
+        # dg_stack/cursor snapshots between calls (see #12514 fix).
+        ctx.fragment_ids_this_run = []
         patched_get_script_run_ctx.return_value = ctx
+
+        # Pin the top DG's delta path to a deterministic value so that
+        # ``fragment_id`` is a function only of the function identity and
+        # ``additional_hash_info`` argument — not of MagicMock repr ids that
+        # can shift between calls when garbage collection reuses addresses.
+        context_dg_stack.get()[-1]._cursor.delta_path = [0, 0]
 
         def my_function():
             return ThreadState.get().fragment_id
@@ -2199,3 +2220,81 @@ class ParallelFragmentAPIRestrictionsTest(unittest.TestCase):
                 _check_not_parallel_worker("@st.dialog")
 
         assert ThreadState.get().is_parallel_worker is True
+
+
+class NestedFragmentContainerRerunTest(DeltaGeneratorTestCase):
+    """Regression tests for #12514: fragments inside a container disappearing
+    on rerender when the parent fragment is rerun.
+    """
+
+    def test_sibling_nested_fragments_get_distinct_ids_on_parent_rerun(
+        self,
+    ) -> None:
+        """Sibling nested fragments written to the same container via
+        separate ``with container:`` blocks must get distinct fragment ids
+        on a parent fragment rerun.
+
+        Before the fix, the inner fragment's ``wrapped_fragment`` unconditionally
+        replaced ``context_dg_stack`` with deep copies whenever
+        ``ctx.fragment_ids_this_run`` was truthy. During a parent's rerun the
+        inner fragment is called via ``wrap`` from the parent's execution, so
+        the deep-copy substitution detached the inner's writes from the
+        enclosing container's cursor. The container's cursor never advanced
+        between sibling ``with container: b(i)`` calls, so both siblings
+        computed identical fragment ids and overwrote each other's deltas.
+        """
+        recorded_fragment_ids: list[str] = []
+
+        @fragment
+        def b(i: int) -> None:
+            recorded_fragment_ids.append(ThreadState.get().fragment_id or "")
+
+        @fragment
+        def a() -> None:
+            container = st.container()
+            with container:
+                b(1)
+            with container:
+                b(2)
+
+        # Initial full app run — registers a, b(1), b(2) with distinct ids.
+        a()
+
+        # Sanity check: on the initial run, b(1) and b(2) get distinct ids.
+        assert len(recorded_fragment_ids) == 2
+        assert recorded_fragment_ids[0] != recorded_fragment_ids[1], (
+            "Even during the initial run, sibling nested fragments should have "
+            "distinct fragment ids."
+        )
+
+        initial_run_ids = recorded_fragment_ids.copy()
+        recorded_fragment_ids.clear()
+
+        # Simulate a fragment rerun of ``a``: look up a's registered
+        # wrapped_fragment and invoke it directly, mirroring what
+        # ScriptRunner does when processing a fragment rerun.
+        ctx = self.script_run_ctx
+        (a_fragment_id,) = [
+            fid
+            for fid, fn in ctx.fragment_storage._fragments.items()
+            if fn.__name__ == "wrapped_fragment"
+            # Filter to the top-level fragment (a): its delta path is short.
+            and fid not in initial_run_ids
+        ]
+        ctx.fragment_ids_this_run = [a_fragment_id]
+
+        wrapped_a = ctx.fragment_storage.lookup(a_fragment_id)
+        wrapped_a()
+
+        assert len(recorded_fragment_ids) == 2, (
+            "Both nested fragments should re-execute during a rerun of the parent."
+        )
+        assert recorded_fragment_ids[0] != recorded_fragment_ids[1], (
+            "Sibling nested fragments must get distinct fragment ids on a "
+            "parent fragment rerun; got a collision at "
+            f"{recorded_fragment_ids[0]!r}."
+        )
+        # The recomputed ids should match the ids assigned during the
+        # initial run — deterministic identity across reruns is what makes
+        # fragment storage/lookup work.
+        assert recorded_fragment_ids == initial_run_ids


### PR DESCRIPTION
## Describe your changes

Fragments nested inside a shared container lost their children (or overwrote each other) after the enclosing parent fragment reran.

`wrapped_fragment` restored the cursor/`dg_stack` snapshots captured at fragment-declaration time whenever `ctx.fragment_ids_this_run` was truthy. During a parent fragment's rerun, a nested fragment is reached *inline* via `wrap` from the parent's body — so that restore replaced `context_dg_stack` with deep copies and detached the nested fragment's writes from the enclosing container's cursor. The container cursor then never advanced between sibling `with container: b(i)` calls, so both siblings hashed to the same fragment id and clobbered each other's deltas.

**Fix** — `lib/streamlit/runtime/fragment.py`:

- Snapshot restore of `ctx.cursors` / `context_dg_stack` now runs only for a **queued top-level rerun**, expressed as `is_queued_toplevel_rerun`: the fragment's id is in `fragment_ids_this_run` **and** `ThreadState.get().fragment_id is None`.
  - The `fragment_id is None` term is what distinguishes a ScriptRunner-driven direct invocation from an inline `wrap` call. `ctx.reset()` initializes `fragment_id` to `None` for each script run, while an inline nested call executes inside the parent's `ThreadState.scoped(fragment_id=...)`. This matters because `order_fragment_ids` intentionally runs queued ancestors before queued descendants, so when a parent *and* its own child are both queued the child's id is still in `fragment_ids_this_run` while the parent invokes it inline — queue membership alone would misclassify it.
- Outside-container wrapper bookkeeping (`evict_outside_wrappers_created_by` + `_reset_outside_wrappers`) deliberately stays on the original broader `if ctx.fragment_ids_this_run:` branch, so nested fragments reached via `wrap` still reset their wrapper cursors and overwrite in place rather than accumulating writes.

## GitHub Issue Link (if applicable)

Fixes #12514

## Testing Plan

- **Unit Tests (Python)** — `lib/tests/streamlit/runtime/fragment_test.py`
  - New `NestedFragmentContainerRerunTest`:
    - `test_sibling_nested_fragments_get_distinct_ids_on_parent_rerun` — parent-only rerun; sibling nested fragments must keep distinct, stable ids.
    - `test_sibling_nested_fragments_keep_distinct_ids_when_parent_and_children_queued` — coalesced parent+children queue, the case queue membership alone gets wrong. Verified load-bearing: with the `fragment_id is None` term removed, it fails with both siblings computing an identical id.
  - Two existing tests updated for the narrowed condition (`test_sets_dg_stack_and_cursor_to_snapshots_if_fragment_ids_this_run` now seeds `fragment_ids_this_run` with the real registered id; the `additional_hash_info` test pins a deterministic delta path).
  - `lib/tests/streamlit/runtime` (2756 passed) and `lib/tests/streamlit/delta_generator_test.py` pass, covering the outside-wrapper paths touched by the second bullet above.
- **E2E Tests** — none added. The regression is an internal fragment-id/cursor bookkeeping bug reproduced deterministically at the unit level; reviewers agreed an e2e repro is a reasonable non-blocking follow-up.
- **Manual testing** — repro from #12514 confirmed broken on `develop` and fixed on this branch.
- `make check` passes.