### PR TITLE
[feature] Provide fully-typed selection state return values

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -46,6 +46,12 @@ typing errors in parameters or return types by using mypy and `assert_type`.
 - Always include `from __future__ import annotations` at the top.
 - Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration
   (e.g. `radio_types.py`, `button_types.py`).
+- For dict-like return values backed by `AttributeDictionary` /
+  `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
+  state, `ButtonColumn` click state), assert both attribute and bracket access
+  (e.g. `state.selection.rows` and `state["selection"]["rows"]`). Use a
+  separate `TypedDict` (`*Input`) for values users assign (e.g.
+  `selection_default`), not the returned attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -44,6 +44,12 @@ typing errors in parameters or return types by using mypy and `assert_type`.
 - Always include `from __future__ import annotations` at the top.
 - Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration
   (e.g. `radio_types.py`, `button_types.py`).
+- For dict-like return values backed by `AttributeDictionary` /
+  `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
+  state, `ButtonColumn` click state), assert both attribute and bracket access
+  (e.g. `state.selection.rows` and `state["selection"]["rows"]`). Use a
+  separate `TypedDict` (`*Input`) for values users assign (e.g.
+  `selection_default`), not the returned attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/e2e_playwright/st_altair_chart_basic_select.py
+++ b/e2e_playwright/st_altair_chart_basic_select.py
@@ -204,7 +204,7 @@ area_interval_selection = st.altair_chart(
 if len(area_interval_selection["selection"]) > 0:
     st.write(
         "Area chart with selection_interval:",
-        str(area_interval_selection.selection),  # type: ignore
+        str(area_interval_selection.selection),
     )
 
 # HISTOGRAM CHART

--- a/e2e_playwright/st_dataframe_selections.py
+++ b/e2e_playwright/st_dataframe_selections.py
@@ -310,7 +310,7 @@ selection = st.dataframe(
 )
 st.write("Programmatic row selection:", str(selection))
 # Attribute access verifies AttributeDictionary is returned (regression test for #14454).
-st.write("Programmatic row selection rows:", str(selection.selection.rows))  # type: ignore[attr-defined]
+st.write("Programmatic row selection rows:", str(selection.selection.rows))
 
 
 def set_programmatic_selection():

--- a/e2e_playwright/st_plotly_chart_select.py
+++ b/e2e_playwright/st_plotly_chart_select.py
@@ -106,7 +106,7 @@ fig = px.bar(
 event_data = st.plotly_chart(
     fig, on_select="rerun", key="StackedBar_chart", selection_mode=["box", "lasso"]
 )
-if len(event_data.selection["points"]) > 0:  # type: ignore
+if len(event_data.selection["points"]) > 0:
     st.write("Countries and their medal data that were selected:")
     points = st.session_state.StackedBar_chart.selection["points"]
     # Extract x and y values directly into lists
@@ -155,7 +155,7 @@ event_data = st.plotly_chart(
     fig_bubble, on_select="rerun", selection_mode=("points", "box")
 )
 if len(event_data["selection"]["points"]) > 0:
-    points = event_data.selection.points  # type: ignore
+    points = event_data.selection.points
     # Extract x and y values directly into lists
     x_values = [point["x"] for point in points]
     y_values = [point["y"] for point in points]
@@ -178,11 +178,9 @@ fig_treemap = px.treemap(
 event_treemap = st.plotly_chart(
     fig_treemap, on_select="rerun", key="treemap_chart", selection_mode="points"
 )
-if (
-    event_treemap and len(event_treemap.selection.get("points", [])) > 0  # type: ignore
-):
+if event_treemap and len(event_treemap.selection.get("points", [])) > 0:
     st.write("Treemap selection:")
-    point = event_treemap.selection["points"][0]  # type: ignore
+    point = event_treemap.selection["points"][0]
     st.write(f"Selected: {point.get('label', 'N/A')}")
     st.write(f"ID: {point.get('id', 'N/A')}")
     st.write(f"Parent: {point.get('parent', 'N/A')}")
@@ -201,11 +199,9 @@ fig_sunburst = px.sunburst(
 event_sunburst = st.plotly_chart(
     fig_sunburst, on_select="rerun", key="sunburst_chart", selection_mode="points"
 )
-if (
-    event_sunburst and len(event_sunburst.selection.get("points", [])) > 0  # type: ignore
-):
+if event_sunburst and len(event_sunburst.selection.get("points", [])) > 0:
     st.write("Sunburst selection:")
-    point = event_sunburst.selection["points"][0]  # type: ignore
+    point = event_sunburst.selection["points"][0]
     st.write(f"Selected: {point.get('label', 'N/A')}")
     st.write(f"ID: {point.get('id', 'N/A')}")
 else:

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/assets/templates/apps/dashboard-companies/streamlit_app.py
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/assets/templates/apps/dashboard-companies/streamlit_app.py
@@ -397,8 +397,8 @@ with st.container(border=True):
     )
 
 # Company drill-down via dialog when Company column cell is clicked
-if selection.selection.cells:  # type: ignore[attr-defined]
-    cell = selection.selection.cells[0]  # type: ignore[attr-defined]  # tuple: (row_index, column_name)
+if selection.selection.cells:
+    cell = selection.selection.cells[0]  # tuple: (row_index, column_name)
     row_idx, col_name = cell
     # Check if the clicked cell is in the company_name column
     if col_name == "company_name":

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -143,8 +143,8 @@ df = pd.DataFrame(
 
 
 def handle_action():
-    click = st.session_state.row_action  # {"row": int, "label": str}
-    st.toast(f"{click['label']} on row {click['row']}")
+    click = st.session_state.row_action  # dict-like: click.row, click.label
+    st.toast(f"{click.label} on row {click.row}")
 
 
 st.dataframe(
@@ -159,7 +159,7 @@ st.dataframe(
 
 **Key points:**
 
-- **`key` is required** to enable clicks/callbacks. Click info lives in `st.session_state[key]` as `{"row", "label"}` — only during the click rerun, then resets to `None`.
+- **`key` is required** to enable clicks/callbacks. Click info lives in `st.session_state[key]` as a dict-like object with `row` and `label` attributes (also supports key access) — only during the click rerun, then resets to `None`.
 - Use `on_click` (with optional `args`/`kwargs`) for the action; read the clicked row/label inside the callback.
 - Always **read-only** — even in `st.data_editor`, the cell values can't be edited, but clicks still fire.
 - Style with `type="primary" | "secondary" | "tertiary"` and `alignment`.

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -38,6 +38,12 @@ typing errors in parameters or return types by using mypy and `assert_type`.
 - Always include `from __future__ import annotations` at the top.
 - Check other typing tests in the `lib/tests/streamlit/typing` directory for inspiration
   (e.g. `radio_types.py`, `button_types.py`).
+- For dict-like return values backed by `AttributeDictionary` /
+  `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
+  state, `ButtonColumn` click state), assert both attribute and bracket access
+  (e.g. `state.selection.rows` and `state["selection"]["rows"]`). Use a
+  separate `TypedDict` (`*Input`) for values users assign (e.g.
+  `selection_default`), not the returned attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -102,14 +102,29 @@ _ROW_SELECTION_MODES: Final[set[SelectionMode]] = {
 }
 
 
-class DataframeSelectionState(TypedDict, total=False):
+class DataframeSelectionStateInput(TypedDict, total=False):
+    """The accepted dictionary schema for a dataframe selection."""
+
+    rows: list[int]
+    columns: list[str]
+    cells: list[tuple[int, str]]
+
+
+class DataframeStateInput(TypedDict):
+    """The accepted dictionary schema for a dataframe event state."""
+
+    selection: DataframeSelectionStateInput
+
+
+class DataframeSelectionState(ReadOnlyAttributeDictionary):
     """
     The schema for the dataframe selection state.
 
     The selection state is stored in a dictionary-like object that supports both
     key and attribute notation. Selection states can be programmatically set
-    through Session State by assigning a ``DataframeSelectionState`` dictionary
-    to the ``"selection"`` key of a ``DataframeState`` dictionary.
+    through Session State by assigning a dictionary matching
+    ``DataframeSelectionStateInput`` to the ``"selection"`` key of a
+    ``DataframeStateInput`` dictionary.
 
     Programmatic selection is supported for all selection modes
     except ``"multi-cell"``. If ``"single-cell"`` isn't included in the
@@ -211,8 +226,23 @@ class DataframeSelectionState(TypedDict, total=False):
     columns: list[str]
     cells: list[tuple[int, str]]
 
+    @overload
+    def __getitem__(self, key: Literal["rows"]) -> list[int]: ...
 
-class DataframeState(TypedDict, total=False):
+    @overload
+    def __getitem__(self, key: Literal["columns"]) -> list[str]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["cells"]) -> list[tuple[int, str]]: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
+
+
+class DataframeState(ReadOnlyAttributeDictionary):
     """
     The schema for the dataframe event state.
 
@@ -229,24 +259,43 @@ class DataframeState(TypedDict, total=False):
     selection : dict
         The state of the ``on_select`` event. This attribute returns a
         dictionary-like object that supports both key and attribute notation.
-        The attributes are described by the ``DataframeSelectionState``
-        dictionary schema.
+        The attributes are described by ``DataframeSelectionState``.
 
     """
 
     selection: DataframeSelectionState
+
+    # ReadOnlyAttributeDictionary routes attribute access through __getitem__,
+    # so the override below is enough to return DataframeSelectionState. Use
+    # dict.__getitem__ for the selection key so the read-only base class does
+    # not re-wrap the already-typed nested instance.
+    @overload
+    def __getitem__(self, key: Literal["selection"]) -> DataframeSelectionState: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        if key == "selection":
+            item = dict.__getitem__(self, key)
+            if not isinstance(item, DataframeSelectionState):
+                return DataframeSelectionState(item)
+            return item
+        return super().__getitem__(key)
 
 
 @dataclass
 class DataframeSelectionSerde:
     """DataframeSelectionSerde is used to serialize and deserialize the dataframe selection state."""
 
-    selection_default: DataframeState | None = None
+    selection_default: DataframeStateInput | None = None
     is_required_row_mode: bool = False
     num_rows: int = 0
 
     def deserialize(self, ui_value: str | None) -> DataframeState:
-        empty_selection_state: DataframeState = {
+        # Keep the empty selection as a plain dict until the end so required-row
+        # and missing-key mutations below can still run before we wrap.
+        empty_selection_state: dict[str, Any] = {
             "selection": {
                 "rows": [],
                 "columns": [],
@@ -255,12 +304,12 @@ class DataframeSelectionSerde:
         }
 
         if ui_value is not None:
-            selection_state: DataframeState = json.loads(ui_value)
+            selection_state: Any = json.loads(ui_value)
         elif self.selection_default is not None:
             # When a selection_default is provided, use it as the initial
             # deserialized value so the first-render Python return matches
             # the default selection the frontend will display.
-            selection_state = self.selection_default
+            selection_state = {"selection": dict(self.selection_default["selection"])}
         else:
             selection_state = empty_selection_state
 
@@ -280,8 +329,10 @@ class DataframeSelectionSerde:
             # This is necessary since there isn't a concept of tuples in JSON
             # The format that the data is transferred to the backend.
             selection_state["selection"]["cells"] = [
-                tuple(cell)  # type: ignore
-                for cell in selection_state["selection"]["cells"]
+                tuple(cell)
+                for cell in cast(
+                    "list[list[Any]]", selection_state["selection"]["cells"]
+                )
             ]
 
         # In single-row-required mode, auto-select the first row if no rows
@@ -293,9 +344,14 @@ class DataframeSelectionSerde:
         ):
             selection_state["selection"]["rows"] = [0]
 
-        return cast("DataframeState", ReadOnlyAttributeDictionary(selection_state))
+        # Eagerly wrap selection so bracket access returns a stable typed
+        # instance instead of creating a shallow copy on every access.
+        selection_state["selection"] = DataframeSelectionState(
+            selection_state["selection"]
+        )
+        return DataframeState(selection_state)
 
-    def serialize(self, state: DataframeState) -> str:
+    def serialize(self, state: DataframeState | DataframeStateInput) -> str:
         return json.dumps(state)
 
 
@@ -383,7 +439,7 @@ def _validate_selection_state(
     num_rows: int,
     column_names: list[str],
     selection_mode_set: set[SelectionMode],
-) -> DataframeState:
+) -> DataframeStateInput:
     """Validate a programmatically set selection state.
 
     Parameters
@@ -416,7 +472,7 @@ def _validate_selection_state(
 
     selection = value["selection"]
 
-    validated_selection: DataframeSelectionState = {
+    validated_selection: DataframeSelectionStateInput = {
         "rows": [],
         "columns": [],
         "cells": [],
@@ -563,7 +619,7 @@ class ArrowMixin:
         key: Key | None = None,
         on_select: Literal["ignore"] = "ignore",
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
-        selection_default: DataframeState | None = None,
+        selection_default: DataframeStateInput | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
         lazy: bool | None = None,
@@ -583,7 +639,7 @@ class ArrowMixin:
         key: Key | None = None,
         on_select: Literal["rerun"] | WidgetCallback,
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
-        selection_default: DataframeState | None = None,
+        selection_default: DataframeStateInput | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
         lazy: bool | None = None,
@@ -603,7 +659,7 @@ class ArrowMixin:
         key: Key | None = None,
         on_select: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
-        selection_default: DataframeState | None = None,
+        selection_default: DataframeStateInput | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
         lazy: bool | None = None,
@@ -867,7 +923,7 @@ class ArrowMixin:
             internal placeholder for the dataframe element. Otherwise, this
             command returns a dictionary-like object that supports both key and
             attribute notation. The attributes are described by the
-            ``DataframeState`` dictionary schema.
+            ``DataframeState`` class.
 
         Examples
         --------
@@ -1178,7 +1234,7 @@ class ArrowMixin:
             normalized_selection_mode = tuple(sorted(selection_mode_set))
 
             selection_default_json: str | None = None
-            validated_default: DataframeState | None = None
+            validated_default: DataframeStateInput | None = None
             if selection_default is not None:
                 validated_default = _validate_selection_state(
                     selection_default,
@@ -1240,16 +1296,10 @@ class ArrowMixin:
                     layout_config=layout_config,
                     has_one_shot_effect=True,
                 )
-                # Return validated state wrapped in ReadOnlyAttributeDictionary for attribute-style access.
-                return cast(
-                    "DataframeState", ReadOnlyAttributeDictionary(validated_state)
-                )
+                return DataframeState(validated_state)
 
             self.dg._enqueue("dataframe", proto, layout_config=layout_config)
-            # Wrap in ReadOnlyAttributeDictionary for attribute-style access
-            return cast(
-                "DataframeState", ReadOnlyAttributeDictionary(widget_state.value)
-            )
+            return DataframeState(widget_state.value)
         return self.dg._enqueue("dataframe", proto, layout_config=layout_config)
 
     @property

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -279,7 +279,11 @@ class DataframeState(ReadOnlyAttributeDictionary):
         if key == "selection":
             item = dict.__getitem__(self, key)
             if not isinstance(item, DataframeSelectionState):
-                return DataframeSelectionState(item)
+                item = DataframeSelectionState(item)
+                # Cache via dict.__setitem__ — ReadOnlyAttributeDictionary
+                # blocks normal mutation, but storing the wrapped instance
+                # keeps identity stable across accesses.
+                dict.__setitem__(self, key, item)
             return item
         return super().__getitem__(key)
 
@@ -309,6 +313,7 @@ class DataframeSelectionSerde:
             # When a selection_default is provided, use it as the initial
             # deserialized value so the first-render Python return matches
             # the default selection the frontend will display.
+            # Shallow copy to avoid mutating the caller's default.
             selection_state = {"selection": dict(self.selection_default["selection"])}
         else:
             selection_state = empty_selection_state
@@ -1296,7 +1301,15 @@ class ArrowMixin:
                     layout_config=layout_config,
                     has_one_shot_effect=True,
                 )
-                return DataframeState(validated_state)
+                # Eagerly wrap like deserialize so nested selection identity
+                # stays stable on this one-shot programmatic path.
+                return DataframeState(
+                    {
+                        "selection": DataframeSelectionState(
+                            validated_state["selection"]
+                        ),
+                    }
+                )
 
             self.dg._enqueue("dataframe", proto, layout_config=layout_config)
             return DataframeState(widget_state.value)

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -292,7 +292,7 @@ class DataframeState(ReadOnlyAttributeDictionary):
 class DataframeSelectionSerde:
     """DataframeSelectionSerde is used to serialize and deserialize the dataframe selection state."""
 
-    selection_default: DataframeStateInput | None = None
+    selection_default: DataframeStateInput | DataframeState | None = None
     is_required_row_mode: bool = False
     num_rows: int = 0
 
@@ -624,7 +624,7 @@ class ArrowMixin:
         key: Key | None = None,
         on_select: Literal["ignore"] = "ignore",
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
-        selection_default: DataframeStateInput | None = None,
+        selection_default: DataframeStateInput | DataframeState | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
         lazy: bool | None = None,
@@ -644,7 +644,7 @@ class ArrowMixin:
         key: Key | None = None,
         on_select: Literal["rerun"] | WidgetCallback,
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
-        selection_default: DataframeStateInput | None = None,
+        selection_default: DataframeStateInput | DataframeState | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
         lazy: bool | None = None,
@@ -664,7 +664,7 @@ class ArrowMixin:
         key: Key | None = None,
         on_select: Literal["ignore", "rerun"] | WidgetCallback = "ignore",
         selection_mode: SelectionMode | Iterable[SelectionMode] = "multi-row",
-        selection_default: DataframeStateInput | None = None,
+        selection_default: DataframeStateInput | DataframeState | None = None,
         row_height: int | None = None,
         placeholder: str | None = None,
         lazy: bool | None = None,

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -255,7 +255,12 @@ class PydeckState(AttributeDictionary):
     # attribute access re-wraps the nested dict as a plain AttributeDictionary.
     @property
     def selection(self) -> PydeckSelectionState:
-        return self["selection"]
+        try:
+            return self["selection"]
+        except KeyError as err:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute 'selection'"
+            ) from err
 
     @selection.setter
     def selection(self, value: PydeckSelectionState) -> None:

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -25,7 +25,6 @@ from typing import (
     Final,
     Literal,
     TypeAlias,
-    TypedDict,
     cast,
     overload,
 )
@@ -112,7 +111,7 @@ def parse_selection_mode(
     return set(parsed_selection_modes)
 
 
-class PydeckSelectionState(TypedDict, total=False):
+class PydeckSelectionState(AttributeDictionary):
     r"""
     The schema for the PyDeck chart selection state.
 
@@ -218,8 +217,22 @@ class PydeckSelectionState(TypedDict, total=False):
     indices: dict[str, list[int]]
     objects: dict[str, list[dict[str, Any]]]
 
+    @overload
+    def __getitem__(self, key: Literal["indices"]) -> dict[str, list[int]]: ...
 
-class PydeckState(TypedDict, total=False):
+    @overload
+    def __getitem__(
+        self, key: Literal["objects"]
+    ) -> dict[str, list[dict[str, Any]]]: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
+
+
+class PydeckState(AttributeDictionary):
     """
     The schema for the PyDeck event state.
 
@@ -234,12 +247,31 @@ class PydeckState(TypedDict, total=False):
     selection : dict
         The state of the ``on_select`` event. This attribute returns a
         dictionary-like object that supports both key and attribute notation.
-        The attributes are described by the ``PydeckSelectionState``
-        dictionary schema.
+        The attributes are described by ``PydeckSelectionState``.
 
     """
 
-    selection: PydeckSelectionState
+    # Keep selection typed as PydeckSelectionState; without this property,
+    # attribute access re-wraps the nested dict as a plain AttributeDictionary.
+    @property
+    def selection(self) -> PydeckSelectionState:
+        return self["selection"]
+
+    @selection.setter
+    def selection(self, value: PydeckSelectionState) -> None:
+        self["selection"] = value
+
+    @overload
+    def __getitem__(self, key: Literal["selection"]) -> PydeckSelectionState: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        item = super().__getitem__(key)
+        if key == "selection" and not isinstance(item, PydeckSelectionState):
+            return PydeckSelectionState(item)
+        return item
 
 
 @dataclass
@@ -247,24 +279,33 @@ class PydeckSelectionSerde:
     """PydeckSelectionSerde is used to serialize and deserialize the Pydeck selection state."""
 
     def deserialize(self, ui_value: str | None) -> PydeckState:
-        empty_selection_state: PydeckState = {
-            "selection": {
-                "indices": {},
-                "objects": {},
+        empty_selection_state = PydeckState(
+            {
+                "selection": PydeckSelectionState(
+                    {
+                        "indices": {},
+                        "objects": {},
+                    }
+                )
             }
-        }
-
-        selection_state = (
-            empty_selection_state if ui_value is None else json.loads(ui_value)
         )
 
+        if ui_value is None:
+            return empty_selection_state
+
+        selection_state = json.loads(ui_value)
         # We have seen some situations where the ui_value was just an empty
         # dict, so we want to ensure that it always returns the empty state in
         # case this happens.
         if "selection" not in selection_state:
-            selection_state = empty_selection_state
+            return empty_selection_state
 
-        return cast("PydeckState", AttributeDictionary(selection_state))
+        # Eagerly wrap selection so bracket access returns a stable typed
+        # instance instead of creating a shallow copy on every access.
+        selection_state["selection"] = PydeckSelectionState(
+            selection_state["selection"]
+        )
+        return PydeckState(selection_state)
 
     def serialize(self, selection_state: PydeckState) -> str:
         return json.dumps(selection_state, default=str)
@@ -438,7 +479,7 @@ class PydeckMixin:
             internal placeholder for the chart element. Otherwise, this method
             returns a dictionary-like object that supports both key and
             attribute notation. The attributes are described by the
-            ``PydeckState`` dictionary schema.
+            ``PydeckState`` class.
 
         Examples
         --------

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -19,7 +19,14 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypedDict, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Literal,
+    TypeAlias,
+    overload,
+)
 
 from streamlit.dataframe_util import DataFormat
 from streamlit.elements.lib.column_types import (
@@ -434,14 +441,28 @@ ColumnConfigMappingInput: TypeAlias = Mapping[
 ButtonColumnMapping: TypeAlias = dict[str, ButtonColumnResult]
 
 
-class ButtonClickState(TypedDict):
+class ButtonColumnClickState(ReadOnlyAttributeDictionary):
     """The schema for button click state in ButtonColumn.
 
-    Both fields are always present when a button click occurs.
+    Read-only dict-like click payload with attribute and key access
+    (``click.row`` / ``click["row"]``). Both fields are always present when a
+    button click occurs.
     """
 
     row: int
     label: str
+
+    @overload
+    def __getitem__(self, key: Literal["row"]) -> int: ...
+
+    @overload
+    def __getitem__(self, key: Literal["label"]) -> str: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
 
 
 @dataclass
@@ -452,14 +473,14 @@ class ButtonClickSerde:
     The frontend sends the click state as a JSON string.
     """
 
-    def serialize(self, v: ButtonClickState | None) -> StringTriggerValue:
+    def serialize(self, v: ButtonColumnClickState | None) -> StringTriggerValue:
         from streamlit.proto.Common_pb2 import StringTriggerValue
 
         if v is None:
             return StringTriggerValue()
         return StringTriggerValue(data=json.dumps(v))
 
-    def deserialize(self, ui_value: str | None) -> ButtonClickState | None:
+    def deserialize(self, ui_value: str | None) -> ButtonColumnClickState | None:
         if not ui_value:
             return None
 
@@ -483,10 +504,7 @@ class ButtonClickSerde:
                 f"Invalid button click row index: {parsed['row']}. Row must be >= 0."
             )
 
-        # Wrap in ReadOnlyAttributeDictionary so the click value supports both
-        # key and attribute notation (e.g. click["row"] and click.row),
-        # matching dataframe selection state.
-        return cast("ButtonClickState", ReadOnlyAttributeDictionary(parsed))
+        return ButtonColumnClickState(parsed)
 
 
 def extract_button_column_configs(

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -235,7 +235,12 @@ class PlotlyState(AttributeDictionary):
     # attribute access re-wraps the nested dict as a plain AttributeDictionary.
     @property
     def selection(self) -> PlotlySelectionState:
-        return self["selection"]
+        try:
+            return self["selection"]
+        except KeyError as err:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute 'selection'"
+            ) from err
 
     @selection.setter
     def selection(self, value: PlotlySelectionState) -> None:

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -22,13 +22,10 @@ from typing import (
     Final,
     Literal,
     TypeAlias,
-    TypedDict,
     Union,
     cast,
     overload,
 )
-
-from typing_extensions import Required
 
 from streamlit import type_util
 from streamlit.deprecation_util import (
@@ -89,7 +86,7 @@ _SELECTION_MODES: Final[set[SelectionMode]] = {"lasso", "points", "box"}
 _LOGGER: Final = get_logger(__name__)
 
 
-class PlotlySelectionState(TypedDict, total=False):
+class PlotlySelectionState(AttributeDictionary):
     """
     The schema for the Plotly chart selection state.
 
@@ -171,13 +168,31 @@ class PlotlySelectionState(TypedDict, total=False):
 
     """
 
-    points: Required[list[dict[str, Any]]]
-    point_indices: Required[list[int]]
-    box: Required[list[dict[str, Any]]]
-    lasso: Required[list[dict[str, Any]]]
+    points: list[dict[str, Any]]
+    point_indices: list[int]
+    box: list[dict[str, Any]]
+    lasso: list[dict[str, Any]]
+
+    @overload
+    def __getitem__(self, key: Literal["points"]) -> list[dict[str, Any]]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["point_indices"]) -> list[int]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["box"]) -> list[dict[str, Any]]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["lasso"]) -> list[dict[str, Any]]: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
 
 
-class PlotlyState(TypedDict, total=False):
+class PlotlyState(AttributeDictionary):
     """
     The schema for the Plotly chart event state.
 
@@ -192,8 +207,7 @@ class PlotlyState(TypedDict, total=False):
     selection : dict
         The state of the ``on_select`` event. This attribute returns a
         dictionary-like object that supports both key and attribute notation.
-        The attributes are described by the ``PlotlySelectionState`` dictionary
-        schema.
+        The attributes are described by ``PlotlySelectionState``.
 
     Example
     -------
@@ -217,7 +231,27 @@ class PlotlyState(TypedDict, total=False):
 
     """
 
-    selection: Required[PlotlySelectionState]
+    # Keep selection typed as PlotlySelectionState; without this property,
+    # attribute access re-wraps the nested dict as a plain AttributeDictionary.
+    @property
+    def selection(self) -> PlotlySelectionState:
+        return self["selection"]
+
+    @selection.setter
+    def selection(self, value: PlotlySelectionState) -> None:
+        self["selection"] = value
+
+    @overload
+    def __getitem__(self, key: Literal["selection"]) -> PlotlySelectionState: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        item = super().__getitem__(key)
+        if key == "selection" and not isinstance(item, PlotlySelectionState):
+            return PlotlySelectionState(item)
+        return item
 
 
 @dataclass
@@ -227,25 +261,30 @@ class PlotlyChartSelectionSerde:
     """
 
     def deserialize(self, ui_value: str | None) -> PlotlyState:
-        empty_selection_state: PlotlyState = {
-            "selection": {
-                "points": [],
-                "point_indices": [],
-                "box": [],
-                "lasso": [],
-            },
-        }
-
-        selection_state = (
-            empty_selection_state
-            if ui_value is None
-            else cast("PlotlyState", AttributeDictionary(json.loads(ui_value)))
+        empty_selection_state = PlotlyState(
+            {
+                "selection": PlotlySelectionState(
+                    {
+                        "points": [],
+                        "point_indices": [],
+                        "box": [],
+                        "lasso": [],
+                    }
+                ),
+            }
         )
 
-        if "selection" not in selection_state:  # pragma: no cover - defensive
-            selection_state = empty_selection_state  # type: ignore[unreachable]
+        if ui_value is None:
+            return empty_selection_state
 
-        return cast("PlotlyState", AttributeDictionary(selection_state))
+        parsed = json.loads(ui_value)
+        if "selection" not in parsed:  # pragma: no cover - defensive
+            return empty_selection_state
+
+        # Eagerly wrap selection so bracket access returns a stable typed
+        # instance instead of creating a shallow copy on every access.
+        parsed["selection"] = PlotlySelectionState(parsed["selection"])
+        return PlotlyState(parsed)
 
     def serialize(self, selection_state: PlotlyState) -> str:
         return json.dumps(selection_state, default=str)
@@ -576,7 +615,7 @@ class PlotlyMixin:
             internal placeholder for the chart element. Otherwise, this command
             returns a dictionary-like object that supports both key and
             attribute notation. The attributes are described by the
-            ``PlotlyState`` dictionary schema.
+            ``PlotlyState`` class.
 
         Examples
         --------

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -255,7 +255,10 @@ class PlotlyState(AttributeDictionary):
     def __getitem__(self, key: Any) -> Any:
         item = super().__getitem__(key)
         if key == "selection" and not isinstance(item, PlotlySelectionState):
-            return PlotlySelectionState(item)
+            item = PlotlySelectionState(item)
+            # Cache so repeated bracket/attribute access stays identity-stable.
+            dict.__setitem__(self, key, item)
+            return item
         return item
 
 

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -192,7 +192,12 @@ class VegaLiteState(AttributeDictionary):
     # the eagerly constructed instance.
     @property
     def selection(self) -> AttributeDictionary:
-        return self["selection"]
+        try:
+            return self["selection"]
+        except KeyError as err:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute 'selection'"
+            ) from err
 
     @selection.setter
     def selection(self, value: AttributeDictionary) -> None:

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -26,13 +26,10 @@ from typing import (
     Any,
     Literal,
     TypeAlias,
-    TypedDict,
     Union,
     cast,
     overload,
 )
-
-from typing_extensions import Required
 
 from streamlit import dataframe_util, type_util
 from streamlit.deprecation_util import (
@@ -87,7 +84,7 @@ AltairChart: TypeAlias = Union[
 _altair_globals_lock = threading.Lock()
 
 
-class VegaLiteState(TypedDict, total=False):
+class VegaLiteState(AttributeDictionary):
     """
     The schema for the Vega-Lite event state.
 
@@ -190,7 +187,28 @@ class VegaLiteState(TypedDict, total=False):
 
     """
 
-    selection: Required[AttributeDictionary]
+    # Keep selection typed as AttributeDictionary; without this property,
+    # attribute access re-wraps the nested dict as a plain AttributeDictionary
+    # without preserving nested typing expectations.
+    @property
+    def selection(self) -> AttributeDictionary:
+        return self["selection"]
+
+    @selection.setter
+    def selection(self, value: AttributeDictionary) -> None:
+        self["selection"] = value
+
+    @overload
+    def __getitem__(self, key: Literal["selection"]) -> AttributeDictionary: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        item = super().__getitem__(key)
+        if key == "selection" and not isinstance(item, AttributeDictionary):
+            return AttributeDictionary(item)
+        return item
 
 
 @dataclass
@@ -200,23 +218,26 @@ class VegaLiteStateSerde:
     selection_parameters: Sequence[str]
 
     def deserialize(self, ui_value: str | None) -> VegaLiteState:
-        empty_selection_state: VegaLiteState = {
-            "selection": AttributeDictionary(
-                # Initialize the select state with empty dictionaries for each selection parameter.
-                {param: {} for param in self.selection_parameters}
-            ),
-        }
-
-        selection_state = (
-            empty_selection_state
-            if ui_value is None
-            else cast("VegaLiteState", AttributeDictionary(json.loads(ui_value)))
+        empty_selection_state = VegaLiteState(
+            {
+                "selection": AttributeDictionary(
+                    # Initialize the select state with empty dictionaries for each selection parameter.
+                    {param: {} for param in self.selection_parameters}
+                ),
+            }
         )
 
-        if "selection" not in selection_state:
-            selection_state = empty_selection_state  # type: ignore[unreachable]
+        if ui_value is None:
+            return empty_selection_state
 
-        return cast("VegaLiteState", AttributeDictionary(selection_state))
+        parsed = json.loads(ui_value)
+        if "selection" not in parsed:
+            return empty_selection_state
+
+        # Eagerly wrap selection so bracket access returns a stable typed
+        # instance instead of creating a shallow copy on every access.
+        parsed["selection"] = AttributeDictionary(parsed["selection"])
+        return VegaLiteState(parsed)
 
     def serialize(self, selection_state: VegaLiteState) -> str:
         return json.dumps(selection_state, default=str)
@@ -1930,7 +1951,7 @@ class VegaChartsMixin:
             internal placeholder for the chart element. Otherwise, this command
             returns a dictionary-like object that supports both key and attribute
             notation. The attributes are described by the ``VegaLiteState``
-            dictionary schema.
+            class.
 
         Examples
         --------
@@ -2162,7 +2183,7 @@ class VegaChartsMixin:
             internal placeholder for the chart element. Otherwise, this command
             returns a dictionary-like object that supports both key and attribute
             notation. The attributes are described by the ``VegaLiteState``
-            dictionary schema.
+            class.
 
         Examples
         --------

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -188,8 +188,8 @@ class VegaLiteState(AttributeDictionary):
     """
 
     # Keep selection typed as AttributeDictionary; without this property,
-    # attribute access re-wraps the nested dict as a plain AttributeDictionary
-    # without preserving nested typing expectations.
+    # __getattr__ re-wraps the value in a plain AttributeDictionary, losing
+    # the eagerly constructed instance.
     @property
     def selection(self) -> AttributeDictionary:
         return self["selection"]

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -23,6 +23,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    TypeAlias,
     cast,
     overload,
 )
@@ -89,9 +90,11 @@ _ACCEPTED_AUDIO_MIME_TYPES: frozenset[str] = frozenset(
     }
 )
 
+_ChatInputValueItem: TypeAlias = str | list[UploadedFile] | UploadedFile | None
+
 
 @dataclass
-class ChatInputValue(MutableMapping[str, Any]):
+class ChatInputValue(MutableMapping[str, _ChatInputValueItem]):
     """Represents the value returned by `st.chat_input` after user interaction.
 
     This dataclass contains the user's input text, any files uploaded, and optionally
@@ -146,7 +149,19 @@ class ChatInputValue(MutableMapping[str, Any]):
             return False
         return key in self._get_included_keys()
 
-    def __getitem__(self, item: str) -> str | list[UploadedFile] | UploadedFile | None:
+    @overload
+    def __getitem__(self, item: Literal["text"]) -> str: ...
+
+    @overload
+    def __getitem__(self, item: Literal["files"]) -> list[UploadedFile]: ...
+
+    @overload
+    def __getitem__(self, item: Literal["audio"]) -> UploadedFile | None: ...
+
+    @overload
+    def __getitem__(self, item: str) -> _ChatInputValueItem: ...
+
+    def __getitem__(self, item: str) -> _ChatInputValueItem:
         if item not in self._get_included_keys():
             raise KeyError(f"Invalid key: {item}")
         try:
@@ -181,10 +196,8 @@ class ChatInputValue(MutableMapping[str, Any]):
         except AttributeError:  # pragma: no cover - defensive
             raise KeyError(f"Invalid key: {key}") from None
 
-    def to_dict(self) -> dict[str, str | list[UploadedFile] | UploadedFile | None]:
-        result: dict[str, str | list[UploadedFile] | UploadedFile | None] = {
-            "text": self.text
-        }
+    def to_dict(self) -> dict[str, _ChatInputValueItem]:
+        result: dict[str, _ChatInputValueItem] = {"text": self.text}
         if self._include_files:
             result["files"] = self.files
         if self._include_audio:

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Mapping
 from functools import lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from streamlit import runtime
 from streamlit.runtime.context_util import maybe_add_page_path, maybe_trim_page_path
@@ -68,6 +68,15 @@ class StreamlitTheme(AttributeDictionary):
     """
 
     type: Literal["dark", "light"] | None
+
+    @overload
+    def __getitem__(self, key: Literal["type"]) -> Literal["dark", "light"] | None: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
 
     def __init__(self, theme_info: dict[str, str | None]):
         super().__init__(theme_info)

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -1421,17 +1421,24 @@ def test_programmatic_selection_returns_attribute_dictionary() -> None:
         )
         # Attribute access would raise AttributeError if result is a plain dict.
         st.text(f"rows: {result.selection.rows}")
+        # Nested selection must stay identity-stable after programmatic set.
+        st.session_state["_selection_stable"] = (
+            result["selection"] is result.selection
+            and result["selection"] is result["selection"]
+        )
 
     at = AppTest.from_function(script).run()
     assert at.text[0].value == "rows: []"
 
     at = at.run()
     assert at.text[0].value == "rows: [1]"
+    assert at.session_state["_selection_stable"] is True
 
     # Third run without modifying session state: selection should persist
     # as AttributeDictionary (verifies the fix applies across subsequent reruns).
     at = at.run()
     assert at.text[0].value == "rows: [1]"
+    assert at.session_state["_selection_stable"] is True
 
 
 def test_selection_state_is_read_only() -> None:

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -34,12 +34,15 @@ from streamlit.dataframe_util import (
 )
 from streamlit.elements.arrow import (
     DataframeSelectionSerde,
+    DataframeSelectionState,
+    DataframeState,
     _validate_selection_state,
     parse_selection_mode,
 )
 from streamlit.elements.lib.column_config_utils import (
     INDEX_IDENTIFIER,
     ButtonClickSerde,
+    ButtonColumnClickState,
 )
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Dataframe_pb2 import Dataframe as DataframeProto
@@ -1263,8 +1266,9 @@ class TestButtonClickSerde:
 
         # Attribute access must work in addition to key access.
         assert result is not None
-        assert result.row == 2  # type: ignore[attr-defined]
-        assert result.label == "Delete"  # type: ignore[attr-defined]
+        assert isinstance(result, ButtonColumnClickState)
+        assert result.row == 2
+        assert result.label == "Delete"
         assert result["row"] == 2
 
         # The dict is read-only; mutating it must raise.
@@ -1316,11 +1320,17 @@ def test_dataframe_selection_serde_deserialize_rows(
 
 
 def test_dataframe_selection_serde_deserialize_returns_attribute_dictionary() -> None:
-    """``deserialize`` wraps the result in a read-only ``ReadOnlyAttributeDictionary``."""
+    """``deserialize`` returns typed, read-only state classes."""
     result = DataframeSelectionSerde().deserialize(None)
 
     # Attribute access must work for users (regression: #14454).
-    assert result.selection.rows == []  # type: ignore[attr-defined]
+    assert isinstance(result, DataframeState)
+    assert isinstance(result.selection, DataframeSelectionState)
+    assert result.selection.rows == []
+    assert result["selection"]["rows"] == []
+    # Nested selection must be a stable stored instance (not a per-access copy).
+    assert result["selection"] is result["selection"]
+    assert result.selection is result["selection"]
     # The dict is read-only; mutating the top-level mapping must raise.
     with pytest.raises(TypeError):
         result["selection"] = {"rows": [99], "columns": [], "cells": []}  # type: ignore[index]

--- a/lib/tests/streamlit/elements/plotly_chart_test.py
+++ b/lib/tests/streamlit/elements/plotly_chart_test.py
@@ -23,6 +23,8 @@ import streamlit as st
 from streamlit.elements.plotly_chart import (
     PlotlyChartSelectionSerde,
     PlotlyMixin,
+    PlotlySelectionState,
+    PlotlyState,
     _resolve_content_height,
     _resolve_content_width,
 )
@@ -717,3 +719,16 @@ def test_plotly_serde_serialize_returns_json_string() -> None:
 
     assert isinstance(payload, str)
     assert "selection" in payload
+
+
+def test_plotly_serde_returns_typed_state_classes() -> None:
+    """The Plotly serde returns typed classes for both state levels."""
+    result = PlotlyChartSelectionSerde().deserialize(None)
+
+    assert isinstance(result, PlotlyState)
+    assert isinstance(result.selection, PlotlySelectionState)
+    assert result.selection.points == []
+    assert result["selection"]["point_indices"] == []
+    # Nested selection must be a stable stored instance (not a per-access copy).
+    assert result["selection"] is result["selection"]
+    assert result.selection is result["selection"]

--- a/lib/tests/streamlit/elements/pydeck_test.py
+++ b/lib/tests/streamlit/elements/pydeck_test.py
@@ -29,6 +29,8 @@ from streamlit.elements import deck_gl_json_chart
 from streamlit.elements.deck_gl_json_chart import (
     PydeckMixin,
     PydeckSelectionSerde,
+    PydeckSelectionState,
+    PydeckState,
     _get_pydeck_width,
     parse_selection_mode,
 )
@@ -673,7 +675,12 @@ class PydeckSelectionSerdeTest(DeltaGeneratorTestCase):
         result = serde.deserialize(json_str)
 
         # Should support both dict and attribute access
+        assert isinstance(result, PydeckState)
+        assert isinstance(result.selection, PydeckSelectionState)
         assert result.selection.indices["layer1"] == [0]
+        # Nested selection must be a stable stored instance (not a per-access copy).
+        assert result["selection"] is result["selection"]
+        assert result.selection is result["selection"]
 
 
 class ParseSelectionModeTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -39,6 +39,8 @@ from streamlit.elements.lib.built_in_chart_utils import (
     StreamlitColumnNotFoundError,
 )
 from streamlit.elements.vega_charts import (
+    VegaLiteState,
+    VegaLiteStateSerde,
     _extract_selection_parameters,
     _parse_selection_mode,
     _reset_counter_pattern,
@@ -55,6 +57,18 @@ if TYPE_CHECKING:
 df1 = pd.DataFrame([["A", "B", "C", "D"], [28, 55, 43, 91]], index=["a", "b"]).T
 df2 = pd.DataFrame([["E", "F", "G", "H"], [11, 12, 13, 14]], index=["a", "b"]).T
 autosize_spec = {"autosize": {"type": "fit", "contains": "padding"}}
+
+
+def test_vega_lite_serde_returns_typed_state() -> None:
+    """The Vega-Lite serde returns a typed event state."""
+    result = VegaLiteStateSerde(["brush"]).deserialize(None)
+
+    assert isinstance(result, VegaLiteState)
+    assert result.selection.brush == {}
+    assert result["selection"]["brush"] == {}
+    # Nested selection must be a stable stored instance (not a per-access copy).
+    assert result["selection"] is result["selection"]
+    assert result.selection is result["selection"]
 
 
 def merge_dicts(x, y):

--- a/lib/tests/streamlit/typing/button_column_types.py
+++ b/lib/tests/streamlit/typing/button_column_types.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from typing_extensions import assert_type
 
@@ -23,11 +23,18 @@ from typing_extensions import assert_type
 # - Without key: returns ColumnConfig
 # - With key: returns ButtonColumnResult
 if TYPE_CHECKING:
+    from streamlit.elements.lib.column_config_utils import ButtonColumnClickState
     from streamlit.elements.lib.column_types import (
         ButtonColumn,
         ButtonColumnResult,
         ColumnConfig,
     )
+
+    click_state = cast("ButtonColumnClickState", object())
+    assert_type(click_state.row, int)
+    assert_type(click_state["row"], int)
+    assert_type(click_state.label, str)
+    assert_type(click_state["label"], str)
 
     # =====================================================================
     # Return type tests - verify overload resolution

--- a/lib/tests/streamlit/typing/chat_input_types.py
+++ b/lib/tests/streamlit/typing/chat_input_types.py
@@ -24,6 +24,7 @@ from typing_extensions import assert_type
 # - accept_file=True/multiple/directory OR accept_audio=True -> returns ChatInputValue | None
 if TYPE_CHECKING:
     from streamlit.elements.widgets.chat import ChatInputValue, ChatMixin
+    from streamlit.runtime.uploaded_file_manager import UploadedFile
 
     chat_input = ChatMixin().chat_input
 
@@ -63,6 +64,15 @@ if TYPE_CHECKING:
         chat_input("Message", accept_file="multiple", accept_audio=True),
         ChatInputValue | None,
     )
+
+    chat_value = chat_input("Message", accept_file=True, accept_audio=True)
+    if chat_value is not None:
+        assert_type(chat_value.text, str)
+        assert_type(chat_value["text"], str)
+        assert_type(chat_value.files, list[UploadedFile])
+        assert_type(chat_value["files"], list[UploadedFile])
+        assert_type(chat_value.audio, UploadedFile | None)
+        assert_type(chat_value["audio"], UploadedFile | None)
 
     # =====================================================================
     # Test key parameter (str or int)

--- a/lib/tests/streamlit/typing/context_types.py
+++ b/lib/tests/streamlit/typing/context_types.py
@@ -1,0 +1,27 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from typing_extensions import assert_type
+
+if TYPE_CHECKING:
+    from streamlit.runtime.context import StreamlitTheme
+
+    theme = StreamlitTheme({"type": "dark"})
+
+    assert_type(theme.type, Literal["dark", "light"] | None)
+    assert_type(theme["type"], Literal["dark", "light"] | None)

--- a/lib/tests/streamlit/typing/dataframe_types.py
+++ b/lib/tests/streamlit/typing/dataframe_types.py
@@ -258,6 +258,12 @@ if TYPE_CHECKING:
         ),
         DataframeState,
     )
+    # Round-trip: returned DataframeState must be valid for selection_default.
+    returned_state = dataframe(df, on_select="rerun")
+    assert_type(
+        dataframe(df, on_select="rerun", selection_default=returned_state),
+        DataframeState,
+    )
 
     # =====================================================================
     # Test row_height parameter (int or None)

--- a/lib/tests/streamlit/typing/dataframe_types.py
+++ b/lib/tests/streamlit/typing/dataframe_types.py
@@ -27,7 +27,11 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.elements.arrow import ArrowMixin, DataframeState
+    from streamlit.elements.arrow import (
+        ArrowMixin,
+        DataframeSelectionState,
+        DataframeState,
+    )
 
     dataframe = ArrowMixin().dataframe
 
@@ -64,6 +68,16 @@ if TYPE_CHECKING:
     assert_type(dataframe(None, on_select="rerun"), DataframeState)
     assert_type(dataframe([[1, 2], [3, 4]], on_select="rerun"), DataframeState)
     assert_type(dataframe({"col1": [1, 2]}, on_select="rerun"), DataframeState)
+
+    dataframe_state = dataframe(df, on_select="rerun")
+    assert_type(dataframe_state.selection, DataframeSelectionState)
+    assert_type(dataframe_state["selection"], DataframeSelectionState)
+    assert_type(dataframe_state.selection.rows, list[int])
+    assert_type(dataframe_state.selection["rows"], list[int])
+    assert_type(dataframe_state["selection"].columns, list[str])
+    assert_type(dataframe_state["selection"]["columns"], list[str])
+    assert_type(dataframe_state.selection.cells, list[tuple[int, str]])
+    assert_type(dataframe_state.selection["cells"], list[tuple[int, str]])
 
     # =====================================================================
     # Return type tests with callback function

--- a/lib/tests/streamlit/typing/plotly_chart_types.py
+++ b/lib/tests/streamlit/typing/plotly_chart_types.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import assert_type
 
@@ -30,7 +30,11 @@ if TYPE_CHECKING:
     from plotly.basedatatypes import BaseFigure
 
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.elements.plotly_chart import PlotlyMixin, PlotlyState
+    from streamlit.elements.plotly_chart import (
+        PlotlyMixin,
+        PlotlySelectionState,
+        PlotlyState,
+    )
 
     plotly_chart = PlotlyMixin().plotly_chart
 
@@ -51,6 +55,18 @@ if TYPE_CHECKING:
     assert_type(plotly_chart(mpl_fig), PlotlyState)
     assert_type(plotly_chart([fig, data]), PlotlyState)
     assert_type(plotly_chart({"data": data}), PlotlyState)
+
+    plotly_state = plotly_chart(fig)
+    assert_type(plotly_state.selection, PlotlySelectionState)
+    assert_type(plotly_state["selection"], PlotlySelectionState)
+    assert_type(plotly_state.selection.points, list[dict[str, Any]])
+    assert_type(plotly_state.selection["points"], list[dict[str, Any]])
+    assert_type(plotly_state.selection.point_indices, list[int])
+    assert_type(plotly_state.selection["point_indices"], list[int])
+    assert_type(plotly_state.selection.box, list[dict[str, Any]])
+    assert_type(plotly_state.selection["box"], list[dict[str, Any]])
+    assert_type(plotly_state.selection.lasso, list[dict[str, Any]])
+    assert_type(plotly_state.selection["lasso"], list[dict[str, Any]])
 
     # =====================================================================
     # Return type tests with on_select="ignore" -> DeltaGenerator

--- a/lib/tests/streamlit/typing/pydeck_chart_types.py
+++ b/lib/tests/streamlit/typing/pydeck_chart_types.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import assert_type
 
@@ -29,7 +29,11 @@ if TYPE_CHECKING:
     from pydeck import Deck
 
     from streamlit.delta_generator import DeltaGenerator
-    from streamlit.elements.deck_gl_json_chart import PydeckMixin, PydeckState
+    from streamlit.elements.deck_gl_json_chart import (
+        PydeckMixin,
+        PydeckSelectionState,
+        PydeckState,
+    )
 
     pydeck_chart = PydeckMixin().pydeck_chart
 
@@ -43,6 +47,14 @@ if TYPE_CHECKING:
     assert_type(pydeck_chart(deck), PydeckState)
     assert_type(pydeck_chart(None), PydeckState)
     assert_type(pydeck_chart(), PydeckState)
+
+    pydeck_state = pydeck_chart(deck)
+    assert_type(pydeck_state.selection, PydeckSelectionState)
+    assert_type(pydeck_state["selection"], PydeckSelectionState)
+    assert_type(pydeck_state.selection.indices, dict[str, list[int]])
+    assert_type(pydeck_state.selection["indices"], dict[str, list[int]])
+    assert_type(pydeck_state.selection.objects, dict[str, list[dict[str, Any]]])
+    assert_type(pydeck_state.selection["objects"], dict[str, list[dict[str, Any]]])
 
     # =====================================================================
     # Return type tests with on_select="ignore" -> DeltaGenerator

--- a/lib/tests/streamlit/typing/vega_charts_types.py
+++ b/lib/tests/streamlit/typing/vega_charts_types.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.elements.vega_charts import VegaChartsMixin, VegaLiteState
+    from streamlit.util import AttributeDictionary
 
     line_chart = VegaChartsMixin().line_chart
     area_chart = VegaChartsMixin().area_chart
@@ -207,6 +208,9 @@ if TYPE_CHECKING:
         altair_chart(chart, on_select="rerun", selection_mode=["p1", "p2"]),
         VegaLiteState,
     )
+    vega_lite_state = altair_chart(chart, on_select="rerun")
+    assert_type(vega_lite_state.selection, AttributeDictionary)
+    assert_type(vega_lite_state["selection"], AttributeDictionary)
     assert_type(
         altair_chart(
             chart,


### PR DESCRIPTION
## Describe your changes

Replaces `TypedDict` selection/event state schemas with typed `AttributeDictionary` / `ReadOnlyAttributeDictionary` subclasses so IDE attribute and bracket access are both accurately typed (`state.selection.rows` and `state["selection"]["rows"]`).

- Splits dataframe assignable input (`DataframeStateInput`) from returned state classes so programmatic selection still accepts plain dicts
- Eagerly wraps nested `selection` in serdes so bracket access returns a stable typed instance
- Renames `ButtonClickState` → `ButtonColumnClickState` (internal typing name; not exported on `st`)

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests (app scripts updated; snapshot updates may still be needed)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 License.

Made with [Cursor](https://cursor.com)