### PR TITLE
[chore] Add product alignment to AI PR review

### DIFF
--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -77,5 +77,5 @@ Run the fixing-pr subagent to fix CI failures and address PR review comments for
 |-------|---------|
 | `fixing-pr` | Fix CI failures and address PR review comments |
 | `qa-testing-feature` | QA test features using Playwright |
-| `reviewing-local-changes` | Code review for quality, security, best practices |
+| `reviewing-local-changes` | Code review for quality, security, best practices, and product/API alignment |
 | `simplifying-local-changes` | Simplify and refine code changes |

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -69,6 +69,11 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
   interaction, default, error message, or other externally observable behavior.
   - Read `specs/AGENTS.md` and evaluate the change against its "Principles of Streamlit API
     Design."
+  - Search `specs/` for a relevant product spec. Product decisions explicitly described in a
+    product spec that is already merged into the PR's base branch are considered approved and
+    aligned; do not relitigate them. Instead, verify that the implementation follows the spec
+    and separately assess any user-facing behavior that the merged spec does not cover. A new
+    or modified spec in the current PR is not already approved by this rule.
   - Inspect analogous Streamlit APIs, configs, and behaviors. Check that the proposed surface
     uses established names, defaults, interaction patterns, return types, and error behavior.
   - Confirm that the change solves a clear user problem, keeps the common case simple, exposes
@@ -119,9 +124,12 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Product Alignment
 
-[State whether the PR has user-facing product impact. If yes, assess the user value and
-complexity tradeoff, consistency with analogous Streamlit surfaces, and alignment with the
-principles in `specs/AGENTS.md`. If no, state why this section is not applicable.]
+[State whether the PR has user-facing product impact. If yes, identify any relevant product
+spec already merged into the base branch, treat its documented product decisions as approved,
+and assess whether the implementation follows it. For user-facing aspects not covered by an
+approved spec, assess the user value and complexity tradeoff, consistency with analogous
+Streamlit surfaces, and alignment with the principles in `specs/AGENTS.md`. If no, state why
+this section is not applicable.]
 
 ## Code Quality
 

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-local-changes
-description: Review the current branch's changes for code quality, test coverage, security, and best practices. Use when asked to perform a code review.
+description: Review the current branch's changes for code quality, test coverage, security, best practices, and product/API alignment. Use when asked to perform a code review.
 model: inherit
 readonly: true
 disallowedTools: Write, Edit
@@ -52,7 +52,7 @@ gh pr view --json number,title,url,body,headRefName,baseRefName -R streamlit/str
 
 ## Goal
 
-Review this branch's changes and ensure the changes are bug-free, backwards compatible, and ready for merge.
+Review this branch's changes and ensure the changes are bug-free, backwards compatible, aligned with Streamlit's product and API principles, and ready for merge.
 
 ## Review Checklist
 

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -64,6 +64,20 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
   - `lib/AGENTS.md` — for any Python changes (`*.py` files)
   - `lib/streamlit/AGENTS.md` — for any Python library changes (inside `lib/streamlit/`)
   - `proto/streamlit/proto/AGENTS.md` — for protobuf changes (inside `proto/streamlit/proto/`)
+- Product alignment is explicitly assessed for user-facing changes. Treat a change as user-facing
+  when it adds or modifies a public API, configuration option, CLI surface, rendered UI or
+  interaction, default, error message, or other externally observable behavior.
+  - Read `specs/AGENTS.md` and evaluate the change against its "Principles of Streamlit API
+    Design."
+  - Inspect analogous Streamlit APIs, configs, and behaviors. Check that the proposed surface
+    uses established names, defaults, interaction patterns, return types, and error behavior.
+  - Confirm that the change solves a clear user problem, keeps the common case simple, exposes
+    complexity progressively, composes with existing features, and adds no more permanent
+    user-facing surface area than its value justifies.
+  - Consider the complete user experience, including discoverability, helpful failures,
+    backwards-compatible evolution, and behavior across supported platforms when relevant.
+  - If the PR has no user-facing product impact, state that explicitly rather than inventing
+    product concerns.
 - No risky aspects that could cause security issues or regressions. Pay closer attention to changes in these security-sensitive areas:
   - WebSocket connection handling, server endpoints, authentication, and session management
   - File upload, file/asset serving, and path traversal risks
