### PR TITLE
[chore] Remove core-previews repo prep from CI workflows

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -132,7 +132,7 @@ steps:
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `pr-preview.yml` | Push/PR to `develop` | Builds wheel, uploads to S3, creates preview deployment |
+| `pr-preview.yml` | Push/PR to `develop` | Builds wheel, uploads to S3, and comments the download links on the PR |
 | `autofix.yml` | `autofix` label on PR | Runs formatters, linters, and other cleanups, then creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -130,7 +130,7 @@ steps:
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `pr-preview.yml` | Push/PR to `develop` | Builds wheel, uploads to S3, creates preview deployment |
+| `pr-preview.yml` | Push/PR to `develop` | Builds wheel, uploads to S3, and comments the download links on the PR |
 | `autofix.yml` | `autofix` label on PR | Runs formatters, linters, and other cleanups, then creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -124,7 +124,7 @@ steps:
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `pr-preview.yml` | Push/PR to `develop` | Builds wheel, uploads to S3, creates preview deployment |
+| `pr-preview.yml` | Push/PR to `develop` | Builds wheel, uploads to S3, and comments the download links on the PR |
 | `autofix.yml` | `autofix` label on PR | Runs formatters, linters, and other cleanups, then creates fix PR |
 | `snapshot-autofix.yml` | `update-snapshots` label | Downloads failed snapshots and creates update PR |
 | `fork-pr-welcome.yml` | PR opened from fork | Posts welcome comment with contribution guidelines |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -143,10 +143,6 @@ jobs:
       run:
         shell: bash
 
-    outputs:
-      enable-setup: ${{ steps.exports.outputs.enable-setup }}
-      s3-url: ${{ steps.exports.outputs.s3-url }}
-
     environment: nightly
 
     steps:
