### PR TITLE
[fix] Keep pills and segmented_control selection highlighted when format_func changes

### DIFF
--- a/e2e_playwright/st_pills.py
+++ b/e2e_playwright/st_pills.py
@@ -361,3 +361,31 @@ st.text(
 if st.button("Switch to ES", key="switch_to_es_btn"):
     st.session_state["dynamic_fmt_lang"] = "es"
     st.rerun()
+
+# --- Interdependent pills with dynamic format_func (gh-16269) ---
+# Regression test: when a parent pill's selection is cleared, the child pill's
+# format_func output (a record count embedded in the label) changes for the
+# still-selected option. The child must stay visually selected at its new label
+# instead of silently deselecting, and its return value must be preserved.
+
+st.header("Pills - interdependent format_func")
+
+# Both the child option set and the per-option counts depend on whether the
+# parent filter is active, mirroring the original repro where a dataframe is
+# filtered by the parent selection: with the parent active fewer rows remain,
+# so the option list shrinks and the counts drop. This exercises the case where
+# a still-selected option ("D") keeps its value across both a label change and a
+# change to the surrounding options list.
+if st.session_state.get("idf_parent"):
+    _idf_counts = {"D": 1, "E": 1}
+else:
+    _idf_counts = {"D": 3, "E": 2, "F": 4}
+
+st.pills("idf parent", options=["A", "B"], key="idf_parent")
+idf_child_val = st.pills(
+    "idf child",
+    options=list(_idf_counts),
+    format_func=lambda x: f"{x} ({_idf_counts[x]})",
+    key="idf_child",
+)
+st.text(f"idf_child value: {idf_child_val}")

--- a/e2e_playwright/st_pills_test.py
+++ b/e2e_playwright/st_pills_test.py
@@ -37,8 +37,15 @@ from e2e_playwright.shared.app_utils import (
 )
 
 
-def get_pill_button(locator: Locator, text: str) -> Locator:
-    return locator.locator("button[data-variant='pills']").filter(has_text=text)
+def get_pill_button(locator: Locator, text: str, *, exact: bool = False) -> Locator:
+    # exact=True anchors the match with a regex (^\s*text\s*$), not Playwright's
+    # built-in exact= parameter, so trailing whitespace the button adds is tolerated.
+    pills = locator.locator("button[data-variant='pills']")
+    if exact:
+        # Anchor the match so e.g. "D (1)" does not also match "D (10)". The
+        # \s* tolerates whitespace the button rendering may add around the label.
+        return pills.filter(has_text=re.compile(rf"^\s*{re.escape(text)}\s*$"))
+    return pills.filter(has_text=text)
 
 
 def test_pills_regression_no_wrap_at_app_start(
@@ -375,6 +382,56 @@ def test_dynamic_format_func_preserves_selection_and_suppresses_callback(
     expect_text(app, "dynamic_fmt_pills value: B")
     naranja_btn = get_pill_button(dynamic_fmt_section, "naranja")
     expect(naranja_btn).to_have_attribute("data-selected", "true")
+
+
+def test_interdependent_format_func_keeps_child_pill_selected(app: Page):
+    """A child pill stays selected when a parent filter change alters its label.
+
+    Regression test for gh-16269: when clearing the parent pill changes the
+    child's format_func output (a record count embedded in the label) for the
+    still-selected option, the child must remain visually selected at its new
+    label rather than silently deselecting. The return value must be preserved.
+    Clearing the parent also expands the child's option list (mirroring a
+    dataframe that is filtered by the parent), so this covers a label change and
+    a change to the surrounding options at once.
+
+    Steps
+    -----
+    1. Select parent "A": the child options become "D (1)" / "E (1)".
+    2. Select child "D (1)": it is selected and the value is "D".
+    3. Deselect the parent by clicking "A" again: the child label becomes
+       "D (3)", a new option "F (4)" appears, and the pill must stay selected at
+       "D (3)" with the value still "D".
+    """
+    parent_section = get_element_by_key(app, "idf_parent")
+    child_section = get_element_by_key(app, "idf_child")
+    expect(parent_section).to_be_visible()
+
+    # Step 1: select the parent "A" so the child labels reflect the filtered count.
+    get_pill_button(parent_section, "A").click()
+    wait_for_app_run(app)
+    child_d_filtered = get_pill_button(child_section, "D (1)", exact=True)
+    expect(child_d_filtered).to_be_visible()
+
+    # Step 2: select the child "D (1)".
+    child_d_filtered.click()
+    wait_for_app_run(app)
+    expect(child_d_filtered).to_have_attribute("data-selected", "true")
+    expect_text(app, "idf_child value: D")
+
+    # Step 3: clear the parent by clicking "A" again. The child's label count
+    # changes from "D (1)" to "D (3)" and the option list expands to include
+    # "F (4)", all without the user touching the child.
+    get_pill_button(parent_section, "A").click()
+    wait_for_app_run(app)
+
+    # Child stays selected at its new label, keeps its value, renders the newly
+    # added option, and no longer shows the stale label (negative assertion).
+    child_d_full = get_pill_button(child_section, "D (3)", exact=True)
+    expect(child_d_full).to_have_attribute("data-selected", "true")
+    expect_text(app, "idf_child value: D")
+    expect(get_pill_button(child_section, "F (4)", exact=True)).to_be_visible()
+    expect(child_section).not_to_contain_text("D (1)")
 
 
 # --- Query parameter binding tests ---

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -97,7 +97,6 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
     default_option_index: int | None
     format_func: Callable[[Any], str]
     session_state_fallback: T | None
-    used_session_state_fallback: bool
 
     def __init__(
         self,
@@ -115,7 +114,6 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         self.default_option_index = default_option_index
         self.format_func = format_func
         self.session_state_fallback = session_state_fallback
-        self.used_session_state_fallback = False
 
     def serialize(self, v: T | str | None) -> list[str]:
         """Serialize single-select value to a list of strings for wire format."""
@@ -168,7 +166,6 @@ class _SingleSelectButtonGroupSerde(Generic[T]):
         # always more accurate than the default because it reflects what the user
         # actually had selected (e.g. user clicked "B" while default was "A").
         if self.session_state_fallback is not None:
-            self.used_session_state_fallback = True
             return self.session_state_fallback
         if self.default_option_index is not None:
             return self.options[self.default_option_index]
@@ -188,7 +185,6 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
     default_option_indices: list[int]
     format_func: Callable[[Any], str]
     session_state_fallback: list[T] | None
-    used_session_state_fallback: bool
 
     def __init__(
         self,
@@ -206,7 +202,6 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
         self.default_option_indices = default_option_indices or []
         self.format_func = format_func
         self.session_state_fallback = session_state_fallback
-        self.used_session_state_fallback = False
 
     def serialize(self, value: list[T | str] | list[T] | None) -> list[str]:
         """Serialize multi-select values to list of strings for wire format."""
@@ -251,20 +246,30 @@ class _MultiSelectButtonGroupSerde(Generic[T]):
             # (e.g. a language switch). validate_and_sync_multiselect_value_with_options
             # applies the same filter for invalid canonical values.
 
-        # If ui_value was non-empty but every entry was stale (all dropped),
-        # fall back to the last known session-state value (the user's live
-        # selection) or, if none, to the configured default so that
-        # _widget_changed sees no difference and suppresses the spurious
-        # on_change callback. Session-state takes priority over the default
-        # because it reflects what the user actually had selected (e.g. user
-        # had ["A","B"] while default was only ["A"]). This mirrors the
-        # single-select behaviour in _SingleSelectButtonGroupSerde.deserialize.
-        if not values and ui_value:
-            if self.session_state_fallback is not None:
-                self.used_session_state_fallback = True
-                return self.session_state_fallback
-            if self.default_option_indices:
-                return [self.options[i] for i in self.default_option_indices]
+        # A label change never changes the selection, so recover stale wire entries
+        # from the last known session-state selection: that keeps _widget_changed
+        # from firing a spurious on_change and stops a relabeled selection from
+        # being truncated. Each unresolvable wire entry is a stale label for one
+        # previously selected option that is not already resolved (a "candidate"),
+        # so comparing counts tells us whether a deselect also happened this rerun:
+        #   - stale_count >= len(candidates): labels only. Recover every candidate
+        #     and keep any newly resolved additions.
+        #   - stale_count <  len(candidates): at least one option was deselected.
+        #     Stale labels are opaque, so keep only the resolved survivors rather
+        #     than risk restoring the option the user just removed (a still-selected
+        #     option relabeled in the same rerun is dropped; this is rare).
+        # With no session-state fallback, use the configured default only if every
+        # entry was stale, mirroring _SingleSelectButtonGroupSerde.deserialize.
+        dropped_stale = len(values) < len(ui_value)
+        if dropped_stale and self.session_state_fallback is not None:
+            candidates = [o for o in self.session_state_fallback if o not in values]
+            stale_count = len(ui_value) - len(values)
+            if stale_count >= len(candidates):
+                additions = [o for o in values if o not in self.session_state_fallback]
+                return list(self.session_state_fallback) + additions
+            return values
+        if not values and ui_value and self.default_option_indices:
+            return [self.options[i] for i in self.default_option_indices]
         return values
 
 
@@ -1087,6 +1092,10 @@ class ButtonGroupMixin:
         # is configured, deserialize would otherwise return None/[] for stale wire
         # values, causing _widget_changed to fire a spurious on_change callback.
         # Using the last known valid value as a fallback keeps the comparison equal.
+        # Value resolution (this fallback, keeping on_change quiet) and label resync
+        # (the wire-vs-fresh-serialization check in _button_group that decides whether
+        # to resend set_value) are independent paths; both are required so on_change
+        # stays quiet while the frontend still gets the updated labels.
         _ss_fallback_single: V | None = None
         _ss_fallback_multi: list[V] | None = None
         if key is not None:
@@ -1107,11 +1116,7 @@ class ButtonGroupMixin:
             except Exception:  # noqa: S110
                 pass  # KeyError (key not yet set) or other SS error; safe to ignore
 
-        # Create appropriate serde based on selection mode. A shared mutable
-        # container tracks whether the stale-wire fallback fired during
-        # deserialization so _button_group can force proto.set_value=True and
-        # send the fresh serialization to the frontend (see _button_group).
-        _stale_fallback_container: list[bool] = [False]
+        # Create appropriate serde based on selection mode.
         serializer: WidgetSerializer[Any]
         deserializer: WidgetDeserializer[Any]
         if selection_mode == "multi":
@@ -1123,17 +1128,8 @@ class ButtonGroupMixin:
                 format_func=actual_format_func,
                 session_state_fallback=_ss_fallback_multi,
             )
-            _multi_base = multi_serde.deserialize
-
-            def _multi_deserialize(
-                ui_value: list[str] | None,
-            ) -> list[V] | list[V | str]:
-                result_ = _multi_base(ui_value)
-                _stale_fallback_container[0] = multi_serde.used_session_state_fallback
-                return result_
-
             serializer = multi_serde.serialize
-            deserializer = cast("WidgetDeserializer[Any]", _multi_deserialize)
+            deserializer = cast("WidgetDeserializer[Any]", multi_serde.deserialize)
         else:
             single_serde = _SingleSelectButtonGroupSerde[V](
                 indexable_options,
@@ -1143,17 +1139,8 @@ class ButtonGroupMixin:
                 format_func=actual_format_func,
                 session_state_fallback=_ss_fallback_single,
             )
-            _single_base = single_serde.deserialize
-
-            def _single_deserialize(
-                ui_value: list[str] | None,
-            ) -> V | None:
-                result_ = _single_base(ui_value)
-                _stale_fallback_container[0] = single_serde.used_session_state_fallback
-                return result_
-
             serializer = single_serde.serialize
-            deserializer = cast("WidgetDeserializer[Any]", _single_deserialize)
+            deserializer = cast("WidgetDeserializer[Any]", single_serde.deserialize)
 
         # Single call to _button_group with the appropriate serde
         result: RegisterWidgetResult[Any] = self._button_group(
@@ -1178,7 +1165,6 @@ class ButtonGroupMixin:
             bind=bind,
             persist_state=persist_state,
             string_formatted_options=formatted_options,
-            stale_fallback_container=_stale_fallback_container,
         )
 
         # Handle return type based on selection mode
@@ -1217,7 +1203,6 @@ class ButtonGroupMixin:
         bind: BindOption = None,
         persist_state: PersistStateOption = None,
         string_formatted_options: list[str] | None = None,
-        stale_fallback_container: list[bool] | None = None,
     ) -> RegisterWidgetResult[T]:
         _maybe_raise_selection_mode_warning(selection_mode)
 
@@ -1340,26 +1325,29 @@ class ButtonGroupMixin:
                     )
                 )
 
-        # The stale-wire fallback fires when the frontend sends a formatted string
-        # from a previous format_func mapping (e.g. "orange" after switching to ES
-        # mode where the mapping no longer contains "orange"). The serde resolves the
-        # canonical value via session_state_fallback but neither value_needs_reset nor
-        # value_changed is True because the canonical value ("B") is unchanged.
-        # We must still send set_value=True with the NEW serialization ("naranja") so
-        # the frontend can update its displayed value; otherwise the stored stale wire
-        # value stays in widgetMgr and on the next rerun the backend would receive a
-        # fresh (non-stale) but wrong formatted string and fire a spurious on_change.
-        stale_fallback_used = (
-            stale_fallback_container is not None and stale_fallback_container[0]
+        # Resend set_value when the selected option's formatted label changed
+        # between reruns. The frontend tracks selection by label, so a stale
+        # label (e.g. after a parent filter clears or a language switch remaps
+        # every label) leaves the pill looking deselected even though the value
+        # is unchanged.
+        #
+        # Compare this run's incoming wire labels (captured before this run's
+        # serializer ran) against a fresh serialization, instead of relying on a
+        # staleness signal raised inside deserialize (#15522), which the
+        # interdependent-pills case can miss.
+        #
+        # The comparison is order-sensitive, so serialize must preserve the
+        # frontend's selection order (locked by
+        # test_multi_select_no_set_value_pushed_when_labels_unchanged); a
+        # serialize-by-option-index change would spuriously churn set_value on
+        # every multi-select rerun.
+        correct_serialization = serializer(cast("T", current_value))
+        labels_changed = (
+            widget_state.incoming_serialized_values is not None
+            and widget_state.incoming_serialized_values != correct_serialization
         )
-        if value_needs_reset or widget_state.value_changed or stale_fallback_used:
-            # Always use string-based raw_values field
-            value_for_serialization = (
-                current_value
-                if (value_needs_reset or stale_fallback_used)
-                else widget_state.value
-            )
-            proto.raw_values[:] = serializer(cast("T", value_for_serialization))
+        if value_needs_reset or widget_state.value_changed or labels_changed:
+            proto.raw_values[:] = correct_serialization
             proto.set_value = True
 
         if ctx:
@@ -1372,7 +1360,7 @@ class ButtonGroupMixin:
             layout_config=layout_config,
             has_one_shot_effect=value_needs_reset
             or widget_state.value_changed
-            or stale_fallback_used,
+            or labels_changed,
         )
 
         # Return widget_state with possibly updated value

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -224,11 +224,20 @@ class RegisterWidgetResult(Generic[T_co]):
         wire form (not re-derived from the deserialized ``value``), callers can
         reconcile a stored value against freshly computed state even when the
         deserialized value is stale.
+    incoming_serialized_values : list of str or None
+        The array-widget counterpart of ``incoming_serialized_value``: the
+        stored serialized (wire) values as they entered this run, captured
+        before this run's serializer was applied. ``None`` for non-array
+        widgets or when no value is stored yet. Because these are the raw wire
+        labels (not re-derived from the deserialized ``value``), callers can
+        detect that a stored selection's formatted label changed between runs
+        even when the deserialized value is unchanged.
     """
 
     value: T_co
     value_changed: bool
     incoming_serialized_value: str | None = None
+    incoming_serialized_values: list[str] | None = None
 
     @classmethod
     def failure(

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1260,10 +1260,11 @@ class SessionState:
 
         # Capture the stored wire value *before* swapping in this run's
         # serializer, so it reflects the value as it was actually stored (using
-        # the serializer it was stored with). For string widgets we expose this
-        # so callers can reconcile a stored value against freshly computed state
-        # without re-deriving it from the deserialized value.
+        # the serializer it was stored with). For string and string-array widgets
+        # we expose this so callers can reconcile a stored value against freshly
+        # computed state without re-deriving it from the deserialized value.
         incoming_serialized_value: str | None = None
+        incoming_serialized_values: list[str] | None = None
         if metadata.value_type == "string_value":
             stored_proto = self._new_widget_state.get_serialized(widget_id)
             if (
@@ -1271,6 +1272,13 @@ class SessionState:
                 and stored_proto.WhichOneof("value") == "string_value"
             ):
                 incoming_serialized_value = stored_proto.string_value
+        elif metadata.value_type == "string_array_value":
+            stored_proto = self._new_widget_state.get_serialized(widget_id)
+            if (
+                stored_proto is not None
+                and stored_proto.WhichOneof("value") == "string_array_value"
+            ):
+                incoming_serialized_values = list(stored_proto.string_array_value.data)
 
         self._set_widget_metadata(metadata)
         if user_key is not None:
@@ -1419,6 +1427,7 @@ class SessionState:
             widget_value,
             widget_value_changed,
             incoming_serialized_value=incoming_serialized_value,
+            incoming_serialized_values=incoming_serialized_values,
         )
 
     def _handle_query_param_binding(

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -296,6 +296,151 @@ class TestButtonGroupSerde:
         res = serde.deserialize(["apple", "naranja"])
         assert res == ["B"]  # Only the valid ES option is returned
 
+    def test_multi_select_deserialize_partial_stale_restores_full_fallback(self):
+        """Partial-stale labels restore the full selection instead of truncating.
+
+        Interdependent pills: one selected option's label changes, another's does
+        not. The one resolvable label must not truncate the selection, so the stored
+        ["A","B"] is restored rather than ["B"] (which would reach on_change as a
+        deselection).
+        """
+        options = ["A", "B"]
+        # This run's mapping: A's label changed ("A (1)" -> "A (5)"); B's is stable.
+        formatted_options = ["A (5)", "B (2)"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "A (5)", "B": "B (2)"}[x],
+            session_state_fallback=["A", "B"],  # user actually had both selected
+        )
+        # Wire carries A's stale label but B's current one.
+        res = serde.deserialize(["A (1)", "B (2)"])
+        assert res == ["A", "B"], (
+            "Expected the full session-state selection to be restored, not truncated to ['B']"
+        )
+
+    def test_multi_select_deserialize_genuine_deselect_ignores_fallback(self):
+        """A genuine deselect is honored even when a session-state fallback exists.
+
+        A deselected option is absent from the wire entirely (not a dropped stale
+        label), so no entry is dropped and the fallback must not fire. Otherwise
+        deselecting A while B stays selected would spuriously restore ["A","B"].
+        """
+        options = ["A", "B"]
+        formatted_options = ["A (5)", "B (2)"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "A (5)", "B": "B (2)"}[x],
+            session_state_fallback=["A", "B"],  # last known selection was both
+        )
+        # User deselected A; the wire carries only B's current, valid label.
+        res = serde.deserialize(["B (2)"])
+        assert res == ["B"], (
+            "Expected the deselect to be honored, not overridden by fallback"
+        )
+
+    def test_multi_select_deserialize_deselect_with_stale_label_never_reselects(self):
+        """A deselect is honored and never reselects the removed option, even when
+        the remaining label goes stale in the same rerun.
+
+        Regression guard: a dropped-stale entry used to restore the full fallback,
+        reselecting the deselected pill. Here one stale wire entry but two unresolved
+        candidates (stale_count < len(candidates)) signals a deselect, so the
+        fallback is not restored; the opaque stale label can't be attributed to an
+        option, so the result is empty. Key property: the deselected A never returns.
+        """
+        options = ["A", "B"]
+        # B's label changed this run ("B (2)" -> "B (7)"); the wire still carries the
+        # stale "B (2)", so it cannot be resolved against the current mapping.
+        formatted_options = ["A (5)", "B (7)"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "A (5)", "B": "B (7)"}[x],
+            session_state_fallback=["A", "B"],  # last known selection was both
+        )
+        # User deselected A AND B's label went stale: wire carries only B's stale
+        # label ("B (2)" from the previous mapping). Nothing resolves, and the
+        # fallback is not restored because the wire shrank.
+        res = serde.deserialize(["B (2)"])
+        assert res == [], (
+            "Expected the deselect to be honored with no fallback restore; the "
+            f"deselected option must never be reselected (got {res!r})"
+        )
+
+    def test_multi_select_deserialize_deselect_with_partial_stale_drops_unresolvable(
+        self,
+    ):
+        """A resolvable survivor is kept while a stale sibling is dropped on deselect.
+
+        Three options were selected; A is deselected, B stays resolvable, C goes
+        stale. C's opaque label can't be attributed, so it is dropped rather than
+        guessed at (guessing could restore the deselected A). Result: just ["B"].
+        """
+        options = ["A", "B", "C"]
+        # C's label changed this run; A and B are stable.
+        formatted_options = ["A (1)", "B (1)", "C (9)"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "A (1)", "B": "B (1)", "C": "C (9)"}[x],
+            session_state_fallback=["A", "B", "C"],  # all three were selected
+        )
+        # User deselected A; B stays (resolvable), C's label went stale.
+        # Wire: B's current label + C's stale label.
+        res = serde.deserialize(["B (1)", "C (2)"])
+        assert res == ["B"], (
+            "Expected only the resolvable survivor B, with the deselected A never "
+            f"reselected (got {res!r})"
+        )
+
+    def test_multi_select_deserialize_add_selection_with_stale_label_keeps_both(self):
+        """A newly selected option is kept when another label goes stale in the
+        same rerun.
+
+        Regression guard: the previous ``len(ui_value) >= len(fallback)`` heuristic
+        restored the full fallback on any drop, discarding a same-rerun addition.
+        User has ["A"] and selects B while A's label goes stale; only B resolves.
+        One stale entry matches one unresolved candidate (A) - no deselect - so A is
+        recovered and B kept, yielding ["A","B"] rather than the stale-only ["A"].
+        """
+        options = ["A", "B"]
+        # A's label changed this run ("A (old)" -> "A (new)"); B's is current.
+        formatted_options = ["A (new)", "B (1)"]
+        formatted_option_to_option_index = {
+            f: i for i, f in enumerate(formatted_options)
+        }
+        serde = _MultiSelectButtonGroupSerde[str](
+            options,
+            formatted_options=formatted_options,
+            formatted_option_to_option_index=formatted_option_to_option_index,
+            format_func=lambda x: {"A": "A (new)", "B": "B (1)"}[x],
+            session_state_fallback=["A"],  # only A was previously selected
+        )
+        # Wire carries A's stale label ("A (old)") plus B's newly selected label.
+        res = serde.deserialize(["A (old)", "B (1)"])
+        assert res == ["A", "B"], (
+            "Expected the newly selected B to be kept alongside the recovered A, "
+            f"not discarded by restoring the stale-only fallback (got {res!r})"
+        )
+
     def test_multi_select_deserialize_all_stale_session_fallback_beats_default(self):
         """Session-state fallback takes priority over configured default for multi-select.
 
@@ -1660,6 +1805,188 @@ class TestDynamicFormatFuncCallback:
             f"(callback_count={at.session_state['callback_count']})"
         )
         assert at.button_group("fruit").value == "A"
