### PR TITLE
[fix] Post AI QA report from correct artifact path

### DIFF
--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -167,9 +167,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: qa-testing-output
-          path: |
-            ${{ env.QA_DIR }}/qa-report.md
-            ${{ env.QA_DIR }}/verdict.txt
+          path: ${{ env.QA_DIR }}/
+          if-no-files-found: error
           retention-days: 7
 
   post-results:
@@ -191,6 +190,10 @@ jobs:
         run: |
           gh pr edit "$PR_NUMBER_ENV" --remove-label "ai-qa-test" --repo "$REPOSITORY" || true
 
+      # actions/upload-artifact strips the shared parent dir ($QA_DIR) when
+      # uploading multiple files, so qa-report.md and verdict.txt download to
+      # qa-artifacts/ directly (not qa-artifacts/$QA_DIR/). Later steps rely on
+      # these flat paths.
       - name: Download QA artifacts
         id: download
         if: needs.ai-qa-testing.result == 'success'

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -49,9 +49,6 @@ jobs:
       pull-requests: read
       issues: read
       actions: read
-    outputs:
-      qa_dir: ${{ steps.qa-setup.outputs.qa_dir }}
-
     concurrency:
       group: ${{ github.workflow }}-pr-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
       cancel-in-progress: true
@@ -107,7 +104,6 @@ jobs:
           echo "$HOME/.cursor/bin" >> $GITHUB_PATH
 
       - name: Set up QA directory
-        id: qa-setup
         env:
           HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
         run: |
@@ -118,9 +114,8 @@ jobs:
           QA_DIR="work-tmp/qa-${FEATURE_NAME}"
           mkdir -p "$QA_DIR"
 
-          # Export for later steps and as output
+          # Export for later steps
           echo "QA_DIR=$QA_DIR" >> "$GITHUB_ENV"
-          echo "qa_dir=$QA_DIR" >> "$GITHUB_OUTPUT"
 
       - name: AI QA Testing
         env:
@@ -230,17 +225,16 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           MODEL_NAME: ${{ env.MODEL }}
           RUN_ID: ${{ github.run_id }}
-          QA_DIR: ${{ needs.ai-qa-testing.outputs.qa_dir }}
         run: |
-          if [ -f "qa-artifacts/${QA_DIR}/qa-report.md" ]; then
+          if [ -f "qa-artifacts/qa-report.md" ]; then
             # Add footer to report
             {
               echo ""
               echo "---"
               echo "*This is an automated QA report by \`$MODEL_NAME\`.*"
-            } >> "qa-artifacts/${QA_DIR}/qa-report.md"
+            } >> "qa-artifacts/qa-report.md"
 
-            gh pr comment "$PR_NUMBER_ENV" --body-file "qa-artifacts/${QA_DIR}/qa-report.md" --repo "$REPOSITORY"
+            gh pr comment "$PR_NUMBER_ENV" --body-file "qa-artifacts/qa-report.md" --repo "$REPOSITORY"
           else
             gh pr comment "$PR_NUMBER_ENV" --body "⚠️ **AI QA Testing completed but no report was generated.**
 
@@ -268,14 +262,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER_ENV: ${{ env.PR_NUMBER }}
           REPOSITORY: ${{ github.repository }}
-          QA_DIR: ${{ needs.ai-qa-testing.outputs.qa_dir }}
         run: |
-          if [ ! -f "qa-artifacts/${QA_DIR}/verdict.txt" ]; then
+          if [ ! -f "qa-artifacts/verdict.txt" ]; then
             echo "Warning: verdict.txt not found, skipping label"
             exit 0
           fi
 
-          VERDICT=$(cat "qa-artifacts/${QA_DIR}/verdict.txt" | tr -d '[:space:]')
+          VERDICT=$(tr -d '[:space:]' < "qa-artifacts/verdict.txt")
           case "$VERDICT" in
             FAIL)
               echo "Adding 'do-not-merge' label"
@@ -294,7 +287,6 @@ jobs:
         env:
           QA_RESULT: ${{ needs.ai-qa-testing.result }}
           HAS_KEY: ${{ needs.check-secrets.outputs.has_key }}
-          QA_DIR: ${{ needs.ai-qa-testing.outputs.qa_dir }}
         run: |
           {
             echo "## AI QA Testing Summary"
@@ -304,7 +296,7 @@ jobs:
             if [ "$HAS_KEY" = "false" ]; then
               echo "- Note: API key not available (fork PR)"
             fi
-            if [ -f "qa-artifacts/${QA_DIR}/verdict.txt" ]; then
-              echo "- Verdict: $(cat "qa-artifacts/${QA_DIR}/verdict.txt")"
+            if [ -f "qa-artifacts/verdict.txt" ]; then
+              echo "- Verdict: $(cat "qa-artifacts/verdict.txt")"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -190,10 +190,10 @@ jobs:
         run: |
           gh pr edit "$PR_NUMBER_ENV" --remove-label "ai-qa-test" --repo "$REPOSITORY" || true
 
-      # actions/upload-artifact strips the shared parent dir ($QA_DIR) when
-      # uploading multiple files, so qa-report.md and verdict.txt download to
-      # qa-artifacts/ directly (not qa-artifacts/$QA_DIR/). Later steps rely on
-      # these flat paths.
+      # The upload step uploads the $QA_DIR/ directory, so its contents
+      # (qa-report.md and verdict.txt) are stored at the artifact root and
+      # download to qa-artifacts/ directly (not qa-artifacts/$QA_DIR/). Later
+      # steps rely on these flat paths.
       - name: Download QA artifacts
         id: download
         if: needs.ai-qa-testing.result == 'success'


### PR DESCRIPTION
## Describe your changes

The `post-results` job looked for the QA report and verdict under `qa-artifacts/${QA_DIR}/` (i.e. `qa-artifacts/work-tmp/qa-<feature>/`), but `actions/upload-artifact` strips the least-common-ancestor directory when uploading multiple files. The files therefore land directly at `qa-artifacts/qa-report.md` and `qa-artifacts/verdict.txt`, so the report was never posted and the verdict label was never applied.

- Fix the report/verdict paths in `post-results` to `qa-artifacts/qa-report.md` and `qa-artifacts/verdict.txt`
- Drop the now-unused `qa_dir` job output and the `qa-setup` step id

## GitHub Issue Link (if applicable)

## Testing Plan

- CI-only workflow change; validated locally with the `oxfmt-yaml` and `check yaml` pre-commit hooks. End-to-end behavior is verified by triggering the `ai-qa-test` label on this PR.

Made with [Cursor](https://cursor.com)