### PR TITLE
[fix] Stage skill replacements so a failed swap cannot destroy the old install

### DIFF
--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -569,6 +569,12 @@ def _install_skill_symlink(
             if target_path.exists() or target_path.is_symlink():
                 # The move-aside failed, so the old install is intact and the staged
                 # link is redundant. Drop it and let the caller fall back.
+                #
+                # Removing this branch happens to reach the same state today - the
+                # direct-lay attempt below would hit FileExistsError and unwind here
+                # anyway - so no test can isolate it. Keep it regardless: it means an
+                # intact install is never a target we attempt to overwrite, rather
+                # than relying on symlink_to refusing to.
                 shutil.rmtree(staging, ignore_errors=True)
                 return False
             # The old link is out of the way but the staged one wouldn't move, leaving

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -16,11 +16,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import errno
 import os
 import shutil
 import sys
 import tempfile
+import time
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -35,6 +37,36 @@ _LOGGER: Final = get_logger(__name__)
 
 # Skill name installed in global mode
 _GLOBAL_SKILL_NAME: Final[str] = "developing-with-streamlit"
+
+# Prefix for the scratch directories a replacement install stages into. Only
+# ``mkdtemp`` produces these names, which is what makes the cleanup sweep in
+# _sweep_staging_dirs safe to run against a directory holding user files.
+#
+# Kept deliberately short, as are the child names below: staging adds a path
+# segment, and Windows still caps paths at 260 characters without long-path
+# support - which is itself one of the failure causes this telemetry is meant to
+# identify. Lengthening the path while hunting a path-length bug would be its own
+# footgun.
+_STAGING_PREFIX: Final[str] = ".st-skills-"
+# Children of the staging dir: the incoming copy and the displaced old install.
+# Single letters for the same path-budget reason; neither name is ever user-visible.
+_STAGING_NEW: Final[str] = "n"
+_STAGING_OLD: Final[str] = "o"
+# How long a staging dir must sit untouched before the sweep will reclaim it. A live
+# install writes into staging within seconds, so anything older was orphaned by a crash
+# or a kill - and anything younger may belong to a concurrent install whose staging dir
+# holds the only copy of the installation it has already moved aside.
+_STAGING_ORPHAN_AGE_S: Final[float] = 3600.0
+# Where a staging dir is moved when it holds the user's only copies (both the swap and
+# the restore failed). Deliberately NOT under _STAGING_PREFIX: the orphan sweep must be
+# unable to match it, or it would eventually delete the data it was retained to save.
+# Nothing reclaims these - that is the point - and the failure is logged with the path.
+_RECOVERY_PREFIX: Final[str] = ".st-recover-"
+# Sentinel written into every staging dir. The sweep requires it before deleting, so a
+# hidden user directory that merely shares the prefix is never touched: mkdtemp
+# guarantees uniqueness for the *creating* side, but the sweep matches on name and age,
+# which is a convention rather than proof of ownership.
+_STAGING_MARKER: Final[str] = ".streamlit-owned"
 
 # The full vocabulary of install-failure causes. Closed so the reason is safe to emit
 # as a telemetry label, and a Literal so mypy rejects a typo'd or ad-hoc reason at the
@@ -450,6 +482,7 @@ def _install_skill_symlink(
     # Pre-symlink filesystem work runs under one guard: any OSError here means we
     # can't lay the symlink, so return False and let the caller fall back to a global
     # copy rather than letting it escape and be misbooked as a hard write failure.
+    replace_owned_link = False
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -466,9 +499,10 @@ def _install_skill_symlink(
                     # Broken symlink or resolution error - check ownership below
                     pass
 
-                # Check if it's a Streamlit-owned symlink we can replace
+                # Check if it's a Streamlit-owned symlink we can replace. Don't
+                # remove it yet - see the staged replacement below.
                 if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                    target_path.unlink()
+                    replace_owned_link = True
                 else:
                     result.skipped.append(f"{rel_target_path} (existing symlink)")
                     return True
@@ -496,15 +530,135 @@ def _install_skill_symlink(
         # absolute (resolved) source path, which still resolves correctly.
         rel_source = os.path.realpath(source_path)
 
-    # Create symlink
+    # Replacing an existing link is staged: ``symlink_to`` won't overwrite, so the
+    # old one has to go first, and "remove then re-create" loses a working install
+    # whenever the re-create fails. Since a failing re-create means this system
+    # can't make symlinks at all, an attempt to restore would fail for the same
+    # reason. So prove we can make the link - inside a private staging dir - BEFORE
+    # removing anything. If that fails, the existing install is still untouched.
+    staging: Path | None = None
+    link_path = target_path
+    if replace_owned_link:
+        try:
+            staging = _open_staging_dir(target_dir)
+        except OSError:
+            return False
+        # ``rel_source`` is relative to target_dir, so while the link sits one level
+        # down in staging it dangles. Nothing reads it there, and the rename below
+        # moves the link verbatim, after which it resolves.
+        link_path = staging / _STAGING_NEW
+
     try:
-        target_path.symlink_to(rel_source, target_is_directory=True)
-        result.installed.append(str(rel_target_path))
-        return True
+        link_path.symlink_to(rel_source, target_is_directory=True)
     except (OSError, NotImplementedError):
         # Symlink not supported (e.g., Windows without Developer Mode, or some
-        # environments where symlinks are not implemented)
+        # environments where symlinks are not implemented). Nothing was removed.
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
         return False
+
+    if staging is not None:
+        # Move the old link aside rather than unlinking it, mirroring the copy path:
+        # if the swap then fails, the canonical path can be restored from staging
+        # instead of being left empty.
+        displaced = staging / _STAGING_OLD
+        try:
+            target_path.rename(displaced)
+            link_path.rename(target_path)
+        except OSError:
+            if target_path.exists() or target_path.is_symlink():
+                # The move-aside failed, so the old install is intact and the staged
+                # link is redundant. Drop it and let the caller fall back.
+                shutil.rmtree(staging, ignore_errors=True)
+                return False
+            # The old link is out of the way but the staged one wouldn't move, leaving
+            # the canonical path empty. Creating a link here demonstrably works - we
+            # just made one - so lay it directly.
+            try:
+                target_path.symlink_to(rel_source, target_is_directory=True)
+            except OSError:
+                # Last resort: put the displaced link back, so the canonical path is
+                # populated even though this install failed.
+                with contextlib.suppress(OSError):
+                    displaced.rename(target_path)
+                if not (target_path.exists() or target_path.is_symlink()):
+                    # The restore didn't land either, so staging holds the only copy
+                    # of the old link. Deleting it here would destroy the very thing
+                    # the move-aside preserved. Keep it, and drop the ownership marker
+                    # so the sweep can't take it later either.
+                    with contextlib.suppress(OSError):
+                        (staging / _STAGING_MARKER).unlink()
+                    return False
+                shutil.rmtree(staging, ignore_errors=True)
+                return False
+        shutil.rmtree(staging, ignore_errors=True)
+
+    result.installed.append(str(rel_target_path))
+    return True
+
+
+def _open_staging_dir(target_dir: Path) -> Path:
+    """Create a private scratch directory inside ``target_dir`` for a replacement.
+
+    Replacing an installed skill can't be done in one step: ``symlink_to`` won't
+    overwrite, and no OS offers an atomic replace for a non-empty directory
+    (``rename`` onto one gives ``ENOTEMPTY``, or ``PermissionError`` on Windows).
+    So a replacement has to build the new copy somewhere else first and then swap
+    it in, which raises the question of *where* "somewhere else" is.
+
+    Three options, and why this is the one:
+
+    - **A fixed sibling name** (``.<skill>.tmp``) is predictable, so clearing it
+      before use can recursively delete a directory the installer never created,
+      and two concurrent installs silently clobber each other's scratch space.
+    - **A unique name with no cleanup** can't collide, but every interrupted
+      install leaves a permanent orphan directory in a folder users browse and
+      gitignore.
+    - **A unique name plus a prefix-scoped sweep** — this. ``mkdtemp`` guarantees
+      the directory is ours and fresh, so nothing is ever deleted that we didn't
+      create; :func:`_sweep_staging_dirs` reclaims orphans on the next install by
+      matching only our own prefix, so they don't accumulate either.
+
+    The one accepted consequence: a staging directory deliberately left behind by
+    an unrecoverable swap (see :func:`_install_skill_copy`) is reclaimed by the
+    next install's sweep. That is bounded — anything in it is a copy of a bundled
+    skill, reproducible from the wheel — and by the time the sweep runs, the
+    install that follows it repopulates the canonical path anyway.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    _sweep_staging_dirs(target_dir)
+    staging = Path(tempfile.mkdtemp(dir=target_dir, prefix=_STAGING_PREFIX))
+    (staging / _STAGING_MARKER).touch()
+    return staging
+
+
+def _sweep_staging_dirs(target_dir: Path) -> None:
+    """Reclaim staging directories orphaned by an interrupted install.
+
+    Two guards, both load-bearing:
+
+    - A candidate must both match :data:`_STAGING_PREFIX` and contain the
+      :data:`_STAGING_MARKER` sentinel. The prefix alone is a convention; the marker
+      is proof we created it, so a hidden user directory that happens to share the
+      prefix is never removed.
+    - Only directories untouched for :data:`_STAGING_ORPHAN_AGE_S` are removed.
+      Sweeping on name alone would delete a *concurrent* install's staging
+      directory - which may already hold the old installation it moved aside, so
+      the sweep would take out both that and its replacement and leave the
+      canonical path empty. Orphan cleanup turning into data loss is worse than
+      the orphans it set out to prevent. A live install writes into staging within
+      seconds, so age separates the two cleanly without needing a lock.
+
+    Best-effort throughout: failing to tidy up must never fail an install.
+    """
+    cutoff = time.time() - _STAGING_ORPHAN_AGE_S
+    with contextlib.suppress(OSError):
+        for stale in target_dir.glob(f"{_STAGING_PREFIX}*"):
+            with contextlib.suppress(OSError):
+                if (
+                    stale / _STAGING_MARKER
+                ).is_file() and stale.stat().st_mtime < cutoff:
+                    shutil.rmtree(stale, ignore_errors=True)
 
 
 def _install_skill_copy(
@@ -522,6 +676,8 @@ def _install_skill_copy(
     # All filesystem work runs under one try so a failure at ANY step is recorded as
     # a write failure classified by errno, instead of escaping as an uncaught OSError
     # the caller can only classify as "unknown".
+    staging: Path | None = None
+    unrecoverable = False
     try:
         # Ensure parent directory exists
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -531,11 +687,14 @@ def _install_skill_copy(
         if target_path.exists() or target_path.is_symlink():
             # Target exists - check if we can replace it
             if target_path.is_symlink():
-                if _is_streamlit_owned_symlink(target_path, bundled_skill_names):
-                    target_path.unlink()
-                else:
+                if not _is_streamlit_owned_symlink(target_path, bundled_skill_names):
                     result.skipped.append(f"{rel_target_path} (existing symlink)")
                     return
+                # Defer removal until after the copy succeeds, same as a directory.
+                # Unlinking here instead would send this case down the plain-copytree
+                # branch below, so a failed copy would delete a working skill and
+                # leave nothing - the exact loss the staged swap exists to prevent.
+                old_target_to_remove = target_path
             elif target_path.is_dir():
                 if _skill_copy_matches(source_path, target_path):
                     result.up_to_date.append(str(rel_target_path))
@@ -545,31 +704,84 @@ def _install_skill_copy(
                 result.skipped.append(f"{rel_target_path} (existing file)")
                 return
 
-        # Copy to a temp location and swap, so a failed copy leaves the working
-        # installation in place.
+        # A replacement builds the new copy in a private staging dir and swaps it
+        # in, so a failed copy leaves the working installation in place. See
+        # _open_staging_dir for why staging is a fresh mkdtemp.
         if old_target_to_remove is not None:
-            temp_path = target_path.with_name(f".{skill_name}.tmp")
-            if temp_path.exists():
-                shutil.rmtree(temp_path)
-            shutil.copytree(source_path, temp_path)
-            # Now safe to remove old and rename new
-            shutil.rmtree(old_target_to_remove)
-            temp_path.rename(target_path)
+            staging = _open_staging_dir(target_dir)
+            new_path = staging / _STAGING_NEW
+            backup_path = staging / _STAGING_OLD
+            shutil.copytree(source_path, new_path)
+            # Move the old target aside rather than deleting it: if the swap then
+            # fails we can put it back, instead of stranding the new copy in
+            # staging with nothing at the path the agent looks in.
+            old_target_to_remove.rename(backup_path)
+            try:
+                new_path.rename(target_path)
+            except OSError:
+                # Put the old install back, then let the handler below record the
+                # write failure. There is no atomic replace for a non-empty
+                # directory on either POSIX or Windows, so this move-aside dance is
+                # the best available and a restore that ALSO fails can't be
+                # recovered in code. Log where both copies ended up - the
+                # user-facing message deliberately carries no server paths, so this
+                # is the only way the state is diagnosable.
+                try:
+                    backup_path.rename(target_path)
+                except OSError:
+                    unrecoverable = True
+                raise
         else:
             shutil.copytree(source_path, target_path)
         result.installed.append(str(rel_target_path))
     except OSError as e:
-        # Clean up temp path only if target still exists (meaning old wasn't removed).
-        # If target is gone, the old directory was deleted and temp is our only copy -
-        # keep it so the user isn't left with nothing.
-        temp_path = target_path.with_name(f".{skill_name}.tmp")
-        if temp_path.exists() and target_path.exists():
-            shutil.rmtree(temp_path, ignore_errors=True)
         # A write failure, not a conflict - record it in ``errored`` so it is
         # classified as such, not "conflict", and note the errno-derived cause so the
         # telemetry reason names which write failed.
         result.errored.append(f"{rel_target_path} (copy failed: {e})")
         result.write_reasons.add(classify_write_error(e))
+    finally:
+        # Dropping staging is bookkeeping and must never turn a landed install into a
+        # reported failure, hence the suppression throughout.
+        if staging is not None:
+            if unrecoverable:
+                # Both the swap and the restore failed, so staging holds the only
+                # copies of the old install and its replacement. Move it OUT of the
+                # swept namespace: leaving it under _STAGING_PREFIX would let a later
+                # install's orphan sweep delete the very thing we kept it for. The
+                # contents are usually reproducible from the wheel, but not if the
+                # user had edited their installed skill - so this is not ours to
+                # garbage-collect on a timer.
+                # Best-effort: relocating is itself a rename, and rename may be the
+                # very operation failing here. If it doesn't work the copies stay
+                # under the staging prefix, where only the age gate protects them -
+                # hence the log below naming their location either way.
+                keep = staging.with_name(
+                    _RECOVERY_PREFIX + staging.name[len(_STAGING_PREFIX) :]
+                )
+                with contextlib.suppress(OSError):
+                    staging.rename(keep)
+                    staging = keep
+                if staging.name.startswith(_STAGING_PREFIX):
+                    # The relocation didn't take - rename may be the very operation
+                    # failing here. Drop the ownership marker instead: the sweep
+                    # requires it, so removing it makes this directory permanently
+                    # invisible to cleanup. Unlinking one small file is far likelier
+                    # to succeed than renaming a directory, so between the two the
+                    # retained copies are protected whichever operation is broken.
+                    with contextlib.suppress(OSError):
+                        (staging / _STAGING_MARKER).unlink()
+                _LOGGER.warning(
+                    "Skills install left %s empty. The previous install is at %s and "
+                    "the new copy at %s - move either one back to recover. Nothing "
+                    "will clean this up automatically.",
+                    target_path,
+                    staging / _STAGING_OLD,
+                    staging / _STAGING_NEW,
+                )
+            else:
+                with contextlib.suppress(OSError):
+                    shutil.rmtree(staging, ignore_errors=True)
 
 
 def _print_result(result: _InstallResult) -> None:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -3151,9 +3151,12 @@ class TestInstallSkillCopyStaging:
         (target / "stale-file.txt").write_text("old", encoding="utf-8")
 
         # Stand in for another process mid-swap: its staging dir already holds the
-        # only copy of the installation it displaced.
+        # only copy of the installation it displaced. It carries the ownership marker,
+        # exactly as _open_staging_dir would have written it, so the marker check
+        # cannot be what spares it - only the age gate can.
         live = target_dir / f"{skills._STAGING_PREFIX}live99"
         (live / skills._STAGING_OLD).mkdir(parents=True)
+        (live / skills._STAGING_MARKER).touch()
         (live / skills._STAGING_OLD / "SKILL.md").write_text(
             "# Their only copy\n", encoding="utf-8"
         )

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -20,6 +20,7 @@ import errno
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import get_args
 from unittest.mock import patch
@@ -1302,6 +1303,50 @@ class TestInstallSkillCopyEdgeCases:
         assert target.is_dir()
         assert (target / "SKILL.md").is_file()
 
+    def test_preserves_existing_symlink_on_copy_failure(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed replacement leaves an existing owned symlink usable.
+
+        Replacing a Streamlit-owned symlink used to unlink it before copying, so a
+        copy that failed (permissions, full disk, antivirus lock) deleted a working
+        skill and left nothing in its place. The symlink case now takes the same
+        staged swap directories do, so the old install survives a failure.
+
+        This is the only test that pins the symlink target onto the staging path at
+        all: unlinking early would silently route it down the plain-copytree branch,
+        where every guarantee in this module is absent and nothing else notices.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        # A working install: an owned symlink pointing at a real skill directory.
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text(
+            "# Working install\n", encoding="utf-8"
+        )
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(skills.shutil, "copytree", side_effect=OSError("Disk full")),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert any("copy failed" in entry for entry in result.errored)
+        assert not result.installed
+
     def test_reports_copy_failure(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
@@ -1356,6 +1401,163 @@ class TestInstallSkillCopyEdgeCases:
         assert any("copy failed" in s for s in result.errored)
         assert not result.skipped
 
+    def test_restores_old_install_when_final_swap_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed swap restores the old install instead of stranding the copy.
+
+        The copy succeeds, so the old target is moved aside — but if renaming the
+        new copy into place then fails (a held handle, antivirus), deleting the old
+        one outright would leave the fresh copy under a hidden dot-name with
+        nothing at the path agents actually read.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
+
+        result = skills._InstallResult()
+        real_rename = skills.Path.rename
+        calls = {"n": 0}
+
+        def _fail_only_the_swap(self: Path, target_name: object) -> object:
+            """Let the move-aside through and fail the swap; the restore then works.
+
+            Blanket-patching ``rename`` would fail the move-aside instead, so the
+            restore branch would never run and a broken restore would still pass.
+            """
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("Access is denied")
+            return real_rename(self, target_name)  # type: ignore[arg-type]
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(skills.Path, "rename", _fail_only_the_swap),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # rename #1 moved the old install aside, #2 (the swap) failed, #3 restored it.
+        assert calls["n"] == 3
+        # The old install is back at the canonical path with its original content.
+        assert target.is_dir()
+        assert not target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Old version\n"
+        # Reported as a failure, and the backup name is not left behind.
+        assert result.errored
+        assert not result.installed
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_keeps_both_copies_when_swap_and_restore_both_fail(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """If the swap and the restore both fail, neither copy is discarded.
+
+        Moving the old install aside succeeds, then both renaming the new copy in
+        and putting the old one back fail. No atomic replace exists for a non-empty
+        directory on POSIX or Windows, so this state cannot be avoided in code — but
+        it must at least be non-destructive, leaving both copies recoverable on disk
+        and reporting the install as failed rather than succeeded.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
+
+        result = skills._InstallResult()
+        real_rename = skills.Path.rename
+        calls = {"n": 0}
+
+        def _only_first_rename_works(self: Path, target_name: object) -> object:
+            """Let the move-aside through; fail the swap and the restore after it."""
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return real_rename(self, target_name)  # type: ignore[arg-type]
+            raise OSError("Access is denied")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(skills.Path, "rename", _only_first_rename_works),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # Reported as a failure, never a success.
+        assert result.errored
+        assert not result.installed
+        # Both copies survive somewhere - nothing is destroyed. They stay under the
+        # staging prefix here rather than moving to the recovery one, because the
+        # relocation is itself a rename and rename is the operation failing in this
+        # scenario. The age gate is then the only thing protecting them, which is why
+        # the warning log names the paths. See
+        # test_never_sweeps_a_retained_recovery_directory for the normal case.
+        kept = list(target_dir.glob(f"{skills._STAGING_PREFIX}*")) + list(
+            target_dir.glob(f"{skills._RECOVERY_PREFIX}*")
+        )
+        assert len(kept) == 1
+        # Relocation is itself a rename, and rename is what is failing here — so the
+        # copies stay under the staging prefix. The ownership marker is dropped instead,
+        # which makes them permanently invisible to the sweep: two independent
+        # protections, so whichever filesystem operation is broken, one still holds.
+        assert not (kept[0] / skills._STAGING_MARKER).exists()
+        assert (kept[0] / skills._STAGING_OLD / "SKILL.md").read_text() == (
+            "# Old version\n"
+        )
+        assert (kept[0] / skills._STAGING_NEW / "SKILL.md").read_text() == (
+            "# Test Skill\n"
+        )
+
+    def test_reports_success_when_only_backup_cleanup_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed backup cleanup after a landed swap is still a success.
+
+        Discarding the staging dir is bookkeeping that happens after the new skill
+        is already at the target. If its error reached the write handler, a correct
+        install would be reported as ``write_failed`` — a false failure in the nudge
+        and a false reason in the telemetry.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "SKILL.md").write_text("# Old version\n", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            # Every rmtree here is cleanup; none of it may affect the outcome.
+            patch.object(
+                skills.shutil, "rmtree", side_effect=OSError("Directory not empty")
+            ),
+        ):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # The new skill landed, so this is a success...
+        assert result.installed
+        assert (target / "SKILL.md").read_text() == "# Test Skill\n"
+        # ...and must not be booked as a write failure.
+        assert not result.errored
+
     def test_reports_mkdir_failure_as_error(
         self, tmp_path: Path, mock_source_skills_dir: Path
     ) -> None:
@@ -1389,6 +1591,22 @@ class TestInstallSkillCopyEdgeCases:
 
 
 class TestInstallSkillSymlinkEdgeCases:
+    @staticmethod
+    def _existing_project_link(tmp_path: Path) -> tuple[Path, Path]:
+        """Create a working Streamlit-owned project symlink.
+
+        Returns ``(target_dir, target)`` — the directory the install writes into and
+        the link itself.
+        """
+        existing = tmp_path / "existing-skill"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text("# Working install\n", encoding="utf-8")
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing, target_is_directory=True)
+        return target_dir, target
+
     """Additional edge case tests for _install_skill_symlink."""
 
     def test_replaces_existing_symlink_with_skill_name(
@@ -1474,6 +1692,240 @@ class TestInstallSkillSymlinkEdgeCases:
         assert not success
         assert not result.errored
         assert not result.installed
+
+    def test_keeps_replaced_symlink_when_link_creation_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """An unmakeable symlink leaves the existing project install alone.
+
+        ``symlink_to`` cannot overwrite, so replacing an owned link means removing
+        it first — and "remove then re-create" loses a working install whenever the
+        re-create fails. A restore attempt is no defence: the re-create only fails
+        because this system won't make symlinks, so the restore fails identically.
+        Hence the new link is staged under a temp name first, and nothing is removed
+        until that has worked. Here every ``symlink_to`` fails, so the original must
+        be exactly as it was.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        existing_skill = tmp_path / "existing-skill"
+        existing_skill.mkdir()
+        (existing_skill / "SKILL.md").write_text(
+            "# Working install\n", encoding="utf-8"
+        )
+        target_dir = tmp_path / "project" / ".agents" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.symlink_to(existing_skill, target_is_directory=True)
+
+        result = skills._InstallResult()
+
+        def _always_fail(*args: object, **kwargs: object) -> None:
+            raise OSError("A required privilege is not held by the client")
+
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "symlink_to", _always_fail),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        # False so the caller still falls back to a global copy...
+        assert not success
+        # ...but the working project install must survive, still pointing where it did.
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert not result.installed
+
+    def _fail_from_nth_rename(self, n: int) -> object:
+        """Rename mock that fails the nth call and every one after it."""
+        real = skills.Path.rename
+        calls = {"n": 0}
+
+        def _rename(self: Path, target: object) -> object:
+            calls["n"] += 1
+            if calls["n"] >= n:
+                raise OSError("Access is denied")
+            return real(self, target)  # type: ignore[arg-type]
+
+        return _rename
+
+    def _fail_nth_rename(self, n: int) -> object:
+        """Rename mock that fails only the nth call, letting the others through."""
+        real = skills.Path.rename
+        calls = {"n": 0}
+
+        def _rename(self: Path, target: object) -> object:
+            calls["n"] += 1
+            if calls["n"] == n:
+                raise OSError("Access is denied")
+            return real(self, target)  # type: ignore[arg-type]
+
+        return _rename
+
+    def test_keeps_old_link_when_move_aside_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """If the old link can't be moved aside, it is left exactly as it was.
+
+        This is the branch staging exists for: the replacement is fully prepared, and
+        the first thing that touches the existing install fails, so nothing is lost.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir, target = self._existing_project_link(tmp_path)
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "rename", self._fail_nth_rename(1)),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.installed
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_lays_link_directly_when_swap_rename_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A failed swap recovers by creating the link at the canonical path.
+
+        The old link is already moved aside and the staged one will not rename into
+        place — but creating a symlink here is proven to work, since the staged one
+        just succeeded, so it is laid directly rather than stranding the install.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir, target = self._existing_project_link(tmp_path)
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "rename", self._fail_nth_rename(2)),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert success
+        assert result.installed
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Test Skill\n"
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_keeps_displaced_link_when_even_the_restore_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """When the restore fails too, the displaced link is not deleted with staging.
+
+        Move-aside succeeded, so staging holds the only copy of the old link. The swap,
+        the direct re-lay and the restore all fail — and the cleanup that follows must
+        not take staging with it, or the move-aside would have destroyed exactly what it
+        was there to preserve. The ownership marker is dropped so no later sweep can
+        take it either.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir, _target = self._existing_project_link(tmp_path)
+
+        real_symlink_to = skills.Path.symlink_to
+        calls = {"n": 0}
+
+        def _only_staged_link_works(
+            self: Path, link_target: object, target_is_directory: bool = False
+        ) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                real_symlink_to(
+                    self, link_target, target_is_directory=target_is_directory
+                )  # type: ignore[arg-type]
+                return
+            raise OSError("A required privilege is not held by the client")
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            # Move-aside is rename #1 and must work; every later rename fails, so both
+            # the swap and the restore are blocked.
+            patch.object(skills.Path, "rename", self._fail_from_nth_rename(2)),
+            patch.object(skills.Path, "symlink_to", _only_staged_link_works),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.installed
+        # The old link survives inside staging, and staging is now un-sweepable.
+        staged = list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+        assert len(staged) == 1
+        assert (staged[0] / skills._STAGING_OLD).is_symlink()
+        assert not (staged[0] / skills._STAGING_MARKER).exists()
+
+    def test_restores_displaced_link_when_recovery_also_fails(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """When nothing else works, the original link goes back at the canonical path.
+
+        The swap failed and the direct re-lay failed too. Moving the old link aside
+        rather than unlinking it means there is still something to put back, so the
+        path an agent reads ends up populated even though the install failed.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir, target = self._existing_project_link(tmp_path)
+
+        real_symlink_to = skills.Path.symlink_to
+        calls = {"n": 0}
+
+        def _only_staged_link_works(
+            self: Path, link_target: object, target_is_directory: bool = False
+        ) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                real_symlink_to(
+                    self, link_target, target_is_directory=target_is_directory
+                )  # type: ignore[arg-type]
+                return
+            raise OSError("A required privilege is not held by the client")
+
+        result = skills._InstallResult()
+        with (
+            patch("pathlib.Path.cwd", return_value=tmp_path / "project"),
+            patch.object(skills.Path, "rename", self._fail_nth_rename(2)),
+            patch.object(skills.Path, "symlink_to", _only_staged_link_works),
+        ):
+            success = skills._install_skill_symlink(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert not success
+        assert not result.installed
+        # The original link is back where agents look for it.
+        assert target.is_symlink()
+        assert (target / "SKILL.md").read_text() == "# Working install\n"
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
 
 
 class TestPromptInstallModeRetry:
@@ -2554,6 +3006,215 @@ class TestClassifyWriteError:
         denied = OSError(errno.EACCES, "denied")
         denied.winerror = 1_000_000  # type: ignore[attr-defined]
         assert skills.classify_write_error(denied) == "write_denied"
+
+
+class TestInstallSkillCopyStaging:
+    """Staging behavior for _install_skill_copy replacements."""
+
+    def test_sweeps_staging_dir_orphaned_by_an_interrupted_install(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """An old staging dir left by a crashed run is reclaimed."""
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        # Existing target with different content forces the staged-swap path.
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        orphan = target_dir / f"{skills._STAGING_PREFIX}abc123"
+        orphan.mkdir()
+        (orphan / "leftover.txt").write_text("leftover", encoding="utf-8")
+        # The sweep requires our ownership marker, so a real orphan carries one.
+        (orphan / skills._STAGING_MARKER).touch()
+        # Backdate it well past the orphan threshold.
+        old = time.time() - skills._STAGING_ORPHAN_AGE_S - 60
+        os.utime(orphan, (old, old))
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        assert (target / "SKILL.md").is_file()
+        assert not (target / "stale-file.txt").exists()
+        # The orphan is gone, and this run's own staging dir left nothing behind.
+        assert not orphan.exists()
+        assert not list(target_dir.glob(f"{skills._STAGING_PREFIX}*"))
+
+    def test_requires_an_ownership_marker_before_sweeping(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A prefix-shaped directory we did not create is never swept.
+
+        ``mkdtemp`` guarantees uniqueness for the side that *creates* the directory, but
+        the sweep matches on name and age — a convention, not proof of ownership. A user
+        directory that happens to share the prefix and is older than the threshold would
+        otherwise be deleted, so the sweep requires a sentinel we wrote ourselves.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+
+        # Prefix-shaped, well past the age gate, but NOT ours - no marker inside.
+        impostor = target_dir / f"{skills._STAGING_PREFIX}notours"
+        impostor.mkdir()
+        (impostor / "precious.txt").write_text("do not delete", encoding="utf-8")
+        ancient = time.time() - skills._STAGING_ORPHAN_AGE_S * 24
+        os.utime(impostor, (ancient, ancient))
+
+        # A replacement install, which is what runs the sweep.
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        assert (impostor / "precious.txt").read_text() == "do not delete"
+
+    def test_never_sweeps_a_retained_recovery_directory(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """Copies kept for manual recovery are never garbage-collected on a timer.
+
+        When the swap and the restore both fail, staging holds the only copies of the
+        old install and its replacement. Leaving them under the staging prefix would
+        let a later install's orphan sweep delete exactly what was retained to save —
+        and the age gate is no defence, since a recovery directory becomes old by
+        definition while it waits for the user. Moving it out of the swept namespace
+        is what makes it safe.
+
+        The contents are usually reproducible from the wheel, but not if the user had
+        edited their installed skill, so this is not ours to reclaim.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+
+        # A recovery dir left by an earlier unrecoverable swap, long past the age gate.
+        recovery = target_dir / f"{skills._RECOVERY_PREFIX}old99"
+        (recovery / skills._STAGING_OLD).mkdir(parents=True)
+        (recovery / skills._STAGING_OLD / "SKILL.md").write_text(
+            "# Their edited skill\n", encoding="utf-8"
+        )
+        ancient = time.time() - skills._STAGING_ORPHAN_AGE_S * 24
+        os.utime(recovery, (ancient, ancient))
+
+        # A later replacement install, which is what runs the sweep.
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        assert (recovery / skills._STAGING_OLD / "SKILL.md").read_text() == (
+            "# Their edited skill\n"
+        )
+
+    def test_leaves_a_concurrent_installs_staging_dir_alone(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """A freshly-created staging dir belongs to a live install — do not touch it.
+
+        Sweeping on name alone would delete a concurrent invocation's staging dir. That
+        dir may already hold the old installation it moved aside, so the sweep would
+        destroy both that and its replacement and leave the canonical path empty —
+        orphan cleanup turned into data loss. Age separates live from abandoned without
+        needing a lock.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        # Stand in for another process mid-swap: its staging dir already holds the
+        # only copy of the installation it displaced.
+        live = target_dir / f"{skills._STAGING_PREFIX}live99"
+        (live / skills._STAGING_OLD).mkdir(parents=True)
+        (live / skills._STAGING_OLD / "SKILL.md").write_text(
+            "# Their only copy\n", encoding="utf-8"
+        )
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        # The other invocation's displaced installation must survive untouched.
+        assert (live / skills._STAGING_OLD / "SKILL.md").read_text() == (
+            "# Their only copy\n"
+        )
+
+    def test_never_deletes_a_directory_it_did_not_create(
+        self, tmp_path: Path, mock_source_skills_dir: Path
+    ) -> None:
+        """Unrelated hidden directories in the target survive an install.
+
+        Staging used to use predictable sibling names (``.<skill>.tmp`` /
+        ``.<skill>.old``) and cleared them before use, so a directory the installer
+        never created could be recursively deleted. Staging is now a fresh
+        ``mkdtemp``, and the sweep matches only its own prefix, so nothing outside
+        that prefix is ever touched.
+        """
+        target_dir = tmp_path / "target" / "skills"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "developing-with-streamlit"
+        target.mkdir()
+        (target / "stale-file.txt").write_text("old", encoding="utf-8")
+
+        # The exact names the old implementation would have wiped, plus a plain one.
+        bystanders = [
+            target_dir / ".developing-with-streamlit.tmp",
+            target_dir / ".developing-with-streamlit.old",
+            target_dir / ".developing-with-streamlit.newlink",
+            target_dir / ".my-notes",
+        ]
+        for d in bystanders:
+            d.mkdir()
+            (d / "precious.txt").write_text("do not delete", encoding="utf-8")
+
+        result = skills._InstallResult()
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            skills._install_skill_copy(
+                "developing-with-streamlit",
+                mock_source_skills_dir,
+                target_dir,
+                result,
+                {"developing-with-streamlit"},
+            )
+
+        assert len(result.installed) == 1
+        for d in bystanders:
+            assert (d / "precious.txt").read_text() == "do not delete"
 
 
 class TestGetMetaSkillDir:


### PR DESCRIPTION
## Summary

Replacing an installed skill has several failure paths that end with nothing at the path the agent looks in. Rework both replacement paths — copy and symlink — into a staged swap with an explicit recovery order, so a failure at any step leaves either the old install or the new one in place, never an empty path.

Stacked on #16279, which carries the reason telemetry. This branch adds no new telemetry values and no new proto fields.

## Why

There is no atomic replace for a non-empty directory. `rename` onto one gives `ENOTEMPTY` on POSIX and `PermissionError` on Windows, and `symlink_to` refuses to overwrite at all. So a replacement has to build the new copy somewhere else and then swap it in, and every step of that swap is a place where a failure can leave the canonical path empty.

The pre-existing code took the shortest path through that problem: remove the old thing, then create the new one. That is fine until the create fails — and on the symlink path a failing create means the system cannot make symlinks at all, so an attempt to restore would fail for the same reason. The old link has to survive until the new one demonstrably exists.

This matters more than it sounds because the paired change in #16279 turns a partial install into a hard error. Before, a user in this state got "working skill plus a soft skip". After, they get "no skill plus a hard error" — so the exposure is amplified exactly where it was already worst.

## What changed

**`_open_staging_dir`** creates scratch space with `mkdtemp` under a private prefix instead of a fixed sibling name. A fixed name (`.<skill>.tmp`) is predictable, so clearing it before use can recursively delete a directory the installer never created, and two concurrent installs silently clobber each other's scratch space. `mkdtemp` guarantees the directory is ours and fresh.

**`_sweep_staging_dirs`** reclaims orphans left by an interrupted install, so unique names do not accumulate in a directory users browse and gitignore. Two gates, both load-bearing:

- The directory must carry an ownership marker. The prefix alone is a convention; the marker is proof the installer created it, so a hidden user directory that happens to share the prefix is never removed.
- It must be untouched for an hour. Sweeping on name alone would delete a *concurrent* install's staging dir — which may already hold the only copy of the installation it moved aside, so the sweep would take out both that and its replacement. Orphan cleanup turning into data loss is worse than the orphans it set out to prevent. A live install writes into staging within seconds, so age separates the two without needing a lock.

**Copy path** — moves the old target aside rather than deleting it, so a failed swap restores it instead of stranding the new copy in staging. When both the swap and the restore fail, staging holds the user's only copies: it is renamed out of the swept namespace so a later sweep cannot collect it; if that rename is itself the failing operation, the ownership marker is dropped instead (unlinking one small file is likelier to succeed than renaming a directory, and the sweep requires the marker); and both locations are logged, since the user-facing message deliberately carries no server paths.

**Symlink path** — creates the new link inside staging *before* removing anything, then moves the old link aside and renames the new one in. If the move-aside fails, the old install is intact and the staged link is dropped. If the swap fails with the old link already displaced, the link is laid directly — creating one demonstrably works, it was just done — and failing that, the displaced link is put back.

Cleanup is suppressed throughout. Dropping staging is bookkeeping and must never turn a landed install into a reported failure.

## Review history worth knowing

Every fix in this branch was verified against a build with the fix reverted. Even so, four of the fixes *introduced* a bug that a later review round caught. That rate is the reason this is split out of the original combined PR rather than shipped with the telemetry: the staging state machine wants review as a whole, not another round of fix-introduce-catch.

| Bug introduced while fixing another | Found by | Now pinned by |
| --- | --- | --- |
| Backup cleanup turned a landed install into a reported write failure | Cursor Bugbot | `test_reports_success_when_only_backup_cleanup_fails` |
| The orphan sweep deleted a concurrent install's displaced data | Greptile | `test_leaves_a_concurrent_installs_staging_dir_alone` |
| Copies retained for manual recovery stayed sweepable | Greptile, Bugbot | `test_never_sweeps_a_retained_recovery_directory` |
| A failed restore deleted the displaced link along with staging | Greptile | `test_keeps_displaced_link_when_even_the_restore_fails` |

A reviewer should read the recovery ordering in both paths as the thing under review, not the individual guards.

## Scope and limitations

**Concurrency is bounded, not solved.** Two `streamlit skills install` runs against the same target are not serialized — there is no lock. What the age gate buys is the one concurrency failure that loses user data: the sweep can no longer delete a live install's staging dir while that dir holds the only copy of the installation it moved aside. Beyond that, interleaved swaps are not made safe, only harmless — both runs copy identical content from the same wheel, so whichever ordering wins leaves a correct tree, though the loser can report a write failure for a target that is in fact fine. That interleaving is reasoned from the code, not tested; a lock file was considered and rejected, since it trades a scenario nobody has reported for a stale-lock failure mode that would affect every install.

**One guard no test isolates.** In `_install_skill_symlink`, the branch that returns early when the move-aside failed and the old install is intact is behavior-preserving to remove: the direct-lay attempt below would hit `FileExistsError` and unwind to the same state. It is kept so an intact install is never a target the code attempts to overwrite, rather than relying on `symlink_to` refusing to. That reasoning is now a comment in the source, since no test can pin it.

**The unrecoverable case is not recovered, only preserved.** When both the swap and the restore fail, the canonical path is empty and the code says so in the log rather than pretending otherwise. Nothing cleans those retained copies up — deliberately, since a user may have edited their installed skill, which makes the contents not reproducible from the wheel.

## Stack

- #16279 — the reason vocabulary and its plumbing (review and merge this first)
- **This PR** — installer hardening, stacked on the branch above
- Supersedes the installer half of #15934

## Testing

**Python** — 207 tests across `skills_test.py` (174) and `backend_operation_handler_test.py` (33); the full `lib/tests/` suite passes at 10,770 passed / 71 skipped, which is #16279's 10,757 plus exactly the 13 tests added here.

Each of the following was verified by reverting the corresponding guard and confirming the named test fails:

- [x] Ownership marker gate — `test_requires_an_ownership_marker_before_sweeping`
- [x] Orphan age gate — `test_leaves_a_concurrent_installs_staging_dir_alone`
- [x] Retained-recovery marker drop — `test_keeps_displaced_link_when_even_the_restore_fails`

The age-gate test needed fixing to earn that. It built its stand-in concurrent staging dir without an ownership marker, so the sweep skipped it on the marker check and never reached the age comparison. It passed with the age gate deleted entirely, while its docstring claimed age was what protected the directory. The marker is now written exactly as `_open_staging_dir` writes it, and deleting the age gate now fails the test.

- [ ] Verify the recovery ordering in `_install_skill_copy` and `_install_skill_symlink` reads correctly as a whole — this is the actual review ask
- [ ] Verify the one-hour orphan threshold is a defensible choice for a CLI install

**Not covered:** no E2E test. These paths need a filesystem induced to fail mid-operation, which the Playwright harness cannot arrange; the unit tests patch `rename` and `copytree` to fail at a chosen call instead.
