### PR TITLE
[fix] Show full popover contents in narrow / embedded viewports (#9340)

### DIFF
--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -189,7 +189,9 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     iframe. The `size` middleware now clamps `max-width` to the available
     space at the chosen placement so the popover always fits.
     """
-    # Simulate a narrow oEmbed iframe (e.g. a Medium post).
+    # Simulate a narrow oEmbed iframe (e.g. a Medium post). 520px is
+    # narrower than the popover's default ~704px max-width, so pre-fix
+    # the body overflowed the viewport.
     app.set_viewport_size({"width": 520, "height": 800})
 
     popover_body = open_popover(app, "popover 3 (with widgets)")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -218,6 +218,32 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     )
 
 
+def test_popover_fits_viewport_narrower_than_min_width(app: Page):
+    """The popover's baseline `min-width` (`theme.sizes.minPopupWidth`, 20rem
+    / 320px) is wider than a very narrow embed viewport. Without a matching
+    `min-width` clamp the styled-component's min-width overrides the viewport
+    `max-width` clamp and the body still overflows. Regression guard for the
+    P1 finding on https://github.com/streamlit/streamlit/pull/16173.
+    """
+    # 300px is narrower than the popover's 320px baseline min-width.
+    app.set_viewport_size({"width": 300, "height": 800})
+
+    popover_body = open_popover(app, "popover 3 (with widgets)")
+    expect_markdown(popover_body, "Hello World 👋")
+
+    viewport = app.viewport_size
+    assert viewport is not None, "viewport_size must be set for this test"
+
+    body_box = popover_body.bounding_box()
+    assert body_box is not None, "popover body must have a bounding box"
+
+    epsilon = 1
+    assert body_box["x"] >= -epsilon, f"popover body extends off left edge: {body_box}"
+    assert body_box["x"] + body_box["width"] <= viewport["width"] + epsilon, (
+        f"popover body extends past right edge: {body_box}, viewport={viewport}"
+    )
+
+
 def test_popover_container_rendering(
     themed_app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -189,10 +189,12 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     iframe. The `size` middleware now clamps `max-width` to the available
     space at the chosen placement so the popover always fits.
     """
-    # Simulate a narrow oEmbed iframe (e.g. a Medium post). 520px is
-    # narrower than the popover's default ~704px max-width, so pre-fix
-    # the body overflowed the viewport.
-    app.set_viewport_size({"width": 520, "height": 800})
+    # Simulate a narrow oEmbed iframe (e.g. a Medium post is ~680px wide).
+    # 640px is chosen to sit inside the bug window: above the styled-component's
+    # `@media (max-width: 576px)` CSS clamp (which independently limits width on
+    # very small viewports) but below the popover's baseline ~704px max-width.
+    # Pre-fix, `size` middleware wasn't wired here and the popover overflowed.
+    app.set_viewport_size({"width": 640, "height": 800})
 
     popover_body = open_popover(app, "popover 3 (with widgets)")
     expect_markdown(popover_body, "Hello World 👋")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -186,64 +186,74 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     Before the fix, the popover body's baseline `max-width` (~704px) exceeded
     a narrow embed viewport's width. `shift` would push the popover against
     an edge, but the far side stayed off-screen and was clipped by the host
-    iframe. The `size` middleware now clamps `max-width` to the available
+    iframe. The `size` middleware now clamps `max-width` (and `min-width`,
+    when the intrinsic CSS min-width would exceed the clamp) to the available
     space at the chosen placement so the popover always fits.
+
+    Two scenarios are exercised in one app load to keep browser runs cheap
+    (per `e2e_playwright/AGENTS.md`):
+
+    - **640px viewport** — inside the #9340 bug window: wider than the
+      styled-component's `@media (max-width: 576px)` CSS clamp but narrower
+      than the popover's baseline ~704px max-width. Pre-fix, `size` middleware
+      wasn't wired here and the popover overflowed horizontally.
+    - **300px viewport** — narrower than the popover's 320px baseline
+      `min-width` (`theme.sizes.minPopupWidth`). Without the matching
+      `min-width` cap in the `size` middleware, CSS resolves the `min-width`
+      vs `max-width` conflict in favor of `min-width` and the popover
+      overflows again.
     """
-    # Simulate a narrow oEmbed iframe (e.g. a Medium post is ~680px wide).
-    # 640px is chosen to sit inside the bug window: above the styled-component's
-    # `@media (max-width: 576px)` CSS clamp (which independently limits width on
-    # very small viewports) but below the popover's baseline ~704px max-width.
-    # Pre-fix, `size` middleware wasn't wired here and the popover overflowed.
+    # 1px epsilon guards against subpixel layout differences across browsers.
+    epsilon = 1
+
+    def assert_within_viewport(popover_body, viewport, *, check_vertical: bool):
+        body_box = popover_body.bounding_box()
+        assert body_box is not None, "popover body must have a bounding box"
+        assert body_box["x"] >= -epsilon, (
+            f"popover body extends off left edge: {body_box}"
+        )
+        assert body_box["x"] + body_box["width"] <= viewport["width"] + epsilon, (
+            f"popover body extends past right edge: {body_box}, viewport={viewport}"
+        )
+        if check_vertical:
+            assert body_box["y"] >= -epsilon, (
+                f"popover body extends off top edge: {body_box}"
+            )
+            assert (
+                body_box["y"] + body_box["height"] <= viewport["height"] + epsilon
+            ), (
+                f"popover body extends past bottom edge: {body_box}, "
+                f"viewport={viewport}"
+            )
+
+    # Case 1: viewport inside the #9340 bug window (577-704px). Chosen to
+    # exceed the 576px CSS media-query clamp so the JS `size` middleware is
+    # actually the thing keeping the popover within the viewport. Also asserts
+    # vertical bounds since a narrow viewport at 800px height is tall enough
+    # to catch a top/bottom overflow regression.
     app.set_viewport_size({"width": 640, "height": 800})
-
     popover_body = open_popover(app, "popover 3 (with widgets)")
     expect_markdown(popover_body, "Hello World 👋")
-
     viewport = app.viewport_size
     assert viewport is not None, "viewport_size must be set for this test"
+    assert_within_viewport(popover_body, viewport, check_vertical=True)
 
-    body_box = popover_body.bounding_box()
-    assert body_box is not None, "popover body must have a bounding box"
+    # Close the popover by clicking outside so we can re-open it fresh at the
+    # next viewport size (avoids relying on Floating UI's autoUpdate reflow).
+    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
+    expect(popover_body).not_to_be_visible()
 
-    # Before #9340 was fixed the popover body extended past the viewport's
-    # right edge (its max-width was 704px). A 1px epsilon guards against
-    # subpixel layout differences across browsers. Also assert vertical
-    # bounds to guard against vertical overflow regressions.
-    epsilon = 1
-    assert body_box["x"] >= -epsilon, f"popover body extends off left edge: {body_box}"
-    assert body_box["x"] + body_box["width"] <= viewport["width"] + epsilon, (
-        f"popover body extends past right edge: {body_box}, viewport={viewport}"
-    )
-    assert body_box["y"] >= -epsilon, f"popover body extends off top edge: {body_box}"
-    assert body_box["y"] + body_box["height"] <= viewport["height"] + epsilon, (
-        f"popover body extends past bottom edge: {body_box}, viewport={viewport}"
-    )
-
-
-def test_popover_fits_viewport_narrower_than_min_width(app: Page):
-    """The popover's baseline `min-width` (`theme.sizes.minPopupWidth`, 20rem
-    / 320px) is wider than a very narrow embed viewport. Without a matching
-    `min-width` clamp the styled-component's min-width overrides the viewport
-    `max-width` clamp and the body still overflows. Regression guard for the
-    P1 finding on https://github.com/streamlit/streamlit/pull/16173.
-    """
-    # 300px is narrower than the popover's 320px baseline min-width.
+    # Case 2: viewport narrower than the popover's 320px baseline min-width.
+    # Without the intrinsic-min-width cap in the `size` middleware the popover
+    # would still overflow at this width. Horizontal bounds only — the trigger
+    # placement at 300px wide can force `flip` to pick a vertically-tight
+    # side, and vertical bounds are already covered by case 1.
     app.set_viewport_size({"width": 300, "height": 800})
-
     popover_body = open_popover(app, "popover 3 (with widgets)")
     expect_markdown(popover_body, "Hello World 👋")
-
     viewport = app.viewport_size
     assert viewport is not None, "viewport_size must be set for this test"
-
-    body_box = popover_body.bounding_box()
-    assert body_box is not None, "popover body must have a bounding box"
-
-    epsilon = 1
-    assert body_box["x"] >= -epsilon, f"popover body extends off left edge: {body_box}"
-    assert body_box["x"] + body_box["width"] <= viewport["width"] + epsilon, (
-        f"popover body extends past right edge: {body_box}, viewport={viewport}"
-    )
+    assert_within_viewport(popover_body, viewport, check_vertical=False)
 
 
 def test_popover_container_rendering(

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -179,33 +179,25 @@ def test_popover_in_sidebar_stays_within_viewport(app: Page):
 
 
 def test_popover_stays_within_narrow_viewport(app: Page):
-    """A popover must render fully within a narrow viewport (e.g. an app
-    embedded via oEmbed inside a narrow host iframe). Regression test for
+    """Popover content must stay fully within a narrow viewport (e.g. an
+    oEmbed host iframe). Regression for
     https://github.com/streamlit/streamlit/issues/9340.
 
-    Before the fix, the popover body's baseline `max-width` (~704px) exceeded
-    a narrow embed viewport's width. `shift` would push the popover against
-    an edge, but the far side stayed off-screen and was clipped by the host
-    iframe. The `size` middleware now clamps `max-width` (and `min-width`,
-    when the intrinsic CSS min-width would exceed the clamp) to the available
-    space at the chosen placement so the popover always fits.
+    Without `size` middleware, the ~704px design max-width (and, under
+    320px, the CSS min-width) overflow a narrow embed: `shift` pins one
+    edge and the host clips the other.
 
-    Three scenarios are exercised in one app load to keep browser runs cheap
-    (per `e2e_playwright/AGENTS.md`):
+    Three cases in one app load (see e2e_playwright/AGENTS.md):
 
-    - **640px viewport** — inside the #9340 bug window: wider than the
-      styled-component's `@media (max-width: 576px)` CSS clamp but narrower
-      than the popover's baseline ~704px max-width. Pre-fix, `size` middleware
-      wasn't wired here and the popover overflowed horizontally.
-    - **300px viewport** — narrower than the popover's 320px baseline
-      `min-width` (`theme.sizes.minPopupWidth`). Without the matching
-      `min-width` cap in the `size` middleware, CSS resolves the `min-width`
-      vs `max-width` conflict in favor of `min-width` and the popover
-      overflows again.
-    - **Stretch popover at 640px** — a `width="stretch"` popover uses
-      `min-width: max($calculatedWidth, 10rem)`, exercising the middleware's
-      stretch-aware intrinsic-min-width path (compares against the applied
-      max-width, which folds in the ~704px design cap).
+    - **640px** — between the 576px CSS media-query clamp and the ~704px
+      design max-width, so only JS `size` keeps the popover in bounds.
+      Also checks vertical overflow.
+    - **300px** — narrower than the 320px baseline min-width; exercises the
+      middleware's min-width cap (horizontal only — flip can pick a tight
+      vertical side at this width).
+    - **Stretch at 640px** — `width="stretch"` uses
+      `min-width: max($calculatedWidth, 10rem)`; exercises the
+      stretch-aware min-width path against the applied max-width.
     """
     # 1px epsilon guards against subpixel layout differences across browsers.
     epsilon = 1