@@ -184,7 +180,6 @@ jobs:
           name: whl_file
           path: lib/dist/*.whl
       - name: Upload wheel to S3
-        id: exports
         env:
           AWS_DEFAULT_REGION: us-west-2
           AWS_ACCESS_KEY_ID: ${{ secrets.CORE_PREVIEWS_S3_KEY_ID }}
@@ -200,11 +195,6 @@ jobs:
           S3_URL="https://core-previews.s3-us-west-2.amazonaws.com/nightly-preview/${WHEELFILE}"
 
           echo -e "Wheel file download link: ${S3_URL}"
-
-          cd ../..
-          # env variables don't carry over between gh action jobs
-          echo "enable-setup=${{ env.AWS_ACCESS_KEY_ID != '' }}" >> $GITHUB_OUTPUT
-          echo "s3-url=${S3_URL}" >> $GITHUB_OUTPUT
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
@@ -215,40 +205,3 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           RUN_ID: ${{ github.run_id }}
         run: python scripts/slack_notifications.py nightly build
-
-  setup-nightly-preview:
-    runs-on: ubuntu-latest
-
-    needs: [create-nightly-tag, create-nightly-build]
-    if: needs.create-nightly-build.outputs.enable-setup == 'true'
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout Core Previews Repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: streamlit/core-previews
-          # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
-          # Accessing streamlit/core-previews repo requires a separate auth token.
-          token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
-          # Save the access token to the local git config, so
-          # later git commands can work.
-          persist-credentials: true
-      - name: Setup preview repo
-        env:
-          NIGHTLY_TAG: ${{ needs.create-nightly-tag.outputs.tag }}
-          S3_URL: ${{ needs.create-nightly-build.outputs.s3-url }}
-        run: |
-          git config --global user.email "core+streamlitbot-github@streamlit.io"
-          git config --global user.name "Streamlit Bot"
-          git branch -D nightly-preview &>/dev/null || true
-          git checkout -b nightly-preview
-
-          echo "$S3_URL" >> requirements.txt
-
-          git add .
-          git commit -m "Nightly Preview: ${NIGHTLY_TAG}"
-          git push -f origin nightly-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -46,8 +46,7 @@ jobs:
                                     "| Name | Link |\n" +
                                     "| :----: | ---- |\n" +
                                     "| 📦 Wheel file | *Building...* |\n" +
-                                    "| 📦 \`@streamlit/component-v2-lib\` | *Building...* |\n" +
-                                    "| 🕹️ Preview app | *Building...* |";
+                                    "| 📦 \`@streamlit/component-v2-lib\` | *Building...* |";
 
             // Find an existing comment; if it exists, we will update it
             const { data: comments } = await github.rest.issues.listComments({
@@ -144,8 +143,7 @@ jobs:
         shell: bash
 
     outputs:
-      enable-setup: ${{ steps.exports.outputs.enable-setup }}
-      preview-branch: ${{ steps.exports.outputs.preview-branch }}
+      wheel-uploaded: ${{ steps.exports.outputs.wheel-uploaded }}
       s3-url: ${{ steps.exports.outputs.s3-url }}
 
     steps:
@@ -218,10 +216,9 @@ jobs:
 
           cd ../..
           # env variables don't carry over between gh action jobs
-          echo "enable-setup=${{ env.AWS_ACCESS_KEY_ID != '' }}" >> $GITHUB_OUTPUT
-          echo "preview-branch=$PREVIEW_BRANCH" >> $GITHUB_OUTPUT
+          echo "wheel-uploaded=${{ env.AWS_ACCESS_KEY_ID != '' }}" >> $GITHUB_OUTPUT
           echo "s3-url=${S3_URL}" >> $GITHUB_OUTPUT
-      - if: steps.exports.outputs.enable-setup == 'true' && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request'
+      - if: steps.exports.outputs.wheel-uploaded == 'true' && success() && github.repository == 'streamlit/streamlit' && github.event_name == 'pull_request'
         name: Set S3 URL as Github Status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -672,60 +669,11 @@ jobs:
           path: frontend/component-v2-lib/*.tgz
           retention-days: 30
 
-  setup-preview:
-    runs-on: ubuntu-latest
-
-    needs: upload-whl
-    if: needs.upload-whl.outputs.enable-setup == 'true'
-
-    defaults:
-      run:
-        shell: bash
-
-    outputs:
-      deploy-url: ${{ steps.deploy-url.outputs.deploy-url }}
-
-    steps:
-      - name: Checkout Core Previews Repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: streamlit/core-previews
-          # The default GITHUB_TOKEN is scoped only to the triggering streamlit/streamlit repo.
-          # Accessing streamlit/core-previews repo requires a separate auth token.
-          token: ${{ secrets.CORE_PREVIEWS_REPO_TOKEN }}
-          # Save the access token to the local git config, so
-          # later git commands can work.
-          persist-credentials: true
-      - name: Setup preview repo
-        env:
-          PREVIEW_BRANCH: ${{ needs.upload-whl.outputs.preview-branch }}
-          S3_URL: ${{ needs.upload-whl.outputs.s3-url }}
-        run: |
-          git config --global user.email "core+streamlitbot-github@streamlit.io"
-          git config --global user.name "Streamlit Bot"
-          git branch -D "$PREVIEW_BRANCH" &>/dev/null || true
-          git checkout -b "$PREVIEW_BRANCH"
-
-          echo "$S3_URL" >> requirements.txt
-
-          git add .
-          git commit -m "Prepare core preview: ${PREVIEW_BRANCH}"
-          git push -f origin ${PREVIEW_BRANCH}
-      - name: Ready to deploy!
-        id: deploy-url
-        env:
-          PREVIEW_BRANCH: ${{ needs.upload-whl.outputs.preview-branch }}
-        run: |
-          DEPLOY_URL="https://share.streamlit.io/deploy?repository=streamlit/core-previews&branch=${PREVIEW_BRANCH}&mainModule=E2E_Tester_🧪.py&subdomain=${PREVIEW_BRANCH}"
-          echo -e "${DEPLOY_URL}"
-          echo "deploy-url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
-
   update-pr-comment:
     runs-on: ubuntu-latest
-    needs:
-      [initial-pr-comment, upload-whl, build-component-v2-lib, setup-preview]
+    needs: [initial-pr-comment, upload-whl, build-component-v2-lib]
     # Only run on PRs that are not from forks
-    if: needs.upload-whl.outputs.enable-setup == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: needs.upload-whl.outputs.wheel-uploaded == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       pull-requests: write
@@ -761,24 +709,19 @@ jobs:
             console.log('Found comment with ID:', commentId);
 
             const s3Url = '${{ needs.upload-whl.outputs.s3-url }}';
-            const deployUrl = '${{ needs.setup-preview.outputs.deploy-url }}';
-
-            const previewBranch = '${{ needs.upload-whl.outputs.preview-branch }}';
-            const viewUrl = `${previewBranch}.streamlit.app`;
 
             // Define the ready template once
             const componentPackageBuilt = '${{ needs.build-component-v2-lib.outputs.package-built }}';
             const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const componentRow = componentPackageBuilt === 'true' ?
-              `| 📦 \`@streamlit/component-v2-lib\` | [Download from artifacts](${workflowRunUrl}) |\n` :
-              `| 📦 \`@streamlit/component-v2-lib\` | *Build failed* |\n`;
+              `| 📦 \`@streamlit/component-v2-lib\` | [Download from artifacts](${workflowRunUrl}) |` :
+              `| 📦 \`@streamlit/component-v2-lib\` | *Build failed* |`;
 
             const readyTemplate = "### ✅ PR preview is ready!\n\n" +
                                  "| Name | Link |\n" +
                                  "| :----: | ---- |\n" +
                                  "| 📦 Wheel file | " + s3Url + " |\n" +
-                                 componentRow +
-                                 "| 🕹️ Preview app | [" + viewUrl + "](https://" + viewUrl + ") (☁️ Deploy [here](" + deployUrl + ") if not accessible)| ";
+                                 componentRow;
 
             await github.rest.issues.updateComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Describe your changes

Stops preparing the `streamlit/core-previews` repo in both the PR preview and nightly build workflows. Wheels are still built and uploaded to S3 as before — we just no longer commit/force-push a preview branch to bootstrap a preview app.

- Removed the `setup-preview` job from `pr-preview.yml` and the `setup-nightly-preview` job from `nightly.yml` (the core-previews repo checkout + `requirements.txt` commit/push).
- Cleaned up the PR preview comment: dropped the "🕹️ Preview app" row (and its deploy URL) from both the building and ready templates.
- Removed now-dead workflow outputs (`preview-branch`, and nightly's `enable-setup`/`s3-url`) and renamed the misleading `enable-setup` output to `wheel-uploaded` in `pr-preview.yml`.

**Follow-ups for a maintainer (outside this repo):**
- The `CORE_PREVIEWS_REPO_TOKEN` secret is no longer referenced by any workflow and can be retired. (`CORE_PREVIEWS_S3_KEY_ID` / `CORE_PREVIEWS_S3_SECRET_KEY` are still used for the S3 wheel uploads.)
- Anything downstream that consumed the core-previews `nightly-preview`/PR preview branches will now go stale, since those branches are no longer updated. The wheels themselves remain available in S3.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- CI-only workflow changes; validated with `make check` (YAML + generated-agent-rules checks pass). No unit/E2E tests apply.

Made with [Cursor](https://cursor.com)