### PR TITLE
Improve tag accessibility in `st.multiselect`

### DIFF
--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -583,20 +583,24 @@ def test_multiselect_preserves_scroll_position_on_remove(app: Page):
     # Get the tags container (scrollable area inside the trigger group)
     value_container = multiselect_elem.locator('[role="group"] > div').first
 
-    # Scroll to middle of the value container (not bottom, to avoid clamping issues
-    # when items are removed and scrollHeight decreases)
-    value_container.evaluate("el => { el.scrollTop = el.scrollHeight / 2; }")
+    # Scroll to the bottom of the tags container
+    value_container.evaluate("el => { el.scrollTop = el.scrollHeight; }")
+    app.wait_for_timeout(50)
 
     # Get initial scroll position (should be > 0 since there are many items)
     initial_scroll = value_container.evaluate("el => el.scrollTop")
     assert initial_scroll > 0
 
-    # Remove an item by clicking its delete button
-    remove_from_multiselect(app, "multiselect 17 - show maxHeight", "twenty")
+    # Remove the last tag ("forty") which is visible at the bottom scroll position.
+    # Using the last tag avoids Playwright's auto-scroll-into-view changing scrollTop
+    # before the click handler fires.
+    remove_from_multiselect(app, "multiselect 17 - show maxHeight", "forty")
 
-    # Verify scroll position is preserved
+    # Verify scroll position is preserved (or clamped to the new max if content shrank)
     final_scroll = value_container.evaluate("el => el.scrollTop")
-    assert final_scroll == initial_scroll
+    max_scroll = value_container.evaluate("el => el.scrollHeight - el.clientHeight")
+    expected = min(initial_scroll, max_scroll)
+    assert abs(final_scroll - expected) <= 1
 
 
 def test_multiselect_custom_objects_without_eq(app: Page):
@@ -711,13 +715,16 @@ def test_multiselect_query_param_seeding_multiple(page: Page, app_base_url: str)
 def test_multiselect_query_param_updates_url(app: Page):
     """Test that changing a bound multiselect updates the URL."""
     select_for_multiselect(app, "Bound multiselect", "Red", True)
-    expect(app).to_have_url(re.compile(r"\?bound_multi=Red"))
+    # Assert text first to confirm the rerun completed before checking the URL
     expect_text(app, "bound_multi: ['Red']")
+    expect(app).to_have_url(re.compile(r"\?bound_multi=Red"), timeout=10_000)
 
     # Add a second selection
     select_for_multiselect(app, "Bound multiselect", "Blue", True)
-    expect(app).to_have_url(re.compile(r"bound_multi=Red&bound_multi=Blue"))
     expect_text(app, "bound_multi: ['Red', 'Blue']")
+    expect(app).to_have_url(
+        re.compile(r"bound_multi=Red&bound_multi=Blue"), timeout=10_000
+    )
 
 
 def test_multiselect_query_param_default_override(page: Page, app_base_url: str):

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -597,11 +597,21 @@ def test_multiselect_preserves_scroll_position_on_remove(app: Page):
     # before the click handler fires.
     remove_from_multiselect(app, "multiselect 17 - show maxHeight", "forty")
 
-    # Verify scroll position is preserved (or clamped to the new max if content shrank)
-    final_scroll = value_container.evaluate("el => el.scrollTop")
-    max_scroll = value_container.evaluate("el => el.scrollHeight - el.clientHeight")
-    expected = min(initial_scroll, max_scroll)
-    assert abs(final_scroll - expected) <= 1
+    # Verify scroll position is preserved (or clamped to the new max if content shrank).
+    # The scroll restore happens in a rAF callback, so use wait_until.
+    wait_until(
+        app,
+        lambda: (
+            abs(
+                value_container.evaluate("el => el.scrollTop")
+                - min(
+                    initial_scroll,
+                    value_container.evaluate("el => el.scrollHeight - el.clientHeight"),
+                )
+            )
+            <= 1
+        ),
+    )
 
 
 def test_multiselect_custom_objects_without_eq(app: Page):

--- a/e2e_playwright/st_multiselect_test.py
+++ b/e2e_playwright/st_multiselect_test.py
@@ -23,6 +23,7 @@ from e2e_playwright.conftest import (
     build_app_url,
     wait_for_app_loaded,
     wait_for_app_run,
+    wait_until,
 )
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
@@ -581,11 +582,11 @@ def test_multiselect_preserves_scroll_position_on_remove(app: Page):
     multiselect_elem = get_multiselect(app, "multiselect 17 - show maxHeight")
 
     # Get the tags container (scrollable area inside the trigger group)
-    value_container = multiselect_elem.locator('[role="group"] > div').first
+    value_container = multiselect_elem.get_by_test_id("stMultiSelectTagsContainer")
 
-    # Scroll to the bottom of the tags container
+    # Scroll to the bottom of the tags container and wait for scroll to settle
     value_container.evaluate("el => { el.scrollTop = el.scrollHeight; }")
