### PR TITLE
[fix] Accept io.StringIO data in st.download_button

### DIFF
--- a/lib/streamlit/runtime/download_data_util.py
+++ b/lib/streamlit/runtime/download_data_util.py
@@ -31,6 +31,12 @@ def convert_data_to_bytes_and_infer_mime(
         string_data = data.read()
         data_as_bytes = string_data.encode()
         inferred_mime_type = "text/plain"
+    elif isinstance(data, io.StringIO):
+        # Use getvalue() so the full buffer is captured regardless of cursor
+        # position (mirrors io.BytesIO). StringIO is a sibling of TextIOWrapper
+        # under io.TextIOBase, so it needs its own branch.
+        data_as_bytes = data.getvalue().encode()
+        inferred_mime_type = "text/plain"
     # Assume bytes; try methods until we run out.
     elif isinstance(data, bytes):
         data_as_bytes = data

--- a/lib/tests/streamlit/elements/download_button_test.py
+++ b/lib/tests/streamlit/elements/download_button_test.py
@@ -255,6 +255,17 @@ class DownloadButtonTest(DeltaGeneratorTestCase):
         assert stored.filename is None
         assert stored.mimetype == "text/plain"
 
+    def test_stringio_marshals_to_text_plain(self) -> None:
+        """io.StringIO is marshalled through the full button -> media-manager
+        path and stored as text/plain, mirroring the io.BytesIO case."""
+        st.download_button("Download", data=io.StringIO("hello"))
+
+        c = self.get_delta_from_queue().new_element.download_button
+        stored = self._stored_file(c)
+        assert stored.content == b"hello"
+        assert stored.filename is None
+        assert stored.mimetype == "text/plain"
+
     def test_stream_raising_on_name_access_keeps_existing_behavior(self) -> None:
         """A stream whose `name` property raises (e.g. a detached or closed
         TextIOWrapper raises ValueError) must not crash inference."""

--- a/lib/tests/streamlit/runtime/download_data_util_test.py
+++ b/lib/tests/streamlit/runtime/download_data_util_test.py
@@ -55,6 +55,24 @@ class ConvertDataToBytesAndInferMimeTest(unittest.TestCase):
             except FileNotFoundError:
                 pass
 
+    def test_stringio_is_converted_to_bytes_and_text_plain(self):
+        """io.StringIO is read fully and inferred as text/plain."""
+        data_as_bytes, mime = convert_data_to_bytes_and_infer_mime(
+            io.StringIO("hello"), unsupported_error=RuntimeError("unsupported")
+        )
+        assert data_as_bytes == b"hello"
+        assert mime == "text/plain"
+
+    def test_stringio_reads_full_buffer_regardless_of_cursor(self):
+        """io.StringIO with a moved cursor still yields its full contents."""
+        sio = io.StringIO()
+        sio.write("hello")  # Leaves the cursor at the end of the buffer.
+        data_as_bytes, mime = convert_data_to_bytes_and_infer_mime(
+            sio, unsupported_error=RuntimeError("unsupported")
+        )
+        assert data_as_bytes == b"hello"
+        assert mime == "text/plain"
+
     def test_bytes_passthrough_and_octet_stream(self):
         """Bytes are returned as-is, with application/octet-stream."""
         payload = b"\x00\x01\x02"


### PR DESCRIPTION
## Describe your changes

`st.download_button` documents `io.StringIO` as a supported file-like value and the public typing tests accept it, but the runtime raised `StreamlitAPIException: Invalid binary data format: <class '_io.StringIO'>`. `convert_data_to_bytes_and_infer_mime` handled `str` and the concrete `io.TextIOWrapper`, but not their sibling `io.StringIO` (both subclass `io.TextIOBase`).

- Adds an `io.StringIO` branch that reads via `getvalue()` (mirroring the existing `io.BytesIO` handling), so the full buffer is captured regardless of cursor position and inferred as `text/plain`.

## GitHub Issue Link (if applicable)

- Closes #16270

## Testing Plan

- [x] Unit Tests (Python) — `lib/tests/streamlit/runtime/download_data_util_test.py` covers StringIO conversion to bytes/`text/plain` and cursor-independence (buffer read fully even after a `write()` leaves the cursor at the end).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to download data marshalling with mirrored BytesIO behavior and new unit/integration tests; no auth, security, or broad API surface impact.
> 
> **Overview**
> **Fixes `st.download_button` rejecting documented `io.StringIO` data** by extending `convert_data_to_bytes_and_infer_mime` with a dedicated `io.StringIO` branch (alongside existing `str` and `io.TextIOWrapper` handling).
> 
> The new path uses **`getvalue().encode()`** so the full in-memory text buffer is exported as **`text/plain`**, matching **`io.BytesIO`** behavior when the read cursor is not at the start.
> 
> Unit tests cover the util (basic conversion and cursor-at-end buffers) and the end-to-end download button → media storage path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600d4d34d0c37b71b50d986ca84745e7a623a67c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->