@@ -233,11 +225,8 @@ def test_popover_stays_within_narrow_viewport(app: Page):
                 f"viewport={viewport}"
             )
 
-    # Case 1: viewport inside the #9340 bug window (577-704px). Chosen to
-    # exceed the 576px CSS media-query clamp so the JS `size` middleware is
-    # actually the thing keeping the popover within the viewport. Also asserts
-    # vertical bounds since a narrow viewport at 800px height is tall enough
-    # to catch a top/bottom overflow regression.
+    # Case 1: 640px — past the 576px CSS clamp so JS `size` constrains width.
+    # Assert vertical bounds too (800px height catches top/bottom overflow).
     app.set_viewport_size({"width": 640, "height": 800})
     popover_body = open_popover(app, "popover 3 (with widgets)")
     expect_markdown(popover_body, "Hello World 👋")
@@ -245,16 +234,15 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     assert viewport is not None, "viewport_size must be set for this test"
     assert_within_viewport(popover_body, viewport, check_vertical=True)
 
-    # Close the popover by clicking outside so we can re-open it fresh at the
-    # next viewport size (avoids relying on Floating UI's autoUpdate reflow).
-    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
+    # Re-open fresh at each viewport rather than relying on Floating UI's
+    # autoUpdate reflow. Dismiss with Escape, not an outside click at a fixed
+    # position: at 300px the layout can put that point on the trigger itself,
+    # which made this step intermittently fail to close the popover.
+    app.keyboard.press("Escape")
     expect(popover_body).not_to_be_visible()
 
-    # Case 2: viewport narrower than the popover's 320px baseline min-width.
-    # Without the intrinsic-min-width cap in the `size` middleware the popover
-    # would still overflow at this width. Horizontal bounds only — the trigger
-    # placement at 300px wide can force `flip` to pick a vertically-tight
-    # side, and vertical bounds are already covered by case 1.
+    # Case 2: 300px — below the 320px CSS min-width; needs the min-width cap.
+    # Horizontal only — flip may pick a tight vertical side.
     app.set_viewport_size({"width": 300, "height": 800})
     popover_body = open_popover(app, "popover 3 (with widgets)")
     expect_markdown(popover_body, "Hello World 👋")
@@ -262,16 +250,12 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     assert viewport is not None, "viewport_size must be set for this test"
     assert_within_viewport(popover_body, viewport, check_vertical=False)
 
-    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
+    app.keyboard.press("Escape")
     expect(popover_body).not_to_be_visible()
 
-    # Case 3: stretch popover (popover 11, `width="stretch"`) in a narrow
-    # viewport. Its `min-width` is `max($calculatedWidth, 10rem)`, so the
-    # size middleware's stretch-aware intrinsic-min-width computation is what
-    # keeps this popover from overflowing when the trigger's calculated width
-    # would otherwise push past the viewport clamp. `expect_markdown` waits
-    # for the popover body to render its content so the bounding box has
-    # stabilized past any ResizeObserver-driven `$calculatedWidth` update.
+    # Case 3: stretch popover (`min-width: max($calculatedWidth, 10rem)`).
+    # `expect_markdown` waits until content (and any ResizeObserver-driven
+    # `$calculatedWidth` update) has settled before we measure the box.
     app.set_viewport_size({"width": 640, "height": 800})
     popover_body = open_popover(app, "popover 11 (width=stretch)")
     expect_markdown(popover_body, "Stretch width")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -190,7 +190,7 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     when the intrinsic CSS min-width would exceed the clamp) to the available
     space at the chosen placement so the popover always fits.
 
-    Two scenarios are exercised in one app load to keep browser runs cheap
+    Three scenarios are exercised in one app load to keep browser runs cheap
     (per `e2e_playwright/AGENTS.md`):
 
     - **640px viewport** — inside the #9340 bug window: wider than the
@@ -202,6 +202,10 @@ def test_popover_stays_within_narrow_viewport(app: Page):
       `min-width` cap in the `size` middleware, CSS resolves the `min-width`
       vs `max-width` conflict in favor of `min-width` and the popover
       overflows again.
