### PR TITLE
[docs] Use st.App in starlette docstring examples

### DIFF
--- a/lib/streamlit/starlette.py
+++ b/lib/streamlit/starlette.py
@@ -19,8 +19,8 @@ applications with any ASGI server (uvicorn, hypercorn, etc.).
 
 Example
 -------
->>> from streamlit.starlette import App
->>> app = App("main.py")
+>>> import streamlit as st
+>>> app = st.App("main.py")
 
 Run with uvicorn:
 

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -345,13 +345,13 @@ class App:
     --------
     Basic usage:
 
-    >>> from streamlit.web.server.starlette import App
-    >>> app = App("main.py")
+    >>> import streamlit as st
+    >>> app = st.App("main.py")
 
     With lifespan hooks:
 
     >>> from contextlib import asynccontextmanager
-    >>> from streamlit.web.server.starlette import App
+    >>> import streamlit as st
     >>>
     >>> @asynccontextmanager
     ... async def lifespan(app):
@@ -359,25 +359,25 @@ class App:
     ...     yield {"model": "loaded"}
     ...     print("Shutting down...")
     >>>
-    >>> app = App("main.py", lifespan=lifespan)
+    >>> app = st.App("main.py", lifespan=lifespan)
 
     With custom routes:
 
+    >>> import streamlit as st
     >>> from starlette.routing import Route
     >>> from starlette.responses import JSONResponse
-    >>> from streamlit.web.server.starlette import App
     >>>
     >>> async def health(request):
     ...     return JSONResponse({"status": "ok"})
     >>>
-    >>> app = App("main.py", routes=[Route("/health", health)])
+    >>> app = st.App("main.py", routes=[Route("/health", health)])
 
     With programmatic secrets:
 
     >>> import os
-    >>> from streamlit.web.server.starlette import App
+    >>> import streamlit as st
     >>>
-    >>> app = App(
+    >>> app = st.App(
     ...     "main.py",
     ...     secrets={
     ...         "database": {
@@ -390,7 +390,7 @@ class App:
     With error monitoring (Sentry):
 
     >>> import sentry_sdk
-    >>> from streamlit.web.server.starlette import App
+    >>> import streamlit as st
     >>>
     >>> sentry_sdk.init(dsn="...")
     >>>
@@ -398,18 +398,17 @@ class App:
     ...     sentry_sdk.capture_exception(exc)
     ...     return None  # Show default exception display
     >>>
-    >>> app = App("main.py", on_script_error=log_to_sentry)
+    >>> app = st.App("main.py", on_script_error=log_to_sentry)
 
     With custom error UI:
 
     >>> import streamlit as st
-    >>> from streamlit.web.server.starlette import App
     >>>
     >>> def custom_error_handler(exc):
     ...     st.error("Something went wrong!")
     ...     return True  # Suppress default exception display
     >>>
-    >>> app = App("main.py", on_script_error=custom_error_handler)
+    >>> app = st.App("main.py", on_script_error=custom_error_handler)
     """
 
     def __init__(
@@ -628,9 +627,9 @@ class App:
         Mount st.App on FastAPI:
 
         >>> from fastapi import FastAPI
-        >>> from streamlit.starlette import App
+        >>> import streamlit as st
         >>>
-        >>> streamlit_app = App("dashboard.py")
+        >>> streamlit_app = st.App("dashboard.py")
         >>> fastapi_app = FastAPI(lifespan=streamlit_app.lifespan())
         >>> fastapi_app.mount("/dashboard", streamlit_app)
         """


### PR DESCRIPTION
## Describe your changes

Update the `App` docstring examples to import via the public `st.App` namespace instead of the internal `streamlit.starlette` / `streamlit.web.server.starlette` module paths, so the shown usage matches the recommended public API.

## GitHub Issue Link (if applicable)

## Testing Plan

- Documentation-only change (docstring examples). No behavior changes, so no additional tests needed. Existing tests already verify `App` is exported from the `st` namespace (`lib/tests/streamlit/web/server/starlette/starlette_app_test.py::TestAppExports`).

Made with [Cursor](https://cursor.com)