-    app.wait_for_timeout(50)
+    wait_until(app, lambda: value_container.evaluate("el => el.scrollTop") > 0)
 
     # Get initial scroll position (should be > 0 since there are many items)
     initial_scroll = value_container.evaluate("el => el.scrollTop")

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -1194,9 +1194,12 @@ describe("Multiselect tag accessibility", () => {
     const tags = getTags()
     expect(tags).toHaveLength(3)
 
+    // Tags are wrapped in a group with accessible label
+    const group = screen.getByRole("group", { name: "Selected values" })
+    expect(group).toBeVisible()
+
     // Each tag has correct semantics
     expect(tags[0]).toHaveAttribute("aria-label", "alpha")
-    expect(tags[0]).toHaveAttribute("aria-roledescription", "tag")
     expect(tags[1]).toHaveAttribute("aria-label", "beta")
 
     // Only first tag is tabbable (roving tabindex)
@@ -1256,7 +1259,7 @@ describe("Multiselect tag accessibility", () => {
     expect(screen.getByRole("combobox")).toHaveFocus()
   })
 
-  it("removes a tag with Delete/Backspace and moves focus appropriately", async () => {
+  it("removes a tag with Delete key", async () => {
     const user = userEvent.setup()
     const props = getProps({
       default: [0, 1, 2],
@@ -1276,6 +1279,82 @@ describe("Multiselect tag accessibility", () => {
       { fromUi: true },
       undefined
     )
+  })
+
+  it("maintains correct tabindex after Backspace removal", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      default: [0, 1, 2],
+      options: ["a", "b", "c"],
+    })
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+    const { rerender } = render(<Multiselect {...props} />)
+
+    // Navigate to the middle tag via keyboard (ArrowRight from first)
+    let tags = getTags()
+    act(() => tags[0].focus())
+    await user.keyboard("{ArrowRight}")
+    expect(tags[1]).toHaveFocus()
+    expect(tags[1]).toHaveAttribute("tabindex", "0")
+
+    // Backspace removes focused tag; left neighbor gets tabindex=0
+    await user.keyboard("{Backspace}")
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
+      props.element,
+      ["a", "c"],
+      { fromUi: true },
+      undefined
+    )
+
+    // Simulate rerender with updated value
+    const updatedProps = getProps({
+      default: [0, 2],
+      options: ["a", "b", "c"],
+    })
+    rerender(<Multiselect {...updatedProps} />)
+
+    tags = getTags()
+    expect(tags).toHaveLength(2)
+    // After removing middle tag, the right neighbor (now at index 1) is tabbable
+    expect(tags[0]).toHaveAttribute("tabindex", "-1")
+    expect(tags[1]).toHaveAttribute("tabindex", "0")
+  })
+
+  it("moves tabindex to left neighbor when last tag is Backspace-removed", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      default: [0, 1, 2],
+      options: ["a", "b", "c"],
+    })
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+    const { rerender } = render(<Multiselect {...props} />)
+
+    // Navigate to the last tag
+    let tags = getTags()
+    act(() => tags[0].focus())
+    await user.keyboard("{End}")
+    expect(tags[2]).toHaveFocus()
+
+    // Backspace last tag — no right neighbor, so left gets focus
+    await user.keyboard("{Backspace}")
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
+      props.element,
+      ["a", "b"],
+      { fromUi: true },
+      undefined
+    )
+
+    const updatedProps = getProps({
+      default: [0, 1],
+      options: ["a", "b", "c"],
+    })
+    rerender(<Multiselect {...updatedProps} />)
+
+    tags = getTags()
+    expect(tags).toHaveLength(2)
+    // Left neighbor (index 1) should now be tabbable
+    expect(tags[0]).toHaveAttribute("tabindex", "-1")
+    expect(tags[1]).toHaveAttribute("tabindex", "0")
   })
 
   it("moves focus to input when the last tag is removed", async () => {

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -1280,12 +1280,16 @@ describe("Multiselect tag accessibility", () => {
       undefined
     )
 
-    // Simulate rerender with updated value
-    const updatedProps = getProps({
-      default: [0, 2],
-      options: ["a", "b", "c"],
-    })
-    rerender(<Multiselect {...updatedProps} />)
+    // Simulate rerender with updated value (same widgetMgr instance)
+    rerender(
+      <Multiselect
+        {...props}
+        element={MultiSelectProto.create({
+          ...props.element,
+          default: [0, 2],
+        })}
+      />
+    )
 
     tags = getTags()
     expect(tags).toHaveLength(2)
@@ -1318,11 +1322,15 @@ describe("Multiselect tag accessibility", () => {
       undefined
     )
 
-    const updatedProps = getProps({
-      default: [0, 1],
-      options: ["a", "b", "c"],
-    })
-    rerender(<Multiselect {...updatedProps} />)
+    rerender(
+      <Multiselect
+        {...props}
+        element={MultiSelectProto.create({
+          ...props.element,
+          default: [0, 1],
+        })}
+      />
+    )
 
     tags = getTags()
     expect(tags).toHaveLength(2)

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -1168,3 +1168,128 @@ describe("Multiselect query param binding", () => {
     expect(props.widgetMgr.registerQueryParamBinding).not.toHaveBeenCalled()
   })
 })
+
+describe("Multiselect tag accessibility", () => {
+  beforeEach(() => {
+    vi.spyOn(Utils, "convertRemToPx").mockImplementation(mockConvertRemToPx)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function getTags(): HTMLElement[] {
+    return screen.getAllByLabelText(/.*/, {
+      selector: "[data-tag]",
+    })
+  }
+
+  it("renders tags with ARIA attributes and roving tabindex", () => {
+    const props = getProps({
+      default: [0, 1, 2],
+      options: ["alpha", "beta", "gamma"],
+    })
+    render(<Multiselect {...props} />)
+
+    const tags = getTags()
+    expect(tags).toHaveLength(3)
+
+    // Each tag has correct semantics
+    expect(tags[0]).toHaveAttribute("aria-label", "alpha")
+    expect(tags[0]).toHaveAttribute("aria-roledescription", "tag")
+    expect(tags[1]).toHaveAttribute("aria-label", "beta")
+
+    // Only first tag is tabbable (roving tabindex)
+    expect(tags[0]).toHaveAttribute("tabindex", "0")
+    expect(tags[1]).toHaveAttribute("tabindex", "-1")
+    expect(tags[2]).toHaveAttribute("tabindex", "-1")
+  })
+
+  it("disables tag focus and hides remove buttons when disabled", () => {
+    const props = getProps(
+      { default: [0, 1], options: ["a", "b", "c"] },
+      { disabled: true }
+    )
+    render(<Multiselect {...props} />)
+
+    const tags = getTags()
+    expect(tags[0]).toHaveAttribute("tabindex", "-1")
+    expect(tags[1]).toHaveAttribute("tabindex", "-1")
+    expect(
+      screen.queryByRole("button", { name: "Remove a" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("navigates between tags with arrow keys, Home, and End", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      default: [0, 1, 2],
+      options: ["a", "b", "c"],
+    })
+    render(<Multiselect {...props} />)
+
+    const tags = getTags()
+    act(() => tags[0].focus())
+    expect(tags[0]).toHaveFocus()
+
+    // ArrowRight moves to next
+    await user.keyboard("{ArrowRight}")
+    expect(tags[1]).toHaveFocus()
+    expect(tags[0]).toHaveAttribute("tabindex", "-1")
+    expect(tags[1]).toHaveAttribute("tabindex", "0")
+
+    // ArrowLeft moves back
+    await user.keyboard("{ArrowLeft}")
+    expect(tags[0]).toHaveFocus()
+
+    // End jumps to last
+    await user.keyboard("{End}")
+    expect(tags[2]).toHaveFocus()
+
+    // Home jumps to first
+    await user.keyboard("{Home}")
+    expect(tags[0]).toHaveFocus()
+
+    // ArrowRight from last moves to input
+    await user.keyboard("{End}")
+    await user.keyboard("{ArrowRight}")
+    expect(screen.getByRole("combobox")).toHaveFocus()
+  })
+
+  it("removes a tag with Delete/Backspace and moves focus appropriately", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      default: [0, 1, 2],
+      options: ["a", "b", "c"],
+    })
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+    render(<Multiselect {...props} />)
+
+    const tags = getTags()
+    act(() => tags[0].focus())
+
+    // Delete removes first tag
+    await user.keyboard("{Delete}")
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
+      props.element,
+      ["b", "c"],
+      { fromUi: true },
+      undefined
+    )
+  })
+
+  it("moves focus to input when the last tag is removed", async () => {
+    const user = userEvent.setup()
+    const props = getProps({
+      default: [0],
+      options: ["a", "b", "c"],
+    })
+    render(<Multiselect {...props} />)
+
+    const tags = getTags()
+    act(() => tags[0].focus())
+
+    await user.keyboard("{Delete}")
+    expect(screen.getByRole("combobox")).toHaveFocus()
+  })
+})

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.test.tsx
@@ -308,36 +308,10 @@ describe("Multiselect widget", () => {
     })
   })
 
