### PR TITLE
[chore] Add typing tests for st.write and st.write_stream

### DIFF
--- a/lib/tests/streamlit/typing/write_types.py
+++ b/lib/tests/streamlit/typing/write_types.py
@@ -1,0 +1,92 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+    from streamlit.elements.write import WriteMixin
+
+    write = WriteMixin().write
+    write_stream = WriteMixin().write_stream
+
+    # =====================================================================
+    # st.write return type tests
+    # =====================================================================
+
+    # Basic usage - returns None
+    assert_type(write("Hello, world!"), None)
+
+    # Multiple positional arguments of any type
+    assert_type(write("1 + 1 = ", 2), None)
+    assert_type(write("a", "b", "c"), None)
+
+    # Non-str values (write accepts *args: Any)
+    assert_type(write(42), None)
+    assert_type(write({"key": "value"}), None)
+    assert_type(write([1, 2, 3]), None)
+
+    # No arguments is allowed
+    assert_type(write(), None)
+
+    # unsafe_allow_html parameter (keyword-only)
+    assert_type(write("<p>HTML</p>", unsafe_allow_html=True), None)
+    assert_type(write("Safe text", unsafe_allow_html=False), None)
+
+    # All parameters combined
+    assert_type(write("Text", 123, unsafe_allow_html=True), None)
+
+    # =====================================================================
+    # st.write_stream return type tests
+    # =====================================================================
+
+    def text_generator() -> Generator[str, None, None]:
+        yield "Hello"
+
+    async def async_text_generator() -> AsyncGenerator[str, None]:
+        yield "Hello"
+
+    # A generator function (Callable) - returns list[Any] | str
+    assert_type(write_stream(text_generator), list[Any] | str)
+
+    # An already-created generator
+    assert_type(write_stream(text_generator()), list[Any] | str)
+
+    # An iterable
+    assert_type(write_stream(["a", "b", "c"]), list[Any] | str)
+
+    # An async generator
+    assert_type(write_stream(async_text_generator()), list[Any] | str)
+
+    # cursor parameter (keyword-only)
+    assert_type(write_stream(text_generator, cursor="▌"), list[Any] | str)
+    assert_type(write_stream(text_generator, cursor=None), list[Any] | str)
+
+    # =====================================================================
+    # Invalid usages - should NOT type check
+    # =====================================================================
+
+    # unsafe_allow_html must be a bool
+    write("Text", unsafe_allow_html="yes")  # type: ignore[arg-type]
+
+    # cursor must be str or None
+    write_stream(text_generator, cursor=123)  # type: ignore[arg-type]
+
+    # cursor is keyword-only, cannot be passed positionally
+    write_stream(text_generator, "▌")  # type: ignore[call-arg]

--- a/lib/tests/streamlit/typing/write_types.py
+++ b/lib/tests/streamlit/typing/write_types.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     assert_type(write({"key": "value"}), None)
     assert_type(write([1, 2, 3]), None)
 
-    # No arguments is allowed
+    # No arguments are allowed
     assert_type(write(), None)
 
     # unsafe_allow_html parameter (keyword-only)
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     async def async_text_generator() -> AsyncGenerator[str, None]:
         yield "Hello"
 
-    # A generator function (Callable) - returns list[Any] | str
+    # A generator function passed uncalled (matches Callable[..., Any])
     assert_type(write_stream(text_generator), list[Any] | str)
 
     # An already-created generator
@@ -71,8 +71,11 @@ if TYPE_CHECKING:
     # An iterable
     assert_type(write_stream(["a", "b", "c"]), list[Any] | str)
 
-    # An async generator
+    # An async generator instance
     assert_type(write_stream(async_text_generator()), list[Any] | str)
+
+    # An async generator function passed uncalled (matches Callable[..., Any])
+    assert_type(write_stream(async_text_generator), list[Any] | str)
 
     # cursor parameter (keyword-only)
     assert_type(write_stream(text_generator, cursor="▌"), list[Any] | str)
@@ -90,3 +93,6 @@ if TYPE_CHECKING:
 
     # cursor is keyword-only, cannot be passed positionally
     write_stream(text_generator, "▌")  # type: ignore[call-arg]
+
+    # stream must be a Callable, Generator, Iterable, or AsyncGenerator
+    write_stream(123)  # type: ignore[arg-type]

--- a/lib/tests/streamlit/typing/write_types.py
+++ b/lib/tests/streamlit/typing/write_types.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     assert_type(write({"key": "value"}), None)
     assert_type(write([1, 2, 3]), None)
 
-    # No arguments are allowed
+    # A no-argument call is valid and returns None
     assert_type(write(), None)
 
     # unsafe_allow_html parameter (keyword-only)


### PR DESCRIPTION
## Describe your changes

Adds `assert_type` coverage for the previously untested `WriteMixin` commands.

- `st.write` — verifies the `None` return type across multiple positional args, non-`str` values, and the keyword-only `unsafe_allow_html` parameter.
- `st.write_stream` — verifies the `list[Any] | str` return type for generator functions, generators, iterables, async generators, and the keyword-only `cursor` parameter, plus negative cases for invalid argument types.

## Testing Plan

- These are mypy-only typing tests (`lib/tests/streamlit/typing/write_types.py`), verified with `uv run mypy`. No runtime tests are needed since the file is never executed.