### PR TITLE
[feature] Turn `st.Page` into a proper class

### DIFF
--- a/e2e_playwright/mega_tester_app.py
+++ b/e2e_playwright/mega_tester_app.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from streamlit.elements.widgets.chat import ChatInputValue
-    from streamlit.navigation.page import StreamlitPage
+    from streamlit.navigation.page import Page
 
 _DUMMY_PDF = (
     "%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n"
@@ -1100,7 +1100,7 @@ def _render_navigation(minor_version: int) -> None:
     many_pages = st.session_state.get("many_pages", False)
     nav_sections = st.session_state.get("nav_sections", True)
 
-    pages: dict[str, list[StreamlitPage]]
+    pages: dict[str, list[Page]]
     if many_pages:
         pages = {
             "General": [
@@ -1144,7 +1144,7 @@ def _render_navigation(minor_version: int) -> None:
             ],
         }
 
-    navigation_pages: list[StreamlitPage] | dict[str, list[StreamlitPage]]
+    navigation_pages: list[Page] | dict[str, list[Page]]
     if nav_sections:
         navigation_pages = pages
     else:

--- a/e2e_playwright/multipage_apps_v2/mpa_v2_page_visibility.py
+++ b/e2e_playwright/multipage_apps_v2/mpa_v2_page_visibility.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 import streamlit as st
 
 if TYPE_CHECKING:
-    from streamlit.navigation.page import StreamlitPage
+    from streamlit.navigation.page import Page
 
 # Check for query parameter to determine navigation position
 nav_position = st.query_params.get("nav_position", "sidebar")
@@ -63,7 +63,7 @@ def home():
 
 home_page = st.Page(home, title="Home", default=True)
 
-pages: list[StreamlitPage] | dict[str, list[StreamlitPage]]
+pages: list[Page] | dict[str, list[Page]]
 if single_visible:
     # Only home page is visible, all others are hidden
     about_hidden = st.Page(

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Literal, NoReturn
 import streamlit as st
 from streamlit.errors import NoSessionContext, StreamlitAPIException
 from streamlit.file_util import get_main_script_directory, normalize_path_join
-from streamlit.navigation.page import StreamlitPage, _validate_registered_page
+from streamlit.navigation.page import Page, _validate_registered_page
 from streamlit.runtime.fragment import _check_not_parallel_worker
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
@@ -193,7 +193,7 @@ def rerun(  # type: ignore[misc]
 
 @gather_metrics("switch_page")
 def switch_page(  # type: ignore[misc]
-    page: str | Path | StreamlitPage,
+    page: str | Path | Page,
     *,
     query_params: QueryParamsInput | None = None,
 ) -> NoReturn:  # ty: ignore[invalid-return-type]
@@ -207,7 +207,7 @@ def switch_page(  # type: ignore[misc]
 
     Parameters
     ----------
-    page : str, Path, or StreamlitPage
+    page : str, Path, or Page
         The page to switch to. This can be one of the following values:
 
         - Path to a Python file: The path can be a string or ``pathlib.Path``
@@ -218,13 +218,13 @@ def switch_page(  # type: ignore[misc]
           ``st.navigation``, the Python file must be your entrypoint file or
           a file in the ``pages/`` directory.
 
-        - ``StreamlitPage``: The source of the ``StreamlitPage`` and its
+        - ``Page``: The source of the ``Page`` and its
           ``url_path`` must match a page defined in ``st.navigation``. The
-          ``StreamlitPage`` must be internal and can't be defined by a URL.
-          Use ``st.Page`` to create a ``StreamlitPage`` object.
+          ``Page`` must be internal and can't be defined by a URL.
+          Use ``st.Page`` to create a ``Page`` object.
 
         To switch to a page defined by a ``callable``, you must use a
-        ``StreamlitPage`` object.
+        ``Page`` object.
 
     query_params : dict, list of tuples, or None
         Query parameters to apply when navigating to the target page.
@@ -296,7 +296,7 @@ def switch_page(  # type: ignore[misc]
         raise NoSessionContext()
 
     page_script_hash = ""
-    if isinstance(page, StreamlitPage):
+    if isinstance(page, Page):
         if page.is_external:
             raise StreamlitAPIException(
                 "Cannot use st.switch_page with external URL pages. "

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from streamlit import config
 from streamlit.errors import StreamlitAPIException
-from streamlit.navigation.page import StreamlitPage
+from streamlit.navigation.page import Page
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.Navigation_pb2 import Navigation as NavigationProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -36,25 +36,25 @@ if TYPE_CHECKING:
     from streamlit.source_util import PageHash, PageInfo
 
 SectionHeader: TypeAlias = str
-PageType: TypeAlias = str | Path | Callable[[], None] | StreamlitPage
+PageType: TypeAlias = str | Path | Callable[[], None] | Page
 
 
 def convert_to_streamlit_page(
     page_input: PageType,
-) -> StreamlitPage:
-    """Convert various input types to StreamlitPage objects."""
-    if isinstance(page_input, StreamlitPage):
+) -> Page:
+    """Convert various input types to Page objects."""
+    if isinstance(page_input, Page):
         return page_input
 
     if isinstance(page_input, str):
-        return StreamlitPage(page_input)
+        return Page(page_input)
 
     if isinstance(page_input, Path):
-        return StreamlitPage(page_input)
+        return Page(page_input)
 
     if callable(page_input):
-        # Convert function to StreamlitPage
-        return StreamlitPage(page_input)
+        # Convert function to Page
+        return Page(page_input)
 
     raise StreamlitAPIException(
         f"Invalid page type: {type(page_input)}. Must be either a string path, "
@@ -63,8 +63,8 @@ def convert_to_streamlit_page(
 
 
 def pages_from_nav_sections(
-    nav_sections: dict[SectionHeader, list[StreamlitPage]],
-) -> list[StreamlitPage]:
+    nav_sections: dict[SectionHeader, list[Page]],
+) -> list[Page]:
     page_list = []
     for pages in nav_sections.values():
         page_list.extend(pages.copy())
@@ -78,7 +78,7 @@ def send_page_not_found(ctx: ScriptRunContext) -> None:
     ctx.enqueue(msg)
 
 
-def _set_external_url(page_proto: AppPageProto, page: StreamlitPage) -> None:
+def _set_external_url(page_proto: AppPageProto, page: Page) -> None:
     """Set external_url on the AppPage proto when the page targets an external URL."""
     external_url = page.external_url
     if external_url is not None:
@@ -91,7 +91,7 @@ def navigation(
     *,
     position: Literal["sidebar", "hidden", "top"] = "sidebar",
     expanded: bool | int = False,
-) -> StreamlitPage:
+) -> Page:
     """
     Configure the available pages in a multipage app.
 
@@ -103,7 +103,7 @@ def navigation(
     ``streamlit run``) acts like a router or frame of common elements around
     each of your pages. Streamlit executes the entrypoint file with every app
     rerun. To execute the current page, you must call the ``.run()`` method on
-    the ``StreamlitPage`` object returned by ``st.navigation``.
+    the ``Page`` object returned by ``st.navigation``.
 
     The set of available pages can be updated with each rerun for dynamic
     navigation. By default, ``st.navigation`` displays the available pages in
@@ -120,7 +120,7 @@ def navigation(
 
         To create a navigation menu with no sections or page groupings,
         ``pages`` must be a list of page-like objects. Page-like objects are
-        anything that can be passed to ``st.Page`` or a ``StreamlitPage``
+        anything that can be passed to ``st.Page`` or a ``Page``
         object returned by ``st.Page``.
 
         To create labeled sections or page groupings within the navigation
@@ -134,7 +134,7 @@ def navigation(
         ``title`` parameter of ``st.Page``.
 
         When you use a string or path as a page-like object, they are
-        internally passed to ``st.Page`` and converted to ``StreamlitPage``
+        internally passed to ``st.Page`` and converted to ``Page``
         objects. In this case, the page will have the default title, icon, and
         path inferred from its path or filename. To customize these attributes
         for your page, initialize your page with ``st.Page``.
@@ -178,7 +178,7 @@ def navigation(
 
     Returns
     -------
-    StreamlitPage
+    Page
         The current page selected by the user. To run the page, you must use
         the ``.run()`` method on it.
 
@@ -192,7 +192,7 @@ def navigation(
 
     You can declare pages from callables or file paths. If you pass callables
     or paths to ``st.navigation`` as a page-like objects, they are internally
-    converted to ``StreamlitPage`` objects using ``st.Page``. In this case, the
+    converted to ``Page`` objects using ``st.Page``. In this case, the
     page titles, icons, and paths are inferred from the file or callable names.
 
     ``page_1.py`` (in the same directory as your entrypoint file):
@@ -334,7 +334,7 @@ def _navigation(
     *,
     position: Literal["sidebar", "hidden", "top"],
     expanded: bool | int,
-) -> StreamlitPage:
+) -> Page:
     if isinstance(pages, Sequence):
         converted_pages = [convert_to_streamlit_page(p) for p in pages]
         nav_sections = {"": converted_pages}

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -49,7 +49,7 @@ from streamlit.errors import (
     StreamlitPageNotFoundError,
 )
 from streamlit.file_util import get_main_script_directory, normalize_path_join
-from streamlit.navigation.page import StreamlitPage, _validate_registered_page
+from streamlit.navigation.page import Page, _validate_registered_page
 from streamlit.proto.Button_pb2 import Button as ButtonProto
 from streamlit.proto.ButtonLikeIconPosition_pb2 import (
     ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
@@ -1095,7 +1095,7 @@ class ButtonMixin:
     @gather_metrics("page_link")
     def page_link(
         self,
-        page: str | Path | StreamlitPage,
+        page: str | Path | Page,
         *,
         label: str | None = None,
         icon: str | None = None,
@@ -1118,7 +1118,7 @@ class ButtonMixin:
 
         Parameters
         ----------
-        page : str, Path, or StreamlitPage
+        page : str, Path, or Page
             The page to switch to on user click. This can be one of the
             following values:
 
@@ -1131,9 +1131,9 @@ class ButtonMixin:
               ``st.navigation``, the Python file must be your entrypoint file
               or a file in the ``pages/`` directory.
 
-            - ``StreamlitPage``: The source of the ``StreamlitPage`` and its
+            - ``Page``: The source of the ``Page`` and its
               ``url_path`` must match a page defined in ``st.navigation``.
-              Use ``st.Page`` to create a ``StreamlitPage`` object.
+              Use ``st.Page`` to create a ``Page`` object.
 
             - URL: The URL must contain an HTTP or HTTPS scheme, like
               ``"https://docs.streamlit.io"``. When a user clicks a
@@ -1142,7 +1142,7 @@ class ButtonMixin:
               ``label`` parameter is required.
 
             To link to a page defined by a ``callable``, you must use a
-            ``StreamlitPage`` object.
+            ``Page`` object.
 
         label : str
             The label for the page link. Labels are required for external pages.
@@ -1165,7 +1165,7 @@ class ButtonMixin:
         icon : str or None
             An optional emoji or icon to display next to the link label. If
             ``icon`` is ``None`` (default), the icon is inferred from the
-            ``StreamlitPage`` object or no icon is displayed. If ``icon`` is a
+            ``Page`` object or no icon is displayed. If ``icon`` is a
             string, the following options are valid:
 
             - A single-character emoji. For example, you can set ``icon="🚨"``
@@ -1520,7 +1520,7 @@ class ButtonMixin:
 
     def _page_link(
         self,
-        page: str | Path | StreamlitPage,
+        page: str | Path | Page,
         *,  # keyword-only arguments:
         label: str | None = None,
         icon: str | None = None,
@@ -1556,12 +1556,12 @@ class ButtonMixin:
         if help is not None:
             page_link_proto.help = dedent(help)
 
-        if isinstance(page, StreamlitPage):
+        if isinstance(page, Page):
             if label is None:
                 page_link_proto.label = page.title
             if icon is None:
                 page_link_proto.icon = page.icon
-                # Here the StreamlitPage's icon is already validated
+                # Here the Page's icon is already validated
                 # (using validate_icon_or_emoji) during its initialization
 
             if page.is_external:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -496,7 +496,7 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
         directory = os.path.basename(main_script_directory)
 
         message = (
-            "Could not find page: `{page}`. You must provide a `StreamlitPage` "
+            "Could not find page: `{page}`. You must provide a `Page` "
             "object or file path relative to the entrypoint file. Only pages "
             "previously defined by `st.Page` and passed to `st.navigation` are "
             "allowed."

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -51,23 +51,14 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-@gather_metrics("Page")
-def Page(  # noqa: N802
-    page: str | Path | Callable[[], None],
-    *,
-    title: str | None = None,
-    icon: str | None = None,
-    url_path: str | None = None,
-    default: bool = False,
-    visibility: Literal["visible", "hidden"] = "visible",
-) -> StreamlitPage:
+class Page:
     """Configure a page for ``st.navigation`` in a multipage app.
 
-    Call ``st.Page`` to initialize a ``StreamlitPage`` object, and pass it to
+    Call ``st.Page`` to initialize a ``Page`` object, and pass it to
     ``st.navigation`` to declare a page in your app.
 
     When a user navigates to a page, ``st.navigation`` returns the selected
-    ``StreamlitPage`` object. Call ``.run()`` on the returned ``StreamlitPage``
+    ``Page`` object. Call ``.run()`` on the returned ``Page``
     object to execute the page. You can only run the page returned by
     ``st.navigation``, and you can only run it once per app rerun.
 
@@ -174,47 +165,6 @@ def Page(  # noqa: N802
            ``st.navigation`` during the new session's initial script
            run. The page can be visible or hidden.
 
-    Returns
-    -------
-    StreamlitPage
-        The page object associated to the given script.
-
-    Example
-    -------
-    .. code-block:: python
-        :filename: streamlit_app.py
-
-        import streamlit as st
-
-        def page2():
-            st.title("Second page")
-
-        pg = st.navigation([
-            st.Page("page1.py", title="First page", icon="🔥"),
-            st.Page(page2, title="Second page", icon=":material/favorite:"),
-            st.Page(
-                "https://docs.streamlit.io",
-                title="Streamlit Docs",
-                icon=":material/open_in_new:"
-            ),
-        ])
-        pg.run()
-    """
-    return StreamlitPage(
-        page,
-        title=title,
-        icon=icon,
-        url_path=url_path,
-        default=default,
-        visibility=visibility,
-    )
-
-
-class StreamlitPage:
-    """A page within a multipage Streamlit app.
-
-    Use ``st.Page`` to initialize a ``StreamlitPage`` object.
-
     Attributes
     ----------
     icon : str
@@ -261,8 +211,29 @@ class StreamlitPage:
            to ``st.navigation`` during the new session's initial script
            run.
 
+    Example
+    -------
+    .. code-block:: python
+        :filename: streamlit_app.py
+
+        import streamlit as st
+
+        def page2():
+            st.title("Second page")
+
+        pg = st.navigation([
+            st.Page("page1.py", title="First page", icon="🔥"),
+            st.Page(page2, title="Second page", icon=":material/favorite:"),
+            st.Page(
+                "https://docs.streamlit.io",
+                title="Streamlit Docs",
+                icon=":material/open_in_new:"
+            ),
+        ])
+        pg.run()
     """
 
+    @gather_metrics("Page", _positional_arg_offset=1)
     def __init__(
         self,
         page: str | Path | Callable[[], None],
@@ -516,11 +487,27 @@ class StreamlitPage:
         return calc_hash(self._url_path)
 
 
-def _validate_registered_page(page: StreamlitPage) -> None:
-    """Validate that a ``StreamlitPage`` matches what was registered with
+# Keep this alias for backward compatibility with existing imports and
+# isinstance checks.
+StreamlitPage = Page
+
+
+def _create_page(page: str | Path, *, default: bool = False) -> Page:
+    """Create an internal Page without recording public-command telemetry."""
+    page_object = Page.__new__(Page)
+    # ``gather_metrics`` wraps ``__init__``, so ``__wrapped__`` is the original
+    # initializer; calling it directly skips the telemetry recorded for st.Page.
+    Page.__init__.__wrapped__(  # type: ignore[attr-defined]
+        page_object, page, default=default
+    )
+    return page_object
+
+
+def _validate_registered_page(page: Page) -> None:
+    """Validate that a ``Page`` matches what was registered with
     ``st.navigation``.
 
-    Page hashes are derived solely from ``url_path``, so two ``StreamlitPage``
+    Page hashes are derived solely from ``url_path``, so two ``Page``
     objects sharing a ``url_path`` collide even when their underlying source
     differs. Without this check, ``st.switch_page`` and ``st.page_link`` would
     silently route to the registered page rather than surfacing the mismatch.

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -413,7 +413,11 @@ def _get_arg_keywords(func: Callable[..., Any]) -> list[str]:
 
 
 def _get_command_telemetry(
-    _command_func: Callable[..., Any], _command_name: str, *args: Any, **kwargs: Any
+    _command_func: Callable[..., Any],
+    _command_name: str,
+    *args: Any,
+    _positional_arg_offset: int = 0,
+    **kwargs: Any,
 ) -> Command:
     """Get telemetry information for the given callable and its arguments."""
     arg_keywords = _get_arg_keywords(_command_func)
@@ -423,7 +427,10 @@ def _get_command_telemetry(
     name = _command_name
 
     for i, arg in enumerate(args):
-        pos = i
+        # Offset the recorded position so a decorated method's first real
+        # argument lands at position 0, matching a plain-function command that
+        # has no leading ``self`` argument (see ``_positional_arg_offset``).
+        pos = i - _positional_arg_offset
         if is_method:
             # If func is a method, ignore the first argument (self)
             i += 1  # noqa: PLW2901
@@ -481,6 +488,8 @@ F = TypeVar("F", bound=Callable[..., Any])
 def gather_metrics(
     name: str,
     func: F,
+    *,
+    _positional_arg_offset: int = 0,
 ) -> F: ...
 
 
@@ -488,10 +497,17 @@ def gather_metrics(
 def gather_metrics(
     name: str,
     func: None = None,
+    *,
+    _positional_arg_offset: int = 0,
 ) -> Callable[[F], F]: ...
 
 
-def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
+def gather_metrics(
+    name: str,
+    func: F | None = None,
+    *,
+    _positional_arg_offset: int = 0,
+) -> Callable[[F], F] | F:
     """Function decorator to add telemetry tracking to commands.
 
     Parameters
@@ -501,6 +517,11 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
     func : callable or None
         The function to track for telemetry. If ``None`` (default), returns a
         decorator that can be applied to a function.
+    _positional_arg_offset : int
+        The number of leading positional arguments to exclude from the recorded
+        argument positions. Set this to ``1`` when decorating a method (such as
+        a class ``__init__``) so that its first real argument is recorded at
+        position ``0``, matching an equivalent plain-function command.
 
     Examples
     --------
@@ -519,6 +540,7 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
             return gather_metrics(
                 name=name,
                 func=f,
+                _positional_arg_offset=_positional_arg_offset,
             )
 
         return wrapper
@@ -550,7 +572,11 @@ def gather_metrics(name: str, func: F | None = None) -> Callable[[F], F] | F:
         if ctx and tracking_activated:
             try:
                 command_telemetry = _get_command_telemetry(
-                    non_optional_func, name, *args, **kwargs
+                    non_optional_func,
+                    name,
+                    *args,
+                    _positional_arg_offset=_positional_arg_offset,
+                    **kwargs,
                 )
 
                 ctx.shared.track_command(command_telemetry, _MAX_TRACKED_PER_COMMAND)

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -518,10 +518,12 @@ def gather_metrics(
         The function to track for telemetry. If ``None`` (default), returns a
         decorator that can be applied to a function.
     _positional_arg_offset : int
-        The number of leading positional arguments to exclude from the recorded
-        argument positions. Set this to ``1`` when decorating a method (such as
-        a class ``__init__``) so that its first real argument is recorded at
-        position ``0``, matching an equivalent plain-function command.
+        How many leading positional arguments to skip when assigning recorded
+        position indexes. The arguments are still tracked; only their stored
+        position (``p``) is shifted. Set this to ``1`` when decorating a method
+        (such as a class ``__init__``) so that its first real argument is
+        recorded at position ``0``, matching an equivalent plain-function
+        command.
 
     Examples
     --------

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -132,7 +132,7 @@ def _mpa_v1(main_script_path: str) -> None:
     from pathlib import Path
 
     from streamlit.commands.navigation import PageType, _navigation
-    from streamlit.navigation.page import StreamlitPage
+    from streamlit.navigation.page import _create_page
 
     # Select the folder that should be used for the pages:
     resolved_main_script_path: Final = Path(main_script_path).resolve()
@@ -151,10 +151,8 @@ def _mpa_v1(main_script_path: str) -> None:
     )
 
     # Use this script as the main page and
-    main_page = StreamlitPage(resolved_main_script_path, default=True)
-    all_pages = [main_page] + [
-        StreamlitPage(pages_folder / page.name) for page in pages
-    ]
+    main_page = _create_page(resolved_main_script_path, default=True)
+    all_pages = [main_page] + [_create_page(pages_folder / page.name) for page in pages]
     # Initialize the navigation with all the pages:
     position: Literal["sidebar", "hidden", "top"] = (
         "hidden"

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -24,7 +24,7 @@ from streamlit.commands.execution_control import (
     switch_page,
 )
 from streamlit.errors import NoSessionContext, StreamlitAPIException
-from streamlit.navigation.page import StreamlitPage
+from streamlit.navigation.page import Page
 from streamlit.runtime.scriptrunner import RerunData
 from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -139,8 +139,8 @@ def test_st_switch_page_context_info(patched_get_script_run_ctx):
 
     patched_get_script_run_ctx.return_value = ctx
 
-    # Mock the StreamlitPage object and its _script_hash attribute
-    mock_page = MagicMock(spec=StreamlitPage)
+    # Mock the Page object and its _script_hash attribute
+    mock_page = MagicMock(spec=Page)
     mock_page._script_hash = "target_page_hash"
     mock_page.is_external = False
 
@@ -181,7 +181,7 @@ def test_st_switch_page_applies_query_params(patched_get_script_run_ctx):
 
     mock_query_params.from_dict.side_effect = _from_dict_side_effect
 
-    mocked_page = MagicMock(spec=StreamlitPage)
+    mocked_page = MagicMock(spec=Page)
     mocked_page._script_hash = "target_page_hash"
     mocked_page.is_external = False
 
@@ -226,7 +226,7 @@ def test_st_switch_page_applies_iterable_query_params(patched_get_script_run_ctx
 
     mock_query_params.from_dict.side_effect = _from_dict_side_effect
 
-    mocked_page = MagicMock(spec=StreamlitPage)
+    mocked_page = MagicMock(spec=Page)
     mocked_page._script_hash = "target_page_hash"
     mocked_page.is_external = False
 
@@ -262,7 +262,7 @@ def test_st_switch_page_rejects_invalid_query_params(patched_get_script_run_ctx)
 
     patched_get_script_run_ctx.return_value = ctx
 
-    mocked_page = MagicMock(spec=StreamlitPage)
+    mocked_page = MagicMock(spec=Page)
     mocked_page._script_hash = "target_page_hash"
     mocked_page.is_external = False
 
@@ -281,7 +281,7 @@ def test_st_switch_page_raises_for_external_page(patched_get_script_run_ctx):
     ctx.script_requests = MagicMock()
     patched_get_script_run_ctx.return_value = ctx
 
-    mock_page = MagicMock(spec=StreamlitPage)
+    mock_page = MagicMock(spec=Page)
     mock_page.is_external = True
 
     with pytest.raises(
@@ -412,8 +412,8 @@ def test_st_switch_page_string_path_unknown_page_raises(
 
 
 @patch("pathlib.Path.is_file", MagicMock(return_value=True))
-class SwitchPageStreamlitPageValidationTest(DeltaGeneratorTestCase):
-    """Test that ``st.switch_page`` validates a passed ``StreamlitPage`` against
+class SwitchPagePageValidationTest(DeltaGeneratorTestCase):
+    """Test that ``st.switch_page`` validates a passed ``Page`` against
     pages registered with ``st.navigation`` and raises when the source does not
     match the registered page sharing the same URL pathname.
 
@@ -421,7 +421,7 @@ class SwitchPageStreamlitPageValidationTest(DeltaGeneratorTestCase):
     """
 
     def test_streamlit_page_with_mismatched_file_path_raises(self) -> None:
-        """Switching to a ``StreamlitPage`` whose file path does not match the
+        """Switching to a ``Page`` whose file path does not match the
         page registered under the same ``url_path`` raises."""
         import streamlit as st
 
@@ -442,7 +442,7 @@ class SwitchPageStreamlitPageValidationTest(DeltaGeneratorTestCase):
             st.switch_page(st.Page("foo.py"))
 
     def test_streamlit_page_callable_with_file_registered_raises(self) -> None:
-        """Switching to a callable-based ``StreamlitPage`` raises when the
+        """Switching to a callable-based ``Page`` raises when the
         registered page sharing its ``url_path`` is file-based."""
         import streamlit as st
 
@@ -455,7 +455,7 @@ class SwitchPageStreamlitPageValidationTest(DeltaGeneratorTestCase):
             st.switch_page(st.Page(some_callable, url_path="foo"))
 
     def test_streamlit_page_matching_source_does_not_raise(self) -> None:
-        """A ``StreamlitPage`` whose source matches the registered page is
+        """A ``Page`` whose source matches the registered page is
         accepted by validation (no ``StreamlitAPIException`` raised)."""
         import streamlit as st
 

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -420,7 +420,7 @@ class SwitchPagePageValidationTest(DeltaGeneratorTestCase):
     Regression coverage for https://github.com/streamlit/streamlit/issues/10572.
     """
 
-    def test_streamlit_page_with_mismatched_file_path_raises(self) -> None:
+    def test_page_with_mismatched_file_path_raises(self) -> None:
         """Switching to a ``Page`` whose file path does not match the
         page registered under the same ``url_path`` raises."""
         import streamlit as st
@@ -431,7 +431,7 @@ class SwitchPagePageValidationTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException, match=r"different page is "):
             st.switch_page(bad_page)
 
-    def test_streamlit_page_with_inferred_url_path_mismatch_raises(self) -> None:
+    def test_page_with_inferred_url_path_mismatch_raises(self) -> None:
         """Switching to ``st.Page("foo.py")`` (url_path inferred as ``foo``)
         raises when a different file is registered under ``url_path="foo"``."""
         import streamlit as st
@@ -441,7 +441,7 @@ class SwitchPagePageValidationTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException, match=r"different page is "):
             st.switch_page(st.Page("foo.py"))
 
-    def test_streamlit_page_callable_with_file_registered_raises(self) -> None:
+    def test_page_callable_with_file_registered_raises(self) -> None:
         """Switching to a callable-based ``Page`` raises when the
         registered page sharing its ``url_path`` is file-based."""
         import streamlit as st
@@ -454,7 +454,7 @@ class SwitchPagePageValidationTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitAPIException, match=r"is a callable"):
             st.switch_page(st.Page(some_callable, url_path="foo"))
 
-    def test_streamlit_page_matching_source_does_not_raise(self) -> None:
+    def test_page_matching_source_does_not_raise(self) -> None:
         """A ``Page`` whose source matches the registered page is
         accepted by validation (no ``StreamlitAPIException`` raised)."""
         import streamlit as st
@@ -465,7 +465,7 @@ class SwitchPagePageValidationTest(DeltaGeneratorTestCase):
         # Validation passes — the rerun side effect is harmless for this test.
         st.switch_page(matching)
 
-    def test_streamlit_page_unregistered_url_path_does_not_raise(self) -> None:
+    def test_page_unregistered_url_path_does_not_raise(self) -> None:
         """If no page with the given ``url_path`` is registered (no hash
         collision), validation is skipped — preserving previous behavior for
         apps that don't use ``st.navigation``."""

--- a/lib/tests/streamlit/commands/navigation_test.py
+++ b/lib/tests/streamlit/commands/navigation_test.py
@@ -19,7 +19,7 @@ import pytest
 import streamlit as st
 from streamlit.commands.navigation import convert_to_streamlit_page
 from streamlit.errors import StreamlitAPIException
-from streamlit.navigation.page import StreamlitPage
+from streamlit.navigation.page import Page, StreamlitPage
 from streamlit.proto.Navigation_pb2 import Navigation as NavigationProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.testutil import patch_config_options
@@ -38,7 +38,9 @@ class NavigationTest(DeltaGeneratorTestCase):
         """Test that a single page is returned"""
         single_page = st.Page("page1.py")
         page = st.navigation([single_page])
-        assert page == single_page
+        assert page is single_page
+        assert type(page) is Page
+        assert isinstance(page, StreamlitPage)
 
     def test_single_page_with_path(self):
         """Test that a single page is returned with a Path object"""
@@ -232,27 +234,28 @@ class NavigationTest(DeltaGeneratorTestCase):
         assert "must be a bool or a non-negative integer" in str(exc.value)
 
     def test_convert_to_streamlit_page_with_string(self):
-        """Test converting string path to StreamlitPage"""
+        """Test converting string path to Page."""
         page = convert_to_streamlit_page("page1.py")
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         assert isinstance(page._page, Path)
         assert str(page._page) == str(Path("page1.py").absolute())
 
     def test_convert_to_streamlit_page_with_function(self):
-        """Test converting function to StreamlitPage"""
+        """Test converting function to Page."""
 
         def test_page():
             pass
 
         page = convert_to_streamlit_page(test_page)
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         assert page._page == test_page
 
     def test_convert_to_streamlit_page_with_streamlit_page(self):
-        """Test passing StreamlitPage directly"""
+        """Test passing Page directly."""
         original_page = st.Page("page1.py")
         page = convert_to_streamlit_page(original_page)
-        assert page == original_page
+        assert page is original_page
+        assert isinstance(page, StreamlitPage)
 
     def test_convert_to_streamlit_page_invalid_type(self):
         """Test that invalid types raise exception"""
@@ -264,7 +267,7 @@ class NavigationTest(DeltaGeneratorTestCase):
         """Test navigation with list of strings"""
         pages = ["page1.py", "page2.py", "page3.py"]
         page = st.navigation(pages)
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         c = self.get_message_from_queue().navigation
         assert len(c.app_pages) == 3
         assert c.app_pages[0].is_default
@@ -282,21 +285,21 @@ class NavigationTest(DeltaGeneratorTestCase):
 
         pages = [page1, page2]
         page = st.navigation(pages)
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         c = self.get_message_from_queue().navigation
         assert len(c.app_pages) == 2
         assert c.app_pages[0].is_default
         assert not c.app_pages[1].is_default
 
     def test_navigation_with_mixed_list(self):
-        """Test navigation with mixed list of strings, functions and StreamlitPages"""
+        """Test navigation with mixed list of strings, functions, and Pages."""
 
         def page2():
             pass
 
         pages = ["page1.py", page2, st.Page("page3.py")]
         page = st.navigation(pages)
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         c = self.get_message_from_queue().navigation
         assert len(c.app_pages) == 3
         assert c.app_pages[0].is_default
@@ -332,9 +335,9 @@ class NavigationTest(DeltaGeneratorTestCase):
             )
 
     def test_convert_to_streamlit_page_with_pathlib_path(self):
-        """Test converting pathlib.Path to StreamlitPage"""
+        """Test converting pathlib.Path to Page."""
         page = convert_to_streamlit_page(Path("page1.py"))
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         assert isinstance(page._page, Path)
         assert str(page._page) == str(Path("page1.py").absolute())
 
@@ -342,7 +345,7 @@ class NavigationTest(DeltaGeneratorTestCase):
         """Test navigation with list of pathlib.Path"""
         pages = [Path("page1.py"), Path("page2.py"), Path("page3.py")]
         page = st.navigation(pages)
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         c = self.get_message_from_queue().navigation
         assert len(c.app_pages) == 3
         assert c.app_pages[0].is_default
@@ -357,7 +360,7 @@ class NavigationTest(DeltaGeneratorTestCase):
 
         pages = [Path("page1.py"), page2, st.Page("page3.py")]
         page = st.navigation(pages)
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         c = self.get_message_from_queue().navigation
         assert len(c.app_pages) == 3
         assert c.app_pages[0].is_default
@@ -390,7 +393,7 @@ class NavigationTest(DeltaGeneratorTestCase):
                 st.Page("page2.py", icon=":material/settings:"),
             ]
         )
-        assert isinstance(page, StreamlitPage)
+        assert type(page) is Page
         c = self.get_message_from_queue().navigation
         assert len(c.app_pages) == 2
         assert c.app_pages[0].icon == "emoji:🚀"

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -30,7 +30,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.elements.widgets.button import marshall_file
 from streamlit.errors import StreamlitAPIException, StreamlitPageNotFoundError
-from streamlit.navigation.page import StreamlitPage
+from streamlit.navigation.page import Page
 from streamlit.proto.ButtonLikeIconPosition_pb2 import (
     ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
 )
@@ -633,10 +633,10 @@ class ButtonTest(DeltaGeneratorTestCase):
                         st.page_link("pages/nonexistent.py")
 
     def test_page_link_with_streamlit_page(self):
-        """Test page_link with StreamlitPage object."""
-        # Create a StreamlitPage manually without going through the constructor
+        """Test page_link with Page object."""
+        # Create a Page manually without going through the constructor
         # that checks for file existence
-        page = MagicMock(spec=StreamlitPage)
+        page = MagicMock(spec=Page)
         page._page = Path("/app/page.py")
         page._title = "Test Page"
         page._icon = "🏠"

--- a/lib/tests/streamlit/elements/page_link_test.py
+++ b/lib/tests/streamlit/elements/page_link_test.py
@@ -200,8 +200,8 @@ class PageLinkTest(DeltaGeneratorTestCase):
 
     @patch("pathlib.Path.is_file", MagicMock(return_value=True))
     def test_st_page_with_none_icon(self):
-        """Test that st.page_link handles None icon from StreamlitPage correctly"""
-        # None icon defaults to empty string in StreamlitPage
+        """Test that st.page_link handles None icon from Page correctly."""
+        # None icon defaults to empty string in Page
         page = st.Page("foo.py", title="Bar Test", icon=None)
         st.page_link(page=page)
 
@@ -215,7 +215,7 @@ class PageLinkTest(DeltaGeneratorTestCase):
         assert c.help == ""
 
     def test_external_streamlit_page(self):
-        """Test that st.page_link works with an external StreamlitPage object."""
+        """Test that st.page_link works with an external Page object."""
         page = st.Page("https://docs.streamlit.io", title="Docs", icon="📖")
         st.page_link(page=page)
 
@@ -227,7 +227,7 @@ class PageLinkTest(DeltaGeneratorTestCase):
         assert not c.disabled
 
     def test_external_streamlit_page_with_label_override(self):
-        """Test that st.page_link label overrides external StreamlitPage title."""
+        """Test that st.page_link label overrides an external Page title."""
         page = st.Page("https://docs.streamlit.io", title="Docs")
         st.page_link(page=page, label="Custom Label")
 

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -22,8 +23,44 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.navigation.page import Page, StreamlitPage, _create_page
 from tests.conftest import enable_mpa_v2_mode
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+
+def test_page_is_a_class_with_compatibility_alias() -> None:
+    """st.Page is the concrete Page class, with StreamlitPage as an alias."""
+    assert inspect.isclass(st.Page)
+    assert st.Page is Page
+    assert StreamlitPage is Page
+
+    page = st.Page(lambda: None, title="Example")
+    assert type(page) is Page
+    assert isinstance(page, st.Page)
+    assert isinstance(page, StreamlitPage)
+
+
+def test_page_constructor_signature() -> None:
+    """The Page class preserves the public factory's constructor parameters."""
+    parameters = inspect.signature(st.Page).parameters
+
+    assert list(parameters) == [
+        "page",
+        "title",
+        "icon",
+        "url_path",
+        "default",
+        "visibility",
+    ]
+    assert parameters["page"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["page"].default is inspect.Parameter.empty
+    for name in ("title", "icon", "url_path", "default", "visibility"):
+        assert parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["title"].default is None
+    assert parameters["icon"].default is None
+    assert parameters["url_path"].default is None
+    assert parameters["default"].default is False
+    assert parameters["visibility"].default == "visible"
 
 
 @patch("pathlib.Path.is_file", MagicMock(return_value=True))
@@ -81,6 +118,25 @@ class StPagesTest(DeltaGeneratorTestCase):
             st.Page(lambda: True, url_path="path_1")._script_hash
             != st.Page(lambda: True, url_path="path_2")._script_hash
         )
+
+    def test_create_page_builds_default_page(self) -> None:
+        """``_create_page`` builds a fully-initialized default page."""
+        page = _create_page("home.py", default=True)
+
+        assert type(page) is Page
+        assert page._default is True
+        # Default pages always report an empty ``url_path`` (the root URL).
+        assert page.url_path == ""
+        assert page.is_external is False
+        # Only the page returned by ``st.navigation`` may be run.
+        assert page._can_be_called is False
+
+    def test_create_page_infers_url_path_for_non_default_page(self) -> None:
+        """``_create_page`` infers the ``url_path`` from the filename."""
+        page = _create_page("settings.py")
+
+        assert page._default is False
+        assert page.url_path == "settings"
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -242,7 +242,8 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
 
     @patch("pathlib.Path.is_file", MagicMock(return_value=True))
     def test_page_constructor_telemetry(self) -> None:
-        """Page preserves the factory's command name and argument metadata."""
+        """Page records the same command name and argument metadata as the
+        previous function-based st.Page."""
         st.Page(
             "foo.py",
             title="Title",
@@ -259,6 +260,10 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         assert command.name == "Page"
         assert len(command.args) == 6
         assert str(command.args[0]).strip() == 'k: "page"\nt: "str"\nm: "len:6"'
+        # ``_positional_arg_offset=1`` must place the first real argument at
+        # position 0 (like a plain function), not 1 (shifted by ``self``).
+        # ``str()`` above omits the proto default ``p: 0``, so assert it directly.
+        assert command.args[0].p == 0
         assert str(command.args[1]).strip() == 'k: "title"\nt: "str"\nm: "len:5"'
         assert str(command.args[2]).strip() == 'k: "icon"\nt: "str"\nm: "len:1"'
         assert str(command.args[3]).strip() == 'k: "url_path"\nt: "str"\nm: "len:3"'

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -33,6 +33,8 @@ import streamlit.components.v1 as components
 from streamlit import config
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.connections import SQLConnection
+from streamlit.errors import StreamlitValueError
+from streamlit.navigation.page import _create_page
 from streamlit.runtime import metrics_util
 from streamlit.runtime.caching import cache_data_api, cache_resource_api
 from streamlit.runtime.scriptrunner import get_script_run_ctx, magic_funcs
@@ -236,6 +238,68 @@ class PageTelemetryTest(DeltaGeneratorTestCase):
         assert (
             str(command_metadata.args[2]).strip()
             == 'k: "disabled"\nt: "bool"\nm: "val:True"'
+        )
+
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_page_constructor_telemetry(self) -> None:
+        """Page preserves the factory's command name and argument metadata."""
+        st.Page(
+            "foo.py",
+            title="Title",
+            icon="🔥",
+            url_path="foo",
+            default=False,
+            visibility="hidden",
+        )
+
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        assert len(ctx.shared.tracked_commands) == 1
+        command = ctx.shared.tracked_commands[0]
+        assert command.name == "Page"
+        assert len(command.args) == 6
+        assert str(command.args[0]).strip() == 'k: "page"\nt: "str"\nm: "len:6"'
+        assert str(command.args[1]).strip() == 'k: "title"\nt: "str"\nm: "len:5"'
+        assert str(command.args[2]).strip() == 'k: "icon"\nt: "str"\nm: "len:1"'
+        assert str(command.args[3]).strip() == 'k: "url_path"\nt: "str"\nm: "len:3"'
+        assert str(command.args[4]).strip() == 'k: "default"\nt: "bool"\nm: "val:False"'
+        assert str(command.args[5]).strip() == 'k: "visibility"\nt: "str"\nm: "len:6"'
+
+    def test_page_constructor_exception_is_tracked(self) -> None:
+        """Page constructor failures retain the existing telemetry event."""
+        with pytest.raises(StreamlitValueError):
+            st.Page("foo.py", visibility="invalid")
+
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        assert len(ctx.shared.tracked_commands) == 1
+        assert ctx.shared.tracked_commands[0].name == "Page"
+
+    @patch("pathlib.Path.is_file", MagicMock(return_value=True))
+    def test_internal_page_creation_is_not_tracked(self) -> None:
+        """Legacy pages-directory bootstrapping does not emit Page commands."""
+        _create_page("foo.py")
+
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        assert ctx.shared.tracked_commands == ()
+
+    def test_decorated_method_positional_metadata_is_unchanged(self) -> None:
+        """The Page-specific position offset does not affect other methods."""
+
+        class Example:
+            @metrics_util.gather_metrics("tracked_method")
+            def tracked_method(self, value: str) -> None:
+                pass
+
+        Example().tracked_method("value")
+
+        ctx = get_script_run_ctx()
+        assert ctx is not None
+        assert len(ctx.shared.tracked_commands) == 1
+        assert (
+            str(ctx.shared.tracked_commands[0].args[0]).strip()
+            == 'k: "value"\nt: "str"\nm: "len:5"\np: 1'
         )
 
     def test_get_command_telemetry_custom_component_v2(self):

--- a/lib/tests/streamlit/typing/button_types.py
+++ b/lib/tests/streamlit/typing/button_types.py
@@ -306,8 +306,8 @@ if TYPE_CHECKING:
     assert_type(page_link("https://example.com", label="External"), DeltaGenerator)
 
     # Page link with Page object
-    streamlit_page = Page("page1.py")
-    assert_type(page_link(streamlit_page), DeltaGenerator)
+    page = Page("page1.py")
+    assert_type(page_link(page), DeltaGenerator)
 
     # Page link with label
     assert_type(page_link("pages/page1.py", label="Page 1"), DeltaGenerator)

--- a/lib/tests/streamlit/typing/button_types.py
+++ b/lib/tests/streamlit/typing/button_types.py
@@ -300,12 +300,12 @@ if TYPE_CHECKING:
     # =====================================================================
 
     # Basic page link - returns DeltaGenerator
-    # page parameter accepts str, Path, or StreamlitPage
+    # page parameter accepts str, Path, or Page
     assert_type(page_link("pages/page1.py"), DeltaGenerator)
     assert_type(page_link(Path("pages/page1.py")), DeltaGenerator)
     assert_type(page_link("https://example.com", label="External"), DeltaGenerator)
 
-    # Page link with StreamlitPage object
+    # Page link with Page object
     streamlit_page = Page("page1.py")
     assert_type(page_link(streamlit_page), DeltaGenerator)
 

--- a/lib/tests/streamlit/typing/navigation_types.py
+++ b/lib/tests/streamlit/typing/navigation_types.py
@@ -26,27 +26,32 @@ if TYPE_CHECKING:
     from streamlit.navigation.page import Page, StreamlitPage
 
     # Test basic list input
-    assert_type(navigation(["page1.py"]), StreamlitPage)
-    assert_type(navigation([Path("page1.py")]), StreamlitPage)
+    assert_type(navigation(["page1.py"]), Page)
+    assert_type(navigation([Path("page1.py")]), Page)
 
     # Test dictionary input with sections
     assert_type(
         navigation(
             {"Section 1": ["page1.py", "page2.py"], "Section 2": [Path("page3.py")]}
         ),
-        StreamlitPage,
+        Page,
     )
 
-    # Test with StreamlitPage objects
+    # Test with Page objects
     page1 = Page("page1.py")
     page2 = Page("page2.py")
-    assert_type(navigation([page1, page2]), StreamlitPage)
+    assert_type(navigation([page1, page2]), Page)
+
+    # StreamlitPage remains a valid identity alias for compatibility.
+    legacy_page: StreamlitPage = Page("legacy.py")
+    assert_type(legacy_page, StreamlitPage)
+    assert_type(StreamlitPage("legacy.py"), Page)
 
     # Test with callable functions
     def page_func() -> None:
         pass
 
-    assert_type(navigation([page_func]), StreamlitPage)
+    assert_type(navigation([page_func]), Page)
 
     # Test with mixed types in a dictionary
     assert_type(
@@ -56,31 +61,27 @@ if TYPE_CHECKING:
                 "Section 2": [page2],
             }
         ),
-        StreamlitPage,
+        Page,
     )
 
     # Test with mixed types in a list
     assert_type(
         navigation(["page1.py", Path("page2.py"), page1, page_func]),
-        StreamlitPage,
+        Page,
     )
 
     # Test with position and expanded parameters
-    assert_type(
-        navigation(["page1.py"], position="sidebar", expanded=True), StreamlitPage
-    )
-    assert_type(
-        navigation(["page1.py"], position="hidden", expanded=False), StreamlitPage
-    )
+    assert_type(navigation(["page1.py"], position="sidebar", expanded=True), Page)
+    assert_type(navigation(["page1.py"], position="hidden", expanded=False), Page)
     # Test expanded with integer values
-    assert_type(navigation(["page1.py"], expanded=5), StreamlitPage)
-    assert_type(navigation(["page1.py"], expanded=0), StreamlitPage)
+    assert_type(navigation(["page1.py"], expanded=5), Page)
+    assert_type(navigation(["page1.py"], expanded=0), Page)
 
     # Test Page with visibility parameter
     visible_page = Page("page.py", visibility="visible")
     hidden_page = Page("page.py", visibility="hidden")
-    assert_type(visible_page, StreamlitPage)
-    assert_type(hidden_page, StreamlitPage)
+    assert_type(visible_page, Page)
+    assert_type(hidden_page, Page)
 
     # Test visibility property returns correct Literal type
     assert_type(visible_page.visibility, Literal["visible", "hidden"])

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -993,7 +993,7 @@ During a sequential fragment rerun, `st.switch_page` is a valid and common patte
 (`lib/streamlit/commands/execution_control.py`):
 
 ```python
-def switch_page(page: str | Path | StreamlitPage, ...) -> NoReturn:
+def switch_page(page: str | Path | Page, ...) -> NoReturn:
     ctx = get_script_run_ctx()
     if ctx:
         _check_not_parallel_worker("st.switch_page")


### PR DESCRIPTION
## Describe your changes

`st.Page` was a factory function that returned a `StreamlitPage` object, which was confusing in the API and docs. `Page` is now a real class, so `type(page) is Page` and `isinstance(page, st.Page)` behave as users expect. `StreamlitPage` is kept as a backward-compatible alias (`StreamlitPage = Page`), so existing imports and `isinstance` checks keep working.

- `gather_metrics` gains a keyword-only `_positional_arg_offset` so the now-method `Page.__init__` records the same telemetry (command name and argument positions) as the previous function-based command.
- Adds an internal `_create_page` helper for MPA v1 bootstrapping that constructs a `Page` without emitting public-command telemetry (matching the prior behavior).

## GitHub Issue Link (if applicable)

- Closes #12953

## Testing Plan

- Unit Tests (Python):
  - `lib/tests/streamlit/navigation/page_test.py` — class/alias identity, constructor signature, and `_create_page` construction.
  - `lib/tests/streamlit/runtime/metrics_util_test.py` — telemetry command name/args, positional-offset non-interference, and no telemetry for internal pages.
  - Updated `navigation`, `button`, `page_link`, and typing tests for the `Page`/`StreamlitPage` rename.
- E2E Tests: existing `e2e_playwright/mega_tester_app_test.py` and `e2e_playwright/multipage_apps_v2/mpa_v2_page_visibility_test.py` exercise navigation, page links, and switch-page; both pass.

Made with [Cursor](https://cursor.com)