### PR TITLE
[fix] Sandbox media responses to block active content

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -548,7 +548,13 @@ def create_media_routes(
         except MediaFileStorageError as exc:
             raise HTTPException(status_code=404, detail="File not found") from exc
 
-        headers: dict[str, str] = {}
+        # Media contents and MIME types can originate from user uploads. Keep
+        # them inline for normal media playback, but prevent active content from
+        # executing with the Streamlit app's origin on direct navigation.
+        headers = {
+            "Content-Security-Policy": "sandbox",
+            "X-Content-Type-Options": "nosniff",
+        }
 
         if media_file.kind == MediaFileKind.DOWNLOADABLE:
             filename = media_file.filename

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -89,6 +89,21 @@ ROUTE_HOST_CONFIG: Final = f"{BASE_ROUTE_CORE}/host-config"
 _ROUTE_MEDIA: Final = f"{BASE_ROUTE_MEDIA}/{{file_id:path}}"
 _ROUTE_UPLOAD_FILE: Final = f"{BASE_ROUTE_UPLOAD_FILE}/{{session_id}}/{{file_id}}"
 
+# Media MIME types that a browser can render as an active document (i.e. that
+# can execute scripts) when navigated to directly. Only these need the
+# Content-Security-Policy: sandbox header. Passive types (images, audio, video,
+# PDFs served as iframe documents via st.iframe) are left un-sandboxed so their
+# inline rendering keeps working.
+_ACTIVE_DOCUMENT_MIME_TYPES: Final = frozenset(
+    {
+        "text/html",
+        "application/xhtml+xml",
+        "image/svg+xml",
+        "text/xml",
+        "application/xml",
+    }
+)
+
 # Component routes
 _ROUTE_COMPONENTS_V1: Final = f"{BASE_ROUTE_COMPONENT}/{{path:path}}"
 _ROUTE_COMPONENTS_V2: Final = f"{BASE_ROUTE_CORE}/bidi-components/{{path:path}}"
@@ -548,13 +563,16 @@ def create_media_routes(
         except MediaFileStorageError as exc:
             raise HTTPException(status_code=404, detail="File not found") from exc
 
-        # Media contents and MIME types can originate from user uploads. Keep
-        # them inline for normal media playback, but prevent active content from
-        # executing with the Streamlit app's origin on direct navigation.
-        headers = {
-            "Content-Security-Policy": "sandbox",
-            "X-Content-Type-Options": "nosniff",
-        }
+        # Media contents and MIME types can originate from user uploads. Always
+        # block MIME sniffing so a declared type cannot be reinterpreted as an
+        # executable document, and additionally sandbox responses whose declared
+        # type could run active content in the app's origin on direct
+        # navigation. Passive types (images, audio, video, PDFs) are left
+        # un-sandboxed so their inline rendering keeps working.
+        headers: dict[str, str] = {"X-Content-Type-Options": "nosniff"}
+        base_mimetype = (media_file.mimetype or "").split(";", 1)[0].strip().lower()
+        if base_mimetype in _ACTIVE_DOCUMENT_MIME_TYPES:
+            headers["Content-Security-Policy"] = "sandbox"
 
         if media_file.kind == MediaFileKind.DOWNLOADABLE:
             filename = media_file.filename

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -563,12 +563,10 @@ def create_media_routes(
         except MediaFileStorageError as exc:
             raise HTTPException(status_code=404, detail="File not found") from exc
 
-        # Media contents and MIME types can originate from user uploads. Always
-        # block MIME sniffing so a declared type cannot be reinterpreted as an
-        # executable document, and additionally sandbox responses whose declared
-        # type could run active content in the app's origin on direct
-        # navigation. Passive types (images, audio, video, PDFs) are left
-        # un-sandboxed so their inline rendering keeps working.
+        # Media contents and MIME types can originate from user uploads, so
+        # always block MIME sniffing and additionally sandbox active-document
+        # types (see _ACTIVE_DOCUMENT_MIME_TYPES) so uploaded content cannot run
+        # in the app's origin on direct navigation.
         headers: dict[str, str] = {"X-Content-Type-Options": "nosniff"}
         base_mimetype = (media_file.mimetype or "").split(";", 1)[0].strip().lower()
         if base_mimetype in _ACTIVE_DOCUMENT_MIME_TYPES:

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -546,6 +546,24 @@ def test_media_endpoint_missing_file_returns_404() -> None:
     assert response.status_code == 404
 
 
+def test_media_endpoint_sandboxes_active_content() -> None:
+    """Media responses cannot execute caller-controlled active content."""
+    storage = MemoryMediaFileStorage("/media")
+    file_id = storage.load_and_get_id(
+        b"<script>document.cookie</script>",
+        "text/html",
+        MediaFileKind.MEDIA,
+    )
+    routes = create_media_routes(storage, "")
+
+    response = _client_for(routes).get(f"/media/{file_id}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.headers["content-security-policy"] == "sandbox"
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+
 def test_media_endpoint_downloadable_without_filename_uses_default() -> None:
     """A downloadable file without a filename gets a generated default name."""
     storage = MemoryMediaFileStorage("/media")

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -553,6 +553,9 @@ def test_media_endpoint_missing_file_returns_404() -> None:
         # the app's origin when the media URL is navigated to directly.
         ("text/html", "sandbox"),
         ("image/svg+xml", "sandbox"),
+        # A charset parameter must be stripped before matching so real-world
+        # Content-Types (e.g. "text/html; charset=utf-8") still get sandboxed.
+        ("text/html; charset=utf-8", "sandbox"),
         # Passive types (e.g. PDFs served as iframe documents via st.iframe, or
         # images) are not sandboxed so their inline rendering keeps working.
         ("application/pdf", None),

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -546,12 +546,27 @@ def test_media_endpoint_missing_file_returns_404() -> None:
     assert response.status_code == 404
 
 
-def test_media_endpoint_sandboxes_active_content() -> None:
-    """Media responses cannot execute caller-controlled active content."""
+@pytest.mark.parametrize(
+    ("mimetype", "expected_csp"),
+    [
+        # Active-document types are sandboxed so injected scripts cannot run in
+        # the app's origin when the media URL is navigated to directly.
+        ("text/html", "sandbox"),
+        ("image/svg+xml", "sandbox"),
+        # Passive types (e.g. PDFs served as iframe documents via st.iframe, or
+        # images) are not sandboxed so their inline rendering keeps working.
+        ("application/pdf", None),
+        ("image/png", None),
+    ],
+)
+def test_media_endpoint_sandboxes_only_active_content(
+    mimetype: str, expected_csp: str | None
+) -> None:
+    """Media responses sandbox active-document types and always block sniffing."""
     storage = MemoryMediaFileStorage("/media")
     file_id = storage.load_and_get_id(
         b"<script>document.cookie</script>",
-        "text/html",
+        mimetype,
         MediaFileKind.MEDIA,
     )
     routes = create_media_routes(storage, "")
@@ -559,8 +574,21 @@ def test_media_endpoint_sandboxes_active_content() -> None:
     response = _client_for(routes).get(f"/media/{file_id}")
 
     assert response.status_code == 200
-    assert response.headers["content-type"] == "text/html; charset=utf-8"
-    assert response.headers["content-security-policy"] == "sandbox"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers.get("content-security-policy") == expected_csp
+
+
+def test_media_endpoint_downloadable_blocks_sniffing() -> None:
+    """Downloadable responses still get the nosniff header (defense-in-depth)."""
+    storage = MemoryMediaFileStorage("/media")
+    file_id = storage.load_and_get_id(
+        b"payload", "text/csv", MediaFileKind.DOWNLOADABLE, "data.csv"
+    )
+    routes = create_media_routes(storage, "")
+
+    response = _client_for(routes).get(f"/media/{file_id}")
+
+    assert response.status_code == 200
     assert response.headers["x-content-type-options"] == "nosniff"
 
 


### PR DESCRIPTION
## Describe your changes

Serve `/media/{file_id}` responses with security headers so user-controlled media (contents and MIME type originate from uploads) cannot execute active content in the Streamlit app's origin when opened via direct navigation.

- Add `X-Content-Type-Options: nosniff` to all media responses so a declared MIME type cannot be reinterpreted as an executable document.
- Add `Content-Security-Policy: sandbox` only for active-document MIME types (`text/html`, `application/xhtml+xml`, `image/svg+xml`, `text/xml`, `application/xml`). Passive types (images, audio, video, PDFs served in iframes) are left un-sandboxed, so normal inline playback/rendering is unaffected — the sandbox only applies when such a response is loaded as a top-level document.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Unit test `test_media_endpoint_sandboxes_only_active_content` (parametrized) in `lib/tests/streamlit/web/server/starlette/starlette_routes_test.py` verifies the `sandbox` CSP is set only for active-document MIME types (including `text/html; charset=utf-8`) while passive types are not, and that `nosniff` is always present.
- Unit test `test_media_endpoint_downloadable_blocks_sniffing` verifies downloadable responses also receive `nosniff`.

Made with [Cursor](https://cursor.com)