-  it("does not clear the selection on Escape when a default exists", async () => {
-    const user = userEvent.setup()
-    const props = getProps()
-    vi.spyOn(props.widgetMgr, "setStringArrayValue")
-    render(<Multiselect {...props} />)
-
-    // The default selection ("a") is rendered.
-    expect(screen.getByRole("button", { name: "Remove a" })).toBeVisible()
-
-    // Focus the input and close the dropdown that opens on click
-    await user.click(screen.getByRole("combobox"))
-    await user.keyboard("{Escape}")
-
-    // Now dropdown is closed — Escape must not clear the value because the
-    // widget has a default (not clearable), matching st.selectbox.
-    await user.keyboard("{Escape}")
-
-    expect(screen.getByRole("button", { name: "Remove a" })).toBeVisible()
-    expect(props.widgetMgr.setStringArrayValue).not.toHaveBeenCalledWith(
-      props.element,
-      [],
-      { fromUi: true },
-      undefined
-    )
-  })
-
-  it("clears the selection on Escape when there is no default", async () => {
+  it("does not clear the selection on Escape regardless of default", async () => {
     const user = userEvent.setup()
     const props = getProps({ default: [] })
-    // Seed a user selection so there is a value to clear (dropdown closed).
+    // Seed a user selection so there is a value to verify preservation.
     props.widgetMgr.setStringArrayValue(
       props.element,
       ["b"],
@@ -353,14 +327,14 @@ describe("Multiselect widget", () => {
     await user.click(screen.getByRole("combobox"))
     await user.keyboard("{Escape}")
 
-    // Now dropdown is closed — Escape clears the value because the widget is
-    // clearable (no default), matching st.selectbox.
+    // Dropdown is closed — additional Escape presses must never clear
+    // committed selections (WAI-ARIA APG: Escape dismisses popup, never
+    // clears committed values). See #16109.
+    await user.keyboard("{Escape}")
     await user.keyboard("{Escape}")
 
-    expect(
-      screen.queryByRole("button", { name: /^Remove / })
-    ).not.toBeInTheDocument()
-    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+    expect(screen.getByRole("button", { name: "Remove b" })).toBeVisible()
+    expect(props.widgetMgr.setStringArrayValue).not.toHaveBeenCalledWith(
       props.element,
       [],
       { fromUi: true },

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -297,7 +297,6 @@ const Multiselect: FC<Props> = props => {
   )
 
   const disabled = props.disabled || placeholderDisable
-  const isClearable = element.default.length === 0
 
   // Max height: cut through 5th tag row
   const maxHeight = useMemo(() => {
@@ -589,12 +588,6 @@ const Multiselect: FC<Props> = props => {
           setInputValue("")
           return
         }
-        if (!isOpenRef.current && isClearable && value.length > 0) {
-          e.preventDefault()
-          e.stopPropagation()
-          setValueWithSource({ value: [], fromUi: true })
-          return
-        }
       }
 
       // Creatable Enter: commit typed text as a new option.
@@ -652,7 +645,6 @@ const Multiselect: FC<Props> = props => {
       element.acceptNewOptions,
       element.maxSelections,
       element.options,
-      isClearable,
       isFilterNone,
       setValueWithSource,
       value,

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -488,8 +488,9 @@ const Multiselect: FC<Props> = props => {
           const nextFocus = tags[idx + 1] ?? tags[idx - 1]
           handleTagGroupRemove(new Set([tagValue]))
           if (nextFocus && nextFocus !== tag) {
-            const nextIdx = tags.indexOf(nextFocus)
-            focusedTagIndexRef.current = e.key === "Delete" ? idx : nextIdx
+            // After removal, right neighbor slides to idx; left stays at idx-1
+            focusedTagIndexRef.current =
+              nextFocus === tags[idx + 1] ? idx : idx - 1
             nextFocus.tabIndex = 0
             nextFocus.focus()
           } else {
@@ -718,34 +719,39 @@ const Multiselect: FC<Props> = props => {
               ref={tagsContainerRef}
               onScroll={handleTagsScroll}
             >
-              {value.map((v, idx) => (
-                <StyledTag
-                  key={v}
-                  tabIndex={
-                    !disabled && idx === focusedTagIndexRef.current ? 0 : -1
-                  }
-                  aria-label={v}
-                  aria-roledescription="tag"
-                  $disabled={disabled}
-                  data-tag=""
-                  data-tag-index={idx}
-                  onKeyDown={disabled ? undefined : handleTagKeyDown}
-                >
-                  <StyledTagText title={v}>{v}</StyledTagText>
-                  {!disabled && (
-                    <StyledTagRemoveButton
-                      aria-label={`Remove ${v}`}
-                      tabIndex={-1}
-                      onClick={e => {
-                        e.stopPropagation()
-                        handleTagGroupRemove(new Set([v]))
-                      }}
+              {value.length > 0 && (
+                <span role="group" aria-label="Selected values">
+                  {value.map((v, idx) => (
+                    <StyledTag
+                      key={v}
+                      tabIndex={
+                        !disabled && idx === focusedTagIndexRef.current
+                          ? 0
+                          : -1
+                      }
+                      aria-label={v}
+                      $disabled={disabled}
+                      data-tag=""
+                      data-tag-index={idx}
+                      onKeyDown={disabled ? undefined : handleTagKeyDown}
                     >
-                      <TagRemoveIcon />
-                    </StyledTagRemoveButton>
-                  )}
-                </StyledTag>
-              ))}
+                      <StyledTagText title={v}>{v}</StyledTagText>
+                      {!disabled && (
+                        <StyledTagRemoveButton
+                          aria-label={`Remove ${v}`}
+                          tabIndex={-1}
+                          onClick={e => {
+                            e.stopPropagation()
+                            handleTagGroupRemove(new Set([v]))
+                          }}
+                        >
+                          <TagRemoveIcon />
+                        </StyledTagRemoveButton>
+                      )}
+                    </StyledTag>
+                  ))}
+                </span>
+              )}
               <StyledFilterInput
                 ref={inputRef}
                 placeholder={value.length === 0 ? placeholder : ""}

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -207,6 +207,7 @@ const Multiselect: FC<Props> = props => {
   const tagsContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const scrollTopRef = useRef(0)
+  const focusedTagIndexRef = useRef(0)
 
   const queryParamBinding = element.queryParamKey
     ? {
@@ -466,6 +467,7 @@ const Multiselect: FC<Props> = props => {
           tag.tabIndex = -1
           prev.tabIndex = 0
           prev.focus()
+          focusedTagIndexRef.current = idx - 1
         }
       } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
         e.preventDefault()
@@ -474,7 +476,9 @@ const Multiselect: FC<Props> = props => {
           tag.tabIndex = -1
           next.tabIndex = 0
           next.focus()
+          focusedTagIndexRef.current = idx + 1
         } else {
+          focusedTagIndexRef.current = 0
           inputRef.current?.focus()
         }
       } else if (e.key === "Delete" || e.key === "Backspace") {
@@ -484,9 +488,12 @@ const Multiselect: FC<Props> = props => {
           const nextFocus = tags[idx + 1] ?? tags[idx - 1]
           handleTagGroupRemove(new Set([tagValue]))
           if (nextFocus && nextFocus !== tag) {
+            const nextIdx = tags.indexOf(nextFocus)
+            focusedTagIndexRef.current = e.key === "Delete" ? idx : nextIdx
             nextFocus.tabIndex = 0
             nextFocus.focus()
           } else {
+            focusedTagIndexRef.current = 0
             inputRef.current?.focus()
           }
         }
@@ -497,6 +504,7 @@ const Multiselect: FC<Props> = props => {
           tag.tabIndex = -1
           first.tabIndex = 0
           first.focus()
+          focusedTagIndexRef.current = 0
         }
       } else if (e.key === "End") {
         e.preventDefault()
@@ -505,6 +513,7 @@ const Multiselect: FC<Props> = props => {
           tag.tabIndex = -1
           last.tabIndex = 0
           last.focus()
+          focusedTagIndexRef.current = tags.length - 1
         }
       }
     },
@@ -663,6 +672,11 @@ const Multiselect: FC<Props> = props => {
     element.options.length <= 10 &&
     !(element.acceptNewOptions ?? false)
 
+  // Clamp focused tag index to valid range after tags are removed
+  if (focusedTagIndexRef.current >= value.length) {
+    focusedTagIndexRef.current = Math.max(0, value.length - 1)
+  }
+
   return (
     <div className="stMultiSelect" data-testid="stMultiSelect">
       <WidgetLabel
@@ -702,15 +716,14 @@ const Multiselect: FC<Props> = props => {
           >
             <StyledTagsContainer
               ref={tagsContainerRef}
-              role="list"
-              aria-label="Selected values"
               onScroll={handleTagsScroll}
             >
               {value.map((v, idx) => (
                 <StyledTag
                   key={v}
-                  role="listitem"
-                  tabIndex={!disabled && idx === 0 ? 0 : -1}
+                  tabIndex={
+                    !disabled && idx === focusedTagIndexRef.current ? 0 : -1
+                  }
                   aria-label={v}
                   aria-roledescription="tag"
                   $disabled={disabled}

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -64,6 +64,7 @@ import {
   SELECT_MATCHES_ID,
   useMultiselectFiltering,
 } from "~lib/hooks/useMultiselectFiltering"
+import { useScrollbarGutterSize } from "~lib/hooks/useScrollbarGutterSize"
 import { convertRemToPx } from "~lib/theme/utils"
 import { isMobile } from "~lib/util/isMobile"
 import {
@@ -153,37 +154,22 @@ const DropdownController = memo<{
 })
 DropdownController.displayName = "DropdownController"
 
-// TODO(mgbarnes): Replace manual tags with RAC TagGroup for arrow-key
-// navigation and Delete-to-remove on any focused tag.
-const TagRemoveButton = memo<{
-  value: string
-  onRemove: (value: string) => void
-}>(({ value, onRemove }) => (
-  <StyledTagRemoveButton
-    aria-label={`Remove ${value}`}
-    tabIndex={-1}
-    onClick={e => {
-      e.stopPropagation()
-      onRemove(value)
-    }}
+const TagRemoveIcon: FC = () => (
+  <svg
+    aria-hidden="true"
+    height="0.5em"
+    width="0.5em"
+    viewBox="0 0 10 10"
+    xmlns="http://www.w3.org/2000/svg"
   >
-    <svg
-      aria-hidden="true"
-      height="0.5em"
-      width="0.5em"
-      viewBox="0 0 10 10"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="2"
-      />
-    </svg>
-  </StyledTagRemoveButton>
-))
-TagRemoveButton.displayName = "TagRemoveButton"
+    <path
+      d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="2"
+    />
+  </svg>
+)
 
 /** Render a single option. Cast required: styled(ListBox) erases the generic item type. */
 const renderOption = (item: unknown): ReactElement => {
@@ -217,6 +203,7 @@ const Multiselect: FC<Props> = props => {
 
   const theme = useEmotionTheme()
   const isInSidebar = useContext(IsSidebarContext)
+  const scrollbarGutterSize = useScrollbarGutterSize()
   const tagsContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const scrollTopRef = useRef(0)
@@ -451,13 +438,77 @@ const Multiselect: FC<Props> = props => {
     }
   }, [])
 
-  const handleRemoveTag = useCallback(
-    (tagValue: string): void => {
-      const newValue = valueRef.current.filter(v => v !== tagValue)
+  const handleTagGroupRemove = useCallback(
+    (keys: Set<Key>): void => {
+      const keysToRemove = new Set([...keys].map(String))
+      const newValue = valueRef.current.filter(v => !keysToRemove.has(v))
       valueRef.current = newValue
       setValueWithSource({ value: newValue, fromUi: true })
     },
     [setValueWithSource]
+  )
+
+  const handleTagKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLSpanElement>): void => {
+      const tag = e.currentTarget
+      const container = tag.parentElement
+      if (!container) return
+
+      const tags = Array.from(
+        container.querySelectorAll<HTMLElement>("[data-tag]")
+      )
+      const idx = tags.indexOf(tag)
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault()
+        const prev = tags[idx - 1]
+        if (prev) {
+          tag.tabIndex = -1
+          prev.tabIndex = 0
+          prev.focus()
+        }
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault()
+        const next = tags[idx + 1]
+        if (next) {
+          tag.tabIndex = -1
+          next.tabIndex = 0
+          next.focus()
+        } else {
+          inputRef.current?.focus()
+        }
+      } else if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault()
+        const tagValue = value[idx]
+        if (tagValue !== undefined) {
+          const nextFocus = tags[idx + 1] ?? tags[idx - 1]
+          handleTagGroupRemove(new Set([tagValue]))
+          if (nextFocus && nextFocus !== tag) {
+            nextFocus.tabIndex = 0
+            nextFocus.focus()
+          } else {
+            inputRef.current?.focus()
+          }
+        }
+      } else if (e.key === "Home") {
+        e.preventDefault()
+        const first = tags[0]
+        if (first && first !== tag) {
+          tag.tabIndex = -1
+          first.tabIndex = 0
+          first.focus()
+        }
+      } else if (e.key === "End") {
+        e.preventDefault()
+        const last = tags[tags.length - 1]
+        if (last && last !== tag) {
+          tag.tabIndex = -1
+          last.tabIndex = 0
+          last.focus()
+        }
+      }
+    },
+    [handleTagGroupRemove, value]
   )
 
   const handleClearAll = useCallback((): void => {
@@ -651,13 +702,34 @@ const Multiselect: FC<Props> = props => {
           >
             <StyledTagsContainer
               ref={tagsContainerRef}
+              role="list"
+              aria-label="Selected values"
               onScroll={handleTagsScroll}
             >
-              {value.map(v => (
-                <StyledTag key={v} $disabled={disabled} data-tag="">
+              {value.map((v, idx) => (
+                <StyledTag
+                  key={v}
+                  role="listitem"
+                  tabIndex={!disabled && idx === 0 ? 0 : -1}
+                  aria-label={v}
+                  aria-roledescription="tag"
+                  $disabled={disabled}
+                  data-tag=""
+                  data-tag-index={idx}
+                  onKeyDown={disabled ? undefined : handleTagKeyDown}
+                >
                   <StyledTagText title={v}>{v}</StyledTagText>
                   {!disabled && (
-                    <TagRemoveButton value={v} onRemove={handleRemoveTag} />
+                    <StyledTagRemoveButton
+                      aria-label={`Remove ${v}`}
+                      tabIndex={-1}
+                      onClick={e => {
+                        e.stopPropagation()
+                        handleTagGroupRemove(new Set([v]))
+                      }}
+                    >
+                      <TagRemoveIcon />
+                    </StyledTagRemoveButton>
                   )}
                 </StyledTag>
               ))}
@@ -703,7 +775,12 @@ const Multiselect: FC<Props> = props => {
             isNonModal
             $isInSidebar={isInSidebar}
             offset={0}
-            style={floatingStyles}
+            style={
+              {
+                ...floatingStyles,
+                "--scrollbar-gutter-size": `${scrollbarGutterSize}px`,
+              } as React.CSSProperties
+            }
           >
             <Virtualizer
               layout={ListLayout}

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -83,6 +83,7 @@ import {
   StyledOpenButton,
   StyledPopover,
   StyledTag,
+  StyledTagGroup,
   StyledTagRemoveButton,
   StyledTagsContainer,
   StyledTagText,
@@ -495,6 +496,9 @@ const Multiselect: FC<Props> = props => {
           next.focus()
           focusedTagIndexRef.current = idx + 1
         } else {
+          tag.tabIndex = -1
+          const first = tags[0]
+          if (first) first.tabIndex = 0
           focusedTagIndexRef.current = 0
           inputRef.current?.focus()
         }
@@ -705,10 +709,11 @@ const Multiselect: FC<Props> = props => {
     element.options.length <= 10 &&
     !(element.acceptNewOptions ?? false)
 
-  // Clamp focused tag index to valid range after tags are removed
-  if (focusedTagIndexRef.current >= value.length) {
-    focusedTagIndexRef.current = Math.max(0, value.length - 1)
-  }
+  // Derive clamped tag index for render — don't mutate ref during render
+  const clampedTagIndex = Math.min(
+    focusedTagIndexRef.current,
+    Math.max(0, value.length - 1)
+  )
 
   return (
     <div className="stMultiSelect" data-testid="stMultiSelect">
@@ -753,19 +758,11 @@ const Multiselect: FC<Props> = props => {
               data-testid="stMultiSelectTagsContainer"
             >
               {value.length > 0 && (
-                <span
-                  role="group"
-                  aria-label="Selected values"
-                  style={{ display: "contents" }}
-                >
+                <StyledTagGroup role="group" aria-label="Selected values">
                   {value.map((v, idx) => (
                     <StyledTag
                       key={v}
-                      tabIndex={
-                        !disabled && idx === focusedTagIndexRef.current
-                          ? 0
-                          : -1
-                      }
+                      tabIndex={!disabled && idx === clampedTagIndex ? 0 : -1}
                       aria-label={v}
                       $disabled={disabled}
                       data-tag=""
@@ -791,7 +788,7 @@ const Multiselect: FC<Props> = props => {
                       )}
                     </StyledTag>
                   ))}
-                </span>
+                </StyledTagGroup>
               )}
               <StyledFilterInput
                 ref={inputRef}

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -207,6 +207,7 @@ const Multiselect: FC<Props> = props => {
   const tagsContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const scrollTopRef = useRef(0)
+  const scrollLockRef = useRef(false)
   const focusedTagIndexRef = useRef(0)
 
   const queryParamBinding = element.queryParamKey
@@ -325,15 +326,22 @@ const Multiselect: FC<Props> = props => {
     return "No results"
   }, [element.maxSelections, value.length])
 
-  // Preserve scroll position when tags are added/removed
+  // Preserve scroll position when tags are removed via UI interaction.
   useLayoutEffect(() => {
-    if (tagsContainerRef.current) {
-      tagsContainerRef.current.scrollTop = scrollTopRef.current
-    }
+    if (!scrollLockRef.current) return
+    const savedScroll = scrollTopRef.current
+    scrollLockRef.current = false
+    const container = tagsContainerRef.current
+    if (!container) return
+    requestAnimationFrame(() => {
+      container.scrollTop = savedScroll
+      scrollTopRef.current = savedScroll
+    })
   }, [value])
 
   const handleTagsScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-    // eslint-disable-next-line streamlit-custom/no-force-reflow-access -- Safe: layout already computed during scroll event
+    if (scrollLockRef.current) return
+    // eslint-disable-next-line streamlit-custom/no-force-reflow-access
     scrollTopRef.current = e.currentTarget.scrollTop
   }, [])
 
@@ -441,6 +449,11 @@ const Multiselect: FC<Props> = props => {
 
   const handleTagGroupRemove = useCallback(
     (keys: Set<Key>): void => {
+      scrollLockRef.current = true
+      if (tagsContainerRef.current) {
+        // eslint-disable-next-line streamlit-custom/no-force-reflow-access
+        scrollTopRef.current = tagsContainerRef.current.scrollTop
+      }
       const keysToRemove = new Set([...keys].map(String))
       const newValue = valueRef.current.filter(v => !keysToRemove.has(v))
       valueRef.current = newValue
@@ -492,10 +505,10 @@ const Multiselect: FC<Props> = props => {
             focusedTagIndexRef.current =
               nextFocus === tags[idx + 1] ? idx : idx - 1
             nextFocus.tabIndex = 0
-            nextFocus.focus()
+            nextFocus.focus({ preventScroll: true })
           } else {
             focusedTagIndexRef.current = 0
-            inputRef.current?.focus()
+            inputRef.current?.focus({ preventScroll: true })
           }
         }
       } else if (e.key === "Home") {
@@ -743,6 +756,7 @@ const Multiselect: FC<Props> = props => {
                           onClick={e => {
                             e.stopPropagation()
                             handleTagGroupRemove(new Set([v]))
+                            inputRef.current?.focus({ preventScroll: true })
                           }}
                         >
                           <TagRemoveIcon />

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -602,7 +602,7 @@ const Multiselect: FC<Props> = props => {
         (e.key === "ArrowDown" || e.key === "ArrowUp") &&
         !isOpenRef.current
       ) {
-        openDropdownRef.current?.("first")
+        openDropdownRef.current?.()
       }
 
       if (e.key === "Escape") {

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -733,7 +733,11 @@ const Multiselect: FC<Props> = props => {
               onScroll={handleTagsScroll}
             >
               {value.length > 0 && (
-                <span role="group" aria-label="Selected values">
+                <span
+                  role="group"
+                  aria-label="Selected values"
+                  style={{ display: "contents" }}
+                >
                   {value.map((v, idx) => (
                     <StyledTag
                       key={v}

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -533,9 +533,26 @@ const Multiselect: FC<Props> = props => {
           last.focus()
           focusedTagIndexRef.current = tags.length - 1
         }
+      } else if (e.key === " ") {
+        e.preventDefault()
       }
     },
     [handleTagGroupRemove, value]
+  )
+
+  const handleTagPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLSpanElement>): void => {
+      const clicked = e.currentTarget
+      const container = clicked.parentElement
+      if (!container) return
+      const tags = container.querySelectorAll<HTMLElement>("[data-tag]")
+      tags.forEach(t => {
+        t.tabIndex = t === clicked ? 0 : -1
+      })
+      const idx = Number(clicked.dataset.tagIndex)
+      focusedTagIndexRef.current = idx
+    },
+    []
   )
 
   const handleClearAll = useCallback((): void => {
@@ -640,6 +657,11 @@ const Multiselect: FC<Props> = props => {
         value.length > 0
       ) {
         e.preventDefault()
+        scrollLockRef.current = true
+        if (tagsContainerRef.current) {
+          // eslint-disable-next-line streamlit-custom/no-force-reflow-access
+          scrollTopRef.current = tagsContainerRef.current.scrollTop
+        }
         const newValue = valueRef.current.slice(0, -1)
         valueRef.current = newValue
         setValueWithSource({ value: newValue, fromUi: true })
@@ -728,6 +750,7 @@ const Multiselect: FC<Props> = props => {
             <StyledTagsContainer
               ref={tagsContainerRef}
               onScroll={handleTagsScroll}
+              data-testid="stMultiSelectTagsContainer"
             >
               {value.length > 0 && (
                 <span
@@ -748,6 +771,9 @@ const Multiselect: FC<Props> = props => {
                       data-tag=""
                       data-tag-index={idx}
                       onKeyDown={disabled ? undefined : handleTagKeyDown}
+                      onPointerDown={
+                        disabled ? undefined : handleTagPointerDown
+                      }
                     >
                       <StyledTagText title={v}>{v}</StyledTagText>
                       {!disabled && (

--- a/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
+++ b/frontend/lib/src/components/widgets/Multiselect/Multiselect.tsx
@@ -136,13 +136,16 @@ const updateWidgetMgrState = (
  * open/close methods and focusedKey via refs. Same pattern as the Selectbox widget.
  */
 const DropdownController = memo<{
-  openRef: React.MutableRefObject<(() => void) | null>
+  openRef: React.MutableRefObject<
+    ((focusStrategy?: "first" | "last" | null) => void) | null
+  >
   focusedKeyRef: React.MutableRefObject<Key | null>
 }>(({ openRef, focusedKeyRef }) => {
   const state = useContext(ComboBoxStateContext)
   useEffect(() => {
     if (state) {
-      openRef.current = () => state.open("first", "manual")
+      openRef.current = (focusStrategy = null) =>
+        state.open(focusStrategy, "manual")
     }
     return () => {
       openRef.current = null
@@ -246,7 +249,9 @@ const Multiselect: FC<Props> = props => {
   useExecuteWhenChanged(() => setInputValue(""), [value])
 
   const isOpenRef = useRef(false)
-  const openDropdownRef = useRef<(() => void) | null>(null)
+  const openDropdownRef = useRef<
+    ((focusStrategy?: "first" | "last" | null) => void) | null
+  >(null)
   const focusedKeyRef = useRef<Key | null>(null)
 
   // In the sidebar, flip/shift are bounded by the viewport so the dropdown can
@@ -576,7 +581,7 @@ const Multiselect: FC<Props> = props => {
         (e.key === "ArrowDown" || e.key === "ArrowUp") &&
         !isOpenRef.current
       ) {
-        openDropdownRef.current?.()
+        openDropdownRef.current?.("first")
       }
 
       if (e.key === "Escape") {

--- a/frontend/lib/src/components/widgets/Multiselect/styled-components.ts
+++ b/frontend/lib/src/components/widgets/Multiselect/styled-components.ts
@@ -83,6 +83,11 @@ export const StyledTagsContainer = styled.div(({ theme }) => ({
   cursor: "text",
 }))
 
+/** Wrapper for the tag group that participates in flex layout without adding a box. */
+export const StyledTagGroup = styled.span({
+  display: "contents",
+})
+
 /** Individual removable tag pill displaying a selected value. */
 export const StyledTag = styled.span<{ $disabled?: boolean }>(
   ({ theme, $disabled }) => ({

--- a/frontend/lib/src/components/widgets/Multiselect/styled-components.ts
+++ b/frontend/lib/src/components/widgets/Multiselect/styled-components.ts
@@ -106,6 +106,10 @@ export const StyledTag = styled.span<{ $disabled?: boolean }>(
     cursor: "default",
     overflow: "hidden",
     whiteSpace: "nowrap",
+    outline: "none",
+    "&:focus-visible": {
+      boxShadow: theme.shadows.focusRing,
+    },
   })
 )
 
@@ -118,21 +122,18 @@ export const StyledTagText = styled.span({
 })
 
 /** Accessible remove button inside each tag. */
-export const StyledTagRemoveButton = styled.button<{ $disabled?: boolean }>(
-  ({ theme, $disabled }) => ({
-    display: "inline-flex",
-    alignItems: "center",
-    justifyContent: "center",
-    border: "none",
-    background: "transparent",
-    padding: theme.spacing.none,
-    paddingLeft: theme.spacing.sm,
-    cursor: $disabled ? "not-allowed" : "pointer",
-    color: "inherit",
-    pointerEvents: $disabled ? "none" : "auto",
-    flexShrink: 0,
-  })
-)
+export const StyledTagRemoveButton = styled.button(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: "none",
+  background: "transparent",
+  padding: theme.spacing.none,
+  paddingLeft: theme.spacing.sm,
+  cursor: "pointer",
+  color: "inherit",
+  flexShrink: 0,
+}))
 
 /**
  * Filter input inline with tags. Fills remaining space on the current flex line.


### PR DESCRIPTION
## Describe your changes
Improves tag accessibility, fixes Escape key behavior, and aligns dropdown focus with WAI-ARIA guidelines in st.multiselect:

**Keyboard navigation (tags)**:
- Roving tabindex on selected tags — Arrow Left/Right/Up/Down, Home/End to navigate between tags
- Delete/Backspace removes the focused tag with sensible focus handoff to the next neighbor or input
- Tags wrapped in role="group" with aria-label="Selected values" for screen reader context
- aria-label on each tag for individual announcement
- :focus-visible ring styling using theme.shadows.focusRing

**Dropdown focus (manual selection model)**:
- Typing to filter no longer auto-highlights the first dropdown option — follows the WAI-ARIA manual selection combobox pattern (no aria-activedescendant while typing)
- ArrowDown/Up when closed opens the dropdown AND focuses the first item (explicit navigation intent)
- Click/pointer opens with no auto-focus
- Aligns with MUI Autocomplete, React Select, and Downshift defaults for multi-select comboboxes

**Escape key fix:**
- Escape no longer clears committed selections (previously cleared all tags when no default was set)
- Aligns with WAI-ARIA APG guidance: Escape dismisses the popup and optionally clears filter text, but never clears committed values

**Scroll preservation**:
- Improved scroll position logic during tag removal using scrollLockRef + requestAnimationFrame to prevent jumps

**Scrollbar gutter**:
- Dropdown popover sets --scrollbar-gutter-size from useScrollbarGutterSize, aligning list padding with Selectbox/DateTimeInput when a scrollbar appears


## Github Issue Link
Closes https://github.com/streamlit/streamlit/issues/16109

## Testing Plan

- JS Unit Tests: ✅ Added (7 new tag accessibility tests covering ARIA attributes, roving tabindex, disabled state, arrow/Home/End navigation, Delete removal, Backspace tabindex consistency, and last-tag-to-input focus)
- Manual Testing: :white_check_mark: Validated with keyboard


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core multiselect input/keyboard and value-update paths used on every interaction; regressions could affect selection clearing, focus order, or scroll behavior, though coverage is expanded in unit and E2E tests.
> 
> **Overview**
> Improves **keyboard and screen-reader support** for selected tags in `st.multiselect`: tags sit in a `role="group"` labeled “Selected values”, each tag gets `aria-label` and **roving tabindex**, with arrow/Home/End navigation, Delete/Backspace removal, and `:focus-visible` styling. Remove actions share **`handleTagGroupRemove`** with scroll locking so the tags list doesn’t jump on delete (including Backspace on an empty input).
> 
> **Escape no longer clears committed selections** (only clears active filter text when typing); behavior is covered by updated unit tests (#16109).
> 
> The dropdown popover passes **`--scrollbar-gutter-size`** from `useScrollbarGutterSize` for alignment with other widgets. E2E tests target `stMultiSelectTagsContainer`, wait for scroll/URL updates, and harden query-param URL assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1889c1c4d964ff8fd6b46b571c133815594ab7e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->