+
+
+class TestDynamicFormatFuncVisualSelection:
+    """Selected pills stay highlighted when format_func labels change between reruns.
+
+    Regression coverage for gh-16269 (interdependent labels, e.g. a record count
+    that shifts when a parent filter clears) and the language-switch path
+    previously handled by ``used_session_state_fallback`` (#15522). The frontend
+    tracks selection by label, so the backend must resend ``set_value`` with the
+    fresh label when it changes, otherwise the pill looks deselected even though
+    the return value is unchanged.
+    """
+
+    def test_single_select_resends_new_label_when_format_func_output_changes(self):
+        """set_value + fresh raw_values are sent when the selected label changes.
+
+        Simulates the issue #16269 flow: a child pill's label embeds a count
+        that changes between reruns while the selection ("D") is unchanged.
+        """
+
+        def script():
+            import streamlit as st
+
+            count = st.session_state.get("count", 2)
+            st.pills(
+                "Category B",
+                ["D", "E"],
+                format_func=lambda x: f"{x} ({count})",
+                key="catb",
+            )
+
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+
+        # User selects "D", displayed as "D (2)".
+        at.button_group("catb").select("D").run()
+        assert not at.exception
+        assert at.button_group("catb").value == "D"
+
+        # The count behind the label changes (as when a parent filter clears),
+        # without the user touching this widget.
+        at.session_state["count"] = 3
+        at = at.run()
+        assert not at.exception
+
+        catb = at.button_group("catb")
+        # The return value is preserved ...
+        assert catb.value == "D"
+        # ... and the backend re-pushes the fresh label so the pill stays
+        # selected instead of silently deselecting.
+        assert catb.proto.set_value is True
+        assert list(catb.proto.raw_values) == ["D (3)"]
+
+    def test_multi_select_resends_new_labels_when_format_func_output_changes(self):
+        """Multi-select resends fresh labels for every still-selected option."""
+
+        def script():
+            import streamlit as st
+
+            count = st.session_state.get("count", 2)
+            st.pills(
+                "Category B",
+                ["D", "E", "F"],
+                format_func=lambda x: f"{x} ({count})",
+                selection_mode="multi",
+                key="catb",
+            )
+
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+
+        at.button_group("catb").select("D").select("E").run()
+        assert not at.exception
+        assert at.button_group("catb").value == ["D", "E"]
+
+        at.session_state["count"] = 3
+        at = at.run()
+        assert not at.exception
+
+        catb = at.button_group("catb")
+        assert catb.value == ["D", "E"]
+        assert catb.proto.set_value is True
+        assert list(catb.proto.raw_values) == ["D (3)", "E (3)"]
+
+    def test_no_set_value_pushed_when_label_unchanged_on_plain_rerun(self):
+        """A plain rerun with an unchanged label must not force set_value.
+
+        Anti-regression guard: the label-change detection must not fire on every
+        rerun, which would churn the frontend and re-run set_value effects
+        needlessly. When nothing changes, set_value stays False.
+        """
+
+        def script():
+            import streamlit as st
+
+            # Static label - format_func output never changes between runs.
+            st.pills(
+                "Category B", ["D", "E"], format_func=lambda x: f"{x}!", key="catb"
+            )
+
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+
+        at.button_group("catb").select("D").run()
+        assert not at.exception
+
+        # Plain rerun with no interaction and no label change.
+        at = at.run()
+        assert not at.exception
+
+        catb = at.button_group("catb")
+        assert catb.value == "D"
+        assert catb.proto.set_value is False
+        assert list(catb.proto.raw_values) == []
+
+    def test_multi_select_no_set_value_pushed_when_labels_unchanged(self):
+        """Multi-select plain rerun with unchanged labels must not force set_value.
+
+        Locks in the label-ordering assumption: the fresh serialization of the
+        still-selected options must match the order the frontend sent, otherwise
+        ``labels_changed`` would fire spuriously on every multi-select rerun.
+        """
+
+        def script():
+            import streamlit as st
+
+            st.pills(
+                "Category B",
+                ["D", "E", "F"],
+                format_func=lambda x: f"{x}!",
+                selection_mode="multi",
+                key="catb",
+            )
+
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+
+        at.button_group("catb").select("D").select("E").run()
+        assert not at.exception
+        assert at.button_group("catb").value == ["D", "E"]
+
+        # Plain rerun with no interaction and no label change.
+        at = at.run()
+        assert not at.exception
+
+        catb = at.button_group("catb")
+        assert catb.value == ["D", "E"]
+        assert catb.proto.set_value is False
+        assert list(catb.proto.raw_values) == []
+
+    def test_no_set_value_pushed_for_empty_selection_on_plain_rerun(self):
+        """An empty selection must not force set_value on a plain rerun.
+
+        Boundary guard for the deselected case: with nothing selected the stored
+        wire labels are empty, so comparing them against the empty fresh
+        serialization must leave ``labels_changed`` False.
+        """
+
+        def script():
+            import streamlit as st
+
+            count = st.session_state.get("count", 2)
+            st.pills(
+                "Category B",
+                ["D", "E"],
+                format_func=lambda x: f"{x} ({count})",
+                key="catb",
+            )
+
+        at = AppTest.from_function(script).run()
+        assert not at.exception
+        assert at.button_group("catb").value is None
+
+        # Changing the label count while nothing is selected must not push a value.
+        at.session_state["count"] = 3
+        at = at.run()
+        assert not at.exception
+
+        catb = at.button_group("catb")
+        assert catb.value is None
+        assert catb.proto.set_value is False
+        assert list(catb.proto.raw_values) == []
 
 
 class PillsBindQueryParamsTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