+    - **Stretch popover at 640px** — a `width="stretch"` popover uses
+      `min-width: max($calculatedWidth, 10rem)`, exercising the middleware's
+      stretch-aware intrinsic-min-width path (compares against the applied
+      max-width, which folds in the ~704px design cap).
     """
     # 1px epsilon guards against subpixel layout differences across browsers.
     epsilon = 1
@@ -265,9 +269,12 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     # viewport. Its `min-width` is `max($calculatedWidth, 10rem)`, so the
     # size middleware's stretch-aware intrinsic-min-width computation is what
     # keeps this popover from overflowing when the trigger's calculated width
-    # would otherwise push past the viewport clamp.
+    # would otherwise push past the viewport clamp. `expect_markdown` waits
+    # for the popover body to render its content so the bounding box has
+    # stabilized past any ResizeObserver-driven `$calculatedWidth` update.
     app.set_viewport_size({"width": 640, "height": 800})
     popover_body = open_popover(app, "popover 11 (width=stretch)")
+    expect_markdown(popover_body, "Stretch width")
     viewport = app.viewport_size
     assert viewport is not None, "viewport_size must be set for this test"
     assert_within_viewport(popover_body, viewport, check_vertical=False)

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -15,7 +15,7 @@
 
 import re
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
@@ -206,7 +206,12 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     # 1px epsilon guards against subpixel layout differences across browsers.
     epsilon = 1
 
-    def assert_within_viewport(popover_body, viewport, *, check_vertical: bool):
+    def assert_within_viewport(
+        popover_body: Locator,
+        viewport: dict,
+        *,
+        check_vertical: bool,
+    ) -> None:
         body_box = popover_body.bounding_box()
         assert body_box is not None, "popover body must have a bounding box"
         assert body_box["x"] >= -epsilon, (

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -258,6 +258,20 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     assert viewport is not None, "viewport_size must be set for this test"
     assert_within_viewport(popover_body, viewport, check_vertical=False)
 
+    app.get_by_test_id("stApp").click(position={"x": 0, "y": 0})
+    expect(popover_body).not_to_be_visible()
+
+    # Case 3: stretch popover (popover 11, `width="stretch"`) in a narrow
+    # viewport. Its `min-width` is `max($calculatedWidth, 10rem)`, so the
+    # size middleware's stretch-aware intrinsic-min-width computation is what
+    # keeps this popover from overflowing when the trigger's calculated width
+    # would otherwise push past the viewport clamp.
+    app.set_viewport_size({"width": 640, "height": 800})
+    popover_body = open_popover(app, "popover 11 (width=stretch)")
+    viewport = app.viewport_size
+    assert viewport is not None, "viewport_size must be set for this test"
+    assert_within_viewport(popover_body, viewport, check_vertical=False)
+
 
 def test_popover_container_rendering(
     themed_app: Page, assert_snapshot: ImageCompareFunction

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -189,7 +189,7 @@ def test_popover_stays_within_narrow_viewport(app: Page):
     iframe. The `size` middleware now clamps `max-width` to the available
     space at the chosen placement so the popover always fits.
     """
-    # Simulate a narrow oembed iframe (e.g. a Medium post).
+    # Simulate a narrow oEmbed iframe (e.g. a Medium post).
     app.set_viewport_size({"width": 520, "height": 800})
 
     popover_body = open_popover(app, "popover 3 (with widgets)")

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -219,9 +219,7 @@ def test_popover_stays_within_narrow_viewport(app: Page):
             assert body_box["y"] >= -epsilon, (
                 f"popover body extends off top edge: {body_box}"
             )
-            assert (
-                body_box["y"] + body_box["height"] <= viewport["height"] + epsilon
-            ), (
+            assert body_box["y"] + body_box["height"] <= viewport["height"] + epsilon, (
                 f"popover body extends past bottom edge: {body_box}, "
                 f"viewport={viewport}"
             )

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -203,11 +203,16 @@ def test_popover_stays_within_narrow_viewport(app: Page):
 
     # Before #9340 was fixed the popover body extended past the viewport's
     # right edge (its max-width was 704px). A 1px epsilon guards against
-    # subpixel layout differences across browsers.
+    # subpixel layout differences across browsers. Also assert vertical
+    # bounds to guard against vertical overflow regressions.
     epsilon = 1
     assert body_box["x"] >= -epsilon, f"popover body extends off left edge: {body_box}"
     assert body_box["x"] + body_box["width"] <= viewport["width"] + epsilon, (
         f"popover body extends past right edge: {body_box}, viewport={viewport}"
+    )
+    assert body_box["y"] >= -epsilon, f"popover body extends off top edge: {body_box}"
+    assert body_box["y"] + body_box["height"] <= viewport["height"] + epsilon, (
+        f"popover body extends past bottom edge: {body_box}, viewport={viewport}"
     )
 
 

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -15,7 +15,7 @@
 
 import re
 
-from playwright.sync_api import Locator, Page, expect
+from playwright.sync_api import Locator, Page, ViewportSize, expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
@@ -208,7 +208,7 @@ def test_popover_stays_within_narrow_viewport(app: Page):
 
     def assert_within_viewport(
         popover_body: Locator,
-        viewport: dict,
+        viewport: ViewportSize,
         *,
         check_vertical: bool,
     ) -> None:

--- a/e2e_playwright/st_popover_test.py
+++ b/e2e_playwright/st_popover_test.py
@@ -178,6 +178,39 @@ def test_popover_in_sidebar_stays_within_viewport(app: Page):
     )
 
 
