### PR TITLE
[chore] Lower uv required-version for Dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = ["streamlit"]
 [tool.uv]
 # The development toolchain is the default local environment.
 default-groups = ["dev"]
-# Dependabot currently requires compatibility with uv 0.11.8.
-# Raise this minimum when Dependabot supports a newer uv version.
+# Keep this floor low enough for Dependabot's bundled uv.
+# Raise it when Dependabot ships a newer uv and we want a tighter floor.
 required-version = ">=0.11.8"
 # Resolve the development lock only for the currently supported Python range.
 environments = ["python_version < '3.15'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ dependencies = ["streamlit"]
 [tool.uv]
 # The development toolchain is the default local environment.
 default-groups = ["dev"]
-# Minimum uv version required for this project
-required-version = ">=0.11.28"
+# Dependabot currently requires compatibility with uv 0.11.8.
+# Raise this minimum when Dependabot supports a newer uv version.
+required-version = ">=0.11.8"
 # Resolve the development lock only for the currently supported Python range.
 environments = ["python_version < '3.15'"]
 # Exclude packages published in the last 24 hours to lower risk from supply chain attacks


### PR DESCRIPTION
## Describe your changes

Lowers `[tool.uv].required-version` from `>=0.11.28` to `>=0.11.8` so Dependabot can resolve the lockfile with the uv version it currently supports. Raise the pin again once Dependabot supports a newer uv.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Explanation of why no additional tests are needed: config-only pin change; no runtime behavior change
- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)