### PR TITLE
[chore] Document subagent model inherit guidance

### DIFF
--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -11,7 +11,7 @@ Prepares the current branch for merge by running quality checks, simplifying cod
 
 ## Workflow
 
-Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding.
+Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding. **Subagent model**: use the same model as this session on every launch (`model: inherit` / omit any model override); do not switch to a different or faster model.
 
 > **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 6, 7, and 8.
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -11,7 +11,7 @@ Prepares the current branch for merge by running quality checks, simplifying cod
 
 ## Workflow
 
-Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding. **Subagent model**: use the same model as this session on every launch (`model: inherit` / omit any model override); do not switch to a different or faster model.
+Follow these steps in order. **Run all subagents in foreground** (not background) unless otherwise specified—wait for each to complete before proceeding. **Subagent model**: use the same model as this session on every launch (`model: inherit` / omit any model override). Do not switch to a different or faster model unless the user explicitly requests it.
 
 > **Note:** For small changes (documentation tweaks, test-only tweaks, one-liners, or other mini-changes), you can skip steps 1, 2, 3, 6, 7, and 8.
 

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -96,6 +96,7 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
+- **Subagent model**: When launching subagents, use the same model as the parent session (`model: inherit` / omit any model override). Do not switch to a different or faster model unless the user explicitly requests it. Prefer the named custom agents in `.claude/agents/` when available.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - Use `agent-wiki/` (gitignored, cloned on first use) to share intermediate files (specs, plans, learnings) relevant for the current PR. This is a local checkout of [streamlit.wiki](https://github.com/streamlit/streamlit.wiki.git). Files are stored in `pull-requests/<pr-number>/` and accessible at `https://issues.streamlit.app/agent_wiki_explorer?file=<relative-path>`. See `sharing-pr-agent-artifacts` skill.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,6 +90,7 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
+- **Subagent model**: When launching subagents, use the same model as the parent session (`model: inherit` / omit any model override). Do not switch to a different or faster model unless the user explicitly requests it. Prefer the named custom agents in `.claude/agents/` when available.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - Use `agent-wiki/` (gitignored, cloned on first use) to share intermediate files (specs, plans, learnings) relevant for the current PR. This is a local checkout of [streamlit.wiki](https://github.com/streamlit/streamlit.wiki.git). Files are stored in `pull-requests/<pr-number>/` and accessible at `https://issues.streamlit.app/agent_wiki_explorer?file=<relative-path>`. See `sharing-pr-agent-artifacts` skill.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Selection of `make` commands for development (run in the repo root):
 ### Development Tips
 
 - **Follow existing patterns**: Check neighboring files for conventions.
+- **Subagent model**: When launching subagents, use the same model as the parent session (`model: inherit` / omit any model override). Do not switch to a different or faster model unless the user explicitly requests it. Prefer the named custom agents in `.claude/agents/` when available.
 - You can use the `work-tmp` directory to store temporary files, specs, and scripts.
 - Use `agent-wiki/` (gitignored, cloned on first use) to share intermediate files (specs, plans, learnings) relevant for the current PR. This is a local checkout of [streamlit.wiki](https://github.com/streamlit/streamlit.wiki.git). Files are stored in `pull-requests/<pr-number>/` and accessible at `https://issues.streamlit.app/agent_wiki_explorer?file=<relative-path>`. See `sharing-pr-agent-artifacts` skill.
 - If you fail to run a `make` command, remember to run it from the root / top-level directory.


### PR DESCRIPTION
## Describe your changes

Documents that AI subagents should inherit the parent session model (`model: inherit`) unless the user explicitly requests otherwise.

- Adds the guidance to `AGENTS.md` (and generated agent-rule copies)
- Mirrors it in the `finalizing-pr` skill workflow

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Explanation of why no additional tests are needed: documentation-only change to agent guidance; no runtime behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)