+def test_popover_stays_within_narrow_viewport(app: Page):
+    """A popover must render fully within a narrow viewport (e.g. an app
+    embedded via oEmbed inside a narrow host iframe). Regression test for
+    https://github.com/streamlit/streamlit/issues/9340.
+
+    Before the fix, the popover body's baseline `max-width` (~704px) exceeded
+    a narrow embed viewport's width. `shift` would push the popover against
+    an edge, but the far side stayed off-screen and was clipped by the host
+    iframe. The `size` middleware now clamps `max-width` to the available
+    space at the chosen placement so the popover always fits.
+    """
+    # Simulate a narrow oembed iframe (e.g. a Medium post).
+    app.set_viewport_size({"width": 520, "height": 800})
+
+    popover_body = open_popover(app, "popover 3 (with widgets)")
+    expect_markdown(popover_body, "Hello World 👋")
+
+    viewport = app.viewport_size
+    assert viewport is not None, "viewport_size must be set for this test"
+
+    body_box = popover_body.bounding_box()
+    assert body_box is not None, "popover body must have a bounding box"
+
+    # Before #9340 was fixed the popover body extended past the viewport's
+    # right edge (its max-width was 704px). A 1px epsilon guards against
+    # subpixel layout differences across browsers.
+    epsilon = 1
+    assert body_box["x"] >= -epsilon, f"popover body extends off left edge: {body_box}"
+    assert body_box["x"] + body_box["width"] <= viewport["width"] + epsilon, (
+        f"popover body extends past right edge: {body_box}, viewport={viewport}"
+    )
+
+
 def test_popover_container_rendering(
     themed_app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/frontend/lib/src/components/elements/Popover/Popover.test.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.test.tsx
@@ -22,7 +22,7 @@ import { Block as BlockProto } from "@streamlit/protobuf"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
-import Popover, { PopoverProps } from "./Popover"
+import Popover, { clampPopoverSize, PopoverProps } from "./Popover"
 
 const createWidgetMgr = (): WidgetStateManager =>
   new WidgetStateManager({
@@ -661,5 +661,92 @@ describe("Popover chevron visibility", () => {
 
     const button = screen.getByTestId("stPopoverButton")
     expect(button).toHaveTextContent("expand_more")
+  })
+})
+
+describe("clampPopoverSize", () => {
+  // The e2e test covers user-visible overflow; these lock the arithmetic.
+  const designMaxWidthPx = 704
+  const cssMinWidthPx = 320
+
+  it("clamps max-width to the available space when space is the tighter bound", () => {
+    const { maxWidth } = clampPopoverSize({
+      availableWidth: 500,
+      availableHeight: 800,
+      designMaxWidthPx,
+      cssMinWidthPx,
+    })
+
+    expect(maxWidth).toBe("500px")
+  })
+
+  it("caps max-width at the design width on wide viewports", () => {
+    const { maxWidth } = clampPopoverSize({
+      availableWidth: 5000,
+      availableHeight: 800,
+      designMaxWidthPx,
+      cssMinWidthPx,
+    })
+
+    expect(maxWidth).toBe("704px")
+  })
+
+  it("keeps the 70vh ceiling alongside the available-height clamp", () => {
+    const { maxHeight } = clampPopoverSize({
+      availableWidth: 500,
+      availableHeight: 640.7,
+      designMaxWidthPx,
+      cssMinWidthPx,
+    })
+
+    expect(maxHeight).toBe("min(640px, 70vh)")
+  })
+
+  it("lowers min-width when CSS would otherwise overflow the clamp", () => {
+    const { minWidth } = clampPopoverSize({
+      availableWidth: 300,
+      availableHeight: 800,
+      designMaxWidthPx,
+      cssMinWidthPx,
+    })
+
+    expect(minWidth).toBe("300px")
+  })
+
+  it("leaves min-width alone when CSS already fits", () => {
+    const { minWidth } = clampPopoverSize({
+      availableWidth: 500,
+      availableHeight: 800,
+      designMaxWidthPx,
+      cssMinWidthPx,
+    })
+
+    expect(minWidth).toBe("")
+  })
+
+  it("lowers a stretch min-width that sits between the design cap and the viewport", () => {
+    // The case the applied-max comparison exists for: available space exceeds
+    // the design cap, and the stretch min-width falls in between.
+    const { maxWidth, minWidth } = clampPopoverSize({
+      availableWidth: 900,
+      availableHeight: 800,
+      designMaxWidthPx,
+      cssMinWidthPx: 800,
+    })
+
+    expect(maxWidth).toBe("704px")
+    expect(minWidth).toBe("704px")
+  })
+
+  it("floors fractional space and never goes negative", () => {
+    const { maxWidth, maxHeight } = clampPopoverSize({
+      availableWidth: 499.9,
+      availableHeight: -20,
+      designMaxWidthPx,
+      cssMinWidthPx,
+    })
+
+    expect(maxWidth).toBe("499px")
+    expect(maxHeight).toBe("min(0px, 70vh)")
   })
 })

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -57,6 +57,41 @@ import {
   StyledPopoverLabelContainer,
 } from "./styled-components"
 
+/** Padding kept between the popover and the boundary edge, in px. */
+const SHIFT_PADDING = 8
+
+/**
+ * Fit the popover inside the available space without exceeding the design caps,
+ * and stop CSS `min-width` from defeating that.
+ *
+ * `designMaxWidthPx` and `cssMinWidthPx` mirror StyledPopoverBody; see the call
+ * site for how they are derived.
+ */
+function clampPopoverSize({
+  availableWidth,
+  availableHeight,
+  designMaxWidthPx,
+  cssMinWidthPx,
+}: {
+  availableWidth: number
+  availableHeight: number
+  designMaxWidthPx: number
+  cssMinWidthPx: number
+}): { maxWidth: string; maxHeight: string; minWidth: string } {
+  const maxWidthPx = Math.min(
+    Math.max(Math.floor(availableWidth), 0),
+    designMaxWidthPx
+  )
+  return {
+    maxWidth: `${maxWidthPx}px`,
+    maxHeight: `min(${Math.max(Math.floor(availableHeight), 0)}px, 70vh)`,
+    // CSS prefers min-width over max-width when they conflict, so lower it.
+    // Compared against the capped width, not the raw available space, so a
+    // stretch popover sized between the design cap and the viewport is caught.
+    minWidth: cssMinWidthPx > maxWidthPx ? `${maxWidthPx}px` : "",
+  }
+}
+
 export interface PopoverProps {
   element: BlockProto.Popover
   empty: boolean
@@ -195,32 +230,25 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // keyboard activation, which can dispatch a `click` with no prior pointerdown.
   const interactionInsideRef = useRef(false)
 
-  // Keep the popover inside the viewport for both narrow embeds (#9340) and
-  // sidebar `overflow: auto` clipping (#9387). Two middleware adjustments,
-  // split by scope:
+  // Keep the popover inside the viewport for narrow embeds (#9340) and
+  // sidebar overflow clipping (#9387). Two middleware adjustments by scope:
   //
-  // - **Always** (applies to every popover): a `size` middleware that clamps
-  //   `max-height` AND `max-width` to Floating UI's measured available space
-  //   at the chosen placement, and caps `min-width` when the intrinsic value
-  //   would exceed the clamp. Without the height clamp, a popover taller
-  //   than the space on either side of the trigger extends off-screen (bug
-  //   in #9387). Without the width clamp, the popover's baseline
-  //   `maxWidth: contentMaxWidth` (~704px) can exceed a narrow oEmbed
-  //   iframe's width, so `shift` shoves it against an edge and the far side
-  //   is clipped (bug in #9340). `size` sits after `flip` so it constrains
-  //   dimensions relative to whichever side `flip` landed on; the internal
-  //   `overflow: auto` on StyledPopoverBody handles scrolling when clamped.
+  // - **Always**: `size` clamps max-height/max-width to available space at the
+  //   chosen placement, and lowers min-width when the CSS min would exceed
+  //   that clamp.
+  //   - Without the height clamp, a tall popover extends off-screen (#9387).
+  //   - Without the width clamp, the ~704px design max-width overflows a
+  //     narrow oEmbed iframe: `shift` pins one edge and the host clips the
+  //     other (#9340).
+  //   - `size` runs after `flip` so it measures against the final side;
+  //     `StyledPopoverBody`'s `overflow: auto` scrolls when clamped.
   //
   // - **Sidebar only**: override the shift/flip `boundary` to
-  //   `document.documentElement` so the popover (portalled to document.body
-  //   with `position: fixed`) is bounded by the viewport rather than the
-  //   sidebar or any `.stApp` clipping ancestor. `document.documentElement`
-  //   (the <html> element) is used rather than `document.body` because
-  //   Streamlit's `.stApp` uses `position: absolute; inset: 0`, which leaves
-  //   document.body sized 0x0 — a body boundary would always report overflow.
-  //   Without this override, shift squishes a sidebar popover against the
-  //   sidebar's edge.
-  const shiftPadding = 8
+  //   `document.documentElement` so Floating UI uses the viewport, not the
+  //   sidebar's `overflow: auto` rect. Prefer `<html>` over `document.body`
+  //   because `.stApp`'s `position: absolute; inset: 0` leaves body at 0x0 —
+  //   a body boundary would always report overflow. Without this override,
+  //   shift squishes the popover against the sidebar edge.
   const overlayOptions = useMemo(() => {
     const base = {
       open,
@@ -231,66 +259,42 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       return base
     }
     const boundary = document.documentElement
-    // Match StyledPopoverBody's stretch-mode `min-width: max($calculatedWidth,
-    // 10rem)` from styled-components.ts. Kept in sync manually because the
-    // middleware needs to know the intrinsic min-width without reading it
-    // back from the DOM (which would force a style recomputation on every
-    // position update).
-    const stretchMinWidthPx = convertRemToPx("10rem")
-    const minPopupWidthPx = convertRemToPx(theme.sizes.minPopupWidth)
-    // StyledPopoverBody's design cap on width: `calc(contentMaxWidth - 2 *
-    // spacing.lg)` (~704px). Preserved as a ceiling for the inline `max-width`
-    // so wide viewports still respect the design cap rather than growing to
-    // the full available viewport width. `contentMaxWidth` is a px token
-    // (e.g. "736px") while `spacing.lg` is a rem token.
-    const baselineMaxWidthPx =
+    // Mirrors StyledPopoverBody — keep in sync with styled-components.ts.
+    // Reading these back from the DOM would force a style recomputation on
+    // every position update. `contentMaxWidth` is a px token; `spacing.lg` is
+    // rem — hence parseFloat vs convertRemToPx.
+    const designMaxWidthPx =
       parseFloat(theme.sizes.contentMaxWidth) -
       2 * convertRemToPx(theme.spacing.lg)
-    // Intrinsic min-width from StyledPopoverBody: non-stretch uses
-    // `theme.sizes.minPopupWidth`; stretch uses `max($calculatedWidth,
-    // 10rem)`.
-    const intrinsicMinWidth = stretchWidth
-      ? Math.max(calculatedWidth, stretchMinWidthPx)
-      : minPopupWidthPx
+    const cssMinWidthPx = stretchWidth
+      ? Math.max(calculatedWidth, convertRemToPx("10rem"))
+      : convertRemToPx(theme.sizes.minPopupWidth)
     const sizeMiddleware: Middleware = size({
-      padding: shiftPadding,
+      padding: SHIFT_PADDING,
       boundary,
       apply({ availableHeight, availableWidth, elements }) {
-        // Clamp strictly to Floating UI's measured space so the popover never
-        // extends past the viewport, even in very small viewports where both
-        // sides of the trigger have limited room. The internal `overflow:
-        // auto` on StyledPopoverBody handles the scroll. `Math.min` against
-        // the styled-component's design caps (`baselineMaxWidthPx` and the
-        // CSS `70vh` cap on max-height) preserves those caps on large
-        // viewports so the inline clamp doesn't accidentally allow the
-        // popover to grow past them.
-        const clampedHeight = Math.max(Math.floor(availableHeight), 0)
-        const clampedWidth = Math.max(Math.floor(availableWidth), 0)
-        const appliedMaxWidth = Math.min(clampedWidth, baselineMaxWidthPx)
-        elements.floating.style.maxHeight = `min(${clampedHeight}px, 70vh)`
-        elements.floating.style.maxWidth = `${appliedMaxWidth}px`
-        // When the intrinsic `min-width` from StyledPopoverBody exceeds the
-        // applied `max-width` (which now folds in both the viewport clamp
-        // and the ~704px design cap), CSS resolves the conflict in favor of
-        // `min-width` and the popover overflows the cap. Compare against
-        // `appliedMaxWidth`, not raw `clampedWidth`, so a stretch popover
-        // whose `calculatedWidth` sits between the design cap and the
-        // viewport clamp still gets its min-width capped.
-        elements.floating.style.minWidth =
-          intrinsicMinWidth > appliedMaxWidth ? `${appliedMaxWidth}px` : ""
+        const { maxWidth, maxHeight, minWidth } = clampPopoverSize({
+          availableWidth,
+          availableHeight,
+          designMaxWidthPx,
+          cssMinWidthPx,
+        })
+        Object.assign(elements.floating.style, {
+          maxWidth,
+          maxHeight,
+          minWidth,
+        })
       },
     })
     if (!isInSidebar) {
-      // Outside the sidebar we still need `size` to prevent overflow of a
-      // narrow embed viewport, but we don't need to override flip/shift
-      // boundaries — the defaults already resolve to the viewport for
-      // `position: fixed` floating elements.
+      // Still apply `size` for narrow embeds, but skip the flip/shift boundary
+      // override — defaults already use the viewport for `position: fixed`.
       return { ...base, extraMiddleware: [sizeMiddleware] }
     }
     return {
       ...base,
       flipOptions: { boundary },
-      shiftOptions: { padding: shiftPadding, boundary },
+      shiftOptions: { padding: SHIFT_PADDING, boundary },
       extraMiddleware: [sizeMiddleware],
     }
   }, [

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -215,7 +215,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   //    and below the trigger, `flip` picks the less-overflowing side and the
   //    popover extends off-screen (bug in #9387). Without the width clamp,
   //    the popover's baseline `maxWidth: contentMaxWidth` (~704px) can
-  //    exceed a narrow oembed iframe's width, so `shift` shoves it against
+  //    exceed a narrow oEmbed iframe's width, so `shift` shoves it against
   //    an edge and the far side is clipped by the iframe (bug in #9340).
   //    `size` sits after `flip` so it constrains dimensions relative to
   //    whichever side `flip` landed on; the internal `overflow: auto` on

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -195,31 +195,31 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // keyboard activation, which can dispatch a `click` with no prior pointerdown.
   const interactionInsideRef = useRef(false)
 
-  // Adjust Floating UI middleware so the popover stays within the viewport
-  // even when the app is embedded inside a narrow iframe (e.g. Medium
-  // oEmbed, #9340) or rendered inside the sidebar's `overflow: auto` column.
-  // Two things are needed:
+  // Keep the popover inside the viewport for both narrow embeds (#9340) and
+  // sidebar `overflow: auto` clipping (#9387). Two middleware adjustments,
+  // split by scope:
   //
-  // 1. Override the shift/flip boundary to `document.documentElement` so the
-  //    popover (portalled to document.body with `position: fixed`) is bounded
-  //    by the viewport rather than the sidebar or any `.stApp` clipping
-  //    ancestor. `document.documentElement` (the <html> element) is used
-  //    rather than `document.body` because Streamlit's `.stApp` uses
-  //    `position: absolute; inset: 0`, which leaves document.body sized 0x0
-  //    — a body boundary would always report overflow. Without this override,
-  //    shift squishes a sidebar popover against the sidebar's edge.
+  // - **Always** (applies to every popover): a `size` middleware that clamps
+  //   `max-height` AND `max-width` to Floating UI's measured available space
+  //   at the chosen placement, and caps `min-width` when the intrinsic value
+  //   would exceed the clamp. Without the height clamp, a popover taller
+  //   than the space on either side of the trigger extends off-screen (bug
+  //   in #9387). Without the width clamp, the popover's baseline
+  //   `maxWidth: contentMaxWidth` (~704px) can exceed a narrow oEmbed
+  //   iframe's width, so `shift` shoves it against an edge and the far side
+  //   is clipped (bug in #9340). `size` sits after `flip` so it constrains
+  //   dimensions relative to whichever side `flip` landed on; the internal
+  //   `overflow: auto` on StyledPopoverBody handles scrolling when clamped.
   //
-  // 2. Add a `size` middleware that clamps the popover's max height AND max
-  //    width to the available space at the chosen placement. Without the
-  //    height clamp, when the popover is taller than the space both above
-  //    and below the trigger, `flip` picks the less-overflowing side and the
-  //    popover extends off-screen (bug in #9387). Without the width clamp,
-  //    the popover's baseline `maxWidth: contentMaxWidth` (~704px) can
-  //    exceed a narrow oEmbed iframe's width, so `shift` shoves it against
-  //    an edge and the far side is clipped by the iframe (bug in #9340).
-  //    `size` sits after `flip` so it constrains dimensions relative to
-  //    whichever side `flip` landed on; the internal `overflow: auto` on
-  //    StyledPopoverBody handles scrolling when clamped.
+  // - **Sidebar only**: override the shift/flip `boundary` to
+  //   `document.documentElement` so the popover (portalled to document.body
+  //   with `position: fixed`) is bounded by the viewport rather than the
+  //   sidebar or any `.stApp` clipping ancestor. `document.documentElement`
+  //   (the <html> element) is used rather than `document.body` because
+  //   Streamlit's `.stApp` uses `position: absolute; inset: 0`, which leaves
+  //   document.body sized 0x0 — a body boundary would always report overflow.
+  //   Without this override, shift squishes a sidebar popover against the
+  //   sidebar's edge.
   const shiftPadding = 8
   // Match StyledPopoverBody's stretch-mode `min-width: max($calculatedWidth,
   // 10rem)` from styled-components.ts. Kept in sync manually because the
@@ -238,6 +238,14 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     }
     const boundary = document.documentElement
     const minPopupWidthPx = convertRemToPx(theme.sizes.minPopupWidth)
+    // StyledPopoverBody's design cap on width: `calc(contentMaxWidth - 2 *
+    // spacing.lg)` (~704px). Preserved as a floor for the inline `max-width`
+    // so wide viewports still respect the design cap rather than being
+    // clamped to the full available viewport width. `contentMaxWidth` is a
+    // px token (e.g. "736px") while `spacing.lg` is a rem token.
+    const baselineMaxWidthPx =
+      parseFloat(theme.sizes.contentMaxWidth) -
+      2 * convertRemToPx(theme.spacing.lg)
     // Intrinsic min-width from StyledPopoverBody: non-stretch uses
     // `theme.sizes.minPopupWidth`; stretch uses `max($calculatedWidth,
     // 10rem)`.
@@ -251,11 +259,15 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         // Clamp strictly to Floating UI's measured space so the popover never
         // extends past the viewport, even in very small viewports where both
         // sides of the trigger have limited room. The internal `overflow:
-        // auto` on StyledPopoverBody handles the scroll.
+        // auto` on StyledPopoverBody handles the scroll. `Math.min` against
+        // the styled-component's design caps (`baselineMaxWidthPx` and the
+        // CSS `70vh` cap on max-height) preserves those caps on large
+        // viewports so the inline clamp doesn't accidentally allow the
+        // popover to grow past them.
         const clampedHeight = Math.max(Math.floor(availableHeight), 0)
         const clampedWidth = Math.max(Math.floor(availableWidth), 0)
-        elements.floating.style.maxHeight = `${clampedHeight}px`
-        elements.floating.style.maxWidth = `${clampedWidth}px`
+        elements.floating.style.maxHeight = `min(${clampedHeight}px, 70vh)`
+        elements.floating.style.maxWidth = `${Math.min(clampedWidth, baselineMaxWidthPx)}px`
         // When the intrinsic `min-width` from StyledPopoverBody exceeds our
         // `max-width` clamp, CSS resolves the conflict in favor of `min-width`
         // and the popover overflows again. Cap `min-width` at the clamp only
@@ -281,7 +293,9 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   }, [
     open,
     theme.spacing.twoXS,
+    theme.spacing.lg,
     theme.sizes.minPopupWidth,
+    theme.sizes.contentMaxWidth,
     isInSidebar,
     stretchWidth,
     calculatedWidth,

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -243,6 +243,14 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         const clampedWidth = Math.max(Math.floor(availableWidth), 0)
         elements.floating.style.maxHeight = `${clampedHeight}px`
         elements.floating.style.maxWidth = `${clampedWidth}px`
+        // StyledPopoverBody has an intrinsic `min-width`
+        // (`theme.sizes.minPopupWidth`, 20rem/320px). On viewports narrower
+        // than that, the min-width overrides `max-width` and the popover
+        // still overflows. Cap `min-width` at the clamped width in that case
+        // so the viewport clamp actually wins.
+        const minPopupWidthPx = convertRemToPx(theme.sizes.minPopupWidth)
+        elements.floating.style.minWidth =
+          clampedWidth < minPopupWidthPx ? `${clampedWidth}px` : ""
       },
     })
     if (!isInSidebar) {
@@ -258,7 +266,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       shiftOptions: { padding: shiftPadding, boundary },
       extraMiddleware: [sizeMiddleware],
     }
