### PR TITLE
[bugfix] Keep multiselect input caret at end after keyboard selection (#16133)

### DIFF
--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -570,7 +570,13 @@ const Multiselect: FC<Props> = props => {
               },
             },
             InputContainer: {
-              style: ({ $isFocused }: { $isFocused: boolean }) => ({
+              style: ({
+                $isFocused,
+                $isEmpty,
+              }: {
+                $isFocused: boolean
+                $isEmpty: boolean
+              }) => ({
                 // Height matches tags
                 height: theme.sizes.elementHighlightHeight,
                 // Alignment and left margin to match tags (ValueContainer padding)
@@ -580,8 +586,13 @@ const Multiselect: FC<Props> = props => {
                 // Bottom margin required to size the container correctly if the
                 // input is orphaned on a new line (in focus)
                 marginBottom: theme.sizes.tagMarginInsideBorder,
-                // Stack input when not focused to prevent premature line wrap
-                position: $isFocused ? "relative" : "absolute",
+                // Stack input absolutely only when there are no selected tags
+                // AND the control is unfocused, so the empty input doesn't push
+                // the placeholder around. When tags exist, keep the input inline
+                // (position: relative) so the caret renders after the tags —
+                // otherwise an absolutely-positioned input overlaps the tags at
+                // the top-left of the flex container. See #16133.
+                position: $isEmpty && !$isFocused ? "absolute" : "relative",
                 width: "fit-content",
                 flexGrow: 0,
                 // Center input vertically


### PR DESCRIPTION
## Summary
Fixes #16133.

After pressing Esc and then focusing the multiselect again, the cursor snapped to the start of the input on the next keystroke, so typed characters were inserted before the existing tags instead of after them.

## Repro
`work-tmp/repro_16133.py` — multiselect with a few pre-selected values → focus, Esc, re-focus, type. Caret sits at position 0.

## Fix
- `frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx` — the styled `InputContainer` used `position: absolute` whenever the input was focused, which detached it from the tag flow and caused BaseWeb to reset the caret. Only apply the absolute positioning when the container is *both* focused **and** empty (BaseWeb's `$isEmpty` prop), matching BaseWeb's own placeholder-overlay pattern.

## Verification
- [x] Bug reproduces on develop
- [x] Fixed on this branch
- [x] `make check` passes