### PR TITLE
[chore] Declare @babel/runtime in frontend app

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -23,6 +23,7 @@
     "typesync:ci": "typesync --dry=fail"
   },
   "dependencies": {
+    "@babel/runtime": "^7.28.4",
     "@emotion-icons/emotion-icon": "^4.1.0",
     "@emotion-icons/material-outlined": "^3.14.0",
     "@emotion-icons/material-rounded": "^3.14.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3321,6 +3321,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@streamlit/app@workspace:app"
   dependencies:
+    "@babel/runtime": "npm:^7.28.4"
     "@emotion-icons/emotion-icon": "npm:^4.1.0"
     "@emotion-icons/material-outlined": "npm:^3.14.0"
     "@emotion-icons/material-rounded": "npm:^3.14.0"


### PR DESCRIPTION
## Describe your changes

Declares `@babel/runtime` as a direct dependency of `@streamlit/app` so the package no longer relies on transitive hoisting (e.g. via `@emotion-icons/*`). This also satisfies the `@babel/runtime` peer dependency of `react-hot-keys` and avoids install/resolution failures under stricter linkers or dependency pruning. The resolved version (`7.28.4`) is unchanged.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No additional tests — dependency declaration only (`package.json` / `yarn.lock`)
- [x] Frontend CI (install/build/unit) validates the lockfile change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.