-  }, [open, theme.spacing.twoXS, isInSidebar])
+  }, [open, theme.spacing.twoXS, theme.sizes.minPopupWidth, isInSidebar])
 
   // Floating UI provides scroll-tracking via autoUpdate. RAC's Popover is
   // fully replaced with FloatingPortal here because Popover has no collection

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -221,12 +221,6 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   //   Without this override, shift squishes a sidebar popover against the
   //   sidebar's edge.
   const shiftPadding = 8
-  // Match StyledPopoverBody's stretch-mode `min-width: max($calculatedWidth,
-  // 10rem)` from styled-components.ts. Kept in sync manually because the
-  // middleware needs to know the intrinsic min-width without reading it back
-  // from the DOM (which would force a style recomputation on every position
-  // update).
-  const stretchMinWidthPx = convertRemToPx("10rem")
   const overlayOptions = useMemo(() => {
     const base = {
       open,
@@ -237,12 +231,18 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       return base
     }
     const boundary = document.documentElement
+    // Match StyledPopoverBody's stretch-mode `min-width: max($calculatedWidth,
+    // 10rem)` from styled-components.ts. Kept in sync manually because the
+    // middleware needs to know the intrinsic min-width without reading it
+    // back from the DOM (which would force a style recomputation on every
+    // position update).
+    const stretchMinWidthPx = convertRemToPx("10rem")
     const minPopupWidthPx = convertRemToPx(theme.sizes.minPopupWidth)
     // StyledPopoverBody's design cap on width: `calc(contentMaxWidth - 2 *
-    // spacing.lg)` (~704px). Preserved as a floor for the inline `max-width`
-    // so wide viewports still respect the design cap rather than being
-    // clamped to the full available viewport width. `contentMaxWidth` is a
-    // px token (e.g. "736px") while `spacing.lg` is a rem token.
+    // spacing.lg)` (~704px). Preserved as a ceiling for the inline `max-width`
+    // so wide viewports still respect the design cap rather than growing to
+    // the full available viewport width. `contentMaxWidth` is a px token
+    // (e.g. "736px") while `spacing.lg` is a rem token.
     const baselineMaxWidthPx =
       parseFloat(theme.sizes.contentMaxWidth) -
       2 * convertRemToPx(theme.spacing.lg)
@@ -266,15 +266,18 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         // popover to grow past them.
         const clampedHeight = Math.max(Math.floor(availableHeight), 0)
         const clampedWidth = Math.max(Math.floor(availableWidth), 0)
+        const appliedMaxWidth = Math.min(clampedWidth, baselineMaxWidthPx)
         elements.floating.style.maxHeight = `min(${clampedHeight}px, 70vh)`
-        elements.floating.style.maxWidth = `${Math.min(clampedWidth, baselineMaxWidthPx)}px`
-        // When the intrinsic `min-width` from StyledPopoverBody exceeds our
-        // `max-width` clamp, CSS resolves the conflict in favor of `min-width`
-        // and the popover overflows again. Cap `min-width` at the clamp only
-        // in that case — leaving it unset otherwise preserves the natural
-        // content-driven sizing for popovers that comfortably fit.
+        elements.floating.style.maxWidth = `${appliedMaxWidth}px`
+        // When the intrinsic `min-width` from StyledPopoverBody exceeds the
+        // applied `max-width` (which now folds in both the viewport clamp
+        // and the ~704px design cap), CSS resolves the conflict in favor of
+        // `min-width` and the popover overflows the cap. Compare against
+        // `appliedMaxWidth`, not raw `clampedWidth`, so a stretch popover
+        // whose `calculatedWidth` sits between the design cap and the
+        // viewport clamp still gets its min-width capped.
         elements.floating.style.minWidth =
-          intrinsicMinWidth > clampedWidth ? `${clampedWidth}px` : ""
+          intrinsicMinWidth > appliedMaxWidth ? `${appliedMaxWidth}px` : ""
       },
     })
     if (!isInSidebar) {
@@ -299,7 +302,6 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     isInSidebar,
     stretchWidth,
     calculatedWidth,
-    stretchMinWidthPx,
   ])
 
   // Floating UI provides scroll-tracking via autoUpdate. RAC's Popover is

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -46,7 +46,10 @@ import {
 import { useCalculatedDimensions } from "~lib/hooks/useCalculatedDimensions"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
-import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
+import {
+  SHIFT_VIEWPORT_PADDING,
+  useFloatingOverlay,
+} from "~lib/hooks/useFloatingOverlay"
 import useWidgetManagerElementState from "~lib/hooks/useWidgetManagerElementState"
 import { convertRemToPx } from "~lib/theme/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -57,9 +60,6 @@ import {
   StyledPopoverLabelContainer,
 } from "./styled-components"
 
