### PR TITLE
[feature] Emit a bounded failure reason on skills-install nudge telemetry

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7360,6 +7360,42 @@ describe("Skills install nudge", () => {
     })
   })
 
+  it("tracks a safety-gate refusal as Refused, not Failed", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // The server prefixes gate reasons with `refused:` — the install was declined
+    // before it was attempted, so it must not inflate the install-failure rate.
+    // Label construction is unit-tested in skillsNudge.test.ts; this asserts App
+    // routes a refusal to the distinct EVENT, which is the funnel discontinuity
+    // this PR introduces and the one thing a unit test cannot see.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockRejectedValue(
+      Object.assign(
+        new Error("Skills install is not available in this environment."),
+        { reason: "refused:non_loopback" }
+      )
+    )
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    // The prefix is stripped, so the gate name stays readable in the label.
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallRefused:non_loopback",
+    })
+    // A refusal is not a failure and must stay off the failure funnel.
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed:refused:non_loopback",
+    })
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed",
+    })
+  })
+
   it("counts a dropped-connection install separately from a failure", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     vi.spyOn(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7302,6 +7302,117 @@ describe("Skills install nudge", () => {
     })
   })
 
+  it("appends the server failure reason to the install-failed label", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // The server classifies the failure (e.g. a filesystem write failure on a
+    // locked-down target dir) and the rejected error carries a machine-readable
+    // reason from the fixed vocabulary.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockRejectedValue(
+      Object.assign(new Error("Could not write ~/.claude/skills/..."), {
+        reason: "write_failed",
+      })
+    )
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    // The reason is a label suffix (mirroring skillsNudgeSuppressedNonLocal:<locality>)
+    // so the funnel can break install failures down by cause.
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed:write_failed",
+    })
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed",
+    })
+  })
+
+  it("tags a rerouted install with the server's fallback reason", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // Installs the server reroutes from project mode to a global copy carry WHY.
+    // Symlinks being unavailable machine-wide (Windows without Developer Mode) is a
+    // different problem from a single link failing, so the label keeps them apart.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockResolvedValue({
+      detail: "Installed to ~/.agents/skills",
+      fallbackReason: "symlinks_unsupported",
+    })
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded:symlinks_unsupported",
+    })
+    // The plain success label must not also fire (it would double-count).
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded",
+    })
+  })
+
+  it("emits the bare success label when no reroute happened", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // A normal project install carries no fallback reason, so no suffix — and an
+    // older backend that omits the field must degrade to this same label.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockResolvedValue({ detail: "Installed to .agents/skills" })
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded",
+    })
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallSucceeded:",
+    })
+  })
+
+  it("tracks a safety-gate refusal as Refused, not Failed", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // The server prefixes gate reasons with `refused:` — the install was declined
+    // before it was attempted, so it must not inflate the install-failure rate.
+    vi.spyOn(
+      BackendOperationClient.prototype,
+      "requestInstallSkills"
+    ).mockRejectedValue(
+      Object.assign(
+        new Error("Skills install is not available in this environment."),
+        { reason: "refused:non_loopback" }
+      )
+    )
+    renderApp(getProps())
+    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
+    sendRecommendingNewSession()
+
+    await user.click(screen.getByRole("button", { name: "Install" }))
+    await flushInstall()
+
+    // The prefix is stripped, so the gate name stays readable in the label.
+    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallRefused:non_loopback",
+    })
+    // A refusal is not a failure and must stay off the failure funnel.
+    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
+      label: "skillsNudgeInstallFailed:refused:non_loopback",
+    })
+  })
+
   it("counts a dropped-connection install separately from a failure", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     vi.spyOn(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -7360,59 +7360,6 @@ describe("Skills install nudge", () => {
     })
   })
 
