### PR TITLE
[fix] Enforce upload size limit while streaming body

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
     from starlette.responses import Response
     from starlette.routing import BaseRoute
+    from starlette.types import Message
 
     from streamlit.components.types.base_component_registry import BaseComponentRegistry
     from streamlit.components.v2.component_manager import BidiComponentManager
@@ -103,6 +104,14 @@ _SAME_SITE_HEADER_VALUES: Final = {
 
 # App static files
 _ROUTE_APP_STATIC: Final = "app/static/{path:path}"
+
+# Extra bytes allowed on top of `server.maxUploadSize` when enforcing the upload
+# size limit at the raw-request-body level (see `_upload_put`). A multipart
+# upload body is slightly larger than the file it carries because of the
+# framing overhead (boundary lines, part headers, filename). This margin ensures
+# a legitimate file of exactly `maxUploadSize` is never rejected while streaming;
+# the exact per-file limit is still enforced after parsing.
+_MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES: Final = 1024 * 1024  # 1 MB
 
 
 def _stats_to_text(stats_by_family: Mapping[str, Sequence[Stat]]) -> str:
@@ -646,6 +655,7 @@ def create_upload_routes(
     """
     from starlette.datastructures import UploadFile
     from starlette.exceptions import HTTPException
+    from starlette.requests import Request as StarletteRequest
     from starlette.responses import Response
     from starlette.routing import Route
 
@@ -706,7 +716,8 @@ def create_upload_routes(
             config.get_option("server.maxUploadSize") * 1024 * 1024
         )
 
-        # 1. Fast fail via header (if present) - check before reading the body
+        # 1. Fast fail via the Content-Length header (if present), before reading
+        # any of the body. This rejects well-behaved oversized uploads early.
         content_length = request.headers.get("content-length")
         if content_length:
             try:
@@ -717,7 +728,33 @@ def create_upload_routes(
                     status_code=400, detail="Invalid Content-Length header"
                 )
 
-        form = await request.form()
+        # 2. Enforce the limit while streaming the body. Content-Length can be
+        # absent or falsified (e.g. Transfer-Encoding: chunked), so we cap the
+        # raw request body as it arrives and abort as soon as it exceeds the
+        # limit. Without this, an oversized upload would be fully buffered in
+        # memory (upload.read()) or spooled to disk (request.form()) before the
+        # size check below could reject it, allowing a single request to exhaust
+        # the server's memory/disk.
+        max_body_bytes = max_size_bytes + _MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES
+        bytes_received = 0
+
+        async def limited_receive() -> Message:
+            nonlocal bytes_received
+            message = await request.receive()
+            if message["type"] == "http.request":
+                bytes_received += len(message.get("body", b""))
+                if bytes_received > max_body_bytes:
+                    # Raising here aborts the multipart parse mid-stream. Starlette
+                    # only closes its spooled temp files on MultiPartException /
+                    # OSError, so this HTTPException leaves that cleanup to GC once
+                    # the frames unwind - the same behavior as an upstream
+                    # ClientDisconnect. Resource use stays bounded (one in-flight
+                    # request), so this is acceptable.
+                    raise HTTPException(status_code=413, detail="File too large")
+            return message
+
+        limited_request = StarletteRequest(request.scope, limited_receive)
+        form = await limited_request.form()
         uploads = [value for value in form.values() if isinstance(value, UploadFile)]
 
         if len(uploads) != 1:
@@ -727,9 +764,8 @@ def create_upload_routes(
 
         upload = uploads[0]
 
-        # 2. Check actual file size (Content-Length may be absent or inaccurate)
-        # TODO(lukasmasuch): Improve by using a streaming approach that rejects uploads as soon as
-        # they exceed max_size_bytes, rather than waiting for the full upload to complete.
+        # 3. Enforce the exact per-file size limit. The streaming cap above
+        # allows a small framing margin, so re-check the parsed file size here.
         try:
             data = await upload.read()
         finally:

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -744,12 +744,22 @@ def create_upload_routes(
             if message["type"] == "http.request":
                 bytes_received += len(message.get("body", b""))
                 if bytes_received > max_body_bytes:
+                    # Log the streaming-cap rejection so operators can tell a
+                    # misconfigured server.maxUploadSize (legitimate uploads being
+                    # rejected) apart from an actual abuse attempt.
+                    _LOGGER.warning(
+                        "Upload rejected: request body exceeded the size limit "
+                        "while streaming (%d bytes received, cap %d bytes). If "
+                        "legitimate uploads are affected, increase "
+                        "server.maxUploadSize.",
+                        bytes_received,
+                        max_body_bytes,
+                    )
                     # Raising here aborts the multipart parse mid-stream. Starlette
                     # only closes its spooled temp files on MultiPartException /
-                    # OSError, so this HTTPException leaves that cleanup to GC once
-                    # the frames unwind - the same behavior as an upstream
-                    # ClientDisconnect. Resource use stays bounded (one in-flight
-                    # request), so this is acceptable.
+                    # OSError, so this HTTPException leaves cleanup to GC once the
+                    # frames unwind - the same as an upstream ClientDisconnect.
+                    # Resource use stays bounded to one in-flight request.
                     raise HTTPException(status_code=413, detail="File too large")
             return message
 

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -105,12 +105,13 @@ _SAME_SITE_HEADER_VALUES: Final = {
 # App static files
 _ROUTE_APP_STATIC: Final = "app/static/{path:path}"
 
-# Extra bytes allowed on top of `server.maxUploadSize` when enforcing the upload
-# size limit at the raw-request-body level (see `_upload_put`). A multipart
-# upload body is slightly larger than the file it carries because of the
-# framing overhead (boundary lines, part headers, filename). This margin ensures
-# a legitimate file of exactly `maxUploadSize` is never rejected while streaming;
-# the exact per-file limit is still enforced after parsing.
+# Framing margin for the streaming upload-size cap in `_upload_put`: the raw
+# request body is rejected once it exceeds `server.maxUploadSize` plus this
+# margin, and the exact per-file limit is still re-checked after parsing. The
+# margin exists because a multipart body is slightly larger than the file it
+# carries (boundary lines, part headers, filename), so without it a legitimate
+# file of exactly `maxUploadSize` could be rejected while streaming. 1 MB
+# comfortably covers that framing overhead.
 _MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES: Final = 1024 * 1024  # 1 MB
 
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -769,6 +769,7 @@ def test_upload_put_chunked_body_capped_before_full_read() -> None:
             "._MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES",
             4096,
         ),
+        patch("streamlit.web.server.starlette.starlette_routes._LOGGER") as mock_logger,
     ):
         with pytest.raises(HTTPException) as exc_info:
             asyncio.run(endpoint(request))
@@ -780,6 +781,9 @@ def test_upload_put_chunked_body_capped_before_full_read() -> None:
     # only a handful of the 102 messages are ever read.
     assert receive_calls < len(messages)
     assert receive_calls <= 6
+    # The streaming cap logs a warning so operators can diagnose whether a
+    # misconfigured maxUploadSize is rejecting legitimate uploads.
+    mock_logger.warning.assert_called_once()
 
 
 def test_upload_put_stores_file_and_returns_204() -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 import asyncio
 import string
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from starlette.applications import Starlette
-from starlette.datastructures import UploadFile
 from starlette.exceptions import HTTPException
+from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
@@ -98,6 +98,59 @@ def _upload_routes() -> list[BaseRoute]:
     return create_upload_routes(
         runtime, MemoryUploadedFileManager("/_stcore/upload_file"), ""
     )
+
+
+def _multipart_body(
+    file_bytes: bytes,
+    *,
+    field_name: str = "file",
+    filename: str = "foo.txt",
+    boundary: str = "testboundary",
+) -> tuple[bytes, str]:
+    """Build a minimal multipart/form-data body carrying a single file part."""
+    body = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            (
+                f'Content-Disposition: form-data; name="{field_name}"; '
+                f'filename="{filename}"\r\n'
+            ).encode(),
+            b"Content-Type: application/octet-stream\r\n\r\n",
+            file_bytes,
+            f"\r\n--{boundary}--\r\n".encode(),
+        ]
+    )
+    return body, boundary
+
+
+def _make_upload_request(
+    body_messages: list[dict[str, Any]],
+    *,
+    boundary: str,
+    session_id: str = "session123",
+    file_id: str = "fileid",
+    on_receive: Callable[[], None] | None = None,
+) -> StarletteRequest:
+    """Build a real PUT Request whose ASGI ``receive`` yields the given body
+    messages one at a time (optionally invoking ``on_receive`` per call)."""
+    scope = {
+        "type": "http",
+        "method": "PUT",
+        "path": f"/_stcore/upload_file/{session_id}/{file_id}",
+        "headers": [
+            (b"content-type", f"multipart/form-data; boundary={boundary}".encode())
+        ],
+        "query_string": b"",
+        "path_params": {"session_id": session_id, "file_id": file_id},
+    }
+    messages = iter(body_messages)
+
+    async def receive() -> dict[str, Any]:
+        if on_receive is not None:
+            on_receive()
+        return next(messages)
+
+    return StarletteRequest(scope, receive)
 
 
 class TestWithBase:
@@ -622,23 +675,37 @@ def test_upload_put_invalid_content_length_returns_400() -> None:
     assert "Invalid Content-Length" in exc_info.value.detail
 
 
-def test_upload_put_oversized_body_returns_413() -> None:
-    """A body that exceeds the configured max upload size is rejected with 413."""
+def test_upload_put_oversized_content_length_returns_413() -> None:
+    """A Content-Length header exceeding the max upload size is rejected early."""
     endpoint = _endpoint_for(_upload_routes(), "PUT")
 
-    upload = MagicMock(spec=UploadFile)
-    upload.read = AsyncMock(return_value=b"x" * 100)
-    upload.file = MagicMock()
-    upload.filename = "foo.txt"
-    upload.content_type = "text/plain"
-    form = MagicMock()
-    form.values.return_value = [upload]
-
     request = MagicMock()
-    request.headers = {}
+    request.headers = {"content-length": str(500 * 1024 * 1024)}
     request.cookies = {}
     request.path_params = {"session_id": "session123", "file_id": "fileid"}
-    request.form = AsyncMock(return_value=form)
+
+    with patch_config_options(
+        {"server.enableXsrfProtection": False, "server.maxUploadSize": 200}
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(endpoint(request))
+
+    assert exc_info.value.status_code == 413
+
+
+def test_upload_put_oversized_body_returns_413() -> None:
+    """A parsed file larger than the configured max upload size is rejected 413.
+
+    Uses a body with no Content-Length so the fast-fail header check is skipped
+    and the post-parse size check is exercised.
+    """
+    endpoint = _endpoint_for(_upload_routes(), "PUT")
+
+    body, boundary = _multipart_body(b"x" * 100)
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": False}],
+        boundary=boundary,
+    )
 
     with patch_config_options(
         {"server.enableXsrfProtection": False, "server.maxUploadSize": 0}
@@ -647,7 +714,132 @@ def test_upload_put_oversized_body_returns_413() -> None:
             asyncio.run(endpoint(request))
 
     assert exc_info.value.status_code == 413
-    upload.file.close.assert_called_once()
+
+
+def test_upload_put_chunked_body_capped_before_full_read() -> None:
+    """A chunked upload without Content-Length is aborted mid-stream once it
+    exceeds the size limit, instead of being fully buffered first.
+
+    Regression test for SNOW-3688979: a chunked PUT bypasses the Content-Length
+    gate, so the handler must enforce the limit while streaming rather than
+    buffering the whole (potentially multi-GB) body into RAM before checking.
+    """
+    endpoint = _endpoint_for(_upload_routes(), "PUT")
+
+    boundary = "boundary"
+    part_header = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="big.bin"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n"
+    ).encode()
+    chunk = b"x" * 1024
+    num_chunks = 100
+
+    messages: list[dict[str, Any]] = [
+        {"type": "http.request", "body": part_header, "more_body": True}
+    ]
+    messages += [
+        {"type": "http.request", "body": chunk, "more_body": True}
+        for _ in range(num_chunks)
+    ]
+    messages.append(
+        {
+            "type": "http.request",
+            "body": f"\r\n--{boundary}--\r\n".encode(),
+            "more_body": False,
+        }
+    )
+
+    receive_calls = 0
+
+    def _count_receive() -> None:
+        nonlocal receive_calls
+        receive_calls += 1
+
+    request = _make_upload_request(
+        messages, boundary=boundary, on_receive=_count_receive
+    )
+
+    with (
+        patch_config_options(
+            {"server.enableXsrfProtection": False, "server.maxUploadSize": 0}
+        ),
+        patch(
+            "streamlit.web.server.starlette.starlette_routes"
+            "._MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES",
+            4096,
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(endpoint(request))
+
+    assert exc_info.value.status_code == 413
+    # The handler must abort well before consuming the entire body, proving the
+    # body is not fully buffered before the size check runs. With a 4 KiB cap and
+    # ~1 KiB chunks, the limit is crossed after the part header plus ~4 chunks, so
+    # only a handful of the 102 messages are ever read.
+    assert receive_calls < len(messages)
+    assert receive_calls <= 6
+
+
+def test_upload_put_stores_file_and_returns_204() -> None:
+    """A valid single-file upload is stored and the handler returns 204."""
+    runtime = MagicMock()
+    runtime.is_active_session.return_value = True
+    upload_mgr = MemoryUploadedFileManager("/_stcore/upload_file")
+    routes = create_upload_routes(runtime, upload_mgr, "")
+
+    with patch_config_options({"server.enableXsrfProtection": False}):
+        response = _client_for(routes).put(
+            "/_stcore/upload_file/session123/fileid",
+            files={"file": ("foo.txt", b"hello world", "text/plain")},
+        )
+
+    assert response.status_code == 204
+    stored = upload_mgr.get_files("session123", ["fileid"])
+    assert len(stored) == 1
+    assert stored[0].data == b"hello world"
+    assert stored[0].name == "foo.txt"
+
+
+def test_upload_put_max_size_file_succeeds() -> None:
+    """A file of exactly ``maxUploadSize`` is accepted, not rejected by the cap.
+
+    The streaming cap allows ``maxUploadSize`` plus a framing margin so that the
+    multipart overhead of a legitimate max-size file does not trip the limit. This
+    patches the margin down to a small value (proving the margin - not a large
+    default - is what lets the framing through) and sends no Content-Length so the
+    header fast-fail is skipped and the streaming cap is the gate under test.
+    """
+    runtime = MagicMock()
+    runtime.is_active_session.return_value = True
+    upload_mgr = MemoryUploadedFileManager("/_stcore/upload_file")
+    endpoint = _endpoint_for(create_upload_routes(runtime, upload_mgr, ""), "PUT")
+
+    max_size_bytes = 1024 * 1024  # server.maxUploadSize is in megabytes
+    file_bytes = b"x" * max_size_bytes
+    body, boundary = _multipart_body(file_bytes, filename="big.bin")
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": False}],
+        boundary=boundary,
+    )
+
+    with (
+        patch_config_options(
+            {"server.enableXsrfProtection": False, "server.maxUploadSize": 1}
+        ),
+        patch(
+            "streamlit.web.server.starlette.starlette_routes"
+            "._MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES",
+            4096,
+        ),
+    ):
+        response = asyncio.run(endpoint(request))
+
+    assert response.status_code == 204
+    stored = upload_mgr.get_files("session123", ["fileid"])
+    assert len(stored) == 1
+    assert stored[0].data == file_bytes
 
 
 def test_component_endpoint_empty_path_returns_404() -> None:


### PR DESCRIPTION
## Describe your changes

Hardens the file-upload endpoint (`_upload_put`) against a single-request memory/disk exhaustion vector (SNOW-3688979).

- Enforce `server.maxUploadSize` **while streaming** the request body via a `limited_receive` ASGI wrapper, so a chunked `PUT` (which has no `Content-Length` and thus bypasses the existing pre-flight header gate) can no longer be fully buffered into RAM/disk before the size check runs. The raw body is capped at `maxUploadSize` + a small multipart-framing margin, then the exact per-file limit is still enforced after parsing.
- The pre-existing `Content-Length` fast-fail and the exact post-parse size check are retained; behavior for legitimate uploads is unchanged.

## GitHub Issue Link (if applicable)

- N/A (internal report SNOW-3688979)

## Testing Plan

- [x] Unit Tests (JS and/or Python)

`lib/tests/streamlit/web/server/starlette/starlette_routes_test.py`:
- `test_upload_put_chunked_body_capped_before_full_read` — regression: a chunked body is aborted mid-stream before full buffering.
- `test_upload_put_oversized_content_length_returns_413` / `test_upload_put_oversized_body_returns_413` — oversized rejected via header gate and post-parse check.
- `test_upload_put_max_size_file_succeeds` — a file at exactly `maxUploadSize` still succeeds (framing margin does not reject legitimate uploads).
- `test_upload_put_stores_file_and_returns_204` — happy-path upload is stored.

Made with [Cursor](https://cursor.com)