@@ -85,10 +99,14 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
 2. Gather relevant context (branch diff, PR details if available).
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
-5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
-6. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
-7. Perform a thorough code review based on the checklist above.
-8. Write your review following the output format below.
+5. Classify whether the PR has user-facing product impact. If it does, read
+   `specs/AGENTS.md`, inspect comparable existing Streamlit surfaces, and perform the product
+   alignment assessment from the checklist. If it does not, mark the Product Alignment section as not
+   applicable and explain why briefly.
+6. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
+7. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
+8. Perform a thorough code review based on the checklist above.
+9. Write your review following the output format below.
 
 ## Output Format
 
@@ -98,6 +116,12 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 ## Summary
 
 [Brief overview and the main changes introduced.]
+
+## Product Alignment
+
+[State whether the PR has user-facing product impact. If yes, assess the user value and
+complexity tradeoff, consistency with analogous Streamlit surfaces, and alignment with the
+principles in `specs/AGENTS.md`. If no, state why this section is not applicable.]
 
 ## Code Quality
 
@@ -137,7 +161,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 Verdict criteria:
 - **APPROVED**: If there are no critical/merge-blocking issues. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
-- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
+- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or clear material violations of documented Streamlit product/API principles and patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
 
 ---
 *This is an automated AI review. Please verify the feedback and use your judgment.*
@@ -149,4 +173,8 @@ Verdict criteria:
 - Do NOT attempt to post comments, edit PRs, or perform any write operations.
 - Focus on the root cause of issues, not cascading failures.
 - Be specific with file references and line numbers when noting issues.
+- Product feedback must cite concrete changed behavior and the relevant documented principle or
+  established Streamlit pattern. Product questions and optional refinements are non-blocking;
+  request changes only when the mismatch would create material user harm or lasting,
+  unjustified complexity in the public surface.
 - Findings that are covered by inline comments should NOT be repeated in the PR-level review body. The PR-level review covers high-level and cross-cutting concerns only. Inline comments handle line-specific findings.

--- a/.codex/agents/reviewing-local-changes.toml
+++ b/.codex/agents/reviewing-local-changes.toml
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 name = "reviewing-local-changes"
-description = "Review the current branch's changes for code quality, test coverage, security, and best practices."
+description = "Review the current branch's changes for code quality, test coverage, security, best practices, and product/API alignment."
 sandbox_mode = "read-only"
 developer_instructions = "Read and follow the instructions in `.claude/agents/reviewing-local-changes.md`."

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -85,5 +85,5 @@ Run the fixing-pr subagent to fix CI failures and address PR review comments for
 |-------|---------|
 | `fixing-pr` | Fix CI failures and address PR review comments |
 | `qa-testing-feature` | QA test features using Playwright |
-| `reviewing-local-changes` | Code review for quality, security, best practices |
+| `reviewing-local-changes` | Code review for quality, security, best practices, and product/API alignment |
 | `simplifying-local-changes` | Simplify and refine code changes |

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -149,7 +149,7 @@ runner's system Python.
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code review using Cursor CLI |
+| `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code and product-alignment review using Cursor CLI |
 | `ai-qa-testing.yml` | `ai-qa-test` label or manual | AI-powered QA testing on PR branches |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
 | `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review and updates |

--- a/.github/instructions/agents.instructions.md
+++ b/.github/instructions/agents.instructions.md
@@ -83,5 +83,5 @@ Run the fixing-pr subagent to fix CI failures and address PR review comments for
 |-------|---------|
 | `fixing-pr` | Fix CI failures and address PR review comments |
 | `qa-testing-feature` | QA test features using Playwright |
-| `reviewing-local-changes` | Code review for quality, security, best practices |
+| `reviewing-local-changes` | Code review for quality, security, best practices, and product/API alignment |
 | `simplifying-local-changes` | Simplify and refine code changes |

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -147,7 +147,7 @@ runner's system Python.
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code review using Cursor CLI |
+| `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code and product-alignment review using Cursor CLI |
 | `ai-qa-testing.yml` | `ai-qa-test` label or manual | AI-powered QA testing on PR branches |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
 | `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review and updates |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -141,7 +141,7 @@ runner's system Python.
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code review using Cursor CLI |
+| `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code and product-alignment review using Cursor CLI |
 | `ai-qa-testing.yml` | `ai-qa-test` label or manual | AI-powered QA testing on PR branches |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
 | `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review and updates |

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -207,7 +207,7 @@ jobs:
 
           ## Goal
 
