### PR TITLE
[chore] Add cursor-grok-4.5-high and remove gemini-3.1-pro from AI PR review models

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -20,8 +20,8 @@ on:
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
-  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking' }}
-  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.4-xhigh,gemini-3.1-pro,claude-opus-4-8-thinking-xhigh"
+  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking,cursor-grok-4.5-high' }}
+  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.4-xhigh,cursor-grok-4.5-high,claude-opus-4-8-thinking-xhigh"
 
 jobs:
   # Job 1: Parse model list and check for API key

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -20,7 +20,7 @@ on:
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
-  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking,cursor-grok-4.5-high' }}
+  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,cursor-grok-4.5-high,claude-4.6-opus-high-thinking' }}
   FINAL_AI_PR_REVIEW_MODELS: "gpt-5.4-xhigh,cursor-grok-4.5-high,claude-opus-4-8-thinking-xhigh"
 
 jobs:


### PR DESCRIPTION
## Describe your changes

- Add `cursor-grok-4.5-high` to the default AI PR review models (`DEFAULT_AI_PR_REVIEW_MODELS`).
- Replace `gemini-3.1-pro` with `cursor-grok-4.5-high` in the final AI PR review models (`FINAL_AI_PR_REVIEW_MODELS`).

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] N/A — CI workflow configuration change only (`.github/workflows/ai-pr-review.yml`).

Made with [Cursor](https://cursor.com)