### PR TITLE
Fix st.help header showing "page.run()" in multipage apps

### DIFF
--- a/e2e_playwright/st_help.py
+++ b/e2e_playwright/st_help.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import streamlit as st
-from streamlit.elements.help import _get_scriptrunner_frame
+from streamlit.elements.help import _get_caller_frame
 
-if _get_scriptrunner_frame() is None:
+if _get_caller_frame() is None:
     st.warning(
         """
         You're running this script in an `exec` context, so the `foo` part

--- a/lib/streamlit/elements/help.py
+++ b/lib/streamlit/elements/help.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import ast
 import contextlib
 import inspect
+import os
 import re
 import types
 from typing import TYPE_CHECKING, Any, Final, cast
@@ -29,11 +30,10 @@ from streamlit.proto.Help_pb2 import Help as HelpProto
 from streamlit.proto.Help_pb2 import Member as MemberProto
 from streamlit.runtime.caching.cache_utils import CachedFunc
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.runtime.scriptrunner.script_runner import (
-    __file__ as SCRIPTRUNNER_FILENAME,  # noqa: N812
-)
 from streamlit.runtime.secrets import Secrets
 from streamlit.string_util import is_mem_address_str
+
+_STREAMLIT_PACKAGE_DIR: Final = os.path.realpath(os.path.dirname(streamlit.__file__))
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -327,16 +327,16 @@ _NEWLINES = re.compile(r"[\n\r]+")
 
 
 def _get_current_line_of_code_as_str() -> str | None:
-    scriptrunner_frame = _get_scriptrunner_frame()
+    caller_frame = _get_caller_frame()
 
-    if scriptrunner_frame is None:
-        # If there's no ScriptRunner frame, something weird is going on. This
-        # can happen when the script is executed with `python myscript.py`.
-        # Either way, let's bail out nicely just in case there's some valid
-        # edge case where this is OK.
+    if caller_frame is None:
+        # If we can't find the caller, something weird is going on. This can
+        # happen when the script is executed with `python myscript.py`. Either
+        # way, let's bail out nicely just in case there's some valid edge case
+        # where this is OK.
         return None
 
-    code_context = scriptrunner_frame.code_context
+    code_context = caller_frame.code_context
 
     if not code_context:
         # Sometimes a frame has no code_context. This can happen inside certain exec() calls, for
@@ -349,27 +349,34 @@ def _get_current_line_of_code_as_str() -> str | None:
     return re.sub(_NEWLINES, "", code_as_string.strip())
 
 
-def _get_scriptrunner_frame() -> inspect.FrameInfo | None:
-    prev_frame = None
-    scriptrunner_frame = None
+def _get_caller_frame() -> inspect.FrameInfo | None:
+    """Return the innermost user frame that called `st.help(...)`.
 
-    # Look back in call stack to get the variable name passed into st.help().
-    # The frame *before* the ScriptRunner frame is the correct one.
-    # IMPORTANT: This will change if we refactor the code. But hopefully our tests will catch the
-    # issue and we'll fix it before it lands upstream!
+    The user frame is the closest frame on the stack whose source file lives
+    outside the ``streamlit`` package. This correctly handles nested cases —
+    e.g. a page function invoked via ``st.navigation`` / ``page.run()`` — where
+    the frame that literally contains the ``st.help(...)`` call is user code
+    that streamlit machinery is a few frames above.
+    """
     for frame in inspect.stack():
-        # Check if this is running inside a funny "exec()" block that won't provide the info we
-        # need. If so, just quit.
+        # A frame with no code_context can happen inside certain exec() calls;
+        # in that case we can't recover the source line either way.
+        # See https://stackoverflow.com/a/12072941
         if frame.code_context is None:
             return None
 
-        if frame.filename == SCRIPTRUNNER_FILENAME:
-            scriptrunner_frame = prev_frame
-            break
+        if not _is_streamlit_internal_frame(frame):
+            return frame
 
-        prev_frame = frame
+    return None
 
-    return scriptrunner_frame
+
+def _is_streamlit_internal_frame(frame: inspect.FrameInfo) -> bool:
+    try:
+        resolved = os.path.realpath(frame.filename)
+    except (OSError, ValueError):
+        return False
+    return resolved.startswith(_STREAMLIT_PACKAGE_DIR + os.sep)
 
 
 def _is_stcommand(tree: Any, command_name: str) -> bool:

--- a/lib/tests/streamlit/elements/help_test.py
+++ b/lib/tests/streamlit/elements/help_test.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import inspect
 import sys
 import unittest
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -37,21 +36,13 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
 
-def patch_varname_getter():
-    """Patches streamlit.elements.help so _get_variable_name() works outside ScriptRunner."""
-    parent_frame_filename = inspect.getouterframes(inspect.currentframe())[2].filename
-
-    return patch("streamlit.elements.help.SCRIPTRUNNER_FILENAME", parent_frame_filename)
-
-
 class StHelpTest(DeltaGeneratorTestCase):
     """Test st.help."""
 
     def test_no_arg(self):
         """When st.help is called with no arguments, show Streamlit docs."""
 
-        with patch_varname_getter():
-            st.help()
+        st.help()
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == ""
@@ -62,8 +53,7 @@ class StHelpTest(DeltaGeneratorTestCase):
     def test_none_arg(self):
         """When st.help is called with None as an argument, don't show Streamlit docs."""
 
-        with patch_varname_getter():
-            st.help(None)
+        st.help(None)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == ""
@@ -81,8 +71,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         def my_func(some_param, another_param=123):
             """This is the doc"""
 
-        with patch_varname_getter():
-            st.help(my_func)
+        st.help(my_func)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "my_func"
@@ -99,8 +88,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         def my_func(some_param, another_param=123):
             pass
 
-        with patch_varname_getter():
-            st.help(my_func)
+        st.help(my_func)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "my_func"
@@ -111,11 +99,31 @@ class StHelpTest(DeltaGeneratorTestCase):
         assert ds.type == "function"
         assert ds.doc_string == ""
 
+    def test_st_help_inside_nested_function(self):
+        """Regression test for GH #11430.
+
+        When ``st.help`` is called inside a nested function (as happens in
+        multipage apps where the page function calls ``st.help(...)`` and is
+        invoked via ``page.run()``), the header/name must come from the frame
+        that literally contains the ``st.help(...)`` call — not from an outer
+        frame whose source line is ``page.run()`` or the function name.
+        """
+
+        def page_function():
+            st.help(st.write)
+
+        page_function()
+
+        ds = self.get_delta_from_queue().new_element.help_info
+        assert ds.name == "st.write"
+        assert ds.type == "method"
+        assert ds.name != "page_function()"
+        assert ds.name != "page.run()"
+
     def test_deltagenerator_func(self):
         """Test Streamlit DeltaGenerator function."""
 
-        with patch_varname_getter():
-            st.help(st.audio)
+        st.help(st.audio)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "st.audio"
@@ -133,8 +141,7 @@ class StHelpTest(DeltaGeneratorTestCase):
     def test_builtin_func(self):
         """Test a built-in function."""
 
-        with patch_varname_getter():
-            st.help(dir)
+        st.help(dir)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "dir"
@@ -146,8 +153,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         """Test a named variable."""
 
         myvar = 123
-        with patch_varname_getter():
-            st.help(myvar)
+        st.help(myvar)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "myvar"
@@ -158,8 +164,7 @@ class StHelpTest(DeltaGeneratorTestCase):
     def test_walrus(self):
         """Test a named variable using walrus operator."""
 
-        with patch_varname_getter():
-            st.help(myvar := 123)  # noqa: F841
+        st.help(myvar := 123)  # noqa: F841
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "myvar"
@@ -172,8 +177,7 @@ class StHelpTest(DeltaGeneratorTestCase):
 
         myvar = {"foo": [None, {"bar": "baz"}]}
 
-        with patch_varname_getter():
-            st.help(myvar["foo"][1]["bar"].strip)
+        st.help(myvar["foo"][1]["bar"].strip)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == 'myvar["foo"][1]["bar"].strip'
@@ -184,8 +188,7 @@ class StHelpTest(DeltaGeneratorTestCase):
     def test_builtin_obj(self):
         """Test a built-in function."""
 
-        with patch_varname_getter():
-            st.help(123)
+        st.help(123)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == ""
@@ -201,8 +204,7 @@ class StHelpTest(DeltaGeneratorTestCase):
 
         array = np.arange(1)
 
-        with patch_varname_getter():
-            st.help(array)
+        st.help(array)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert ds.name == "array"
@@ -217,8 +219,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         class MyClass:
             pass
 
-        with patch_varname_getter():
-            st.help(MyClass)
+        st.help(MyClass)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert type(MyClass) is type
@@ -237,8 +238,7 @@ class StHelpTest(DeltaGeneratorTestCase):
         class MyClass:
             pass
 
-        with patch_varname_getter():
-            st.help(MyClass)
+        st.help(MyClass)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert type(MyClass) is type
@@ -272,8 +272,7 @@ class StHelpTest(DeltaGeneratorTestCase):
             def classmethod1(cls, y=20):
                 "Class method 1"
 
-        with patch_varname_getter():
-            st.help(MyClass)
+        st.help(MyClass)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert len(ds.members) == 5
@@ -316,8 +315,7 @@ class StHelpTest(DeltaGeneratorTestCase):
 
         my_instance = MyClass()
 
-        with patch_varname_getter():
-            st.help(my_instance)
+        st.help(my_instance)
 
         ds = self.get_delta_from_queue().new_element.help_info
         assert len(ds.members) == 7


### PR DESCRIPTION
## Summary

Fixes #11430.

When `st.help(x)` is called from a page function invoked via `st.navigation` + `page.run()`, the header shows `page.run()` instead of `x`. The variable-name recovery walked back exactly one frame from the script runner, which landed on the entrypoint script line containing `page.run()` rather than the user's actual `st.help(x)` call site inside the page function.

Walk the stack from innermost outward and pick the first frame whose source file lives outside the streamlit package. That frame contains the real `st.help(...)` call regardless of how many streamlit-internal frames sit between it and the script runner. Also fixes the same issue for `st.help(x)` called from user-defined helper functions that streamlit-internal machinery invokes on their behalf.

## Test plan

- [x] Added `test_st_help_inside_nested_function` regression test
- [x] Existing `help_test.py` suite still passes (42/42)
- [x] Removed the now-obsolete `patch_varname_getter` shim (the new algorithm no longer depends on a module-level filename constant)
- [x] Manually reproduced #11430 on `develop` with a minimal `st.navigation` + `page.run()` app, then verified the fix renders `st.write` as the header in all three call contexts (top-level, direct helper call, page-run)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to `st.help` introspection for display labels only; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **#11430**: `st.help` was showing the wrong header (e.g. `page.run()`) in multipage apps because variable-name recovery used the frame immediately before the script runner.
> 
> **Caller detection** is reworked: `_get_scriptrunner_frame` becomes `_get_caller_frame`, which walks the stack from the innermost frame and returns the first frame whose file is **outside** the `streamlit` package (`_is_streamlit_internal_frame`). That picks up the real `st.help(...)` line inside page functions and nested helpers.
> 
> Tests drop the `patch_varname_getter` shim and add **`test_st_help_inside_nested_function`**; the e2e helper imports `_get_caller_frame` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a539e790bb7b7721e4ee32832dfe2c145f73b482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->