-          Review this branch (PR: $PR_HTML_URL) and ensure the changes are bug-free, backwards compatible, and ready for merge.
+          Review this branch (PR: $PR_HTML_URL) and ensure the changes are bug-free, backwards compatible, aligned with Streamlit's product and API principles, and ready for merge.
 
           $(cat scripts/assets/code-review-instructions.md)
 
@@ -348,7 +348,7 @@ jobs:
           4. **Track missing reviews** - if any expected models are missing from the reviews above, note them as 'failed to complete review'
           5. **Determine final verdict**:
              - APPROVED: If the majority of available reviews approve AND there are no critical/merge-blocking issues raised by any reviewer. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
-             - CHANGES_REQUESTED: If majority request changes OR any reviewer raised critical/merge-blocking issues (bugs, security vulnerabilities, breaking changes, missing required tests). Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
+             - CHANGES_REQUESTED: If majority request changes OR any reviewer raised critical/merge-blocking issues (bugs, security vulnerabilities, breaking changes, missing required tests, or clear material violations of documented Streamlit product/API principles). Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
 
           __CONSOLIDATION_INSTRUCTIONS__
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -348,7 +348,7 @@ jobs:
           4. **Track missing reviews** - if any expected models are missing from the reviews above, note them as 'failed to complete review'
           5. **Determine final verdict**:
              - APPROVED: If the majority of available reviews approve AND there are no critical/merge-blocking issues raised by any reviewer. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
-             - CHANGES_REQUESTED: If majority request changes OR any reviewer raised critical/merge-blocking issues (bugs, security vulnerabilities, breaking changes, missing required tests, or clear material violations of documented Streamlit product/API principles). Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
+             - CHANGES_REQUESTED: If majority request changes OR any reviewer raised critical/merge-blocking issues (bugs, security vulnerabilities, breaking changes, missing required tests, or clear material violations of documented Streamlit product/API principles and patterns). Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES_REQUESTED.
 
           __CONSOLIDATION_INSTRUCTIONS__
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ Subagents run autonomously in a fresh context, which optimizes for context size 
 
 | Subagent | When to use |
 |----------|-------------|
-| `reviewing-local-changes` | When you want a code review of the current branch's changes |
+| `reviewing-local-changes` | When you want a code review of the current branch's changes for quality, security, best practices, and product/API alignment |
 | `simplifying-local-changes` | When you want to simplify and refine code for clarity and maintainability |
 | `fixing-pr` | When a PR needs CI fixes, review feedback handling, and validation before merge |
 | `qa-testing-feature` | After implementing a feature to perform comprehensive QA testing before finalizing a PR |

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -13,6 +13,11 @@
   interaction, default, error message, or other externally observable behavior.
   - Read `specs/AGENTS.md` and evaluate the change against its "Principles of Streamlit API
     Design."
+  - Search `specs/` for a relevant product spec. Product decisions explicitly described in a
+    product spec that is already merged into the PR's base branch are considered approved and
+    aligned; do not relitigate them. Instead, verify that the implementation follows the spec
+    and separately assess any user-facing behavior that the merged spec does not cover. A new
+    or modified spec in the current PR is not already approved by this rule.
   - Inspect analogous Streamlit APIs, configs, and behaviors. Check that the proposed surface
     uses established names, defaults, interaction patterns, return types, and error behavior.
   - Confirm that the change solves a clear user problem, keeps the common case simple, exposes
@@ -63,9 +68,12 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 ## Product Alignment
 
-[State whether the PR has user-facing product impact. If yes, assess the user value and
-complexity tradeoff, consistency with analogous Streamlit surfaces, and alignment with the
-principles in `specs/AGENTS.md`. If no, state why this section is not applicable.]
+[State whether the PR has user-facing product impact. If yes, identify any relevant product
+spec already merged into the base branch, treat its documented product decisions as approved,
+and assess whether the implementation follows it. For user-facing aspects not covered by an
+approved spec, assess the user value and complexity tradeoff, consistency with analogous
+Streamlit surfaces, and alignment with the principles in `specs/AGENTS.md`. If no, state why
+this section is not applicable.]
 
 ## Code Quality
 

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -8,6 +8,20 @@
   - `lib/AGENTS.md` — for any Python changes (`*.py` files)
   - `lib/streamlit/AGENTS.md` — for any Python library changes (inside `lib/streamlit/`)
   - `proto/streamlit/proto/AGENTS.md` — for protobuf changes (inside `proto/streamlit/proto/`)