-  it("emits the bare success label when no reroute happened", async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    // A normal project install carries no fallback reason, so no suffix — and an
-    // older backend that omits the field must degrade to this same label.
-    vi.spyOn(
-      BackendOperationClient.prototype,
-      "requestInstallSkills"
-    ).mockResolvedValue({ detail: "Installed to .agents/skills" })
-    renderApp(getProps())
-    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
-    sendRecommendingNewSession()
-
-    await user.click(screen.getByRole("button", { name: "Install" }))
-    await flushInstall()
-
-    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallSucceeded",
-    })
-    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallSucceeded:",
-    })
-  })
-
-  it("tracks a safety-gate refusal as Refused, not Failed", async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    // The server prefixes gate reasons with `refused:` — the install was declined
-    // before it was attempted, so it must not inflate the install-failure rate.
-    vi.spyOn(
-      BackendOperationClient.prototype,
-      "requestInstallSkills"
-    ).mockRejectedValue(
-      Object.assign(
-        new Error("Skills install is not available in this environment."),
-        { reason: "refused:non_loopback" }
-      )
-    )
-    renderApp(getProps())
-    const metricsManager = getStoredValue<MetricsManager>(MetricsManager)
-    sendRecommendingNewSession()
-
-    await user.click(screen.getByRole("button", { name: "Install" }))
-    await flushInstall()
-
-    // The prefix is stripped, so the gate name stays readable in the label.
-    expect(metricsManager.enqueue).toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallRefused:non_loopback",
-    })
-    // A refusal is not a failure and must stay off the failure funnel.
-    expect(metricsManager.enqueue).not.toHaveBeenCalledWith("menuClick", {
-      label: "skillsNudgeInstallFailed:refused:non_loopback",
-    })
-  })
-
   it("counts a dropped-connection install separately from a failure", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     vi.spyOn(

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -29,10 +29,11 @@ import {
   isSkillsNudgeDismissed,
   isSkillsNudgeDroppedConnection,
   isSkillsNudgeSnoozed,
-  REFUSED_REASON_PREFIX,
   setSkillsNudgeDismissed,
   setSkillsNudgeSnoozed,
   SKILLS_NUDGE_DROPPED_MESSAGE,
+  skillsNudgeInstallFailureLabel,
+  skillsNudgeInstallSuccessLabel,
 } from "@streamlit/app/src/components/SkillsNudgeToast/skillsNudge"
 import SkillsNudgeToast from "@streamlit/app/src/components/SkillsNudgeToast/SkillsNudgeToast"
 import StatusWidget from "@streamlit/app/src/components/StatusWidget/StatusWidget"
@@ -86,7 +87,6 @@ import {
   FileUploadClient,
   FormsData,
   generateUID,
-  getBackendOperationReason,
   getElementId,
   getEmbeddingIdClassName,
   getIFrameEnclosingApp,
@@ -1606,17 +1606,8 @@ export class App extends PureComponent<Props, State> {
         // — no need to also write the permanent "don't show again" flag here,
         // which would conflate "installed" with a permanent opt-out. The card
         // shows its own success confirmation and auto-dismisses.
-        //
-        // Tag installs the server rerouted from project mode to a global copy with
-        // the reason it gave (a bounded set — see fallback_reason in the proto). The
-        // distinctions matter because they point at different fixes, and a fallback
-        // install is otherwise indistinguishable from a project install in the
-        // success telemetry.
-        const fallbackReason = result.fallbackReason
         this.trackSkillsNudge(
-          fallbackReason
-            ? `skillsNudgeInstallSucceeded:${fallbackReason}`
-            : "skillsNudgeInstallSucceeded"
+          skillsNudgeInstallSuccessLabel(result.fallbackReason)
         )
         return result.detail ?? undefined
       })
@@ -1630,23 +1621,10 @@ export class App extends PureComponent<Props, State> {
           this.trackSkillsNudge("skillsNudgeInstallDropped")
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)
         }
-        // Append the server's machine-readable reason as a label suffix —
-        // mirroring `skillsNudgeSuppressedNonLocal:<locality>` — so outcomes split
-        // by cause (e.g. "conflict", "write_failed", "source_missing"). A reason the
-        // server marked with REFUSED_REASON_PREFIX is an install a safety gate
-        // declined to attempt, not one that ran and failed, so it goes under a
-        // distinct `skillsNudgeInstallRefused:<reason>` and never inflates the
-        // failure rate. Reasons are a fixed server-side vocabulary (never user input).
-        const reason = getBackendOperationReason(error)
-        const isRefusal = reason?.startsWith(REFUSED_REASON_PREFIX) ?? false
-        const eventName = isRefusal
-          ? "skillsNudgeInstallRefused"
-          : "skillsNudgeInstallFailed"
-        // Strip the marker so the label reads `...Refused:non_loopback`.
-        const suffix = isRefusal
-          ? reason?.slice(REFUSED_REASON_PREFIX.length)
-          : reason
-        this.trackSkillsNudge(suffix ? `${eventName}:${suffix}` : eventName)
+        // Append the server's machine-readable reason as a label suffix, and
+        // count a safety-gate refusal under its own event rather than as a
+        // failure. See skillsNudgeInstallFailureLabel.
+        this.trackSkillsNudge(skillsNudgeInstallFailureLabel(error))
         // Re-throw so the toast renders its error state.
         throw error
       })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -29,6 +29,7 @@ import {
   isSkillsNudgeDismissed,
   isSkillsNudgeDroppedConnection,
   isSkillsNudgeSnoozed,
+  REFUSED_REASON_PREFIX,
   setSkillsNudgeDismissed,
   setSkillsNudgeSnoozed,
   SKILLS_NUDGE_DROPPED_MESSAGE,
@@ -1604,20 +1605,47 @@ export class App extends PureComponent<Props, State> {
         // — no need to also write the permanent "don't show again" flag here,
         // which would conflate "installed" with a permanent opt-out. The card
         // shows its own success confirmation and auto-dismisses.
-        this.trackSkillsNudge("skillsNudgeInstallSucceeded")
+        //
+        // Tag installs the server rerouted from project mode to a global copy with
+        // the reason it gave (a bounded set — see fallback_reason in the proto). The
+        // distinctions matter because they point at different fixes, and a fallback
+        // install is otherwise indistinguishable from a project install in the
+        // success telemetry.
+        const fallbackReason = result.fallbackReason
+        this.trackSkillsNudge(
+          fallbackReason
+            ? `skillsNudgeInstallSucceeded:${fallbackReason}`
+            : "skillsNudgeInstallSucceeded"
+        )
         return result.detail ?? undefined
       })
       .catch((error: unknown) => {
-        // A dropped or timed-out connection during a long install (e.g. the
-        // GitHub global fallback) rejects the request even though the server
-        // install may have completed. Count it separately — not as a failure,
-        // which would over-count the funnel — and surface a reassuring,
-        // retry-friendly message; re-install is idempotent.
+        // A dropped or timed-out connection during a long install rejects the
+        // request even though the server install may have completed. Count it
+        // separately — not as a failure, which would over-count the funnel —
+        // and surface a reassuring, retry-friendly message; re-install is
+        // idempotent.
         if (isSkillsNudgeDroppedConnection(error)) {
           this.trackSkillsNudge("skillsNudgeInstallDropped")
           throw new Error(SKILLS_NUDGE_DROPPED_MESSAGE)
         }
-        this.trackSkillsNudge("skillsNudgeInstallFailed")
+        // Append the server's machine-readable reason as a label suffix —
+        // mirroring `skillsNudgeSuppressedNonLocal:<locality>` — so outcomes split
+        // by cause (e.g. "conflict", "write_failed", "source_missing"). A reason the
+        // server marked with REFUSED_REASON_PREFIX is an install a safety gate
+        // declined to attempt, not one that ran and failed, so it goes under a
+        // distinct `skillsNudgeInstallRefused:<reason>` and never inflates the
+        // failure rate. Reasons are a fixed server-side vocabulary (never user input).
+        const reason = (error as { reason?: string } | null)?.reason
+        const isRefusal = reason?.startsWith(REFUSED_REASON_PREFIX) ?? false
+        const eventName = isRefusal
+          ? "skillsNudgeInstallRefused"
+          : "skillsNudgeInstallFailed"
+        // Strip the marker so the label reads `...Refused:non_loopback`.
+        const suffix = isRefusal
+          ? reason?.slice(REFUSED_REASON_PREFIX.length)
+          : reason
+        this.trackSkillsNudge(suffix ? `${eventName}:${suffix}` : eventName)
         // Re-throw so the toast renders its error state.
         throw error
       })

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -86,6 +86,7 @@ import {
   FileUploadClient,
   FormsData,
   generateUID,
+  getBackendOperationReason,
   getElementId,
   getEmbeddingIdClassName,
   getIFrameEnclosingApp,
@@ -1636,7 +1637,7 @@ export class App extends PureComponent<Props, State> {
         // declined to attempt, not one that ran and failed, so it goes under a
         // distinct `skillsNudgeInstallRefused:<reason>` and never inflates the
         // failure rate. Reasons are a fixed server-side vocabulary (never user input).
-        const reason = (error as { reason?: string } | null)?.reason
+        const reason = getBackendOperationReason(error)
         const isRefusal = reason?.startsWith(REFUSED_REASON_PREFIX) ?? false
         const eventName = isRefusal
           ? "skillsNudgeInstallRefused"

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.test.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.test.ts
@@ -28,6 +28,8 @@ import {
   SKILLS_NUDGE_DISMISSED_KEY,
   SKILLS_NUDGE_SNOOZE_MS,
   SKILLS_NUDGE_SNOOZED_AT_KEY,
+  skillsNudgeInstallFailureLabel,
+  skillsNudgeInstallSuccessLabel,
 } from "./skillsNudge"
 
 describe("skillsNudge preferences", () => {
@@ -130,6 +132,64 @@ describe("skillsNudge preferences", () => {
       // so it must not be reclassified as a dropped connection.
       expect(isSkillsNudgeDroppedConnection(CONNECTION_CLOSED_MESSAGE)).toBe(
         false
+      )
+    })
+  })
+
+  describe("skillsNudgeInstallSuccessLabel", () => {
+    it("is the bare label when no reroute happened", () => {
+      expect(skillsNudgeInstallSuccessLabel(undefined)).toBe(
+        "skillsNudgeInstallSucceeded"
+      )
+      // An older backend omits fallback_reason; protobuf sends "" for an unset
+      // string. Neither may produce a dangling ":" suffix.
+      expect(skillsNudgeInstallSuccessLabel(null)).toBe(
+        "skillsNudgeInstallSucceeded"
+      )
+      expect(skillsNudgeInstallSuccessLabel("")).toBe(
+        "skillsNudgeInstallSucceeded"
+      )
+    })
+
+    it("suffixes the reason a project install was rerouted to a global copy", () => {
+      // The Windows cohort's diagnostic signal rides the SUCCESS label, because
+      // they cannot lay symlinks, get rerouted, and then succeed.
+      expect(skillsNudgeInstallSuccessLabel("symlinks_no_privilege")).toBe(
+        "skillsNudgeInstallSucceeded:symlinks_no_privilege"
+      )
+    })
+  })
+
+  describe("skillsNudgeInstallFailureLabel", () => {
+    it("suffixes the server's failure reason", () => {
+      expect(
+        skillsNudgeInstallFailureLabel(
+          Object.assign(new Error("nope"), { reason: "write_denied" })
+        )
+      ).toBe("skillsNudgeInstallFailed:write_denied")
+    })
+
+    it("counts a safety-gate refusal as Refused, with the prefix stripped", () => {
+      // A refusal never ran, so it must not land on the failure metric — the
+      // install-failure rate is the number this whole vocabulary exists to explain.
+      const label = skillsNudgeInstallFailureLabel(
+        Object.assign(new Error("not available"), {
+          reason: "refused:non_loopback",
+        })
+      )
+      expect(label).toBe("skillsNudgeInstallRefused:non_loopback")
+      expect(label).not.toContain("Failed")
+      expect(label).not.toContain("refused:")
+    })
+
+    it("falls back to the bare label when the server sends no reason", () => {
+      // An older backend has no error_reason field at all, and a rejection need
+      // not be an Error. Both must still count as a failure, without a suffix.
+      expect(skillsNudgeInstallFailureLabel(new Error("nope"))).toBe(
+        "skillsNudgeInstallFailed"
+      )
+      expect(skillsNudgeInstallFailureLabel(undefined)).toBe(
+        "skillsNudgeInstallFailed"
       )
     })
   })

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -15,17 +15,22 @@
  */
 
 /**
- * Client-side preference helpers for the in-app "install skills" nudge.
+ * Client-side helpers for the in-app "install skills" nudge.
  *
  * The nudge's *visibility* is owned by ``App`` (it depends on the per-session
- * ``recommendSkillsInstall`` flag and React state), but the browser-local
- * preference logic — the ``localStorage`` snooze/dismiss flags and the
- * dropped-connection classification — is pure and lives here so it can be unit
- * tested in isolation and kept out of the already-large ``App`` component.
+ * ``recommendSkillsInstall`` flag and React state), but everything here is pure —
+ * the ``localStorage`` snooze/dismiss flags, the dropped-connection
+ * classification, and the telemetry labels an install outcome maps to — so it can
+ * be unit tested in isolation and kept out of the already-large ``App`` component.
+ *
+ * Keeping the label functions here also keeps the whole emitted vocabulary in one
+ * file, including the ``refused:`` marker the server namespaces gate refusals
+ * with, which no other module needs to know about.
  */
 
 import {
   CONNECTION_CLOSED_MESSAGE,
+  getBackendOperationReason,
   REQUEST_TIMED_OUT_MESSAGE,
 } from "@streamlit/lib"
 import { localStorageAvailable } from "@streamlit/utils"
@@ -124,12 +129,54 @@ export function isSkillsNudgeDroppedConnection(error: unknown): boolean {
 }
 
 /**
+ * Telemetry label for a successful install.
+ *
+ * A `fallbackReason` means the server rerouted a project install to a global copy
+ * and named why (a bounded set — see `fallback_reason` in the proto). It becomes a
+ * label suffix because a fallback install is otherwise indistinguishable from a
+ * project install in the success telemetry, and the causes point at different
+ * fixes — only Developer Mode being off is something a user can simply turn on.
+ */
+export function skillsNudgeInstallSuccessLabel(
+  fallbackReason?: string | null
+): string {
+  return fallbackReason
+    ? `skillsNudgeInstallSucceeded:${fallbackReason}`
+    : "skillsNudgeInstallSucceeded"
+}
+
+/**
  * Prefix the server puts on an `error_reason` when a safety gate *refused* the
  * install before attempting it (headless server, no agent harness, non-loopback
- * connection) rather than an install that ran and failed. Refusals are tracked
- * under their own event (`skillsNudgeInstallRefused:<reason>`) so they don't
- * inflate the genuine install-failure rate. The server owns which reasons are
- * refusals — we only strip the prefix — so a gate added there needs no change
- * here. Mirrors `_REFUSED_REASON_PREFIX` in `backend_operation_handler.py`.
+ * connection) rather than an install that ran and failed. The server owns which
+ * reasons are refusals — we only strip the prefix — so a gate added there needs no
+ * change here. Mirrors `_REFUSED_REASON_PREFIX` in `backend_operation_handler.py`.
  */
-export const REFUSED_REASON_PREFIX = "refused:"
+const REFUSED_REASON_PREFIX = "refused:"
+
+/**
+ * Telemetry label for an install the server rejected.
+ *
+ * Splits two outcomes the funnel must not conflate: an install that *ran and
+ * failed*, and one a safety gate *refused* before touching the filesystem —
+ * refusals get their own event so they never inflate the genuine failure rate.
+ * Either way the server's machine-readable reason becomes a label suffix,
+ * mirroring `skillsNudgeSuppressedNonLocal:<locality>`, so outcomes split by cause
+ * (e.g. `skillsNudgeInstallFailed:write_denied`). Reasons are a fixed server-side
+ * vocabulary, never user input, so they are safe to emit verbatim.
+ *
+ * Callers must check {@link isSkillsNudgeDroppedConnection} first — a dropped
+ * connection is neither outcome and is counted separately.
+ */
+export function skillsNudgeInstallFailureLabel(error: unknown): string {
+  // getBackendOperationReason already narrows to a non-empty string, so an older
+  // backend that omits error_reason lands on the bare label below.
+  const reason = getBackendOperationReason(error) ?? ""
+  const isRefusal = reason.startsWith(REFUSED_REASON_PREFIX)
+  const event = isRefusal
+    ? "skillsNudgeInstallRefused"
+    : "skillsNudgeInstallFailed"
+  // Strip the marker so the label reads `...Refused:non_loopback`.
+  const cause = isRefusal ? reason.slice(REFUSED_REASON_PREFIX.length) : reason
+  return cause ? `${event}:${cause}` : event
+}

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -122,3 +122,14 @@ export function isSkillsNudgeDroppedConnection(error: unknown): boolean {
     message === REQUEST_TIMED_OUT_MESSAGE
   )
 }
+
+/**
+ * Prefix the server puts on an `error_reason` when a safety gate *refused* the
+ * install before attempting it (headless server, no agent harness, non-loopback
+ * connection) rather than an install that ran and failed. Refusals are tracked
+ * under their own event (`skillsNudgeInstallRefused:<reason>`) so they don't
+ * inflate the genuine install-failure rate. The server owns which reasons are
+ * refusals — we only strip the prefix — so a gate added there needs no change
+ * here. Mirrors `_REFUSED_REASON_PREFIX` in `backend_operation_handler.py`.
+ */
+export const REFUSED_REASON_PREFIX = "refused:"

--- a/frontend/lib/src/BackendOperationClient.test.ts
+++ b/frontend/lib/src/BackendOperationClient.test.ts
@@ -252,6 +252,48 @@ describe("BackendOperationClient", () => {
     await expect(promise).rejects.toThrow("No skills found")
   })
 
+  it("attaches the server's error_reason to the rejected install error", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        errorMsg: "developing-with-streamlit already exists.",
+        errorReason: "conflict",
+      })
+    )
+
+    // The rejection carries both the human message and the machine-readable
+    // reason (so App can route it to install-failure telemetry by cause).
+    await expect(promise).rejects.toMatchObject({
+      message: "developing-with-streamlit already exists.",
+      reason: "conflict",
+    })
+  })
+
+  it("leaves reason undefined when the server omits error_reason", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        errorMsg: "Failed to install skills.",
+      })
+    )
+
+    await expect(promise).rejects.toSatisfy(
+      (error: unknown) => (error as { reason?: string }).reason === undefined
+    )
+  })
+
   it("sends dismiss skills nudge requests and resolves on the ack", async () => {
     const sendRequest = vi.fn()
     const client = createClient(sendRequest)

--- a/frontend/lib/src/BackendOperationClient.test.ts
+++ b/frontend/lib/src/BackendOperationClient.test.ts
@@ -19,7 +19,10 @@ import {
   BackendOperationResponse,
 } from "@streamlit/protobuf"
 
-import { BackendOperationClient } from "./BackendOperationClient"
+import {
+  BackendOperationClient,
+  getBackendOperationReason,
+} from "./BackendOperationClient"
 
 function createClient(
   sendRequest = vi.fn(),
@@ -290,8 +293,53 @@ describe("BackendOperationClient", () => {
     )
 
     await expect(promise).rejects.toSatisfy(
-      (error: unknown) => (error as { reason?: string }).reason === undefined
+      (error: unknown) => getBackendOperationReason(error) === undefined
     )
+  })
+
+  it("preserves the server's fallback_reason on a successful install", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        installSkills: {
+          detail: "Installed to ~/.agents/skills",
+          fallbackReason: "symlinks_no_privilege",
+        },
+      })
+    )
+
+    // A project install rerouted to a global copy still SUCCEEDS, so this cohort's
+    // only diagnostic signal is the fallback reason riding the success payload
+    // through to skillsNudgeInstallSucceeded:<fallback_reason>.
+    await expect(promise).resolves.toEqual({
+      detail: "Installed to ~/.agents/skills",
+      fallbackReason: "symlinks_no_privilege",
+    })
+  })
+
+  it("leaves fallbackReason empty for a normal project install", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        installSkills: { detail: "Installed", fallbackReason: "" },
+      })
+    )
+
+    const payload = await promise
+    // Must stay falsy, or App would tag an ordinary symlink install as a fallback.
+    expect(payload.fallbackReason).toBeFalsy()
   })
 
   it("sends dismiss skills nudge requests and resolves on the ack", async () => {

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -39,12 +39,12 @@ const DATAFRAME_CHUNK_REQUEST_TIMEOUT_MS = 120_000
 /**
  * Timeout for skills-install requests (3 minutes).
  *
- * The default 30s is too short here: a project-mode install is fast (it just
- * creates symlinks), but `streamlit skills` falls back to downloading the
- * skills archive from GitHub when symlinks aren't supported (e.g. Windows
- * without Developer Mode). That download can exceed 30s on a slow network,
- * which would surface a spurious "install failed" in the toast while the
- * server keeps installing. We use the same generous budget as deferred files.
+ * The default 30s is too short here: an install does real filesystem I/O -
+ * copying the bundled meta-skill/content skills into project or home dirs -
+ * which can be slow on locked-down machines (antivirus scans, networked or
+ * OneDrive-backed home directories). A too-short timeout would surface a
+ * spurious "install failed" in the toast while the server keeps installing.
+ * We use the same generous budget as deferred files.
  */
 const INSTALL_SKILLS_REQUEST_TIMEOUT_MS = 180_000
 
@@ -57,6 +57,24 @@ export const CONNECTION_CLOSED_MESSAGE = "Connection closed"
 
 /** Rejection message used when a request exceeds its timeout. */
 export const REQUEST_TIMED_OUT_MESSAGE = "Request timed out"
+
+/**
+ * Error a backend operation rejects with when the server returns a failure.
+ * Carries the server's machine-readable `reason` (e.g. the skills-install
+ * failure cause) alongside the human-readable message, so callers can route it
+ * to telemetry without parsing the message text. Not exported: it is thrown
+ * from within this module and consumers read the `reason` property structurally
+ * (`(error as { reason?: string }).reason`) rather than via `instanceof`.
+ */
+class BackendOperationError extends Error {
+  public readonly reason?: string
+
+  constructor(message: string, reason?: string) {
+    super(message)
+    this.name = "BackendOperationError"
+    this.reason = reason || undefined
+  }
+}
 
 /** Information about a pending request. */
 interface PendingRequest<T> {
@@ -193,15 +211,19 @@ export class BackendOperationClient {
   /**
    * Request a one-click install of the bundled Streamlit agent skills.
    *
-   * @returns A promise that resolves with an optional outcome detail, or
-   * rejects with the server-provided error message on failure.
+   * @returns A promise that resolves with an optional outcome detail and a
+   * `fallbackReason` naming why a project install was rerouted to a global copy
+   * (empty when it wasn't), or rejects with a {@link BackendOperationError} whose
+   * `reason` classifies the failure for telemetry.
    */
-  public requestInstallSkills(): Promise<{ detail?: string | null }> {
-    return this.request<{ detail?: string | null }>(
-      "installSkills",
-      {},
-      INSTALL_SKILLS_REQUEST_TIMEOUT_MS
-    )
+  public requestInstallSkills(): Promise<{
+    detail?: string | null
+    fallbackReason?: string | null
+  }> {
+    return this.request<{
+      detail?: string | null
+      fallbackReason?: string | null
+    }>("installSkills", {}, INSTALL_SKILLS_REQUEST_TIMEOUT_MS)
   }
 
   /**
@@ -230,7 +252,12 @@ export class BackendOperationClient {
     this.cleanupRequest(requestId)
 
     if (response.errorMsg) {
-      pending.resolver.reject(new Error(response.errorMsg))
+      pending.resolver.reject(
+        new BackendOperationError(
+          response.errorMsg,
+          response.errorReason ?? undefined
+        )
+      )
     } else {
       try {
         const payload = this.extractResponsePayload(response)

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -62,9 +62,10 @@ export const REQUEST_TIMED_OUT_MESSAGE = "Request timed out"
  * Error a backend operation rejects with when the server returns a failure.
  * Carries the server's machine-readable `reason` (e.g. the skills-install
  * failure cause) alongside the human-readable message, so callers can route it
- * to telemetry without parsing the message text. Not exported: it is thrown
- * from within this module and consumers read the `reason` property structurally
- * (`(error as { reason?: string }).reason`) rather than via `instanceof`.
+ * to telemetry without parsing the message text. Read it via
+ * {@link getBackendOperationReason} rather than exporting the class, which keeps
+ * the throw site inside this module and gives callers a typed accessor instead of
+ * a hand-written structural cast.
  */
 class BackendOperationError extends Error {
   public readonly reason?: string
@@ -74,6 +75,27 @@ class BackendOperationError extends Error {
     this.name = "BackendOperationError"
     this.reason = reason || undefined
   }
+}
+
+/**
+ * Return the server's machine-readable failure reason from a rejected backend
+ * operation, or `undefined` for any other error.
+ *
+ * The reason is a bounded server-side vocabulary (never user input), so callers
+ * may safely use it as a telemetry label suffix.
+ *
+ * Reads the property structurally rather than via `instanceof
+ * BackendOperationError`, deliberately. The class is thrown inside
+ * `@streamlit/lib` and read in `@streamlit/app`, and an `instanceof` across that
+ * boundary is only sound while both sides resolve to one class identity — which
+ * bundling and test mocks do not guarantee. What this accessor buys is the thing
+ * that matters: callers no longer hand-write `(error as { reason?: string })`, and
+ * renaming the property is a one-line change here instead of a silent `undefined`
+ * at every call site.
+ */
+export function getBackendOperationReason(error: unknown): string | undefined {
+  const reason = (error as { reason?: unknown } | null | undefined)?.reason
+  return typeof reason === "string" && reason ? reason : undefined
 }
 
 /** Information about a pending request. */

--- a/frontend/lib/src/index.ts
+++ b/frontend/lib/src/index.ts
@@ -109,6 +109,7 @@ export { FileUploadClient } from "./FileUploadClient"
 export {
   BackendOperationClient,
   CONNECTION_CLOSED_MESSAGE,
+  getBackendOperationReason,
   REQUEST_TIMED_OUT_MESSAGE,
 } from "./BackendOperationClient"
 export type { BackendOperationClientProps } from "./BackendOperationClient"

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -275,16 +275,12 @@ class InstallSkillsHandler(BackendOperationHandler):
                 if isinstance(ex, click.ClickException)
                 else "Failed to install skills."
             )
-            # ``skills.InstallError`` carries a bounded, machine-readable ``reason``
-            # that the client forwards to telemetry as a label suffix. Read it ONLY
-            # from that known type - never getattr-duck-type, or an unrelated
-            # exception that happens to expose a str ``.reason`` (e.g.
+            # Read the reason ONLY from the known type - never getattr-duck-type, or
+            # an unrelated exception that happens to expose a str ``.reason`` (e.g.
             # UnicodeDecodeError.reason) would emit an unbounded label and break the
-            # fixed vocabulary. A bare ``OSError`` that escaped the installer (e.g. a
-            # permission error before the copy's own try/except) gets the same errno
-            # classification the installer would have applied, so it lands in a
-            # specific write_* bucket rather than being flattened; anything else
-            # "unknown".
+            # fixed vocabulary. A bare ``OSError`` that escaped the installer gets the
+            # same errno classification, so it lands in a specific write_* bucket
+            # rather than being flattened to "unknown".
             reason: str
             if isinstance(ex, skills.InstallError):
                 reason = ex.reason

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -42,6 +42,13 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = get_logger(__name__)
 
+# Prefix marking an ``error_reason`` as a refusal: the operation was declined by a
+# safety gate before it ran, rather than attempted and failed. The client strips the
+# prefix and counts refusals under their own telemetry event, so they never inflate
+# the genuine failure rate. Mirrored by REFUSED_REASON_PREFIX in the frontend's
+# components/SkillsNudgeToast/skillsNudge.ts.
+_REFUSED_REASON_PREFIX: Final[str] = "refused:"
+
 
 def connection_locality(session_id: str) -> str:
     """Classify the WebSocket peer of ``session_id`` for the skills nudge.
@@ -224,14 +231,29 @@ class InstallSkillsHandler(BackendOperationHandler):
         # after a dropped connection whose first attempt already completed
         # server-side — surfacing a success as an unrecoverable error and
         # logging it as a failed install. Idempotent retry is the correct path.
-        if (
-            config.get_option("server.headless")
-            or not skills.detect_installed_agents()
-            or connection_locality(session_id) != "loopback"
-        ):
+        #
+        # Check the conditions in order; the first that trips names the telemetry
+        # reason. This short-circuits, so e.g. detect_installed_agents() (which
+        # touches the filesystem) isn't called in headless mode.
+        if config.get_option("server.headless"):
+            gate_reason = "headless"
+        elif not skills.detect_installed_agents():
+            gate_reason = "no_agent"
+        elif connection_locality(session_id) != "loopback":
+            gate_reason = "non_loopback"
+        else:
+            gate_reason = None
+
+        if gate_reason is not None:
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg="Skills install is not available in this environment.",
+                # The ``refused:`` prefix tells the client this install was declined
+                # before it ran, so it counts separately from installs that ran and
+                # failed. Namespacing it server-side keeps that distinction in one
+                # place: a gate added here is classified correctly without the
+                # frontend having to mirror the list of gate names.
+                error_reason=f"{_REFUSED_REASON_PREFIX}{gate_reason}",
             )
 
         try:
@@ -253,9 +275,27 @@ class InstallSkillsHandler(BackendOperationHandler):
                 if isinstance(ex, click.ClickException)
                 else "Failed to install skills."
             )
+            # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
+            # that the client forwards to telemetry as a label suffix. Read it ONLY
+            # from that known type - never getattr-duck-type, or an unrelated
+            # exception that happens to expose a str ``.reason`` (e.g.
+            # UnicodeDecodeError.reason) would emit an unbounded label and break the
+            # fixed vocabulary. A bare ``OSError`` that escaped the installer (e.g. a
+            # permission error before the copy's own try/except) gets the same errno
+            # classification the installer would have applied, so it lands in a
+            # specific write_* bucket rather than being flattened; anything else
+            # "unknown".
+            reason: str
+            if isinstance(ex, skills._InstallError):
+                reason = ex.reason
+            elif isinstance(ex, OSError):
+                reason = skills._classify_write_error(ex)
+            else:
+                reason = "unknown"
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",
+                error_reason=reason,
             )
 
         # Invalidate the cached "skills installed" detection so a later session
@@ -265,7 +305,8 @@ class InstallSkillsHandler(BackendOperationHandler):
         return BackendOperationResponse(
             request_id=request.request_id,
             install_skills=InstallSkillsResponsePayload(
-                detail=skills.summarize_install(result)
+                detail=skills.summarize_install(result),
+                fallback_reason=result.fallback_reason or "",
             ),
         )
 

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -275,7 +275,7 @@ class InstallSkillsHandler(BackendOperationHandler):
                 if isinstance(ex, click.ClickException)
                 else "Failed to install skills."
             )
-            # ``skills._InstallError`` carries a bounded, machine-readable ``reason``
+            # ``skills.InstallError`` carries a bounded, machine-readable ``reason``
             # that the client forwards to telemetry as a label suffix. Read it ONLY
             # from that known type - never getattr-duck-type, or an unrelated
             # exception that happens to expose a str ``.reason`` (e.g.
@@ -286,10 +286,10 @@ class InstallSkillsHandler(BackendOperationHandler):
             # specific write_* bucket rather than being flattened; anything else
             # "unknown".
             reason: str
-            if isinstance(ex, skills._InstallError):
+            if isinstance(ex, skills.InstallError):
                 reason = ex.reason
             elif isinstance(ex, OSError):
-                reason = skills._classify_write_error(ex)
+                reason = skills.classify_write_error(ex)
             else:
                 reason = "unknown"
             return BackendOperationResponse(

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -36,15 +36,9 @@ _LOGGER: Final = get_logger(__name__)
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
 
-# The full vocabulary of install-failure causes. A closed set so the reason stays
-# safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
-# typo or an ad-hoc reason at the raise site instead of silently minting a new
-# label the analysis queries won't know about.
-#
-# The ``write_*`` values subdivide what would otherwise be a single opaque
-# "a write failed". That distinction is the point: a lock clears on retry, a path
-# that is too long can be shortened, and neither is fixed by the permissions advice
-# a generic write failure would earn. See :func:`classify_write_error`.
+# The full vocabulary of install-failure causes. Closed so the reason is safe to emit
+# as a telemetry label, and a Literal so mypy rejects a typo'd or ad-hoc reason at the
+# raise site rather than silently minting a label no query knows about.
 _InstallFailureReason = Literal[
     "conflict",  # A pre-existing file or foreign symlink we won't overwrite.
     "incomplete",  # Project symlinks failed and the global fallback was cancelled.
@@ -60,12 +54,10 @@ _InstallFailureReason = Literal[
     "write_failed",  # A write failed for a reason none of the above cover.
 ]
 
-# Why a project install was rerouted to a global copy. Split as finely as the OS lets
-# us, because most Windows users take this path and then SUCCEED - so this, not the
-# failure vocabulary, is where their diagnostic signal lives. The distinctions map to
-# different responses: Developer Mode off is a documentable user action, a denial on
-# the project directory is an environment problem, a filesystem with no symlink support
-# at all is neither, and a link failing after the pre-check passed is closer to a bug.
+# Why a project install was rerouted to a global copy. Split finely because most
+# Windows users take this path and then SUCCEED, so this - not the failure vocabulary
+# above - is where their diagnostic signal lives, and only the first is a cause a user
+# can fix themselves.
 _FallbackReason = Literal[
     "symlinks_no_privilege",  # Windows Developer Mode off (ERROR_PRIVILEGE_NOT_HELD).
     "symlinks_denied",  # Permissions on the project dir refused the probe.
@@ -77,11 +69,9 @@ _FallbackReason = Literal[
 # are not all defined everywhere) simply omits it rather than failing at import.
 _ERRNO_GROUPS: Final[tuple[tuple[tuple[str, ...], _InstallFailureReason], ...]] = (
     (("EACCES", "EPERM", "EROFS"), "write_denied"),
-    # EFBIG is deliberately absent: a file-size limit is not out of space, so it stays
-    # the honest write_failed rather than pointing whoever reads it at a full disk.
+    # EFBIG is deliberately absent: a file-size limit is not out of space.
     (("ENOSPC", "EDQUOT"), "write_no_space"),
-    # EAGAIN sits here on retry semantics rather than locking specifically - like a
-    # held file, the call may well succeed if simply repeated.
+    # EAGAIN belongs here on retry semantics rather than locking specifically.
     (("EBUSY", "EAGAIN", "ETXTBSY"), "write_locked"),
     (("ENAMETOOLONG",), "write_name_too_long"),
 )
@@ -92,10 +82,10 @@ _WRITE_REASON_BY_ERRNO: Final[dict[int, _InstallFailureReason]] = {
     if (code := getattr(errno, name, None)) is not None
 }
 
-# Windows native codes, consulted BEFORE errno because CPython's mapping is lossy in
-# exactly the way that would mislead us: a sharing violation (antivirus or OneDrive
-# holding the file) arrives as EACCES, which reads as a permissions problem and sends
-# us after folder ACLs when the actual fix is to retry.
+# Consulted BEFORE errno: CPython's mapping is lossy in the one direction that would
+# mislead us. A sharing violation (antivirus or a sync client holding the file) arrives
+# as EACCES, so trusting errno on Windows sends us after folder ACLs when the fix is to
+# retry.
 _WRITE_REASON_BY_WINERROR: Final[dict[int, _InstallFailureReason]] = {
     5: "write_denied",  # ERROR_ACCESS_DENIED
     19: "write_denied",  # ERROR_WRITE_PROTECT
@@ -110,12 +100,10 @@ _WRITE_REASON_BY_WINERROR: Final[dict[int, _InstallFailureReason]] = {
 def classify_write_error(error: OSError) -> _InstallFailureReason:
     """Map a filesystem ``OSError`` to a bounded, actionable failure reason.
 
-    Only the error *class* is used - never the message, which can embed an absolute
-    server path - so the result stays safe to emit as a telemetry label.
-
-    Returns the generic ``"write_failed"`` when the code is unrecognised, so an
-    unclassified failure is visible as such in the data rather than being guessed
-    into the wrong bucket.
+    Only the error *class* is used, never the message, which can embed an absolute
+    server path - so the result stays safe to emit as a telemetry label. An
+    unrecognised code stays the generic ``"write_failed"`` rather than being guessed
+    into a specific bucket that would point at the wrong fix.
     """
     winerror = getattr(error, "winerror", None)
     if isinstance(winerror, int) and winerror in _WRITE_REASON_BY_WINERROR:
@@ -128,14 +116,10 @@ def classify_write_error(error: OSError) -> _InstallFailureReason:
 class InstallError(click.ClickException):
     """A skills-install failure carrying a stable machine-readable ``reason`` code.
 
-    The ``reason`` (see :data:`_InstallFailureReason`) is what the backend-operation
-    handler forwards to the client so the nudge's install-failure telemetry can be
-    split by cause. It is a fixed vocabulary set at each raise site, never user
-    input, so it is safe to emit as a telemetry label suffix.
-
-    Otherwise this behaves like a normal ``click.ClickException`` — its
-    ``format_message`` still supplies the user-facing text shown in the CLI and the
-    in-app nudge — so raising it changes nothing a user sees.
+    The backend-operation handler forwards the ``reason`` to the client, which emits
+    it as a telemetry label suffix - hence the fixed :data:`_InstallFailureReason`
+    vocabulary, never user input. Behaves like a plain ``click.ClickException``
+    otherwise, so raising it changes nothing a user sees.
     """
 
     def __init__(self, message: str, *, reason: _InstallFailureReason) -> None:
@@ -169,21 +153,17 @@ class _InstallResult:
     up_to_date: list[str] = field(default_factory=list)
     # Pre-existing files/symlinks we won't overwrite - a genuine "conflict".
     skipped: list[str] = field(default_factory=list)
-    # Filesystem failures during the global copy (OSError: permissions, disk space,
-    # locked files). Tracked separately from ``skipped`` so a write failure is never
-    # misreported as a "conflict" - both in the CLI summary and, crucially, in the
-    # nudge's install-failure telemetry reason. Only the copy path fills this;
-    # symlink failures reroute to a global install instead of being recorded here.
+    # Filesystem failures during the global copy. Kept apart from ``skipped`` so a
+    # write failure is never misreported as a "conflict", in the CLI summary and in
+    # the nudge's telemetry reason. Only the copy path fills this.
     errored: list[str] = field(default_factory=list)
-    # The distinct classified causes behind ``errored``. A set, not a per-entry list:
-    # the only consumer asks whether the failed targets agreed on one cause, never
-    # which target had which. Kept apart from the display strings above because those
-    # carry raw OSError text (fine for the CLI, never for the browser) while these are
-    # the bounded telemetry reasons.
+    # The distinct causes behind ``errored``. A set, not a per-entry list: the only
+    # consumer asks whether the failed targets agreed on one cause, never which
+    # target had which. Separate from the display strings above, which carry raw
+    # OSError text that must not reach the browser.
     write_reasons: set[_InstallFailureReason] = field(default_factory=set)
-    # Set when a project install was rerouted to a global copy, naming why (see
-    # :data:`_FallbackReason`). Surfaced to telemetry so that cohort is countable and
-    # separable - see InstallSkillsResponsePayload.
+    # Set when a project install was rerouted to a global copy, naming why. Surfaced
+    # to telemetry so that cohort is countable - see InstallSkillsResponsePayload.
     fallback_reason: _FallbackReason | None = None
 
 
@@ -407,12 +387,9 @@ def _symlink_blocker(project_root: Path, source_path: Path) -> _FallbackReason |
     """Return why project install can't use symlinks here, or ``None`` if it can.
 
     Probes by actually creating one in a temp dir, then classifies the failure rather
-    than collapsing it to "unsupported". This is the highest-value split in the whole
-    vocabulary: most Windows users land here and then *succeed* via the global
-    fallback, so this is what their success label carries, and the causes want
-    completely different responses. ``symlinks_no_privilege`` (Developer Mode off) is
-    a documentable user action, while a denial on the project directory or a
-    filesystem that has no symlinks at all are not.
+    than collapsing it to "unsupported" - most Windows users land here and then
+    *succeed* via the global fallback, so this is what their success label carries,
+    and only ``symlinks_no_privilege`` (Developer Mode off) is a cause a user can fix.
     """
     try:
         with tempfile.TemporaryDirectory(
@@ -470,10 +447,9 @@ def _install_skill_symlink(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.cwd())
 
-    # Pre-symlink filesystem work (creating the parent dir, inspecting or removing
-    # an existing target) runs under one guard: any OSError here means we can't
-    # lay the symlink, so return False and let the caller fall back to a global
-    # copy - never let it escape and get misbooked as a hard write_failed.
+    # Pre-symlink filesystem work runs under one guard: any OSError here means we
+    # can't lay the symlink, so return False and let the caller fall back to a global
+    # copy rather than letting it escape and be misbooked as a hard write failure.
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -543,10 +519,9 @@ def _install_skill_copy(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.home(), use_tilde=True)
 
-    # All filesystem work runs under one try so a failure at ANY step - creating
-    # the target dir, removing an old streamlit-owned target, or the copy itself
-    # - is recorded as a write failure (classified by errno) instead of escaping
-    # as an uncaught OSError the caller can only classify as "unknown".
+    # All filesystem work runs under one try so a failure at ANY step is recorded as
+    # a write failure classified by errno, instead of escaping as an uncaught OSError
+    # the caller can only classify as "unknown".
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -570,10 +545,8 @@ def _install_skill_copy(
                 result.skipped.append(f"{rel_target_path} (existing file)")
                 return
 
-        # Replacing an existing install copies to a temp dir and swaps, so a
-        # failed copy leaves the working installation in place. Removing the old
-        # target up front would delete a usable skill and then fail, leaving the
-        # user with nothing.
+        # Copy to a temp location and swap, so a failed copy leaves the working
+        # installation in place.
         if old_target_to_remove is not None:
             temp_path = target_path.with_name(f".{skill_name}.tmp")
             if temp_path.exists():
@@ -725,11 +698,10 @@ def _confirm_global_installation(target_dirs: list[Path]) -> bool:
 def _concise_install_paths(entries: list[str]) -> list[str]:
     """Collapse ``_InstallResult`` entries to short paths safe to show a user.
 
-    Entries look like ``"<path> (why)"``. Both failure messages built from them
-    are shown verbatim in the in-app nudge, so this keeps only the
-    ``<harness>/skills/<skill>`` tail and drops the parenthetical: neither an
-    absolute server path nor a raw ``OSError`` string may reach the browser.
-    Shared by the two error builders so that invariant lives in one place.
+    Entries look like ``"<path> (why)"``. Both failure messages built from them are
+    shown verbatim in the in-app nudge, so keep only the ``<harness>/skills/<skill>``
+    tail and drop the parenthetical: neither an absolute server path nor a raw
+    ``OSError`` string may reach the browser.
     """
     paths = []
     for entry in entries:
@@ -764,14 +736,10 @@ def _conflict_error(skipped: list[str]) -> InstallError:
 def _write_error(result: _InstallResult) -> InstallError:
     """Build a "couldn't write" error for filesystem failures during copy.
 
-    Distinct from :func:`_conflict_error`: ``errored`` entries are ``OSError``
-    failures, not pre-existing files. Keeping them apart stops the nudge's failure
-    telemetry from misreporting a write failure as a ``conflict``.
-
-    The reason is the specific cause when every failed target agreed on one, and the
+    Distinct from :func:`_conflict_error`, which reports pre-existing files. The
+    reason is the specific cause when every failed target agreed on one, and the
     generic ``write_failed`` when they disagreed - claiming "permission denied" for a
-    set of failures that were half permissions and half disk-full would point whoever
-    reads the telemetry at the wrong fix.
+    set that was half permissions and half disk-full would point at the wrong fix.
     """
     joined = ", ".join(_concise_install_paths(result.errored))
     reasons = result.write_reasons

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -736,10 +736,14 @@ def _conflict_error(skipped: list[str]) -> InstallError:
 def _write_error(result: _InstallResult) -> InstallError:
     """Build a "couldn't write" error for filesystem failures during copy.
 
-    Distinct from :func:`_conflict_error`, which reports pre-existing files. The
-    reason is the specific cause when every failed target agreed on one, and the
-    generic ``write_failed`` when they disagreed - claiming "permission denied" for a
-    set that was half permissions and half disk-full would point at the wrong fix.
+    Distinct from :func:`_conflict_error`, which reports pre-existing files.
+
+    The reason follows what the failed targets agreed on:
+
+    - all agreed on one cause -> that cause
+    - they disagreed -> the generic ``write_failed``, because claiming "permission
+      denied" for a set that was half permissions and half disk-full would point
+      whoever reads the telemetry at the wrong fix
     """
     joined = ", ".join(_concise_install_paths(result.errored))
     reasons = result.write_reasons

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import shutil
 import sys
@@ -23,7 +24,7 @@ import tempfile
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
 import click
 
@@ -34,6 +35,108 @@ _LOGGER: Final = get_logger(__name__)
 
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
+
+# The full vocabulary of install-failure causes. A closed set so the reason stays
+# safe to emit as a telemetry label; typing it as a Literal makes mypy reject a
+# typo or an ad-hoc reason at the raise site instead of silently minting a new
+# label the analysis queries won't know about.
+#
+# The ``write_*`` values subdivide what would otherwise be a single opaque
+# "a write failed". That distinction is the point: a lock clears on retry, a path
+# that is too long can be shortened, and neither is fixed by the permissions advice
+# a generic write failure would earn. See :func:`_classify_write_error`.
+_InstallFailureReason = Literal[
+    "conflict",  # A pre-existing file or foreign symlink we won't overwrite.
+    "incomplete",  # Project symlinks failed and the global fallback was cancelled.
+    "no_skills",  # The bundled skills dir exists but contains nothing installable.
+    "non_interactive",  # No TTY to prompt on and --yes wasn't passed.
+    "source_missing",  # The bundled skills dir is absent from the installation.
+    "source_incomplete",  # The dir is present but a required file is missing.
+    "symlinks_unsupported",  # Project install needs symlinks; this OS won't make them.
+    "write_denied",  # Permissions, or a read-only filesystem.
+    "write_locked",  # Another process holds the path (antivirus, sync clients).
+    "write_name_too_long",  # The path exceeded the OS limit (Windows MAX_PATH).
+    "write_no_space",  # Out of disk, or over a quota.
+    "write_failed",  # A write failed for a reason none of the above cover.
+]
+
+# Why a project install was rerouted to a global copy. Split as finely as the OS lets
+# us, because most Windows users take this path and then SUCCEED - so this, not the
+# failure vocabulary, is where their diagnostic signal lives. The distinctions map to
+# different responses: Developer Mode off is a documentable user action, a denial on
+# the project directory is an environment problem, a filesystem with no symlink support
+# at all is neither, and a link failing after the pre-check passed is closer to a bug.
+_FallbackReason = Literal[
+    "symlinks_no_privilege",  # Windows Developer Mode off (ERROR_PRIVILEGE_NOT_HELD).
+    "symlinks_denied",  # Permissions on the project dir refused the probe.
+    "symlinks_unsupported",  # The filesystem/OS has no directory symlinks.
+    "symlink_failed",  # Pre-check passed, then an individual link would not lay.
+]
+
+# OSError.errno -> reason. Built by name so a platform missing one of these (they
+# are not all defined everywhere) simply omits it rather than failing at import.
+_ERRNO_GROUPS: Final[tuple[tuple[tuple[str, ...], _InstallFailureReason], ...]] = (
+    (("EACCES", "EPERM", "EROFS"), "write_denied"),
+    (("ENOSPC", "EDQUOT", "EFBIG"), "write_no_space"),
+    (("EBUSY", "EAGAIN", "ETXTBSY"), "write_locked"),
+    (("ENAMETOOLONG",), "write_name_too_long"),
+)
+_WRITE_REASON_BY_ERRNO: Final[dict[int, _InstallFailureReason]] = {
+    code: reason
+    for names, reason in _ERRNO_GROUPS
+    for name in names
+    if (code := getattr(errno, name, None)) is not None
+}
+
+# Windows native codes, consulted BEFORE errno because CPython's mapping is lossy in
+# exactly the way that would mislead us: a sharing violation (antivirus or OneDrive
+# holding the file) arrives as EACCES, which reads as a permissions problem and sends
+# us after folder ACLs when the actual fix is to retry.
+_WRITE_REASON_BY_WINERROR: Final[dict[int, _InstallFailureReason]] = {
+    5: "write_denied",  # ERROR_ACCESS_DENIED
+    19: "write_denied",  # ERROR_WRITE_PROTECT
+    32: "write_locked",  # ERROR_SHARING_VIOLATION
+    33: "write_locked",  # ERROR_LOCK_VIOLATION
+    39: "write_no_space",  # ERROR_HANDLE_DISK_FULL
+    112: "write_no_space",  # ERROR_DISK_FULL
+    206: "write_name_too_long",  # ERROR_FILENAME_EXCED_RANGE
+}
+
+
+def _classify_write_error(error: OSError) -> _InstallFailureReason:
+    """Map a filesystem ``OSError`` to a bounded, actionable failure reason.
+
+    Only the error *class* is used - never the message, which can embed an absolute
+    server path - so the result stays safe to emit as a telemetry label.
+
+    Returns the generic ``"write_failed"`` when the code is unrecognised, so an
+    unclassified failure is visible as such in the data rather than being guessed
+    into the wrong bucket.
+    """
+    winerror = getattr(error, "winerror", None)
+    if isinstance(winerror, int) and winerror in _WRITE_REASON_BY_WINERROR:
+        return _WRITE_REASON_BY_WINERROR[winerror]
+    if error.errno is not None and error.errno in _WRITE_REASON_BY_ERRNO:
+        return _WRITE_REASON_BY_ERRNO[error.errno]
+    return "write_failed"
+
+
+class _InstallError(click.ClickException):
+    """A skills-install failure carrying a stable machine-readable ``reason`` code.
+
+    The ``reason`` (see :data:`_InstallFailureReason`) is what the backend-operation
+    handler forwards to the client so the nudge's install-failure telemetry can be
+    split by cause. It is a fixed vocabulary set at each raise site, never user
+    input, so it is safe to emit as a telemetry label suffix.
+
+    Otherwise this behaves like a normal ``click.ClickException`` — its
+    ``format_message`` still supplies the user-facing text shown in the CLI and the
+    in-app nudge — so raising it changes nothing a user sees.
+    """
+
+    def __init__(self, message: str, *, reason: _InstallFailureReason) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 def _generate_gitignore_snippet(
@@ -60,7 +163,22 @@ class _InstallResult:
 
     installed: list[str] = field(default_factory=list)
     up_to_date: list[str] = field(default_factory=list)
+    # Pre-existing files/symlinks we won't overwrite - a genuine "conflict".
     skipped: list[str] = field(default_factory=list)
+    # Filesystem failures during the global copy (OSError: permissions, disk space,
+    # locked files). Tracked separately from ``skipped`` so a write failure is never
+    # misreported as a "conflict" - both in the CLI summary and, crucially, in the
+    # nudge's install-failure telemetry reason. Only the copy path fills this;
+    # symlink failures reroute to a global install instead of being recorded here.
+    errored: list[str] = field(default_factory=list)
+    # Classified cause for each ``errored`` entry, in the same order. Kept apart from
+    # the display strings above because those carry raw OSError text (fine for the
+    # CLI, never for the browser) while these are the bounded telemetry reasons.
+    write_reasons: list[_InstallFailureReason] = field(default_factory=list)
+    # Set when a project install was rerouted to a global copy, naming why (see
+    # :data:`_FallbackReason`). Surfaced to telemetry so that cohort is countable and
+    # separable - see InstallSkillsResponsePayload.
+    fallback_reason: _FallbackReason | None = None
 
 
 def _get_source_skills_dir() -> Path:
@@ -279,17 +397,41 @@ def _skill_copy_matches(source_path: Path, target_path: Path) -> bool:
     return True
 
 
-def _symlinks_supported(project_root: Path, source_path: Path) -> bool:
-    """Return whether project install can create directory symlinks."""
+def _symlink_blocker(project_root: Path, source_path: Path) -> _FallbackReason | None:
+    """Return why project install can't use symlinks here, or ``None`` if it can.
+
+    Probes by actually creating one in a temp dir, then classifies the failure rather
+    than collapsing it to "unsupported". This is the highest-value split in the whole
+    vocabulary: most Windows users land here and then *succeed* via the global
+    fallback, so this is what their success label carries, and the causes want
+    completely different responses. ``symlinks_no_privilege`` (Developer Mode off) is
+    a documentable user action, while a denial on the project directory or a
+    filesystem that has no symlinks at all are not.
+    """
     try:
         with tempfile.TemporaryDirectory(
             prefix=".streamlit-skills-", dir=project_root
         ) as temp_dir:
             link_path = Path(temp_dir) / "skill-link"
             link_path.symlink_to(source_path, target_is_directory=True)
-            return link_path.is_symlink()
-    except (OSError, NotImplementedError):
-        return False
+            if link_path.is_symlink():
+                return None
+            # Created without error yet isn't a symlink: treat as unsupported rather
+            # than claiming success we can't verify.
+            return "symlinks_unsupported"
+    except NotImplementedError:
+        return "symlinks_unsupported"
+    except OSError as e:
+        # ERROR_PRIVILEGE_NOT_HELD: the account lacks SeCreateSymbolicLinkPrivilege,
+        # which in practice means Windows Developer Mode is off. Distinguishing this
+        # is the point of the exercise - it is the one cause a user can simply fix.
+        if getattr(e, "winerror", None) == 1314:
+            return "symlinks_no_privilege"
+        if e.errno in _WRITE_REASON_BY_ERRNO and (
+            _WRITE_REASON_BY_ERRNO[e.errno] == "write_denied"
+        ):
+            return "symlinks_denied"
+        return "symlinks_unsupported"
 
 
 def _get_display_path(
@@ -319,31 +461,38 @@ def _install_skill_symlink(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.cwd())
 
-    # Ensure parent directory exists
-    target_dir.mkdir(parents=True, exist_ok=True)
+    # Pre-symlink filesystem work (creating the parent dir, inspecting or removing
+    # an existing target) runs under one guard: any OSError here means we can't
+    # lay the symlink, so return False and let the caller fall back to a global
+    # copy - never let it escape and get misbooked as a hard write_failed.
+    try:
+        # Ensure parent directory exists
+        target_dir.mkdir(parents=True, exist_ok=True)
 
-    if target_path.exists() or target_path.is_symlink():
-        # Target exists - check if it's a matching symlink
-        if target_path.is_symlink():
-            try:
-                resolved = target_path.resolve()
-                if resolved == source_path.resolve():
-                    result.up_to_date.append(str(rel_target_path))
+        if target_path.exists() or target_path.is_symlink():
+            # Target exists - check if it's a matching symlink
+            if target_path.is_symlink():
+                try:
+                    resolved = target_path.resolve()
+                    if resolved == source_path.resolve():
+                        result.up_to_date.append(str(rel_target_path))
+                        return True
+                except (OSError, ValueError):
+                    # Broken symlink or resolution error - check ownership below
+                    pass
+
+                # Check if it's a Streamlit-owned symlink we can replace
+                if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
+                    target_path.unlink()
+                else:
+                    result.skipped.append(f"{rel_target_path} (existing symlink)")
                     return True
-            except (OSError, ValueError):
-                # Broken symlink or resolution error - check ownership pattern below
-                pass
-
-            # Check if it's a Streamlit-owned symlink we can replace
-            if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                target_path.unlink()
             else:
-                result.skipped.append(f"{rel_target_path} (existing symlink)")
+                # Regular file or directory - skip
+                result.skipped.append(f"{rel_target_path} (existing file or directory)")
                 return True
-        else:
-            # Regular file or directory - skip
-            result.skipped.append(f"{rel_target_path} (existing file or directory)")
-            return True
+    except (OSError, NotImplementedError):
+        return False
 
     # Compute the relative symlink target from the REAL (symlink-resolved) paths
     # of both ends. os.path.relpath counts ``..`` levels against the logical
@@ -385,33 +534,38 @@ def _install_skill_copy(
     target_path = target_dir / skill_name
     rel_target_path = _get_display_path(target_path, Path.home(), use_tilde=True)
 
-    # Ensure parent directory exists
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    old_target_to_remove: Path | None = None
-
-    if target_path.exists() or target_path.is_symlink():
-        # Target exists - check if we can replace it
-        if target_path.is_symlink():
-            if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                target_path.unlink()
-            else:
-                result.skipped.append(f"{rel_target_path} (existing symlink)")
-                return
-        elif target_path.is_dir():
-            if _skill_copy_matches(source_path, target_path):
-                result.up_to_date.append(str(rel_target_path))
-                return
-            # Defer removal until after successful copy to ensure atomicity
-            old_target_to_remove = target_path
-        else:
-            result.skipped.append(f"{rel_target_path} (existing file)")
-            return
-
-    # Copy skill directory - use temp location first to ensure atomicity
+    # All filesystem work runs under one try so a failure at ANY step - creating
+    # the target dir, removing an old streamlit-owned target, or the copy itself
+    # - is recorded as a write failure (classified by errno) instead of escaping
+    # as an uncaught OSError the caller can only classify as "unknown".
     try:
+        # Ensure parent directory exists
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        old_target_to_remove: Path | None = None
+
+        if target_path.exists() or target_path.is_symlink():
+            # Target exists - check if we can replace it
+            if target_path.is_symlink():
+                if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
+                    target_path.unlink()
+                else:
+                    result.skipped.append(f"{rel_target_path} (existing symlink)")
+                    return
+            elif target_path.is_dir():
+                if _skill_copy_matches(source_path, target_path):
+                    result.up_to_date.append(str(rel_target_path))
+                    return
+                old_target_to_remove = target_path
+            else:
+                result.skipped.append(f"{rel_target_path} (existing file)")
+                return
+
+        # Replacing an existing install copies to a temp dir and swaps, so a
+        # failed copy leaves the working installation in place. Removing the old
+        # target up front would delete a usable skill and then fail, leaving the
+        # user with nothing.
         if old_target_to_remove is not None:
-            # Copy to temp location, then swap
             temp_path = target_path.with_name(f".{skill_name}.tmp")
             if temp_path.exists():
                 shutil.rmtree(temp_path)
@@ -429,7 +583,11 @@ def _install_skill_copy(
         temp_path = target_path.with_name(f".{skill_name}.tmp")
         if temp_path.exists() and target_path.exists():
             shutil.rmtree(temp_path, ignore_errors=True)
-        result.skipped.append(f"{rel_target_path} (copy failed: {e})")
+        # A write failure, not a conflict - record it in ``errored`` so it is
+        # classified as such, not "conflict", and keep the errno-derived cause
+        # alongside it so the telemetry reason names which write failed.
+        result.errored.append(f"{rel_target_path} (copy failed: {e})")
+        result.write_reasons.append(_classify_write_error(e))
 
 
 def _print_result(result: _InstallResult) -> None:
@@ -452,6 +610,11 @@ def _print_result(result: _InstallResult) -> None:
         click.secho("\n⚠ Skipped due to conflicts:", fg="yellow", bold=True)
         for path in result.skipped:
             click.echo(f"  {click.style('→', fg='yellow')} {path}")
+
+    if result.errored:
+        click.secho("\n✗ Failed to write:", fg="red", bold=True)
+        for path in result.errored:
+            click.echo(f"  {click.style('→', fg='red')} {path}")
 
 
 def _prompt_install_mode() -> str:
@@ -550,7 +713,24 @@ def _confirm_global_installation(target_dirs: list[Path]) -> bool:
     return click.confirm("Proceed with installation?", default=True)
 
 
-def _conflict_error(skipped: list[str]) -> click.ClickException:
+def _concise_install_paths(entries: list[str]) -> list[str]:
+    """Collapse ``_InstallResult`` entries to short paths safe to show a user.
+
+    Entries look like ``"<path> (why)"``. Both failure messages built from them
+    are shown verbatim in the in-app nudge, so this keeps only the
+    ``<harness>/skills/<skill>`` tail and drops the parenthetical: neither an
+    absolute server path nor a raw ``OSError`` string may reach the browser.
+    Shared by the two error builders so that invariant lives in one place.
+    """
+    paths = []
+    for entry in entries:
+        raw = entry.split(" (", 1)[0]
+        parts = Path(raw).parts
+        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+    return paths
+
+
+def _conflict_error(skipped: list[str]) -> _InstallError:
     """Build a specific "couldn't install" error that names the conflicting
     paths, rather than a vague "remove conflicting files".
 
@@ -562,16 +742,37 @@ def _conflict_error(skipped: list[str]) -> click.ClickException:
     stand on its own (the CLI's detailed ``_print_result`` output never reaches
     the browser).
     """
-    paths = []
-    for entry in skipped:
-        raw = entry.split(" (", 1)[0]
-        parts = Path(raw).parts
-        paths.append(Path(*parts[-3:]).as_posix() if len(parts) >= 3 else raw)
+    paths = _concise_install_paths(skipped)
     joined = ", ".join(paths)
     plural = len(paths) != 1
-    return click.ClickException(
+    return _InstallError(
         f"{joined} already exist{'' if plural else 's'}. "
-        f"Remove {'them' if plural else 'it'} and try again."
+        f"Remove {'them' if plural else 'it'} and try again.",
+        reason="conflict",
+    )
+
+
+def _write_error(result: _InstallResult) -> _InstallError:
+    """Build a "couldn't write" error for filesystem failures during copy.
+
+    Distinct from :func:`_conflict_error`: ``errored`` entries are ``OSError``
+    failures, not pre-existing files. Keeping them apart stops the nudge's failure
+    telemetry from misreporting a write failure as a ``conflict``.
+
+    The reason is the specific cause when every failed target agreed on one, and the
+    generic ``write_failed`` when they disagreed - claiming "permission denied" for a
+    set of failures that were half permissions and half disk-full would point whoever
+    reads the telemetry at the wrong fix.
+    """
+    joined = ", ".join(_concise_install_paths(result.errored))
+    distinct = set(result.write_reasons)
+    reason: _InstallFailureReason = (
+        next(iter(distinct)) if len(distinct) == 1 else "write_failed"
+    )
+    return _InstallError(
+        f"Could not write {joined}. Check folder permissions and free disk "
+        "space, then try again.",
+        reason=reason,
     )
 
 
@@ -588,14 +789,17 @@ def _install_project_skills(
         # Keep the absolute path in the server log only - this message is shown
         # verbatim in the in-app nudge, so it must not leak a server path.
         _LOGGER.warning("Bundled skills directory not found at %s", source_skills_dir)
-        raise click.ClickException(
+        raise _InstallError(
             "Bundled skills were not found in your Streamlit installation. "
-            "Reinstall Streamlit and try again."
+            "Reinstall Streamlit and try again.",
+            reason="source_missing",
         )
 
     skills = _discover_skills(source_skills_dir)
     if not skills:
-        raise click.ClickException("No installable skills found in Streamlit package.")
+        raise _InstallError(
+            "No installable skills found in Streamlit package.", reason="no_skills"
+        )
 
     # Determine targets. The in-app installer passes ``app_dir`` so the project
     # root resolves from the running app's directory (matching the nudge's skill
@@ -603,7 +807,8 @@ def _install_project_skills(
     project_root = _find_project_root(Path(app_dir) if app_dir else None)
     target_dirs = _get_project_target_dirs(project_root)
 
-    if not _symlinks_supported(project_root, source_skills_dir / skills[0]):
+    symlink_blocker = _symlink_blocker(project_root, source_skills_dir / skills[0])
+    if symlink_blocker is not None:
         if fallback_to_global:
             click.secho(
                 "\n⚠ Symlinks not supported on this system.",
@@ -619,10 +824,13 @@ def _install_project_skills(
                 "Developer Mode to use project installs."
             )
             click.echo()
-            return _install_global_skills(yes=yes)
+            global_result = _install_global_skills(yes=yes)
+            global_result.fallback_reason = symlink_blocker
+            return global_result
 
-        raise click.ClickException(
-            "Symlinks not supported. Use --global for global installation."
+        raise _InstallError(
+            "Symlinks not supported. Use --global for global installation.",
+            reason="symlinks_unsupported",
         )
 
     # Confirm installation
@@ -659,20 +867,26 @@ def _install_project_skills(
         click.echo("Falling back to global installation mode...")
         click.echo()
         try:
-            return _install_global_skills(yes=yes)
+            global_result = _install_global_skills(yes=yes)
+            # The pre-check said symlinks work here, yet laying one still failed -
+            # distinct from the categorical case above, and worth chasing separately.
+            global_result.fallback_reason = "symlink_failed"
+            return global_result
         except click.ClickException:
             # Global install failed - partial project symlinks remain as fallback
             raise
         except click.exceptions.Abort:
             # User cancelled global install - report that nothing was fully installed
-            raise click.ClickException(
+            raise _InstallError(
                 "Installation incomplete. Project symlinks failed and global install "
-                "was cancelled."
+                "was cancelled.",
+                reason="incomplete",
             )
 
     if symlink_failed:
-        raise click.ClickException(
-            "Symlinks not supported. Use --global for global installation."
+        raise _InstallError(
+            "Symlinks not supported. Use --global for global installation.",
+            reason="symlinks_unsupported",
         )
 
     # Report results
@@ -744,9 +958,13 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
             _GLOBAL_SKILL_NAME,
             meta_skill_dir,
         )
-        raise click.ClickException(
+        raise _InstallError(
             f"The bundled '{_GLOBAL_SKILL_NAME}' meta-skill was not found in your "
-            "Streamlit installation. Reinstall Streamlit and try again."
+            "Streamlit installation. Reinstall Streamlit and try again.",
+            # Distinct from source_missing: the directory is there but a required
+            # file is not, which points at a too-narrow package-data glob rather
+            # than skills being absent from the wheel entirely.
+            reason="source_incomplete",
         )
 
     # Install to each target directory
@@ -764,6 +982,12 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
 
     # Report results
     _print_result(result)
+
+    # A write failure on ANY target is a hard failure, even if another target
+    # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
+    # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
+    if result.errored:
+        raise _write_error(result)
 
     if result.installed or result.up_to_date:
         click.echo()
@@ -815,8 +1039,9 @@ def install_skills(
     """
     # Check if running interactively
     if not yes and not sys.stdin.isatty():
-        raise click.ClickException(
-            "Non-interactive terminal detected. Use --yes to skip prompts."
+        raise _InstallError(
+            "Non-interactive terminal detected. Use --yes to skip prompts.",
+            reason="non_interactive",
         )
 
     # Interactive mode selection (when not using flags)

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -427,8 +427,11 @@ def _symlink_blocker(project_root: Path, source_path: Path) -> _FallbackReason |
         # is the point of the exercise - it is the one cause a user can simply fix.
         if getattr(e, "winerror", None) == 1314:
             return "symlinks_no_privilege"
-        if e.errno in _WRITE_REASON_BY_ERRNO and (
-            _WRITE_REASON_BY_ERRNO[e.errno] == "write_denied"
+        # ``errno`` is Optional on OSError, and dict.get is typed to reject None, so
+        # the guard is for the type checker rather than for runtime behaviour.
+        if (
+            e.errno is not None
+            and _WRITE_REASON_BY_ERRNO.get(e.errno) == "write_denied"
         ):
             return "symlinks_denied"
         return "symlinks_unsupported"

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -44,7 +44,7 @@ _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
 # The ``write_*`` values subdivide what would otherwise be a single opaque
 # "a write failed". That distinction is the point: a lock clears on retry, a path
 # that is too long can be shortened, and neither is fixed by the permissions advice
-# a generic write failure would earn. See :func:`_classify_write_error`.
+# a generic write failure would earn. See :func:`classify_write_error`.
 _InstallFailureReason = Literal[
     "conflict",  # A pre-existing file or foreign symlink we won't overwrite.
     "incomplete",  # Project symlinks failed and the global fallback was cancelled.
@@ -77,7 +77,11 @@ _FallbackReason = Literal[
 # are not all defined everywhere) simply omits it rather than failing at import.
 _ERRNO_GROUPS: Final[tuple[tuple[tuple[str, ...], _InstallFailureReason], ...]] = (
     (("EACCES", "EPERM", "EROFS"), "write_denied"),
-    (("ENOSPC", "EDQUOT", "EFBIG"), "write_no_space"),
+    # EFBIG is deliberately absent: a file-size limit is not out of space, so it stays
+    # the honest write_failed rather than pointing whoever reads it at a full disk.
+    (("ENOSPC", "EDQUOT"), "write_no_space"),
+    # EAGAIN sits here on retry semantics rather than locking specifically - like a
+    # held file, the call may well succeed if simply repeated.
     (("EBUSY", "EAGAIN", "ETXTBSY"), "write_locked"),
     (("ENAMETOOLONG",), "write_name_too_long"),
 )
@@ -103,7 +107,7 @@ _WRITE_REASON_BY_WINERROR: Final[dict[int, _InstallFailureReason]] = {
 }
 
 
-def _classify_write_error(error: OSError) -> _InstallFailureReason:
+def classify_write_error(error: OSError) -> _InstallFailureReason:
     """Map a filesystem ``OSError`` to a bounded, actionable failure reason.
 
     Only the error *class* is used - never the message, which can embed an absolute
@@ -121,7 +125,7 @@ def _classify_write_error(error: OSError) -> _InstallFailureReason:
     return "write_failed"
 
 
-class _InstallError(click.ClickException):
+class InstallError(click.ClickException):
     """A skills-install failure carrying a stable machine-readable ``reason`` code.
 
     The ``reason`` (see :data:`_InstallFailureReason`) is what the backend-operation
@@ -171,10 +175,12 @@ class _InstallResult:
     # nudge's install-failure telemetry reason. Only the copy path fills this;
     # symlink failures reroute to a global install instead of being recorded here.
     errored: list[str] = field(default_factory=list)
-    # Classified cause for each ``errored`` entry, in the same order. Kept apart from
-    # the display strings above because those carry raw OSError text (fine for the
-    # CLI, never for the browser) while these are the bounded telemetry reasons.
-    write_reasons: list[_InstallFailureReason] = field(default_factory=list)
+    # The distinct classified causes behind ``errored``. A set, not a per-entry list:
+    # the only consumer asks whether the failed targets agreed on one cause, never
+    # which target had which. Kept apart from the display strings above because those
+    # carry raw OSError text (fine for the CLI, never for the browser) while these are
+    # the bounded telemetry reasons.
+    write_reasons: set[_InstallFailureReason] = field(default_factory=set)
     # Set when a project install was rerouted to a global copy, naming why (see
     # :data:`_FallbackReason`). Surfaced to telemetry so that cohort is countable and
     # separable - see InstallSkillsResponsePayload.
@@ -587,10 +593,10 @@ def _install_skill_copy(
         if temp_path.exists() and target_path.exists():
             shutil.rmtree(temp_path, ignore_errors=True)
         # A write failure, not a conflict - record it in ``errored`` so it is
-        # classified as such, not "conflict", and keep the errno-derived cause
-        # alongside it so the telemetry reason names which write failed.
+        # classified as such, not "conflict", and note the errno-derived cause so the
+        # telemetry reason names which write failed.
         result.errored.append(f"{rel_target_path} (copy failed: {e})")
-        result.write_reasons.append(_classify_write_error(e))
+        result.write_reasons.add(classify_write_error(e))
 
 
 def _print_result(result: _InstallResult) -> None:
@@ -733,7 +739,7 @@ def _concise_install_paths(entries: list[str]) -> list[str]:
     return paths
 
 
-def _conflict_error(skipped: list[str]) -> _InstallError:
+def _conflict_error(skipped: list[str]) -> InstallError:
     """Build a specific "couldn't install" error that names the conflicting
     paths, rather than a vague "remove conflicting files".
 
@@ -748,14 +754,14 @@ def _conflict_error(skipped: list[str]) -> _InstallError:
     paths = _concise_install_paths(skipped)
     joined = ", ".join(paths)
     plural = len(paths) != 1
-    return _InstallError(
+    return InstallError(
         f"{joined} already exist{'' if plural else 's'}. "
         f"Remove {'them' if plural else 'it'} and try again.",
         reason="conflict",
     )
 
 
-def _write_error(result: _InstallResult) -> _InstallError:
+def _write_error(result: _InstallResult) -> InstallError:
     """Build a "couldn't write" error for filesystem failures during copy.
 
     Distinct from :func:`_conflict_error`: ``errored`` entries are ``OSError``
@@ -768,11 +774,11 @@ def _write_error(result: _InstallResult) -> _InstallError:
     reads the telemetry at the wrong fix.
     """
     joined = ", ".join(_concise_install_paths(result.errored))
-    distinct = set(result.write_reasons)
+    reasons = result.write_reasons
     reason: _InstallFailureReason = (
-        next(iter(distinct)) if len(distinct) == 1 else "write_failed"
+        next(iter(reasons)) if len(reasons) == 1 else "write_failed"
     )
-    return _InstallError(
+    return InstallError(
         f"Could not write {joined}. Check folder permissions and free disk "
         "space, then try again.",
         reason=reason,
@@ -792,7 +798,7 @@ def _install_project_skills(
         # Keep the absolute path in the server log only - this message is shown
         # verbatim in the in-app nudge, so it must not leak a server path.
         _LOGGER.warning("Bundled skills directory not found at %s", source_skills_dir)
-        raise _InstallError(
+        raise InstallError(
             "Bundled skills were not found in your Streamlit installation. "
             "Reinstall Streamlit and try again.",
             reason="source_missing",
@@ -800,7 +806,7 @@ def _install_project_skills(
 
     skills = _discover_skills(source_skills_dir)
     if not skills:
-        raise _InstallError(
+        raise InstallError(
             "No installable skills found in Streamlit package.", reason="no_skills"
         )
 
@@ -831,7 +837,7 @@ def _install_project_skills(
             global_result.fallback_reason = symlink_blocker
             return global_result
 
-        raise _InstallError(
+        raise InstallError(
             "Symlinks not supported. Use --global for global installation.",
             reason="symlinks_unsupported",
         )
@@ -880,14 +886,14 @@ def _install_project_skills(
             raise
         except click.exceptions.Abort:
             # User cancelled global install - report that nothing was fully installed
-            raise _InstallError(
+            raise InstallError(
                 "Installation incomplete. Project symlinks failed and global install "
                 "was cancelled.",
                 reason="incomplete",
             )
 
     if symlink_failed:
-        raise _InstallError(
+        raise InstallError(
             "Symlinks not supported. Use --global for global installation.",
             reason="symlinks_unsupported",
         )
@@ -961,7 +967,7 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
             _GLOBAL_SKILL_NAME,
             meta_skill_dir,
         )
-        raise _InstallError(
+        raise InstallError(
             f"The bundled '{_GLOBAL_SKILL_NAME}' meta-skill was not found in your "
             "Streamlit installation. Reinstall Streamlit and try again.",
             # Distinct from source_missing: the directory is there but a required
@@ -1042,7 +1048,7 @@ def install_skills(
     """
     # Check if running interactively
     if not yes and not sys.stdin.isatty():
-        raise _InstallError(
+        raise InstallError(
             "Non-interactive terminal detected. Use --yes to skip prompts.",
             reason="non_interactive",
         )

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -222,6 +222,32 @@ def test_install_skills_handler_installs_in_project_mode() -> None:
         response.install_skills.detail == "Installed to .agents/skills, .claude/skills."
     )
     assert response.error_msg == ""
+    # A normal project (symlink) install did not take the global fallback.
+    assert response.install_skills.fallback_reason == ""
+
+
+def test_install_skills_handler_forwards_global_fallback_flag() -> None:
+    """A fallback install forwards WHICH fallback route it took, so the frontend can
+    emit skillsNudgeInstallSucceeded:<fallback_reason> and the two causes stay
+    separable in the funnel.
+    """
+    install_result = skills._InstallResult(
+        installed=["~/.agents/skills/foo"], fallback_reason="symlink_failed"
+    )
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", return_value=install_result),
+        patch.object(skills, "clear_installed_skills_cache"),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.HasField("install_skills")
+    assert response.install_skills.fallback_reason == "symlink_failed"
 
 
 def test_install_skills_handler_reports_failure() -> None:
@@ -241,16 +267,49 @@ def test_install_skills_handler_reports_failure() -> None:
         )
 
     assert response.error_msg == "No skills found"
+    assert response.error_reason == "unknown"
+    assert not response.HasField("install_skills")
+
+
+def test_install_skills_handler_forwards_failure_reason() -> None:
+    """A ``skills._InstallError`` propagates its machine-readable ``reason`` into
+    the response's ``error_reason`` so the client can split install-failure
+    telemetry by cause (e.g. conflict vs. write_failed vs. source_missing)."""
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch(
+            "streamlit.web.skills.install_skills",
+            side_effect=skills._InstallError(
+                "developing-with-streamlit already exists. Remove it and try again.",
+                reason="conflict",
+            ),
+        ),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_msg == (
+        "developing-with-streamlit already exists. Remove it and try again."
+    )
+    assert response.error_reason == "conflict"
     assert not response.HasField("install_skills")
 
 
 def test_install_skills_handler_does_not_leak_os_error_path() -> None:
-    """A non-``ClickException`` (e.g. ``OSError``) yields a generic message.
+    """A non-``ClickException`` ``OSError`` yields a generic message but a
+    ``write_failed`` reason.
 
     ``click.ClickException`` messages are developer-authored and safe to show in
-    the browser toast, but a raw ``OSError`` can embed an absolute server path.
-    The handler must forward only the former verbatim and replace anything else
-    with a generic string, so a server path can never leak into the nudge.
+    the browser toast, but a raw ``OSError`` can embed an absolute server path -
+    so the message is replaced with a generic string. The reason, however, is
+    still meaningful: a bare ``OSError`` escaping the installer (e.g. a
+    permission error creating the target dir, before the copy's own try/except)
+    is a filesystem write failure, so it's classified ``write_failed`` rather
+    than buried in ``unknown``.
     """
     with (
         patch("streamlit.config.get_option", return_value=False),
@@ -268,7 +327,33 @@ def test_install_skills_handler_does_not_leak_os_error_path() -> None:
 
     assert response.error_msg == "Failed to install skills."
     assert "/absolute/server/path" not in response.error_msg
+    assert response.error_reason == "write_failed"
     assert not response.HasField("install_skills")
+
+
+def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
+    """A non-_InstallError exception exposing a str ``.reason`` must NOT be emitted.
+
+    The handler used to read the reason with ``getattr(ex, 'reason')``, so any
+    exception carrying a free-form str ``.reason`` (``UnicodeDecodeError`` and
+    several stdlib errors do) would emit an unbounded telemetry label and break the
+    fixed vocabulary. The reason is now trusted ONLY from skills._InstallError; a
+    non-OSError foreign exception is classified ``unknown``.
+    """
+    foreign = ValueError("boom")
+    foreign.reason = "some-unbounded-string"  # type: ignore[attr-defined]
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", side_effect=foreign),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_reason == "unknown"
 
 
 def test_install_skills_handler_refuses_without_agent_harness() -> None:
@@ -289,6 +374,7 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
+    assert response.error_reason == "refused:no_agent"
     assert not response.HasField("install_skills")
 
 
@@ -313,6 +399,7 @@ def test_install_skills_handler_refuses_non_loopback_connection() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
+    assert response.error_reason == "refused:non_loopback"
     assert not response.HasField("install_skills")
 
 
@@ -353,6 +440,7 @@ def test_install_skills_handler_allows_idempotent_retry_when_already_installed()
         global_mode=False, yes=True, app_dir="/app/dir"
     )
     assert response.error_msg == ""
+    assert response.error_reason == ""
     assert response.HasField("install_skills")
     assert response.install_skills.detail == "Skills are already up to date."
 
@@ -373,6 +461,7 @@ def test_install_skills_handler_refuses_in_headless_mode() -> None:
 
     mock_install.assert_not_called()
     assert response.error_msg == "Skills install is not available in this environment."
+    assert response.error_reason == "refused:headless"
     assert not response.HasField("install_skills")
 
 

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -272,7 +272,7 @@ def test_install_skills_handler_reports_failure() -> None:
 
 
 def test_install_skills_handler_forwards_failure_reason() -> None:
-    """A ``skills._InstallError`` propagates its machine-readable ``reason`` into
+    """A ``skills.InstallError`` propagates its machine-readable ``reason`` into
     the response's ``error_reason`` so the client can split install-failure
     telemetry by cause (e.g. conflict vs. write_failed vs. source_missing)."""
     with (
@@ -280,7 +280,7 @@ def test_install_skills_handler_forwards_failure_reason() -> None:
         patch.object(skills, "detect_installed_agents", return_value=["claude"]),
         patch(
             "streamlit.web.skills.install_skills",
-            side_effect=skills._InstallError(
+            side_effect=skills.InstallError(
                 "developing-with-streamlit already exists. Remove it and try again.",
                 reason="conflict",
             ),
@@ -332,12 +332,12 @@ def test_install_skills_handler_does_not_leak_os_error_path() -> None:
 
 
 def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
-    """A non-_InstallError exception exposing a str ``.reason`` must NOT be emitted.
+    """A non-InstallError exception exposing a str ``.reason`` must NOT be emitted.
 
     The handler used to read the reason with ``getattr(ex, 'reason')``, so any
     exception carrying a free-form str ``.reason`` (``UnicodeDecodeError`` and
     several stdlib errors do) would emit an unbounded telemetry label and break the
-    fixed vocabulary. The reason is now trusted ONLY from skills._InstallError; a
+    fixed vocabulary. The reason is now trusted ONLY from skills.InstallError; a
     non-OSError foreign exception is classified ``unknown``.
     """
     foreign = ValueError("boom")

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import subprocess
 import sys
@@ -1027,7 +1028,9 @@ class TestInstallSkillsCli:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(skills, "_symlinks_supported", return_value=False),
+            patch.object(
+                skills, "_symlink_blocker", return_value="symlinks_unsupported"
+            ),
             patch.object(skills, "_install_global_skills") as install_global_skills,
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
@@ -1317,7 +1320,10 @@ class TestInstallSkillCopyEdgeCases:
                 {"developing-with-streamlit"},
             )
 
-        assert any("copy failed" in s for s in result.skipped)
+        assert any("copy failed" in s for s in result.errored)
+        # A write failure must land in ``errored``, never ``skipped`` - otherwise
+        # the caller labels it reason="conflict".
+        assert not result.skipped
 
     def test_preserves_existing_directory_on_copy_failure(
         self, tmp_path: Path, mock_source_skills_dir: Path
@@ -1346,7 +1352,39 @@ class TestInstallSkillCopyEdgeCases:
         # Original should be preserved with old content
         assert target.is_dir()
         assert (target / "SKILL.md").read_text() == "# Old version\n"
-        assert any("copy failed" in s for s in result.skipped)
+        assert any("copy failed" in s for s in result.errored)
+        assert not result.skipped
+
+    def test_reports_mkdir_failure_as_error(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A permission error creating the target dir is an error, not a skip.
+
+        Regression: the mkdir/existence checks ran outside the copy try/except,
+        so a permission-denied mkdir escaped as an uncaught OSError (which the
+        handler could only classify as 'unknown'). It must land in ``errored``
+        so it maps to reason='write_failed'.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        result = skills._InstallResult()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(
+                skills.Path, "mkdir", side_effect=OSError("Permission denied")
+            ),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert result.errored
+        assert not result.skipped
+        assert not result.installed
 
 
 class TestInstallSkillSymlinkEdgeCases:
@@ -1404,6 +1442,37 @@ class TestInstallSkillSymlinkEdgeCases:
             )
 
         assert not success
+
+    def test_returns_false_when_prework_fails_for_fallback(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A filesystem error in the symlink PRE-work returns False (-> fallback).
+
+        The mkdir / existence-check / unlink steps used to run outside the guard, so
+        an OSError there escaped as a hard write_failed and bypassed the
+        symlink->global fallback. Whatever stops us laying the symlink, the caller
+        should get the chance to fall back to a global copy.
+        """
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        result = skills._InstallResult()
+
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(
+                skills.Path, "mkdir", side_effect=OSError("Permission denied")
+            ),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.errored
+        assert not result.installed
 
 
 class TestPromptInstallModeRetry:
@@ -1468,6 +1537,127 @@ class TestGlobalInstallationConflicts:
         # The error names the specific conflicting path, not a vague "conflicts".
         assert ".agents/skills/developing-with-streamlit" in result.output
         assert "already exist" in result.output
+
+    def test_copy_failure_reports_write_failed_not_conflict(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """A filesystem copy failure raises reason='write_failed', not 'conflict'.
+
+        An ``OSError`` during the global copy (permissions, disk space, locked dir)
+        used to land in ``skipped`` and be labeled ``conflict``, so the nudge's
+        failure telemetry misclassified write failures - the dominant residual
+        Windows cause - as conflicts.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch.object(
+                skills.shutil, "copytree", side_effect=OSError("Permission denied")
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_failed"
+        # Must NOT be misclassified as a conflict.
+        assert "already exist" not in exc.value.format_message()
+
+    def test_reports_the_specific_write_cause_not_a_generic_failure(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """A permission error surfaces as write_denied, end to end.
+
+        The point of the whole exercise: "a write failed" does not say what to do,
+        while "permission denied" and "path too long" imply different fixes. The
+        errno has to survive from the copy site out to the raised reason.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=OSError(errno.EACCES, "Permission denied"),
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_denied"
+
+    def test_generalises_when_targets_fail_for_different_reasons(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """Disagreeing targets report the generic write_failed, not a guess.
+
+        Claiming "permission denied" when one target was denied and the other was out
+        of disk would send whoever reads the telemetry after half the problem.
+        """
+        home = tmp_path / "home"
+        # ~/.claude present -> _get_global_target_dirs yields two targets.
+        (home / ".claude").mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=[
+                    OSError(errno.EACCES, "Permission denied"),
+                    OSError(errno.ENOSPC, "No space left"),
+                ],
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_failed"
+
+    def test_partial_write_failure_reports_write_failed_not_success(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """One target succeeds, another OSErrors -> hard write_failed, not success.
+
+        ``_get_global_target_dirs`` returns TWO targets when ``~/.claude`` exists. If
+        ``~/.agents`` copies OK (result.installed non-empty) but ``~/.claude`` raises
+        OSError (result.errored), the success branch used to win over the errored
+        branch - so a half-installed system reported success and emitted no
+        write_failed telemetry for exactly the locked-down cohort under study. Any
+        errored target must fail loud.
+        """
+        home = tmp_path / "home"
+        # ~/.claude present -> _get_global_target_dirs yields both targets.
+        (home / ".claude").mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            # First target (~/.agents) copies fine; second (~/.claude) fails.
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=[None, OSError("Permission denied")],
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "write_failed"
 
 
 class TestInteractiveModeSelection:
@@ -1737,6 +1927,15 @@ class TestConflictError:
         assert ".agents/skills/developing-with-streamlit already exists." in message
         assert "Remove it and try again." in message
 
+    def test_conflict_error_carries_conflict_reason(self) -> None:
+        """The conflict error is an ``_InstallError`` tagged ``reason="conflict"`` so
+        the handler forwards it to install-failure telemetry."""
+        err = skills._conflict_error(
+            [".agents/skills/developing-with-streamlit (existing file or directory)"]
+        )
+        assert isinstance(err, skills._InstallError)
+        assert err.reason == "conflict"
+
 
 class TestInstallSkillsReturnsResult:
     """install_skills returns the structured result for callers (e.g. the nudge)."""
@@ -1972,10 +2171,10 @@ class TestInstallProjectSkillsNoFallback:
     """Tests for _install_project_skills with fallback_to_global=False."""
 
     @pytest.mark.parametrize(
-        ("symlinks_supported", "install_skill_symlink_return"),
+        ("precheck_blocker", "install_skill_symlink_return"),
         [
-            (False, True),
-            (True, False),
+            ("symlinks_unsupported", True),
+            (None, False),
         ],
         ids=["symlinks_unsupported_globally", "individual_symlink_failed"],
     )
@@ -1983,7 +2182,7 @@ class TestInstallProjectSkillsNoFallback:
         self,
         tmp_path: Path,
         mock_source_skills_dir: Path,
-        symlinks_supported: bool,
+        precheck_blocker: str | None,
         install_skill_symlink_return: bool,
     ) -> None:
         """Raises ClickException when symlinks are unavailable and fallback disabled."""
@@ -1994,9 +2193,7 @@ class TestInstallProjectSkillsNoFallback:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(
-                skills, "_symlinks_supported", return_value=symlinks_supported
-            ),
+            patch.object(skills, "_symlink_blocker", return_value=precheck_blocker),
             patch.object(
                 skills,
                 "_install_skill_symlink",
@@ -2035,7 +2232,7 @@ class TestInstallProjectSkillsFallbackErrors:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
-            patch.object(skills, "_symlinks_supported", return_value=True),
+            patch.object(skills, "_symlink_blocker", return_value=None),
             patch.object(skills, "_install_skill_symlink", return_value=False),
             patch.object(
                 skills,
@@ -2049,42 +2246,280 @@ class TestInstallProjectSkillsFallbackErrors:
                 skills._install_project_skills(yes=True)
 
 
-class TestInstallSkillCopyTempCleanup:
-    """Tests for temp file cleanup paths in _install_skill_copy."""
+class TestInstallProjectSkillsFallbackSignal:
+    """fallback_reason names WHY an install took the symlink->global path."""
 
-    def test_removes_leftover_temp_before_copying(
+    @pytest.mark.parametrize(
+        ("precheck_blocker", "expected_reason"),
+        [
+            ("symlinks_no_privilege", "symlinks_no_privilege"),
+            ("symlinks_denied", "symlinks_denied"),
+            ("symlinks_unsupported", "symlinks_unsupported"),
+            (None, "symlink_failed"),
+        ],
+        ids=["dev_mode_off", "project_dir_denied", "no_symlink_support", "link_failed"],
+    )
+    def test_fallback_records_its_cause(
+        self,
+        tmp_path: Path,
+        mock_source_skills_dir: Path,
+        precheck_blocker: str | None,
+        expected_reason: str,
+    ) -> None:
+        """Each fallback route is recorded distinctly, not collapsed into one flag.
+
+        A project install that can't lay symlinks is silently rerouted to a global
+        copy, so it looks identical to a project install in the success telemetry.
+        Most Windows users land here and then succeed, which makes this the label
+        carrying their diagnostic signal — and Developer Mode being off is a
+        documentable user action, while the others are not.
+        """
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(skills, "_symlink_blocker", return_value=precheck_blocker),
+            # Force the per-skill symlink to fail (only reached when the pre-check
+            # said symlinks work); harmless on the pre-check path.
+            patch.object(skills, "_install_skill_symlink", return_value=False),
+            patch.object(
+                skills,
+                "_install_global_skills",
+                return_value=skills._InstallResult(
+                    installed=["~/.agents/skills/developing-with-streamlit"]
+                ),
+            ),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        ):
+            result = skills._install_project_skills(yes=True)
+
+        assert result.fallback_reason == expected_reason
+
+    def test_project_symlink_install_has_no_fallback_reason(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
-        """Removes leftover temp directory from a previous failed copy."""
-        target_dir = tmp_path / "target" / "skills"
-        target_dir.mkdir(parents=True)
-        # Existing target directory with different content forces use of the
-        # temp-swap path.
-        target = target_dir / "developing-with-streamlit"
-        target.mkdir()
-        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+        """A normal project (symlink) install records no fallback reason."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(skills, "_symlink_blocker", return_value=None),
+            patch.object(skills, "_install_skill_symlink", return_value=True),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        ):
+            result = skills._install_project_skills(yes=True)
 
-        # Leftover temp directory from a previous failed run.
-        leftover_temp = target_dir / ".developing-with-streamlit.tmp"
-        leftover_temp.mkdir()
-        (leftover_temp / "leftover.txt").write_text("leftover", encoding="utf-8")
+        assert result.fallback_reason is None
 
-        result = skills._InstallResult()
-        with patch("pathlib.Path.home", return_value=tmp_path):
-            skills._install_skill_copy(
-                "developing-with-streamlit",
-                mock_source_skills_dir,
-                target_dir,
-                result,
-                {"developing-with-streamlit"},
-            )
 
-        assert len(result.installed) == 1
-        # New target must replace the old one and contain only the source content.
-        assert (target / "SKILL.md").is_file()
-        assert not (target / "stale-file.txt").exists()
-        # Temp directory must be cleaned up after the swap.
-        assert not leftover_temp.exists()
+class TestRaiseSiteReasons:
+    """Every raise site reports the reason the telemetry vocabulary expects.
+
+    mypy rejects an *invalid* reason but not a wrong *choice* among valid ones — so
+    tagging the meta-skill check ``source_missing`` instead of ``source_incomplete``
+    would type-check, ship, and quietly point a dashboard at the wrong packaging bug.
+    The existing tests for these paths assert on user-facing messages, which a
+    mis-tagged reason passes. These assert the reason itself.
+    """
+
+    def test_absent_skills_directory_is_source_missing(self, tmp_path: Path) -> None:
+        """Nothing installed in the wheel at all -> missing package data."""
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=tmp_path / "nope"
+            ),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_project_skills(yes=True)
+
+        assert exc.value.reason == "source_missing"
+
+    def test_incomplete_meta_skill_is_source_incomplete(self, tmp_path: Path) -> None:
+        """Directory present but a required file missing -> too-narrow glob.
+
+        Distinct from source_missing on purpose: "the wheel has no skills" and "the
+        wheel has the folder but not scripts/discover.py" are different packaging
+        bugs with different fixes.
+        """
+        meta_dir = tmp_path / "meta"
+        skill_dir = meta_dir / "developing-with-streamlit"
+        skill_dir.mkdir(parents=True)
+        # SKILL.md present, scripts/discover.py absent - the router without its target.
+        (skill_dir / "SKILL.md").write_text("# Meta\n", encoding="utf-8")
+
+        with (
+            patch.object(skills, "_get_meta_skill_dir", return_value=meta_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_global_skills(yes=True)
+
+        assert exc.value.reason == "source_incomplete"
+
+    def test_empty_skills_directory_is_no_skills(self, tmp_path: Path) -> None:
+        """The directory exists but discovery found nothing installable."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with (
+            patch.object(skills, "_get_source_skills_dir", return_value=empty),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_project_skills(yes=True)
+
+        assert exc.value.reason == "no_skills"
+
+    def test_no_tty_without_yes_is_non_interactive(
+        self, mock_source_skills_dir: Path
+    ) -> None:
+        """CLI-only: nothing to prompt on and --yes was not passed."""
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch("sys.stdin.isatty", return_value=False),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills.install_skills()
+
+        assert exc.value.reason == "non_interactive"
+
+    def test_cancelled_global_fallback_is_incomplete(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """Project symlinks failed and the user declined the global fallback."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        with (
+            patch.object(
+                skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
+            ),
+            patch.object(skills, "_symlink_blocker", return_value=None),
+            patch.object(skills, "_install_skill_symlink", return_value=False),
+            patch.object(
+                skills, "_install_global_skills", side_effect=click.exceptions.Abort()
+            ),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            pytest.raises(skills._InstallError) as exc,
+        ):
+            skills._install_project_skills(yes=True)
+
+        assert exc.value.reason == "incomplete"
+
+
+class TestSymlinkBlocker:
+    """_symlink_blocker names WHY symlinks are unavailable, not just that they are."""
+
+    def test_returns_none_when_symlinks_work(self, tmp_path: Path) -> None:
+        """A successful probe reports no blocker."""
+        _skip_if_symlinks_not_supported(tmp_path)
+        source = tmp_path / "source"
+        source.mkdir()
+        assert skills._symlink_blocker(tmp_path, source) is None
+
+    def test_identifies_windows_developer_mode_off(self, tmp_path: Path) -> None:
+        """ERROR_PRIVILEGE_NOT_HELD is reported as symlinks_no_privilege.
+
+        This is the single most useful value in the vocabulary: it means the account
+        lacks SeCreateSymbolicLinkPrivilege, i.e. Developer Mode is off — the one
+        cause of a global-fallback install that a user can simply fix. Collapsing it
+        into "unsupported" would hide a documentable action behind a dead end.
+        """
+        source = tmp_path / "source"
+        source.mkdir()
+        denied = OSError(errno.EPERM, "A required privilege is not held")
+        denied.winerror = 1314  # type: ignore[attr-defined]
+
+        with patch.object(skills.Path, "symlink_to", side_effect=denied):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_no_privilege"
+
+    def test_distinguishes_a_denied_project_directory(self, tmp_path: Path) -> None:
+        """A plain permission denial is an environment problem, not a missing feature."""
+        source = tmp_path / "source"
+        source.mkdir()
+        with patch.object(
+            skills.Path, "symlink_to", side_effect=OSError(errno.EACCES, "denied")
+        ):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_denied"
+
+    def test_reports_unsupported_for_a_filesystem_without_symlinks(
+        self, tmp_path: Path
+    ) -> None:
+        """NotImplementedError means the platform has no directory symlinks at all."""
+        source = tmp_path / "source"
+        source.mkdir()
+        with patch.object(skills.Path, "symlink_to", side_effect=NotImplementedError):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_unsupported"
+
+    def test_reports_unsupported_when_the_link_silently_is_not_one(
+        self, tmp_path: Path
+    ) -> None:
+        """A probe that "succeeds" without producing a symlink is not support.
+
+        Some filesystems accept the call and create something else. Claiming support
+        we could not verify would route the install down the symlink path and fail
+        later, with a worse reason attached.
+        """
+        source = tmp_path / "source"
+        source.mkdir()
+        with (
+            patch.object(skills.Path, "symlink_to"),
+            patch.object(skills.Path, "is_symlink", return_value=False),
+        ):
+            assert skills._symlink_blocker(tmp_path, source) == "symlinks_unsupported"
+
+
+class TestClassifyWriteError:
+    """_classify_write_error maps OSError codes to actionable reasons."""
+
+    @pytest.mark.parametrize(
+        ("errno_name", "expected"),
+        [
+            ("EACCES", "write_denied"),
+            ("EPERM", "write_denied"),
+            ("EROFS", "write_denied"),
+            ("ENOSPC", "write_no_space"),
+            ("EBUSY", "write_locked"),
+            ("ENAMETOOLONG", "write_name_too_long"),
+        ],
+    )
+    def test_maps_posix_errnos(self, errno_name: str, expected: str) -> None:
+        """Each POSIX code that implies a distinct fix gets its own reason."""
+        code = getattr(errno, errno_name)
+        assert skills._classify_write_error(OSError(code, "boom")) == expected
+
+    def test_unrecognised_errno_stays_generic(self) -> None:
+        """An unmapped code reports write_failed rather than being mis-bucketed.
+
+        Guessing would be worse than admitting ignorance: a wrong specific reason
+        sends whoever reads the telemetry after the wrong fix.
+        """
+        assert skills._classify_write_error(OSError(errno.EIO, "io")) == "write_failed"
+        assert skills._classify_write_error(OSError()) == "write_failed"
+
+    def test_winerror_takes_precedence_over_errno(self) -> None:
+        """A Windows sharing violation is a lock, not a permissions problem.
+
+        CPython maps ERROR_SHARING_VIOLATION (32) to EACCES, so trusting errno on
+        Windows would report write_denied and point at folder ACLs — when the real
+        cause is antivirus or a sync client holding the file, and the real fix is to
+        retry. winerror is therefore consulted first.
+        """
+        locked = OSError(errno.EACCES, "in use")
+        locked.winerror = 32  # type: ignore[attr-defined]
+        assert skills._classify_write_error(locked) == "write_locked"
+
+    def test_unrecognised_winerror_falls_back_to_errno(self) -> None:
+        """An unmapped Windows code still uses whatever errno CPython supplied."""
+        denied = OSError(errno.EACCES, "denied")
+        denied.winerror = 1_000_000  # type: ignore[attr-defined]
+        assert skills._classify_write_error(denied) == "write_denied"
 
 
 class TestGetMetaSkillDir:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2178,14 +2178,19 @@ class TestInstallProjectSkillsNoFallback:
         ],
         ids=["symlinks_unsupported_globally", "individual_symlink_failed"],
     )
-    def test_raises_clickexception_without_fallback(
+    def test_raises_symlinks_unsupported_without_fallback(
         self,
         tmp_path: Path,
         mock_source_skills_dir: Path,
         precheck_blocker: str | None,
         install_skill_symlink_return: bool,
     ) -> None:
-        """Raises ClickException when symlinks are unavailable and fallback disabled."""
+        """Raises the symlinks_unsupported reason when fallback is disabled.
+
+        Both no-fallback raise sites carry ``reason="symlinks_unsupported"``. Pin the
+        reason, not just the parent ``ClickException``, so the telemetry vocabulary
+        stays covered here the way it is everywhere else in this file.
+        """
         project_dir = tmp_path / "project"
         project_dir.mkdir()
 
@@ -2202,8 +2207,12 @@ class TestInstallProjectSkillsNoFallback:
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
         ):
-            with pytest.raises(click.ClickException, match="Symlinks not supported"):
+            with pytest.raises(
+                skills._InstallError, match="Symlinks not supported"
+            ) as exc:
                 skills._install_project_skills(yes=True, fallback_to_global=False)
+
+        assert exc.value.reason == "symlinks_unsupported"
 
 
 class TestInstallProjectSkillsFallbackErrors:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import get_args
 from unittest.mock import patch
 
 import click
@@ -1559,7 +1560,7 @@ class TestGlobalInstallationConflicts:
             patch.object(
                 skills.shutil, "copytree", side_effect=OSError("Permission denied")
             ),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
 
@@ -1589,7 +1590,7 @@ class TestGlobalInstallationConflicts:
                 "copytree",
                 side_effect=OSError(errno.EACCES, "Permission denied"),
             ),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
 
@@ -1620,7 +1621,7 @@ class TestGlobalInstallationConflicts:
                     OSError(errno.ENOSPC, "No space left"),
                 ],
             ),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
 
@@ -1653,7 +1654,7 @@ class TestGlobalInstallationConflicts:
                 "copytree",
                 side_effect=[None, OSError("Permission denied")],
             ),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
 
@@ -1928,12 +1929,12 @@ class TestConflictError:
         assert "Remove it and try again." in message
 
     def test_conflict_error_carries_conflict_reason(self) -> None:
-        """The conflict error is an ``_InstallError`` tagged ``reason="conflict"`` so
+        """The conflict error is an ``InstallError`` tagged ``reason="conflict"`` so
         the handler forwards it to install-failure telemetry."""
         err = skills._conflict_error(
             [".agents/skills/developing-with-streamlit (existing file or directory)"]
         )
-        assert isinstance(err, skills._InstallError)
+        assert isinstance(err, skills.InstallError)
         assert err.reason == "conflict"
 
 
@@ -2208,7 +2209,7 @@ class TestInstallProjectSkillsNoFallback:
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
         ):
             with pytest.raises(
-                skills._InstallError, match="Symlinks not supported"
+                skills.InstallError, match="Symlinks not supported"
             ) as exc:
                 skills._install_project_skills(yes=True, fallback_to_global=False)
 
@@ -2327,6 +2328,30 @@ class TestInstallProjectSkillsFallbackSignal:
         assert result.fallback_reason is None
 
 
+@pytest.mark.parametrize(
+    "reason",
+    sorted(
+        {*get_args(skills._InstallFailureReason), *get_args(skills._FallbackReason)}
+    ),
+)
+def test_every_reason_in_the_vocabulary_is_named_by_a_test(reason: str) -> None:
+    """Fail when a reason is added to either vocabulary and no test names it.
+
+    mypy constrains raise sites to the vocabulary but says nothing about the reverse
+    direction: a value can be added, shipped, and never exercised, so nobody notices
+    it is unreachable or mis-tagged until an analysis query returns an empty bucket.
+
+    This is a tripwire on that gap, not proof the covering assertion is a good one -
+    it only checks the literal appears somewhere in this file. The classes below are
+    where it should appear.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    assert f'"{reason}"' in source, (
+        f"{reason!r} is in the reason vocabulary but no test in this file names it. "
+        "Add one asserting the raise site or classification that produces it."
+    )
+
+
 class TestRaiseSiteReasons:
     """Every raise site reports the reason the telemetry vocabulary expects.
 
@@ -2343,7 +2368,7 @@ class TestRaiseSiteReasons:
             patch.object(
                 skills, "_get_source_skills_dir", return_value=tmp_path / "nope"
             ),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_project_skills(yes=True)
 
@@ -2365,7 +2390,7 @@ class TestRaiseSiteReasons:
         with (
             patch.object(skills, "_get_meta_skill_dir", return_value=meta_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
 
@@ -2377,7 +2402,7 @@ class TestRaiseSiteReasons:
         empty.mkdir()
         with (
             patch.object(skills, "_get_source_skills_dir", return_value=empty),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_project_skills(yes=True)
 
@@ -2392,7 +2417,7 @@ class TestRaiseSiteReasons:
                 skills, "_get_source_skills_dir", return_value=mock_source_skills_dir
             ),
             patch("sys.stdin.isatty", return_value=False),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills.install_skills()
 
@@ -2415,7 +2440,7 @@ class TestRaiseSiteReasons:
             ),
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
-            pytest.raises(skills._InstallError) as exc,
+            pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_project_skills(yes=True)
 
@@ -2485,7 +2510,7 @@ class TestSymlinkBlocker:
 
 
 class TestClassifyWriteError:
-    """_classify_write_error maps OSError codes to actionable reasons."""
+    """classify_write_error maps OSError codes to actionable reasons."""
 
     @pytest.mark.parametrize(
         ("errno_name", "expected"),
@@ -2501,7 +2526,7 @@ class TestClassifyWriteError:
     def test_maps_posix_errnos(self, errno_name: str, expected: str) -> None:
         """Each POSIX code that implies a distinct fix gets its own reason."""
         code = getattr(errno, errno_name)
-        assert skills._classify_write_error(OSError(code, "boom")) == expected
+        assert skills.classify_write_error(OSError(code, "boom")) == expected
 
     def test_unrecognised_errno_stays_generic(self) -> None:
         """An unmapped code reports write_failed rather than being mis-bucketed.
@@ -2509,8 +2534,8 @@ class TestClassifyWriteError:
         Guessing would be worse than admitting ignorance: a wrong specific reason
         sends whoever reads the telemetry after the wrong fix.
         """
-        assert skills._classify_write_error(OSError(errno.EIO, "io")) == "write_failed"
-        assert skills._classify_write_error(OSError()) == "write_failed"
+        assert skills.classify_write_error(OSError(errno.EIO, "io")) == "write_failed"
+        assert skills.classify_write_error(OSError()) == "write_failed"
 
     def test_winerror_takes_precedence_over_errno(self) -> None:
         """A Windows sharing violation is a lock, not a permissions problem.
@@ -2522,13 +2547,13 @@ class TestClassifyWriteError:
         """
         locked = OSError(errno.EACCES, "in use")
         locked.winerror = 32  # type: ignore[attr-defined]
-        assert skills._classify_write_error(locked) == "write_locked"
+        assert skills.classify_write_error(locked) == "write_locked"
 
     def test_unrecognised_winerror_falls_back_to_errno(self) -> None:
         """An unmapped Windows code still uses whatever errno CPython supplied."""
         denied = OSError(errno.EACCES, "denied")
         denied.winerror = 1_000_000  # type: ignore[attr-defined]
-        assert skills._classify_write_error(denied) == "write_denied"
+        assert skills.classify_write_error(denied) == "write_denied"
 
 
 class TestGetMetaSkillDir:

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -159,17 +159,10 @@ message InstallSkillsResponsePayload {
   //   "symlinks_denied"       - permissions on the project dir refused the probe
   //   "symlinks_unsupported"  - the filesystem/OS has no directory symlinks
   //   "symlink_failed"        - pre-check passed, then an individual link would not lay
-  // Split this finely because most Windows users take this path and then SUCCEED, so
-  // this is where their diagnostic signal lives - and only the first of these is
-  // something a user can simply fix. Lets the nudge telemetry count each cohort
-  // (skillsNudgeInstallSucceeded:<fallback_reason>), since a fallback install is
-  // otherwise indistinguishable from a project install.
-  string fallback_reason = 3;
-
-  // 2 was a bool used_global_fallback, superseded by the fallback_reason string
-  // above. Never released, but a PR preview wheel carried it, so the number is
-  // retired rather than retyped.
-  reserved 2;
+  // Reported on SUCCESS: most Windows users cannot lay symlinks, get rerouted, and
+  // then succeed, so this is where that cohort's diagnostic signal lives
+  // (skillsNudgeInstallSucceeded:<fallback_reason>).
+  string fallback_reason = 2;
 }
 
 // Acknowledgement payload for dismissing the skills nudge. Carries no data;

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -120,6 +120,13 @@ message BackendOperationResponse {
   // Error message if request failed (empty on success)
   string error_msg = 2;
 
+  // Machine-readable, bounded failure classification (empty on success).
+  // Parallels the human-readable error_msg. For the one-click skills install
+  // this is the cause of the failure (e.g. "conflict", "write_failed",
+  // "source_missing"), forwarded to telemetry so the nudge's install-failure
+  // rate can be broken down by cause.
+  string error_reason = 7;
+
   oneof payload {
     // Response for deferred file requests
     DeferredFileResponsePayload deferred_file = 3;
@@ -141,11 +148,28 @@ message DeferredFileResponsePayload {
 }
 
 // Response payload for one-click skills install. A successful, empty detail
-// indicates a clean install; failures are reported via the response's
-// error_msg field instead.
+// indicates a clean install; failures are not reported here at all, but via the
+// parent response's error_msg (human-readable) and error_reason (machine-readable).
 message InstallSkillsResponsePayload {
   // Optional human-readable detail about the install outcome.
   string detail = 1;
+
+  // Why a project install was rerouted to a global copy, empty when it wasn't:
+  //   "symlinks_no_privilege" - Windows Developer Mode off (ERROR_PRIVILEGE_NOT_HELD)
+  //   "symlinks_denied"       - permissions on the project dir refused the probe
+  //   "symlinks_unsupported"  - the filesystem/OS has no directory symlinks
+  //   "symlink_failed"        - pre-check passed, then an individual link would not lay
+  // Split this finely because most Windows users take this path and then SUCCEED, so
+  // this is where their diagnostic signal lives - and only the first of these is
+  // something a user can simply fix. Lets the nudge telemetry count each cohort
+  // (skillsNudgeInstallSucceeded:<fallback_reason>), since a fallback install is
+  // otherwise indistinguishable from a project install.
+  string fallback_reason = 3;
+
+  // 2 was a bool used_global_fallback, superseded by the fallback_reason string
+  // above. Never released, but a PR preview wheel carried it, so the number is
+  // retired rather than retyped.
+  reserved 2;
 }
 
 // Acknowledgement payload for dismissing the skills nudge. Carries no data;


### PR DESCRIPTION
## Summary

When the one-click "install skills" nudge fails, it emits a single `skillsNudgeInstallFailed` label with no cause attached — the server's `error_msg` is a human string and never reaches telemetry. Path conflict? Permissions? OneDrive-backed home directory? Symlinks refused? All indistinguishable today.

That matters because Windows is still **~5× the macOS failure rate** after #16026 removed the leading suspect (the GitHub-download fallback) in 1.60.0. That change helped materially — Windows 11.8% → 7.3%, overall 9.7% → 6.2% — but a real residual cause remains and the label cannot name it. <a href="#user-content-numbers">Funnel numbers and methodology ↓</a>

This threads a bounded, machine-readable **reason** end to end so those outcomes split by cause. Two installer corrections come with it, because a reason attached to the wrong signal measures nothing: write failures were being labelled conflicts — and a half-installed system reported outright success — while pre-symlink filesystem errors escaped with no classification at all.

> Related: #15933 — this is the instrumentation to diagnose the residual Windows failures, not a fix for the install itself.

## Telemetry

| Label | When |
| --- | --- |
| `skillsNudgeInstallSucceeded` | Normal project (symlink) install |
| `skillsNudgeInstallSucceeded:<fallback_reason>` | Rerouted from project mode to a global copy, naming why |
| `skillsNudgeInstallFailed:<reason>` | The install ran and failed |
| `skillsNudgeInstallRefused:<gate>` | The user clicked Install and a safety gate declined it |
| `skillsNudgeInstallDropped` | Connection dropped mid-install (unchanged) |

`Refused` means the toast **was** shown and clicked and the server declined before touching the filesystem — not that the nudge was hidden. A nudge never shown is the separate, pre-existing `skillsNudgeSuppressedNonLocal:<locality>`. Gates are `headless`, `no_agent`, `non_loopback`.

Reasons are a closed server-side vocabulary, never user input. Nothing is derived from an error *message* — only from error classes and numeric codes — so no path or OS string can reach a label.

| Reason | Means | Points at |
| --- | --- | --- |
| `write_denied` | `EACCES`/`EPERM`/`EROFS`, `ERROR_ACCESS_DENIED` | Permissions, or a read-only location |
| `write_locked` | `ERROR_SHARING_VIOLATION`, `EBUSY` | Antivirus or a sync client holding the file — **a retry would fix this** |
| `write_name_too_long` | `ENAMETOOLONG`, `ERROR_FILENAME_EXCED_RANGE` | Windows `MAX_PATH` — **shortening paths would fix this** |
| `write_no_space` | `ENOSPC`, `ERROR_DISK_FULL` | Disk or quota |
| `write_failed` | Anything unrecognised | Genuinely unknown — deliberately not guessed |
| `conflict` | A pre-existing file or foreign symlink | Messaging, or an opt-in overwrite |
| `source_missing` | The bundled skills directory is absent | Missing package data in the wheel |
| `source_incomplete` | Directory present, a required file missing | A too-narrow package-data glob |
| `no_skills` | Nothing installable discovered | Packaging |
| `incomplete` / `non_interactive` | CLI-only prompt outcomes | n/a |
| `unknown` | A non-`OSError` escaped the installer | Read the server log |

`winerror` is consulted before `errno` because CPython's mapping is lossy in exactly the misleading direction: `ERROR_SHARING_VIOLATION` arrives as `EACCES`, so trusting `errno` on Windows would report a permissions problem and send us after folder ACLs when the fix is to retry.

**Fallback reasons matter more than the failure list**, because most Windows users cannot lay symlinks, get rerouted to a global copy, and then *succeed* — so their diagnostic signal lives on the **success** label:

| `fallback_reason` | Means |
| --- | --- |
| `symlinks_no_privilege` | `ERROR_PRIVILEGE_NOT_HELD` — Developer Mode off. The one cause a user can fix themselves |
| `symlinks_denied` | Permissions on the project directory refused the probe |
| `symlinks_unsupported` | The filesystem has no directory symlinks at all |
| `symlink_failed` | Pre-check passed, then an individual link would not lay — closer to a bug |

From the nudge, only the `write_*` family, `conflict`, `source_*`, `no_skills` and `unknown` are reachable — `incomplete` and `non_interactive` are CLI-only, and `symlinks_unsupported`-as-a-failure is currently unreachable (its raise sites sit behind `fallback_to_global=False`, which no production caller passes). The `write_*` reasons arise only in the global-copy path, so from the nudge they appear *only* after symlinks have already failed — exactly the Windows cohort under study.

### Heads-up for dashboards

Three discontinuities land with this change:

1. **Safety-gate refusals move off the failure metric** onto `skillsNudgeInstallRefused:<gate>`. Near-zero volume, but the historical series will step down.
2. **Failure labels gain a `:<reason>` suffix**, so exact-match queries on `skillsNudgeInstallFailed` must become prefix matches.
3. **So does the success label.** A rerouted install emits `skillsNudgeInstallSucceeded:<fallback_reason>`, so exact-match queries will silently undercount successes. The same prefix fix is needed on *both* sides of the funnel.

Downstream analysis splits with `split_part(label, ':', 2)`; the suffix shape mirrors the existing `skillsNudgeSuppressedNonLocal:<locality>` and rides the existing `menuClick` / `gatherUsageStats` plumbing.

## What changed

- **Proto** — `error_reason` on `BackendOperationResponse` (field 7, a machine-readable sibling to the human `error_msg`) and `fallback_reason` on `InstallSkillsResponsePayload` (field 2). No released client sets or reads either, and mixed versions degrade gracefully: an older backend omits them and the frontend falls back to the bare labels.
- **`skills.py`** — `InstallError(click.ClickException)` carries a stable `reason`, typed as a `Literal` so mypy rejects a typo'd or ad-hoc reason at the raise site rather than silently minting a label no query knows about. It still behaves like a plain `ClickException`, so nothing a user sees changes. `classify_write_error` maps an `OSError` to a `write_*` reason from its numeric code; `_symlink_blocker` reports *why* symlinks are unavailable rather than just that they are.
- **`InstallSkillsHandler`** — forwards the reason, read *only* from `InstallError`; a `getattr(ex, "reason")` would duck-type stdlib exceptions that expose a free-form `.reason` and blow the bounded vocabulary. A bare `OSError` that escapes the installer gets the same errno classification; anything else is `unknown`. Gate refusals are namespaced `refused:<gate>` server-side, so a gate added there needs no frontend change.
- **Frontend** — `BackendOperationClient` rejects with an error carrying the reason, read back through the `getBackendOperationReason` accessor rather than a hand-written cast; `skillsNudge.ts` maps an install outcome to its label (pure, unit-tested, with the `refused:` marker private to that module).

## Installer corrections

Instrumenting the installer surfaced two places where the *reported* outcome did not match what happened on disk. Both are fixed here because the reason codes are meaningless without them. Nothing else about the installer is touched — the replacement/staging machinery is #16280's subject, and this PR does not modify it.

**Write failures are no longer reported as conflicts, or as success.** An `OSError` during a copy used to land in the `skipped` bucket, which the caller labels `conflict` — so genuine permission and disk failures (the likeliest residual Windows cause) were indistinguishable from a pre-existing file. They now land in a separate `errored` bucket and raise a `write_*` reason.

> **Behavior change:** a partial global install — say `~/.agents/skills` writes fine but `~/.claude/skills` is denied — previously reported success. It now fails, which changes the exit code of `streamlit skills install --global` for anyone in that state. That is deliberate: a half-install reported as success is exactly the blind spot this exists to close.
>
> Note this makes a partial *write failure* hard while a partial *conflict* stays soft — one target conflicting while another installs still reports success, with the conflict named in the summary. That asymmetry is deliberate. A conflict is a file the user chose to put there, so skipping it and installing everywhere else is the right outcome; failing the whole install would report failure to someone who has a working one. A write failure is the opposite — nothing about it was intentional. And only the write case was ever *mislabelled*, which is what this PR is correcting.

**Symlink pre-work failures fall back instead of erroring.** `mkdir` / existence-check / unlink errors in `_install_skill_symlink` used to escape as an uncaught `OSError`, which the handler could only classify as `unknown`; they now return `False`, so the caller falls back to a global copy like any other symlink failure.

## Testing

- **Python** — `skills_test.py` (175) and `backend_operation_handler_test.py` (33). The reason reaches `error_reason`; a plain `ClickException` falls back to `unknown`; an exception carrying a *foreign* `.reason` is not trusted; a bare `OSError` is classified by errno; success leaves `error_reason` empty; each gate reports its own `refused:<gate>`; a copy `OSError` reports `write_*` rather than `conflict` and never lands in `skipped`; targets failing for *different* reasons generalise to `write_failed`; a partial write failure fails rather than reporting success; and `fallback_reason` is recorded on each of the four reroute paths and empty for a normal project install.
- A **guard test** enumerates both `Literal` vocabularies and fails if a value is added without a test naming it — verified by injecting an unnamed reason and watching it fail.
- **Frontend** — `skillsNudge.test.ts` (18) covers the label functions directly, including the fallback-tagged success label, a refusal landing on `Refused` rather than `Failed`, and an older backend that sends no reason. `BackendOperationClient.test.ts` (17) covers the reason arriving on the rejection and `fallback_reason` surviving the client-to-payload hop on success. `App.test.tsx` keeps one wiring test per branch of the install handler.
- `frontend-types`, `frontend-lint`, `frontend-knip` clean; `make protobuf` regenerated the Python and TS bindings.

## Stack

- **This PR** — the reason vocabulary and its end-to-end plumbing, plus the two installer corrections the reason codes depend on
- #16280 — all installer hardening: both replacement paths reworked into a staged swap with an explicit recovery order, and the fixed `.{skill}.tmp` scratch name replaced by a private `mkdtemp` with a gated orphan sweep (draft, stacked on this branch)
- Supersedes #15934, which carried both halves and is now closed to review

The two are split on a single line: a change is here only if the telemetry reports the wrong thing without it. Everything about *surviving* a failed write, as opposed to *reporting* it, is #16280.

## Follow-up

`error_reason` is generic on `BackendOperationResponse`, so the other backend operations (deferred file, dismiss) can adopt reason codes later; only the install path sets it today.

---

<details id="numbers">
<summary><b>Funnel numbers and methodology</b> (snapshot 2026-07-30, nine days of 1.60.0)</summary>

Counted per **developer** (`COALESCE(MACHINE_ID_V4, MACHINE_ID_V3)`) rather than per event, over 2026-07-22 → 07-30:

| Funnel step | Developers |
| --- | --- |
| Saw the nudge | 147,095 |
| Clicked Install | 27,412 |
| Got a resolved outcome (success or failure) | 27,313 |

That last row is the denominator below — **not** the nudge audience, which is 5× larger. "Blocked" means at least one failure and no success in the window:

| Platform | Developers | Blocked | Rate |
| --- | --- | --- | --- |
| Windows | 22,254 | 1,626 | **7.3%** |
| macOS | 4,202 | 60 | 1.4% |
| Linux/ChromeOS | 857 | 21 | 2.5% |
| **All** | **27,313** | **1,707** | **6.2%** |

**On grain:** these rates are per developer. Failures are retried — 5,693 failure events came from 1,922 distinct developers (3.0 each; one machine retried 95 times) — so the per-*attempt* rate runs roughly 3× higher. Do not mix the two.

**On these counts:** late-arriving telemetry means a re-run moves the absolute numbers (an earlier run of the same query over the same window returned 25,654 developers, ~6% lower) while the *rates* held to a tenth of a point. Trust the percentages; re-derive the counts. If these look small next to a dashboard, check three things: the window is nine days, it is 1.60.0-only, and the denominator is resolved outcomes rather than everyone who saw the nudge.

</details>

<sub>Rebased onto `develop` post-1.60.0. #16026 removed the GitHub-download global-install path, so the `download_failed` / `extract_failed` / `download_empty` / `archive_missing_skill` reasons no longer exist and were dropped; a missing or incomplete bundled skill is now `source_missing` / `source_incomplete`. `error_reason` was renumbered 6 → 7 to avoid colliding with `dataframe_chunk`. An earlier revision of this branch carried a `bool used_global_fallback = 2` on `InstallSkillsResponsePayload`; it never reached `develop` or a release, so field 2 is reused by `fallback_reason` rather than reserved.</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skills install filesystem I/O and changes CLI exit behavior for partial global installs; telemetry label shapes change (prefix queries). Bounded server vocabulary limits exposure; gate refusals move off the failure metric by design.
> 
> **Overview**
> Adds **machine-readable install outcomes** end to end so the skills nudge funnel can split by cause instead of a single `skillsNudgeInstallFailed` / `skillsNudgeInstallSucceeded`.
> 
> The proto gains `error_reason` and `fallback_reason`; the Python installer raises `InstallError` with a closed vocabulary, classifies write/symlink failures, and the handler forwards reasons (including `refused:<gate>` for safety gates). The frontend maps these to suffixed `menuClick` labels (`skillsNudgeInstallFailed:<reason>`, `skillsNudgeInstallRefused:<gate>`, `skillsNudgeInstallSucceeded:<fallback_reason>`).
> 
> **Installer fixes tied to correct telemetry:** copy `OSError`s go to `errored` with `write_*` reasons (not `conflict`); partial global write failures now fail hard; symlink pre-work errors return false so global fallback can run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a322dedc305e1ed674e6b1d6593270e0507261c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->