Keeps `st.pills` and `st.segmented_control` selections visually highlighted when a `format_func` produces a different label for a still-selected option between reruns. Both widgets share the same `_button_group` backend, so the fix covers both.

- Compare the incoming wire labels against a freshly computed serialization and resend `set_value` with the new labels when they differ, so the selection stays highlighted. The frontend tracks selection by label, so a changed label (interdependent pills whose label embeds a record count that shifts when a parent filter clears, or a language switch that remaps labels) previously made the selection silently disappear even though the return value was unchanged.
- Generalizes the earlier language-switch fix (#15522) to also cover interdependent pills, replacing the `used_session_state_fallback` signal with a direct wire-label comparison.

## GitHub Issue Link

- Closes #16269

## Testing Plan

- Unit Tests: `lib/tests/streamlit/elements/button_group_test.py` — resend fresh labels on change (single and multi select), plus anti-regression guards (plain rerun, multi-select label ordering, empty selection)
- E2E Tests: `e2e_playwright/st_pills_test.py::test_interdependent_format_func_keeps_child_pill_selected` (covers a child label change and a change to the child's options list)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | committing-with-conventional-commits | 1 |
| skill | tdd | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 3 |
| subagent | general-purpose | 4 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core widget registration and button-group serde/deserialize paths used by pills and segmented_control; behavior changes around stale wire values and when `set_value` is sent, though heavily tested.
> 
> **Overview**
> **Fixes `st.pills` / `st.segmented_control` looking deselected when a still-selected option’s display label changes between reruns** (e.g. interdependent parent/child filters with counts in labels, or language switches). The frontend keys off formatted labels, so the canonical value can stay the same while the UI drops the highlight.
> 
> The shared `_button_group` path now **detects label drift** by comparing **incoming stored wire labels** (`incoming_serialized_values`, captured in `register_widget` for `string_array_value` widgets) against a **fresh serialization** of the resolved value, and pushes **`set_value` with updated `raw_values`** when they differ. This **replaces** the prior `used_session_state_fallback` / `stale_fallback_container` hook inside deserialize.
> 
> **Multi-select deserialize** gains **count-based logic** when some wire entries are stale: restore the full session-state selection when only labels changed, but **honor real deselects** (and keep same-rerun additions) so `on_change` and selection aren’t wrong.
> 
> **Tests:** new Playwright scenario for parent/child interdependent `format_func`, plus unit/AppTest coverage for label resync and multi-select edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23a47fd3db97cbc64d8e24e3caf012a2ec7c118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
