### PR TITLE
[spec] Refresh OIDC tokens with st.user.refresh()

### DIFF
--- a/specs/2026-07-28-auth-token-refresh/product-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/product-spec.md
@@ -105,11 +105,13 @@ faithful mental model (API principle #20, "one use case, one command").
    provider returns one), and refreshed identity claims.
 4. **Success:** the auth cookies are rewritten, the live session's identity is updated,
    and the app reruns. `st.user` and `st.user.tokens` now reflect the fresh values.
-5. **Recoverable failure** (e.g., transient network error): the current identity is left
-   untouched; a warning is logged; `st.user` is unchanged.
-6. **Unrecoverable failure** (refresh token expired/revoked/missing): the user is logged
-   out (cookies cleared) and the app reruns in the logged-out state so they can
-   re-authenticate. This avoids leaving the app in a stuck "logged in but broken" state.
+5. **Recoverable failure** (transient network error, or no refresh token available —
+   e.g. the provider never returned one because `offline_access` wasn't requested): the
+   current identity is left untouched; a warning is logged; `st.user` is unchanged.
+6. **Unrecoverable failure** (refresh token expired or revoked — the provider rejects the
+   grant with `invalid_grant`): the user is logged out (cookies cleared) and the app
+   reruns in the logged-out state so they can re-authenticate. This avoids leaving the app
+   in a stuck "logged in but broken" state.
 
 > **Note:** Because `refresh()` triggers a rerun, calling it unconditionally at the top of
 > a script creates an infinite refresh loop — the same footgun as an unconditional

--- a/specs/2026-07-28-auth-token-refresh/product-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/product-spec.md
@@ -1,0 +1,192 @@
+---
+author: lukasmasuch
+created: 2026-07-28
+---
+
+# Refresh OIDC tokens and user info with `st.user.refresh()`
+
+## Summary
+
+Add a new command, `st.user.refresh()`, that uses the OIDC refresh token to obtain
+fresh access/ID tokens and updated identity claims from the provider, then updates
+`st.user` and `st.user.tokens` in place. It runs in the background (no full page reload,
+no re-login) and lays the groundwork for automatic token refresh.
+
+## Problem
+
+`st.login()` establishes a long-lived identity cookie (30 days), but the tokens and
+claims captured at login are effectively frozen for the life of that cookie. Streamlit
+reads `st.user` and `st.user.tokens` from the auth cookie **only at the start of a
+session** and never updates them afterward. Two concrete pain points result:
+
+| # | Use case | GitHub issue |
+|---|----------|--------------|
+| 1 | Pick up **updated user claims** from the IdP mid-session (e.g., the user changed their language/profile in the provider, or an admin updated group membership) without forcing a re-login. | [#12043](https://github.com/streamlit/streamlit/issues/12043) |
+| 2 | Recover from **expired access tokens** when calling external APIs on behalf of the user. Access tokens are commonly short-lived (minutes to a couple of hours), but the identity cookie lives for 30 days. After expiry, `st.user.is_logged_in` is still `True` while `st.user.tokens.access` is stale, so API calls silently fail with `401`/`403`. | [#13489](https://github.com/streamlit/streamlit/issues/13489) |
+
+**Current workaround:** the only way to obtain fresh tokens/claims today is
+`st.logout()` followed by `st.login()` — a disruptive full re-authentication and page
+reload for what is often just an expired access token.
+
+**Real-world report** ([#12696](https://github.com/streamlit/streamlit/pull/12696#issuecomment)):
+a team running Streamlit against self-hosted GitLab with `expose_tokens = ["access"]`
+hits `401`s two hours into every session once GitLab's access token expires. They added
+`offline_access` to the scope to get a refresh token, but discovered that Streamlit's
+OAuth callback **discards the refresh token** entirely
+(`tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}`), so no
+refresh is possible even when the provider returns one.
+
+**Prior art (community PRs):**
+
+- [#12696](https://github.com/streamlit/streamlit/pull/12696) (velochy) — adds
+  `st.user.refresh()` via a **full-page redirect** to a `/auth/refresh` endpoint. Works,
+  but reloads the app on every refresh. Closed by the author in favor of #14437.
+- [#14437](https://github.com/streamlit/streamlit/pull/14437) (tobka777) — extends #12696
+  to refresh **without redirects** (background request), so `st.user` and the tokens
+  update smoothly with no reload. 11+ 👍, multiple "please merge" requests. This spec
+  formalizes and refines that approach.
+
+### Goals
+
+| Goal | Outcome |
+|------|---------|
+| Refresh tokens + claims without re-login | Long-running apps keep valid access tokens and current user info |
+| No full page reload | Session state, scroll position, and in-flight widget input are preserved |
+| Secure by default | The refresh token stays server-side (httponly, signed cookie) and is **never** exposed to the app or browser JS |
+| Foundation for automatic refresh | Same infrastructure can later drive proactive refresh (#13489) |
+| Backward compatible | No change to `st.login()`, `st.logout()`, `st.user`, or `expose_tokens` for existing apps |
+
+### Non-goals (this iteration)
+
+| Out of scope | Rationale |
+|--------------|-----------|
+| Automatic/proactive refresh before expiry (#13489) | Ship the manual primitive first; automatic mode is a follow-up built on the same infra (see [Out of Scope](#out-of-scope-future-work)) |
+| Exposing the `refresh` token via `st.user.tokens` | High security risk; the refresh token is a long-lived credential and stays server-side only |
+| Refresh for non-OIDC identity (trusted user headers, SiS/host-provided identity) | Those flows have no OIDC refresh token; `refresh()` is a no-op / not available there |
+| Refresh inside embedded/iframed apps | Consistent with `st.login()`, which is unsupported when embedded |
+
+## Proposal
+
+### API
+
+A new method on the existing `st.user` object:
+
+```python
+st.user.refresh() -> None
+```
+
+No parameters. Returns `None`. Like `st.login()` and `st.logout()`, it is **non-blocking
+and asynchronous**: it triggers a background refresh and then reruns the app. The updated
+values are visible **on the resulting rerun**, not synchronously within the same run.
+This mirrors the documented behavior of `st.user` ("`st.user` only reads from the
+identity cookie at the start of a session").
+
+**Why `st.user.refresh()` (not `st.refresh_user()`):**
+
+| Option | Pros | Cons |
+|--------|------|------|
+| `st.user.refresh()` ✅ **PREFERRED** | Groups the action with the object it mutates (`st.user` / `st.user.tokens`); reads naturally as "refresh the user"; `st.user` already carries methods (`to_dict()`) and properties (`tokens`); matches both community PRs. | Adds behavior to a Mapping-like proxy. |
+| `st.refresh_user()` (top-level) | Consistent with top-level `st.login()` / `st.logout()`. | Less discoverable; detached from the `tokens`/claims it updates; pollutes the flat namespace with an auth-only verb. |
+
+`st.login()`/`st.logout()` are top-level because they **create or destroy** the identity;
+`refresh()` **mutates the existing** `st.user`, so nesting it under `st.user` is the more
+faithful mental model (API principle #20, "one use case, one command").
+
+### Behavior
+
+1. **Preconditions (validated synchronously):** if authentication is not configured or
+   the user is not logged in, `st.user.refresh()` raises a clear `StreamlitAuthError`
+   (fail fast, principle #23). Calling it when identity comes from trusted user headers or
+   a host platform (no OIDC refresh token) is a no-op that logs a warning.
+2. **Trigger:** the command instructs the browser to perform a background refresh request
+   and requests a rerun.
+3. **Refresh:** Streamlit exchanges the stored refresh token at the provider's token
+   endpoint for a new access token, a new ID token (and a rotated refresh token, if the
+   provider returns one), and refreshed identity claims.
+4. **Success:** the auth cookies are rewritten, the live session's identity is updated,
+   and the app reruns. `st.user` and `st.user.tokens` now reflect the fresh values.
+5. **Recoverable failure** (e.g., transient network error): the current identity is left
+   untouched; a warning is logged; `st.user` is unchanged.
+6. **Unrecoverable failure** (refresh token expired/revoked/missing): the user is logged
+   out (cookies cleared) and the app reruns in the logged-out state so they can
+   re-authenticate. This avoids leaving the app in a stuck "logged in but broken" state.
+
+### Requirements for the refresh token
+
+Most providers only return a refresh token when the app requests the `offline_access`
+scope (or a provider-specific equivalent). This is configured through the existing
+`client_kwargs`:
+
+```toml
+[auth]
+redirect_uri = "http://localhost:8501/oauth2callback"
+cookie_secret = "xxx"
+client_id = "xxx"
+client_secret = "xxx"
+server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"
+expose_tokens = ["access"]
+client_kwargs = { scope = "openid email profile offline_access" }
+```
+
+When present, Streamlit stores the refresh token in the existing signed, **httponly**
+tokens cookie. It is used only server-side by the refresh flow and is **never** added to
+`st.user.tokens` (which continues to surface only the token types listed in
+`expose_tokens`, i.e. `"id"` and/or `"access"`).
+
+### Examples
+
+**Example 1: Refresh an expired access token before calling an API**
+
+```python
+import streamlit as st
+import requests
+
+if not st.user.is_logged_in:
+    st.button("Log in", on_click=st.login)
+    st.stop()
+
+if st.button("Refresh session"):
+    st.user.refresh()  # reruns with fresh tokens + claims
+
+resp = requests.get(
+    "https://api.example.com/me",
+    headers={"Authorization": f"Bearer {st.user.tokens.access}"},
+)
+st.json(resp.json())
+```
+
+**Example 2: Reflect profile changes made in the identity provider**
+
+```python
+import streamlit as st
+
+st.write(f"Preferred language: {st.user.locale}")
+
+# After the user updates their profile in the IdP, pull the new claims in
+# without forcing a re-login:
+st.button("Reload my profile", on_click=st.user.refresh)
+```
+
+## Out of Scope (Future Work)
+
+- **Automatic refresh (#13489).** The background-refresh infrastructure in this spec is
+  the building block for proactively refreshing tokens shortly before they expire. A
+  follow-up can add an opt-in config (e.g. `[auth] auto_refresh = true`) that schedules a
+  background refresh ahead of the token `exp`, so API calls never see an expired token.
+  We ship the manual primitive first (API principle #4, "start minimal") and gather
+  feedback before committing to an automatic policy.
+- **`retry-on-401` semantics.** Automatically retrying a failed downstream API call after
+  a refresh is app-specific and out of Streamlit's control; documented as a pattern.
+- **Exposing token expiry.** Surfacing `expires_at` on `st.user.tokens` to let apps decide
+  when to refresh could be a small complementary addition, deferred until there's demand.
+
+## Checklist
+
+| Item | ✅ or comment |
+|------|---------------|
+| Works on SiS, Cloud, etc? | N/A on SiS and for trusted-header identity (no OIDC refresh token) — no-op there. Works on self-hosted and Cloud wherever `st.login()` works. Not supported for embedded apps (consistent with `st.login()`). |
+| No breaking API changes | ✅ Purely additive: a new `st.user.refresh()` method. Storing the refresh token in the (already existing) httponly tokens cookie does not change `st.user`/`st.user.tokens` output. |
+| No new dependencies | ✅ Reuses Authlib and the existing OIDC client. |
+| Metrics collected | Track `user.refresh` calls via `@gather_metrics`, plus refresh success/failure counts server-side. |
+| Any security/legal impact? | Refresh token is now persisted server-side in the signed, httponly tokens cookie (never exposed to JS or `st.user.tokens`). Refresh endpoint is XSRF-protected and same-origin. See tech spec's Security section. |
+| Any docs changes needed? | Auth guide: document `st.user.refresh()`, the `offline_access` scope requirement, and the automatic-refresh pattern. |

--- a/specs/2026-07-28-auth-token-refresh/product-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/product-spec.md
@@ -28,7 +28,7 @@ session** and never updates them afterward. Two concrete pain points result:
 `st.logout()` followed by `st.login()` — a disruptive full re-authentication and page
 reload for what is often just an expired access token.
 
-**Real-world report** ([#12696](https://github.com/streamlit/streamlit/pull/12696#issuecomment)):
+**Real-world report** ([#12696](https://github.com/streamlit/streamlit/pull/12696#issuecomment-3861008419)):
 a team running Streamlit against self-hosted GitLab with `expose_tokens = ["access"]`
 hits `401`s two hours into every session once GitLab's access token expires. They added
 `offline_access` to the scope to get a refresh token, but discovered that Streamlit's
@@ -110,6 +110,11 @@ faithful mental model (API principle #20, "one use case, one command").
 6. **Unrecoverable failure** (refresh token expired/revoked/missing): the user is logged
    out (cookies cleared) and the app reruns in the logged-out state so they can
    re-authenticate. This avoids leaving the app in a stuck "logged in but broken" state.
+
+> **Note:** Because `refresh()` triggers a rerun, calling it unconditionally at the top of
+> a script creates an infinite refresh loop — the same footgun as an unconditional
+> `st.rerun()`. Always gate it behind a button, callback, or another condition (as in the
+> examples below).
 
 ### Requirements for the refresh token
 

--- a/specs/2026-07-28-auth-token-refresh/tech-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/tech-spec.md
@@ -176,9 +176,26 @@ def refresh(self) -> None:
         return
     if not is_authlib_installed():
         raise StreamlitMissingAuthlibError()
-    validate_auth_credentials("default")  # or the active provider
-    if not _get_user_info().get("is_logged_in"):
+
+    user_info = _get_user_info()
+    if not user_info.get("is_logged_in"):
         raise StreamlitAuthError("st.user.refresh() requires a logged-in user.")
+
+    # Identities that don't come from OIDC login (trusted user headers or a
+    # host-provided identity) have no refresh token: documented no-op with a
+    # warning, not an error (product spec behavior #1).
+    if not _is_oidc_login(user_info):
+        _LOGGER.warning(
+            "st.user.refresh() is a no-op for non-OIDC (header/host) identities."
+        )
+        return
+
+    # Resolve the provider the user actually logged in with — the same value the
+    # /auth/refresh endpoint reads back from the user cookie — so named providers
+    # (e.g. st.login("google")) validate and refresh correctly instead of always
+    # assuming a "default" auth section.
+    provider = _get_provider_from_user_info(user_info)
+    validate_auth_credentials(provider)
 
     base_path = config.get_option("server.baseUrlPath")
     fwd_msg = ForwardMsg()
@@ -192,6 +209,12 @@ Notes:
 - Validation is synchronous (fail fast). The token exchange itself is async via the
   frontend round-trip, so `refresh()` returns `None` and the fresh values appear on the
   triggered rerun — identical mental model to `st.login()`/`st.logout()`.
+- The precondition ordering mirrors the product spec's behavior contract: not
+  logged in / auth not configured → raise; logged in via a non-OIDC identity
+  (trusted headers or host) → no-op with a warning; logged in via OIDC → enqueue the
+  refresh. Provider resolution and validation reuse the *active* provider from the user
+  cookie (the same one `/auth/refresh` uses), so named-provider logins are handled
+  identically to the implicit `default` provider.
 - `AUTH_REFRESH_ENDPOINT = "/auth/refresh"` alongside the existing endpoint constants.
 
 ### 5. Protobuf: `AuthRefresh` message

--- a/specs/2026-07-28-auth-token-refresh/tech-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/tech-spec.md
@@ -76,6 +76,17 @@ the endpoint can (a) write the new cookies for future connects/reloads **and** (
 the already-connected session's in-memory `user_info` so the *current* session sees the
 new identity on its next rerun — all without a page reload.
 
+> **Deployment assumption.** The in-place session update (b) relies on the
+> `/auth/refresh` request landing on the same process that holds the live WebSocket
+> session, since sessions live in a process-local `SessionManager`. Streamlit serves each
+> app from a single server process, and multi-replica deployments already require
+> WebSocket session affinity (sticky sessions) to function at all — the same-origin POST
+> inherits that affinity. If the update still can't be applied in-process (e.g. the POST
+> is routed to a different replica), it degrades gracefully rather than erroring: the auth
+> cookies are always rewritten, so the refreshed identity is picked up on the next
+> reconnect/reload even if the *immediate* rerun would otherwise show stale claims (this
+> is the same no-op path as the identity-mismatch case in step 7).
+
 ### 1. Persist the refresh token (backend)
 
 In `_auth_callback`, keep the refresh token alongside id/access when the provider returns
@@ -116,6 +127,10 @@ navigation). Behavior:
    (`refresh_failed`).
 5. Derive refreshed claims: prefer decoding the returned `id_token`; if the grant does not
    return an `id_token`, call the provider's `userinfo_endpoint` with the new access token.
+   If neither is available (no `id_token` **and** the provider metadata exposes no
+   `userinfo_endpoint`), keep the previous identity claims and log a warning — the token
+   exchange itself still succeeded, so the new tokens are persisted and the
+   expired-access-token use case works even when claims can't be refreshed.
 6. Build the new cookie payloads (same shape as `_auth_callback`: user claims +
    `origin`/`is_logged_in`/`provider`; tokens = id/access/refresh, **preserving the old
    refresh token if the provider did not rotate it**). Write both cookies via
@@ -245,10 +260,14 @@ authRefresh: (authRefresh: AuthRefresh) => {
   request origin against `redirect_uri`. A cross-site page cannot trigger a refresh.
 - **Session-update authorization.** The `sessionId` in the request body only *routes* the
   in-memory update; the refresh itself is authorized by the httponly cookie. The endpoint
-  must verify the target session's current identity (`sub`/`origin`) matches the cookie
-  identity before applying the update, so a stray/guessed session id cannot be
-  cross-populated with a different user's identity. If it doesn't match, skip the in-memory
-  update (cookies are still rewritten for the caller's own next connect).
+  must verify the target session's current identity (`sub`, `provider`, and `origin`)
+  matches the cookie identity before applying the update, so a stray/guessed session id
+  cannot be cross-populated with a different user's identity. Binding on `provider` (or the
+  token issuer `iss`) alongside `sub` is essential because OIDC subject identifiers are
+  only unique *within* a provider — the same `sub` value issued by a different provider
+  must not be treated as the same user. The `provider` is already retained in the user
+  cookie. If it doesn't match, skip the in-memory update (cookies are still rewritten for
+  the caller's own next connect).
 - **Rotated refresh tokens.** If the provider returns a new refresh token, persist it and
   drop the old one; if not, retain the existing one so subsequent refreshes keep working.
 - **Failure hygiene.** `invalid_grant` clears cookies (forces clean re-auth); transient

--- a/specs/2026-07-28-auth-token-refresh/tech-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/tech-spec.md
@@ -1,0 +1,289 @@
+---
+author: lukasmasuch
+created: 2026-07-28
+---
+
+# Tech spec: `st.user.refresh()` OIDC token/claims refresh
+
+## Summary
+
+Implement `st.user.refresh()` by (1) persisting the OIDC refresh token in the existing
+signed, httponly tokens cookie, (2) adding a same-origin, XSRF-protected
+`POST /auth/refresh` endpoint that performs the `grant_type=refresh_token` exchange and
+rewrites the auth cookies, and (3) driving that endpoint from the browser via a background
+`fetch` (no navigation), followed by an in-place update of the live session's `user_info`
+and a rerun. No full page reload occurs.
+
+## Problem
+
+Two hard constraints in the current auth architecture make refresh non-trivial:
+
+1. **Cookies can only be written on an HTTP response.** Auth state lives in signed,
+   httponly cookies (`_streamlit_user`, `_streamlit_user_tokens`) set via `Set-Cookie` in
+   the Starlette auth routes (`starlette_auth_routes.py`). The Python `ScriptRunner`
+   communicates with the browser over a **WebSocket** and has no HTTP response to attach
+   `Set-Cookie` to. So the script cannot update the auth cookies directly — this is why
+   `st.login()`/`st.logout()` work by telling the browser to hit an HTTP endpoint.
+2. **`st.user` is read from cookies only at WebSocket connect.** In
+   `starlette_websocket.py::_websocket_endpoint`, the user cookie and (filtered) tokens
+   cookie are parsed into `user_info` **once**, at handshake time, then passed to
+   `runtime.connect_session(...)`. During a live session `user_info` is never re-read.
+   Critically, reconnecting with an `existing_session_id` **reuses the existing session
+   and does not re-apply `user_info`** (`websocket_session_manager.py::connect_session`
+   uses the reconnect's `user_info` only for metrics). So a plain WS reconnect will *not*
+   refresh `st.user`.
+
+Additionally, the OAuth callback currently **discards the refresh token**
+(`starlette_auth_routes.py::_auth_callback`):
+
+```python
+tokens = {k: token[k] for k in ["id_token", "access_token"] if k in token}
+```
+
+so even when a provider returns a refresh token, it never reaches the cookie.
+
+## Proposal
+
+### Overview of the flow (no redirect)
+
+```
+Script                Frontend (App.tsx)            Server
+------                ------------------            ------
+st.user.refresh()
+  ├─ validate (logged in? auth configured?)  ── raises synchronously on error
+  ├─ enqueue ForwardMsg{auth_refresh}
+  └─ request rerun
+        │  ForwardMsg{auth_refresh}
+        └──────────────► fetch POST /auth/refresh
+                          {sessionId}, XSRF header, credentials:'include'
+                                             │
+                                             ├─ read refresh_token from httponly cookie
+                                             ├─ POST token endpoint (grant_type=refresh_token)
+                                             ├─ decode new id_token / fetch userinfo
+                                             ├─ Set-Cookie: _streamlit_user, _streamlit_user_tokens
+                                             ├─ runtime.update_user_info_for_session(sessionId, claims)
+                                             └─ 200 OK  (or 4xx on failure)
+        ◄─────────────────────────────────────┘
+   on 200 → send rerun BackMsg
+   on 4xx (unrecoverable) → navigate to /auth/logout (or receive cleared cookies) → reconnect
+        │  BackMsg{rerun}
+        └──────────────► script reruns; st.user now reflects the updated in-memory user_info
+```
+
+Because the refresh HTTP request and the WebSocket session share the same server process,
+the endpoint can (a) write the new cookies for future connects/reloads **and** (b) update
+the already-connected session's in-memory `user_info` so the *current* session sees the
+new identity on its next rerun — all without a page reload.
+
+### 1. Persist the refresh token (backend)
+
+In `_auth_callback`, keep the refresh token alongside id/access when the provider returns
+one:
+
+```python
+tokens = {
+    k: token[k]
+    for k in ["id_token", "access_token", "refresh_token"]
+    if k in token
+}
+```
+
+- The tokens cookie is already signed + httponly + chunked when large
+  (`set_cookie_with_chunks`), so no new storage mechanism is needed.
+- **Exposure is unchanged.** The WebSocket handler filters the tokens cookie down to
+  `expose_tokens` before putting anything in `user_info["tokens"]`, and
+  `get_expose_tokens_config()` only permits `"id"`/`"access"`. The refresh token therefore
+  cannot appear in `st.user.tokens`. (Defense-in-depth: also skip `refresh` explicitly in
+  the filter.)
+
+### 2. `POST /auth/refresh` endpoint (backend)
+
+Add `_auth_refresh(request)` and register it in `create_auth_routes` as a **POST** route
+at `auth/refresh` (POST so it is non-idempotent and not triggerable by top-level GET
+navigation). Behavior:
+
+1. Enforce XSRF (same mechanism used for the WebSocket handshake) and same-origin (reuse
+   `_get_origin_from_secrets()` / origin validation). Reject otherwise with `403`.
+2. Read `refresh_token` from the incoming httponly tokens cookie
+   (`_get_cookie_value_from_request(request, TOKENS_COOKIE_NAME)`). If absent → `400`
+   (`no_refresh_token`).
+3. Determine the provider from the user cookie (as `_get_provider_logout_url` already
+   does), build the OAuth client via `_create_oauth_client(provider)`.
+4. Perform the refresh:
+   `new_token = await client.fetch_access_token(grant_type="refresh_token", refresh_token=...)`
+   (Authlib). On provider error (`invalid_grant`, revoked/expired) → `401`
+   (`refresh_failed`).
+5. Derive refreshed claims: prefer decoding the returned `id_token`; if the grant does not
+   return an `id_token`, call the provider's `userinfo_endpoint` with the new access token.
+6. Build the new cookie payloads (same shape as `_auth_callback`: user claims +
+   `origin`/`is_logged_in`/`provider`; tokens = id/access/refresh, **preserving the old
+   refresh token if the provider did not rotate it**). Write both cookies via
+   `_set_auth_cookie(response, ...)`.
+7. If a valid `sessionId` is supplied and its current identity matches the cookie identity
+   (see Security), update the live session in place via
+   `runtime.update_user_info_for_session(session_id, filtered_user_info)`.
+8. Return `200` with a minimal JSON status (no identity/token material in the body).
+
+All failure paths leave existing cookies untouched **except** the unrecoverable
+`invalid_grant` case, where the endpoint clears the auth cookies (reusing
+`_clear_auth_cookie`) so the browser lands logged-out.
+
+### 3. Update a live session's identity (runtime)
+
+Add a method symmetric to the existing `clear_user_info_for_session`:
+
+```python
+# runtime.py
+def update_user_info_for_session(self, session_id: str, user_info: UserInfoType) -> None:
+    session_info = self._session_mgr.get_session_info(session_id)
+    if session_info is not None:
+        session_info.session.set_user_info(user_info)
+```
+
+`AppSession` already owns `user_info` and exposes `clear_user_info()` (which mutates
+`self._user_info` **in place** via `.clear()`). Add a `set_user_info(user_info)`
+counterpart that likewise mutates in place (`clear()` + `update(...)`), because the same
+dict reference is handed to each per-rerun `ScriptRunner` — rebinding the attribute would
+not be seen by the next run. This is the smallest change that lets the current session
+observe the refreshed identity without a reconnect, and it keeps identity handling
+server-side.
+
+### 4. `st.user.refresh()` command (backend)
+
+In `user_info.py`, add a `refresh()` method to `UserInfoProxy`:
+
+```python
+@gather_metrics("user.refresh")
+def refresh(self) -> None:
+    ctx = _get_script_run_ctx()
+    if ctx is None:
+        return
+    if not is_authlib_installed():
+        raise StreamlitMissingAuthlibError()
+    validate_auth_credentials("default")  # or the active provider
+    if not _get_user_info().get("is_logged_in"):
+        raise StreamlitAuthError("st.user.refresh() requires a logged-in user.")
+
+    base_path = config.get_option("server.baseUrlPath")
+    fwd_msg = ForwardMsg()
+    fwd_msg.auth_refresh.url = make_url_path(base_path, AUTH_REFRESH_ENDPOINT)
+    ctx.enqueue(fwd_msg)
+    # A rerun is requested by the frontend once the background refresh succeeds.
+```
+
+Notes:
+
+- Validation is synchronous (fail fast). The token exchange itself is async via the
+  frontend round-trip, so `refresh()` returns `None` and the fresh values appear on the
+  triggered rerun — identical mental model to `st.login()`/`st.logout()`.
+- `AUTH_REFRESH_ENDPOINT = "/auth/refresh"` alongside the existing endpoint constants.
+
+### 5. Protobuf: `AuthRefresh` message
+
+`auth_redirect` triggers a full `window.location` navigation, which is exactly what we
+want to avoid. Add a sibling message so the frontend can distinguish "navigate" from
+"refresh in the background":
+
+```proto
+// proto/streamlit/proto/AuthRefresh.proto
+message AuthRefresh {
+  string url = 1;  // Refresh endpoint to POST to (background fetch, no navigation).
+}
+```
+
+Add it to the `ForwardMsg` `type` oneof next to `auth_redirect`, then `make protobuf`.
+
+### 6. Frontend (App.tsx)
+
+Add an `authRefresh` handler to the `dispatchOneOf` in `handleMessage`:
+
+```ts
+authRefresh: (authRefresh: AuthRefresh) => {
+  void this.handleAuthRefresh(authRefresh.url)
+},
+```
+
+`handleAuthRefresh(url)`:
+
+1. `POST` to `url` with `credentials: "include"` and the XSRF token header, sending
+   `{ sessionId }` (available from `SessionInfo`).
+2. On `200`: request a rerun through the existing connection so the script re-executes and
+   reads the session's updated `user_info`. No navigation.
+3. On `401` (`refresh_failed`): the server has cleared the cookies; reconnect the
+   WebSocket so the app re-reads the (now empty) auth state and renders logged-out.
+4. On other errors: log a warning and leave the app as-is.
+5. Embedded apps: consistent with `authRedirect`, this flow is not supported when
+   `isInChildFrame()` (auth is unsupported for embedded apps); no-op with a warning.
+
+### File-change summary
+
+| Area | File(s) | Change |
+|------|---------|--------|
+| Persist refresh token | `starlette_auth_routes.py` | Keep `refresh_token` in the tokens cookie at callback |
+| Refresh endpoint | `starlette_auth_routes.py` | `_auth_refresh` + POST route; token exchange, cookie rewrite, session update |
+| Token exchange helper | `auth_util.py` | Helper to run `grant_type=refresh_token` and derive claims |
+| Live session update | `runtime.py`, `app_session.py` | `update_user_info_for_session` / `AppSession.set_user_info` |
+| Command | `user_info.py` | `UserInfoProxy.refresh()` + `AUTH_REFRESH_ENDPOINT` |
+| Proto | `AuthRefresh.proto`, `ForwardMsg.proto` | New message in the oneof |
+| Frontend | `app/src/App.tsx` | `authRefresh` handler + background fetch + rerun/reconnect |
+| Never-expose guard | `starlette_websocket.py` | Ensure `refresh` is excluded from `st.user.tokens` |
+
+## Security
+
+- **Refresh token secrecy.** Stored only in the signed, httponly `_streamlit_user_tokens`
+  cookie. Never sent to JS, never returned in the `/auth/refresh` response body, never
+  added to `st.user.tokens`. This is the reason the refresh happens through a server
+  endpoint rather than in the browser.
+- **CSRF / same-origin.** `/auth/refresh` is `POST`, requires the XSRF token (same check as
+  the WS handshake and enabled automatically when auth is configured), and validates the
+  request origin against `redirect_uri`. A cross-site page cannot trigger a refresh.
+- **Session-update authorization.** The `sessionId` in the request body only *routes* the
+  in-memory update; the refresh itself is authorized by the httponly cookie. The endpoint
+  must verify the target session's current identity (`sub`/`origin`) matches the cookie
+  identity before applying the update, so a stray/guessed session id cannot be
+  cross-populated with a different user's identity. If it doesn't match, skip the in-memory
+  update (cookies are still rewritten for the caller's own next connect).
+- **Rotated refresh tokens.** If the provider returns a new refresh token, persist it and
+  drop the old one; if not, retain the existing one so subsequent refreshes keep working.
+- **Failure hygiene.** `invalid_grant` clears cookies (forces clean re-auth); transient
+  failures never partially update cookies.
+
+## Testing plan
+
+- **Python unit tests** (`lib/tests/streamlit/web/server/starlette/starlette_auth_routes_test.py`,
+  `user_info_test.py`): refresh happy path, missing refresh token, `invalid_grant`
+  (cookie-clear), rotated vs. non-rotated refresh token, refresh-token never exposed in
+  `st.user.tokens`, XSRF/origin rejection, `refresh()` raises when not logged in.
+- **Frontend unit tests** (`App.test.tsx`): `authRefresh` issues the background fetch (no
+  `window.location` change), reruns on success, reconnects on `401`, no-ops when embedded.
+- **E2E** (`e2e_playwright/auth_test.py`): extend the existing mock OIDC `testprovider` to
+  support the `refresh_token` grant; assert that after `st.user.refresh()` the displayed
+  claims/tokens update **without a page navigation** and session state is preserved.
+
+## Alternatives considered
+
+**A. Redirect-based refresh (PR #12696).** `st.user.refresh()` enqueues an
+`auth_redirect` to a `GET /auth/refresh` endpoint; the browser navigates there, the server
+rewrites cookies, then redirects back to `/`.
+- Pros: minimal code — reuses `auth_redirect`, no new proto/frontend path, no live-session
+  update (the resulting fresh connection re-reads cookies naturally).
+- Cons: **full page reload** on every refresh — flicker, lost scroll position and
+  in-flight widget input, and unusable for silent/automatic refresh (#13489). Rejected as
+  the primary design; it remains the conceptual fallback if the background path proves
+  problematic on a platform.
+
+**B. Refresh entirely in the Python `ScriptRunner`.** The backend has the client
+credentials and could call the token endpoint itself. Rejected: it still cannot persist
+the new tokens to the browser cookie (no HTTP response over the WebSocket), so it would
+need to hand tokens back to the frontend to set — reintroducing exposure and complexity.
+
+**C. Return refreshed claims/tokens in the fetch response for the frontend to apply.**
+Rejected: identity/token material would transit through browser JS, weakening the httponly
+guarantee that `st.login()` currently provides. Keeping everything server-side is a
+deliberate constraint.
+
+**D. Make WebSocket reconnect re-read cookies into `user_info`.** Instead of an explicit
+`update_user_info_for_session`, change reconnect semantics so `user_info` is re-applied.
+Rejected for this iteration: it changes behavior for *all* reconnects (identity could
+silently change mid-session on any network blip) and is a broader, riskier change than a
+scoped, explicit session update triggered only by refresh.

--- a/specs/2026-07-28-auth-token-refresh/tech-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/tech-spec.md
@@ -94,9 +94,7 @@ one:
 
 ```python
 tokens = {
-    k: token[k]
-    for k in ["id_token", "access_token", "refresh_token"]
-    if k in token
+    k: token[k] for k in ["id_token", "access_token", "refresh_token"] if k in token
 }
 ```
 
@@ -150,7 +148,9 @@ Add a method symmetric to the existing `clear_user_info_for_session`:
 
 ```python
 # runtime.py
-def update_user_info_for_session(self, session_id: str, user_info: UserInfoType) -> None:
+def update_user_info_for_session(
+    self, session_id: str, user_info: UserInfoType
+) -> None:
     session_info = self._session_mgr.get_session_info(session_id)
     if session_info is not None:
         session_info.session.set_user_info(user_info)

--- a/specs/2026-07-28-auth-token-refresh/tech-spec.md
+++ b/specs/2026-07-28-auth-token-refresh/tech-spec.md
@@ -65,7 +65,8 @@ st.user.refresh()
                                              └─ 200 OK  (or 4xx on failure)
         ◄─────────────────────────────────────┘
    on 200 → send rerun BackMsg
-   on 4xx (unrecoverable) → navigate to /auth/logout (or receive cleared cookies) → reconnect
+   on 401 refresh_failed (unrecoverable) → cookies already cleared by server → reconnect (logged-out)
+   on other 4xx/5xx (recoverable) → log warning, leave app as-is
         │  BackMsg{rerun}
         └──────────────► script reruns; st.user now reflects the updated in-memory user_info
 ```
@@ -214,6 +215,11 @@ authRefresh: (authRefresh: AuthRefresh) => {
 4. On other errors: log a warning and leave the app as-is.
 5. Embedded apps: consistent with `authRedirect`, this flow is not supported when
    `isInChildFrame()` (auth is unsupported for embedded apps); no-op with a warning.
+6. Concurrent refreshes: if an `authRefresh` message arrives while a previous
+   `/auth/refresh` POST is still in flight, ignore it (debounce via an in-flight flag)
+   rather than issuing a second request. A refresh has no per-call arguments, so
+   coalescing overlapping requests avoids redundant token exchanges and a possible race
+   between two rotated refresh tokens.
 
 ### File-change summary
 


### PR DESCRIPTION
## Describe your changes

Product and tech spec proposing `st.user.refresh()` — a command that uses the OIDC
refresh token to obtain fresh access/ID tokens and updated identity claims and update
`st.user`/`st.user.tokens` **in place**, with no full page reload and no re-login.

- **Product spec** — motivates the feature from the two user-facing pain points (picking
  up updated IdP claims mid-session, and recovering from expired access tokens), proposes
  `st.user.refresh()` (vs. a top-level `st.refresh_user()`), and defines async behavior,
  the `offline_access` requirement, and error handling. Automatic refresh (#13489) is
  scoped as follow-up work built on the same infrastructure.
- **Tech spec** — designs the no-redirect flow around the two hard constraints (cookies
  can only be written on HTTP responses; `st.user` is read only at WebSocket connect):
  persist the refresh token in the existing signed httponly tokens cookie, add a
  same-origin XSRF-protected `POST /auth/refresh` endpoint, update the live session's
  `user_info` in place, and drive it from a background `fetch` + rerun. Includes security
  analysis and alternatives considered (redirect-based #12696, backend-only,
  return-to-JS, reconnect-reread).

## GitHub Issue Link (if applicable)

- Addresses #12043
- Addresses #13489
- Builds on the approaches in #12696 and #14437

## Testing Plan

- [x] Not applicable — spec/design document only, no code changes.

Made with [Cursor](https://cursor.com)