### PR TITLE
[fix] Robust backend port detection in make debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,8 +382,9 @@ debug:
 			echo "Error: Streamlit backend exited before startup completed. Check $$DEBUG_DIR/backend.log"; \
 			exit 1; \
 		fi; \
-		if [[ -z "$$BACKEND_PORT" ]]; then \
-			BACKEND_PORT=$$(awk '/[Ss]erver started on/ { n=split($$NF, a, ":"); print a[n]; exit }' "$$DEBUG_DIR/backend.log"); \
+		DETECTED_BACKEND_PORT=$$(awk '/[Ss]erver started on|Starting uvicorn runner on/ { n=split($$NF, a, ":"); port=a[n] } END { if (port ~ /^[0-9]+$$/) print port }' "$$DEBUG_DIR/backend.log"); \
+		if [[ -n "$$DETECTED_BACKEND_PORT" ]]; then \
+			BACKEND_PORT=$$DETECTED_BACKEND_PORT; \
 		fi; \
 		if [[ -n "$$BACKEND_PORT" ]] && curl -fsS "http://localhost:$$BACKEND_PORT/_stcore/health" > /dev/null 2>&1; then \
 			BACKEND_READY=true; \

--- a/Makefile
+++ b/Makefile
@@ -382,6 +382,8 @@ debug:
 			echo "Error: Streamlit backend exited before startup completed. Check $$DEBUG_DIR/backend.log"; \
 			exit 1; \
 		fi; \
+		# Detect the backend port from the INFO "server started on" or DEBUG "Starting \
+		# uvicorn runner on" log lines, keeping the last numeric match (dev mode retries ports). \
 		DETECTED_BACKEND_PORT=$$(awk '/[Ss]erver started on|Starting uvicorn runner on/ { n=split($$NF, a, ":"); port=a[n] } END { if (port ~ /^[0-9]+$$/) print port }' "$$DEBUG_DIR/backend.log"); \
 		if [[ -n "$$DETECTED_BACKEND_PORT" ]]; then \
 			BACKEND_PORT=$$DETECTED_BACKEND_PORT; \


### PR DESCRIPTION
## Describe your changes

Makes the `make debug` backend port detection robust against the log output produced in development mode.

- Under `--global.developmentMode=true` the backend takes the `UvicornRunner` path, which only emits a pre-bind DEBUG-level `Starting uvicorn runner on <host>:<port>` line (and runs a port-search retry loop) and never the post-bind INFO-level `Uvicorn server started on ...` line the detection previously relied on. As a result the port was not detected in dev mode. Now match both patterns so detection works in either path.
- Take the last matching port and only accept it when it is numeric, guarding against partially-written log lines and stale/failed retry attempts.
- Re-detect on every poll iteration so a valid port overwrites a previously unset/invalid value.

## GitHub Issue Link (if applicable)

## Testing Plan

- Dev-tooling change to the `make debug` target only; no library code paths are affected, so no unit/e2e tests are added.
- Manually verified `make debug <script.py>` detects the backend port and reports the app URL.