+- Product alignment is explicitly assessed for user-facing changes. Treat a change as user-facing
+  when it adds or modifies a public API, configuration option, CLI surface, rendered UI or
+  interaction, default, error message, or other externally observable behavior.
+  - Read `specs/AGENTS.md` and evaluate the change against its "Principles of Streamlit API
+    Design."
+  - Inspect analogous Streamlit APIs, configs, and behaviors. Check that the proposed surface
+    uses established names, defaults, interaction patterns, return types, and error behavior.
+  - Confirm that the change solves a clear user problem, keeps the common case simple, exposes
+    complexity progressively, composes with existing features, and adds no more permanent
+    user-facing surface area than its value justifies.
+  - Consider the complete user experience, including discoverability, helpful failures,
+    backwards-compatible evolution, and behavior across supported platforms when relevant.
+  - If the PR has no user-facing product impact, state that explicitly rather than inventing
+    product concerns.
 - No risky aspects that could cause security issues or regressions. Pay closer attention to changes in these security-sensitive areas:
   - WebSocket connection handling, server endpoints, authentication, and session management
   - File upload, file/asset serving, and path traversal risks
@@ -29,10 +43,14 @@
 2. Gather relevant context (branch diff, PR details if available).
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
-5. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
-6. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
-7. Perform a thorough code review based on the checklist above.
-8. Write your review following the output format below.
+5. Classify whether the PR has user-facing product impact. If it does, read
+   `specs/AGENTS.md`, inspect comparable existing Streamlit surfaces, and perform the product
+   alignment assessment from the checklist. If it does not, mark the Product Alignment section as not
+   applicable and explain why briefly.
+6. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
+7. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
+8. Perform a thorough code review based on the checklist above.
+9. Write your review following the output format below.
 
 ## Output Format
 
@@ -42,6 +60,12 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 ## Summary
 
 [Brief overview and the main changes introduced.]
+
+## Product Alignment
+
+[State whether the PR has user-facing product impact. If yes, assess the user value and
+complexity tradeoff, consistency with analogous Streamlit surfaces, and alignment with the
+principles in `specs/AGENTS.md`. If no, state why this section is not applicable.]
 
 ## Code Quality
 
@@ -81,7 +105,7 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 Verdict criteria:
 - **APPROVED**: If there are no critical/merge-blocking issues. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
-- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or violations of documented patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
+- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, breaking changes, missing required tests, or clear material violations of documented Streamlit product/API principles and patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
 
 ---
 *This is an automated AI review. Please verify the feedback and use your judgment.*
@@ -93,4 +117,8 @@ Verdict criteria:
 - Do NOT attempt to post comments, edit PRs, or perform any write operations.
 - Focus on the root cause of issues, not cascading failures.
 - Be specific with file references and line numbers when noting issues.
+- Product feedback must cite concrete changed behavior and the relevant documented principle or
+  established Streamlit pattern. Product questions and optional refinements are non-blocking;
+  request changes only when the mismatch would create material user harm or lasting,
+  unjustified complexity in the public surface.
 - Findings that are covered by inline comments should NOT be repeated in the PR-level review body. The PR-level review covers high-level and cross-cutting concerns only. Inline comments handle line-specific findings.


### PR DESCRIPTION
## Describe your changes

Extends AI PR review (workflow + local reviewing agent) with an explicit product-alignment assessment for user-facing changes, grounded in `specs/AGENTS.md` and comparable Streamlit surfaces.

- Adds a required Product Alignment section; non-user-facing PRs mark it N/A
- Treats clear material product/API principle violations as merge-blocking; product questions stay non-blocking

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Explanation of why no additional tests are needed — instruction/docs-only changes to AI review prompts and agent guidance; no runtime code paths changed
- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 License.


Made with [Cursor](https://cursor.com)