-/** Padding kept between the popover and the boundary edge, in px. */
-const SHIFT_PADDING = 8
-
 /**
  * Fit the popover inside the available space without exceeding the design caps,
  * and stop CSS `min-width` from defeating that.
@@ -67,7 +67,7 @@ const SHIFT_PADDING = 8
  * `designMaxWidthPx` and `cssMinWidthPx` mirror StyledPopoverBody; see the call
  * site for how they are derived.
  */
-function clampPopoverSize({
+export function clampPopoverSize({
   availableWidth,
   availableHeight,
   designMaxWidthPx,
@@ -270,7 +270,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       ? Math.max(calculatedWidth, convertRemToPx("10rem"))
       : convertRemToPx(theme.sizes.minPopupWidth)
     const sizeMiddleware: Middleware = size({
-      padding: SHIFT_PADDING,
+      padding: SHIFT_VIEWPORT_PADDING,
       boundary,
       apply({ availableHeight, availableWidth, elements }) {
         const { maxWidth, maxHeight, minWidth } = clampPopoverSize({
@@ -294,7 +294,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
     return {
       ...base,
       flipOptions: { boundary },
-      shiftOptions: { padding: SHIFT_PADDING, boundary },
+      shiftOptions: { padding: SHIFT_VIEWPORT_PADDING, boundary },
       extraMiddleware: [sizeMiddleware],
     }
   }, [

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -221,6 +221,12 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   //    whichever side `flip` landed on; the internal `overflow: auto` on
   //    StyledPopoverBody handles scrolling when clamped.
   const shiftPadding = 8
+  // Match StyledPopoverBody's stretch-mode `min-width: max($calculatedWidth,
+  // 10rem)` from styled-components.ts. Kept in sync manually because the
+  // middleware needs to know the intrinsic min-width without reading it back
+  // from the DOM (which would force a style recomputation on every position
+  // update).
+  const stretchMinWidthPx = convertRemToPx("10rem")
   const overlayOptions = useMemo(() => {
     const base = {
       open,
@@ -231,6 +237,13 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       return base
     }
     const boundary = document.documentElement
+    const minPopupWidthPx = convertRemToPx(theme.sizes.minPopupWidth)
+    // Intrinsic min-width from StyledPopoverBody: non-stretch uses
+    // `theme.sizes.minPopupWidth`; stretch uses `max($calculatedWidth,
+    // 10rem)`.
+    const intrinsicMinWidth = stretchWidth
+      ? Math.max(calculatedWidth, stretchMinWidthPx)
+      : minPopupWidthPx
     const sizeMiddleware: Middleware = size({
       padding: shiftPadding,
       boundary,
@@ -243,22 +256,13 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         const clampedWidth = Math.max(Math.floor(availableWidth), 0)
         elements.floating.style.maxHeight = `${clampedHeight}px`
         elements.floating.style.maxWidth = `${clampedWidth}px`
-        // StyledPopoverBody has an intrinsic `min-width` — either
-        // `theme.sizes.minPopupWidth` (20rem/320px) or, for stretch popovers,
-        // `max($calculatedWidth, 10rem)` where `$calculatedWidth` is the
-        // trigger width. When that intrinsic value exceeds our `max-width`
-        // clamp, CSS resolves the conflict in favor of `min-width` and the
-        // popover overflows again. Reset our own inline override so we can
-        // read the CSS-resolved value, then cap it at the clamp only when it
-        // would exceed it (covers both baseline and stretch cases without
-        // artificially widening narrow content).
-        elements.floating.style.minWidth = ""
-        const intrinsicMinWidth =
-          // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Inside Floating UI's `size.apply`; layout has already been read to compute `availableWidth`, and the popover is only mounted when open, so the extra style read is bounded and only fires on open/scroll/resize (via `autoUpdate`), not per animation frame. The value gained — correctly capping the intrinsic min-width including the stretch case `max($calculatedWidth, 10rem)` without threading `$stretchWidth`/`$calculatedWidth` down here — outweighs the cost.
-          parseFloat(window.getComputedStyle(elements.floating).minWidth) || 0
-        if (intrinsicMinWidth > clampedWidth) {
-          elements.floating.style.minWidth = `${clampedWidth}px`
-        }
+        // When the intrinsic `min-width` from StyledPopoverBody exceeds our
+        // `max-width` clamp, CSS resolves the conflict in favor of `min-width`
+        // and the popover overflows again. Cap `min-width` at the clamp only
+        // in that case — leaving it unset otherwise preserves the natural
+        // content-driven sizing for popovers that comfortably fit.
+        elements.floating.style.minWidth =
+          intrinsicMinWidth > clampedWidth ? `${clampedWidth}px` : ""
       },
     })
     if (!isInSidebar) {
@@ -274,7 +278,15 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       shiftOptions: { padding: shiftPadding, boundary },
       extraMiddleware: [sizeMiddleware],
     }
-  }, [open, theme.spacing.twoXS, isInSidebar])
+  }, [
+    open,
+    theme.spacing.twoXS,
+    theme.sizes.minPopupWidth,
+    isInSidebar,
+    stretchWidth,
+    calculatedWidth,
+    stretchMinWidthPx,
+  ])
 
   // Floating UI provides scroll-tracking via autoUpdate. RAC's Popover is
   // fully replaced with FloatingPortal here because Popover has no collection

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -254,6 +254,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         // artificially widening narrow content).
         elements.floating.style.minWidth = ""
         const intrinsicMinWidth =
+          // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Inside Floating UI's `size.apply`; layout has already been read to compute `availableWidth`, and the popover is only mounted when open, so the extra style read is bounded and only fires on open/scroll/resize (via `autoUpdate`), not per animation frame. The value gained — correctly capping the intrinsic min-width including the stretch case `max($calculatedWidth, 10rem)` without threading `$stretchWidth`/`$calculatedWidth` down here — outweighs the cost.
           parseFloat(window.getComputedStyle(elements.floating).minWidth) || 0
         if (intrinsicMinWidth > clampedWidth) {
           elements.floating.style.minWidth = `${clampedWidth}px`

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -195,27 +195,31 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   // keyboard activation, which can dispatch a `click` with no prior pointerdown.
   const interactionInsideRef = useRef(false)
 
-  // When inside the sidebar, adjust Floating UI middleware so the popover can
-  // escape the sidebar's `overflow: auto` clipping rect and stay within the
-  // viewport. Two things are needed:
+  // Adjust Floating UI middleware so the popover stays within the viewport
+  // even when the app is embedded inside a narrow iframe (e.g. Medium
+  // oEmbed, #9340) or rendered inside the sidebar's `overflow: auto` column.
+  // Two things are needed:
   //
   // 1. Override the shift/flip boundary to `document.documentElement` so the
   //    popover (portalled to document.body with `position: fixed`) is bounded
-  //    by the viewport rather than the sidebar. `document.documentElement`
-  //    (the <html> element) is used rather than `document.body` because
-  //    Streamlit's `.stApp` uses `position: absolute; inset: 0`, which leaves
-  //    document.body sized 0x0 — a body boundary would always report overflow
-  //    and re-introduce the same flip. Without this override, shift squishes
-  //    the popover (whose min-width exceeds the sidebar column) against the
-  //    sidebar's edge.
+  //    by the viewport rather than the sidebar or any `.stApp` clipping
+  //    ancestor. `document.documentElement` (the <html> element) is used
+  //    rather than `document.body` because Streamlit's `.stApp` uses
+  //    `position: absolute; inset: 0`, which leaves document.body sized 0x0
+  //    — a body boundary would always report overflow. Without this override,
+  //    shift squishes a sidebar popover against the sidebar's edge.
   //
-  // 2. Add a `size` middleware that clamps the popover's maxHeight to the
-  //    available space at the chosen placement. Without this, when the popover
-  //    is taller than the space both above and below the trigger, `flip` picks
-  //    the less-overflowing side and the popover extends off-screen (bug in
-  //    #9387: popover clipped above the viewport top). `size` sits after
-  //    `flip` so it constrains the height to whichever side `flip` landed on,
-  //    causing the internal `overflow: auto` on StyledPopoverBody to kick in.
+  // 2. Add a `size` middleware that clamps the popover's max height AND max
+  //    width to the available space at the chosen placement. Without the
+  //    height clamp, when the popover is taller than the space both above
+  //    and below the trigger, `flip` picks the less-overflowing side and the
+  //    popover extends off-screen (bug in #9387). Without the width clamp,
+  //    the popover's baseline `maxWidth: contentMaxWidth` (~704px) can
+  //    exceed a narrow oembed iframe's width, so `shift` shoves it against
+  //    an edge and the far side is clipped by the iframe (bug in #9340).
+  //    `size` sits after `flip` so it constrains dimensions relative to
+  //    whichever side `flip` landed on; the internal `overflow: auto` on
+  //    StyledPopoverBody handles scrolling when clamped.
   const shiftPadding = 8
   const overlayOptions = useMemo(() => {
     const base = {
@@ -223,22 +227,31 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       placement: "bottom-start" as const,
       offsetPx: convertRemToPx(theme.spacing.twoXS),
     }
-    if (!isInSidebar || typeof document === "undefined") {
+    if (typeof document === "undefined") {
       return base
     }
     const boundary = document.documentElement
     const sizeMiddleware: Middleware = size({
       padding: shiftPadding,
       boundary,
-      apply({ availableHeight, elements }) {
+      apply({ availableHeight, availableWidth, elements }) {
         // Clamp strictly to Floating UI's measured space so the popover never
-        // extends past the viewport, even in very short viewports where both
+        // extends past the viewport, even in very small viewports where both
         // sides of the trigger have limited room. The internal `overflow:
         // auto` on StyledPopoverBody handles the scroll.
         const clampedHeight = Math.max(Math.floor(availableHeight), 0)
+        const clampedWidth = Math.max(Math.floor(availableWidth), 0)
         elements.floating.style.maxHeight = `${clampedHeight}px`
+        elements.floating.style.maxWidth = `${clampedWidth}px`
       },
     })
+    if (!isInSidebar) {
+      // Outside the sidebar we still need `size` to prevent overflow of a
+      // narrow embed viewport, but we don't need to override flip/shift
+      // boundaries — the defaults already resolve to the viewport for
+      // `position: fixed` floating elements.
+      return { ...base, extraMiddleware: [sizeMiddleware] }
+    }
     return {
       ...base,
       flipOptions: { boundary },

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -254,9 +254,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         // artificially widening narrow content).
         elements.floating.style.minWidth = ""
         const intrinsicMinWidth =
-          parseFloat(
-            window.getComputedStyle(elements.floating).minWidth
-          ) || 0
+          parseFloat(window.getComputedStyle(elements.floating).minWidth) || 0
         if (intrinsicMinWidth > clampedWidth) {
           elements.floating.style.minWidth = `${clampedWidth}px`
         }

--- a/frontend/lib/src/components/elements/Popover/Popover.tsx
+++ b/frontend/lib/src/components/elements/Popover/Popover.tsx
@@ -243,14 +243,23 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
         const clampedWidth = Math.max(Math.floor(availableWidth), 0)
         elements.floating.style.maxHeight = `${clampedHeight}px`
         elements.floating.style.maxWidth = `${clampedWidth}px`
-        // StyledPopoverBody has an intrinsic `min-width`
-        // (`theme.sizes.minPopupWidth`, 20rem/320px). On viewports narrower
-        // than that, the min-width overrides `max-width` and the popover
-        // still overflows. Cap `min-width` at the clamped width in that case
-        // so the viewport clamp actually wins.
-        const minPopupWidthPx = convertRemToPx(theme.sizes.minPopupWidth)
-        elements.floating.style.minWidth =
-          clampedWidth < minPopupWidthPx ? `${clampedWidth}px` : ""
+        // StyledPopoverBody has an intrinsic `min-width` — either
+        // `theme.sizes.minPopupWidth` (20rem/320px) or, for stretch popovers,
+        // `max($calculatedWidth, 10rem)` where `$calculatedWidth` is the
+        // trigger width. When that intrinsic value exceeds our `max-width`
+        // clamp, CSS resolves the conflict in favor of `min-width` and the
+        // popover overflows again. Reset our own inline override so we can
+        // read the CSS-resolved value, then cap it at the clamp only when it
+        // would exceed it (covers both baseline and stretch cases without
+        // artificially widening narrow content).
+        elements.floating.style.minWidth = ""
+        const intrinsicMinWidth =
+          parseFloat(
+            window.getComputedStyle(elements.floating).minWidth
+          ) || 0
+        if (intrinsicMinWidth > clampedWidth) {
+          elements.floating.style.minWidth = `${clampedWidth}px`
+        }
       },
     })
     if (!isInSidebar) {
@@ -266,7 +275,7 @@ const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
       shiftOptions: { padding: shiftPadding, boundary },
       extraMiddleware: [sizeMiddleware],
     }
-  }, [open, theme.spacing.twoXS, theme.sizes.minPopupWidth, isInSidebar])
+  }, [open, theme.spacing.twoXS, isInSidebar])
 
   // Floating UI provides scroll-tracking via autoUpdate. RAC's Popover is
   // fully replaced with FloatingPortal here because Popover has no collection


### PR DESCRIPTION
## Summary
Fixes #9340.

Popovers rendered outside the sidebar could overflow the viewport (or an oEmbed iframe) horizontally and vertically because the floating-ui `size` middleware was only configured for the sidebar-anchored variant. In narrow embedded apps this clipped the popover's content behind the iframe edge.

## Repro
Mount an `st.popover` with wide content inside an oEmbed iframe narrower than the popover's natural width. Content is clipped by the iframe edge with no scroll offered.

## Fix
- `frontend/lib/src/components/elements/Popover/Popover.tsx` — apply the floating-ui `size` middleware in the non-sidebar path (already used for sidebar), clamping `max-width` and `max-height` to the available viewport and enabling internal scroll when the natural size would exceed it.

## Screenshots

After the fix, in a 450 px wide viewport, the popover clamps to the available width and enables internal scroll instead of clipping behind the viewport edge:

- [after-fix-narrow-viewport.png](https://issues.streamlit.app/agent_wiki_explorer?file=pull-requests/16173/after-fix-narrow-viewport.png)

## Verification
- [x] Bug reproduces on develop
- [x] Fixed on this branch
- [x] `make check` passes
- [x] New Playwright test `e2e_playwright/st_popover_test.py::test_popover_stays_within_narrow_viewport`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Popover overlay positioning and styling; no auth, data, or API changes. Regression risk is mainly popover layout in sidebar vs main vs stretch width.
> 
> **Overview**
> Fixes **#9340** by keeping `st.popover` panels inside narrow viewports (e.g. oEmbed iframes) instead of clipping past the host edge.
> 
> **Popover floating layout** now always runs Floating UI’s `size` middleware (previously only in the sidebar). It sets inline `max-width` / `max-height` from available space (capped at the ~704px design width and `70vh`) and lowers `min-width` when CSS min-width would beat that clamp—including `width="stretch"`. Sidebar popovers still override flip/shift `boundary` to `<html>`; main-area popovers only add `size`. Sizing logic is centralized in exported **`clampPopoverSize`**, with padding wired via **`SHIFT_VIEWPORT_PADDING`**.
> 
> **Tests:** unit coverage for `clampPopoverSize` arithmetic and a Playwright test (`test_popover_stays_within_narrow_viewport`) at 640px, 300px, and stretch width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5acd13eed7d982fcffcf24e8197a9ce31f4742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->