### PR TITLE
fix(selectbox): flip sidebar dropdown up instead of clipping

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -295,3 +295,18 @@ v_bound_clear = st.selectbox(
     bind="query-params",
 )
 st.write("bound select clear value:", v_bound_clear)
+
+# Regression test for https://github.com/streamlit/streamlit/issues/16181:
+# a selectbox near the bottom of the sidebar must flip its dropdown up and stay
+# within the viewport instead of opening downward and overflowing. The
+# fixed-height spacer pushes the trigger toward the bottom so there is
+# insufficient room below for the dropdown.
+with st.sidebar:
+    st.container(height=500, border=False)
+    v_sidebar_bottom = st.selectbox(
+        "sidebar selectbox (bottom)",
+        [f"Option {i}" for i in range(1, 8)],
+        index=None,
+        key="sidebar_bottom_select",
+    )
+    st.write("sidebar bottom value:", v_sidebar_bottom)

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from e2e_playwright.conftest import ImageCompareFunction
 
 
-NUM_SELECTBOXES = 29
+NUM_SELECTBOXES = 30
 
 
 def get_selectbox_input(
@@ -812,3 +812,45 @@ def test_selectbox_query_param_non_clearable_empty_value(page: Page, app_port: i
     # Non-clearable selectbox should reject empty value, show default "cat"
     expect_prefixed_markdown(page, "bound select value:", "cat")
     expect(page).not_to_have_url(re.compile(r"[?&]bound_select="))
+
+
+def test_selectbox_in_sidebar_flips_up_within_viewport(app: Page):
+    """A selectbox near the bottom of the sidebar must flip its dropdown up and
+    stay within the viewport instead of opening downward and overflowing past
+    the bottom.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/16181,
+    where flip was disabled inside the sidebar so the dropdown always opened
+    downward and got clipped.
+    """
+    app.set_viewport_size({"width": 1280, "height": 720})
+
+    selectbox = get_element_by_key(app, "sidebar_bottom_select")
+    selectbox.scroll_into_view_if_needed()
+
+    trigger_box = selectbox.bounding_box()
+    assert trigger_box is not None, "selectbox trigger must have a bounding box"
+
+    selectbox.locator("input").click()
+
+    dropdown = app.get_by_test_id("stSelectboxVirtualDropdown")
+    expect(dropdown).to_be_visible()
+    expect(dropdown.get_by_role("option")).to_have_count(7)
+
+    dropdown_box = dropdown.bounding_box()
+    assert dropdown_box is not None, "dropdown must have a bounding box"
+
+    viewport = app.viewport_size
+    assert viewport is not None
+
+    # Primary regression check: the dropdown must not overflow past the bottom
+    # of the viewport. A 1px epsilon guards against subpixel layout differences.
+    epsilon = 1
+    assert dropdown_box["y"] + dropdown_box["height"] <= viewport["height"] + epsilon, (
+        f"dropdown overflows the viewport bottom: {dropdown_box}, viewport={viewport}"
+    )
+
+    # The dropdown must open above the trigger (flip up), not below it.
+    assert dropdown_box["y"] < trigger_box["y"], (
+        f"dropdown did not flip up: dropdown={dropdown_box}, trigger={trigger_box}"
+    )

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -25,6 +25,8 @@ import { userEvent } from "@testing-library/user-event"
 
 import { streamlit } from "@streamlit/protobuf"
 
+import IsSidebarContext from "~lib/components/core/IsSidebarContext"
+import * as UseFloatingOverlay from "~lib/hooks/useFloatingOverlay"
 import { render } from "~lib/test_util"
 import * as MobileUtil from "~lib/util/isMobile"
 import { LabelVisibilityOptions } from "~lib/util/utils"
@@ -881,6 +883,46 @@ describe("Selectbox widget with optional props", () => {
 
     // "AA" is case-sensitively distinct from "aa", "Aa", "aA" → Add option shown
     expect(screen.getByRole("option", { name: /Add: AA/i })).toBeVisible()
+  })
+})
+
+describe("Selectbox dropdown positioning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Regression test for #16181: inside the sidebar, flip stays enabled and is
+  // bounded by the viewport so a trigger near the bottom flips its dropdown up
+  // instead of opening downward and overflowing. The bug set flipOptions to
+  // false, disabling flip entirely.
+  it("keeps flip enabled with a viewport boundary inside the sidebar", () => {
+    const overlaySpy = vi.spyOn(UseFloatingOverlay, "useFloatingOverlay")
+    render(
+      <IsSidebarContext.Provider value={true}>
+        <Selectbox {...getProps()} />
+      </IsSidebarContext.Provider>
+    )
+
+    const options = overlaySpy.mock.calls[0][0]
+    expect(options.flipOptions).toMatchObject({
+      boundary: document.documentElement,
+    })
+    // Preserve the shared shift padding when overriding shiftOptions, rather
+    // than falling back to Floating UI's 0 default (the reason the constant is
+    // exported).
+    expect(options.shiftOptions).toMatchObject({
+      boundary: document.documentElement,
+      padding: UseFloatingOverlay.SHIFT_VIEWPORT_PADDING,
+    })
+  })
+
+  it("uses default flip/shift behavior outside the sidebar", () => {
+    const overlaySpy = vi.spyOn(UseFloatingOverlay, "useFloatingOverlay")
+    render(<Selectbox {...getProps()} />)
+
+    const options = overlaySpy.mock.calls[0][0]
+    expect(options.flipOptions).toBeUndefined()
+    expect(options.shiftOptions).toBeUndefined()
   })
 })
 

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.tsx
@@ -44,7 +44,10 @@ import { WidgetLabel } from "~lib/components/widgets/BaseWidget/WidgetLabel"
 import { WidgetLabelHelpIcon } from "~lib/components/widgets/BaseWidget/WidgetLabelHelpIcon"
 import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import { useExecuteWhenChanged } from "~lib/hooks/useExecuteWhenChanged"
-import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
+import {
+  SHIFT_VIEWPORT_PADDING,
+  useFloatingOverlay,
+} from "~lib/hooks/useFloatingOverlay"
 import { convertRemToPx } from "~lib/theme/utils"
 import {
   filterSelectOptions,
@@ -219,13 +222,40 @@ const Selectbox: FC<Props> = ({
   // on both refs being mounted — the actual ComboBox open state is irrelevant
   // here since the floating element only exists in the DOM when RAC's Popover
   // renders it (i.e. when the dropdown is open).
-  const { refs, floatingStyles } = useFloatingOverlay({
-    open: true,
-    placement: "bottom-start",
-    offsetPx: convertRemToPx(theme.spacing.twoXS),
-    flipOptions: isInSidebar ? false : undefined,
-    matchTriggerWidth: true,
-  })
+  //
+  // In the sidebar, flip/shift are bounded by the viewport
+  // (document.documentElement) rather than the sidebar's `overflow: auto`
+  // clipping rect. Otherwise the dropdown cannot flip up when the trigger sits
+  // near the bottom of the sidebar and it overflows the viewport instead (issue
+  // #16181). This mirrors the sidebar handling in elements/Popover/Popover.tsx.
+  // `document.documentElement` is used rather than `document.body` because
+  // Streamlit's `.stApp` uses `position: absolute; inset: 0`, leaving
+  // document.body sized 0x0, so a body boundary would always report overflow
+  // and re-introduce the same clipping.
+  //
+  // Unlike Popover.tsx, no `size` middleware is needed here: the option list is
+  // already height-capped by CSS (`min(maxDropdownHeight, 70vh)` with internal
+  // scroll in Selectbox.styled.ts), so the dropdown cannot overflow the way
+  // arbitrary Popover content can.
+  const overlayOptions = useMemo(() => {
+    const base = {
+      open: true,
+      placement: "bottom-start" as const,
+      offsetPx: convertRemToPx(theme.spacing.twoXS),
+      matchTriggerWidth: true,
+    }
+    if (!isInSidebar || typeof document === "undefined") {
+      return base
+    }
+    const boundary = document.documentElement
+    return {
+      ...base,
+      flipOptions: { boundary },
+      shiftOptions: { boundary, padding: SHIFT_VIEWPORT_PADDING },
+    }
+  }, [theme.spacing.twoXS, isInSidebar])
+
+  const { refs, floatingStyles } = useFloatingOverlay(overlayOptions)
 
   // Locally committed value (last value sent to Streamlit). Re-synced from
   // propValue when the backend pushes an update (form-clear, session state, etc.).

--- a/frontend/lib/src/hooks/useFloatingOverlay.ts
+++ b/frontend/lib/src/hooks/useFloatingOverlay.ts
@@ -43,7 +43,12 @@ interface UseFloatingOverlayOptions {
   extraMiddleware?: Middleware[]
 }
 
-const SHIFT_VIEWPORT_PADDING = 8
+/**
+ * Default padding (px) kept between a shifted overlay and its boundary edge.
+ * Exported so callers that override `shiftOptions` (e.g. to set a boundary) can
+ * preserve the same padding instead of falling back to Floating UI's 0 default.
+ */
+export const SHIFT_VIEWPORT_PADDING = 8
 const EMPTY_MIDDLEWARE: Middleware[] = []
 
 /**


### PR DESCRIPTION
## Describe your changes

Fixes a layout regression where `st.selectbox` near the bottom of the sidebar opened its dropdown **downward** and overflowed past the bottom of the viewport instead of flipping **up**. This regressed in 1.59 with the `react-aria-components` ComboBox rewrite.

**Root cause:** the dropdown is positioned by Floating UI. Inside the sidebar the positioning hook was called with `flipOptions: isInSidebar ? false`, which drops the `flip()` middleware entirely, so the popover could no longer flip to the top when there was not enough room below. The pre-1.59 BaseWeb widget used `ignoreBoundary: isInSidebar` (flip stays enabled but becomes viewport-relative); that intent was lost when it was translated to `shouldFlip={!isInSidebar}` (#15438) and then `flipOptions: false` (#15638).

**Fix:** keep `flip()` / `shift()` enabled in the sidebar but bound them to the viewport (`document.documentElement`) rather than the sidebar's `overflow: auto` clipping rect. This mirrors the existing sidebar handling in `Popover.tsx` (the analogous fix for #9387). `document.documentElement` is used rather than `document.body` because `.stApp` is `position: absolute; inset: 0`, leaving `document.body` sized 0x0. `SHIFT_VIEWPORT_PADDING` is exported from `useFloatingOverlay` so the overridden `shiftOptions` preserves the same padding.

## GitHub Issue Link (if applicable)

Fixes https://github.com/streamlit/streamlit/issues/16181

## Testing Plan

- **Unit Tests (JS):** Added two tests in `Selectbox.test.tsx` verifying that, inside the sidebar, the positioning hook is called with `flip` enabled and a viewport boundary (not `flipOptions: false`), and that the non-sidebar path keeps the default flip/shift behavior.
- **E2E Tests:** Added `test_selectbox_in_sidebar_flips_up_within_viewport` in `st_selectbox_test.py` (with a sidebar selectbox pushed near the bottom in `st_selectbox.py`). It asserts the opened dropdown flips up and does not overflow the viewport bottom. Verified this test **fails without the fix** (dropdown bottom landed at y=946 in a 720px viewport) and passes with it.
- **Manual testing:** Reproduced the issue's app via `make debug` and confirmed with Playwright that the dropdown flips up and stays within the viewport.

Before:
<img width="320" height="652" alt="Screenshot 2026-07-27 at 3 29 38 PM" src="https://github.com/user-attachments/assets/675de232-aff9-4c80-80c9-bcc6e2639b30" />

After:
<img width="323" height="449" alt="Screenshot 2026-07-27 at 3 29 47 PM" src="https://github.com/user-attachments/assets/4c3d44d8-9290-471d-8bd9-1f8e48d1429d" />

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 1 |
| subagent | general-purpose | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI positioning change for sidebar selectboxes only; main-area behavior is unchanged and tests lock in the regression fix.
> 
> **Overview**
> Fixes **#16181** by changing how sidebar `st.selectbox` dropdowns are positioned: instead of disabling Floating UI flip (`flipOptions: false`), flip and shift stay on but use **`document.documentElement`** as the boundary so the menu can open upward near the bottom of the sidebar without being clipped by the sidebar scroll container or overflowing the viewport.
> 
> `Selectbox.tsx` builds overlay options in a `useMemo` (mirroring `Popover.tsx` for sidebar, without extra `size` middleware because the list is already height-capped in CSS). **`SHIFT_VIEWPORT_PADDING`** is exported from `useFloatingOverlay` so custom `shiftOptions` keep the same padding as the default hook behavior.
> 
> Coverage adds JS unit tests on `useFloatingOverlay` call args for sidebar vs main area, plus a Playwright case with a bottom-of-sidebar selectbox that asserts the dropdown flips above the trigger and stays within the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e402f0bb2742e798b65944d7ac3ac1f2261988da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->